### PR TITLE
[Customer Portal][Web] Implement inline time zone gate for calls panel with updated tests and caching improvements

### DIFF
--- a/apps/customer-portal/webapp/src/api/useGetUserDetails.ts
+++ b/apps/customer-portal/webapp/src/api/useGetUserDetails.ts
@@ -58,9 +58,12 @@ const useGetUserDetails = (): UseQueryResult<UserDetails, Error> => {
           );
         }
 
-        const data = await response.json();
+        const data = (await response.json()) as Record<string, unknown>;
         logger.debug("[useGetUserDetails] Data received:", data);
-        return data;
+        const tzRaw = data.timeZone ?? data.timezone ?? data.time_zone;
+        const timeZone =
+          typeof tzRaw === "string" ? tzRaw : tzRaw != null ? String(tzRaw) : "";
+        return { ...data, timeZone } as UserDetails;
       } catch (error) {
         logger.error("[useGetUserDetails] Error:", error);
         throw error;

--- a/apps/customer-portal/webapp/src/api/useGetUserDetails.ts
+++ b/apps/customer-portal/webapp/src/api/useGetUserDetails.ts
@@ -47,6 +47,7 @@ const useGetUserDetails = (): UseQueryResult<UserDetails, Error> => {
 
         const response = await authFetch(requestUrl, {
           method: "GET",
+          cache: "no-store",
         });
 
         logger.debug(`[useGetUserDetails] Response status: ${response.status}`);
@@ -66,9 +67,9 @@ const useGetUserDetails = (): UseQueryResult<UserDetails, Error> => {
       }
     },
     enabled: isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
     refetchOnWindowFocus: false,
-    refetchOnMount: false,
+    refetchOnMount: true,
   });
 };
 

--- a/apps/customer-portal/webapp/src/api/usePatchUserMe.ts
+++ b/apps/customer-portal/webapp/src/api/usePatchUserMe.ts
@@ -23,6 +23,7 @@ import { useAsgardeo } from "@asgardeo/react";
 import { useAuthApiClient } from "@api/useAuthApiClient";
 import { useLogger } from "@hooks/useLogger";
 import type { PatchUserMeRequest } from "@models/requests";
+import type { UserDetails } from "@models/responses";
 
 export interface PatchUserMeResponse {
   phoneNumber?: string;
@@ -83,8 +84,27 @@ export function usePatchUserMe(): UseMutationResult<
       }
       return (await response.json()) as PatchUserMeResponse;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["userDetails"] });
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData<UserDetails>(["userDetails"], (old) => {
+        if (!old) {
+          return old;
+        }
+        return {
+          ...old,
+          ...(variables.timeZone !== undefined
+            ? { timeZone: variables.timeZone }
+            : {}),
+          ...(variables.phoneNumber !== undefined
+            ? {
+                phoneNumber:
+                  data.phoneNumber !== undefined
+                    ? data.phoneNumber
+                    : variables.phoneNumber,
+              }
+            : {}),
+        };
+      });
+      void queryClient.invalidateQueries();
     },
   });
 }

--- a/apps/customer-portal/webapp/src/api/usePatchUserMe.ts
+++ b/apps/customer-portal/webapp/src/api/usePatchUserMe.ts
@@ -104,7 +104,9 @@ export function usePatchUserMe(): UseMutationResult<
             : {}),
         };
       });
-      void queryClient.invalidateQueries();
+      void queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey[0] !== "userDetails",
+      });
     },
   });
 }

--- a/apps/customer-portal/webapp/src/components/common/header/Header.tsx
+++ b/apps/customer-portal/webapp/src/components/common/header/Header.tsx
@@ -25,6 +25,7 @@ import SearchBar from "@components/common/header/SearchBar";
 import ProjectSwitcher from "@components/common/header/ProjectSwitcher";
 import { useAsgardeo } from "@asgardeo/react";
 import { shouldExcludeS0 } from "@utils/subscriptionUtils";
+import { setLastSelectedProjectId } from "@utils/settingsStorage";
 
 interface HeaderProps {
   onToggleSidebar: () => void;
@@ -73,6 +74,13 @@ export default function Header({ onToggleSidebar }: HeaderProps): JSX.Element {
     return projects.find((p) => p.id === projectId);
   }, [projectId, projects]);
 
