### PR TITLE
Remove title from git issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: "🐞 Report a Bug"
 description: Create an issue if something does not work as expected.
-title: ""
 labels: ["Type/Bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: "💡 New Feature Request"
 description: Suggest new functionality or features for the product.
-title: ""
 labels: ["Type/New Feature"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/improvement_request.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_request.yml
@@ -1,6 +1,5 @@
 name: "🚀 Improvement Request"
 description: Suggest an improvement to existing functionality.
-title: "[Improvement] "
 labels: ["Type/Improvement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,6 +1,5 @@
 name: "✍️ Create a Task"
 description: Create a task for an app, module, or shared operation in the monorepo.
-title: ""
 labels: ["Type/Task"]
 body:
   - type: markdown


### PR DESCRIPTION
## Description
- Remove title from git issue templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed title fields from issue templates (bug report, feature request, improvement request, and task) to simplify the submission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->