### PR TITLE
[Customer Portal][BE] Add createdBy query param to project stats endpoints for user-specific filtering

### DIFF
--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -84,12 +84,21 @@ public isolated function getProjectActivityStats(string idToken, string id) retu
 # + idToken - ID token for authorization
 # + id - Unique ID of the project
 # + caseTypes - Optional array of case types to filter statistics
+# + createdBy - Optional filter for cases created by a specific user
 # + return - Project cases statistics or error
-public isolated function getCaseStatsForProject(string idToken, string id, CaseType[]? caseTypes)
-    returns ProjectCaseStatsResponse|error {
+public isolated function getCaseStatsForProject(string idToken, string id, CaseType[]? caseTypes,
+        StatsFilter? createdBy) returns ProjectCaseStatsResponse|error {
 
     if caseTypes is CaseType[] {
+        if createdBy is StatsFilter {
+            return csEntityClient->/projects/[id]/cases/stats.get(generateHeaders(idToken), caseTypes = caseTypes,
+                createdBy = createdBy
+            );
+        }
         return csEntityClient->/projects/[id]/cases/stats.get(generateHeaders(idToken), caseTypes = caseTypes);
+    }
+    if createdBy is StatsFilter {
+        return csEntityClient->/projects/[id]/cases/stats.get(generateHeaders(idToken), createdBy = createdBy);
     }
     return csEntityClient->/projects/[id]/cases/stats.get(generateHeaders(idToken));
 }
@@ -98,10 +107,14 @@ public isolated function getCaseStatsForProject(string idToken, string id, CaseT
 #
 # + idToken - ID token for authorization
 # + id - Unique ID of the project
+# + createdBy - Optional filter for conversations created by a specific user
 # + return - Project conversations statistics or error
-public isolated function getConversationStatsForProject(string idToken, string id)
+public isolated function getConversationStatsForProject(string idToken, string id, StatsFilter? createdBy)
     returns ProjectConversationStatsResponse|error {
 
+    if createdBy is StatsFilter {
+        return csEntityClient->/projects/[id]/conversations/stats.get(generateHeaders(idToken), createdBy = createdBy);
+    }
     return csEntityClient->/projects/[id]/conversations/stats.get(generateHeaders(idToken));
 }
 
@@ -235,10 +248,11 @@ public isolated function deleteAttachment(string idToken, IdString attachmentId)
 # + 'limit - Limit for pagination
 # + return - Products response or error
 public isolated function getDeployedProducts(string idToken, string deploymentId, int offset = DEFAULT_OFFSET,
-    int 'limit = DEFAULT_LIMIT) returns DeployedProductsResponse|error {
+        int 'limit = DEFAULT_LIMIT) returns DeployedProductsResponse|error {
 
     return csEntityClient->/deployed\-products/search.post({deploymentId, pagination: {offset, 'limit}},
-        generateHeaders(idToken));
+        generateHeaders(idToken)
+    );
 }
 
 # Create a deployed product.
@@ -476,7 +490,7 @@ public isolated function getProjectTimeCardStats(string idToken, string projectI
 }
 
 # Get change request by ID.
-# 
+#
 # + idToken - ID token for authorization
 # + changeRequestId - Unique ID of the change request to be retrieved
 # + return - Change request response containing details of the retrieved change request or error
@@ -498,7 +512,7 @@ public isolated function searchChangeRequests(string idToken, ChangeRequestSearc
 }
 
 # Update a change request.
-# 
+#
 # + idToken - ID token for authorization
 # + changeRequestId - Unique ID of the change request to be updated
 # + payload - Change request update payload containing details to be updated in the change request
@@ -508,6 +522,7 @@ public isolated function updateChangeRequest(string idToken, string changeReques
 
     return csEntityClient->/change\-requests/[changeRequestId].patch(payload, generateHeaders(idToken));
 }
+
 # Search catalogs.
 #
 # + idToken - ID token for authorization

--- a/apps/customer-portal/backend/modules/entity/enums.bal
+++ b/apps/customer-portal/backend/modules/entity/enums.bal
@@ -60,3 +60,8 @@ public enum CaseType {
 public enum TimeCardState {
     APPROVED = "Approved"
 }
+
+# Stats filter enum
+public enum StatsFilter {
+    ME = "me"
+}

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -406,6 +406,12 @@ paths:
           nullable: true
           items:
             $ref: '#/components/schemas/CaseType'
+      - name: createdBy
+        in: query
+        schema:
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/StatsFilter'
       responses:
         "200":
           description: Ok
@@ -443,6 +449,12 @@ paths:
           nullable: true
           items:
             $ref: '#/components/schemas/CaseType'
+      - name: createdBy
+        in: query
+        schema:
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/StatsFilter'
       responses:
         "200":
           description: Ok
@@ -473,6 +485,12 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/IdString'
+      - name: createdBy
+        in: query
+        schema:
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/StatsFilter'
       responses:
         "200":
           description: Ok
@@ -510,6 +528,12 @@ paths:
           nullable: true
           items:
             $ref: '#/components/schemas/CaseType'
+      - name: createdBy
+        in: query
+        schema:
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/StatsFilter'
       responses:
         "200":
           description: Ok
@@ -4905,6 +4929,10 @@ components:
       enum:
       - desc
       - asc
+    StatsFilter:
+      type: string
+      enum:
+      - me
     SubscriptionData:
       required:
       - clientId

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -792,7 +792,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     #
     # + id - ID of the project
     # + return - Project statistics response or error
-    resource function get projects/[entity:IdString id]/stats(http:RequestContext ctx, entity:CaseType[]? caseTypes)
+    resource function get projects/[entity:IdString id]/stats(http:RequestContext ctx, entity:CaseType[]? caseTypes,
+        entity:StatsFilter? createdBy)
         returns types:ProjectStatsResponse|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
@@ -806,7 +807,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
 
         // Fetch case stats
         entity:ProjectCaseStatsResponse|error caseStats =
-            entity:getCaseStatsForProject(userInfo.idToken, id, caseTypes);
+            entity:getCaseStatsForProject(userInfo.idToken, id, caseTypes, createdBy);
         if caseStats is error {
             log:printError(ERR_MSG_CASES_STATISTICS, caseStats);
             // To return other stats even if case stats retrieval fails, error will not be returned.
@@ -814,7 +815,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
 
         // Fetch conversation stats
         entity:ProjectConversationStatsResponse|error conversationStats =
-            entity:getConversationStatsForProject(userInfo.idToken, id);
+            entity:getConversationStatsForProject(userInfo.idToken, id, createdBy);
         if conversationStats is error {
             log:printError(ERR_MSG_CONVERSATION_STATISTICS, conversationStats);
             // To return other stats even if conversation stats retrieval fails, error will not be returned.
@@ -860,7 +861,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the project
     # + return - Project statistics overview or error response
     resource function get projects/[entity:IdString id]/stats/cases(http:RequestContext ctx,
-            entity:CaseType[]? caseTypes)
+            entity:CaseType[]? caseTypes, entity:StatsFilter? createdBy)
         returns types:ProjectCaseStats|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
@@ -873,7 +874,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         }
 
         entity:ProjectCaseStatsResponse|error caseStats =
-            entity:getCaseStatsForProject(userInfo.idToken, id, caseTypes);
+            entity:getCaseStatsForProject(userInfo.idToken, id, caseTypes, createdBy);
         if caseStats is error {
             log:printError(ERR_MSG_CASES_STATISTICS, caseStats);
             return <http:InternalServerError>{
@@ -897,7 +898,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     #
     # + id - ID of the project
     # + return - Conversation statistics overview or error response
-    resource function get projects/[entity:IdString id]/stats/conversations(http:RequestContext ctx)
+    resource function get projects/[entity:IdString id]/stats/conversations(http:RequestContext ctx,
+        entity:StatsFilter? createdBy)
         returns types:ConversationStats|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
@@ -910,7 +912,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         }
 
         entity:ProjectConversationStatsResponse|error conversationStats =
-            entity:getConversationStatsForProject(userInfo.idToken, id);
+            entity:getConversationStatsForProject(userInfo.idToken, id, createdBy);
         if conversationStats is error {
             if getStatusCode(conversationStats) == http:STATUS_UNAUTHORIZED {
                 log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
@@ -949,7 +951,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the project
     # + return - Project support statistics or error response
     resource function get projects/[entity:IdString id]/stats/support(http:RequestContext ctx,
-            entity:CaseType[]? caseTypes)
+            entity:CaseType[]? caseTypes, entity:StatsFilter? createdBy)
         returns types:ProjectSupportStats|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
@@ -963,7 +965,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
 
         // Fetch case stats 
         entity:ProjectCaseStatsResponse|error caseStats =
-            entity:getCaseStatsForProject(userInfo.idToken, id, caseTypes);
+            entity:getCaseStatsForProject(userInfo.idToken, id, caseTypes, createdBy);
         if caseStats is error {
             log:printError(ERR_MSG_CASES_STATISTICS, caseStats);
             // To return other stats even if case stats retrieval fails, error will not be returned.
@@ -971,7 +973,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
 
         // Fetch conversation stats
         entity:ProjectConversationStatsResponse|error conversationStats =
-            entity:getConversationStatsForProject(userInfo.idToken, id);
+            entity:getConversationStatsForProject(userInfo.idToken, id, createdBy);
         if conversationStats is error {
             log:printError(ERR_MSG_CONVERSATION_STATISTICS, conversationStats);
             // To return other stats even if conversation stats retrieval fails, error will not be returned.


### PR DESCRIPTION
## Descrption
This PR adds support for a `createdBy` query parameter to project stats endpoints for cases and conversations, enabling user-specific statistics.

## Changes

### 1️⃣ Project Stats – Cases
- Updated endpoint to accept `createdBy` query parameter
- Filtered case statistics based on the user who created the cases

### 2️⃣ Project Stats – Conversations
- Updated endpoint to accept `createdBy` query parameter
- Filtered conversation statistics based on the user who created the conversations

Updated:
- Request handling logic
- Service-layer filtering and aggregation
- Validation for query parameters

## Reason
Previously, project stats endpoints returned aggregated data across all users.  
This enhancement enables:

- Fetching user-specific statistics
- Supporting personalized dashboards
- Improving visibility into individual user activity
- Reducing the need for frontend filtering

## Impact
- Non-breaking change (query parameter is optional)
- Default behavior remains unchanged when `createdBy` is not provided
- Enables more granular stats retrieval

## Testing
- Verified stats filtering for specific users
- Tested behavior with and without `createdBy` parameter
- Confirmed correct aggregation logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional filtering to project statistics endpoints to view statistics filtered by creator, enabling users to see cases, conversations, and support statistics for items they created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->