+  useEffect(() => {
+    const id = projectId?.trim();
+    if (id) {
+      setLastSelectedProjectId(id);
+    }
+  }, [projectId]);
+
   const excludeS0 = shouldExcludeS0(selectedProject?.type?.label);
 
   /**
@@ -85,7 +93,7 @@ export default function Header({ onToggleSidebar }: HeaderProps): JSX.Element {
       const project = projects.find((p) => p.id === id);
       if (project) {
         logger.debug(`Switching to project: ${project.name} (${project.id})`);
-
+        setLastSelectedProjectId(project.id);
         navigate(`/projects/${project.id}/dashboard`);
       } else {
         logger.warn(`Project with ID ${id} not found for switching`);

--- a/apps/customer-portal/webapp/src/components/common/header/UserProfileModal.tsx
+++ b/apps/customer-portal/webapp/src/components/common/header/UserProfileModal.tsx
@@ -208,13 +208,8 @@ export default function UserProfileModal({
           return;
         }
 
-        onClose();
-        if (hasTimeZoneInPayload) {
-          window.location.reload();
-          return;
-        }
-
         showSuccess("Profile updated successfully");
+        onClose();
       },
       onError: (err) => {
         const msg = err?.message ?? "";

--- a/apps/customer-portal/webapp/src/components/common/header/UserProfileModal.tsx
+++ b/apps/customer-portal/webapp/src/components/common/header/UserProfileModal.tsx
@@ -208,8 +208,13 @@ export default function UserProfileModal({
           return;
         }
 
-        showSuccess("Profile updated successfully");
         onClose();
+        if (hasTimeZoneInPayload) {
+          window.location.reload();
+          return;
+        }
+
+        showSuccess("Profile updated successfully");
       },
       onError: (err) => {
         const msg = err?.message ?? "";

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallsPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallsPanel.tsx
@@ -98,14 +98,28 @@ export default function CallsPanel({
   const {
     data: userDetails,
     refetch: refetchUserDetails,
-    isLoading: isUserDetailsLoading,
+    isPending: isUserDetailsPending,
+    isFetching: isUserDetailsFetching,
+    isError: isUserDetailsError,
   } = useGetUserDetails();
-  const userTimeZone = userDetails?.timeZone || undefined;
+
+  const resolvedUserTimeZone =
+    userDetails?.timeZone?.trim() ||
+    (userDetails as { timezone?: string } | undefined)?.timezone?.trim() ||
+    "";
+
+  const userTimeZone = resolvedUserTimeZone || undefined;
+
+  /** True while GET /users/me has not returned usable profile data for this panel. */
+  const isUserMeLoading =
+    !isUserDetailsError &&
+    (isUserDetailsPending ||
+      (isUserDetailsFetching && userDetails === undefined));
 
   const needsTimeZone =
-    !isUserDetailsLoading &&
+    !isUserMeLoading &&
     !!userDetails &&
