### PR TITLE
[Customer Portal][FE][Web] Refactor: remove severity from Engagements + add visibility controls to list components

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/CaseCardDescriptionClamp.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/CaseCardDescriptionClamp.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Typography, type SxProps, type Theme } from "@wso2/oxygen-ui";
+import DOMPurify from "dompurify";
+import type { JSX, MouseEvent } from "react";
+import {
+  isAnnouncementDescriptionEffectivelyEmpty,
+  normalizeAnnouncementDescriptionHtml,
+} from "@features/announcements/utils/announcements";
+
+export type CaseCardDescriptionClampProps = {
+  description: string | null | undefined;
+  /** Shown when description is empty or whitespace-only after normalization. */
+  emptyLabel?: string;
+  /** Merged after base styles (e.g. `overflowWrap`, `minWidth`). */
+  sx?: SxProps<Theme>;
+  /**
+   * When true, render nothing if there is no visible description (no placeholder
+   * row). Used on compact overview cards next to a title line.
+   */
+  hideWhenEmpty?: boolean;
+};
+
+const baseHtmlSx: SxProps<Theme> = {
+  typography: "body2",
+  color: "text.secondary",
+  mb: 2,
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  overflow: "hidden",
+  wordBreak: "break-word",
+  minWidth: 0,
+  overflowWrap: "anywhere",
+  "& p": { mb: 0.5 },
+  "& p:last-child": { mb: 0 },
+  "& a": {
+    color: "primary.main",
+    textDecoration: "underline",
+  },
+  "& code": {
+    display: "inline",
+    fontSize: "0.875rem",
+    whiteSpace: "pre-wrap",
+    overflowWrap: "break-word",
+  },
+};
+
+/**
+ * Two-line clamped HTML description for case-style list cards (sanitized; link
+ * clicks do not bubble to parent `Form.CardButton`).
+ *
+ * @param props - Raw API description and optional empty label / sx overrides.
+ * @returns {JSX.Element | null} Plain placeholder, sanitized HTML block, or null.
+ */
+export default function CaseCardDescriptionClamp({
+  description,
+  emptyLabel = "--",
+  sx,
+  hideWhenEmpty = false,
+}: CaseCardDescriptionClampProps): JSX.Element | null {
+  const isEmpty =
+    !description || isAnnouncementDescriptionEffectivelyEmpty(description);
+
+  if (hideWhenEmpty && isEmpty) {
+    return null;
+  }
+
+  if (isEmpty) {
+    const emptySx = [({ mb: 2 } as const), ...(sx ? [sx] : [])] as SxProps<Theme>;
+    return (
+      <Typography variant="body2" color="text.secondary" sx={emptySx}>
+        {emptyLabel}
+      </Typography>
+    );
+  }
+
+  const htmlSx = [baseHtmlSx, ...(sx ? [sx] : [])] as SxProps<Theme>;
+
+  return (
+    <Box
+      component="div"
+      onClick={(e: MouseEvent) => {
+        if ((e.target as HTMLElement).closest("a")) {
+          e.stopPropagation();
+        }
+      }}
+      sx={htmlSx}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized with DOMPurify
+      dangerouslySetInnerHTML={{
+        __html: DOMPurify.sanitize(
+          normalizeAnnouncementDescriptionHtml(description),
+        ),
+      }}
+    />
+  );
+}

--- a/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
@@ -27,6 +27,7 @@ import { Calendar, FileText, User } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, KeyboardEvent } from "react";
 import type { CaseListItem } from "@features/support/types/cases";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
