### PR TITLE
Add recommendations endpoint for chat history and conversation context

### DIFF
--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -708,10 +708,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
-  /recommendations:
+  /conversations/recommendations/search:
     post:
       summary: Get recommendations for a given chat history and conversation context.
-      operationId: postRecommendations
+      operationId: postConversationsRecommendationsSearch
       requestBody:
         description: Recommendation request payload
         content:

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -708,6 +708,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+  /recommendations:
+    post:
+      summary: Get recommendations for a given chat history and conversation context.
+      operationId: postRecommendations
+      requestBody:
+        description: Recommendation request payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendationRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendationResponse'
+        "500":
+          description: InternalServerError
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
   /projects/{id}/conversations/search:
     post:
       summary: Search conversations for a specific project with filters and pagination.
@@ -2310,12 +2336,10 @@ components:
           type: string
           description: Allowed domain list of the account
           nullable: true
-          default: ""
         classification:
           type: string
           description: Account classification
           nullable: true
-          default: ""
         isPartner:
           type: boolean
           description: Whether the account is a partner or not
@@ -2706,6 +2730,7 @@ components:
           slaResponseTime:
             type: string
             description: SLA response time
+            nullable: true
           project:
             description: Project
             nullable: true
@@ -3404,6 +3429,31 @@ components:
           allOf:
           - $ref: '#/components/schemas/ReferenceItem'
       description: Conversation data.
+    ConversationData:
+      required:
+      - chatHistory
+      - envProducts
+      - region
+      - tier
+      type: object
+      properties:
+        chatHistory:
+          type: string
+          description: Chat history as a string
+        envProducts:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          description: Environment products
+        region:
+          type: string
+          description: Region
+        tier:
+          type: string
+          description: Tier
+      description: Conversation data for recommendations.
     ConversationPayload:
       required:
       - message
@@ -4041,6 +4091,22 @@ components:
           description: Whether the contact is a security contact or not
       additionalProperties: false
       description: Payload for updating membership security flag.
+    Message:
+      required:
+      - content
+      - role
+      - timestamp
+      type: object
+      properties:
+        role:
+          $ref: '#/components/schemas/Role'
+        content:
+          type: string
+          description: Message content
+        timestamp:
+          type: string
+          description: ISO timestamp
+      description: Single chat message for UI rendering.
     MetadataResponse:
       required:
       - timeZones
@@ -4731,6 +4797,54 @@ components:
           nullable: true
       additionalProperties: false
       description: Recent activity details.
+    RecommendationItem:
+      required:
+      - articleId
+      - score
+      - title
+      type: object
+      properties:
+        title:
+          type: string
+          description: Article title
+        articleId:
+          type: string
+          description: Article ID
+        score:
+          type: number
+          description: Similarity score
+          format: float
+      description: Recommendation item.
+    RecommendationRequest:
+      required:
+      - chatHistory
+      - conversationData
+      type: object
+      properties:
+        chatHistory:
+          type: array
+          description: Chat history
+          items:
+            $ref: '#/components/schemas/Message'
+        conversationData:
+          $ref: '#/components/schemas/ConversationData'
+      additionalProperties: false
+      description: Recommendation request.
+    RecommendationResponse:
+      required:
+      - query
+      type: object
+      properties:
+        query:
+          type: string
+          description: Original query (shortDescription from classification)
+        recommendations:
+          type: array
+          description: Top matching articles
+          items:
+            $ref: '#/components/schemas/RecommendationItem'
+          default: []
+      description: Recommendation response.
     RecommendedUpdateLevel:
       required:
       - availableSecurityUpdatesCount
@@ -4857,6 +4971,11 @@ components:
           description: Created for user email
       additionalProperties: false
       description: Registry token creation payload.
+    Role:
+      type: string
+      enum:
+      - assistant
+      - user
     ServiceRequestVariable:
       required:
       - name

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1286,7 +1286,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     #
     # + payload - Recommendation request payload
     # + return - Recommendation response or an error
-    resource function post conversations/recommendations/search(http:RequestContext ctx, ai_chat_agent:RecommendationRequest payload)
+    resource function post conversations/recommendations/search(http:RequestContext ctx,
+            ai_chat_agent:RecommendationRequest payload)
         returns ai_chat_agent:RecommendationResponse|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1286,7 +1286,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     #
     # + payload - Recommendation request payload
     # + return - Recommendation response or an error
-    resource function post recommendations/search(http:RequestContext ctx, ai_chat_agent:RecommendationRequest payload)
+    resource function post conversations/recommendations/search(http:RequestContext ctx, ai_chat_agent:RecommendationRequest payload)
         returns ai_chat_agent:RecommendationResponse|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1286,7 +1286,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     #
     # + payload - Recommendation request payload
     # + return - Recommendation response or an error
-    resource function post recommendations(http:RequestContext ctx, ai_chat_agent:RecommendationRequest payload)
+    resource function post recommendations/search(http:RequestContext ctx, ai_chat_agent:RecommendationRequest payload)
         returns ai_chat_agent:RecommendationResponse|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1282,6 +1282,36 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return classificationResponse;
     }
 
+    # Get recommendations for a given chat history and conversation context.
+    #
+    # + payload - Recommendation request payload
+    # + return - Recommendation response or an error
+    resource function post recommendations(http:RequestContext ctx, ai_chat_agent:RecommendationRequest payload)
+        returns ai_chat_agent:RecommendationResponse|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        ai_chat_agent:RecommendationResponse|error recommendationResponse =
+            ai_chat_agent:getRecommendation(payload);
+        if recommendationResponse is error {
+            string customError = "Failed to retrieve recommendations.";
+            log:printError(customError, recommendationResponse);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+        return recommendationResponse;
+    }
+
     # Search conversations for a specific project with filters and pagination.
     #
     # + id - ID of the project


### PR DESCRIPTION
## Add `/recommendations` endpoint to customer portal backend

Exposes the existing `ai_chat_agent:getRecommendation` function as a new `POST /recommendations` resource on the customer portal service, allowing clients to fetch article recommendations for a given chat history and conversation context (env products, region, tier) without having to go through the full conversation-create flow.

### Changes
- **[service.bal](apps/customer-portal/backend/service.bal)**: New `post recommendations` resource that validates the user info header and delegates to `ai_chat_agent:getRecommendation`, returning `RecommendationResponse` or `500` on upstream failure (mirrors the `cases/classify` pattern).
- **[openapi.yaml](apps/customer-portal/backend/openapi.yaml)**: Regenerated via `bal openapi -i service.bal` — adds the `/recommendations` path and `RecommendationRequest`, `RecommendationResponse`, `RecommendationItem`, `ConversationData`, `Message`, and `Role` schemas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a POST /recommendations API that accepts conversation data (chat history with roles and timestamps, environment/products, region, tier) and returns ranked recommendation items (201). Returns 400/500 on errors.

* **Bug Fixes / Data**
  * Updated account and case response field constraints to better represent missing or nullable values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->