### PR TITLE
[Customer Portal][BE] Add listener configuration to resolve HTTP 431 header size issue

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -55,11 +55,18 @@ service class ErrorInterceptor {
     }
 }
 
+// TODO: Remove after the ballerina header configs setting through choreo issue is fixed
+http:ListenerConfiguration listenerConf = {
+    requestLimits: {
+        maxHeaderSize: 16384
+    }
+};
+
 @display {
     label: "Customer Portal",
     id: "cs/customer-portal"
 }
-service http:InterceptableService / on new http:Listener(9090) {
+service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     public function createInterceptors() returns http:Interceptor[] =>
         [new authorization:JwtInterceptor(), new ErrorInterceptor()];
 


### PR DESCRIPTION
## Description
This PR adds an explicit Ballerina listener configuration to address the HTTP 431 (Request Header Fields Too Large) issue.

## Background
We were encountering HTTP 431 errors due to large request headers (e.g., tokens with groups claims).  

Although the header size was configured via Choreo, it did not take effect as expected.

After investigation, the support team identified this behavior as related to Ballerina listener configuration handling. When the header size was explicitly configured at the Ballerina listener level, the issue was resolved.

## Changes
- Added listener configuration to explicitly increase allowed header size
- Verified configuration overrides default header limits
- Ensured compatibility with existing deployment configuration

Example (simplified):
- Configured max header size at the Ballerina listener level

## Reason
- Choreo-level header configuration alone was insufficient
- Explicit listener configuration ensures predictable behavior
- Prevents HTTP 431 errors for large authentication headers

## Testing
- Verified requests with large headers no longer return 431
- Tested locally and in deployed environment
- Confirmed no regression in other endpoints

## Impact
- Infrastructure-level configuration change
- No API contract changes
- Improves reliability for requests containing large JWTs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced HTTP listener configuration to support larger header sizes, improving compatibility with requests containing extensive header information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->