### PR TITLE
[Customer Portal][Backend] : Normalize WebSocket subprotocol string

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -4524,7 +4524,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
 
 # WebSocket service to proxy messages between the browser and the upstream Python AI chat agent for real-time communication in chat sessions.
 @websocket:ServiceConfig {
-    subProtocols: ["WSO2 Developer Platform-oauth2-token", "choreo-test-key"]
+    subProtocols: ["wso2-developer-platform-oauth2-token", "choreo-test-key"]
 }
 isolated service / on new websocket:Listener(wsPort) {
 
@@ -4535,14 +4535,14 @@ isolated service / on new websocket:Listener(wsPort) {
     # + return - WebSocket service or upgrade error
     isolated resource function get ws(http:Request req, string sessionId) returns websocket:Service|websocket:UpgradeError {
         // Fallback: extract tokens from Sec-WebSocket-Protocol header.
-        // Format: "WSO2 Developer Platform-oauth2-token, <accessToken>, <userIdToken>"
+        // Format: "wso2-developer-platform-oauth2-token, <accessToken>, <userIdToken>"
         string|error protocolHeader = req.getHeader("Sec-WebSocket-Protocol");
         if protocolHeader is error {
             return error websocket:UpgradeError(ERR_MSG_USER_INFO_HEADER_NOT_FOUND);
         }
         string[] parts = re `,`.split(protocolHeader);
         if parts.length() < 3 {
-            return error websocket:UpgradeError("Invalid Sec-WebSocket-Protocol format. Expected: WSO2 Developer Platform-oauth2-token, <accessToken>, <userIdToken>");
+            return error websocket:UpgradeError("Invalid Sec-WebSocket-Protocol format. Expected: wso2-developer-platform-oauth2-token, <accessToken>, <userIdToken>");
         }
         string accessToken = parts[1].trim();
         string userIdToken = parts[2].trim();


### PR DESCRIPTION
Update the WebSocket service to use the lowercase, hyphenated subprotocol 'wso2-developer-platform-oauth2-token' (replacing 'WSO2 Developer Platform-oauth2-token') in the service config, comment, and validation error message. This keeps the expected Sec-WebSocket-Protocol format consistent for header parsing and improves compatibility with clients.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated WebSocket subprotocol configuration to use the correct lowercase format for platform identification.
* Adjusted validation of WebSocket protocol headers to properly recognize the updated subprotocol format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->