### PR TITLE
[Customer Portal][FE][Web] Refactor query behavior to disable caching and always fetch fresh data

### DIFF
--- a/apps/customer-portal/webapp/src/AppWithConfig.tsx
+++ b/apps/customer-portal/webapp/src/AppWithConfig.tsx
@@ -52,6 +52,7 @@ const queryClient: QueryClient = new QueryClient({
     queries: {
       retry: shouldRetry,
       retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+      refetchOnWindowFocus: false,
     },
     mutations: {
       retry: shouldRetry,

--- a/apps/customer-portal/webapp/src/api/__tests__/useGetProjectCases.test.tsx
+++ b/apps/customer-portal/webapp/src/api/__tests__/useGetProjectCases.test.tsx
@@ -79,8 +79,7 @@ describe("useGetProjectCases", () => {
       queryKey: ["project-cases", "project-1", requestBody],
     })[0];
 
-    expect((query?.options as any).staleTime).toBe(5 * 60 * 1000);
-    expect((query?.options as any).refetchOnWindowFocus).toBe(false);
+    expect((query?.options as any).staleTime).toBe(0);
   });
 
   it("should not fetch if projectId is missing", () => {

--- a/apps/customer-portal/webapp/src/api/useGetMetadata.ts
+++ b/apps/customer-portal/webapp/src/api/useGetMetadata.ts
@@ -57,6 +57,5 @@ export default function useGetMetadata(): UseQueryResult<
     },
     enabled: isSignedIn && !isAuthLoading,
     staleTime: 10 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
   });
 }

--- a/apps/customer-portal/webapp/src/api/useGetProjectCases.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjectCases.ts
@@ -105,6 +105,5 @@ export default function useGetProjectCases(
     enabled:
       (options?.enabled ?? true) && !!projectId && isSignedIn && !isAuthLoading,
     staleTime:  0,
-    refetchOnWindowFocus: false,
   });
 }

--- a/apps/customer-portal/webapp/src/api/useGetProjectCases.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjectCases.ts
@@ -104,7 +104,7 @@ export default function useGetProjectCases(
     },
     enabled:
       (options?.enabled ?? true) && !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime:  0,
     refetchOnWindowFocus: false,
   });
 }

--- a/apps/customer-portal/webapp/src/api/useGetProjectCasesPage.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjectCasesPage.ts
@@ -88,7 +88,7 @@ export function useGetProjectCasesPage(
       !isAuthLoading &&
       offset >= 0 &&
       limit > 0,
-    staleTime: 5 * 60 * 1000,
+    staleTime:  0,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/api/useGetProjectCasesPage.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjectCasesPage.ts
@@ -89,7 +89,5 @@ export function useGetProjectCasesPage(
       offset >= 0 &&
       limit > 0,
     staleTime:  0,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
   });
 }

--- a/apps/customer-portal/webapp/src/api/useGetProjectDetails.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjectDetails.ts
@@ -84,6 +84,6 @@ export default function useGetProjectDetails(
       }
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/api/useGetProjectFilters.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjectFilters.ts
@@ -76,10 +76,6 @@ export default function useGetProjectFilters(
       }
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 10 * 60 * 1000, // Filters don't change often, keep for 10 mins
-    gcTime: 10 * 60 * 1000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    staleTime:  0,
   });
 }

--- a/apps/customer-portal/webapp/src/api/useGetProjects.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjects.ts
@@ -138,7 +138,7 @@ export default function useInfiniteProjects({
       return totalFetched;
     },
     initialPageParam: 0,
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 0,
   });
 }
 

--- a/apps/customer-portal/webapp/src/api/usePostProjectDeploymentsSearch.ts
+++ b/apps/customer-portal/webapp/src/api/usePostProjectDeploymentsSearch.ts
@@ -135,7 +135,7 @@ export function usePostProjectDeploymentsSearchInfinite(
       return undefined;
     },
     enabled: enabled && !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }
 
@@ -215,6 +215,6 @@ export function usePostProjectDeploymentsSearchAll(
       return results;
     },
     enabled: enabled && !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementDetailsPage.tsx
