### PR TITLE
fix(service-requests): React hooks dependency fixes

### DIFF
--- a/apps/customer-portal/webapp/src/components/support/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/components/support/service-requests/VariableFormFields.tsx
@@ -27,7 +27,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Upload, X } from "@wso2/oxygen-ui-icons-react";
-import { useEffect, type JSX } from "react";
+import { useEffect, useMemo, type JSX } from "react";
 import type { CatalogItemVariable } from "@models/responses";
 import {
   isAttachmentField,
@@ -195,16 +195,22 @@ export default function VariableFormFields({
   onAttachmentRemove,
   onAttachmentAdd,
 }: VariableFormFieldsProps): JSX.Element {
-  const sortedVariables = variables
-    ? [...variables].sort((a, b) => a.order - b.order)
-    : [];
+  const sortedVariables = useMemo(
+    () =>
+      variables ? [...variables].sort((a, b) => a.order - b.order) : [],
+    [variables],
+  );
   const deduplicatedForDisplay = deduplicateVariables(sortedVariables);
 
-  const allContextFields = contextValues
-    ? sortedVariables.filter((v) =>
-        isContextField(v.questionText, contextValues),
-      )
-    : [];
+  const allContextFields = useMemo(
+    () =>
+      contextValues
+        ? sortedVariables.filter((v) =>
+            isContextField(v.questionText, contextValues),
+          )
+        : [],
+    [contextValues, sortedVariables],
+  );
   const contextFieldsForDisplay = deduplicateVariables(allContextFields).filter(
     (v) =>
       !CONTEXT_FIELDS_HIDDEN_FROM_DISPLAY.some((p) =>
@@ -225,7 +231,7 @@ export default function VariableFormFields({
         onChange(v.id, val);
       }
     });
-  }, [contextValues, allContextFields, onChange]);
+  }, [contextValues, allContextFields, onChange, values]);
 
   if (isLoading) {
     return (

--- a/apps/customer-portal/webapp/src/pages/CreateServiceRequestPage.tsx
+++ b/apps/customer-portal/webapp/src/pages/CreateServiceRequestPage.tsx
@@ -135,7 +135,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
       (i) => i.id === selectedCatalogItemId,
     );
     return item?.label;
-  }, [catalogsData?.catalogs, selectedCatalogId, selectedCatalogItemId]);
+  }, [catalogsData, selectedCatalogId, selectedCatalogItemId]);
 
   const { mutate: postCase, isPending: isCreatePending } = usePostCase();
 


### PR DESCRIPTION
Resolves React Compiler and exhaustive-deps warnings in service request components:

- **VariableFormFields**: Add `values` to useEffect deps; memoize `sortedVariables` and `allContextFields` to avoid unstable deps
- **CreateServiceRequestPage**: Use `catalogsData` in useMemo deps instead of `catalogsData?.catalogs` for correct memoization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Enhanced rendering efficiency for service request creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->