### PR TITLE
[Customer Portal][BE] Remove case checks and update case response

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -288,6 +288,14 @@ public type CaseResponse record {|
         # Email address
         string? email;
     }? csManager;
+    # Case closed date and time
+    string? closedOn?;
+    # User who closed the case
+    ReferenceTableItem? closedBy?;
+    # Close notes for the case closure
+    string? closeNotes?;
+    # Indicates if the case is auto closed
+    boolean? hasAutoClosed?;
     json...;
 |};
 

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -867,36 +867,6 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
-        // Verify case validation for the user
-        entity:CaseResponse|error caseDetails = entity:getCase(userInfo.idToken, id);
-        if caseDetails is error {
-            if getStatusCode(caseDetails) == http:STATUS_UNAUTHORIZED {
-                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
-                return <http:Unauthorized>{
-                    body: {
-                        message: ERR_MSG_UNAUTHORIZED_ACCESS
-                    }
-                };
-            }
-
-            if getStatusCode(caseDetails) == http:STATUS_FORBIDDEN {
-                logForbiddenCaseAccess(id, userInfo.userId);
-                return <http:Forbidden>{
-                    body: {
-                        message: ERR_MSG_CASE_ACCESS_FORBIDDEN
-                    }
-                };
-            }
-
-            string customError = "Failed to retrieve case details.";
-            log:printError(customError, caseDetails);
-            return <http:InternalServerError>{
-                body: {
-                    message: customError
-                }
-            };
-        }
-
         entity:CommentsResponse|error commentsResponse = entity:getComments(userInfo.idToken, id, 'limit, offset);
         if commentsResponse is error {
             string customError = "Failed to retrieve comments.";
@@ -932,27 +902,6 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             return <http:BadRequest>{
                 body: {
                     message: ERR_LIMIT_OFFSET_INVALID
-                }
-            };
-        }
-
-        // Verify case validation for the user
-        entity:CaseResponse|error caseDetails = entity:getCase(userInfo.idToken, id);
-        if caseDetails is error {
-            if getStatusCode(caseDetails) == http:STATUS_FORBIDDEN {
-                logForbiddenCaseAccess(id, userInfo.userId);
-                return <http:Forbidden>{
-                    body: {
-                        message: ERR_MSG_CASE_ACCESS_FORBIDDEN
-                    }
-                };
-            }
-
-            string customError = "Failed to retrieve case details.";
-            log:printError(customError, caseDetails);
-            return <http:InternalServerError>{
-                body: {
-                    message: customError
                 }
             };
         }


### PR DESCRIPTION
## Description
This PR removes the case validation/check logic from the stats endpoint and updates the case response structure.

## Changes

### Remove Case Check from Stats Endpoint
- Removed case existence/validation logic from stats endpoint
- Delegated case validation responsibility to ServiceNow (SN)
- Simplified endpoint flow

### Update Case Response
- Updated case response model (fields adjusted as per latest changes)
- Ensured consistent serialization

## Reason

### Stats Endpoint Simplification
Case validation is now handled by ServiceNow (SN). Keeping the check in this service resulted in redundant validation and unnecessary coupling.

Removing it:
- Simplifies backend logic
- Avoids duplicate validation
- Aligns responsibility boundaries between services

### Case Response Update
The case response structure has been updated to reflect the latest contract and functional requirements.

## Testing
- Verified stats endpoint works without local case validation
- Confirmed correct behavior when SN handles case validation
- Tested updated case response structure=


## Related PRs
- https://github.com/wso2-enterprise/digiops-cs/pull/1346



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case responses now include expanded closure metadata: closure timestamp, responsible agent information, closure notes, and automatic closure indicator for better case resolution visibility.

* **Refactor**
  * Optimized request handling by streamlining case access validation, removing redundant checks from comment and attachment retrieval endpoints for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->