### PR TITLE
[Customer portal] [web] Redirect to Project Dashboard on Project Switch

### DIFF
--- a/apps/customer-portal/webapp/src/components/common/header/Header.tsx
+++ b/apps/customer-portal/webapp/src/components/common/header/Header.tsx
@@ -101,16 +101,12 @@ export default function Header({ onToggleSidebar }: HeaderProps): JSX.Element {
       if (project) {
         logger.debug(`Switching to project: ${project.name} (${project.id})`);
 
-        const pathParts = location.pathname.split("/").filter(Boolean);
-        const projectIndex = pathParts.indexOf("projects");
-        const subPath =
-          projectIndex !== -1 ? pathParts.slice(projectIndex + 2).join("/") : "";
-        navigate(`/projects/${project.id}/${subPath || "dashboard"}`);
+        navigate(`/projects/${project.id}/dashboard`);
       } else {
         logger.warn(`Project with ID ${id} not found for switching`);
       }
     },
-    [projects, logger, location.pathname, navigate],
+    [projects, logger, navigate],
   );
 
   return (


### PR DESCRIPTION
### Description

This pull request makes a small update to the project switching logic in the `Header` component. Now, when a user switches projects, they are always redirected to the project's dashboard, instead of preserving the previous sub-path.

* Simplified project navigation: When switching projects, the user is redirected to `/projects/{project.id}/dashboard` instead of retaining the previous sub-path. This ensures a consistent landing page after switching projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified project navigation to consistently direct to the project dashboard when switching between projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->