-    !userDetails.timeZone?.trim();
+    !resolvedUserTimeZone;
 
   // Derive filtered state keys from project filters (all non-Canceled states for search body)
   const callRequestStateKeys = useMemo<number[] | undefined>(() => {
@@ -404,8 +418,15 @@ export default function CallsPanel({
         />
       )}
 
-      {isUserDetailsLoading ? (
-        <CallsListSkeleton />
+      {isUserMeLoading ? (
+        <Box
+          role="status"
+          aria-busy="true"
+          aria-label="Loading your profile for call scheduling"
+          sx={{ width: "100%" }}
+        >
+          <CallsListSkeleton />
+        </Box>
       ) : needsTimeZone ? (
         <Box
           sx={{

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallsPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/CallsPanel.tsx
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Pagination, Stack } from "@wso2/oxygen-ui";
-import { PhoneCall } from "@wso2/oxygen-ui-icons-react";
+import { Box, Button, Pagination, Stack, Typography } from "@wso2/oxygen-ui";
+import { MapPin, PhoneCall } from "@wso2/oxygen-ui-icons-react";
 import {
   useState,
   useCallback,
@@ -40,7 +40,6 @@ import RequestCallModal from "@case-details-calls/RequestCallModal";
 import DeleteCallRequestModal from "@case-details-calls/DeleteCallRequestModal";
 import RejectCallRequestModal from "@case-details-calls/RejectCallRequestModal";
 import ApproveCallRequestModal from "@case-details-calls/ApproveCallRequestModal";
-import MissingTimezoneDialog from "@case-details-calls/MissingTimezoneDialog";
 import UserProfileModal from "@components/common/header/UserProfileModal";
 import ErrorBanner from "@components/common/error-banner/ErrorBanner";
 import SuccessBanner from "@components/common/success-banner/SuccessBanner";
@@ -85,25 +84,28 @@ export default function CallsPanel({
   const [deleteCall, setDeleteCall] = useState<CallRequest | null>(null);
   const [approveCall, setApproveCall] = useState<CallRequest | null>(null);
   const [rejectCall, setRejectCall] = useState<CallRequest | null>(null);
-  const [isMissingTzDialogOpen, setIsMissingTzDialogOpen] = useState(false);
-  const [missingTzVariant, setMissingTzVariant] = useState<
-    "informational" | "required"
-  >("informational");
   const [pendingCallAfterTz, setPendingCallAfterTz] = useState<
     | { type: "create" }
     | { type: "edit"; call: CallRequest }
     | null
   >(null);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
-  const [hasShownTzPrompt, setHasShownTzPrompt] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [callRequestsPage, setCallRequestsPage] = useState(1);
 
   const { data: projectFilters } = useGetProjectFilters(projectId);
-  const { data: userDetails, refetch: refetchUserDetails } =
-    useGetUserDetails();
+  const {
+    data: userDetails,
+    refetch: refetchUserDetails,
+    isLoading: isUserDetailsLoading,
+  } = useGetUserDetails();
   const userTimeZone = userDetails?.timeZone || undefined;
+
+  const needsTimeZone =
+    !isUserDetailsLoading &&
+    !!userDetails &&
+    !userDetails.timeZone?.trim();
 
   // Derive filtered state keys from project filters (all non-Canceled states for search body)
   const callRequestStateKeys = useMemo<number[] | undefined>(() => {
@@ -226,8 +228,7 @@ export default function CallsPanel({
     setErrorMessage(null);
     if (!userDetails?.timeZone?.trim()) {
       setPendingCallAfterTz({ type: "create" });
-      setMissingTzVariant("required");
-      setIsMissingTzDialogOpen(true);
+      setIsProfileModalOpen(true);
       return;
     }
     setEditCall(null);
@@ -240,8 +241,7 @@ export default function CallsPanel({
   const handleEditClick = (call: CallRequest) => {
     if (!userDetails?.timeZone?.trim()) {
       setPendingCallAfterTz({ type: "edit", call });
-      setMissingTzVariant("required");
-      setIsMissingTzDialogOpen(true);
+      setIsProfileModalOpen(true);
       return;
     }
     setEditCall(call);
@@ -338,16 +338,6 @@ export default function CallsPanel({
     return () => clearTimeout(t);
   }, [errorMessage]);
 
-  // Prompt once per mount when the user has no timezone set and data is loaded
-  useEffect(() => {
-    if (hasShownTzPrompt) return;
-    if (userDetails && !userDetails.timeZone?.trim()) {
-      setMissingTzVariant("required");
-      setIsMissingTzDialogOpen(true);
-      setHasShownTzPrompt(true);
-    }
-  }, [userDetails, hasShownTzPrompt]);
-
   const requestCallButton = (
     <Button
       variant="contained"
@@ -360,21 +350,8 @@ export default function CallsPanel({
     </Button>
   );
 
-  return (
-    <Stack spacing={3}>
-      {successMessage && (
-        <SuccessBanner
-          message={successMessage}
-          onClose={() => setSuccessMessage(null)}
-        />
-      )}
-      {errorMessage && (
-        <ErrorBanner
-          message={errorMessage}
-          onClose={() => setErrorMessage(null)}
-        />
-      )}
-
+  const mainCallsContent = (
+    <>
       {!(allCallRequests.length === 0 && !isPending && !isError) && (
         <Box sx={{ alignSelf: "flex-start" }}>{requestCallButton}</Box>
       )}
@@ -408,6 +385,70 @@ export default function CallsPanel({
             </Box>
           )}
         </Stack>
+      )}
+    </>
+  );
+
+  return (
+    <Stack spacing={3} sx={{ flex: 1, minHeight: 0, width: "100%" }}>
+      {successMessage && (
+        <SuccessBanner
+          message={successMessage}
+          onClose={() => setSuccessMessage(null)}
+        />
+      )}
+      {errorMessage && (
+        <ErrorBanner
+          message={errorMessage}
+          onClose={() => setErrorMessage(null)}
+        />
+      )}
+
+      {isUserDetailsLoading ? (
+        <CallsListSkeleton />
+      ) : needsTimeZone ? (
+        <Box
+          sx={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: 280,
+            width: "100%",
+            py: 4,
+            px: 2,
+          }}
+        >
+          <Box
+            role="region"
+            aria-label="Time zone required"
+            sx={{
+              maxWidth: 520,
+              width: "100%",
+              textAlign: "center",
+            }}
+          >
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mb: 2, textAlign: "center" }}
+            >
+              Set your time zone first to request or reschedule a call. Go to
+              your profile to choose your time zone.
+            </Typography>
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<MapPin size={16} />}
+              onClick={() => setIsProfileModalOpen(true)}
+            >
+              Set Time Zone
+            </Button>
+          </Box>
+        </Box>
+      ) : (
+        mainCallsContent
       )}
 
       <DeleteCallRequestModal
@@ -455,23 +496,16 @@ export default function CallsPanel({
         isRejecting={patchCallRequest.isPending}
       />
 
-      <MissingTimezoneDialog
-        open={isMissingTzDialogOpen}
-        variant={missingTzVariant}
-        onClose={() => setIsMissingTzDialogOpen(false)}
-        onSetTimeZone={() => {
-          setIsMissingTzDialogOpen(false);
-          setIsProfileModalOpen(true);
-        }}
-      />
-
       <UserProfileModal
         open={isProfileModalOpen}
         onClose={() => {
           setIsProfileModalOpen(false);
-          void refetchUserDetails().then((result) => {
-            const tz = result.data?.timeZone?.trim();
-            if (pendingCallAfterTz && tz) {
+          void refetchUserDetails()
+            .then((result) => {
+              const tz = result.data?.timeZone?.trim();
+              if (!pendingCallAfterTz || !tz) {
+                return;
+              }
               if (pendingCallAfterTz.type === "create") {
                 setEditCall(null);
                 setIsModalOpen(true);
@@ -480,11 +514,10 @@ export default function CallsPanel({
                 setIsModalOpen(true);
               }
               setPendingCallAfterTz(null);
-            } else if (pendingCallAfterTz && !tz) {
-              setMissingTzVariant("required");
-              setIsMissingTzDialogOpen(true);
-            }
-          });
+            })
+            .catch(() => {
+              setPendingCallAfterTz(null);
+            });
         }}
       />
     </Stack>

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/MissingTimezoneDialog.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/MissingTimezoneDialog.tsx
@@ -86,7 +86,7 @@ export default function MissingTimezoneDialog({
           color="text.secondary"
         >
           {isRequired
-            ? "You must set your time zone before you can request or reschedule a call. Open your profile to choose a time zone."
+            ? "Set your time zone first to request or reschedule a call. Go to your profile to choose your time zone."
             : "Your profile does not have a time zone configured. Please set your time zone so call request times are displayed accurately in your local time."}
         </Typography>
       </DialogContent>

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/CallsPanel.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/CallsPanel.test.tsx
@@ -464,10 +464,18 @@ describe("CallsPanel", () => {
         caseId={mockCaseId}
         caseStatusLabel="Work In Progress"
       />);
-    expect(screen.getByText("Time Zone Not Set")).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: /time zone required/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Set your time zone first to request or reschedule a call/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Request Call$/ }),
+    ).not.toBeInTheDocument();
   });
 
-  it("should show required timezone dialog instead of Request Call modal when profile has no timezone", () => {
+  it("should block Request Call flow with time zone gate when profile has no timezone", () => {
     vi.mocked(useGetUserDetails).mockReturnValue({
       data: { timeZone: null },
       refetch: vi.fn().mockResolvedValue({ data: { timeZone: null } }),
@@ -494,9 +502,11 @@ describe("CallsPanel", () => {
       />,
     );
     expect(
-      screen.getByText(/must set your time zone before/i),
+      screen.getByText(/Set your time zone first to request or reschedule a call/i),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Later/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Request Call$/ }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByPlaceholderText(
         /Describe your call request or topics you'd like to discuss/i,

--- a/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/MissingTimezoneDialog.test.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/calls-tab/__tests__/MissingTimezoneDialog.test.tsx
@@ -57,7 +57,7 @@ describe("MissingTimezoneDialog", () => {
   it("should omit Later and show required copy when variant is required", () => {
     render(<MissingTimezoneDialog {...defaultProps} variant="required" />);
     expect(
-      screen.getByText(/must set your time zone before/i),
+      screen.getByText(/Set your time zone first to request or reschedule a call/i),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Later/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Set Time Zone/i })).toBeInTheDocument();

--- a/apps/customer-portal/webapp/src/components/support/case-details/header/CaseDetailsTabPanels.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/header/CaseDetailsTabPanels.tsx
@@ -108,15 +108,25 @@ export default function CaseDetailsTabPanels({
         );
       }
       return (
-        <CallsPanel
-          projectId={resolvedProjectId}
-          caseId={caseId}
-          isCaseClosed={
-            !!data?.closedOn || data?.status?.label === "Closed"
-          }
-          caseStatusLabel={data?.status?.label}
-          caseSeverityId={data?.severity?.id}
-        />
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "auto",
+          }}
+        >
+          <CallsPanel
+            projectId={resolvedProjectId}
+            caseId={caseId}
+            isCaseClosed={
+              !!data?.closedOn || data?.status?.label === "Closed"
+            }
+            caseStatusLabel={data?.status?.label}
+            caseSeverityId={data?.severity?.id}
+          />
+        </Box>
       );
     }
     case 4:


### PR DESCRIPTION
### Description

This pull request introduces significant improvements to the user experience and logic around time zone requirements for requesting or rescheduling calls in the customer portal. The main changes include replacing the modal-based time zone prompt with an inline, page-level gate, updating related copy and tests, and improving the cache and refetching behavior for user details. These updates ensure users must set their time zone before interacting with call features, and provide clearer, more consistent messaging and UI.

**Time zone requirement enforcement and UX improvements:**

* Replaced the `MissingTimezoneDialog` modal with an inline, page-level gate in `CallsPanel`, blocking access to call request/reschedule features until the user sets a time zone. The new UI provides clear instructions and a direct link to the profile modal for setting the time zone. [[1]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL17-R18) [[2]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL43) [[3]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL88-R109) [[4]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL229-R231) [[5]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL243-R244) [[6]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL341-L350) [[7]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL363-R354) [[8]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdR389-R452) [[9]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL458-R508) [[10]](diffhunk://#diff-e55ccc08c29dd4352ff91694d926dfb4d6d70c3d9a953fb23d7e2e15654e7abdL483-R519)
* Updated the time zone required message copy for clarity and consistency in both the inline gate and the (now legacy) dialog.

**User details fetching and caching improvements:**

* Changed the `useGetUserDetails` query to always fetch fresh data (`cache: "no-store"`, `staleTime: 0`, `refetchOnMount: true`) to ensure up-to-date user profile information, especially after changes. [[1]](diffhunk://#diff-7f83a658a272ad57836f40901314d1b071ab9975db97ac56850e3ee8cea5a852R50) [[2]](diffhunk://#diff-7f83a658a272ad57836f40901314d1b071ab9975db97ac56850e3ee8cea5a852L69-R72)
* Improved cache updating after a user profile patch by updating only the relevant fields in the cached `userDetails` query, and then invalidating all queries to ensure consistency. [[1]](diffhunk://#diff-1f61f64389b94e0e9be787c458c0e42b11f61c3c5b62774b7c33af7324bfe45fR26) [[2]](diffhunk://#diff-1f61f64389b94e0e9be787c458c0e42b11f61c3c5b62774b7c33af7324bfe45fL86-R107)

**Testing and copy updates:**

* Updated tests for `CallsPanel` and `MissingTimezoneDialog` to reflect the new inline time zone gate and revised messaging, ensuring correct blocking behavior and UI rendering. [[1]](diffhunk://#diff-f8edf28f366e102eb4c86d0797e66a3b6359d019c5aaf45c17b81d480a8554cdL467-R478) [[2]](diffhunk://#diff-f8edf28f366e102eb4c86d0797e66a3b6359d019c5aaf45c17b81d480a8554cdL497-R509) [[3]](diffhunk://#diff-72b358db6b7d4a70f4b739b026af61696b10cdd0cf76108ce0c32ee618a57eb7L60-R60)

**Layout and structural adjustments:**

* Wrapped the `CallsPanel` in a flex container for improved layout consistency and scrolling behavior within the case details tab panels. [[1]](diffhunk://#diff-ffd4dc69d4731138b46eacd4c798d2cfdef277be4ec918453bfb2783bed89cd2R111-R119) [[2]](diffhunk://#diff-ffd4dc69d4731138b46eacd4c798d2cfdef277be4ec918453bfb2783bed89cd2R129)