### PR TITLE
[Customer Portal][FE][Web] add preview URL support, enforce owner-only attachment actions, and align dashboard/deployments display rules

### DIFF
--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
@@ -25,16 +25,11 @@ import {
   Typography,
   Chip,
   Paper,
-  Avatar,
   TablePagination,
   alpha,
 } from "@wso2/oxygen-ui";
 import { type JSX } from "react";
-import {
-  getInitials,
-  getStatusColor,
-  mapSeverityToDisplay,
-} from "@features/support/utils/support";
+import { getStatusColor, mapSeverityToDisplay } from "@features/support/utils/support";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import CasesTableSkeleton from "@features/dashboard/components/cases-table/CasesTableSkeleton";
@@ -147,11 +142,7 @@ const CasesList = ({
                       typeof assignedEngineerValue === "string"
                         ? assignedEngineerValue.trim()
                         : assignedEngineerValue?.label?.trim() || "";
-                    const assignedEngineerDisplay =
-                      assignedEngineerName || "Not available";
-                    const assignedEngineerInitials = assignedEngineerName
-                      ? getInitials(assignedEngineerName)
-                      : "";
+                    const assignedEngineerDisplay = assignedEngineerName || "--";
 
                     return (
                       <>
@@ -209,14 +200,9 @@ const CasesList = ({
                     })()}
                   </TableCell>
                   <TableCell>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                      <Avatar sx={{ width: 24, height: 24, fontSize: 12 }}>
-                        {assignedEngineerInitials}
-                      </Avatar>
-                      <Typography variant="body2" color="text.primary">
-                        {assignedEngineerDisplay}
-                      </Typography>
-                    </Box>
+                    <Typography variant="body2" color="text.primary">
+                      {assignedEngineerDisplay}
+                    </Typography>
                   </TableCell>
                   <TableCell>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesList.test.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesList.test.tsx
@@ -320,6 +320,6 @@ describe("CasesList", () => {
     // Note: title is rendered inside a Typography, date has two display parts
     const dashes = screen.getAllByText("--");
     expect(dashes.length).toBeGreaterThanOrEqual(3);
-    expect(screen.getByText("Not available")).toBeInTheDocument();
+    expect(dashes.length).toBeGreaterThanOrEqual(5);
   });
 });

--- a/apps/customer-portal/webapp/src/features/dashboard/utils/__tests__/dashboardCharts.test.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/utils/__tests__/dashboardCharts.test.ts
@@ -124,6 +124,30 @@ describe("buildEngagementsPieSlices", () => {
     );
   });
 
+  it("hides zero-value Services, Follow up, and Improvements only", () => {
+    const slices = buildEngagementsPieSlices(
+      {
+        categories: [
+          { name: "Services", value: 0 },
+          { name: "Follow up", value: 0 },
+          { name: "Improvements", value: 0 },
+          { name: "Onboarding", value: 0 },
+          { name: "Migration", value: 0 },
+        ],
+        total: 0,
+      },
+      false,
+      false,
+      errorGrey,
+      fallbackGrey,
+    );
+    expect(slices.some((s) => s.name === "Services")).toBe(false);
+    expect(slices.some((s) => s.name === "Follow up")).toBe(false);
+    expect(slices.some((s) => s.name === "Improvements")).toBe(false);
+    expect(slices.some((s) => s.name === "Onboarding")).toBe(true);
+    expect(slices.some((s) => s.name === "Migration")).toBe(true);
+  });
+
   it("uses error grey when error and not loading", () => {
     const slices = buildEngagementsPieSlices(
       { categories: [], total: 0 },

--- a/apps/customer-portal/webapp/src/features/dashboard/utils/dashboardCharts.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/utils/dashboardCharts.ts
@@ -299,14 +299,27 @@ export function buildEngagementsPieSlices(
         color: isError && !isLoading ? errorGrey : item.color,
       }));
     default:
-      return safeData.categories.map((category, index) => ({
+      return safeData.categories
+        .filter((category) => {
+          const normalized = category.name.trim().toLowerCase();
+          switch (normalized) {
+            case "services":
+            case "improvements":
+            case "follow up":
+            case "follow-up":
+              return category.value > 0;
+            default:
+              return true;
+          }
+        })
+        .map((category, index) => ({
         name: category.name,
         value: category.value,
         color:
           colorByLabel.get(category.name.toLowerCase()) ??
           fallbackColors[index % fallbackColors.length] ??
           fallbackGrey,
-      }));
+        }));
   }
 }
 

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentDocumentList.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentDocumentList.tsx
@@ -42,6 +42,7 @@ import { useState, useMemo, type JSX } from "react";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useDeleteAttachment } from "@features/support/api/useDeleteAttachment";
 import { useGetAttachment } from "@api/useGetAttachment";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import UploadAttachmentModal from "@case-details-attachments/UploadAttachmentModal";
