### PR TITLE
[Customer Portal][BE] Update call request update payload

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -1205,6 +1205,8 @@ public type CallRequest record {|
     string updatedOn;
     # State information
     ChoiceListItem state;
+    # Cancellation reason
+    string? cancellationReason?;
     json...;
 |};
 
@@ -1267,8 +1269,8 @@ public type CallRequestCreateResponse record {|
 public type CallRequestUpdatePayload record {|
     # State key
     int stateKey;
-    # Reason for the update
-    string reason;
+    # Reason for the requested call cancellation
+    string cancellationReason?;
     # New preferred UTC times for the call (mandatory when stateKey is 2)
     DateTime[] utcTimes?;
 |};

--- a/apps/customer-portal/backend/modules/entity/utils.bal
+++ b/apps/customer-portal/backend/modules/entity/utils.bal
@@ -84,12 +84,30 @@ public isolated function getAttachments(string idToken, string id, ReferenceType
 public isolated function validateCallRequestUpdatePayload(CallRequestUpdatePayload payload) returns string? {
     int stateKey = payload.stateKey;
     string[]? utcTimes = payload.utcTimes;
+    string? cancellationReason = payload?.cancellationReason;
     boolean hasUtcTimes = utcTimes !is () && utcTimes.length() > 0;
 
-    if stateKey == PENDING_ON_WSO2 && !hasUtcTimes {
-        return "At least one UTC time is required when the status is Pending on WSO2.";
-    } else if (stateKey == CUSTOMER_REJECTED || stateKey == CANCELED) && utcTimes !is () {
-        return "UTC times should not be provided when the status is Customer Rejected or Canceled.";
+    if stateKey == PENDING_ON_WSO2 {
+        if !hasUtcTimes {
+            return "At least one UTC time is required when the status is Pending on WSO2.";
+        }
+        if cancellationReason !is () {
+            return "Cancellation reason should not be provided when the status is Pending on WSO2.";
+        }
+    } else if stateKey == CUSTOMER_REJECTED {
+        if utcTimes !is () {
+            return "UTC times should not be provided when the status is Customer Rejected.";
+        }
+        if cancellationReason !is () {
+            return "Cancellation reason should not be provided when the status is Customer Rejected.";
+        }
+    } else if stateKey == CANCELED {
+        if utcTimes !is () {
+            return "UTC times should not be provided when the status is Canceled.";
+        }
+        if cancellationReason is () || cancellationReason.trim().length() == 0 {
+            return "Cancellation reason is required when the status is Canceled.";
+        }
     } else if (stateKey != PENDING_ON_WSO2 && stateKey != CUSTOMER_REJECTED && stateKey != CANCELED) {
         return "Provided state is invalid. Allowed values are Pending on WSO2, Customer Rejected, or Canceled.";
     }

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -949,8 +949,8 @@ public type CallRequestCreatePayload record {|
 public type CallRequestUpdatePayload record {|
     # State key
     int stateKey;
-    # Reason for the update
-    string reason;
+    # Reason for the requested call cancellation
+    string cancellationReason?;
     # New preferred UTC times for the call (mandatory when stateKey is 2)
     entity:DateTime[] utcTimes?;
 |};


### PR DESCRIPTION
## Description
This PR updates the call request update payload by renaming the field `reason` to `cancellationReason`.

## Changes
- Renamed payload field:
  - FROM: `reason`
  - TO:   `cancellationReason`
- Updated request DTOs/records
- Adjusted validation logic and mappings
- Ensured consistent serialization/deserialization

## Reason
The previous field name `reason` was ambiguous.  
Renaming it to `cancellationReason` improves clarity and better reflects its actual purpose in the context of call request updates and made it a required field when cancelling a call request.

## Impact
⚠ This is a breaking change for consumers using the previous payload field.

Consumers must update requests to use:
- `cancellationReason` instead of `reason`

## Testing
- Verified update endpoint works with the new field
- Confirmed validation and mapping logic
- Ensured old field is no longer accepted (or handled if backward compatibility is provided)

## Related PRs
- https://github.com/wso2-enterprise/digiops-cs/pull/1538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now optionally provide cancellation reasons when canceling call requests.

* **Improvements**
  * Validation for call request cancellations has been enhanced with stricter state-specific requirements and more detailed error feedback for different cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->