### PR TITLE
[Customer Portal][BE] Update attachment byte field type from string to int

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -436,7 +436,7 @@ public type Attachment record {|
     # MIME type of the file
     string 'type;
     # File size
-    int size;
+    int sizeBytes;
     # User who created the attachment
     string createdBy;
     # Created date and time
@@ -572,7 +572,7 @@ public type CreatedAttachment record {|
     # System ID of the created attachment
     string id;
     # File size
-    int size;
+    int sizeBytes;
     # Created date and time
     string createdOn;
     # User who created the attachment

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1083,7 +1083,7 @@ service http:InterceptableService / on new http:Listener(9090) {
     # + id - ID of the case
     # + return - Created attachment or error response
     resource function post cases/[string id]/attachments(http:RequestContext ctx, AttachmentPayload payload)
-        returns entity:CreatedAttachment|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+        returns CreatedAttachment|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -1139,7 +1139,13 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        return createdAttachmentResponse.attachment;
+        return {
+            id: createdAttachmentResponse.attachment.id,
+            size: createdAttachmentResponse.attachment.sizeBytes,
+            createdOn: createdAttachmentResponse.attachment.createdOn,
+            createdBy: createdAttachmentResponse.attachment.createdBy,
+            downloadUrl: createdAttachmentResponse.attachment.downloadUrl
+        };
     }
 
     # Get products of a deployment by deployment ID.

--- a/apps/customer-portal/backend/types.bal
+++ b/apps/customer-portal/backend/types.bal
@@ -228,6 +228,20 @@ public type CommentsResponse record {|
     *entity:Pagination;
 |};
 
+# Created attachment details.
+public type CreatedAttachment record {|
+    # System ID of the created attachment
+    string id;
+    # File size(in Bytes)
+    int size;
+    # Created date and time
+    string createdOn;
+    # User who created the attachment
+    string createdBy;
+    # Download URL
+    string downloadUrl;
+|};
+
 # Attachment data.
 public type Attachment record {|
     # ID of the attachment
@@ -236,7 +250,7 @@ public type Attachment record {|
     string name;
     # MIME type of the file
     string 'type;
-    # File size
+    # File size(in Bytes)
     int size;
     # User who created the attachment
     string createdBy;

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -176,7 +176,7 @@ public isolated function mapAttachmentsResponse(entity:AttachmentsResponse respo
             id: attachment.id,
             name: attachment.name,
             'type: attachment.'type,
-            size: attachment.size,
+            size: attachment.sizeBytes,
             createdBy: attachment.createdBy,
             createdOn: attachment.createdOn,
             downloadUrl: attachment.downloadUrl


### PR DESCRIPTION
## Description
This PR updates the attachment model by changing the `size` field type from `string` to `int`.

## Changes
- Modified attachment model: changed `size` field from `string` to `int`
- Updated related DTOs and mappings
- Adjusted validation and serialization logic
- Updated API responses accordingly

## Reason
Previously, the `size` field was defined as a `string`. Since this value is used only for display purposes in the UI, representing it as an `int` provides better flexibility. The frontend can now format or convert it as needed (e.g., KB/MB conversion) without being restricted by a string representation.

This change improves type correctness and separation of concerns between backend and frontend formatting.

## Related PRs
- https://github.com/wso2-enterprise/digiops-cs/pull/1296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Attachment size values are now integers instead of strings.
  * Attachment upload responses now return a plain created-attachment object rather than the previous wrapped entity shape.

* **New Features**
  * A new created-attachment response structure is exposed, containing id, size, creation timestamp, creator, and download URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->