### PR TITLE
[Customer Portal][FE][Web] enable case actions in details panel with close-only option and improved messaging

### DIFF
--- a/apps/customer-portal/webapp/src/components/support/announcements/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/support/announcements/AnnouncementDetailsPanel.tsx
@@ -29,6 +29,7 @@ import DOMPurify from "dompurify";
 import { ArrowLeft, Calendar, FileText } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ReactElement } from "react";
 import type { CaseDetails } from "@models/responses";
+import CaseDetailsActionRow from "@components/support/case-details/header/CaseDetailsActionRow";
 import {
   formatUtcToLocalNoTimezone,
   getStatusColor,
@@ -42,6 +43,8 @@ export interface AnnouncementDetailsPanelProps {
   isLoading: boolean;
   isError: boolean;
   onBack: () => void;
+  projectId?: string;
+  caseId?: string;
 }
 
 /**
@@ -83,9 +86,9 @@ function normalizeAnnouncementDescriptionHtml(html: string): string {
 }
 
 /**
- * AnnouncementDetailsPanel displays announcement details: Back, title, date, issue type, Description.
+ * AnnouncementDetailsPanel displays announcement details: Back, title, date, issue type, state management buttons, and description.
  *
- * @param {AnnouncementDetailsPanelProps} props - Data, loading/error state, onBack.
+ * @param {AnnouncementDetailsPanelProps} props - Data, loading/error state, onBack, projectId, caseId.
  * @returns {JSX.Element} The rendered announcement details panel.
  */
 export default function AnnouncementDetailsPanel({
@@ -93,6 +96,8 @@ export default function AnnouncementDetailsPanel({
   isLoading,
   isError,
   onBack,
+  projectId = "",
+  caseId = "",
 }: AnnouncementDetailsPanelProps): JSX.Element {
   const theme = useTheme();
 
@@ -247,7 +252,17 @@ export default function AnnouncementDetailsPanel({
           )}
         </Stack>
       </Paper>
-
+      {data && data.status?.label?.toLowerCase() !== "closed" && (
+        <CaseDetailsActionRow
+          projectId={projectId}
+          caseId={caseId}
+          statusLabel={data.status?.label}
+          assignedEngineer={data.assignedEngineer}
+          engineerInitials={data.assignedEngineer?.name?.split(" ")?.[0]?.[0] ?? ""}
+          closedOn={data.closedOn}
+          restrictToCloseOnly={true}
+        />
+      )}
       <Paper
         variant="outlined"
         elevation={0}

--- a/apps/customer-portal/webapp/src/components/support/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/components/support/case-details/header/CaseDetailsActionRow.tsx
@@ -81,6 +81,7 @@ export interface CaseDetailsActionRowProps {
   showOnlyEngineer?: boolean;
   /** When true, hides assigned engineer (e.g. security report analysis). */
   hideAssignedEngineer?: boolean;
+  restrictToCloseOnly?: boolean;
 }
 
 /**
@@ -121,6 +122,7 @@ export default function CaseDetailsActionRow({
   isLoading = false,
   showOnlyEngineer = false,
   hideAssignedEngineer = false,
+  restrictToCloseOnly = false,
 }: CaseDetailsActionRowProps): JSX.Element {
   void assignedEngineer;
   void engineerInitials;
@@ -140,6 +142,9 @@ export default function CaseDetailsActionRow({
 
   const availableActions = getAvailableCaseActions(statusLabel).filter(
     (label) => {
+      if (restrictToCloseOnly && label !== "Closed") {
+        return false;
+      }
       if (label === "Open Related Case" && !isWithinOpenRelatedCaseWindow(closedOn)) {
         return false;
       }
@@ -225,7 +230,7 @@ export default function CaseDetailsActionRow({
                             { stateKey: stateKey! },
                             {
                               onSuccess: () => {
-                                showSuccess("Case status updated successfully.");
+                                showSuccess("State updated successfully.");
                               },
                               onError: (err) => {
                                 showError(

--- a/apps/customer-portal/webapp/src/pages/AnnouncementDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/pages/AnnouncementDetailsPage.tsx
@@ -78,6 +78,8 @@ export default function AnnouncementDetailsPage(): JSX.Element {
       data={data}
       isLoading={showSkeletons}
       isError={isError}
+      caseId={caseId || ""}
+      projectId={projectId || ""}
       onBack={handleBack}
     />
   );


### PR DESCRIPTION
### Description

This pull request enhances the `AnnouncementDetailsPanel` component by adding state management actions for announcements, specifically allowing users to close related cases directly from the announcement details view. The changes also introduce a new prop to restrict available actions to "Close only" and improve the clarity of success messages.

**Enhancements to Announcement Details Panel:**

- Added the `CaseDetailsActionRow` component to the `AnnouncementDetailsPanel`, enabling state management actions (e.g., closing a case) when the announcement is not already closed. [[1]](diffhunk://#diff-856ce70f330fe9fcbd3073730c5dcaceb9db61777607176252d8dc61df036df2R32) [[2]](diffhunk://#diff-856ce70f330fe9fcbd3073730c5dcaceb9db61777607176252d8dc61df036df2L250-R265)
- Extended `AnnouncementDetailsPanelProps` to accept optional `projectId` and `caseId` props, which are passed to the action row for context. [[1]](diffhunk://#diff-856ce70f330fe9fcbd3073730c5dcaceb9db61777607176252d8dc61df036df2R46-R47) [[2]](diffhunk://#diff-856ce70f330fe9fcbd3073730c5dcaceb9db61777607176252d8dc61df036df2L86-R100) [[3]](diffhunk://#diff-b1e28a57852f44e89890fdd540a1bff5d7873ad0e973f4df6fd87a4348ec11abR81-R82)

**Improvements to Case Action Row:**

- Added a new `restrictToCloseOnly` prop to `CaseDetailsActionRow` and its props interface, allowing the component to limit available actions to only closing the case. [[1]](diffhunk://#diff-4c216bf3fe770cfee35cc3f42e28c1379bfebe37bbfcdcad8d8056ffb60385b7R84) [[2]](diffhunk://#diff-4c216bf3fe770cfee35cc3f42e28c1379bfebe37bbfcdcad8d8056ffb60385b7R125) [[3]](diffhunk://#diff-4c216bf3fe770cfee35cc3f42e28c1379bfebe37bbfcdcad8d8056ffb60385b7R145-R147)
- Updated the success message shown after a state change to be more generic ("State updated successfully.").