### PR TITLE
[Customer Portal][Web] Enhance Time Display, Enforce Timezone for Scheduling, and Refine Call Request UI Logic

### DIFF
--- a/apps/customer-portal/webapp/src/api/usePatchCallRequest.ts
+++ b/apps/customer-portal/webapp/src/api/usePatchCallRequest.ts
@@ -67,6 +67,9 @@ export function usePatchCallRequest(
       if (rest.utcTimes != null && rest.utcTimes.length > 0) {
         body.utcTimes = rest.utcTimes;
       }
+      if (rest.durationInMinutes != null) {
+        body.durationInMinutes = rest.durationInMinutes;
+      }
       logger.debug("[usePatchCallRequest] Request payload:", body);
 
       try {

--- a/apps/customer-portal/webapp/src/components/project-details/project-overview/service-hours-allocations/ServiceHoursAllocationsCard.tsx
+++ b/apps/customer-portal/webapp/src/components/project-details/project-overview/service-hours-allocations/ServiceHoursAllocationsCard.tsx
@@ -25,7 +25,10 @@ import { Clock } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 
 import type { ProjectDetails } from "@models/responses";
-import { formatProjectDate } from "@utils/projectDetails";
+import {
+  formatProjectDate,
+  formatServiceHoursDecimalAsHrMin,
+} from "@utils/projectDetails";
 import ErrorIndicator from "@components/common/error-indicator/ErrorIndicator";
 
 export interface ServiceHoursAllocationsCardProps {
@@ -44,12 +47,11 @@ function formatHoursDisplay(
   const c = Number(consumed ?? 0);
   const t = Number(total ?? 0);
   const pct = t === 0 ? 0 : Math.round((c / t) * 100);
-  return `${c}/${t}h (${pct}%)`;
+  return `${formatServiceHoursDecimalAsHrMin(c)}/${formatServiceHoursDecimalAsHrMin(t)} (${pct}%)`;
 }
 
 function formatRemaining(value: number | undefined): string {
-  if (value == null || typeof value !== "number") return NOT_AVAILABLE;
-  return `${value}h`;
+  return formatServiceHoursDecimalAsHrMin(value);
 }
 
 /**

--- a/apps/customer-portal/webapp/src/components/project-details/project-overview/service-hours-allocations/__tests__/ServiceHoursAllocationsCard.test.tsx
+++ b/apps/customer-portal/webapp/src/components/project-details/project-overview/service-hours-allocations/__tests__/ServiceHoursAllocationsCard.test.tsx
@@ -48,10 +48,14 @@ describe("ServiceHoursAllocationsCard", () => {
 
     expect(screen.getByText("Query Hours")).toBeInTheDocument();
     expect(screen.getByText("Onboarding Hours")).toBeInTheDocument();
-    expect(screen.getByText("45/100h (45%)")).toBeInTheDocument();
-    expect(screen.getByText("180/200h (90%)")).toBeInTheDocument();
-    expect(screen.getByText("55h")).toBeInTheDocument();
-    expect(screen.getByText("20h")).toBeInTheDocument();
+    expect(
+      screen.getByText("45 hrs/100 hrs (45%)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("180 hrs/200 hrs (90%)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("55 hrs")).toBeInTheDocument();
+    expect(screen.getByText("20 hrs")).toBeInTheDocument();
     expect(screen.getByText("Apr 30, 2026")).toBeInTheDocument();
   });
 

--- a/apps/customer-portal/webapp/src/components/project-details/time-tracking/ServiceHoursStatCards.tsx
+++ b/apps/customer-portal/webapp/src/components/project-details/time-tracking/ServiceHoursStatCards.tsx
@@ -19,7 +19,10 @@ import { Clock } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 
 import type { ProjectDetails } from "@models/responses";
-import { formatProjectDate } from "@utils/projectDetails";
+import {
+  formatProjectDate,
+  formatServiceHoursDecimalAsHrMin,
+} from "@utils/projectDetails";
 import ErrorIndicator from "@components/common/error-indicator/ErrorIndicator";
 
 export interface ServiceHoursStatCardsProps {
@@ -38,12 +41,11 @@ function formatHoursDisplay(
   const c = Number(consumed ?? 0);
   const t = Number(total ?? 0);
   const pct = t === 0 ? 0 : Math.round((c / t) * 100);
-  return `${c}/${t}h (${pct}%)`;
+  return `${formatServiceHoursDecimalAsHrMin(c)}/${formatServiceHoursDecimalAsHrMin(t)} (${pct}%)`;
 }
 
 function formatRemaining(value: number | undefined): string {
-  if (value == null || typeof value !== "number") return NOT_AVAILABLE;
-  return `${value}h`;
+  return formatServiceHoursDecimalAsHrMin(value);
 }
 
 /**

--- a/apps/customer-portal/webapp/src/components/project-details/time-tracking/TimeTrackingCard.tsx
+++ b/apps/customer-portal/webapp/src/components/project-details/time-tracking/TimeTrackingCard.tsx
@@ -17,7 +17,10 @@
 import { Card, Box, Typography, Chip, useTheme } from "@wso2/oxygen-ui";
 import { type JSX } from "react";
 import type { TimeCard } from "@models/responses";
-import { getTimeCardStateColorPath } from "@utils/projectDetails";
+import {
+  formatMinutesAsHrMin,
+  getTimeCardStateColorPath,
+} from "@utils/projectDetails";
 import { getSupportOverviewChipSx, getPlainChipSx } from "@utils/support";
 
 interface TimeTrackingCardProps {
@@ -40,11 +43,7 @@ export default function TimeTrackingCard({
   const caseNumber = caseData?.number?.trim() || "--";
   const approvedByName = approvedBy?.label?.trim() || "--";
 
-  // Convert totalTime from minutes to hours
-  const totalTimeInHours =
-    totalTime !== undefined && totalTime !== null
-      ? Math.round((totalTime / 60) * 100) / 100
-      : null;
+  const totalTimeDisplay = formatMinutesAsHrMin(totalTime);
 
   const stateColorPath = getTimeCardStateColorPath(state);
 
@@ -119,7 +118,7 @@ export default function TimeTrackingCard({
               color: "text.primary",
             }}
           >
-            {totalTimeInHours !== null ? `${totalTimeInHours} hrs` : "--"}
+            {totalTimeDisplay === "Not Available" ? "--" : totalTimeDisplay}
           </Typography>
         </Box>
       </Box>

--- a/apps/customer-portal/webapp/src/components/project-details/time-tracking/__tests__/ServiceHoursStatCards.test.tsx
+++ b/apps/customer-portal/webapp/src/components/project-details/time-tracking/__tests__/ServiceHoursStatCards.test.tsx
@@ -39,10 +39,14 @@ describe("ServiceHoursStatCards", () => {
 
     expect(screen.getByText("Query Hours")).toBeInTheDocument();
     expect(screen.getByText("Onboarding Hours")).toBeInTheDocument();
-    expect(screen.getByText("45/100h (45%)")).toBeInTheDocument();
-    expect(screen.getByText("180/200h (90%)")).toBeInTheDocument();
-    expect(screen.getByText("55h")).toBeInTheDocument();
-    expect(screen.getByText("20h")).toBeInTheDocument();
+    expect(
+      screen.getByText("45 hrs/100 hrs (45%)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("180 hrs/200 hrs (90%)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("55 hrs")).toBeInTheDocument();
+    expect(screen.getByText("20 hrs")).toBeInTheDocument();
     expect(screen.getByText("Apr 30, 2026")).toBeInTheDocument();
   });
 

--- a/apps/customer-portal/webapp/src/components/project-details/time-tracking/__tests__/TimeTrackingCard.test.tsx
+++ b/apps/customer-portal/webapp/src/components/project-details/time-tracking/__tests__/TimeTrackingCard.test.tsx
@@ -42,7 +42,7 @@ describe("TimeTrackingCard", () => {
     expect(screen.getByText("Approved")).toBeInTheDocument();
     expect(screen.getByText("Billable")).toBeInTheDocument();
     expect(screen.getByText("CS0437343")).toBeInTheDocument();
-    expect(screen.getByText("1 hrs")).toBeInTheDocument(); // 60 minutes = 1 hour
+    expect(screen.getByText("1 hr")).toBeInTheDocument(); // 60 minutes = 1 hour
     expect(
       screen.getByText(/Approved by: Dileepa Peiris \(Intern\)/),
     ).toBeInTheDocument();
@@ -60,7 +60,7 @@ describe("TimeTrackingCard", () => {
     render(<TimeTrackingCard card={incompleteCard} />);
 
     expect(screen.getByText(/Approved by: --/)).toBeInTheDocument();
-    expect(screen.getByText(/State:\s*--/)).toBeInTheDocument();
+    expect(screen.getAllByText("--").length).toBeGreaterThan(0);
   });
 
   it("should not render Billable chip when hasBillable is false", () => {

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallRequestCard.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallRequestCard.tsx
@@ -35,7 +35,11 @@ import {
   getCallRequestStatusColor,
   resolveColorFromTheme,
 } from "@utils/support";
-import { CallRequestStatus } from "@constants/supportConstants";
+import {
+  CALL_REQUEST_STATE_CUSTOMER_REJECTED,
+  CALL_REQUEST_STATE_NOTES_PENDING_ID,
+  CallRequestStatus,
+} from "@constants/supportConstants";
 
 export interface CallRequestCardProps {
   call: CallRequest;
@@ -81,6 +85,15 @@ export default function CallRequestCard({
     isCancelled || statusLabel === CallRequestStatus.COMPLETED;
   const isPendingOnCustomer =
     statusLabel === CallRequestStatus.PENDING_ON_CUSTOMER;
+  const isNotesPending =
+    call.state?.id === CALL_REQUEST_STATE_NOTES_PENDING_ID ||
+    statusLabel === CallRequestStatus.NOTES_PENDING ||
+    statusLower.includes("notes pending");
+  const isCustomerRejected =
+    call.state?.id === String(CALL_REQUEST_STATE_CUSTOMER_REJECTED) ||
+    statusLabel === CallRequestStatus.REJECTED ||
+    statusLower.includes("customer rejected");
+  const hideCustomerActions = isNotesPending || isCustomerRejected;
   const colorPath = getCallRequestStatusColor(statusLabel);
   const resolvedColor = isCancelled
     ? theme.palette.error.main
@@ -197,7 +210,7 @@ export default function CallRequestCard({
                   Reject
                 </Button>
               </>
-            ) : (
+            ) : hideCustomerActions ? null : (
               <>
                 <Button
                   variant="contained"

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallsPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallsPanel.tsx
@@ -86,6 +86,14 @@ export default function CallsPanel({
   const [approveCall, setApproveCall] = useState<CallRequest | null>(null);
   const [rejectCall, setRejectCall] = useState<CallRequest | null>(null);
   const [isMissingTzDialogOpen, setIsMissingTzDialogOpen] = useState(false);
+  const [missingTzVariant, setMissingTzVariant] = useState<
+    "informational" | "required"
+  >("informational");
+  const [pendingCallAfterTz, setPendingCallAfterTz] = useState<
+    | { type: "create" }
+    | { type: "edit"; call: CallRequest }
+    | null
+  >(null);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [hasShownTzPrompt, setHasShownTzPrompt] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -93,7 +101,8 @@ export default function CallsPanel({
   const [callRequestsPage, setCallRequestsPage] = useState(1);
 
   const { data: projectFilters } = useGetProjectFilters(projectId);
-  const { data: userDetails } = useGetUserDetails();
+  const { data: userDetails, refetch: refetchUserDetails } =
+    useGetUserDetails();
   const userTimeZone = userDetails?.timeZone || undefined;
 
   // Derive filtered state keys from project filters (all non-Canceled states for search body)
@@ -213,9 +222,15 @@ export default function CallsPanel({
   };
 
   const handleOpenModal = () => {
-    setEditCall(null);
     setSuccessMessage(null);
     setErrorMessage(null);
+    if (!userDetails?.timeZone?.trim()) {
+      setPendingCallAfterTz({ type: "create" });
+      setMissingTzVariant("required");
+      setIsMissingTzDialogOpen(true);
+      return;
+    }
+    setEditCall(null);
     setIsModalOpen(true);
   };
   const handleCloseModal = () => {
@@ -223,6 +238,12 @@ export default function CallsPanel({
     setEditCall(null);
   };
   const handleEditClick = (call: CallRequest) => {
+    if (!userDetails?.timeZone?.trim()) {
+      setPendingCallAfterTz({ type: "edit", call });
+      setMissingTzVariant("required");
+      setIsMissingTzDialogOpen(true);
+      return;
+    }
     setEditCall(call);
     setIsModalOpen(true);
   };
@@ -320,7 +341,8 @@ export default function CallsPanel({
   // Prompt once per mount when the user has no timezone set and data is loaded
   useEffect(() => {
     if (hasShownTzPrompt) return;
-    if (userDetails && !userDetails.timeZone) {
+    if (userDetails && !userDetails.timeZone?.trim()) {
+      setMissingTzVariant("required");
       setIsMissingTzDialogOpen(true);
       setHasShownTzPrompt(true);
     }
@@ -391,6 +413,7 @@ export default function CallsPanel({
       <DeleteCallRequestModal
         open={!!deleteCall}
         call={deleteCall}
+        userTimeZone={userTimeZone}
         onClose={handleCloseDeleteModal}
         onConfirm={handleConfirmDelete}
         isDeleting={patchCallRequest.isPending}
@@ -434,6 +457,7 @@ export default function CallsPanel({
 
       <MissingTimezoneDialog
         open={isMissingTzDialogOpen}
+        variant={missingTzVariant}
         onClose={() => setIsMissingTzDialogOpen(false)}
         onSetTimeZone={() => {
           setIsMissingTzDialogOpen(false);
@@ -443,7 +467,25 @@ export default function CallsPanel({
 
       <UserProfileModal
         open={isProfileModalOpen}
-        onClose={() => setIsProfileModalOpen(false)}
+        onClose={() => {
+          setIsProfileModalOpen(false);
+          void refetchUserDetails().then((result) => {
+            const tz = result.data?.timeZone?.trim();
+            if (pendingCallAfterTz && tz) {
+              if (pendingCallAfterTz.type === "create") {
+                setEditCall(null);
+                setIsModalOpen(true);
+              } else {
+                setEditCall(pendingCallAfterTz.call);
+                setIsModalOpen(true);
+              }
+              setPendingCallAfterTz(null);
+            } else if (pendingCallAfterTz && !tz) {
+              setMissingTzVariant("required");
+              setIsMissingTzDialogOpen(true);
+            }
+          });
+        }}
       />
     </Stack>
   );

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/DeleteCallRequestModal.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/DeleteCallRequestModal.tsx
@@ -34,11 +34,12 @@ import {
   type JSX,
 } from "react";
 import type { CallRequest } from "@models/responses";
-import { formatCallRequestPromptScheduledTime } from "@utils/support";
+import { formatUtcToLocal } from "@utils/support";
 
 export interface DeleteCallRequestModalProps {
   open: boolean;
   call: CallRequest | null;
+  userTimeZone?: string;
   onClose: () => void;
   onConfirm: (reason: string) => void;
   isDeleting?: boolean;
@@ -55,6 +56,7 @@ export interface DeleteCallRequestModalProps {
 export default function DeleteCallRequestModal({
   open,
   call,
+  userTimeZone,
   onClose,
   onConfirm,
   isDeleting = false,
@@ -93,12 +95,10 @@ export default function DeleteCallRequestModal({
 
   const canConfirm = reason.trim() !== "";
 
+  const firstPreferredTime = call?.preferredTimes?.find((t) => t?.trim())?.trim();
   const promptWhen =
-    call != null
-      ? formatCallRequestPromptScheduledTime(
-          call.preferredTimes,
-          call.scheduleTime,
-        )
+    userTimeZone && firstPreferredTime
+      ? formatUtcToLocal(firstPreferredTime, "short", false, userTimeZone)
       : "--";
   const cancelDescription =
     call == null
@@ -144,7 +144,7 @@ export default function DeleteCallRequestModal({
         </Typography>
         <TextField
           id="cancel-call-reason"
-          label="Reason *"
+          label="Reason"
           placeholder="Enter reason for cancellation..."
           value={reason}
           onChange={handleReasonChange}

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/MissingTimezoneDialog.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/MissingTimezoneDialog.tsx
@@ -25,29 +25,48 @@ import {
 import { Clock } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
 
+export type MissingTimezoneDialogVariant = "informational" | "required";
+
 export interface MissingTimezoneDialogProps {
   open: boolean;
   onClose: () => void;
   /** Called when user clicks the "Set Time Zone" button. */
   onSetTimeZone: () => void;
+  variant?: MissingTimezoneDialogVariant;
 }
 
 /**
  * Dialog shown when the user has no time zone configured on their profile.
  * Prompts the user to open their profile modal to set a time zone.
  *
- * @param {MissingTimezoneDialogProps} props - open, onClose, onSetTimeZone.
+ * @param {MissingTimezoneDialogProps} props - open, onClose, onSetTimeZone, variant.
  * @returns {JSX.Element} The missing timezone dialog.
  */
 export default function MissingTimezoneDialog({
   open,
   onClose,
   onSetTimeZone,
+  variant = "informational",
 }: MissingTimezoneDialogProps): JSX.Element {
+  const isRequired = variant === "required";
+
+  const handleDialogClose = (
+    _event: unknown,
+    reason: "backdropClick" | "escapeKeyDown",
+  ) => {
+    if (
+      isRequired &&
+      (reason === "backdropClick" || reason === "escapeKeyDown")
+    ) {
+      return;
+    }
+    onClose();
+  };
+
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={handleDialogClose}
       maxWidth="xs"
       fullWidth
       aria-labelledby="missing-timezone-dialog-title"
@@ -66,15 +85,17 @@ export default function MissingTimezoneDialog({
           variant="body2"
           color="text.secondary"
         >
-          Your profile does not have a time zone configured. Please set your
-          time zone so call request times are displayed accurately in your
-          local time.
+          {isRequired
+            ? "You must set your time zone before you can request or reschedule a call. Open your profile to choose a time zone."
+            : "Your profile does not have a time zone configured. Please set your time zone so call request times are displayed accurately in your local time."}
         </Typography>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2.5, gap: 1 }}>
-        <Button variant="outlined" onClick={onClose}>
-          Later
-        </Button>
+        {!isRequired && (
+          <Button variant="outlined" onClick={onClose}>
+            Later
+          </Button>
+        )}
         <Button variant="contained" color="primary" onClick={onSetTimeZone}>
           Set Time Zone
         </Button>

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/RequestCallModal.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/RequestCallModal.tsx
@@ -209,7 +209,8 @@ export default function RequestCallModal({
   const isPending = postCallRequest.isPending || patchCallRequest.isPending;
   const isValid =
     form.preferredDateTimesLocal.every((value) => value.trim() !== "") &&
-    (isEdit || (form.notes.trim() !== "" && form.durationInMinutes > 0));
+    form.durationInMinutes > 0 &&
+    (isEdit || form.notes.trim() !== "");
 
   const handleClose = useCallback(() => {
     setForm(INITIAL_FORM);
@@ -314,6 +315,7 @@ export default function RequestCallModal({
           callRequestId: editCall.id,
           stateKey,
           utcTimes,
+          durationInMinutes: form.durationInMinutes,
         },
         {
           onSuccess: () => {
@@ -375,7 +377,7 @@ export default function RequestCallModal({
           sx={{ mt: 0.5, fontWeight: "normal", fontSize: "0.875rem" }}
         >
           {isEdit
-            ? "Update preferred times for this call request."
+            ? "Update preferred times and meeting duration for this call request."
             : "Schedule a call with our support team."}
         </Typography>
         <IconButton
@@ -473,8 +475,7 @@ export default function RequestCallModal({
           </Box>
         )}
 
-        {!isEdit && (
-          <FormControl fullWidth size="small" sx={{ mt: 1, mb: 2 }}>
+        <FormControl fullWidth size="small" sx={{ mt: 1, mb: 2 }}>
           <InputLabel id="duration-label">Meeting Duration *</InputLabel>
           <Select<number>
             labelId="duration-label"
@@ -491,7 +492,6 @@ export default function RequestCallModal({
             ))}
           </Select>
         </FormControl>
-        )}
 
         {!isEdit && (
           <TextField

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/ApproveCallRequestModal.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/ApproveCallRequestModal.test.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import type { ReactElement } from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { usePatchCallRequest } from "@api/usePatchCallRequest";
@@ -83,9 +83,20 @@ describe("ApproveCallRequestModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render the preferred time input prefilled from API wall clock", () => {
-    renderWithProviders(<ApproveCallRequestModal {...defaultProps} />);
-    expect(screen.getByDisplayValue("2024-10-29T14:00")).toBeInTheDocument();
+  it("should render the preferred time input prefilled from API wall clock", async () => {
+    const futureCall: CallRequest = {
+      ...mockCall,
+      preferredTimes: ["2027-06-15 14:00:00"],
+    };
+    renderWithProviders(
+      <ApproveCallRequestModal {...defaultProps} call={futureCall} />,
+    );
+    await waitFor(() => {
+      const input = document.getElementById(
+        "approve-preferred-time-0",
+      ) as HTMLInputElement;
+      expect(input?.value).toContain("2027-06-15");
+    });
     expect(screen.getAllByLabelText(/Preferred Time/i).length).toBeGreaterThan(0);
   });
 

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/CallRequestCard.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/CallRequestCard.test.tsx
@@ -54,6 +54,38 @@ describe("CallRequestCard", () => {
     expect(screen.queryByRole("button", { name: /Reject/i })).not.toBeInTheDocument();
   });
 
+  it("should hide Reschedule and Cancel for Notes Pending state", () => {
+    const notesPendingCall: CallRequest = {
+      ...mockCall,
+      state: { id: "7", label: "Notes Pending" },
+    };
+    render(
+      <CallRequestCard
+        call={notesPendingCall}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Reschedule/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Cancel/i })).not.toBeInTheDocument();
+  });
+
+  it("should hide Reschedule and Cancel for Customer Rejected state", () => {
+    const customerRejectedCall: CallRequest = {
+      ...mockCall,
+      state: { id: "4", label: "Customer Rejected" },
+    };
+    render(
+      <CallRequestCard
+        call={customerRejectedCall}
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Reschedule/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Cancel/i })).not.toBeInTheDocument();
+  });
+
   it("should show Approve and Reject buttons for 'Pending on Customer' state", () => {
     const pendingOnCustomerCall: CallRequest = {
       ...mockCall,

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/CallsPanel.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/CallsPanel.test.tsx
@@ -88,6 +88,9 @@ describe("CallsPanel", () => {
     mockPatchMutate.mockClear();
     vi.mocked(useGetUserDetails).mockReturnValue({
       data: { timeZone: "America/New_York" },
+      refetch: vi
+        .fn()
+        .mockResolvedValue({ data: { timeZone: "America/New_York" } }),
       isLoading: false,
       isError: false,
     } as unknown as ReturnType<typeof useGetUserDetails>);
@@ -440,6 +443,7 @@ describe("CallsPanel", () => {
   it("should show missing timezone dialog when user has no timezone set", () => {
     vi.mocked(useGetUserDetails).mockReturnValue({
       data: { timeZone: null },
+      refetch: vi.fn().mockResolvedValue({ data: { timeZone: null } }),
       isLoading: false,
       isError: false,
     } as unknown as ReturnType<typeof useGetUserDetails>);
@@ -463,6 +467,43 @@ describe("CallsPanel", () => {
     expect(screen.getByText("Time Zone Not Set")).toBeInTheDocument();
   });
 
+  it("should show required timezone dialog instead of Request Call modal when profile has no timezone", () => {
+    vi.mocked(useGetUserDetails).mockReturnValue({
+      data: { timeZone: null },
+      refetch: vi.fn().mockResolvedValue({ data: { timeZone: null } }),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetUserDetails>);
+
+    vi.mocked(useGetCallRequests).mockReturnValue({
+      isPending: false,
+      isError: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isFetchNextPageError: false,
+      data: { pages: [{ callRequests: [] }] },
+    } as unknown as ReturnType<typeof useGetCallRequests>);
+
+    renderWithProviders(
+      <CallsPanel
+        projectId={mockProjectId}
+        caseId={mockCaseId}
+        caseStatusLabel="Work In Progress"
+      />,
+    );
+    expect(
+      screen.getByText(/must set your time zone before/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Later/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(
+        /Describe your call request or topics you'd like to discuss/i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("should open Request Call modal when button is clicked", () => {
     vi.mocked(useGetCallRequests).mockReturnValue({
       isPending: false,
@@ -481,7 +522,7 @@ describe("CallsPanel", () => {
         caseStatusLabel="Work In Progress"
       />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Request Call/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Request Call$/ }));
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(document.getElementById("preferred-time-0")).toBeTruthy();

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/DeleteCallRequestModal.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/DeleteCallRequestModal.test.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CallRequest } from "@models/responses";
+import DeleteCallRequestModal from "@case-details-calls/DeleteCallRequestModal";
+
+const mockCall: CallRequest = {
+  id: "call-1",
+  case: { id: "case-1", label: "CS0438719" },
+  reason: "Cancel",
+  preferredTimes: ["2026-04-02 15:45:00"],
+  durationMin: 30,
+  scheduleTime: "",
+  createdOn: "2026-04-02 10:00:00",
+  updatedOn: "2026-04-02 10:00:00",
+  state: { id: "3", label: "Scheduled" },
+};
+
+describe("DeleteCallRequestModal", () => {
+  it("should show converted preferred time in confirmation text", () => {
+    render(
+      <DeleteCallRequestModal
+        open
+        call={mockCall}
+        userTimeZone="America/New_York"
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/scheduled for Apr 2, 11:45 AM/i),
+    ).toBeInTheDocument();
+  });
+
+  it("should render required reason label with a single required indicator", () => {
+    render(
+      <DeleteCallRequestModal
+        open
+        call={mockCall}
+        userTimeZone="America/New_York"
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/Reason/)).toBeInTheDocument();
+    expect(screen.queryByText(/\*\s*\*/)).not.toBeInTheDocument();
+  });
+});
+

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/MissingTimezoneDialog.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/MissingTimezoneDialog.test.tsx
@@ -53,4 +53,13 @@ describe("MissingTimezoneDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /Set Time Zone/i }));
     expect(onSetTimeZone).toHaveBeenCalled();
   });
+
+  it("should omit Later and show required copy when variant is required", () => {
+    render(<MissingTimezoneDialog {...defaultProps} variant="required" />);
+    expect(
+      screen.getByText(/must set your time zone before/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Later/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Set Time Zone/i })).toBeInTheDocument();
+  });
 });

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/RequestCallModal.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/RequestCallModal.test.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import type { ReactElement } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import RequestCallModal from "@case-details-calls/RequestCallModal";
@@ -61,11 +61,11 @@ describe("RequestCallModal", () => {
     expect(document.getElementById("preferred-time-0")).toBeTruthy();
     expect(screen.getByLabelText(/Meeting Duration/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Reason \*/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Request Call/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Request Call$/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
   });
 
-  it("should show Edit Call Request title and hide Meeting Duration when editCall is provided", () => {
+  it("should show Edit Call Request title and Meeting Duration when editCall is provided", () => {
     const editCall = {
       id: "call-1",
       case: { id: "case-1", label: "CS1" },
@@ -87,7 +87,7 @@ describe("RequestCallModal", () => {
       />,
     );
     expect(screen.getByText(/Edit Call Request/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText(/Meeting Duration/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/^Meeting Duration \*$/i)).toBeInTheDocument();
   });
 
   it("should disable submit button when required fields are empty", () => {
@@ -99,10 +99,10 @@ describe("RequestCallModal", () => {
         onClose={vi.fn()}
       />,
     );
-    expect(screen.getByRole("button", { name: /Request Call/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^Request Call$/ })).toBeDisabled();
   });
 
-  it("should disable submit when description is empty in reschedule mode", () => {
+  it("should enable submit in reschedule mode when preferred times and duration are set without reason text", async () => {
     const editCall = {
       id: "call-1",
       case: { id: "case-1", label: "CS1" },
@@ -120,9 +120,14 @@ describe("RequestCallModal", () => {
         projectId="proj-1"
         caseId="case-1"
         editCall={editCall}
+        userTimeZone="UTC"
         onClose={vi.fn()}
       />,
     );
-    expect(screen.getByRole("button", { name: /Update Call Request/i })).toBeDisabled();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Update Call Request/i }),
+      ).not.toBeDisabled();
+    });
   });
 });

--- a/apps/customer-portal/webapp/src/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/supportConstants.ts
@@ -108,7 +108,11 @@ export const CallRequestStatus = {
   PENDING_ON_CUSTOMER: "Pending on Customer",
   REJECTED: "Rejected",
   SCHEDULED: "Scheduled",
+  NOTES_PENDING: "Notes Pending",
 } as const;
+
+/** API call request state id for Notes Pending (hide customer reschedule/cancel). */
+export const CALL_REQUEST_STATE_NOTES_PENDING_ID = "7";
 
 export type CallRequestStatus =
   (typeof CallRequestStatus)[keyof typeof CallRequestStatus];

--- a/apps/customer-portal/webapp/src/models/requests.ts
+++ b/apps/customer-portal/webapp/src/models/requests.ts
@@ -227,6 +227,7 @@ export interface PatchCallRequest {
   cancellationReason?: string;
   stateKey: number;
   utcTimes?: string[];
+  durationInMinutes?: number;
 }
 
 // Request body for updating current user profile (PATCH /users/me).

--- a/apps/customer-portal/webapp/src/pages/EngagementsPage.tsx
+++ b/apps/customer-portal/webapp/src/pages/EngagementsPage.tsx
@@ -272,7 +272,7 @@ export default function EngagementsPage(): JSX.Element {
               labelId="sort-label"
               id="sort"
               value={sortOrder}
-              label="Sort"
+              label="Order By"
               onChange={(e) =>
                 handleSortChange(e.target.value as "desc" | "asc")
               }

--- a/apps/customer-portal/webapp/src/utils/projectDetails.ts
+++ b/apps/customer-portal/webapp/src/utils/projectDetails.ts
@@ -453,3 +453,69 @@ export const getProductSupportStatusColor = (
       return "default";
   }
 };
+
+/**
+ * Formats decimal service-hours values (API hours) as hours and minutes for display.
+ *
+ * @param {number | null | undefined} hours - Decimal hours from API.
+ * @returns {string} e.g. "1 hr and 30 min", or "Not Available".
+ */
+export function formatServiceHoursDecimalAsHrMin(
+  hours: number | null | undefined,
+): string {
+  if (
+    hours == null ||
+    typeof hours !== "number" ||
+    !Number.isFinite(hours)
+  ) {
+    return "Not Available";
+  }
+  const totalMinutes = Math.round(hours * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  const hrPart = h === 0 ? "" : h === 1 ? "1 hr" : `${h} hrs`;
+  const minPart = m === 0 ? "" : m === 1 ? "1 min" : `${m} min`;
+  if (hrPart && minPart) {
+    return `${hrPart} and ${minPart}`;
+  }
+  if (hrPart) {
+    return hrPart;
+  }
+  if (minPart) {
+    return minPart;
+  }
+  return "0 min";
+}
+
+/**
+ * Formats minute values (API minutes) as hours and minutes for display.
+ *
+ * @param {number | null | undefined} minutes - Total minutes from API.
+ * @returns {string} e.g. "1 hr and 4 min", or "Not Available".
+ */
+export function formatMinutesAsHrMin(
+  minutes: number | null | undefined,
+): string {
+  if (
+    minutes == null ||
+    typeof minutes !== "number" ||
+    !Number.isFinite(minutes)
+  ) {
+    return "Not Available";
+  }
+  const totalMinutes = Math.round(minutes);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  const hrPart = h === 0 ? "" : h === 1 ? "1 hr" : `${h} hrs`;
+  const minPart = m === 0 ? "" : m === 1 ? "1 min" : `${m} min`;
+  if (hrPart && minPart) {
+    return `${hrPart} and ${minPart}`;
+  }
+  if (hrPart) {
+    return hrPart;
+  }
+  if (minPart) {
+    return minPart;
+  }
+  return "0 min";
+}


### PR DESCRIPTION
### Description

This pull request introduces several improvements to the display and handling of time and scheduling information in the customer portal, especially around service hours, time tracking, and support call requests. The changes focus on more user-friendly time formatting, stricter enforcement of user time zone requirements for scheduling calls, and improved UI logic for call request actions.

**Time formatting and display improvements:**

- Updated the formatting of service hours and time tracking displays to use a more readable "X hr(s)/Y hr(s)" format (e.g., "45 hrs/100 hrs (45%)" instead of "45/100h (45%)"), and refactored the code to use new formatting utility functions for consistency across components (`ServiceHoursAllocationsCard.tsx`, `ServiceHoursStatCards.tsx`, `TimeTrackingCard.tsx`). [[1]](diffhunk://#diff-b337f4185448de2e3fa3dda3a3c0876ef3e0ddca4217c5702322087cf33ac791L47-R54) [[2]](diffhunk://#diff-445de34758c7829e7e379edd42aa96fdfbea44aa39750c117f8e82e309186c0bL41-R48) [[3]](diffhunk://#diff-87857cb8da7fcc469c1a41c31783c43aa9ad3f17266ca09094a4c059c537462fL43-R46)
- Adjusted test cases to match the new time formatting, ensuring that UI tests expect the updated strings (e.g., "1 hr" instead of "1 hrs" for singular values) (`ServiceHoursAllocationsCard.test.tsx`, `ServiceHoursStatCards.test.tsx`, `TimeTrackingCard.test.tsx`). [[1]](diffhunk://#diff-540f0b562b76af9d6dce3c7ff12bbc491afe0975532517332ce2e18a94375871L51-R58) [[2]](diffhunk://#diff-a5f7f559b99a90ff88b8e6871c7a1d59226707f01a949caef4d8071bfd0cdd76L42-R49) [[3]](diffhunk://#diff-24166efd578d586ad4ff2b01ff170a725daa0e8ad07d0da9d6cf954e99f49e7aL45-R45) [[4]](diffhunk://#diff-24166efd578d586ad4ff2b01ff170a725daa0e8ad07d0da9d6cf954e99f49e7aL63-R63)

**User time zone enforcement for call scheduling:**

- Enhanced the call request flow to require users to set a time zone before they can create or edit a call request. If a user without a time zone attempts these actions, a modal prompts them to set their time zone, and the action is paused until this is completed (`CallsPanel.tsx`, `MissingTimezoneDialog.tsx`). [[1]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL216-R246) [[2]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL323-R345) [[3]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdR460) [[4]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL446-R488) [[5]](diffhunk://#diff-32dd275a8ae36eed67a3fe1994d9b150d68b235649d85dd8faae1e9b52b88341R28-R69)
- Refactored the `MissingTimezoneDialog` to support a "required" variant that prevents closing the dialog with backdrop clicks or the escape key, ensuring users cannot bypass the prompt when a time zone is mandatory.
- Ensured that after setting the time zone, the pending call action (create/edit) resumes automatically if the time zone is now set, or the prompt reappears if not (`CallsPanel.tsx`).

**Support call request and modal improvements:**

- Improved logic for hiding customer action buttons (e.g., Approve/Reject) on call requests that are in "notes pending" or "customer rejected" states, based on both status labels and internal state IDs (`CallRequestCard.tsx`). [[1]](diffhunk://#diff-2434191c82862ae1c543b73974e9b0c745f7097946ca07bbe39161e65cb1ac07R88-R96) [[2]](diffhunk://#diff-2434191c82862ae1c543b73974e9b0c745f7097946ca07bbe39161e65cb1ac07L200-R213)
- Updated the delete call request modal to display the user's local time for the scheduled call based on their time zone, and adjusted the reason input label to remove the asterisk, making the UI clearer (`DeleteCallRequestModal.tsx`). [[1]](diffhunk://#diff-42d56bcae4ad7fff8b6a365da2f63842122ca4b960133c5920eb62ccd7a67fe9L37-R42) [[2]](diffhunk://#diff-42d56bcae4ad7fff8b6a365da2f63842122ca4b960133c5920eb62ccd7a67fe9R59) [[3]](diffhunk://#diff-42d56bcae4ad7fff8b6a365da2f63842122ca4b960133c5920eb62ccd7a67fe9R98-R101) [[4]](diffhunk://#diff-42d56bcae4ad7fff8b6a365da2f63842122ca4b960133c5920eb62ccd7a67fe9L147-R147)

**API and backend interaction:**

- Added support for sending `durationInMinutes` in the request body when patching a call request, enabling more precise scheduling and updates (`usePatchCallRequest.ts`).

These changes collectively improve the user experience around time-sensitive actions, make UI feedback more consistent and informative, and ensure correct business logic for scheduling and managing support calls.