### PR TITLE
[Customer Portal][BE] Add relatedCaseId support in case creation and return related case information

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -267,7 +267,7 @@ public type CaseCreatePayload record {|
     # Severity key (required for DEFAULT_CASE)
     int severityKey?;
     # Related case ID (if the case is related to an existing case)
-    IdString parentCaseId?;
+    IdString relatedCaseId?;
     # Conversation ID (if the case is related to a conversation)
     IdString conversationId?;
     # Catalog ID (required for SERVICE_REQUEST)
@@ -440,8 +440,10 @@ public type CaseMetaData record {|
     ReferenceTableItem? deployedProduct;
     # Assigned engineer
     ReferenceTableItem? assignedEngineer;
-    # Related case information (if the case is related to an existing case)
+    # Parent case information
     ReferenceTableItem? parentCase;
+    # Related case information
+    ReferenceTableItem? relatedCase;
     # Conversation information (if the case is related to a conversation)
     ReferenceTableItem? conversation;
 |};
@@ -479,9 +481,11 @@ public type CaseResponse record {|
     ReferenceTableItem? caseType;
     # Assigned engineer
     ReferenceTableItem? assignedEngineer;
-    # Related case information (if the case is related to an existing case)
+    # Parent case information
     ReferenceTableItem? parentCase;
-    # Conversation information (if the case is related to a conversation)
+    # Related case information
+    ReferenceTableItem? relatedCase;
+    # Conversation information
     ReferenceTableItem? conversation;
     # Deployment information
     record {

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -125,9 +125,11 @@ public type CaseResponse record {|
     ReferenceItem? 'type;
     # Assigned engineer
     ReferenceItem? assignedEngineer;
-    # Related case information (if the case is related to an existing case)
+    # Parent case information
     ReferenceItem? parentCase;
-    # Conversation information (if the case is related to a conversation)
+    # Related case information
+    ReferenceItem? relatedCase;
+    # Conversation information
     ReferenceItem? conversation;
     # Deployment information
     record {
@@ -200,9 +202,11 @@ public type CaseMetaData record {|
     ReferenceItem? deployedProduct;
     # Assigned engineer
     ReferenceItem? assignedEngineer;
-    # Related case information (if the case is related to an existing case)
+    # Parent case information
     ReferenceItem? parentCase;
-    # Conversation information (if the case is related to a conversation)
+    # Related case information
+    ReferenceItem? relatedCase;
+    # Conversation information
     ReferenceItem? conversation;
 |};
 

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -3019,7 +3019,7 @@ components:
           type: integer
           description: Severity key (required for DEFAULT_CASE)
           format: int64
-        parentCaseId:
+        relatedCaseId:
           $ref: '#/components/schemas/IdString'
         conversationId:
           $ref: '#/components/schemas/IdString'
@@ -3053,6 +3053,7 @@ components:
         - deployment
         - parentCase
         - project
+        - relatedCase
         - slaResponseTime
         - type
         - updatedOn
@@ -3081,13 +3082,17 @@ components:
             allOf:
             - $ref: '#/components/schemas/ReferenceItem'
           parentCase:
-            description: Related case information (if the case is related to an existing
-              case)
+            description: Parent case information
+            nullable: true
+            allOf:
+            - $ref: '#/components/schemas/ReferenceItem'
+          relatedCase:
+            description: Related case information
             nullable: true
             allOf:
             - $ref: '#/components/schemas/ReferenceItem'
           conversation:
-            description: Conversation information (if the case is related to a conversation)
+            description: Conversation information
             nullable: true
             allOf:
             - $ref: '#/components/schemas/ReferenceItem'

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -57,6 +57,7 @@ public isolated function searchCases(string idToken, string projectId, types:Cas
         let entity:ReferenceTableItem? deployment = case.deployment
         let entity:ReferenceTableItem? assignedEngineer = case.assignedEngineer
         let entity:ReferenceTableItem? parentCase = case.parentCase
+        let entity:ReferenceTableItem? relatedCase = case.relatedCase
         let entity:ReferenceTableItem? conversation = case.conversation
         let entity:ChoiceListItem? severity = case.severity
         let entity:ChoiceListItem? state = case.state
@@ -81,6 +82,7 @@ public isolated function searchCases(string idToken, string projectId, types:Cas
             deployment: deployment != () ? {id: deployment.id, label: deployment.name} : (),
             assignedEngineer: assignedEngineer != () ? {id: assignedEngineer.id, label: assignedEngineer.name} : (),
             parentCase: parentCase != () ? {id: parentCase.id, label: parentCase.name} : (),
+            relatedCase: relatedCase != () ? {id: relatedCase.id, label: relatedCase.name} : (),
             conversation: conversation != () ? {id: conversation.id, label: conversation.name} : (),
             severity: severity != () ? {id: severity.id.toString(), label: severity.label} : (),
             status: state != () ? {id: state.id.toString(), label: state.label} : (),
@@ -543,6 +545,7 @@ public isolated function mapCaseResponse(entity:CaseResponse response) returns t
     entity:ChoiceListItem? issueType = response.issueType;
     entity:ReferenceTableItem? assignedEngineer = response.assignedEngineer;
     entity:ReferenceTableItem? parentCase = response.parentCase;
+    entity:ReferenceTableItem? relatedCase = response.relatedCase;
     entity:ReferenceTableItem? conversation = response.conversation;
     entity:ChoiceListItem? severity = response.severity;
     entity:ChoiceListItem? state = response.state;
@@ -570,6 +573,7 @@ public isolated function mapCaseResponse(entity:CaseResponse response) returns t
         issueType: issueType != () ? {id: issueType.id.toString(), label: issueType.label} : (),
         assignedEngineer: assignedEngineer != () ? {id: assignedEngineer.id, label: assignedEngineer.name} : (),
         parentCase: parentCase != () ? {id: parentCase.id, label: parentCase.name} : (),
+        relatedCase: relatedCase != () ? {id: relatedCase.id, label: relatedCase.name} : (),
         conversation: conversation != () ? {id: conversation.id, label: conversation.name} : (),
         severity: severity != () ? {id: severity.id.toString(), label: severity.label} : (),
         status: state != () ? {id: state.id.toString(), label: state.label} : (),


### PR DESCRIPTION
## Summary
This PR updates the case creation flow to use `relatedCaseId` instead of `parentCaseId` and enhances the case response to include related case information.

## Changes

### 1️⃣ Case Creation Payload Update
- Replaced `parentCaseId` with `relatedCaseId` in case create payload
- Updated request DTOs/records and validation logic
- Adjusted service-layer mappings

Reason:
`relatedCaseId` better represents the relationship between cases compared to `parentCaseId`, providing more flexibility in linking cases.

---

### 2️⃣ Case Response Enhancement
- Extended case response to include related case information
- Updated DTOs and mapping logic
- Ensured consistent serialization

Reason:
Including related case details improves:
- Case traceability
- UI display and navigation between related cases
- Reduced need for additional API calls

## Impact
⚠ Potential breaking change:
- Payload field renamed (`parentCaseId` → `relatedCaseId`)

Consumers must update their requests accordingly.

## Testing
- Verified case creation with `relatedCaseId`
- Tested scenarios with and without related case
- Confirmed related case information is returned in response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved case relationship functionality to distinguish between parent and related cases in the system.
  * Enhanced case metadata structure for clearer relationship tracking.

* **API Changes**
  * Updated case creation and response structures to support separate parent and related case references.
  * Refined API documentation for improved clarity in case operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->