### PR TITLE
[Customer Portal][FE][Web] Refine Project Types, Deployment Schema, and Subscription Permission Logic

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentCard.tsx
@@ -94,7 +94,7 @@ export default function DeploymentCard({
                 {displayValue(name, "Not Available")}
               </Typography>
               <Chip
-                label={deployment.id}
+                label={displayValue(deployment.number, "Not Available")}
                 size="small"
                 variant="outlined"
                 sx={{ height: 20, fontSize: "0.75rem" }}

--- a/apps/customer-portal/webapp/src/features/project-details/types/deployments.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/deployments.ts
@@ -93,6 +93,7 @@ export type ProjectDeploymentsListResponse = PaginationResponse & {
 // Item type for a single item from GET /projects/:projectId/deployments.
 export type ProjectDeploymentItem = AuditMetadata & {
   id: string;
+  number?: string | null;
   name: string;
   description: string | null;
   url: string | null;

--- a/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
@@ -60,6 +60,7 @@ export type ProjectDetails = {
   hasKbReferences?: boolean;
   type: IdLabelRef;
   sfId?: string;
+  hasPdpSubscription?: boolean;
   hasSr: boolean;
   startDate?: string;
   endDate?: string;

--- a/apps/customer-portal/webapp/src/utils/permission.ts
+++ b/apps/customer-portal/webapp/src/utils/permission.ts
@@ -97,7 +97,7 @@ export function getProjectPermissions(
 
     case ProjectType.SUBSCRIPTION:
       permissions.hasOperations = false;
-      permissions.hasSR = true;
+      permissions.hasSR = false;
       permissions.hasCR = false;
       permissions.hasDeployments = true;
       permissions.hasQueryHours = true;


### PR DESCRIPTION
### Description

This pull request introduces several updates to the project types and permissions logic, as well as an enhancement to the deployments data structure. The main changes include adding new optional fields to project types, updating the deployments item type, and correcting the permissions for subscription projects.

**Project type enhancements:**

* Added the optional field `hasPdpSubscription` to the `ProjectDetails` type, allowing the UI and logic to distinguish projects with a PDP subscription.

**Deployments data structure:**

* Added an optional `number` field to the `ProjectDeploymentItem` type to support deployments that may have an associated number, improving deployment tracking and display.

**Permissions logic correction:**

* Updated the `getProjectPermissions` function to set `hasSR` to `false` for projects of type `SUBSCRIPTION`, ensuring correct permission assignment for subscription projects.