### PR TITLE
[Customer Portal[BE] Add get attachment endpoint and remove content field from attachment responses

### DIFF
--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -187,6 +187,15 @@ public isolated function createAttachment(string idToken, AttachmentCreatePayloa
     return csEntityClient->/attachments.post(payload, generateHeaders(idToken));
 }
 
+# Get attachment by ID.
+#
+# + idToken - ID token for authorization
+# + attachmentId - ID of the attachment
+# + return - Attachment response or error
+public isolated function getAttachment(string idToken, IdString attachmentId) returns AttachmentResponse|error {
+    return csEntityClient->/attachments/[attachmentId].get(generateHeaders(idToken));
+}
+
 # Update an attachment.
 #
 # + idToken - ID token for authorization

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -715,8 +715,6 @@ public type Attachment record {|
     string createdOn;
     # Download URL
     string? downloadUrl;
-    # Base64 encoded file content (data URI format: data:@file/<type>;base64,<content>)
-    string content;
     # Description of the attachment
     string? description;
     json...;
@@ -777,6 +775,14 @@ public type AttachmentDeleteResponse record {|
         string deletedOn;
         json...;
     |} attachment;
+|};
+
+# Attachment details response.
+public type AttachmentResponse record {|
+    *Attachment;
+    # Base64 encoded file content (data URI format: data:@file/<type>;base64,<content>)
+    string content;
+    json...;
 |};
 
 # Deployed product data.

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -502,8 +502,6 @@ public type Attachment record {|
     string createdOn;
     # Download URL
     string? downloadUrl;
-    # Base64 encoded file content (data URI format: data:@file/<type>;base64,<content>)
-    string content;
     # Description of the attachment
     string? description;
 |};

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1957,6 +1957,63 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return response.attachment;
     }
 
+    # Get an attachment.
+    #
+    # + id - ID of the attachment
+    # + return - Attachment response or error
+    resource function get attachments/[entity:IdString id](http:RequestContext ctx)
+        returns entity:AttachmentResponse|http:Unauthorized|http:Forbidden|http:NotFound|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:AttachmentResponse|error response = entity:getAttachment(userInfo.idToken, id);
+        if response is error {
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                log:printWarn(string `User: ${userInfo.userId} is forbidden to get the attachment with ID: ${id}!`);
+                return <http:Forbidden>{
+                    body: {
+                        message: "You're not authorized to get the requested attachment. " +
+                        "Please check your access permissions or contact support."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_NOT_FOUND {
+                log:printWarn(string `Attachment with ID: ${id} not found for user: ${userInfo.userId}`);
+                return <http:NotFound>{
+                    body: {
+                        message: "The attachment you're trying to get does not exist. " +
+                        "Please check and try again."
+                    }
+                };
+            }
+
+            string customError = "Failed to get the attachment.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return response;
+    }
+
     # Delete an attachment.
     #
     # + id - ID of the attachment

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -229,7 +229,6 @@ public isolated function mapAttachmentsResponse(entity:AttachmentsResponse respo
             createdBy: attachment.createdBy,
             createdOn: attachment.createdOn,
             downloadUrl: attachment.downloadUrl,
-            content: attachment.content,
             description: attachment.description
         };
 


### PR DESCRIPTION
## Description
This PR introduces a new endpoint to retrieve attachment content and updates the attachment response by removing the `content` field.

## Changes

### 1️⃣ Add Get Attachment Endpoint
- Added endpoint to retrieve attachment content directly
- Implemented validation and proper error handling (e.g., not found scenarios)
- Ensured secure retrieval of attachment data

Example:
GET /attachments/{attachmentId}

---

### 2️⃣ Remove `content` from Attachment Response
- Removed `content` field from attachment responses
- Updated response models/DTOs
- Adjusted serialization logic accordingly

## Reason
Previously, attachment responses included the file `content`, which increased payload size and caused unnecessary data transfer.

Separating metadata from file content improves:
- API performance
- Response payload size
- Security and control over file retrieval

Attachment metadata is now returned in standard endpoints, while the file content is fetched through the dedicated get attachment endpoint.

## Testing
- Verified new endpoint correctly retrieves attachment content
- Confirmed attachment responses no longer include `content`
- Performed regression testing on attachment-related endpoints

## Impact
- Attachment response structure updated (content field removed)
- New endpoint added for fetching attachment content
- Improves API performance and attachment handling

## Related PRs
- https://github.com/wso2-enterprise/digiops-cs/pull/1473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to retrieve individual attachments by ID through a new API endpoint.

* **Refactor**
  * Updated attachment response structure to separate content data from attachment metadata, improving API efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->