### PR TITLE
Refactor WebSocket service path for chat session proxying

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -4322,7 +4322,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
 }
 
 # WebSocket service to proxy messages between the browser and the upstream Python AI chat agent for real-time communication in chat sessions.
-isolated service / on new websocket:Listener(wsPort, listenerConf) {
+isolated service /ws on new websocket:Listener(wsPort) {
 
     # Upgrade an HTTP request to WebSocket for a given chat session.
     #


### PR DESCRIPTION
Refactor WebSocket service path for chat session proxying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebSocket service endpoint routing to use the `/ws` path instead of the root path
  * Simplified WebSocket listener configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->