### PR TITLE
[Customer Portal][Web] Add enabled flag to project timecard hook

### DIFF
--- a/apps/customer-portal/webapp/src/api/useSearchProjectTimeCards.ts
+++ b/apps/customer-portal/webapp/src/api/useSearchProjectTimeCards.ts
@@ -31,6 +31,7 @@ export interface UseSearchProjectTimeCardsParams {
   startDate?: string;
   endDate?: string;
   states?: string[];
+  enabled?: boolean;
 }
 
 /**
@@ -44,6 +45,7 @@ export default function useSearchProjectTimeCards({
   startDate,
   endDate,
   states,
+  enabled,
 }: UseSearchProjectTimeCardsParams): UseInfiniteQueryResult<
   InfiniteData<TimeCardSearchResponse>,
   Error
@@ -114,7 +116,12 @@ export default function useSearchProjectTimeCards({
       return nextOffset < lastPage.totalRecords ? nextOffset : undefined;
     },
     enabled:
-      !!projectId && !!startDate && !!endDate && isSignedIn && !isAuthLoading,
+      enabled !== false &&
+      !!projectId &&
+      !!startDate &&
+      !!endDate &&
+      isSignedIn &&
+      !isAuthLoading,
     staleTime: 5 * 60 * 1000,
   });
 }


### PR DESCRIPTION
This pull request updates the `useSearchProjectTimeCards` API hook to add more flexibility in controlling when the query is enabled. The main change is the introduction of an optional `enabled` parameter, allowing consumers to explicitly enable or disable the query in addition to the existing automatic conditions.

Enhancements to query control:

* Added an optional `enabled` parameter to the `UseSearchProjectTimeCardsParams` interface and the `useSearchProjectTimeCards` function, allowing callers to explicitly control whether the query is enabled. [[1]](diffhunk://#diff-74d578f19f19f8860cc3404a18778542c4efe075f75ce1bcad05806028b126d9R34) [[2]](diffhunk://#diff-74d578f19f19f8860cc3404a18778542c4efe075f75ce1bcad05806028b126d9R48)
* Updated the query's `enabled` property logic to include the new `enabled` parameter, so the query will only run if `enabled` is not set to `false` and all other conditions are met.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional control to enable or disable project time card search queries, allowing users to manage when search operations execute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->