### PR TITLE
[Customer Portal][BE] Add issueTypeKey filter to case search and include issueTypes in metadata response

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -288,8 +288,6 @@ public type CaseMetadataResponse record {|
     ChoiceListItem[] states;
     # List of available case severities (eg: S0, S1, etc.)
     ChoiceListItem[] severities;
-    # List of available case types (eg: Incident, Service Request, etc.)
-    ReferenceTableItem[] caseTypes;
     # List of available issue types (eg: Error, Total Outage, etc.)
     ChoiceListItem[] issueTypes;
     json...;

--- a/apps/customer-portal/backend/types.bal
+++ b/apps/customer-portal/backend/types.bal
@@ -133,8 +133,6 @@ public type CaseFilterOptions record {|
     ReferenceItem[] statuses;
     # List of case severities
     ReferenceItem[] severities;
-    # List of case types
-    ReferenceItem[] caseTypes;
     # List of issue types
     ReferenceItem[] issueTypes;
 |};

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -81,8 +81,6 @@ public isolated function getCaseFilters(entity:CaseMetadataResponse caseMetadata
         select {id: item.id.toString(), label: item.label};
     ReferenceItem[] severities = from entity:ChoiceListItem item in caseMetadata.severities
         select {id: item.id.toString(), label: item.label};
-    ReferenceItem[] caseTypes = from entity:ReferenceTableItem item in caseMetadata.caseTypes
-        select {id: item.id, label: item.name};
     ReferenceItem[] issueTypes = from entity:ChoiceListItem item in caseMetadata.issueTypes
         select {id: item.id.toString(), label: item.label};
 
@@ -90,7 +88,6 @@ public isolated function getCaseFilters(entity:CaseMetadataResponse caseMetadata
     return {
         statuses,
         severities,
-        caseTypes,
         issueTypes
     };
 }


### PR DESCRIPTION
## Description
This PR adds support for `issueTypeKeys[]` in the case search payload and updates the case metadata response to include `issueTypes[]`.

## Changes
- Added `issueTypeKeys[]` to case search request payload
- Updated search logic to filter cases by issue type
- Extended case metadata response to return `issueTypes[]`
- Updated related DTOs/models and validations

## Reason
Previously, the case search API did not support filtering by issue type, and the metadata response lacked issue type information. This caused limitations in filtering and incomplete data for consumers.

This change aligns the API with functional and UI requirements.

## Testing
- Tested case search with and without `issueTypeKey[]`
- Verified correct filtering behavior
- Validated metadata response includes `issueTypes[]`
- Ran regression tests on existing endpoints

## Related Issue
- https://github.com/wso2-open-operations/cs-tools/issues/116

## Related PRs
- https://github.com/wso2-enterprise/digiops-cs/pull/1284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering cases by issue type, enabling more precise search results within the customer portal.
  * Updated the way issue type information is presented in case metadata responses for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->