### PR TITLE
[Customer Portal[BE] Make download url optional

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -692,7 +692,7 @@ public type Attachment record {|
     # Created date and time
     string createdOn;
     # Download URL
-    string downloadUrl;
+    string? downloadUrl;
     # Base64 encoded file content (data URI format: data:@file/<type>;base64,<content>)
     string content;
     # Description of the attachment

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -479,7 +479,7 @@ public type Attachment record {|
     # Created date and time
     string createdOn;
     # Download URL
-    string downloadUrl;
+    string? downloadUrl;
     # Base64 encoded file content (data URI format: data:@file/<type>;base64,<content>)
     string content;
     # Description of the attachment


### PR DESCRIPTION
## Description
Update attachment response by making download URL optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Download URLs for attachments are now optional, allowing attachments to be stored without a required download link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->