### PR TITLE
[Customer Portal][FE][Web] Restrict case creation to primary production deployments for Cloud Support projects

### DIFF
--- a/apps/customer-portal/webapp/src/components/common/novera-floating-chat/NoveraFloatingChat.tsx
+++ b/apps/customer-portal/webapp/src/components/common/novera-floating-chat/NoveraFloatingChat.tsx
@@ -47,6 +47,7 @@ import { useAllDeploymentProducts } from "@hooks/useAllDeploymentProducts";
 import { useChatWebSocket } from "@api/useChatWebSocket";
 import type { Message } from "@models/chatTypes";
 import { buildEnvProducts } from "@utils/caseCreation";
+import { filterDeploymentsForCaseCreation } from "@utils/subscriptionUtils";
 import { getFinalMessageFromPayload } from "@utils/chat";
 import {
   CHAT_SENDER_BOT,
@@ -89,8 +90,16 @@ export default function NoveraFloatingChat(): JSX.Element | null {
     projectDetails?.hasAgent ?? projectDetails?.account?.hasAgent ?? false;
   const accountId = projectDetails?.account?.id ?? projectId ?? "";
 
-  const { data: projectDeployments } = usePostProjectDeploymentsSearchAll(
+  const { data: allProjectDeployments } = usePostProjectDeploymentsSearchAll(
     projectId || "",
+  );
+  const projectDeployments = useMemo(
+    () =>
+      filterDeploymentsForCaseCreation(
+        allProjectDeployments,
+        projectDetails?.type?.label,
+      ),
+    [allProjectDeployments, projectDetails?.type?.label],
   );
   const { productsByDeploymentId } =
     useAllDeploymentProducts(projectDeployments);

--- a/apps/customer-portal/webapp/src/components/support/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
@@ -52,6 +52,7 @@ export interface BasicInformationSectionProps {
   extraProductOptions?: string[];
   isRelatedCaseMode?: boolean;
   isDeploymentDisabled?: boolean;
+  hideDeploymentField?: boolean;
   onLoadMoreDeployments?: () => void;
   hasMoreDeployments?: boolean;
   isFetchingMoreDeployments?: boolean;
@@ -82,6 +83,7 @@ export function BasicInformationSection({
   extraProductOptions,
   isRelatedCaseMode = false,
   isDeploymentDisabled = false,
+  hideDeploymentField = false,
   onLoadMoreDeployments,
   hasMoreDeployments = false,
   isFetchingMoreDeployments = false,
@@ -177,6 +179,7 @@ export function BasicInformationSection({
         </Grid>
 
         {/* deployment selection field wrapper */}
+        {!hideDeploymentField && (
         <Grid size={{ xs: 12 }}>
           {/* deployment field label container */}
           <Box sx={{ mb: 1, display: "flex", alignItems: "center", gap: 1 }}>
@@ -241,6 +244,7 @@ export function BasicInformationSection({
             </FormControl>
           )}
         </Grid>
+        )}
 
         {/* product selection field wrapper */}
         <Grid size={{ xs: 12 }}>

--- a/apps/customer-portal/webapp/src/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/pages/CreateCasePage.tsx
@@ -30,9 +30,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import useGetProjectFilters from "@api/useGetProjectFilters";
 import useGetProjectDetails from "@api/useGetProjectDetails";
 import { useAuthApiClient } from "@api/useAuthApiClient";
-import {
-  usePostProjectDeploymentsSearchInfinite,
-} from "@api/usePostProjectDeploymentsSearch";
+import { usePostProjectDeploymentsSearchInfinite } from "@api/usePostProjectDeploymentsSearch";
 import {
   extractDeploymentProducts,
   usePostDeploymentProductsSearchInfinite,
@@ -163,14 +161,17 @@ export default function CreateCasePage(): JSX.Element {
   const attachmentNamesRef = useRef<Map<string, string>>(new Map());
   const attachmentIdCounterRef = useRef(0);
   const [isPreparingAttachments, setIsPreparingAttachments] = useState(false);
-  const [isSubmitLocked, setIsSubmitLocked] = useState(false);
   const [isAttachmentModalOpen, setIsAttachmentModalOpen] = useState(false);
-  const deploymentsQuery = usePostProjectDeploymentsSearchInfinite(projectId || "", {
-    pageSize: 10,
-    enabled: !!projectId,
-  });
+  const deploymentsQuery = usePostProjectDeploymentsSearchInfinite(
+    projectId || "",
+    {
+      pageSize: 10,
+      enabled: !!projectId,
+    },
+  );
   const allProjectDeployments = useMemo(
-    () => deploymentsQuery.data?.pages.flatMap((p) => p.deployments ?? []) ?? [],
+    () =>
+      deploymentsQuery.data?.pages.flatMap((p) => p.deployments ?? []) ?? [],
     [deploymentsQuery.data],
   );
   const isPrimaryProductionOnly = shouldRestrictToPrimaryProductionDeployments(
@@ -199,14 +200,13 @@ export default function CreateCasePage(): JSX.Element {
   const deploymentProductsLoading = deploymentProductsQuery.isLoading;
   const deploymentProductsError = deploymentProductsQuery.isError;
   const allDeploymentProducts = useMemo(() => {
-    const items = deploymentProductsQuery.data?.pages.flatMap((page) =>
-      extractDeploymentProducts(page),
-    ) ?? [];
+    const items =
+      deploymentProductsQuery.data?.pages.flatMap((page) =>
+        extractDeploymentProducts(page),
+      ) ?? [];
     return items.filter((item) => {
       const label = getDeploymentProductDisplayLabel(item);
-      return (
-        Boolean(label.trim()) && !isUnknownPlaceholderProductLabel(label)
-      );
+      return Boolean(label.trim()) && !isUnknownPlaceholderProductLabel(label);
     });
   }, [deploymentProductsQuery.data]);
   const baseProductOptions = getBaseProductOptions(allDeploymentProducts);
@@ -669,33 +669,23 @@ export default function CreateCasePage(): JSX.Element {
       reader.readAsDataURL(file);
     });
 
-  const failSubmit = useCallback(
-    (message: string) => {
-      showError(message);
-      setIsSubmitLocked(false);
-    },
-    [showError],
-  );
-
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!projectId) return;
-    if (isSubmitLocked) return;
-    setIsSubmitLocked(true);
 
     const titlePlain = htmlToPlainText(title).trim();
     const descriptionPlain = htmlToPlainText(description).trim();
     if (!titlePlain) {
-      failSubmit("Please enter a case title.");
+      showError("Please enter a case title.");
       return;
     }
     if (!descriptionPlain) {
-      failSubmit("Please enter a description.");
+      showError("Please enter a description.");
       return;
     }
 
     if (isSecurityReport && attachments.length === 0) {
-      failSubmit("Please attach at least one security report file.");
+      showError("Please attach at least one security report file.");
       return;
     }
 
@@ -704,14 +694,16 @@ export default function CreateCasePage(): JSX.Element {
       projectDeployments,
       undefined,
     );
-    if (!deploymentMatch) {
-      failSubmit("Please select a deployment type.");
+    const resolvedDeploymentId =
+      deploymentMatch?.id ?? relatedCase?.deploymentId ?? "";
+    if (!resolvedDeploymentId) {
+      showError("Please select a deployment type.");
       return;
     }
 
     const productId = resolveProductId(product, allDeploymentProducts);
     if (!productId) {
-      failSubmit("Please select a product version.");
+      showError("Please select a product version.");
       return;
     }
 
@@ -722,12 +714,12 @@ export default function CreateCasePage(): JSX.Element {
     if (!isSecurityReport) {
       issueTypeKey = resolveIssueTypeKey(issueType, filters?.issueTypes);
       if (!issueTypeKey) {
-        failSubmit("Please select an issue type.");
+        showError("Please select an issue type.");
         return;
       }
       const parsedSeverity = parseInt(severity, 10);
       if (Number.isNaN(parsedSeverity)) {
-        failSubmit("Please select a severity.");
+        showError("Please select a severity.");
         return;
       }
       severityKey = parsedSeverity;
@@ -751,7 +743,7 @@ export default function CreateCasePage(): JSX.Element {
           error instanceof Error && error.message
             ? error.message
             : "Failed to process attachments. Please try again.";
-        failSubmit(message);
+        showError(message);
         return;
       } finally {
         setIsPreparingAttachments(false);
@@ -793,23 +785,20 @@ export default function CreateCasePage(): JSX.Element {
 
         showSuccess("Case created successfully");
 
-        try {
-          if (projectId) {
-            await triggerPostCreationApiCalls(
-              authFetch,
-              projectId,
-              CaseType.DEFAULT_CASE,
-            );
-            await refreshCaseQueriesAfterCreation(
-              queryClient,
-              projectId,
-              CaseType.DEFAULT_CASE,
-            );
-          }
-        } catch (err) {
-          logger.error("Failed to refresh case queries after creation", err);
+        if (projectId) {
+          await triggerPostCreationApiCalls(
+            authFetch,
+            projectId,
+            CaseType.DEFAULT_CASE,
+          );
+          await refreshCaseQueriesAfterCreation(
+            queryClient,
+            projectId,
+            CaseType.DEFAULT_CASE,
+          );
         }
 
+        // Clean up sessionStorage safely
         try {
           sessionStorage.removeItem(STORAGE_KEY);
           sessionStorage.removeItem(CONVERSATION_ID_STORAGE_KEY);
@@ -820,16 +809,13 @@ export default function CreateCasePage(): JSX.Element {
           );
         }
 
-        try {
-          if (isCreatedSecurityReport) {
-            navigate(
-              `/projects/${projectId}/security-center/security-report-analysis/${caseId}?tab=${SecurityTab.VULNERABILITIES}`,
-            );
-          } else {
-            navigate(`/projects/${projectId}/support/cases/${caseId}`);
-          }
-        } finally {
-          setIsSubmitLocked(false);
+        // Refetch security vulnerabilities if this was a security report
+        if (isCreatedSecurityReport) {
+          navigate(
+            `/projects/${projectId}/security-center/security-report-analysis/${caseId}?tab=${SecurityTab.VULNERABILITIES}`,
+          );
+        } else {
+          navigate(`/projects/${projectId}/support/cases/${caseId}`);
         }
       },
       onError: (error) => {
@@ -837,7 +823,6 @@ export default function CreateCasePage(): JSX.Element {
           error?.message?.trim() ||
           "We couldn't create your case. Please check required fields and try again.";
         showError(msg);
-        setIsSubmitLocked(false);
       },
     });
   };
@@ -902,7 +887,10 @@ export default function CreateCasePage(): JSX.Element {
             isDeploymentDisabled={!!relatedCase}
             hideDeploymentField={isPrimaryProductionOnly}
             onLoadMoreDeployments={() => {
-              if (deploymentsQuery.hasNextPage && !deploymentsQuery.isFetchingNextPage) {
+              if (
+                deploymentsQuery.hasNextPage &&
+                !deploymentsQuery.isFetchingNextPage
+              ) {
                 void deploymentsQuery.fetchNextPage();
               }
             }}
@@ -960,7 +948,6 @@ export default function CreateCasePage(): JSX.Element {
                 isFiltersLoading ||
                 isCreatePending ||
                 isPreparingAttachments ||
-                isSubmitLocked ||
                 !projectId ||
                 !selectedDeploymentId ||
                 deploymentProductsLoading ||

--- a/apps/customer-portal/webapp/src/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/pages/CreateCasePage.tsx
@@ -189,7 +189,8 @@ export default function CreateCasePage(): JSX.Element {
     () => resolveDeploymentMatch(deployment, projectDeployments, undefined),
     [deployment, projectDeployments],
   );
-  const selectedDeploymentId = selectedDeploymentMatch?.id ?? "";
+  const selectedDeploymentId =
+    selectedDeploymentMatch?.id ?? relatedCase?.deploymentId ?? "";
   const deploymentProductsQuery = usePostDeploymentProductsSearchInfinite(
     selectedDeploymentId,
     { pageSize: 10, enabled: !!selectedDeploymentId },
@@ -692,7 +693,9 @@ export default function CreateCasePage(): JSX.Element {
       projectDeployments,
       undefined,
     );
-    if (!deploymentMatch) {
+    const resolvedDeploymentId =
+      deploymentMatch?.id ?? relatedCase?.deploymentId ?? "";
+    if (!resolvedDeploymentId) {
       showError("Please select a deployment type.");
       return;
     }
@@ -751,7 +754,7 @@ export default function CreateCasePage(): JSX.Element {
       type: isSecurityReport
         ? CaseType.SECURITY_REPORT_ANALYSIS
         : CaseType.DEFAULT_CASE,
-      deploymentId: String(deploymentMatch.id),
+      deploymentId: String(resolvedDeploymentId),
       description,
       issueTypeKey,
       deployedProductId: String(productId),

--- a/apps/customer-portal/webapp/src/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/pages/CreateCasePage.tsx
@@ -73,7 +73,11 @@ import {
   CaseType,
 } from "@constants/supportConstants";
 import { SecurityTab } from "@constants/securityConstants";
-import { shouldExcludeS0 } from "@utils/subscriptionUtils";
+import {
+  filterDeploymentsForCaseCreation,
+  shouldExcludeS0,
+  shouldRestrictToPrimaryProductionDeployments,
+} from "@utils/subscriptionUtils";
 import { escapeHtml, htmlToPlainText } from "@utils/richTextEditor";
 import UploadAttachmentModal from "@components/support/case-details/attachments-tab/UploadAttachmentModal";
 import { ROUTE_PREVIOUS_PAGE } from "@/constants/commonConstants";
@@ -164,9 +168,20 @@ export default function CreateCasePage(): JSX.Element {
     pageSize: 10,
     enabled: !!projectId,
   });
-  const projectDeployments = useMemo(
+  const allProjectDeployments = useMemo(
     () => deploymentsQuery.data?.pages.flatMap((p) => p.deployments ?? []) ?? [],
     [deploymentsQuery.data],
+  );
+  const isPrimaryProductionOnly = shouldRestrictToPrimaryProductionDeployments(
+    projectDetails?.type?.label,
+  );
+  const projectDeployments = useMemo(
+    () =>
+      filterDeploymentsForCaseCreation(
+        allProjectDeployments,
+        projectDetails?.type?.label,
+      ),
+    [allProjectDeployments, projectDetails?.type?.label],
   );
   const isDeploymentsLoading = deploymentsQuery.isLoading;
   const baseDeploymentOptions = getBaseDeploymentOptions(projectDeployments);
@@ -358,6 +373,18 @@ export default function CreateCasePage(): JSX.Element {
     setDeployment(value);
     setProduct("");
   }, []);
+
+  // For Cloud Support / Cloud Evaluation Support: auto-pick the first primary
+  // production deployment and keep it locked to that value.
+  useEffect(() => {
+    if (!isPrimaryProductionOnly) return;
+    if (!baseDeploymentOptions.length) return;
+    const first = baseDeploymentOptions[0];
+    if (!first) return;
+    setDeployment((prev) =>
+      baseDeploymentOptions.includes(prev) ? prev : first,
+    );
+  }, [isPrimaryProductionOnly, baseDeploymentOptions]);
 
   const handleProductChange = useCallback((value: string) => {
     setProduct(value);
@@ -854,6 +881,7 @@ export default function CreateCasePage(): JSX.Element {
             isRelatedCaseMode={noAiMode}
             extraProductOptions={extraProductOptions}
             isDeploymentDisabled={!!relatedCase}
+            hideDeploymentField={isPrimaryProductionOnly}
             onLoadMoreDeployments={() => {
               if (deploymentsQuery.hasNextPage && !deploymentsQuery.isFetchingNextPage) {
                 void deploymentsQuery.fetchNextPage();

--- a/apps/customer-portal/webapp/src/pages/CreateServiceRequestPage.tsx
+++ b/apps/customer-portal/webapp/src/pages/CreateServiceRequestPage.tsx
@@ -57,6 +57,10 @@ import {
   refreshCaseQueriesAfterCreation,
   triggerPostCreationApiCalls,
 } from "@utils/caseRefresh";
+import {
+  filterDeploymentsForCaseCreation,
+  shouldRestrictToPrimaryProductionDeployments,
+} from "@utils/subscriptionUtils";
 import { htmlToPlainText } from "@utils/richTextEditor";
 import type { CreateServiceRequestPayload } from "@models/requests";
 import CatalogSelector from "@components/support/service-requests/CatalogSelector";
@@ -103,9 +107,20 @@ export default function CreateServiceRequestPage(): JSX.Element {
     pageSize: 10,
     enabled: !!projectId,
   });
-  const projectDeployments = useMemo(
+  const allProjectDeployments = useMemo(
     () => deploymentsQuery.data?.pages.flatMap((p) => p.deployments ?? []) ?? [],
     [deploymentsQuery.data],
+  );
+  const isPrimaryProductionOnly = shouldRestrictToPrimaryProductionDeployments(
+    projectDetails?.type?.label,
+  );
+  const projectDeployments = useMemo(
+    () =>
+      filterDeploymentsForCaseCreation(
+        allProjectDeployments,
+        projectDetails?.type?.label,
+      ),
+    [allProjectDeployments, projectDetails?.type?.label],
   );
   const isDeploymentsLoading = deploymentsQuery.isLoading;
 
@@ -197,6 +212,18 @@ export default function CreateServiceRequestPage(): JSX.Element {
     setVariableValues({});
     setAttachments([]);
   }, []);
+
+  // For Cloud Support / Cloud Evaluation Support: auto-pick the first primary
+  // production deployment so the hidden field still resolves to a valid value.
+  useEffect(() => {
+    if (!isPrimaryProductionOnly) return;
+    if (!baseDeploymentOptions.length) return;
+    const first = baseDeploymentOptions[0];
+    if (!first) return;
+    setDeployment((prev) =>
+      baseDeploymentOptions.includes(prev) ? prev : first,
+    );
+  }, [isPrimaryProductionOnly, baseDeploymentOptions]);
 
   const handleProductChange = useCallback((value: string) => {
     setProduct(value);
@@ -410,6 +437,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
           isProductAutoDetected={false}
           isDeploymentAutoDetected={false}
           isRelatedCaseMode
+          hideDeploymentField={isPrimaryProductionOnly}
           metadata={{ deploymentTypes: baseDeploymentOptions }}
           isDeploymentLoading={isProjectLoading || isDeploymentsLoading}
           isProductDropdownDisabled={isProductDropdownDisabled}

--- a/apps/customer-portal/webapp/src/pages/CreateServiceRequestPage.tsx
+++ b/apps/customer-portal/webapp/src/pages/CreateServiceRequestPage.tsx
@@ -213,6 +213,18 @@ export default function CreateServiceRequestPage(): JSX.Element {
     setAttachments([]);
   }, []);
 
+  useEffect(() => {
+    const depId = searchParams.get("deploymentId")?.trim();
+    if (!depId) return;
+    if (allProjectDeployments.some((d) => d.id === depId)) return;
+    if (
+      deploymentsQuery.hasNextPage &&
+      !deploymentsQuery.isFetchingNextPage
+    ) {
+      void deploymentsQuery.fetchNextPage();
+    }
+  }, [searchParams, allProjectDeployments, deploymentsQuery]);
+
   // For Cloud Support / Cloud Evaluation Support: auto-pick the first primary
   // production deployment so the hidden field still resolves to a valid value.
   useEffect(() => {

--- a/apps/customer-portal/webapp/src/pages/DescribeIssuePage.tsx
+++ b/apps/customer-portal/webapp/src/pages/DescribeIssuePage.tsx
@@ -31,6 +31,7 @@ import useGetProjectDetails from "@api/useGetProjectDetails";
 import { useAllDeploymentProducts } from "@hooks/useAllDeploymentProducts";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { buildEnvProducts } from "@utils/caseCreation";
+import { filterDeploymentsForCaseCreation } from "@utils/subscriptionUtils";
 import { htmlToPlainText } from "@utils/richTextEditor";
 import type { ChatNavState } from "@/models/chatTypes";
 
@@ -52,8 +53,17 @@ export default function DescribeIssuePage(): JSX.Element {
   const [value, setValue] = useState("");
   const [isLoadingAfterClick, setIsLoadingAfterClick] = useState(false);
 
-  const { data: projectDeployments } = usePostProjectDeploymentsSearchAll(
+  const { data: allProjectDeployments } = usePostProjectDeploymentsSearchAll(
     projectId || "",
+  );
+  const { data: projectDetails } = useGetProjectDetails(projectId || "");
+  const projectDeployments = useMemo(
+    () =>
+      filterDeploymentsForCaseCreation(
+        allProjectDeployments,
+        projectDetails?.type?.label,
+      ),
+    [allProjectDeployments, projectDetails?.type?.label],
   );
   const { productsByDeploymentId } =
     useAllDeploymentProducts(projectDeployments);
@@ -61,7 +71,6 @@ export default function DescribeIssuePage(): JSX.Element {
     () => buildEnvProducts(productsByDeploymentId, projectDeployments),
     [productsByDeploymentId, projectDeployments],
   );
-  const { data: projectDetails } = useGetProjectDetails(projectId || "");
 
   const isSubmitting = false;
   const submittingRef = useRef(false);

--- a/apps/customer-portal/webapp/src/pages/DescribeIssuePage.tsx
+++ b/apps/customer-portal/webapp/src/pages/DescribeIssuePage.tsx
@@ -65,7 +65,7 @@ export default function DescribeIssuePage(): JSX.Element {
       ),
     [allProjectDeployments, projectDetails?.type?.label],
   );
-  const { productsByDeploymentId } =
+  const { productsByDeploymentId, isLoading: isLoadingDeploymentProducts } =
     useAllDeploymentProducts(projectDeployments);
   const envProducts = useMemo(
     () => buildEnvProducts(productsByDeploymentId, projectDeployments),
@@ -119,7 +119,8 @@ export default function DescribeIssuePage(): JSX.Element {
     showError,
   ]);
 
-  const isSubmitDisabled = !projectId || !plainText.trim();
+  const isSubmitDisabled =
+    !projectId || !plainText.trim() || isLoadingDeploymentProducts;
 
   return (
     <Box

--- a/apps/customer-portal/webapp/src/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/pages/NoveraChatPage.tsx
@@ -49,6 +49,7 @@ import {
   formatChatHistoryForClassification,
   buildEnvProducts,
 } from "@utils/caseCreation";
+import { filterDeploymentsForCaseCreation } from "@utils/subscriptionUtils";
 import { htmlToPlainText } from "@utils/richTextEditor";
 import type { ChatNavState, Message } from "@models/chatTypes";
 import ChatHeader from "@components/support/novera-ai-assistant/novera-chat-page/ChatHeader";
@@ -85,10 +86,18 @@ export default function NoveraChatPage(): JSX.Element {
     }
   };
 
-  const { data: projectDeployments } = usePostProjectDeploymentsSearchAll(
+  const { data: allProjectDeployments } = usePostProjectDeploymentsSearchAll(
     projectId || "",
   );
   const { data: projectDetails } = useGetProjectDetails(projectId || "");
+  const projectDeployments = useMemo(
+    () =>
+      filterDeploymentsForCaseCreation(
+        allProjectDeployments,
+        projectDetails?.type?.label,
+      ),
+    [allProjectDeployments, projectDetails?.type?.label],
+  );
   const { productsByDeploymentId, isLoading: isAllProductsLoading } =
     useAllDeploymentProducts(projectDeployments);
   const envProducts = useMemo(

--- a/apps/customer-portal/webapp/src/utils/subscriptionUtils.ts
+++ b/apps/customer-portal/webapp/src/utils/subscriptionUtils.ts
@@ -134,6 +134,7 @@ export function filterDeploymentsForCaseCreation<
   deployments: T[] | undefined,
   projectTypeLabel: string | null | undefined,
 ): T[] {
+  if (projectTypeLabel === undefined) return [];
   const list = deployments ?? [];
   if (!shouldRestrictToPrimaryProductionDeployments(projectTypeLabel)) {
     return list;

--- a/apps/customer-portal/webapp/src/utils/subscriptionUtils.ts
+++ b/apps/customer-portal/webapp/src/utils/subscriptionUtils.ts
@@ -101,6 +101,49 @@ export function shouldExcludeS0(
   return !getProjectPermissions(projectTypeLabel).includeS0InSupportMetrics;
 }
 
+/** Deployment type label that represents primary production environments. */
+export const PRIMARY_PRODUCTION_DEPLOYMENT_TYPE_LABEL = "Primary Production";
+
+/**
+ * Whether case/SR/security report flows should be restricted to primary
+ * production deployments only (Cloud Support and Cloud Evaluation Support).
+ *
+ * @param projectTypeLabel - Value from project.type.label.
+ * @returns True when only primary production deployments should be used.
+ */
+export function shouldRestrictToPrimaryProductionDeployments(
+  projectTypeLabel: string | null | undefined,
+): boolean {
+  return (
+    projectTypeLabel === PROJECT_TYPE_LABELS.CLOUD_SUPPORT ||
+    projectTypeLabel === PROJECT_TYPE_LABELS.CLOUD_EVALUATION_SUPPORT
+  );
+}
+
+/**
+ * Filters a deployment list to only primary production entries when the
+ * project type requires it; otherwise returns the list unchanged.
+ *
+ * @param deployments - Project deployments.
+ * @param projectTypeLabel - Value from project.type.label.
+ * @returns Deployments narrowed per project type rules.
+ */
+export function filterDeploymentsForCaseCreation<
+  T extends { type?: { label?: string | null } | null },
+>(
+  deployments: T[] | undefined,
+  projectTypeLabel: string | null | undefined,
+): T[] {
+  const list = deployments ?? [];
+  if (!shouldRestrictToPrimaryProductionDeployments(projectTypeLabel)) {
+    return list;
+  }
+  const target = PRIMARY_PRODUCTION_DEPLOYMENT_TYPE_LABEL.toLowerCase();
+  return list.filter(
+    (d) => (d.type?.label ?? "").trim().toLowerCase() === target,
+  );
+}
+
 export interface ProjectOperationsStatsResult {
   total: number;
   serviceRequests: number;


### PR DESCRIPTION
### Description

This pull request updates the case creation and related flows to ensure that, for Cloud Support and Cloud Evaluation Support projects, users can only select from "Primary Production" deployments. It introduces utility functions to filter deployments and conditionally hides or auto-selects the deployment field in the UI where appropriate. The changes are applied consistently across case creation, service request, and chat-related pages.

**Deployment filtering and UI logic for Cloud Support/Evaluation projects:**

* Added `shouldRestrictToPrimaryProductionDeployments` and `filterDeploymentsForCaseCreation` utilities to enforce that only primary production deployments are selectable for Cloud Support and Cloud Evaluation Support projects (`apps/customer-portal/webapp/src/utils/subscriptionUtils.ts`).
* Updated pages and components (`CreateCasePage`, `CreateServiceRequestPage`, `DescribeIssuePage`, `NoveraChatPage`, and `NoveraFloatingChat`) to use the new filtering utilities, ensuring only valid deployments are shown and auto-selecting the first available deployment when appropriate [[1]](diffhunk://#diff-7d88474abb84138eb3b47a93f57e88c03f98ee53fcdc4be3942643844952cc09L167-R185) [[2]](diffhunk://#diff-7d88474abb84138eb3b47a93f57e88c03f98ee53fcdc4be3942643844952cc09R377-R388) [[3]](diffhunk://#diff-fc6813e681e4f29ed7d22f70b9458d7d22fdb02a045a652e8ea7e4c009b9e626L106-R124) [[4]](diffhunk://#diff-fc6813e681e4f29ed7d22f70b9458d7d22fdb02a045a652e8ea7e4c009b9e626R216-R227) [[5]](diffhunk://#diff-faf13113222124ba01ca2ed9ee52476af224f58361203dd0b2f8356c5246edeeL55-L64) [[6]](diffhunk://#diff-33d56ba3f12ca759e2c509fc8057731f1ff8ed9d5324627f05bb25771a36f734L88-R100) [[7]](diffhunk://#diff-8a4299ea139d50733577dd2bdecd27f429e4eeb47778b07b653fe42a7802af64L92-R103).
* Modified the `BasicInformationSection` component to accept a new `hideDeploymentField` prop, allowing the deployment selection field to be hidden in the UI when restricted to primary production deployments [[1]](diffhunk://#diff-569ab1d9a67b68b8f4d9ad88e6705ae7d91c0590b980fdc915003eef1fc500c7R55) [[2]](diffhunk://#diff-569ab1d9a67b68b8f4d9ad88e6705ae7d91c0590b980fdc915003eef1fc500c7R86) [[3]](diffhunk://#diff-569ab1d9a67b68b8f4d9ad88e6705ae7d91c0590b980fdc915003eef1fc500c7R182) [[4]](diffhunk://#diff-569ab1d9a67b68b8f4d9ad88e6705ae7d91c0590b980fdc915003eef1fc500c7R247).
* Updated the relevant pages to pass the `hideDeploymentField` prop to `BasicInformationSection` based on project type [[1]](diffhunk://#diff-7d88474abb84138eb3b47a93f57e88c03f98ee53fcdc4be3942643844952cc09R884) [[2]](diffhunk://#diff-fc6813e681e4f29ed7d22f70b9458d7d22fdb02a045a652e8ea7e4c009b9e626R440).
* Refactored imports and variable names across affected files to support the new filtering logic and maintain code clarity [[1]](diffhunk://#diff-8a4299ea139d50733577dd2bdecd27f429e4eeb47778b07b653fe42a7802af64R50) [[2]](diffhunk://#diff-7d88474abb84138eb3b47a93f57e88c03f98ee53fcdc4be3942643844952cc09L76-R80) [[3]](diffhunk://#diff-fc6813e681e4f29ed7d22f70b9458d7d22fdb02a045a652e8ea7e4c009b9e626R60-R63) [[4]](diffhunk://#diff-faf13113222124ba01ca2ed9ee52476af224f58361203dd0b2f8356c5246edeeR34) [[5]](diffhunk://#diff-33d56ba3f12ca759e2c509fc8057731f1ff8ed9d5324627f05bb25771a36f734R52).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments available during case creation are now filtered based on subscription type.
  * Certain subscription types are restricted to primary production deployments only.
  * Deployment selection field is automatically hidden for subscription types limited to primary production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->