### PR TITLE
[Customer Portal] Fix unauthorized access response status

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -70,7 +70,7 @@ service http:InterceptableService / on new http:Listener(9090) {
     # Fetch user information of the logged in user.
     #
     # + return - User info object or error response
-    resource function get users/me(http:RequestContext ctx) returns User|http:Forbidden|http:InternalServerError {
+    resource function get users/me(http:RequestContext ctx) returns User|http:Unauthorized|http:InternalServerError {
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
             return <http:InternalServerError>{
@@ -91,11 +91,11 @@ service http:InterceptableService / on new http:Listener(9090) {
 
         entity:UserResponse|error userDetails = entity:getUserBasicInfo(userInfo.email, userInfo.idToken);
         if userDetails is error {
-            if getStatusCode(userDetails) == http:STATUS_FORBIDDEN {
-                log:printWarn(string `User: ${userInfo.userId} does not have access to the customer portal!`);
-                return <http:Forbidden>{
+            if getStatusCode(userDetails) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `Access denied for user: ${userInfo.userId} to Customer Portal`);
+                return <http:Unauthorized>{
                     body: {
-                        message: "User is not authorized to access the customer portal!"
+                        message: "Unauthorized access to the customer portal."
                     }
                 };
             }


### PR DESCRIPTION
## Description

This PR updates the access validation logic to return **401 Unauthorized** instead of **403 Forbidden** when a user is not authorized to access the Customer Portal.

Previously, unauthorized access attempts were incorrectly handled as forbidden responses. 

## Changes

- Updated access validation to return `401 Unauthorized` for unauthorized users.
- Updated error message for unauthorized access responses.

## Impact

- Improves correctness of HTTP status codes with entity response.

## Related Issues
- https://github.com/wso2-open-operations/cs-tools/issues/79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP status codes and error messaging for authentication failures in the user profile endpoint to accurately reflect unauthorized access attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->