@@ -73,6 +74,7 @@ export default function DeploymentDocumentList({
   deploymentId,
 }: DeploymentDocumentListProps): JSX.Element {
   const { showError } = useErrorBanner();
+  const { data: userDetails } = useGetUserDetails();
   const queryClient = useQueryClient();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const {
@@ -85,6 +87,7 @@ export default function DeploymentDocumentList({
   } = useInfiniteDeploymentDocuments(deploymentId);
 
   const documents = flattenDeploymentDocuments(data);
+  const currentUserEmail = userDetails?.email?.trim().toLowerCase() ?? "";
 
   const handleAddSuccess = () => {
     setIsAddModalOpen(false);
@@ -158,6 +161,7 @@ export default function DeploymentDocumentList({
               key={doc.id}
               doc={doc}
               deploymentId={deploymentId}
+              currentUserEmail={currentUserEmail}
               onError={showError}
             />
           ))}
@@ -263,6 +267,7 @@ function DocumentsSkeleton(): JSX.Element {
 function DocumentRow({
   doc,
   deploymentId,
+  currentUserEmail,
   onError,
 }: DeploymentDocumentRowProps): JSX.Element {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -276,6 +281,10 @@ function DocumentRow({
   const uploadedBy = displayValue(
     doc.uploadedBy ?? doc.createdBy,
     PROJECT_DETAILS_NOT_AVAILABLE_DISPLAY,
+  );
+  const isOwner = Boolean(
+    currentUserEmail &&
+      doc.createdBy?.trim().toLowerCase() === currentUserEmail,
   );
   const sizeStr = formatBytes(sizeBytes);
   const category = doc.category;
@@ -407,22 +416,26 @@ function DocumentRow({
               </Box>
             </Box>
             <Box sx={{ display: "flex", gap: 0.25, flexShrink: 0 }}>
-              <IconButton
-                size="small"
-                aria-label={`Edit ${name}`}
-                sx={{ color: "text.secondary" }}
-                onClick={() => setEditModalOpen(true)}
-              >
-                <PencilLine size={16} aria-hidden />
-              </IconButton>
-              <IconButton
-                size="small"
-                aria-label={`Delete ${name}`}
-                sx={{ color: "text.secondary" }}
-                onClick={() => setDeleteModalOpen(true)}
-              >
-                <Trash2 size={16} aria-hidden />
-              </IconButton>
+              {isOwner && (
+                <>
+                  <IconButton
+                    size="small"
+                    aria-label={`Edit ${name}`}
+                    sx={{ color: "text.secondary" }}
+                    onClick={() => setEditModalOpen(true)}
+                  >
+                    <PencilLine size={16} aria-hidden />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    aria-label={`Delete ${name}`}
+                    sx={{ color: "text.secondary" }}
+                    onClick={() => setDeleteModalOpen(true)}
+                  >
+                    <Trash2 size={16} aria-hidden />
+                  </IconButton>
+                </>
+              )}
               <IconButton
                 size="small"
                 aria-label={`Download ${name}`}

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentProductList.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentProductList.tsx
@@ -100,7 +100,6 @@ function ProductsSkeleton(): JSX.Element {
                   }}
                 >
                   <Skeleton variant="text" width="42%" height={22} />
-                  <Skeleton variant="rounded" width={56} height={20} />
                 </Box>
                 <Skeleton
                   variant="text"
@@ -330,13 +329,6 @@ function ProductItemRow({
 }: DeploymentProductItemRowProps): JSX.Element {
   const emptyVal = "Not Available";
   const name = displayValue(item.product?.label, emptyVal);
-  const versionLabel =
-    typeof item.version === "object" && item.version?.label
-      ? item.version.label
-      : typeof item.version === "string"
-        ? item.version
-        : "";
-  const version = displayValue(versionLabel, emptyVal);
   const description = displayValue(item.description, emptyVal);
   const coresStr =
     typeof item.cores === "number"
@@ -431,12 +423,6 @@ function ProductItemRow({
               >
                 {name}
               </Typography>
-              <Chip
-                label={version}
-                size="small"
-                variant="outlined"
-                sx={{ height: 20, fontSize: "0.75rem" }}
-              />
             </Box>
             <Typography
               variant="caption"

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/__tests__/DeploymentDocumentList.test.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/__tests__/DeploymentDocumentList.test.tsx
@@ -31,6 +31,7 @@ const mockDocuments: DeploymentDocument[] = [
     sizeBytes: 1048576, // 1 MB
     uploadedAt: "2026-01-12",
     uploadedBy: "John Doe",
+    createdBy: "john.doe@example.com",
   },
   {
     id: "doc-2",
@@ -39,6 +40,7 @@ const mockDocuments: DeploymentDocument[] = [
     sizeBytes: 2097152, // 2 MB
     uploadedAt: "2026-01-15",
     uploadedBy: "Jane Smith",
+    createdBy: "john.doe@example.com",
   },
 ];
 
@@ -110,6 +112,15 @@ vi.mock("@features/project-details/api/useInfiniteDeploymentDocuments", () => ({
 vi.mock("@case-details-attachments/UploadAttachmentModal", () => ({
   default: ({ open }: { open: boolean }) =>
     open ? <div data-testid="upload-modal">Upload Modal</div> : null,
+}));
+
+vi.mock("@features/settings/api/useGetUserDetails", () => ({
+  __esModule: true,
+  default: () => ({
+    data: { email: "john.doe@example.com" },
+    isLoading: false,
+    isError: false,
+  }),
 }));
 
 const queryClient = new QueryClient({

--- a/apps/customer-portal/webapp/src/features/project-details/types/deployments.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/deployments.ts
@@ -50,6 +50,7 @@ export type DeploymentDocument = {
   createdBy?: string;
   content?: string | null;
   downloadUrl?: string;
+  previewUrl?: string | null;
 };
 
 // Response type for GET /deployments/:deploymentId/attachments.

--- a/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
@@ -168,6 +168,7 @@ export type DeploymentDocumentListProps = {
 export type DeploymentDocumentRowProps = {
   doc: DeploymentDocument;
   deploymentId: string;
+  currentUserEmail: string;
   onError: (message: string) => void;
 };
 

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
@@ -26,6 +26,7 @@ import type { CaseAttachment } from "@features/support/types/cases";
 import { useDeleteAttachment } from "@features/support/api/useDeleteAttachment";
 import { useGetAttachment } from "@api/useGetAttachment";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import UploadAttachmentModal from "@case-details-attachments/UploadAttachmentModal";
 import AttachmentListItem from "@case-details-attachments/AttachmentListItem";
 import AttachmentsListSkeleton from "@case-details-attachments/AttachmentsListSkeleton";
@@ -48,6 +49,7 @@ export default function CaseDetailsAttachmentsPanel({
   isCaseClosed = false,
 }: CaseDetailsAttachmentsPanelProps): JSX.Element {
   const { showError } = useErrorBanner();
+  const { data: userDetails } = useGetUserDetails();
   const { downloadAttachment, isDownloading, downloadingId } =
     useGetAttachment();
   const [uploadOpen, setUploadOpen] = useState(false);
@@ -70,6 +72,7 @@ export default function CaseDetailsAttachmentsPanel({
   const deleteAttachment = useDeleteAttachment();
 
   const allAttachments = useMemo(() => flattenCaseAttachments(data), [data]);
+  const currentUserEmail = userDetails?.email?.trim().toLowerCase() ?? "";
 
   const totalRecords = data?.pages?.[0]?.totalRecords ?? 0;
   const totalPages = Math.ceil(totalRecords / ITEMS_PER_PAGE);
@@ -222,17 +225,25 @@ export default function CaseDetailsAttachmentsPanel({
             {isFetchingNextPage && paginatedAttachments.length === 0 ? (
               <AttachmentsListSkeleton />
             ) : (
-              paginatedAttachments.map((att) => (
-                <AttachmentListItem
-                  key={att.id}
-                  attachment={att}
-                  onDownload={handleDownload}
-                  onDelete={isCaseClosed ? undefined : handleDeleteClick}
-                  onEdit={isCaseClosed ? undefined : handleEditClick}
-                  hideDescription
-                  isDownloadLoading={isDownloading && downloadingId === att.id}
-                />
-              ))
+              paginatedAttachments.map((att) => {
+                // Only the uploader can edit/delete their own attachments.
+                const createdByEmail = att.createdBy?.trim().toLowerCase() ?? "";
+                const isOwner =
+                  createdByEmail.length > 0 &&
+                  currentUserEmail.length > 0 &&
+                  createdByEmail === currentUserEmail;
+                return (
+                  <AttachmentListItem
+                    key={att.id}
+                    attachment={att}
+                    onDownload={handleDownload}
+                    onDelete={isCaseClosed || !isOwner ? undefined : handleDeleteClick}
+                    onEdit={isCaseClosed || !isOwner ? undefined : handleEditClick}
+                    hideDescription
+                    isDownloadLoading={isDownloading && downloadingId === att.id}
+                  />
+                );
+              })
             )}
             {totalPages > 1 && (
               <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/__tests__/CaseDetailsAttachmentsPanel.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/__tests__/CaseDetailsAttachmentsPanel.test.tsx
@@ -86,6 +86,15 @@ vi.mock("@features/support/api/useGetCaseAttachments", () => ({
     data?.pages?.flatMap((p: any) => p.attachments ?? []) ?? [],
 }));
 
+vi.mock("@features/settings/api/useGetUserDetails", () => ({
+  __esModule: true,
+  default: () => ({
+    data: { email: "admin@test.com" },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 function renderPanel(caseId = "case-1") {
   return render(
     <QueryClientProvider client={queryClient}>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/calls-tab/CallRequestCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/calls-tab/CallRequestCard.tsx
@@ -45,7 +45,7 @@ import {
 function formatPreferredTimes(
   times: string[] | undefined,
   userTimeZone?: string,
-) : string[] {
+): string[] {
   if (!times?.length) return ["--"];
   const formatted = times
     .map((time) => formatUtcToLocal(time, "short", false, userTimeZone))
@@ -86,7 +86,10 @@ export default function CallRequestCard({
   const resolvedColor = isCancelled
     ? theme.palette.error.main
     : resolveColorFromTheme(colorPath, theme);
-  const preferredTimeLines = formatPreferredTimes(call.preferredTimes, userTimeZone);
+  const preferredTimeLines = formatPreferredTimes(
+    call.preferredTimes,
+    userTimeZone,
+  );
 
   return (
     <Card variant="outlined">
@@ -271,8 +274,8 @@ export default function CallRequestCard({
                   pl: 2.5,
                 }}
               >
-                {preferredTimeLines.map((timeValue) => (
-                  <Box component="li" key={timeValue}>
+                {preferredTimeLines.map((timeValue, index) => (
+                  <Box component="li" key={`${index}-${timeValue}`}>
                     <Typography variant="body2">{timeValue}</Typography>
                   </Box>
                 ))}

--- a/apps/customer-portal/webapp/src/features/support/types/attachments.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/attachments.ts
@@ -22,6 +22,7 @@ export type CaseCommentInlineAttachment = AuditMetadata & {
   fileName: string;
   contentType: string;
   downloadUrl: string;
+  previewUrl?: string | null;
   sys_id?: string;
   url?: string;
 };
@@ -35,6 +36,7 @@ export type AttachmentDownloadResponse = AuditMetadata & {
   type: string;
   sizeBytes?: number;
   downloadUrl?: string | null;
+  previewUrl?: string | null;
   description?: string | null;
 };
 

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -290,6 +290,7 @@ export type CaseAttachment = AuditMetadata & {
   sizeBytes?: string;
   content?: string | null;
   downloadUrl?: string | null;
+  previewUrl?: string | null;
 };
 
 // Response type for case attachments list.

--- a/apps/customer-portal/webapp/src/features/support/types/supportInlineAttachment.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportInlineAttachment.ts
@@ -20,7 +20,8 @@
  */
 export type InlineAttachment = {
   id?: string;
-  downloadUrl?: string;
-  sys_id?: string;
-  url?: string;
+  downloadUrl?: string | null;
+  previewUrl?: string | null;
+  sys_id?: string | null;
+  url?: string | null;
 };

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/support.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/support.test.ts
@@ -863,6 +863,20 @@ describe("support utils", () => {
       expect(result).toContain("https://cdn.example.com/att.png");
     });
 
+    it("should prefer previewUrl over downloadUrl for inline image rendering", () => {
+      const html = '<img src="/att456.iix">';
+      const attachments = [
+        {
+          id: "att456",
+          previewUrl: "https://cdn.example.com/att-preview.png",
+          downloadUrl: "https://cdn.example.com/att-download.png",
+        },
+      ];
+      const result = replaceInlineImageSources(html, attachments);
+      expect(result).toContain("https://cdn.example.com/att-preview.png");
+      expect(result).not.toContain("https://cdn.example.com/att-download.png");
+    });
+
     it("should use same-origin .iix as img src without adding a download URL fallback attr", () => {
       const html =
         '<img src="https://wso2sndev.wso2.com/att456.iix" alt="inline">';

--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -1279,7 +1279,7 @@ function resolveInlineImageDisplaySrc(
   if (originMatch && id) {
     return `${originMatch[1]}/${id}.iix`;
   }
-  return attachment.downloadUrl ?? attachment.url ?? originalSrc;
+  return attachment.previewUrl ?? attachment.downloadUrl ?? attachment.url ?? originalSrc;
 }
 
 /**


### PR DESCRIPTION
### Description

This pull request introduces several enhancements to improve security, media handling, and overall UI consistency. Edit and Delete actions for documents and attachments are now restricted to their original creators, ensuring proper ownership verification. Inline image rendering has been improved by prioritizing preview URLs when available, resulting in more reliable display of images. Additionally, UI refinements include updated fallback text in the cases table for better clarity, removal of the product version chip to simplify the interface, and improved engagement pie chart filtering to exclude zero-value categories, making the visualization more accurate and easier to read.