@@ -37,13 +37,13 @@ export default function AnnouncementDetailsPage(): JSX.Element {
   const { showLoader, hideLoader } = useLoader();
   const { showError } = useErrorBanner();
 
-  const { data, isLoading, isFetching, isError } = useGetCaseDetails(
+  const { data, isLoading, isError } = useGetCaseDetails(
     projectId || "",
     caseId || "",
   );
 
   const showSkeletons =
-    isLoading || isFetching || (data === undefined && !isError);
+    isLoading || (data === undefined && !isError);
 
   useEffect(() => {
     if (showSkeletons) {

--- a/apps/customer-portal/webapp/src/features/dashboard/api/__tests__/useGetProjectCasesStats.test.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/api/__tests__/useGetProjectCasesStats.test.tsx
@@ -91,11 +91,8 @@ describe("useGetProjectCasesStats", () => {
     })[0];
 
     expect((query?.options as Record<string, unknown>).staleTime).toBe(
-      5 * 60 * 1000,
+      0,
     );
-    expect(
-      (query?.options as Record<string, unknown>).refetchOnWindowFocus,
-    ).toBe(false);
   });
 
   it("should not fetch if id is missing", () => {

--- a/apps/customer-portal/webapp/src/features/dashboard/api/useGetProjectCasesStats.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/api/useGetProjectCasesStats.ts
@@ -142,9 +142,6 @@ export function useGetProjectCasesStats(
       }
     },
     enabled: !!id && isSignedIn && !isAuthLoading && enabled,
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    staleTime:  0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/dashboard/api/useGetProjectChangeRequestsStats.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/api/useGetProjectChangeRequestsStats.ts
@@ -87,10 +87,6 @@ export function useGetProjectChangeRequestsStats(
       }
     },
     enabled,
-    staleTime: enabled ? 5 * 60 * 1000 : 0,
-    gcTime: enabled ? 10 * 60 * 1000 : 0,
-    refetchOnMount: true,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
@@ -262,9 +262,9 @@ const CasesTable = ({
   // fetching cases
   const isFetchingCases = showAll
     ? isLoadingAll ||
-      infiniteQuery.isFetching ||
+      infiniteQuery.isLoading ||
       infiniteQuery.isFetchingNextPage
-    : pageQuery.isFetching;
+    : pageQuery.isLoading;
 
   // error
   const isError = showAll ? infiniteQuery.isError : pageQuery.isError;

--- a/apps/customer-portal/webapp/src/features/operations/api/useGetCatalogItemVariables.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/useGetCatalogItemVariables.ts
@@ -68,6 +68,6 @@ export function useGetCatalogItemVariables(
       return data;
     },
     enabled: !!catalogId && !!itemId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/operations/api/useGetChangeRequestDetails.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/useGetChangeRequestDetails.ts
@@ -73,6 +73,6 @@ export default function useGetChangeRequestDetails(
       }
     },
     enabled: !!changeRequestId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/operations/api/useGetChangeRequests.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/useGetChangeRequests.ts
@@ -115,8 +115,7 @@ export default function useGetChangeRequests(
       !isAuthLoading &&
       offset >= 0 &&
       limit > 0,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,
   });
 }
 
@@ -211,7 +210,6 @@ export function useGetChangeRequestsInfinite(
     initialPageParam: 0,
     enabled:
       (options?.enabled ?? true) && !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/operations/api/useGetProjectChangeRequestStats.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/useGetProjectChangeRequestStats.ts
@@ -89,10 +89,6 @@ export function useGetProjectChangeRequestStats(
       }
     },
     enabled,
-    staleTime: 2 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
-    refetchOnMount: "always",
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    staleTime:  0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/operations/api/useSearchCatalogs.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/useSearchCatalogs.ts
@@ -68,6 +68,6 @@ export function useSearchCatalogs(
       return data;
     },
     enabled: !!deployedProductId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/operations/pages/OperationsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/OperationsPage.tsx
@@ -85,7 +85,7 @@ export default function OperationsPage(): JSX.Element {
 
   const {
     data: srData,
-    isFetching: isSrLoading,
+    isLoading: isSrLoading,
     isError: isSrError,
   } = useGetProjectCases(
     projectId || "",

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestDetailsPage.tsx
@@ -40,13 +40,13 @@ export default function ServiceRequestDetailsPage(): JSX.Element {
   const { showLoader, hideLoader } = useLoader();
   const { showError } = useErrorBanner();
 
-  const { data, isLoading, isFetching, isError } = useGetCaseDetails(
+  const { data, isLoading, isError } = useGetCaseDetails(
     projectId || "",
     serviceRequestId || "",
   );
 
   const showSkeletons =
-    isLoading || isFetching || (data === undefined && !isError);
+    isLoading || (data === undefined && !isError);
 
   useEffect(() => {
     if (showSkeletons) {

--- a/apps/customer-portal/webapp/src/features/project-details/api/useGetDeploymentDocuments.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useGetDeploymentDocuments.ts
@@ -85,6 +85,6 @@ export function useGetDeploymentDocuments(
       }
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/useGetProducts.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useGetProducts.ts
@@ -72,7 +72,6 @@ export function useGetProducts(params?: {
       }
     },
     enabled: isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/useGetProjectStat.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useGetProjectStat.ts
@@ -71,6 +71,6 @@ export function useGetProjectStat(
       }
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/useGetProjectUsageStats.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useGetProjectUsageStats.ts
@@ -46,6 +46,6 @@ export default function useGetProjectUsageStats(projectId: string | undefined) {
       return response.json() as Promise<UsageStatsResponse>;
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/useInfiniteDeploymentDocuments.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useInfiniteDeploymentDocuments.ts
@@ -91,7 +91,7 @@ export function useInfiniteDeploymentDocuments(deploymentId: string) {
       return nextOffset < totalRecords ? nextOffset : undefined;
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }
 

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeployedProductInstancesMetricsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeployedProductInstancesMetricsSearch.ts
@@ -60,6 +60,6 @@ export default function usePostDeployedProductInstancesMetricsSearch(
       return response.json() as Promise<InstanceMetricsResponse>;
     },
     enabled: !!deployedProductId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeployedProductInstancesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeployedProductInstancesSearch.ts
@@ -60,6 +60,6 @@ export default function usePostDeployedProductInstancesSearch(
       return response.json() as Promise<InstancesResponse>;
     },
     enabled: !!deployedProductId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeployedProductInstancesUsagesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeployedProductInstancesUsagesSearch.ts
@@ -60,6 +60,6 @@ export default function usePostDeployedProductInstancesUsagesSearch(
       return response.json() as Promise<InstanceUsageResponse>;
     },
     enabled: !!deployedProductId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesMetricsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesMetricsSearch.ts
@@ -56,6 +56,6 @@ export default function usePostDeploymentInstancesMetricsSearch(
       return response.json() as Promise<InstanceMetricsResponse>;
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesSearch.ts
@@ -56,6 +56,6 @@ export default function usePostDeploymentInstancesSearch(
       return response.json() as Promise<InstancesResponse>;
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesUsagesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesUsagesSearch.ts
@@ -56,6 +56,6 @@ export default function usePostDeploymentInstancesUsagesSearch(
       return response.json() as Promise<InstanceUsageResponse>;
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentProductsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentProductsSearch.ts
@@ -266,7 +266,7 @@ export function usePostDeploymentProductsSearchInfinite(
       return undefined;
     },
     enabled: enabled && !!deploymentId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }
 
@@ -308,7 +308,7 @@ export function usePostDeploymentProductsSearchAll(
         logger,
       }),
     enabled: enabled && !!deploymentId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }
 

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesMetricsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesMetricsSearch.ts
@@ -57,6 +57,6 @@ export default function usePostProjectInstancesMetricsSearch(
       return response.json() as Promise<InstanceMetricsResponse>;
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesSearch.ts
@@ -56,6 +56,6 @@ export default function usePostProjectInstancesSearch(
       return response.json() as Promise<InstancesResponse>;
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesSearch.ts
@@ -56,6 +56,6 @@ export default function usePostProjectInstancesUsagesSearch(
       return response.json() as Promise<InstanceUsageResponse>;
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/api/useSearchProductVersions.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useSearchProductVersions.ts
@@ -81,7 +81,6 @@ export function useSearchProductVersions(
       }
     },
     enabled: !!productId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentProductList.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentProductList.tsx
@@ -168,8 +168,7 @@ export default function DeploymentProductList({
     return products.find((p) => p.id === editingProduct.id) ?? editingProduct;
   }, [products, editingProduct]);
   const isLoading = productsQuery.isLoading;
-  const isFetching = productsQuery.isFetching;
-  const isError = productsQuery.isError;
+    const isError = productsQuery.isError;
   const patchProduct = usePatchDeploymentProduct();
 
   const handleDeleteClick = (item: DeploymentProductItem) => {
@@ -213,7 +212,7 @@ export default function DeploymentProductList({
             <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
               WSO2 Products
             </Typography>
-            {isLoading || isFetching ? (
+            {isLoading ? (
               <Skeleton
                 variant="rounded"
                 width={32}
@@ -239,7 +238,7 @@ export default function DeploymentProductList({
             Add Product
           </Button>
         </Box>
-        {isLoading || isFetching ? (
+        {isLoading ? (
           <ProductsSkeleton />
         ) : isError ? (
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, py: 2 }}>

--- a/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
@@ -66,7 +66,7 @@ export default function ProjectDetails(): JSX.Element {
 
   const {
     data: project,
-    isFetching: isProjectFetching,
+    isLoading: isProjectLoading,
     error: projectError,
   } = useGetProjectDetails(projectId || "");
 
@@ -74,14 +74,14 @@ export default function ProjectDetails(): JSX.Element {
 
   const {
     data: stats,
-    isFetching: isStatsFetching,
+    isLoading: isStatsLoading,
     error: statsError,
   } = useGetProjectStat(projectId || "");
 
   const isDetailsLoading = getProjectDetailsLoadingState({
     isAuthLoading,
-    isProjectFetching,
-    isStatsFetching,
+    isProjectLoading,
+    isStatsLoading,
     project,
     projectError,
     stats,

--- a/apps/customer-portal/webapp/src/features/project-details/utils/projectDetailsPage.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/utils/projectDetailsPage.ts
@@ -20,8 +20,8 @@ import { ProjectDetailsTabId } from "@features/project-details/types/projectDeta
 
 export type ProjectDetailsLoadingParams = {
   isAuthLoading: boolean;
-  isProjectFetching: boolean;
-  isStatsFetching: boolean;
+  isProjectLoading: boolean;
+  isStatsLoading: boolean;
   project: unknown;
   projectError: unknown;
   stats: unknown;
@@ -39,15 +39,15 @@ export function getProjectDetailsLoadingState(
 ): boolean {
   const {
     isAuthLoading,
-    isProjectFetching,
-    isStatsFetching,
+    isProjectLoading,
+    isStatsLoading,
     project,
     projectError,
     stats,
     statsError,
   } = params;
 
-  if (isAuthLoading || isProjectFetching || isStatsFetching) {
+  if (isAuthLoading || isProjectLoading || isStatsLoading) {
     return true;
   }
   if (!project && !projectError) {

--- a/apps/customer-portal/webapp/src/features/security/api/useGetProductVulnerabilities.ts
+++ b/apps/customer-portal/webapp/src/features/security/api/useGetProductVulnerabilities.ts
@@ -71,6 +71,6 @@ export function useGetProductVulnerabilities(
       }
     },
     enabled: !!vulnerabilityId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/security/api/useGetProductVulnerability.ts
+++ b/apps/customer-portal/webapp/src/features/security/api/useGetProductVulnerability.ts
@@ -69,6 +69,6 @@ export function useGetProductVulnerability(
       }
     },
     enabled: !!id && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/security/api/useGetVulnerabilitiesMetaData.ts
+++ b/apps/customer-portal/webapp/src/features/security/api/useGetVulnerabilitiesMetaData.ts
@@ -59,6 +59,6 @@ export function useGetVulnerabilitiesMetaData(): UseQueryResult<
       return data;
     },
     enabled: isSignedIn && !isAuthLoading,
-    staleTime: 10 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/security/api/usePostProductVulnerabilitiesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/security/api/usePostProductVulnerabilitiesSearch.ts
@@ -74,6 +74,6 @@ export function usePostProductVulnerabilitiesSearch(
       return data;
     },
     enabled: isSignedIn && !isAuthLoading,
-    staleTime: 2 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/security/components/ProductVulnerabilitiesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/ProductVulnerabilitiesTable.tsx
@@ -76,7 +76,7 @@ const ProductVulnerabilitiesTable = ({
     [debouncedSearch, filters, page, rowsPerPage],
   );
 
-  const { data, isFetching, isError } =
+  const { data, isLoading, isError } =
     usePostProductVulnerabilitiesSearch(searchRequest);
 
   useEffect(() => {
@@ -159,7 +159,7 @@ const ProductVulnerabilitiesTable = ({
       )}
 
       <ProductVulnerabilitiesList
-        isLoading={isFetching || (!data && !isError)}
+        isLoading={isLoading || (!data && !isError)}
         isError={isError}
         data={paginatedData}
         page={page}

--- a/apps/customer-portal/webapp/src/features/security/pages/VulnerabilityDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/security/pages/VulnerabilityDetailsPage.tsx
@@ -36,11 +36,11 @@ export default function VulnerabilityDetailsPage(): JSX.Element {
   const { showLoader, hideLoader } = useLoader();
   const { showError } = useErrorBanner();
 
-  const { data, isLoading, isFetching, isError } =
+  const { data, isLoading, isError } =
     useGetProductVulnerability(vulnerabilityId || "");
 
   const showSkeletons =
-    isLoading || isFetching || (data === undefined && !isError);
+    isLoading || (data === undefined && !isError);
 
   useEffect(() => {
     if (showSkeletons) {

--- a/apps/customer-portal/webapp/src/features/settings/api/useGetIntegrationUsers.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/useGetIntegrationUsers.ts
@@ -73,6 +73,6 @@ export function useGetIntegrationUsers(
       }
     },
     enabled: !!projectId && !!isSignedIn && !isAuthLoading && enabled,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/settings/api/useGetProjectContacts.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/useGetProjectContacts.ts
@@ -71,6 +71,6 @@ export default function useGetProjectContacts(
       }
     },
     enabled: !!projectId && !!isSignedIn && !isAuthLoading,
-    staleTime: 2 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/settings/api/useGetUserDetails.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/useGetUserDetails.ts
@@ -110,8 +110,6 @@ const useGetUserDetails = (): UseQueryResult<UserDetails, Error> => {
     },
     retryDelay: (attemptIndex) => Math.min(400 * 2 ** attemptIndex, 3000),
     staleTime: 0,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
   });
 };
 

--- a/apps/customer-portal/webapp/src/features/settings/api/useSearchRegistryTokens.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/useSearchRegistryTokens.ts
@@ -73,6 +73,6 @@ export function useSearchRegistryTokens(
       }
     },
     enabled: !!projectId && !!isSignedIn && !isAuthLoading,
-    staleTime: 2 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsRegistryTokens.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsRegistryTokens.tsx
@@ -125,10 +125,9 @@ export default function SettingsRegistryTokens({
   const {
     data: allTokens = [],
     isLoading,
-    isFetching,
     error,
   } = useSearchRegistryTokens(projectId);
-  const isTableLoading = isLoading || isFetching;
+  const isTableLoading = isLoading;
   const userTokens = useMemo(
     () => allTokens.filter((t) => t.tokenType === RegistryTokenType.USER),
     [allTokens],

--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
@@ -102,7 +102,6 @@ export default function SettingsUserManagement({
   const {
     data: contacts = [],
     isLoading,
-    isFetching,
     error,
   } = useGetProjectContacts(projectId);
   const postContact = usePostProjectContact(projectId);
@@ -181,7 +180,7 @@ export default function SettingsUserManagement({
     [editTarget, patchContact, showSuccess, showError],
   );
 
-  const isEffectiveLoading = isLoading || isFetching;
+  const isEffectiveLoading = isLoading;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>

--- a/apps/customer-portal/webapp/src/features/support/api/__tests__/useGetCallRequests.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/api/__tests__/useGetCallRequests.test.tsx
@@ -134,9 +134,7 @@ describe("useGetCallRequests", () => {
       queryKey: ["case-call-requests", projectId, caseId],
     })[0];
 
-    expect((query?.options as { staleTime?: number }).staleTime).toBe(
-      5 * 60 * 1000,
-    );
+    expect((query?.options as { staleTime?: number }).staleTime).toBe(0);
   });
 
   it("should handle API errors", async () => {

--- a/apps/customer-portal/webapp/src/features/support/api/__tests__/useGetChatHistory.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/api/__tests__/useGetChatHistory.test.tsx
@@ -118,9 +118,7 @@ describe("useGetChatHistory", () => {
       queryKey: ["chat-history", "project-1"],
     })[0];
 
-    expect((query?.options as { staleTime?: number }).staleTime).toBe(
-      5 * 60 * 1000,
-    );
+    expect((query?.options as { staleTime?: number }).staleTime).toBe(0);
   });
 
   it("should handle API error", async () => {

--- a/apps/customer-portal/webapp/src/features/support/api/__tests__/useGetProjectSupportStats.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/api/__tests__/useGetProjectSupportStats.test.tsx
@@ -108,8 +108,7 @@ describe("useGetProjectSupportStats", () => {
       queryKey: ["support-stats", "project-1"],
     })[0];
 
-    expect((query?.options as any).staleTime).toBe(5 * 60 * 1000);
-    expect((query?.options as any).refetchOnWindowFocus).toBeUndefined();
+    expect((query?.options as any).staleTime).toBe(0);
   });
 
   it("should handle API error", async () => {

--- a/apps/customer-portal/webapp/src/features/support/api/useGetCallRequests.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetCallRequests.ts
@@ -127,6 +127,6 @@ export function useGetCallRequests(
       return nextOffset < totalRecords ? nextOffset : undefined;
     },
     enabled: !!caseId && !isAuthLoading && isSignedIn,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/api/useGetCaseAttachments.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetCaseAttachments.ts
@@ -97,7 +97,7 @@ export function useGetCaseAttachments(caseId: string) {
       return nextOffset < totalRecords ? nextOffset : undefined;
     },
     enabled: !!caseId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }
 

--- a/apps/customer-portal/webapp/src/features/support/api/useGetCaseComments.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetCaseComments.ts
@@ -79,6 +79,6 @@ export default function useGetCaseComments(
       }
     },
     enabled: !!projectId && !!caseId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/api/useGetCaseDetails.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetCaseDetails.ts
@@ -74,6 +74,6 @@ export default function useGetCaseDetails(
       }
     },
     enabled: !!caseId && !isAuthLoading && isSignedIn,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/api/useGetChatHistory.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetChatHistory.ts
@@ -69,6 +69,6 @@ export function useGetChatHistory(
       }
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/api/useGetConversationMessages.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetConversationMessages.ts
@@ -86,7 +86,7 @@ export function useGetConversationMessages(
       return data;
     },
     enabled: !!conversationId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
     getNextPageParam: (lastPage) => {
       const nextOffset = lastPage.offset + lastPage.limit;
       if (nextOffset >= lastPage.totalRecords) {

--- a/apps/customer-portal/webapp/src/features/support/api/useGetConversationStats.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetConversationStats.ts
@@ -88,8 +88,7 @@ export function useGetConversationStats(
       }
     },
     enabled: (enabled ?? true) && !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
+    staleTime: 0,
     retry: 2,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/api/useGetConversationSummary.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetConversationSummary.ts
@@ -73,7 +73,6 @@ export default function useGetConversationSummary(
       }
     },
     enabled: !!projectId && !!conversationId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/api/useGetProjectSupportStats.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetProjectSupportStats.ts
@@ -97,6 +97,6 @@ export function useGetProjectSupportStats(
       }
     },
     enabled: !!id && isSignedIn && !isAuthLoading && enabled,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/api/useSearchConversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useSearchConversations.ts
@@ -79,6 +79,6 @@ export function useSearchConversations(
       }
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/hooks/useAllDeploymentProducts.ts
+++ b/apps/customer-portal/webapp/src/features/support/hooks/useAllDeploymentProducts.ts
@@ -60,7 +60,7 @@ export function useAllDeploymentProducts(
         });
       },
       enabled: !!deploymentId,
-      staleTime: 5 * 60 * 1000,
+      staleTime: 0,
     })),
   });
 

--- a/apps/customer-portal/webapp/src/features/support/pages/CaseDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CaseDetailsPage.tsx
@@ -39,7 +39,7 @@ export default function CaseDetailsPage(): JSX.Element {
   const { showLoader, hideLoader } = useLoader();
   const { showError } = useErrorBanner();
 
-  const { data, isLoading, isFetching, isError } = useGetCaseDetails(
+  const { data, isLoading, isError } = useGetCaseDetails(
     projectId || "",
     caseId || "",
   );
@@ -51,7 +51,7 @@ export default function CaseDetailsPage(): JSX.Element {
 
   // Show skeletons immediately when no data (avoid "-" flash on refresh) and when loading/refetching.
   const showSkeletons =
-    isLoading || isFetching || (data === undefined && !isError);
+    isLoading || (data === undefined && !isError);
 
   useEffect(() => {
     if (showSkeletons) {

--- a/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
@@ -57,7 +57,7 @@ export default function SupportPage(): JSX.Element {
 
   const {
     data: stats,
-    isFetching,
+    isLoading,
     isError,
   } = useGetProjectSupportStats(projectId || "", {
     caseTypes: [CaseType.DEFAULT_CASE],
@@ -65,7 +65,7 @@ export default function SupportPage(): JSX.Element {
 
   const {
     data,
-    isFetching: isCasesLoading,
+    isLoading: isCasesLoading,
     isError: isCasesError,
   } = useGetProjectCases(
     projectId || "",
@@ -82,7 +82,7 @@ export default function SupportPage(): JSX.Element {
 
   const {
     data: conversationsData,
-    isFetching: isChatLoading,
+    isLoading: isChatLoading,
     isError: isChatError,
   } = useSearchConversations(projectId || "", {
     pagination: { limit: SUPPORT_OVERVIEW_CHAT_LIMIT, offset: 0 },
@@ -112,7 +112,7 @@ export default function SupportPage(): JSX.Element {
     status: c.state?.label ?? "Open",
   }));
 
-  const isActuallyLoading = isAuthLoading || isFetching || (!stats && !isError);
+  const isActuallyLoading = isAuthLoading || isLoading || (!stats && !isError);
 
   useEffect(() => {
     if (isError) {

--- a/apps/customer-portal/webapp/src/features/updates/api/__tests__/useGetProductUpdateLevels.test.tsx
+++ b/apps/customer-portal/webapp/src/features/updates/api/__tests__/useGetProductUpdateLevels.test.tsx
@@ -118,9 +118,7 @@ describe("useGetProductUpdateLevels", () => {
       queryKey: ["product-update-levels"],
     })[0];
 
-    expect((query?.options as { staleTime?: number }).staleTime).toBe(
-      5 * 60 * 1000,
-    );
+    expect((query?.options as { staleTime?: number }).staleTime).toBe(0);
   });
 
   it("should handle API error", async () => {

--- a/apps/customer-portal/webapp/src/features/updates/api/useGetProductUpdateLevels.ts
+++ b/apps/customer-portal/webapp/src/features/updates/api/useGetProductUpdateLevels.ts
@@ -71,6 +71,6 @@ export function useGetProductUpdateLevels(): UseQueryResult<
       }
     },
     enabled: isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/updates/api/useGetRecommendedUpdateLevels.ts
+++ b/apps/customer-portal/webapp/src/features/updates/api/useGetRecommendedUpdateLevels.ts
@@ -71,7 +71,6 @@ export function useGetRecommendedUpdateLevels(): UseQueryResult<
       }
     },
     enabled: isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/updates/api/usePostUpdateLevelsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/updates/api/usePostUpdateLevelsSearch.ts
@@ -76,7 +76,6 @@ export function usePostUpdateLevelsSearch(
       return data;
     },
     enabled: !!params && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/useGetTimeCardsStats.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/useGetTimeCardsStats.ts
@@ -98,6 +98,6 @@ export default function useGetTimeCardsStats({
     },
     enabled:
       !!projectId && !!startDate && !!endDate && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/useGetTimeTrackingDetails.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/useGetTimeTrackingDetails.ts
@@ -73,6 +73,6 @@ export default function useGetTimeTrackingDetails(
       }
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/useSearchProjectTimeCards.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/useSearchProjectTimeCards.ts
@@ -111,6 +111,6 @@ export default function useSearchProjectTimeCards({
       return nextOffset < lastPage.totalRecords ? nextOffset : undefined;
     },
     enabled: enabled !== false && !!projectId && isSignedIn && !isAuthLoading,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   });
 }


### PR DESCRIPTION
### Description

This pull request updates the data fetching behavior across the customer portal webapp to ensure queries always return fresh data by disabling caching and automatic refetching on window focus. The main change is setting `staleTime` to `0` for all relevant queries and removing options related to cache persistence and refetch triggers. Additionally, some UI components and tests are updated to align with the new loading and fetching logic.

**Query and Caching Behavior Updates:**

* Set `staleTime: 0` for all project, case, filter, and catalog-related queries to ensure data is always treated as stale and refetched on each query. Removed other cache and refetch-related options such as `gcTime`, `refetchOnWindowFocus`, `refetchOnReconnect`, and `refetchOnMount` where present. [[1]](diffhunk://#diff-0c3a65535e31c6c997e47c708482482834349a30da02498b819a898c38490314L107-R107) [[2]](diffhunk://#diff-e0cb48ee3f1844057713a80fa43caf558e3d6df9c917e8e104106ea83a99f076L91-R91) [[3]](diffhunk://#diff-a9e5b3dce74633638dcc84da3114251cc20edf910d98bfa38bbec96e3ccee48cL79-R79) [[4]](diffhunk://#diff-0432d4e3e9f17d96b148fcfaa2a12b090797b1db09c7cae15719e0bba65918cfL87-R87) [[5]](diffhunk://#diff-52f777500efa9f29564afa08b7017a615af900bdea0a925b45a8a803a89ff3f3L141-R141) [[6]](diffhunk://#diff-36ac2af69f3a90e052d3e52763c7889bb2586b60909ed0d66792bbcfe29e66d5L138-R138) [[7]](diffhunk://#diff-36ac2af69f3a90e052d3e52763c7889bb2586b60909ed0d66792bbcfe29e66d5L218-R218) [[8]](diffhunk://#diff-07143536103480da9bc603273d3fd81487b089c7c9f7a095a6d4112fc7191f5aL145-R145) [[9]](diffhunk://#diff-d7c95ec5ebbcbca4928a7a167d519f012a32ee4a8ab68cbc46376ce77182193eL90-R90) [[10]](diffhunk://#diff-4964890f05a625787705fb9a24ef65992ec855ef5ebd969281ef33e9ed0b311fL71-R71) [[11]](diffhunk://#diff-e45a0564abab9ef1052ffbba914b57585af6f4f2d1a40866859f74a0c9061602L76-R76) [[12]](diffhunk://#diff-5deb2e037e21a5cec37fcb2d0d0ee02bb263e9418a13298a1f20d061d52f7e88L118-R118) [[13]](diffhunk://#diff-5deb2e037e21a5cec37fcb2d0d0ee02bb263e9418a13298a1f20d061d52f7e88L214-R213) [[14]](diffhunk://#diff-e2c87150ee38a154429ae7c0e284e6fa7ed489d9bec1145f630da98351193af3L92-R92) [[15]](diffhunk://#diff-59e6d81f9715d92bf1255db06d65b78deeee487586c6303680c3d9a9c3713ff9L71-R71) [[16]](diffhunk://#diff-bcb0642d5b3d44569a33aa03f5c8b1d9ee4dd20b3cdffd446d54775bbb1f22ecL60)

* Set `refetchOnWindowFocus: false` globally for the query client to prevent automatic refetching when the browser window regains focus.

**UI and Loading State Adjustments:**

* Updated UI components to use `isLoading` instead of `isFetching` for loading state, reflecting the new query behavior. [[1]](diffhunk://#diff-ec2c6653d99076fcef5961b7e905c993275d7a2f0a2a2ba7061e112238ecda13L40-R46) [[2]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cL265-R267) [[3]](diffhunk://#diff-58687b500ef8553bdd96f52b4620b6c38d7fbb91bba51451fc3a399bfc5cdbf6L88-R88)

**Test Updates:**

* Adjusted tests to expect `staleTime` of `0` and removed assertions related to `refetchOnWindowFocus`. [[1]](diffhunk://#diff-a2f3ab76cb62fe31558019f69c6ac80cda1725ee3c747e5e0cdd1a97ff9d3d31L82-R82) [[2]](diffhunk://#diff-57ef98866228563f706120b6e843e43069403226414a5ef1ccc824656d2aaa14L94-L98)

These changes ensure that users always see the most up-to-date data and that the UI accurately reflects loading states under the new query configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading indicators to display only during initial data loads, not during background refreshes, improving UI responsiveness.

* **Chores**
  * Updated data caching behavior to prioritize fresher data by immediately marking cached results as stale, enabling more frequent refetches where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->