+import CaseCardDescriptionClamp from "@components/list-view/CaseCardDescriptionClamp";
 import {
   formatDateTime,
   getAssignedEngineerLabel,
@@ -35,7 +36,6 @@ import {
   hasSeverityLabelForChip,
   mapSeverityToDisplay,
   resolveColorFromTheme,
-  stripHtml,
 } from "@features/support/utils/support";
 
 export interface ListCardProps {
@@ -167,22 +167,7 @@ export default function ListCard({
         >
           {caseItem.title || "--"}
         </Typography>
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{
-            mb: 2,
-            display: "-webkit-box",
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
-            overflowWrap: "anywhere",
-            wordBreak: "break-word",
-            minWidth: 0,
-          }}
-        >
-          {stripHtml(caseItem.description) || "--"}
-        </Typography>
+        <CaseCardDescriptionClamp description={caseItem.description} />
       </Form.CardContent>
 
       <Form.CardActions

--- a/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
@@ -32,6 +32,7 @@ import {
   getAssignedEngineerLabel,
   getStatusColor,
   getStatusIcon,
+  hasSeverityLabelForChip,
   mapSeverityToDisplay,
   resolveColorFromTheme,
   stripHtml,
@@ -52,6 +53,7 @@ export interface ListCardProps {
 export default function ListCard({
   caseItem,
   onClick,
+  hideSeverity = false,
 }: ListCardProps): JSX.Element {
   const theme = useTheme();
   const StatusIcon = getStatusIcon(caseItem.status?.label);
@@ -96,27 +98,29 @@ export default function ListCard({
             <Typography variant="body2" fontWeight={500} color="text.primary">
               {caseItem.number || "--"}
             </Typography>
-            <Chip
-              label={mapSeverityToDisplay(caseItem.severity?.label)}
-              size="small"
-              variant="outlined"
-              sx={{
-                bgcolor: alpha(
-                  getSeverityLegendColor(caseItem.severity?.label),
-                  0.1,
-                ),
-                color: getSeverityLegendColor(caseItem.severity?.label),
-                borderColor: alpha(
-                  getSeverityLegendColor(caseItem.severity?.label),
-                  0.3,
-                ),
-                fontWeight: 500,
-                px: 0,
-                height: 20,
-                fontSize: "0.75rem",
-                "& .MuiChip-label": { pl: "6px", pr: "6px" },
-              }}
-            />
+            {!hideSeverity && hasSeverityLabelForChip(caseItem.severity?.label) && (
+              <Chip
+                label={mapSeverityToDisplay(caseItem.severity?.label)}
+                size="small"
+                variant="outlined"
+                sx={{
+                  bgcolor: alpha(
+                    getSeverityLegendColor(caseItem.severity?.label),
+                    0.1,
+                  ),
+                  color: getSeverityLegendColor(caseItem.severity?.label),
+                  borderColor: alpha(
+                    getSeverityLegendColor(caseItem.severity?.label),
+                    0.3,
+                  ),
+                  fontWeight: 500,
+                  px: 0,
+                  height: 20,
+                  fontSize: "0.75rem",
+                  "& .MuiChip-label": { pl: "6px", pr: "6px" },
+                }}
+              />
+            )}
             <Chip
               size="small"
               variant="outlined"

--- a/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
@@ -41,6 +41,7 @@ import {
 export interface ListCardProps {
   caseItem: CaseListItem;
   onClick?: (caseItem: CaseListItem) => void;
+  hideSeverity?: boolean;
 }
 
 /**

--- a/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
@@ -67,6 +67,7 @@ export default function ListFilters({
   onFilterChange,
   excludeS0 = false,
   restrictSeverityToLow = false,
+  hideSeverityFilter = false,
   onLoadMoreDeployments,
   hasMoreDeployments = false,
   isFetchingMoreDeployments = false,
@@ -82,6 +83,9 @@ export default function ListFilters({
   return (
     <Grid container spacing={2} sx={{ mt: 1 }}>
       {ALL_CASES_FILTER_DEFINITIONS.map((def) => {
+        if (hideSeverityFilter && def.id === "severity") {
+          return null;
+        }
         if (def.metadataKey === "severities" && restrictSeverityToLow) {
           return null;
         }

--- a/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
@@ -49,6 +49,7 @@ export interface ListFiltersProps {
   onFilterChange: (field: string, value: string) => void;
   excludeS0?: boolean;
   restrictSeverityToLow?: boolean;
+  hideSeverityFilter?: boolean;
   onLoadMoreDeployments?: () => void;
   hasMoreDeployments?: boolean;
   isFetchingMoreDeployments?: boolean;

--- a/apps/customer-portal/webapp/src/components/list-view/ListItems.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListItems.tsx
@@ -30,6 +30,7 @@ export interface ListItemsProps {
   hasListRefinement?: boolean;
   onCaseClick?: (caseItem: CaseListItem) => void;
   entityName?: string;
+  hideSeverity?: boolean;
 }
 
 /**
@@ -45,6 +46,7 @@ export default function ListItems({
   hasListRefinement = false,
   onCaseClick,
   entityName = "items",
+  hideSeverity = false,
 }: ListItemsProps): JSX.Element {
   if (isLoading) {
     return <ListSkeleton />;
@@ -113,7 +115,12 @@ export default function ListItems({
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       {cases.map((caseItem) => (
-        <ListCard key={caseItem.id} caseItem={caseItem} onClick={onCaseClick} />
+        <ListCard
+          key={caseItem.id}
+          caseItem={caseItem}
+          onClick={onCaseClick}
+          hideSeverity={hideSeverity}
+        />
       ))}
     </Box>
   );

--- a/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
@@ -39,6 +39,7 @@ export interface ListSearchPanelProps {
   onClearFilters: () => void;
   excludeS0?: boolean;
   restrictSeverityToLow?: boolean;
+  hideSeverityFilter?: boolean;
   isProjectContextLoading?: boolean;
   onLoadMoreDeployments?: () => void;
   hasMoreDeployments?: boolean;
@@ -64,11 +65,15 @@ export default function ListSearchPanel({
   onClearFilters,
   excludeS0 = false,
   restrictSeverityToLow = false,
+  hideSeverityFilter = false,
   isProjectContextLoading = false,
   onLoadMoreDeployments,
   hasMoreDeployments = false,
   isFetchingMoreDeployments = false,
 }: ListSearchPanelProps): JSX.Element {
+  const filtersForCount = hideSeverityFilter
+    ? { ...filters, severityId: undefined }
+    : filters;
   return (
     <ListSearchBar
       searchPlaceholder={searchPlaceholder}
@@ -76,7 +81,10 @@ export default function ListSearchPanel({
       onSearchChange={onSearchChange}
       isFiltersOpen={isFiltersOpen}
       onFiltersToggle={onFiltersToggle}
-      activeFiltersCount={countListSearchAndFilters(searchTerm, filters)}
+      activeFiltersCount={countListSearchAndFilters(
+        searchTerm,
+        filtersForCount,
+      )}
       onClearFilters={onClearFilters}
       isLoading={isProjectContextLoading}
       filtersContent={
@@ -87,6 +95,7 @@ export default function ListSearchPanel({
           onFilterChange={onFilterChange}
           excludeS0={excludeS0}
           restrictSeverityToLow={restrictSeverityToLow}
+          hideSeverityFilter={hideSeverityFilter}
           onLoadMoreDeployments={onLoadMoreDeployments}
           hasMoreDeployments={hasMoreDeployments}
           isFetchingMoreDeployments={isFetchingMoreDeployments}

--- a/apps/customer-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/apiConstants.ts
@@ -81,7 +81,24 @@ export const WS_CHOREO_OAUTH2_TOKEN = "choreo-oauth2-token";
 export const WS_CUSTOMER_PORTAL = "cs-customer-portal";
 export const CONNECT_HANDSHAKE_TIMEOUT_MS = 25_000;
 
+/**
+ * Backoff delays (ms) between ID-token retrieval attempts inside
+ * `useAuthApiClient` (`resolveIdTokenWithRetry`). Array length equals the
+ * maximum number of token retrieval attempts before surfacing failure.
+ */
 export const TOKEN_RETRY_DELAYS_MS = [150, 300, 600, 1000] as const;
 
+/**
+ * Asgardeo SPA SDK internal error code when `getIdToken()` runs before the auth
+ * client is ready (observed with `@asgardeo/auth-react`; value may change on SDK
+ * upgrades — re-verify against SDK release notes if token retrieval misbehaves).
+ */
 export const ASGARDEO_UNAUTHENTICATED_CODE = "SPA-AUTH_CLIENT-VM-IV02";
+
+/**
+ * Synthetic error message thrown when ID token cannot be obtained after retries
+ * because auth is not ready (`getIdToken` kept returning unauthenticated).
+ * Used by `useGetUserDetails` and other callers to retry without treating as a
+ * hard failure.
+ */
 export const AUTH_NOT_READY_ERROR_MESSAGE = "Authentication is not ready yet";

--- a/apps/customer-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/apiConstants.ts
@@ -80,3 +80,8 @@ export const ApiMutationKeys = {
 export const WS_CHOREO_OAUTH2_TOKEN = "choreo-oauth2-token";
 export const WS_CUSTOMER_PORTAL = "cs-customer-portal";
 export const CONNECT_HANDSHAKE_TIMEOUT_MS = 25_000;
+
+export const TOKEN_RETRY_DELAYS_MS = [150, 300, 600, 1000] as const;
+
+export const ASGARDEO_UNAUTHENTICATED_CODE = "SPA-AUTH_CLIENT-VM-IV02";
+export const AUTH_NOT_READY_ERROR_MESSAGE = "Authentication is not ready yet";

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -44,6 +44,7 @@ import {
   ANNOUNCEMENTS_BACK_LABEL,
 } from "@features/announcements/constants/announcementsConstants";
 import {
+  formatAnnouncementDateDisplay,
   isAnnouncementDescriptionEffectivelyEmpty,
   normalizeAnnouncementDescriptionHtml,
 } from "@features/announcements/utils/announcements";
@@ -118,6 +119,7 @@ export default function AnnouncementDetailsPanel({
   const statusColorPath = getStatusColor(statusLabel ?? undefined);
   const resolvedStatusColor = resolveColorFromTheme(statusColorPath, theme);
   const statusChipIcon = getStatusIconElement(statusLabel, 12);
+  const createdOnLabel = formatAnnouncementDateDisplay(data.createdOn);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -201,7 +203,7 @@ export default function AnnouncementDetailsPanel({
               aria-hidden
             />
             <Typography variant="body2" color="text.secondary">
-              {data.createdOn || "--"}
+              {createdOnLabel}
             </Typography>
           </Stack>
           {data.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -30,7 +30,6 @@ import { ArrowLeft, Calendar, FileText } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ReactElement } from "react";
 import CaseDetailsActionRow from "@features/support/components/case-details/header/CaseDetailsActionRow";
 import {
-  formatUtcToLocalNoTimezone,
   getStatusColor,
   getStatusIconElement,
   resolveColorFromTheme,
@@ -202,7 +201,7 @@ export default function AnnouncementDetailsPanel({
               aria-hidden
             />
             <Typography variant="body2" color="text.secondary">
-              {formatUtcToLocalNoTimezone(data.createdOn) || "--"}
+              {data.createdOn || "--"}
             </Typography>
           </Stack>
           {data.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -17,12 +17,13 @@
 import { Box, Chip, Form, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { Calendar, FileText } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
+import CaseCardDescriptionClamp from "@components/list-view/CaseCardDescriptionClamp";
 import {
-  stripHtml,
   getStatusColor,
   getStatusIconElement,
   resolveColorFromTheme,
 } from "@features/support/utils/support";
+import { formatAnnouncementDateDisplay } from "@features/announcements/utils/announcements";
 
 import ListSkeleton from "@components/list-view/ListSkeleton";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
@@ -97,6 +98,7 @@ export default function AnnouncementList({
         const statusColor = getStatusColor(statusLabel);
         const resolvedStatusColor = resolveColorFromTheme(statusColor, theme);
         const statusChipIcon = getStatusIconElement(statusLabel, 12);
+        const createdOnLabel = formatAnnouncementDateDisplay(caseItem.createdOn);
 
         const cardContent = (
           <>
@@ -155,19 +157,7 @@ export default function AnnouncementList({
                 {caseItem.title || "--"}
               </Typography>
 
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{
-                  mb: 2,
-                  display: "-webkit-box",
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: "vertical",
-                  overflow: "hidden",
-                }}
-              >
-                {stripHtml(caseItem.description) || "--"}
-              </Typography>
+              <CaseCardDescriptionClamp description={caseItem.description} />
             </Form.CardContent>
 
             <Form.CardActions
@@ -200,7 +190,7 @@ export default function AnnouncementList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    Created {caseItem.createdOn || "--"}
+                    Created {createdOnLabel}
                   </Typography>
                 </Box>
                 {caseItem.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -18,7 +18,6 @@ import { Box, Chip, Form, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { Calendar, FileText } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import {
-  formatUtcToLocalNoTimezone,
   stripHtml,
   getStatusColor,
   getStatusIconElement,
@@ -201,7 +200,7 @@ export default function AnnouncementList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    Created {formatUtcToLocalNoTimezone(caseItem.createdOn)}
+                    Created {caseItem.createdOn || "--"}
                   </Typography>
                 </Box>
                 {caseItem.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
@@ -203,7 +203,9 @@ export function normalizeAnnouncementDescriptionHtml(html: string): string {
  * @param html - Raw or normalized HTML.
  * @returns Whether the description should show the empty placeholder.
  */
-export function isAnnouncementDescriptionEffectivelyEmpty(html: string): boolean {
+export function isAnnouncementDescriptionEffectivelyEmpty(
+  html: string,
+): boolean {
   const normalizedHtml = normalizeAnnouncementDescriptionHtml(html);
   const normalizedText = normalizedHtml
     .replace(/<br\s*\/?>/gi, "")
@@ -211,4 +213,32 @@ export function isAnnouncementDescriptionEffectivelyEmpty(html: string): boolean
     .replace(/<[^>]*>/g, "")
     .trim();
   return !normalizedText;
+}
+
+/**
+ * Formats an API date string (ISO or ServiceNow-style `YYYY-MM-DD HH:mm:ss`) for
+ * list and detail views using the runtime locale.
+ *
+ * @param raw - Raw timestamp from the API.
+ * @returns Formatted date/time or `"--"` when missing or unparsable.
+ */
+export function formatAnnouncementDateDisplay(
+  raw: string | null | undefined,
+): string {
+  if (raw == null || String(raw).trim() === "") {
+    return "--";
+  }
+  try {
+    const normalized = String(raw).trim().replace(" ", "T");
+    const date = new Date(normalized);
+    if (Number.isNaN(date.getTime())) {
+      return "--";
+    }
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(date);
+  } catch {
+    return "--";
+  }
 }

--- a/apps/customer-portal/webapp/src/features/engagements/components/EngagementsListSection.tsx
+++ b/apps/customer-portal/webapp/src/features/engagements/components/EngagementsListSection.tsx
@@ -73,6 +73,7 @@ export default function EngagementsListSection({
         onClearFilters={onClearFilters}
         excludeS0={excludeS0}
         restrictSeverityToLow={restrictSeverityToLow}
+        hideSeverityFilter
         isProjectContextLoading={isProjectContextLoading}
       />
 
@@ -94,6 +95,7 @@ export default function EngagementsListSection({
         hasListRefinement={listHasRefinement}
         entityName={ENGAGEMENTS_LIST_ENTITY_LABEL}
         onCaseClick={onCaseClick}
+        hideSeverity
       />
 
       <ListPagination

--- a/apps/customer-portal/webapp/src/features/engagements/constants/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/constants/engagements.ts
@@ -79,6 +79,5 @@ export const ENGAGEMENTS_STAT_CARDS_CONFIG: SupportStatConfig<EngagementsStatKey
 export const ENGAGEMENTS_SORT_OPTIONS: readonly EngagementsSortOption[] = [
   { value: EngagementsSortField.CreatedOn, label: "Created on" },
   { value: EngagementsSortField.UpdatedOn, label: "Updated on" },
-  { value: EngagementsSortField.Severity, label: "Severity" },
   { value: EngagementsSortField.State, label: "State" },
 ];

--- a/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
@@ -59,14 +59,6 @@ export function useEngagementsPageState() {
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.DESC);
   const [page, setPage] = useState(1);
 
-  useEffect(() => {
-    setSortField((prev) =>
-      prev === EngagementsSortField.Severity
-        ? EngagementsSortField.CreatedOn
-        : prev,
-    );
-  }, []);
-
   const { data: project, isLoading: isProjectLoading } = useGetProjectDetails(
     projectId || "",
   );

--- a/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
@@ -59,6 +59,14 @@ export function useEngagementsPageState() {
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.DESC);
   const [page, setPage] = useState(1);
 
+  useEffect(() => {
+    setSortField((prev) =>
+      prev === EngagementsSortField.Severity
+        ? EngagementsSortField.CreatedOn
+        : prev,
+    );
+  }, []);
+
   const { data: project, isLoading: isProjectLoading } = useGetProjectDetails(
     projectId || "",
   );
@@ -192,7 +200,10 @@ export function useEngagementsPageState() {
     setPage(1);
   };
 
-  const listHasRefinement = hasListSearchOrFilters(searchTerm, filters);
+  const listHasRefinement = hasListSearchOrFilters(searchTerm, {
+    ...filters,
+    severityId: undefined,
+  });
 
   const onCaseClick =
     projectId !== undefined

--- a/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
@@ -68,6 +68,16 @@ describe("buildEngagementSearchRequest", () => {
     );
     expect(req.filters?.severityId).toBeUndefined();
   });
+
+  it("normalizes legacy Severity sort field to CreatedOn in API payload", () => {
+    const req = buildEngagementSearchRequest(
+      {},
+      "",
+      EngagementsSortField.Severity,
+      SortOrder.DESC,
+    );
+    expect(req.sortBy?.field).toBe(EngagementsSortField.CreatedOn);
+  });
 });
 
 describe("buildEngagementDetailPath", () => {

--- a/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
@@ -38,6 +38,12 @@ describe("parseEngagementsSortField", () => {
       EngagementsSortField.State,
     );
   });
+
+  it("maps legacy Severity sort to CreatedOn", () => {
+    expect(parseEngagementsSortField(EngagementsSortField.Severity)).toBe(
+      EngagementsSortField.CreatedOn,
+    );
+  });
 });
 
 describe("buildEngagementSearchRequest", () => {
@@ -51,6 +57,16 @@ describe("buildEngagementSearchRequest", () => {
     expect(req.filters?.caseTypes).toEqual([CaseType.ENGAGEMENT]);
     expect(req.sortBy?.field).toBe(EngagementsSortField.CreatedOn);
     expect(req.sortBy?.order).toBe(SortOrder.DESC);
+  });
+
+  it("does not send severity filter", () => {
+    const req = buildEngagementSearchRequest(
+      { severityId: "99" },
+      "",
+      EngagementsSortField.CreatedOn,
+      SortOrder.DESC,
+    );
+    expect(req.filters?.severityId).toBeUndefined();
   });
 });
 

--- a/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
@@ -68,6 +68,11 @@ export function buildEngagementSearchRequest(
   sortField: EngagementsSortField,
   sortOrder: SortOrder,
 ): Omit<CaseSearchRequest, "pagination"> {
+  const normalizedSortField =
+    sortField === EngagementsSortField.Severity
+      ? EngagementsSortField.CreatedOn
+      : sortField;
+
   return {
     filters: {
       caseTypes: [CaseType.ENGAGEMENT],
@@ -77,7 +82,7 @@ export function buildEngagementSearchRequest(
       searchQuery: searchTerm.trim() || undefined,
     },
     sortBy: {
-      field: sortField,
+      field: normalizedSortField,
       order: sortOrder,
     },
   };

--- a/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
@@ -44,9 +44,10 @@ export function parseEngagementsSortField(value: string): EngagementsSortField {
   switch (value) {
     case EngagementsSortField.CreatedOn:
     case EngagementsSortField.UpdatedOn:
-    case EngagementsSortField.Severity:
     case EngagementsSortField.State:
       return value;
+    case EngagementsSortField.Severity:
+      return EngagementsSortField.CreatedOn;
     default:
       return EngagementsSortField.CreatedOn;
   }
@@ -71,7 +72,6 @@ export function buildEngagementSearchRequest(
     filters: {
       caseTypes: [CaseType.ENGAGEMENT],
       statusIds: filters.statusId ? [Number(filters.statusId)] : undefined,
-      severityId: filters.severityId ? Number(filters.severityId) : undefined,
       issueId: filters.issueTypes ? Number(filters.issueTypes) : undefined,
       deploymentId: filters.deploymentId || undefined,
       searchQuery: searchTerm.trim() || undefined,

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
@@ -165,27 +165,6 @@ export default function ChangeRequestsList({
                   }}
                 />
               )}
-              {item.state?.label && (
-                <Chip
-                  icon={<StatusIcon size={12} />}
-                  label={item.state.label}
-                  size="small"
-                  sx={{
-                    bgcolor: alpha(statusColor, 0.1),
-                    color: statusColor,
-                    borderColor: alpha(statusColor, 0.2),
-                    border: "1px solid",
-                    height: 22,
-                    fontSize: "0.75rem",
-                    fontWeight: 500,
-                    "& .MuiChip-icon": {
-                      color: statusColor,
-                      ml: "6px",
-                      mr: "-2px",
-                    },
-                  }}
-                />
-              )}
             </Box>
 
             <Box sx={{ flex: 1, minWidth: 0, order: 1 }}>
@@ -243,6 +222,27 @@ export default function ChangeRequestsList({
                 >
                   {item.number || CHANGE_REQUESTS_LIST_PLACEHOLDER}
                 </Typography>
+                {item.state?.label && (
+                  <Chip
+                    icon={<StatusIcon size={12} />}
+                    label={item.state.label}
+                    size="small"
+                    sx={{
+                      bgcolor: alpha(statusColor, 0.1),
+                      color: statusColor,
+                      borderColor: alpha(statusColor, 0.2),
+                      border: "1px solid",
+                      height: 22,
+                      fontSize: "0.75rem",
+                      fontWeight: 500,
+                      "& .MuiChip-icon": {
+                        color: statusColor,
+                        ml: "6px",
+                        mr: "-2px",
+                      },
+                    }}
+                  />
+                )}
                 {item.case?.number && (
                   <>
                     <Typography variant="body2" color="text.disabled">

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsListSkeleton.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsListSkeleton.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Skeleton, Card } from "@wso2/oxygen-ui";
+import { Box, Form, Skeleton } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 
 /**
@@ -26,7 +26,7 @@ export default function ChangeRequestsListSkeleton(): JSX.Element {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       {[...Array(5)].map((_, index) => (
-        <Card
+        <Form.CardButton
           key={index}
           sx={{
             p: 3,
@@ -37,7 +37,6 @@ export default function ChangeRequestsListSkeleton(): JSX.Element {
             gap: 3,
           }}
         >
-          {/* Right Section - Status badges */}
           <Box
             sx={{
               display: "flex",
@@ -47,48 +46,46 @@ export default function ChangeRequestsListSkeleton(): JSX.Element {
               order: 2,
             }}
           >
-            <Skeleton variant="rounded" width={60} height={22} />
-            <Skeleton variant="rounded" width={80} height={22} />
+            <Skeleton variant="rounded" width={72} height={22} />
           </Box>
 
-          {/* Left Section */}
           <Box sx={{ flex: 1, minWidth: 0, order: 1 }}>
-            {/* Title */}
             <Box sx={{ mb: 1.5 }}>
               <Skeleton variant="text" width="60%" height={24} />
             </Box>
 
-            {/* Details row */}
             <Box
               sx={{
                 display: "flex",
                 alignItems: "center",
                 gap: 1.5,
                 mb: 1.5,
+                flexWrap: "wrap",
               }}
             >
               <Skeleton variant="text" width={100} height={20} />
+              <Skeleton variant="rounded" width={88} height={22} />
               <Skeleton variant="text" width={8} height={20} />
               <Skeleton variant="text" width={90} height={20} />
               <Skeleton variant="text" width={8} height={20} />
               <Skeleton variant="text" width={120} height={20} />
             </Box>
 
-            {/* Date/Time row */}
             <Box
               sx={{
                 display: "flex",
                 alignItems: "center",
                 gap: 1.5,
+                flexWrap: "wrap",
               }}
             >
               <Skeleton variant="text" width={150} height={20} />
               <Skeleton variant="text" width={8} height={20} />
               <Skeleton variant="text" width={150} height={20} />
-              <Skeleton variant="rounded" width={50} height={20} />
+              <Skeleton variant="rounded" width={56} height={20} />
             </Box>
           </Box>
-        </Card>
+        </Form.CardButton>
       ))}
     </Box>
   );

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/OutstandingChangeRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/OutstandingChangeRequestsList.tsx
@@ -17,7 +17,6 @@
 import { Box, Chip, Form, Typography, alpha } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 import type { OutstandingChangeRequestsListProps } from "@features/operations/types/changeRequests";
-import { NULL_PLACEHOLDER } from "@constants/common";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import { formatRelativeTime } from "@features/support/utils/support";
 import OutstandingChangeRequestsSkeleton from "./OutstandingChangeRequestsSkeleton";
@@ -91,9 +90,49 @@ export default function OutstandingChangeRequestsList({
           <Form.CardHeader
             sx={{ p: 0 }}
             title={
-              <Typography variant="body2" fontWeight={500} color="text.primary">
-                {cr.number}
-              </Typography>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexWrap: "wrap",
+                }}
+              >
+                <Typography variant="body2" fontWeight={500} color="text.primary">
+                  {cr.number}
+                </Typography>
+                {cr.state?.label
+                  ? (() => {
+                      const statusColor = getChangeRequestStateColor(cr.state);
+                      const StatusIcon = getChangeRequestStateIcon(cr.state);
+                      return (
+                        <Chip
+                          icon={<StatusIcon size={12} />}
+                          label={cr.state.label}
+                          size="small"
+                          variant="outlined"
+                          sx={{
+                            bgcolor: alpha(statusColor, 0.1),
+                            color: statusColor,
+                            px: 0,
+                            height: 20,
+                            fontSize: "0.75rem",
+                            fontWeight: 500,
+                            "& .MuiChip-icon": {
+                              color: statusColor,
+                              ml: "6px",
+                              mr: "6px",
+                            },
+                            "& .MuiChip-label": {
+                              pl: 0,
+                              pr: "6px",
+                            },
+                          }}
+                        />
+                      );
+                    })()
+                  : null}
+              </Box>
             }
           />
           <Form.CardContent sx={{ p: 0 }}>
@@ -116,47 +155,12 @@ export default function OutstandingChangeRequestsList({
           <Form.CardActions
             sx={{
               p: 0,
-              justifyContent: "space-between",
+              justifyContent: "flex-end",
               alignItems: "center",
               flexWrap: "wrap",
               gap: 1,
             }}
           >
-            {cr.state?.label ? (
-              (() => {
-                const statusColor = getChangeRequestStateColor(cr.state);
-                const StatusIcon = getChangeRequestStateIcon(cr.state);
-                return (
-                  <Chip
-                    icon={<StatusIcon size={12} />}
-                    label={cr.state.label}
-                    size="small"
-                    variant="outlined"
-                    sx={{
-                      bgcolor: alpha(statusColor, 0.1),
-                      color: statusColor,
-                      px: 0,
-                      height: 20,
-                      fontSize: "0.75rem",
-                      fontWeight: 500,
-                      "& .MuiChip-icon": {
-                        color: statusColor,
-                        ml: "6px",
-                        mr: "6px",
-                      },
-                      "& .MuiChip-label": {
-                        pl: 0,
-                        pr: "6px",
-                      },
-                    }}
-                  />
-                );
-              })()
-            ) : (
-              <Typography variant="caption" color="text.secondary">
-                {NULL_PLACEHOLDER}
-              </Typography>
-            )}
             <Typography variant="caption" color="text.secondary">
               {formatRelativeTime(cr.createdOn ?? undefined)}
             </Typography>

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/OutstandingChangeRequestsSkeleton.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/OutstandingChangeRequestsSkeleton.tsx
@@ -36,19 +36,33 @@ export default function OutstandingChangeRequestsSkeleton(): JSX.Element {
             display: "flex",
             flexDirection: "column",
             alignItems: "stretch",
-            gap: 1.5,
+            gap: 1,
           }}
         >
-          <Skeleton variant="text" width={60} height={20} />
+          <Form.CardHeader
+            sx={{ p: 0 }}
+            title={
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexWrap: "wrap",
+                }}
+              >
+                <Skeleton variant="text" width={60} height={20} />
+                <Skeleton variant="rounded" width={72} height={20} />
+              </Box>
+            }
+          />
           <Skeleton variant="text" width="90%" height={24} />
           <Box
             sx={{
               display: "flex",
-              justifyContent: "space-between",
+              justifyContent: "flex-end",
               alignItems: "center",
             }}
           >
-            <Skeleton variant="rounded" width={80} height={20} />
             <Skeleton variant="text" width={100} height={16} />
           </Box>
         </Form.CardButton>

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
@@ -26,13 +26,13 @@ import {
 import { Calendar, Layers, Package, Users } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import { NULL_PLACEHOLDER } from "@constants/common";
+import CaseCardDescriptionClamp from "@components/list-view/CaseCardDescriptionClamp";
 import {
   formatDateTime,
   getAssignedEngineerLabel,
   getStatusColor,
   getStatusIcon,
   resolveColorFromTheme,
-  stripHtml,
 } from "@features/support/utils/support";
 import ServiceRequestsListSkeleton from "@features/operations/components/service-requests/ServiceRequestsListSkeleton";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
@@ -190,19 +190,10 @@ export default function ServiceRequestsList({
                 {sr.title || NULL_PLACEHOLDER}
               </Typography>
 
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{
-                  mb: 2,
-                  display: "-webkit-box",
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: "vertical",
-                  overflow: "hidden",
-                }}
-              >
-                {stripHtml(sr.description) || NULL_PLACEHOLDER}
-              </Typography>
+              <CaseCardDescriptionClamp
+                description={sr.description}
+                emptyLabel={NULL_PLACEHOLDER}
+              />
             </Form.CardContent>
 
             <Form.CardActions

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
@@ -29,10 +29,8 @@ import { NULL_PLACEHOLDER } from "@constants/common";
 import {
   formatDateTime,
   getAssignedEngineerLabel,
-  getSeverityColor,
   getStatusColor,
   getStatusIcon,
-  mapSeverityToDisplay,
   resolveColorFromTheme,
   stripHtml,
 } from "@features/support/utils/support";
@@ -146,24 +144,6 @@ export default function ServiceRequestsList({
                   >
                     {sr.number || NULL_PLACEHOLDER}
                   </Typography>
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 0.5,
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        width: 8,
-                        height: 8,
-                        bgcolor: getSeverityColor(sr.severity?.label),
-                      }}
-                    />
-                    <Typography variant="caption" color="text.secondary">
-                      {mapSeverityToDisplay(sr.severity?.label)}
-                    </Typography>
-                  </Box>
                   <Chip
                     size="small"
                     variant="outlined"

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsListSkeleton.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsListSkeleton.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, Stack, Skeleton } from "@wso2/oxygen-ui";
+import { Box, Form, Skeleton, Stack } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 
 /**
@@ -26,24 +26,48 @@ export default function ServiceRequestsListSkeleton(): JSX.Element {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       {[1, 2, 3, 4, 5].map((i) => (
-        <Card key={i} sx={{ p: 3 }}>
-          <Box sx={{ mb: 1 }}>
-            <Stack direction="row" spacing={1.5} sx={{ mb: 1 }}>
-              <Skeleton variant="text" width={80} height={20} />
-              <Skeleton variant="text" width={60} height={20} />
-              <Skeleton variant="rounded" width={70} height={20} />
-              <Skeleton variant="rounded" width={100} height={20} />
-            </Stack>
+        <Form.CardButton
+          key={i}
+          sx={{
+            p: 3,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "stretch",
+            gap: 1,
+          }}
+        >
+          <Form.CardHeader
+            sx={{ p: 0 }}
+            title={
+              <Stack
+                direction="row"
+                spacing={1.5}
+                alignItems="center"
+                sx={{ mb: 1, flexWrap: "wrap" }}
+              >
+                <Skeleton variant="text" width={72} height={20} />
+                <Skeleton variant="rounded" width={88} height={20} />
+                <Skeleton variant="rounded" width={96} height={20} />
+              </Stack>
+            }
+          />
+          <Form.CardContent sx={{ p: 0 }}>
             <Skeleton variant="text" width="70%" height={32} sx={{ mb: 1 }} />
             <Skeleton variant="text" width="90%" height={20} />
             <Skeleton variant="text" width="85%" height={20} />
-            <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
-              <Skeleton variant="text" width={120} height={16} />
-              <Skeleton variant="text" width={150} height={16} />
-              <Skeleton variant="text" width={100} height={16} />
-            </Stack>
-          </Box>
-        </Card>
+          </Form.CardContent>
+          <Form.CardActions
+            sx={{
+              p: 0,
+              justifyContent: "space-between",
+              flexWrap: "wrap",
+              gap: 2,
+            }}
+          >
+            <Skeleton variant="text" width={120} height={16} />
+            <Skeleton variant="text" width={100} height={16} />
+          </Form.CardActions>
+        </Form.CardButton>
       ))}
     </Box>
   );

--- a/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
@@ -320,10 +320,6 @@ export const SERVICE_REQUESTS_SORT_FIELD_OPTIONS: ServiceRequestSortFieldOption[
       label: "Updated on",
     },
     {
-      value: ServiceRequestCaseSortField.Severity,
-      label: "Severity",
-    },
-    {
       value: ServiceRequestCaseSortField.State,
       label: "State",
     },

--- a/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestDetailsPage.tsx
@@ -63,8 +63,6 @@ import { formatDateTime } from "@features/support/utils/support";
 import {
   formatImpactLabel,
   getChangeRequestImpactColorShades,
-  getChangeRequestStateColorShades,
-  getChangeRequestStateIcon,
 } from "@features/operations/utils/changeRequestUi";
 
 /**
@@ -109,8 +107,6 @@ export default function ChangeRequestDetailsPage(): JSX.Element {
   const impactColor = getChangeRequestImpactColorShades(
     changeRequest?.impact?.label,
   );
-  const statusColor = getChangeRequestStateColorShades(changeRequest?.state);
-
   const handleApproveChange = () => {
     if (!changeRequest || decisionMode === ChangeRequestDecisionMode.NONE)
       return;
@@ -184,12 +180,6 @@ export default function ChangeRequestDetailsPage(): JSX.Element {
   if (!changeRequest) {
     return <ChangeRequestDetailsLoadingSkeleton />;
   }
-
-  // Render state icon from stable id/label resolution
-  const renderStateIcon = () => {
-    const IconComponent = getChangeRequestStateIcon(changeRequest.state);
-    return <IconComponent size={12} />;
-  };
 
   const renderHtmlContent = (
     html: string | null | undefined,
@@ -324,23 +314,6 @@ export default function ChangeRequestDetailsPage(): JSX.Element {
                           color: impactColor.text,
                           borderColor: impactColor.border,
                           border: "1px solid",
-                        }}
-                      />
-                    )}
-                  {changeRequest.state?.label &&
-                    typeof changeRequest.state.label === "string" && (
-                      <Chip
-                        icon={renderStateIcon()}
-                        label={String(changeRequest.state.label)}
-                        size="small"
-                        sx={{
-                          bgcolor: statusColor.bg,
-                          color: statusColor.text,
-                          borderColor: statusColor.border,
-                          border: "1px solid",
-                          "& .MuiChip-icon": {
-                            color: statusColor.text,
-                          },
                         }}
                       />
                     )}

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
@@ -103,14 +103,6 @@ export default function ServiceRequestsPage(): JSX.Element {
   const [page, setPage] = useState(1);
   const pageSize = OPERATIONS_LIST_PAGE_SIZE;
 
-  useEffect(() => {
-    setSortField((prev) =>
-      prev === ServiceRequestCaseSortField.Severity
-        ? ServiceRequestCaseSortField.CreatedOn
-        : prev,
-    );
-  }, []);
-
   const { data: project, isLoading: isProjectLoading } = useGetProjectDetails(
     projectId || "",
   );

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
@@ -103,6 +103,14 @@ export default function ServiceRequestsPage(): JSX.Element {
   const [page, setPage] = useState(1);
   const pageSize = OPERATIONS_LIST_PAGE_SIZE;
 
+  useEffect(() => {
+    setSortField((prev) =>
+      prev === ServiceRequestCaseSortField.Severity
+        ? ServiceRequestCaseSortField.CreatedOn
+        : prev,
+    );
+  }, []);
+
   const { data: project, isLoading: isProjectLoading } = useGetProjectDetails(
     projectId || "",
   );
@@ -274,7 +282,10 @@ export default function ServiceRequestsPage(): JSX.Element {
     }
   }, [projectDetailsReady, permissions.hasDeployments, filters.deploymentId]);
 
-  const listHasRefinement = hasListSearchOrFilters(searchTerm, filters);
+  const listHasRefinement = hasListSearchOrFilters(searchTerm, {
+    ...filters,
+    severityId: undefined,
+  });
 
   const handleNewServiceRequest = () => {
     navigate(`/projects/${projectId}/${navSegment}/service-requests/create`);
@@ -365,6 +376,7 @@ export default function ServiceRequestsPage(): JSX.Element {
         onClearFilters={handleClearFilters}
         excludeS0={excludeS0}
         restrictSeverityToLow={restrictSeverityToLow}
+        hideSeverityFilter
         isProjectContextLoading={isProjectContextLoading}
       />
 
@@ -385,6 +397,7 @@ export default function ServiceRequestsPage(): JSX.Element {
         isError={isCasesError}
         hasListRefinement={listHasRefinement}
         entityName={SERVICE_REQUESTS_ENTITY_LABEL}
+        hideSeverity
         onCaseClick={(c) =>
           navigate(
             `/projects/${projectId}/${navSegment}/service-requests/${c.id}`,

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
@@ -122,6 +122,17 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
     );
     expect(req.filters?.severityId).toBeUndefined();
   });
+
+  it("normalizes legacy Severity sort field to CreatedOn in API payload", () => {
+    const req = buildServiceRequestsPageCaseSearchRequest(
+      {},
+      "",
+      ServiceRequestCaseSortField.Severity,
+      SortOrder.DESC,
+      false,
+    );
+    expect(req.sortBy?.field).toBe(ServiceRequestCaseSortField.CreatedOn);
+  });
 });
 
 describe("formatOperationsOverviewServiceRequestsSubtitle", () => {

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
@@ -111,6 +111,17 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
     expect(req.filters?.caseTypes).toEqual([CaseType.SERVICE_REQUEST]);
     expect(req.sortBy?.field).toBe("createdOn");
   });
+
+  it("does not send severity filter", () => {
+    const req = buildServiceRequestsPageCaseSearchRequest(
+      { severityId: "99" },
+      "",
+      ServiceRequestCaseSortField.CreatedOn,
+      SortOrder.DESC,
+      false,
+    );
+    expect(req.filters?.severityId).toBeUndefined();
+  });
 });
 
 describe("formatOperationsOverviewServiceRequestsSubtitle", () => {

--- a/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
@@ -161,7 +161,6 @@ export function buildServiceRequestsPageCaseSearchRequest(
     filters: {
       caseTypes: [CaseType.SERVICE_REQUEST],
       statusIds: filters.statusId ? [Number(filters.statusId)] : undefined,
-      severityId: filters.severityId ? Number(filters.severityId) : undefined,
       issueId: filters.issueTypes ? Number(filters.issueTypes) : undefined,
       deploymentId: filters.deploymentId || undefined,
       searchQuery: searchTerm.trim() || undefined,

--- a/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
@@ -157,6 +157,11 @@ export function buildServiceRequestsPageCaseSearchRequest(
   sortOrder: SortOrder,
   createdByMe: boolean,
 ): Omit<CaseSearchRequest, "pagination"> {
+  const normalizedSortField =
+    sortField === ServiceRequestCaseSortField.Severity
+      ? ServiceRequestCaseSortField.CreatedOn
+      : sortField;
+
   return {
     filters: {
       caseTypes: [CaseType.SERVICE_REQUEST],
@@ -167,7 +172,7 @@ export function buildServiceRequestsPageCaseSearchRequest(
       createdByMe: createdByMe || undefined,
     },
     sortBy: {
-      field: sortField,
+      field: normalizedSortField,
       order: sortOrder,
     },
   };

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentDocumentList.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentDocumentList.tsx
@@ -60,7 +60,10 @@ import {
   DEPLOYMENT_DOCUMENT_IMAGE_FILE_REGEX,
   PROJECT_DETAILS_NOT_AVAILABLE_DISPLAY,
 } from "@features/project-details/constants/projectDetailsConstants";
-import { DEPLOYMENT_DOCUMENT_DELETE_TOOLTIP_NOT_OWNER } from "@features/support/constants/supportConstants";
+import {
+  DEPLOYMENT_DOCUMENT_DELETE_TOOLTIP_NOT_OWNER,
+  DEPLOYMENT_DOCUMENT_EDIT_TOOLTIP_NOT_OWNER,
+} from "@features/support/constants/supportConstants";
 import type {
   DeploymentDocumentListProps,
   DeploymentDocumentRowProps,
@@ -418,14 +421,32 @@ function DocumentRow({
               </Box>
             </Box>
             <Box sx={{ display: "flex", gap: 0.25, flexShrink: 0 }}>
-              <IconButton
-                size="small"
-                aria-label={`Edit ${name}`}
-                sx={{ color: "text.secondary" }}
-                onClick={() => setEditModalOpen(true)}
-              >
-                <PencilLine size={16} aria-hidden />
-              </IconButton>
+              {!isOwner ? (
+                <Tooltip
+                  title={DEPLOYMENT_DOCUMENT_EDIT_TOOLTIP_NOT_OWNER}
+                  arrow
+                >
+                  <span>
+                    <IconButton
+                      size="small"
+                      aria-label={`Edit ${name}`}
+                      sx={{ color: "text.secondary" }}
+                      disabled
+                    >
+                      <PencilLine size={16} aria-hidden />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              ) : (
+                <IconButton
+                  size="small"
+                  aria-label={`Edit ${name}`}
+                  sx={{ color: "text.secondary" }}
+                  onClick={() => setEditModalOpen(true)}
+                >
+                  <PencilLine size={16} aria-hidden />
+                </IconButton>
+              )}
               {!isOwner ? (
                 <Tooltip
                   title={DEPLOYMENT_DOCUMENT_DELETE_TOOLTIP_NOT_OWNER}

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentDocumentList.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentDocumentList.tsx
@@ -26,6 +26,7 @@ import {
   CircularProgress,
   IconButton,
   Skeleton,
+  Tooltip,
   Typography,
   alpha,
 } from "@wso2/oxygen-ui";
@@ -59,6 +60,7 @@ import {
   DEPLOYMENT_DOCUMENT_IMAGE_FILE_REGEX,
   PROJECT_DETAILS_NOT_AVAILABLE_DISPLAY,
 } from "@features/project-details/constants/projectDetailsConstants";
+import { DEPLOYMENT_DOCUMENT_DELETE_TOOLTIP_NOT_OWNER } from "@features/support/constants/supportConstants";
 import type {
   DeploymentDocumentListProps,
   DeploymentDocumentRowProps,
@@ -416,25 +418,39 @@ function DocumentRow({
               </Box>
             </Box>
             <Box sx={{ display: "flex", gap: 0.25, flexShrink: 0 }}>
-              {isOwner && (
-                <>
-                  <IconButton
-                    size="small"
-                    aria-label={`Edit ${name}`}
-                    sx={{ color: "text.secondary" }}
-                    onClick={() => setEditModalOpen(true)}
-                  >
-                    <PencilLine size={16} aria-hidden />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    aria-label={`Delete ${name}`}
-                    sx={{ color: "text.secondary" }}
-                    onClick={() => setDeleteModalOpen(true)}
-                  >
-                    <Trash2 size={16} aria-hidden />
-                  </IconButton>
-                </>
+              <IconButton
+                size="small"
+                aria-label={`Edit ${name}`}
+                sx={{ color: "text.secondary" }}
+                onClick={() => setEditModalOpen(true)}
+              >
+                <PencilLine size={16} aria-hidden />
+              </IconButton>
+              {!isOwner ? (
+                <Tooltip
+                  title={DEPLOYMENT_DOCUMENT_DELETE_TOOLTIP_NOT_OWNER}
+                  arrow
+                >
+                  <span>
+                    <IconButton
+                      size="small"
+                      aria-label={`Delete ${name}`}
+                      sx={{ color: "text.secondary" }}
+                      disabled
+                    >
+                      <Trash2 size={16} aria-hidden />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              ) : (
+                <IconButton
+                  size="small"
+                  aria-label={`Delete ${name}`}
+                  sx={{ color: "text.secondary" }}
+                  onClick={() => setDeleteModalOpen(true)}
+                >
+                  <Trash2 size={16} aria-hidden />
+                </IconButton>
               )}
               <IconButton
                 size="small"

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
@@ -102,7 +102,7 @@ export default function TimeTrackingCard({
             {label}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            Approved by: {reportedByName}
+            Reported by: {reportedByName}
           </Typography>
         </Box>
         <Box sx={{ textAlign: "right" }}>

--- a/apps/customer-portal/webapp/src/features/security/components/SecurityStats.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/SecurityStats.tsx
@@ -75,6 +75,7 @@ export default function SecurityStats(): JSX.Element {
         entityName={SECURITY_STATS_ENTITY_NAME}
         stats={stats}
         configs={SECURITY_STAT_CONFIGS}
+        itemSize={{ xs: 12, sm: 4, md: 4 }}
       />
     </Box>
   );

--- a/apps/customer-portal/webapp/src/features/settings/api/useGetUserDetails.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/useGetUserDetails.ts
@@ -54,9 +54,11 @@ const useGetUserDetails = (): UseQueryResult<UserDetails, Error> => {
         logger.debug(`[useGetUserDetails] Response status: ${response.status}`);
 
         if (!response.ok) {
-          throw new Error(
-            `Error fetching user details: ${response.statusText}`,
-          );
+          const err = new Error(
+            `Error fetching user details: ${response.status} ${response.statusText}`,
+          ) as Error & { status?: number };
+          err.status = response.status;
+          throw err;
         }
 
         const data = (await response.json()) as Record<string, unknown>;
@@ -82,9 +84,31 @@ const useGetUserDetails = (): UseQueryResult<UserDetails, Error> => {
       }
     },
     enabled: isSignedIn && !isAuthLoading,
-    retry: (failureCount, error) =>
-      error.message.includes(AUTH_NOT_READY_ERROR_MESSAGE) && failureCount < 4,
-    retryDelay: (attemptIndex) => Math.min(500 * 2 ** attemptIndex, 4000),
+    retry: (failureCount, error) => {
+      if (failureCount >= 3) {
+        return false;
+      }
+      if (
+        error instanceof Error &&
+        error.message.includes(AUTH_NOT_READY_ERROR_MESSAGE)
+      ) {
+        return true;
+      }
+      const status = (error as Error & { status?: number }).status;
+      if (typeof status === "number") {
+        if (status >= 500) {
+          return true;
+        }
+        if (status >= 400 && status < 500) {
+          return false;
+        }
+      }
+      if (error instanceof TypeError) {
+        return true;
+      }
+      return false;
+    },
+    retryDelay: (attemptIndex) => Math.min(400 * 2 ** attemptIndex, 3000),
     staleTime: 0,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/apps/customer-portal/webapp/src/features/settings/api/useGetUserDetails.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/useGetUserDetails.ts
@@ -19,6 +19,7 @@ import { useAsgardeo } from "@asgardeo/react";
 import { useAuthApiClient } from "@utils/useAuthApiClient";
 import type { UserDetails } from "@features/settings/types/users";
 import { useLogger } from "@hooks/useLogger";
+import { AUTH_NOT_READY_ERROR_MESSAGE } from "@constants/apiConstants";
 
 /**
  * Hook to get user details.
@@ -69,11 +70,21 @@ const useGetUserDetails = (): UseQueryResult<UserDetails, Error> => {
               : "";
         return { ...data, timeZone } as UserDetails;
       } catch (error) {
-        logger.error("[useGetUserDetails] Error:", error);
+        if (
+          error instanceof Error &&
+          error.message.includes(AUTH_NOT_READY_ERROR_MESSAGE)
+        ) {
+          logger.warn("[useGetUserDetails] Auth not ready yet; will retry.");
+        } else {
+          logger.error("[useGetUserDetails] Error:", error);
+        }
         throw error;
       }
     },
     enabled: isSignedIn && !isAuthLoading,
+    retry: (failureCount, error) =>
+      error.message.includes(AUTH_NOT_READY_ERROR_MESSAGE) && failureCount < 4,
+    retryDelay: (attemptIndex) => Math.min(500 * 2 ** attemptIndex, 4000),
     staleTime: 0,
     refetchOnWindowFocus: false,
     refetchOnMount: true,

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
@@ -198,16 +198,22 @@ export default function AttachmentListItem({
               cursor: "pointer",
               alignSelf: "flex-start",
               maxWidth: "100%",
+              maxHeight: 200,
+              overflow: "hidden",
+              display: "block",
             }}
           >
             <Box
               component="img"
               src={previewUrl}
               alt={attachment.name}
+              loading="lazy"
               sx={{
-                width: "auto",
                 maxWidth: "100%",
+                maxHeight: 200,
+                width: "auto",
                 height: "auto",
+                objectFit: "contain",
                 display: "block",
               }}
             />

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
@@ -21,6 +21,7 @@ import {
   IconButton,
   Paper,
   Stack,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import {
@@ -32,9 +33,13 @@ import {
   PencilLine,
   Trash2,
 } from "@wso2/oxygen-ui-icons-react";
-import type { JSX } from "react";
+import { useState, type JSX } from "react";
 import type { CaseAttachment } from "@features/support/types/cases";
-import { formatFileSize, getAttachmentFileCategory } from "@features/support/utils/support";
+import {
+  formatFileSize,
+  getAttachmentFileCategory,
+} from "@features/support/utils/support";
+import ImageFullscreenModal from "@case-details-activity/ImageFullscreenModal";
 
 // TODO: Use attachment category enum when introduced (see support.ts AttachmentFileCategory).
 function getAttachmentIcon(att: CaseAttachment): JSX.Element {
@@ -54,9 +59,10 @@ function getAttachmentIcon(att: CaseAttachment): JSX.Element {
 }
 
 /**
- * Single attachment row with icon, name, meta, and download button.
+ * Single attachment row: header (icon, name, actions), optional image preview (`previewUrl` only),
+ * then meta line. Clicking the preview opens the same fullscreen dialog as the activity tab.
  *
- * @param {AttachmentListItemProps} props - Attachment, handlers, optional download loading.
+ * @param {AttachmentListItemProps} props - Attachment, handlers, delete disabled/tooltip, download loading.
  * @returns {JSX.Element} The attachment list item.
  */
 export default function AttachmentListItem({
@@ -64,47 +70,155 @@ export default function AttachmentListItem({
   onDownload,
   onDelete,
   onEdit,
+  deleteDisabled = false,
+  deleteTooltip,
   hideDescription = false,
   isDownloadLoading = false,
 }: AttachmentListItemProps): JSX.Element {
-  return (
-    <Paper
-      variant="outlined"
-      sx={{
-        p: 2,
-        display: "flex",
-        alignItems: "center",
-        gap: 2,
-        "&:hover": {
-          bgcolor: "action.hover",
-        },
-      }}
+  const [fullscreenSrc, setFullscreenSrc] = useState<string | null>(null);
+  const attachmentCategory = getAttachmentFileCategory(
+    attachment.name ?? "",
+    attachment.type ?? "",
+  );
+  const previewUrl = attachment.previewUrl?.trim() ?? "";
+  const hasPreviewImage =
+    attachmentCategory === "image" && previewUrl.length > 0;
+
+  const deleteIconButton = onDelete ? (
+    <IconButton
+      size="small"
+      aria-label={`Delete ${attachment.name}`}
+      sx={{ color: "text.secondary" }}
+      disabled={deleteDisabled}
+      onClick={() => onDelete(attachment)}
     >
-      <Box
+      <Trash2 size={16} aria-hidden />
+    </IconButton>
+  ) : null;
+
+  const deleteButton =
+    deleteIconButton && deleteDisabled && deleteTooltip ? (
+      <Tooltip title={deleteTooltip} arrow>
+        <span>{deleteIconButton}</span>
+      </Tooltip>
+    ) : (
+      deleteIconButton
+    );
+
+  return (
+    <>
+      <Paper
+        variant="outlined"
         sx={{
-          width: 40,
-          height: 40,
-          bgcolor: "action.hover",
+          p: 2,
           display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "text.secondary",
-          flexShrink: 0,
+          flexDirection: "column",
+          alignItems: "stretch",
+          gap: 1.5,
+          "&:hover": {
+            bgcolor: "action.hover",
+          },
         }}
-        aria-hidden
       >
-        {getAttachmentIcon(attachment)}
-      </Box>
-      <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography variant="body2" color="text.primary" noWrap>
-          {attachment.name}
-        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 2,
+            minWidth: 0,
+          }}
+        >
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              bgcolor: "action.hover",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "text.secondary",
+              flexShrink: 0,
+            }}
+            aria-hidden
+          >
+            {getAttachmentIcon(attachment)}
+          </Box>
+          <Typography
+            variant="body2"
+            color="text.primary"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              fontWeight: 500,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {attachment.name}
+          </Typography>
+          <Stack direction="row" spacing={0.25} sx={{ flexShrink: 0 }}>
+            {onEdit && (
+              <IconButton
+                size="small"
+                aria-label={`Edit ${attachment.name}`}
+                sx={{ color: "text.secondary" }}
+                onClick={() => onEdit(attachment)}
+              >
+                <PencilLine size={16} aria-hidden />
+              </IconButton>
+            )}
+            {deleteButton}
+            <IconButton
+              size="small"
+              aria-label={`Download ${attachment.name}`}
+              aria-busy={isDownloadLoading || undefined}
+              sx={{ color: "text.secondary" }}
+              disabled={isDownloadLoading}
+              onClick={() => onDownload(attachment)}
+            >
+              {isDownloadLoading ? (
+                <CircularProgress color="inherit" size={16} aria-hidden />
+              ) : (
+                <Download size={16} aria-hidden />
+              )}
+            </IconButton>
+          </Stack>
+        </Box>
+
+        {hasPreviewImage && (
+          <Box
+            component="button"
+            type="button"
+            onClick={() => setFullscreenSrc(previewUrl)}
+            sx={{
+              m: 0,
+              p: 0,
+              border: "none",
+              background: "none",
+              cursor: "pointer",
+              alignSelf: "flex-start",
+              maxWidth: "100%",
+            }}
+          >
+            <Box
+              component="img"
+              src={previewUrl}
+              alt={attachment.name}
+              sx={{
+                width: "auto",
+                maxWidth: "100%",
+                height: "auto",
+                display: "block",
+              }}
+            />
+          </Box>
+        )}
+
         {!hideDescription && attachment.description && (
           <Typography
             variant="body2"
             color="text.secondary"
             sx={{
-              mt: 0.25,
               display: "-webkit-box",
               WebkitLineClamp: 2,
               WebkitBoxOrient: "vertical",
@@ -114,13 +228,8 @@ export default function AttachmentListItem({
             {attachment.description}
           </Typography>
         )}
-        <Stack
-          direction="row"
-          spacing={1}
-          alignItems="center"
-          flexWrap="wrap"
-          sx={{ mt: 0.5 }}
-        >
+
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
           <Typography variant="caption" color="text.secondary" component="span">
             {formatFileSize(attachment.size ?? attachment.sizeBytes)}
           </Typography>
@@ -137,43 +246,13 @@ export default function AttachmentListItem({
             {attachment.createdOn}
           </Typography>
         </Stack>
-      </Box>
-      <Stack direction="row" spacing={0.25}>
-        {onEdit && (
-          <IconButton
-            size="small"
-            aria-label={`Edit ${attachment.name}`}
-            sx={{ color: "text.secondary" }}
-            onClick={() => onEdit(attachment)}
-          >
-            <PencilLine size={16} aria-hidden />
-          </IconButton>
-        )}
-        {onDelete && (
-          <IconButton
-            size="small"
-            aria-label={`Delete ${attachment.name}`}
-            sx={{ color: "text.secondary" }}
-            onClick={() => onDelete(attachment)}
-          >
-            <Trash2 size={16} aria-hidden />
-          </IconButton>
-        )}
-        <IconButton
-          size="small"
-          aria-label={`Download ${attachment.name}`}
-          aria-busy={isDownloadLoading || undefined}
-          sx={{ color: "text.secondary" }}
-          disabled={isDownloadLoading}
-          onClick={() => onDownload(attachment)}
-        >
-          {isDownloadLoading ? (
-            <CircularProgress color="inherit" size={16} aria-hidden />
-          ) : (
-            <Download size={16} aria-hidden />
-          )}
-        </IconButton>
-      </Stack>
-    </Paper>
+      </Paper>
+
+      <ImageFullscreenModal
+        open={!!fullscreenSrc}
+        imageSrc={fullscreenSrc}
+        onClose={() => setFullscreenSrc(null)}
+      />
+    </>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
@@ -250,7 +250,9 @@ export default function CaseDetailsAttachmentsPanel({
                     onDelete={handleDeleteClick}
                     deleteDisabled={deleteDisabled}
                     deleteTooltip={deleteTooltip}
-                    onEdit={isCaseClosed ? undefined : handleEditClick}
+                    onEdit={
+                      isOwner && !isCaseClosed ? handleEditClick : undefined
+                    }
                     hideDescription
                     isDownloadLoading={isDownloading && downloadingId === att.id}
                   />

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
@@ -33,6 +33,10 @@ import AttachmentsListSkeleton from "@case-details-attachments/AttachmentsListSk
 import DeleteAttachmentModal from "@case-details-attachments/DeleteAttachmentModal";
 import EditCaseAttachmentModal from "@case-details-attachments/EditCaseAttachmentModal";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
+import {
+  ATTACHMENT_DELETE_TOOLTIP_CASE_CLOSED,
+  ATTACHMENT_DELETE_TOOLTIP_NOT_OWNER,
+} from "@features/support/constants/supportConstants";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -232,13 +236,21 @@ export default function CaseDetailsAttachmentsPanel({
                   createdByEmail.length > 0 &&
                   currentUserEmail.length > 0 &&
                   createdByEmail === currentUserEmail;
+                const deleteDisabled = isCaseClosed || !isOwner;
+                const deleteTooltip = isCaseClosed
+                  ? ATTACHMENT_DELETE_TOOLTIP_CASE_CLOSED
+                  : !isOwner
+                    ? ATTACHMENT_DELETE_TOOLTIP_NOT_OWNER
+                    : undefined;
                 return (
                   <AttachmentListItem
                     key={att.id}
                     attachment={att}
                     onDownload={handleDownload}
-                    onDelete={isCaseClosed || !isOwner ? undefined : handleDeleteClick}
-                    onEdit={isCaseClosed || !isOwner ? undefined : handleEditClick}
+                    onDelete={handleDeleteClick}
+                    deleteDisabled={deleteDisabled}
+                    deleteTooltip={deleteTooltip}
+                    onEdit={isCaseClosed ? undefined : handleEditClick}
                     hideDescription
                     isDownloadLoading={isDownloading && downloadingId === att.id}
                   />

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -14,7 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { CaseDetailsContentProps } from "@features/support/types/supportComponents";
+import type {
+  CaseDetailsContentProps,
+  CaseDetailsHeaderVariant,
+} from "@features/support/types/supportComponents";
 import { Box, Paper, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { useEffect, useMemo, useState, type JSX } from "react";
 import { useLocation } from "react-router";
@@ -27,6 +30,7 @@ import {
   resolveColorFromTheme,
   getStatusIconElement,
   getInitials,
+  hasSeverityLabelForChip,
   isSecurityReportAnalysisType,
 } from "@features/support/utils/support";
 import {
@@ -124,6 +128,13 @@ export default function CaseDetailsContent({
   const engineerInitials = getInitials(assignedEngineer);
 
   const isSecurityReportAnalysis = isSecurityReportAnalysisType(data?.type);
+
+  const headerVariant: CaseDetailsHeaderVariant = useMemo(() => {
+    if (isEngagementRoute) return "engagement";
+    if (isServiceRequest) return "serviceRequest";
+    return "default";
+  }, [isEngagementRoute, isServiceRequest]);
+
   const hideAssignedEngineer =
     isSecurityReportAnalysis ||
     isSecurityReportAnalysisRoute ||
@@ -199,6 +210,7 @@ export default function CaseDetailsContent({
             hideActionRow={hideActionRow}
             showEngineerOnly={showEngineerOnly}
             hideAssignedEngineer={hideAssignedEngineer}
+            headerVariant={headerVariant}
           />
         </Paper>
       </Box>
@@ -266,7 +278,13 @@ export default function CaseDetailsContent({
                 statusChipIcon={statusChipIcon}
                 statusChipSx={statusChipSx}
                 isLoading={isLoading}
-                showSeverityChip={!isSecurityReportAnalysis}
+                showSeverityChip={
+                  headerVariant === "default" &&
+                  !isSecurityReportAnalysis &&
+                  hasSeverityLabelForChip(severityLabel)
+                }
+                showStatusChip={headerVariant !== "engagement"}
+                variant={headerVariant}
               />
 
               {(!hideActionRow || showEngineerOnly) && (

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsHeader.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsHeader.tsx
@@ -18,11 +18,15 @@ import type { CaseDetailsHeaderProps } from "@features/support/types/supportComp
 import { Box, Chip, Stack, Typography, alpha } from "@wso2/oxygen-ui";
 import { type ReactElement, type JSX } from "react";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
-import { formatValue, mapSeverityToDisplay } from "@features/support/utils/support";
+import {
+  formatValue,
+  hasSeverityLabelForChip,
+  mapSeverityToDisplay,
+} from "@features/support/utils/support";
 import { CaseDetailsHeaderSkeleton } from "@case-details/CaseDetailsSkeleton";
 
 /**
- * Case details header: case number, severity, status chip, and title.
+ * Case details header: case number, optional severity, optional status chip, and title.
  *
  * @param {CaseDetailsHeaderProps} props - Header data and styling.
  * @returns {JSX.Element} The header block.
@@ -36,10 +40,15 @@ export default function CaseDetailsHeader({
   statusChipSx,
   isLoading = false,
   showSeverityChip = true,
+  showStatusChip = true,
+  variant = "default",
 }: CaseDetailsHeaderProps): JSX.Element {
   if (isLoading) {
-    return <CaseDetailsHeaderSkeleton />;
+    return <CaseDetailsHeaderSkeleton variant={variant} />;
   }
+
+  const displaySeverity =
+    showSeverityChip && hasSeverityLabelForChip(severityLabel);
 
   return (
     <Box>
@@ -52,7 +61,7 @@ export default function CaseDetailsHeader({
         <Typography variant="body2" fontWeight={500} color="text.primary">
           {formatValue(caseNumber)}
         </Typography>
-        {showSeverityChip && (
+        {displaySeverity && (
           <Chip
             label={mapSeverityToDisplay(severityLabel ?? undefined)}
             size="small"
@@ -78,13 +87,15 @@ export default function CaseDetailsHeader({
             }}
           />
         )}
-        <Chip
-          size="small"
-          variant="outlined"
-          label={formatValue(statusLabel)}
-          icon={statusChipIcon as ReactElement}
-          sx={statusChipSx}
-        />
+        {showStatusChip && (
+          <Chip
+            size="small"
+            variant="outlined"
+            label={formatValue(statusLabel)}
+            icon={statusChipIcon as ReactElement}
+            sx={statusChipSx}
+          />
+        )}
       </Stack>
       <Typography variant="h6" color="text.primary" sx={{ fontWeight: 500 }}>
         {formatValue(title)}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsSkeleton.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsSkeleton.tsx
@@ -14,17 +14,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { CaseDetailsSkeletonProps } from "@features/support/types/supportComponents";
+import type {
+  CaseDetailsHeaderVariant,
+  CaseDetailsSkeletonProps,
+} from "@features/support/types/supportComponents";
 import { Box, Paper, Skeleton, Stack } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 
+export type CaseDetailsHeaderSkeletonProps = {
+  variant?: CaseDetailsHeaderVariant;
+};
+
 /**
- * Header-only skeleton: case ID, severity, status chip, and title.
+ * Header-only skeleton: case ID and optional chip placeholders, title.
  * Used by CaseDetailsHeader when loading and by CaseDetailsSkeleton.
  *
+ * @param props - Optional variant matching {@link CaseDetailsHeader}.
  * @returns {JSX.Element} The header skeleton block.
  */
-export function CaseDetailsHeaderSkeleton(): JSX.Element {
+export function CaseDetailsHeaderSkeleton({
+  variant = "default",
+}: CaseDetailsHeaderSkeletonProps = {}): JSX.Element {
   return (
     <Box>
       <Stack
@@ -34,13 +44,20 @@ export function CaseDetailsHeaderSkeleton(): JSX.Element {
         sx={{ mb: 0.5, flexWrap: "wrap" }}
       >
         <Skeleton variant="text" width={100} height={20} />
-        <Skeleton
-          variant="rounded"
-          width={56}
-          height={20}
-          sx={{ borderRadius: "10px" }}
-        />
-        <Skeleton variant="rounded" width={72} height={20} />
+        {variant === "default" && (
+          <>
+            <Skeleton
+              variant="rounded"
+              width={56}
+              height={20}
+              sx={{ borderRadius: "10px" }}
+            />
+            <Skeleton variant="rounded" width={72} height={20} />
+          </>
+        )}
+        {variant === "serviceRequest" && (
+          <Skeleton variant="rounded" width={72} height={20} />
+        )}
       </Stack>
       <Skeleton variant="text" width="70%" height={28} sx={{ maxWidth: 400 }} />
     </Box>
@@ -58,11 +75,12 @@ export default function CaseDetailsSkeleton({
   hideActionRow = false,
   showEngineerOnly = false,
   hideAssignedEngineer = false,
+  headerVariant = "default",
 }: CaseDetailsSkeletonProps = {}): JSX.Element {
   void hideAssignedEngineer;
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <CaseDetailsHeaderSkeleton />
+      <CaseDetailsHeaderSkeleton variant={headerVariant} />
 
       {/* Action row: manage status label placeholder */}
       {!hideActionRow && (

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
@@ -27,6 +27,7 @@ import {
 } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 import { NULL_PLACEHOLDER } from "@constants/common";
+import CaseCardDescriptionClamp from "@components/list-view/CaseCardDescriptionClamp";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
 import OutstandingCasesSkeleton from "./OutstandingCasesSkeleton";
@@ -110,7 +111,12 @@ export default function OutstandingCasesList({
             <Form.CardHeader
               sx={{ p: 0 }}
               title={
-                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  flexWrap="wrap"
+                >
                   <Typography
                     variant="body2"
                     fontWeight={500}
@@ -145,7 +151,14 @@ export default function OutstandingCasesList({
             />
 
             <Form.CardContent sx={{ p: 0 }}>
-              <Box sx={{ minWidth: 0 }}>
+              <Box
+                sx={{
+                  minWidth: 0,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 0.5,
+                }}
+              >
                 <Typography
                   variant="body2"
                   color="text.primary"
@@ -159,6 +172,11 @@ export default function OutstandingCasesList({
                 >
                   {stripHtml(c.title)}
                 </Typography>
+                <CaseCardDescriptionClamp
+                  description={c.description}
+                  hideWhenEmpty
+                  sx={{ mb: 0 }}
+                />
               </Box>
             </Form.CardContent>
 

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
@@ -25,18 +25,16 @@ import {
   alpha,
   useTheme,
 } from "@wso2/oxygen-ui";
-import { Clock } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import { NULL_PLACEHOLDER } from "@constants/common";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
 import OutstandingCasesSkeleton from "./OutstandingCasesSkeleton";
-import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import {
   formatRelativeTime,
   getAssignedEngineerLabel,
   getStatusColor,
-  mapSeverityToDisplay,
+  getStatusIcon,
   resolveColorFromTheme,
   stripHtml,
 } from "@features/support/utils/support";
@@ -95,6 +93,7 @@ export default function OutstandingCasesList({
       {cases.map((c) => {
         const colorPath = getStatusColor(c.status?.label);
         const resolvedColor = resolveColorFromTheme(colorPath, theme);
+        const StatusIcon = getStatusIcon(c.status?.label);
 
         return (
           <Form.CardButton
@@ -111,7 +110,7 @@ export default function OutstandingCasesList({
             <Form.CardHeader
               sx={{ p: 0 }}
               title={
-                <Stack direction="row" spacing={1} alignItems="center">
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
                   <Typography
                     variant="body2"
                     fontWeight={500}
@@ -120,25 +119,23 @@ export default function OutstandingCasesList({
                     {c.number}
                   </Typography>
                   <Chip
-                    label={mapSeverityToDisplay(c.severity?.label)}
                     size="small"
                     variant="outlined"
+                    label={c.status?.label ?? NULL_PLACEHOLDER}
+                    icon={<StatusIcon size={12} />}
                     sx={{
-                      bgcolor: alpha(
-                        getSeverityLegendColor(c.severity?.label),
-                        0.1,
-                      ),
-                      color: getSeverityLegendColor(c.severity?.label),
-                      borderColor: alpha(
-                        getSeverityLegendColor(c.severity?.label),
-                        0.3,
-                      ),
-                      fontWeight: 500,
-                      px: 0,
+                      bgcolor: alpha(resolvedColor, 0.1),
+                      color: resolvedColor,
                       height: 20,
                       fontSize: "0.75rem",
+                      px: 0,
+                      "& .MuiChip-icon": {
+                        color: "inherit",
+                        ml: "6px",
+                        mr: "6px",
+                      },
                       "& .MuiChip-label": {
-                        pl: "6px",
+                        pl: 0,
                         pr: "6px",
                       },
                     }}
@@ -165,29 +162,7 @@ export default function OutstandingCasesList({
               </Box>
             </Form.CardContent>
 
-            <Form.CardActions sx={{ p: 0, justifyContent: "space-between" }}>
-              <Chip
-                size="small"
-                variant="outlined"
-                label={c.status?.label ?? NULL_PLACEHOLDER}
-                icon={<Clock size={12} />}
-                sx={{
-                  bgcolor: alpha(resolvedColor, 0.1),
-                  color: resolvedColor,
-                  px: 0,
-                  height: 20,
-                  fontSize: "0.75rem",
-                  "& .MuiChip-icon": {
-                    color: "inherit",
-                    ml: "6px",
-                    mr: "6px",
-                  },
-                  "& .MuiChip-label": {
-                    pl: 0,
-                    pr: "6px",
-                  },
-                }}
-              />
+            <Form.CardActions sx={{ p: 0, justifyContent: "flex-end" }}>
               <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
                 {(() => {
                   const label = getAssignedEngineerLabel(c.assignedEngineer);

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesSkeleton.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesSkeleton.tsx
@@ -36,40 +36,40 @@ export default function OutstandingCasesSkeleton(): JSX.Element {
             display: "flex",
             flexDirection: "column",
             alignItems: "stretch",
-            gap: 1.5,
+            gap: 1,
           }}
         >
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-              flexWrap: "wrap",
-            }}
-          >
-            <Skeleton variant="text" width={60} height={20} />
-            <Skeleton
-              variant="rounded"
-              width={56}
-              height={20}
-              sx={{ borderRadius: "10px" }}
-            />
-            <Skeleton
-              variant="rounded"
-              width={70}
-              height={20}
-              sx={{ borderRadius: "10px" }}
-            />
-          </Box>
+          <Form.CardHeader
+            sx={{ p: 0 }}
+            title={
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexWrap: "wrap",
+                }}
+              >
+                <Skeleton variant="text" width={60} height={20} />
+                <Skeleton
+                  variant="rounded"
+                  width={72}
+                  height={20}
+                  sx={{ borderRadius: "10px" }}
+                />
+              </Box>
+            }
+          />
           <Skeleton variant="text" width="90%" height={24} />
           <Box
             sx={{
               display: "flex",
-              justifyContent: "space-between",
+              justifyContent: "flex-end",
               alignItems: "center",
+              gap: 1.5,
             }}
           >
-            <Skeleton variant="rounded" width={80} height={20} />
+            <Skeleton variant="text" width={120} height={16} />
             <Skeleton variant="text" width={100} height={16} />
           </Box>
         </Form.CardButton>

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/__tests__/OutstandingCasesList.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/__tests__/OutstandingCasesList.test.tsx
@@ -19,9 +19,20 @@ import { describe, expect, it, vi } from "vitest";
 import OutstandingCasesList from "@features/support/components/support-overview-cards/OutstandingCasesList";
 import type { CaseListItem } from "@features/support/types/cases";
 
-vi.mock("@features/support/utils/support", () => ({
-  formatRelativeTime: vi.fn(() => "2 hours ago"),
-  stripHtml: vi.fn((html) => html),
+vi.mock("@features/support/utils/support", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@features/support/utils/support")
+  >();
+  return {
+    ...actual,
+    formatRelativeTime: vi.fn(() => "2 hours ago"),
+    stripHtml: vi.fn((html: string) => html),
+  };
+});
+
+vi.mock("@features/announcements/utils/announcements", () => ({
+  isAnnouncementDescriptionEffectivelyEmpty: vi.fn(() => true),
+  normalizeAnnouncementDescriptionHtml: vi.fn((html: string) => html),
 }));
 
 const mockCases: CaseListItem[] = [
@@ -48,11 +59,10 @@ describe("OutstandingCasesList", () => {
     expect(screen.getByText("No outstanding cases.")).toBeInTheDocument();
   });
 
-  it("should render case number, title, severity and status", () => {
+  it("should render case number, title, and status", () => {
     render(<OutstandingCasesList cases={mockCases} />);
     expect(screen.getByText("CASE-2845")).toBeInTheDocument();
     expect(screen.getByText("API Gateway timeout issues")).toBeInTheDocument();
-    expect(screen.getByText("High")).toBeInTheDocument();
     expect(screen.getByText("Work In Progress")).toBeInTheDocument();
     expect(screen.getByText(/Assigned to Sarah Chen/)).toBeInTheDocument();
     expect(screen.getByText("2 hours ago")).toBeInTheDocument();

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -195,6 +195,10 @@ export const ATTACHMENT_DELETE_TOOLTIP_NOT_OWNER =
 export const DEPLOYMENT_DOCUMENT_DELETE_TOOLTIP_NOT_OWNER =
   "Only the person who uploaded this document can delete it.";
 
+/** Tooltip for deployment documents when edit is disabled for non-owners. */
+export const DEPLOYMENT_DOCUMENT_EDIT_TOOLTIP_NOT_OWNER =
+  "Only the person who uploaded this document can edit it.";
+
 /**
  * Valid keys for all cases statistics.
  */

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -183,6 +183,18 @@ export const MAX_IMAGE_SIZE_BYTES = 15 * 1024 * 1024;
 // Initial limit for case attachments list.
 export const CASE_ATTACHMENTS_INITIAL_LIMIT = 50;
 
+/** Tooltip when delete is disabled because the case is closed. */
+export const ATTACHMENT_DELETE_TOOLTIP_CASE_CLOSED =
+  "Attachments cannot be deleted on a closed case.";
+
+/** Tooltip when delete is disabled because the current user did not upload the file. */
+export const ATTACHMENT_DELETE_TOOLTIP_NOT_OWNER =
+  "Only the person who uploaded this attachment can delete it.";
+
+/** Tooltip for deployment documents when delete is disabled for non-owners. */
+export const DEPLOYMENT_DOCUMENT_DELETE_TOOLTIP_NOT_OWNER =
+  "Only the person who uploaded this document can delete it.";
+
 /**
  * Valid keys for all cases statistics.
  */

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -261,6 +261,7 @@ export type AttachmentListItemProps = {
   onDelete?: (attachment: CaseAttachment) => void;
   onEdit?: (attachment: CaseAttachment) => void;
   deleteDisabled?: boolean;
+  deleteTooltip?: string;
   hideDescription?: boolean;
   isDownloadLoading?: boolean;
 };

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -36,6 +36,9 @@ import type { ChatAction } from "@features/support/constants/supportConstants";
 import type { ProductVersionOption } from "@features/support/types/caseCreationOptions";
 import type { AssignedEngineerValue } from "@features/support/utils/support";
 
+/** Header layout variant for case / SR / engagement detail shells. */
+export type CaseDetailsHeaderVariant = "default" | "engagement" | "serviceRequest";
+
 export type CaseDetailsHeaderProps = {
   caseNumber: string | null | undefined;
   title: string | null | undefined;
@@ -45,6 +48,8 @@ export type CaseDetailsHeaderProps = {
   statusChipSx: Record<string, unknown>;
   isLoading?: boolean;
   showSeverityChip?: boolean;
+  showStatusChip?: boolean;
+  variant?: CaseDetailsHeaderVariant;
 };
 
 export type OutstandingCasesListProps = {
@@ -255,6 +260,7 @@ export type AttachmentListItemProps = {
   onDownload: (attachment: CaseAttachment) => void;
   onDelete?: (attachment: CaseAttachment) => void;
   onEdit?: (attachment: CaseAttachment) => void;
+  deleteDisabled?: boolean;
   hideDescription?: boolean;
   isDownloadLoading?: boolean;
 };
@@ -390,6 +396,7 @@ export type CaseDetailsSkeletonProps = {
   hideActionRow?: boolean;
   showEngineerOnly?: boolean;
   hideAssignedEngineer?: boolean;
+  headerVariant?: CaseDetailsHeaderVariant;
 };
 
 export type CaseDetailsBackButtonProps = {

--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -1023,8 +1023,8 @@ export function hasSeverityLabelForChip(label?: string | null): boolean {
   if (label == null || String(label).trim() === "") {
     return false;
   }
-  const display = mapSeverityToDisplay(label);
-  return display !== "—" && display.trim() !== "";
+  const display = mapSeverityToDisplay(label).trim();
+  return display !== "—" && display !== "";
 }
 
 /**

--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -1014,6 +1014,20 @@ export function mapSeverityToDisplay(label?: string): string {
 }
 
 /**
+ * Whether a severity chip should be shown (hide when API has no severity to avoid "—" chips).
+ *
+ * @param label - Raw severity label from API.
+ * @returns {boolean} True when severity is present and maps to a display value.
+ */
+export function hasSeverityLabelForChip(label?: string | null): boolean {
+  if (label == null || String(label).trim() === "") {
+    return false;
+  }
+  const display = mapSeverityToDisplay(label);
+  return display !== "—" && display.trim() !== "";
+}
+
+/**
  * Returns true if the case has S0 (Catastrophic) severity.
  * Used to filter out S0 cases when project type is not Managed Cloud Subscription.
  *

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -259,7 +259,6 @@ function InstanceAccordionRow({
   expanded,
   onToggle,
 }: InstanceAccordionRowProps): JSX.Element {
-  const borderMuted = alpha(colors.grey?.[500] ?? "#6B7280", 0.2);
   const wellBg = alpha(colors.grey?.[500] ?? "#6B7280", 0.04);
 
   return (
@@ -273,7 +272,7 @@ function InstanceAccordionRow({
         boxShadow: 1,
         overflow: "hidden",
         border: "1px solid",
-        borderColor: borderMuted,
+        borderColor: "divider",
         borderRadius: 0,
         bgcolor: "background.paper",
         "&.Mui-expanded": { margin: 0 },
@@ -396,11 +395,10 @@ function ProductAccordionRow({
         boxShadow: 1,
         overflow: "hidden",
         border: "1px solid",
-        borderColor: a.borderDefault,
+        borderColor: "divider",
         borderRadius: 0,
-        transition: "border-color 0.2s ease",
         bgcolor: "background.paper",
-        "&:hover": { borderColor: a.borderHover },
+        "&:hover": { bgcolor: "action.hover" },
         "&.Mui-expanded": { margin: 0 },
       }}
     >

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -94,8 +94,6 @@ function ExpandedProductCard({
       sx={{
         p: 2,
         height: "100%",
-        border: "1px solid",
-        borderColor: alpha(a.main, 0.15),
       }}
     >
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1.5 }}>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -25,7 +25,6 @@ import {
   Skeleton,
   StatCard,
   Typography,
-  alpha,
   useTheme,
   useMediaQuery,
 } from "@wso2/oxygen-ui";
@@ -91,6 +90,7 @@ function ExpandedProductCard({
 }: ExpandedProductCardProps): JSX.Element {
   return (
     <Card
+      variant="outlined"
       sx={{
         p: 2,
         height: "100%",
@@ -288,7 +288,7 @@ function EnvironmentBreakdownAccordion({
         boxShadow: 1,
         overflow: "hidden",
         border: "1px solid",
-        borderColor: a.border,
+        borderColor: "divider",
         borderRadius: 0,
         bgcolor: "background.paper",
         "&.Mui-expanded": { margin: 0 },

--- a/apps/customer-portal/webapp/src/utils/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/utils/useAuthApiClient.ts
@@ -14,8 +14,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { ASGARDEO_UNAUTHENTICATED_CODE, AUTH_NOT_READY_ERROR_MESSAGE, TOKEN_RETRY_DELAYS_MS } from "@constants/apiConstants";
+import {
+  ASGARDEO_UNAUTHENTICATED_CODE,
+  AUTH_NOT_READY_ERROR_MESSAGE,
+  TOKEN_RETRY_DELAYS_MS,
+} from "@constants/apiConstants";
 import { useAsgardeo } from "@asgardeo/react";
+import { useLogger } from "@hooks/useLogger";
 
 // Waits for the provided duration.
 function sleep(delayMs: number): Promise<void> {
@@ -34,41 +39,51 @@ function isAsgardeoUnauthenticatedError(error: unknown): boolean {
   return maybeCode === ASGARDEO_UNAUTHENTICATED_CODE;
 }
 
+function isNonReplayableBody(body: unknown): boolean {
+  if (body == null) {
+    return false;
+  }
+  if (typeof ReadableStream !== "undefined" && body instanceof ReadableStream) {
+    return true;
+  }
+  if (ArrayBuffer.isView(body)) {
+    return true;
+  }
+  return false;
+}
+
 // A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
   const { getIdToken } = useAsgardeo();
-  
+  const logger = useLogger();
+
   const resolveIdTokenWithRetry = async (): Promise<string> => {
     let lastError: unknown;
-    for (
-      let attempt = 0;
-      attempt <= TOKEN_RETRY_DELAYS_MS.length;
-      attempt += 1
-    ) {
+    const delays = TOKEN_RETRY_DELAYS_MS;
+    for (let attempt = 0; attempt < delays.length; attempt += 1) {
       try {
         const token = await getIdToken();
         if (token) {
           return token;
         }
-        console.warn("[authFetch] token-unavailable", { attempt: attempt + 1 });
+        logger.warn("[authFetch] token-unavailable", { attempt: attempt + 1 });
       } catch (error) {
         lastError = error;
         if (isAsgardeoUnauthenticatedError(error)) {
-          console.warn("[authFetch] token-unavailable", {
+          logger.warn("[authFetch] token-unavailable", {
             attempt: attempt + 1,
             reason: "asgardeo-auth-not-ready",
           });
         } else {
-          console.warn("[authFetch] token-retrieval-error", {
+          logger.warn("[authFetch] token-retrieval-error", {
             attempt: attempt + 1,
             error,
           });
         }
       }
 
-      const nextDelay = TOKEN_RETRY_DELAYS_MS[attempt];
-      if (nextDelay) {
-        await sleep(nextDelay);
+      if (attempt < delays.length - 1) {
+        await sleep(delays[attempt]);
       }
     }
 
@@ -109,7 +124,10 @@ export function useAuthApiClient() {
         body instanceof Blob ||
         body instanceof ArrayBuffer ||
         (typeof URLSearchParams !== "undefined" &&
-          body instanceof URLSearchParams);
+          body instanceof URLSearchParams) ||
+        (typeof ReadableStream !== "undefined" &&
+          body instanceof ReadableStream) ||
+        ArrayBuffer.isView(body);
 
       if (!isNonJsonType && !headers.has("Content-Type")) {
         headers.set("Content-Type", "application/json");
@@ -129,9 +147,21 @@ export function useAuthApiClient() {
       headers: buildRequestHeaders(options, token),
     });
 
-    if (response.status === 401) {
-      console.warn("[authFetch] 401-retried", {
-        url: typeof input === "string" ? input : input.toString(),
+    const urlLabel =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+
+    const body = options?.body;
+    const canRetry401 =
+      (typeof input === "string" || input instanceof URL) &&
+      !isNonReplayableBody(body);
+
+    if (response.status === 401 && canRetry401) {
+      logger.warn("[authFetch] 401-retried", {
+        url: urlLabel,
         method: options?.method ?? "GET",
       });
       const retryToken = await resolveIdTokenWithRetry();
@@ -140,11 +170,20 @@ export function useAuthApiClient() {
         headers: buildRequestHeaders(options, retryToken),
       });
       if (response.status === 401) {
-        console.error("[authFetch] 401-final-failure", {
-          url: typeof input === "string" ? input : input.toString(),
+        logger.error("[authFetch] 401-final-failure", {
+          url: urlLabel,
           method: options?.method ?? "GET",
         });
       }
+    } else if (response.status === 401 && !canRetry401) {
+      logger.warn("[authFetch] 401-skipped-retry", {
+        url: urlLabel,
+        method: options?.method ?? "GET",
+        reason:
+          typeof input !== "string" && !(input instanceof URL)
+            ? "request-object-input"
+            : "non-replayable-body",
+      });
     }
 
     return response;

--- a/apps/customer-portal/webapp/src/utils/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/utils/useAuthApiClient.ts
@@ -14,43 +14,95 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { ASGARDEO_UNAUTHENTICATED_CODE, AUTH_NOT_READY_ERROR_MESSAGE, TOKEN_RETRY_DELAYS_MS } from "@constants/apiConstants";
 import { useAsgardeo } from "@asgardeo/react";
 
-/**
- * A custom hook that returns a smart `fetch` wrapper.
- * It automatically fetches a fresh ID Token from Asgardeo,
- * and merges the Authorization Header alongside the necessary payload descriptors.
- *
- * @returns {typeof GlobalFetch.fetch} A decorated `fetch` API.
- */
+// Waits for the provided duration.
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, delayMs);
+  });
+}
+
+// Checks whether an error indicates Asgardeo auth state is not ready yet.
+function isAsgardeoUnauthenticatedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybeCode = (error as { code?: unknown }).code;
+  return maybeCode === ASGARDEO_UNAUTHENTICATED_CODE;
+}
+
+// A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
   const { getIdToken } = useAsgardeo();
+  
+  const resolveIdTokenWithRetry = async (): Promise<string> => {
+    let lastError: unknown;
+    for (
+      let attempt = 0;
+      attempt <= TOKEN_RETRY_DELAYS_MS.length;
+      attempt += 1
+    ) {
+      try {
+        const token = await getIdToken();
+        if (token) {
+          return token;
+        }
+        console.warn("[authFetch] token-unavailable", { attempt: attempt + 1 });
+      } catch (error) {
+        lastError = error;
+        if (isAsgardeoUnauthenticatedError(error)) {
+          console.warn("[authFetch] token-unavailable", {
+            attempt: attempt + 1,
+            reason: "asgardeo-auth-not-ready",
+          });
+        } else {
+          console.warn("[authFetch] token-retrieval-error", {
+            attempt: attempt + 1,
+            error,
+          });
+        }
+      }
 
-  const authFetch = async (
-    input: RequestInfo | URL,
-    options?: RequestInit,
-  ): Promise<Response> => {
-    // 1. Get the fresh token automatically
-    const token = await getIdToken();
-
-    if (!token) {
-      throw new Error("Unable to retrieve ID token");
+      const nextDelay = TOKEN_RETRY_DELAYS_MS[attempt];
+      if (nextDelay) {
+        await sleep(nextDelay);
+      }
     }
 
-    const headers = new Headers(options?.headers);
+    if (lastError) {
+      if (isAsgardeoUnauthenticatedError(lastError)) {
+        throw new Error(AUTH_NOT_READY_ERROR_MESSAGE);
+      }
+      throw lastError instanceof Error
+        ? lastError
+        : new Error("Unable to retrieve ID token");
+    }
+    throw new Error("Unable to retrieve ID token");
+  };
 
+  /**
+   * Builds request headers with auth and payload defaults.
+   *
+   * @param {RequestInit | undefined} options - Request init options.
+   * @param {string} token - ID token used as bearer and user token header.
+   * @returns {Headers} Final headers for request execution.
+   */
+  const buildRequestHeaders = (
+    options: RequestInit | undefined,
+    token: string,
+  ): Headers => {
+    const headers = new Headers(options?.headers);
     headers.set("Authorization", `Bearer ${token}`);
     headers.set("x-user-id-token", token);
-
-    // Default Accept header if not present
     if (!headers.has("Accept")) {
       headers.set("Accept", "application/json");
     }
 
-    // Smartly set Content-Type: application/json
     const method = options?.method?.toUpperCase() || "GET";
     const body = options?.body;
-
     if (["POST", "PUT", "PATCH"].includes(method) && body) {
       const isNonJsonType =
         body instanceof FormData ||
@@ -64,8 +116,38 @@ export function useAuthApiClient() {
       }
     }
 
-    // 3. Execute the native fetch
-    return fetch(input, { ...options, headers });
+    return headers;
+  };
+
+  const authFetch = async (
+    input: RequestInfo | URL,
+    options?: RequestInit,
+  ): Promise<Response> => {
+    const token = await resolveIdTokenWithRetry();
+    let response = await fetch(input, {
+      ...options,
+      headers: buildRequestHeaders(options, token),
+    });
+
+    if (response.status === 401) {
+      console.warn("[authFetch] 401-retried", {
+        url: typeof input === "string" ? input : input.toString(),
+        method: options?.method ?? "GET",
+      });
+      const retryToken = await resolveIdTokenWithRetry();
+      response = await fetch(input, {
+        ...options,
+        headers: buildRequestHeaders(options, retryToken),
+      });
+      if (response.status === 401) {
+        console.error("[authFetch] 401-final-failure", {
+          url: typeof input === "string" ? input : input.toString(),
+          method: options?.method ?? "GET",
+        });
+      }
+    }
+
+    return response;
   };
 
   return authFetch;


### PR DESCRIPTION
### Description 

This pull request refactors the handling of the "severity" field in the Engagements list and related components. It removes the ability to sort or filter Engagements by severity, hides severity chips in Engagements list items, and ensures the UI and API requests do not reference severity for Engagements. Additionally, it introduces new props to control the visibility of severity filters and chips in reusable list components, and makes minor UI and test adjustments for consistency.

**Engagements: Remove Severity Sorting and Filtering**
* Removed the "Severity" sort option from the Engagements list and replaced any legacy usage with "CreatedOn" for both UI and API requests. [[1]](diffhunk://#diff-1971d0cad75b493093dc45879afda9b302cfdcefa872b69c29181bbc35cdade7L82) [[2]](diffhunk://#diff-feacbcb4059727622d3882bd6fbe51920c41e4ac14ae8c9708194fb5033414ebL47-R50) [[3]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fR62-R69) [[4]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77R41-R46)
* The severity filter is no longer sent in Engagements search requests, and the UI does not show the severity filter or highlight it as a refinement. [[1]](diffhunk://#diff-feacbcb4059727622d3882bd6fbe51920c41e4ac14ae8c9708194fb5033414ebL74) [[2]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL195-R206) [[3]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8R42) [[4]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8R68-R87) [[5]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8R98) [[6]](diffhunk://#diff-b103e78f2c87b69980c62620aa37faca74da1c4db029697388b94df63ca436f4R76) [[7]](diffhunk://#diff-b103e78f2c87b69980c62620aa37faca74da1c4db029697388b94df63ca436f4R98) [[8]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77R61-R70)
* Severity chips are hidden in Engagements list items using the new `hideSeverity` prop. [[1]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271R33) [[2]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271R49) [[3]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271L116-R123) [[4]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R44) [[5]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R57) [[6]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R102) [[7]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R124) [[8]](diffhunk://#diff-b103e78f2c87b69980c62620aa37faca74da1c4db029697388b94df63ca436f4R98)

**Reusable List Components: Add Props for Severity Visibility**
* Added `hideSeverity` and `hideSeverityFilter` props to `ListCard`, `ListItems`, `ListFilters`, and `ListSearchPanel` to control the display of severity chips and filters in a flexible, context-aware manner. [[1]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R44) [[2]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R57) [[3]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R102) [[4]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R124) [[5]](diffhunk://#diff-49b2fe3619021eb87cd3157f997cbd88f00d2cd003c683022b77ace1881fdea6R52) [[6]](diffhunk://#diff-49b2fe3619021eb87cd3157f997cbd88f00d2cd003c683022b77ace1881fdea6R71) [[7]](diffhunk://#diff-49b2fe3619021eb87cd3157f997cbd88f00d2cd003c683022b77ace1881fdea6R87-R89) [[8]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271R33) [[9]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271R49) [[10]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271L116-R123) [[11]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8R42) [[12]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8R68-R87) [[13]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8R98)

**Minor UI and Consistency Fixes**
* Announcement lists and details now display the raw `createdOn` field instead of formatting it, for consistency and simplicity. [[1]](diffhunk://#diff-c22b1772a5f43db7b9459085bc5ce8013b058e329638fd3c6502dbce10dc7cc2L33) [[2]](diffhunk://#diff-c22b1772a5f43db7b9459085bc5ce8013b058e329638fd3c6502dbce10dc7cc2L205-R204) [[3]](diffhunk://#diff-8b06f4a6f812c25f1561eccc1b21d502757cabc7d30d54c6aa968858ac252f37L21) [[4]](diffhunk://#diff-8b06f4a6f812c25f1561eccc1b21d502757cabc7d30d54c6aa968858ac252f37L204-R203)
* Moved the display of the change request state chip in `ChangeRequestsList` to align better with the item number, and made a minor import fix in the skeleton component. [[1]](diffhunk://#diff-4e57ef6a36604b02bea328a8860c0fc5951345d1ee5fecb12c51ddd0066d2e85L168-L188) [[2]](diffhunk://#diff-4e57ef6a36604b02bea328a8860c0fc5951345d1ee5fecb12c51ddd0066d2e85R225-R245) [[3]](diffhunk://#diff-4ef8d23eb603dac13a94a3bd1f3cec33e9658ce7265f846efbfa52c5c6ee920cL17-R17) [[4]](diffhunk://#diff-4ef8d23eb603dac13a94a3bd1f3cec33e9658ce7265f846efbfa52c5c6ee920cL29-R29)

**Constants**
* Added several new authentication and retry-related constants to `apiConstants.ts` (for future use or consistency).

These changes ensure the Engagements feature no longer references "severity" in any user-facing or backend-interacting way, while improving the flexibility of shared list components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline image preview capability for attachments with fullscreen modal support.
  * Enhanced authentication retry logic with exponential backoff for improved reliability.

* **Bug Fixes**
  * Improved access control feedback with tooltips for disabled delete actions on attachments and documents.

* **Changes**
  * Removed severity sorting and filtering options from engagement and service request views.
  * Repositioned status information display in change request cards.
  * Updated "Approved by" label to "Reported by" in time-tracking cards.
  * Refined border styling to use consistent theme colors across UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->