### PR TITLE
[Customer Portal][Web] Auto-initiate sign-in for unauthenticated users instead of redirecting to /home

### DIFF
--- a/apps/customer-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/customer-portal/webapp/src/layouts/AuthGuard.tsx
@@ -14,8 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { type JSX } from "react";
-import { Navigate } from "react-router";
+import { type JSX, useEffect } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import AppLayout from "@layouts/AppLayout";
 
@@ -27,10 +26,16 @@ import AppLayout from "@layouts/AppLayout";
  * @returns {JSX.Element} AppLayout or redirect to home.
  */
 export default function AuthGuard(): JSX.Element {
-  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
+  const { isSignedIn, isLoading: isAuthLoading, signIn } = useAsgardeo();
+
+  useEffect(() => {
+    if (!isSignedIn && !isAuthLoading) {
+      void signIn();
+    }
+  }, [isSignedIn, isAuthLoading, signIn]);
 
   if (!isSignedIn && !isAuthLoading) {
-    return <Navigate to="/home" replace />;
+    return <AppLayout />;
   }
 
   return <AppLayout />;


### PR DESCRIPTION
## Description

Start the authentication flow automatically for unauthenticated users instead of redirecting them to /home. Add useEffect and signIn from useAsgardeo to trigger signIn when not signed in and not loading; remove the Navigate redirect and show AppLayout while the sign-in is initiated. Also import useEffect and include signIn in the hook destructure.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication flow to automatically initiate sign-in when needed instead of requiring manual redirection for unauthenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->