### PR TITLE
[Customer Portal][Web] Improve Issue Flow with Create Case Fallback

### DIFF
--- a/apps/customer-portal/webapp/src/components/project-details/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/components/project-details/time-tracking/TimeCardsDateFilter.tsx
@@ -132,7 +132,7 @@ export default function TimeCardsDateFilter({
         </Box>
 
         {/* State Filter */}
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2, flex: 1, minWidth: "300px" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2, minWidth: "300px", marginLeft: "auto" }}>
           <Typography
             id="state-filter-label"
             variant="body2"

--- a/apps/customer-portal/webapp/src/pages/DescribeIssuePage.tsx
+++ b/apps/customer-portal/webapp/src/pages/DescribeIssuePage.tsx
@@ -23,7 +23,7 @@ import {
   Stack,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft, Send } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Send, PlusCircle } from "@wso2/oxygen-ui-icons-react";
 import { useState, useRef, useCallback, useMemo, type JSX } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import Editor from "@components/common/rich-text-editor/Editor";
@@ -55,6 +55,7 @@ export default function DescribeIssuePage(): JSX.Element {
   const { projectId } = useParams<{ projectId: string }>();
   const { showError } = useErrorBanner();
   const [value, setValue] = useState("");
+  const [hasApiFailed, setHasApiFailed] = useState(false);
 
   const { data: projectDeployments } = useGetProjectDeployments(
     projectId || "",
@@ -103,6 +104,7 @@ export default function DescribeIssuePage(): JSX.Element {
       };
       navigate(`/${projectId}/support/chat`, { state });
     } catch {
+      setHasApiFailed(true);
       showError("Could not get help. Please try again or create a support case.");
     } finally {
       submittingRef.current = false;
@@ -115,6 +117,13 @@ export default function DescribeIssuePage(): JSX.Element {
     navigate,
     showError,
   ]);
+
+  const handleCreateCase = useCallback(() => {
+    if (!projectId) return;
+    navigate(`/${projectId}/support/chat/create-case`, {
+      state: { skipChat: true },
+    });
+  }, [projectId, navigate]);
 
   const isSubmitDisabled =
     !projectId || !plainText.trim() || isSubmitting || isProductsLoading;
@@ -183,7 +192,18 @@ export default function DescribeIssuePage(): JSX.Element {
               </Typography>
             </Box>
 
-            <Box sx={{ display: "flex", justifyContent: "flex-end", flexShrink: 0 }}>
+            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2, flexShrink: 0 }}>
+              {hasApiFailed && (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  startIcon={<PlusCircle size={18} />}
+                  onClick={handleCreateCase}
+                  disabled={!projectId}
+                >
+                  Create Case
+                </Button>
+              )}
               <Button
                 variant="contained"
                 color="warning"


### PR DESCRIPTION
### Description

This pull request introduces a user experience improvement to the issue description flow in the customer portal. The main enhancement is providing users with a clear "Create Case" option if the automated help API fails, making it easier to escalate issues. Additionally, there are minor UI adjustments for layout consistency.

**User experience improvements:**

* Added a "Create Case" button (with a `PlusCircle` icon) that appears when the automated help API fails, allowing users to directly create a support case. This button is disabled if `projectId` is not available and triggers navigation to the case creation page, passing a `skipChat` flag in state. [[1]](diffhunk://#diff-faf13113222124ba01ca2ed9ee52476af224f58361203dd0b2f8356c5246edeeR58) [[2]](diffhunk://#diff-faf13113222124ba01ca2ed9ee52476af224f58361203dd0b2f8356c5246edeeR107) [[3]](diffhunk://#diff-faf13113222124ba01ca2ed9ee52476af224f58361203dd0b2f8356c5246edeeR121-R127) [[4]](diffhunk://#diff-faf13113222124ba01ca2ed9ee52476af224f58361203dd0b2f8356c5246edeeL186-R206) [[5]](diffhunk://#diff-faf13113222124ba01ca2ed9ee52476af224f58361203dd0b2f8356c5246edeeL26-R26)

**UI/layout adjustments:**

* Adjusted the alignment of the state filter in `TimeCardsDateFilter` by removing the `flex: 1` property and adding `marginLeft: "auto"` to ensure correct positioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Create Case" button to the issue describe page that appears when API submission fails, enabling case creation for the current project.

* **Style**
  * Refined layout alignment in the time tracking filter section.
  * Increased spacing between action buttons on the describe issue page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->