### PR TITLE
[Customer Portal][BE] Enhance project and deployment responses with PDP subscription and number field

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -114,6 +114,8 @@ public type Project record {|
     string? description;
     # Project type
     ReferenceTableItem 'type;
+    # Indicates whether the project has a PDP subscription
+    boolean hasPdpSubscription;
     # Agent enabled status for the project
     boolean hasAgent;
     # Knowledge base references enabled status for the project
@@ -164,8 +166,8 @@ public type ProjectResponse record {|
     ReferenceTableItem 'type;
     # Salesforce ID
     string sfId;
-    # Indicates if the project has service requests
-    boolean hasSr;
+    # Indicates whether the project has a PDP subscription
+    boolean hasPdpSubscription;
     # Project start date
     Date? startDate;
     # Project end date 
@@ -1188,6 +1190,8 @@ public type InstanceUsagePayload record {|
 public type Deployment record {|
     # ID
     IdString id;
+    # Number of the deployment
+    string? number;
     # Name
     string name;
     # Created date and time

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -294,6 +294,8 @@ public type Project record {|
     string? description;
     # Project type
     ReferenceItem 'type;
+    # Indicates whether the project has a PDP subscription
+    boolean hasPdpSubscription;
     # Novera agent enabled status for the project
     boolean hasAgent;
     # Knowledge base references enabled status for the project
@@ -322,8 +324,8 @@ public type ProjectResponse record {|
     ReferenceItem 'type;
     # Salesforce ID
     string sfId;
-    # Indicates if the project has service requests
-    boolean hasSr;
+    # Indicates whether the project has a PDP subscription
+    boolean hasPdpSubscription;
     # Project start date
     entity:Date? startDate;
     # Project end date 
@@ -583,6 +585,8 @@ public type DeploymentSearchPayload record {|
 public type Deployment record {|
     # ID
     string id;
+    # Number of the deployment
+    string? number;
     # Name
     string name;
     # Created date and time

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2695,10 +2695,12 @@ components:
           type: string
           description: Allowed domain list of the account
           nullable: true
+          default: ""
         classification:
           type: string
           description: Account classification
           nullable: true
+          default: ""
         isPartner:
           type: boolean
           description: Whether the account is a partner or not
@@ -4825,7 +4827,7 @@ components:
       - endDate
       - goLiveDate
       - goLivePlanDate
-      - hasSr
+      - hasPdpSubscription
       - id
       - key
       - name
@@ -4860,9 +4862,9 @@ components:
         sfId:
           type: string
           description: Salesforce ID
-        hasSr:
+        hasPdpSubscription:
           type: boolean
-          description: Indicates if the project has service requests
+          description: Indicates whether the project has a PDP subscription
         startDate:
           description: Project start date
           nullable: true

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -256,6 +256,7 @@ public isolated function mapDeployments(entity:DeploymentsResponse response) ret
         select {
             id: deployment.id,
             name: deployment.name,
+            number: deployment.number,
             createdOn: deployment.createdOn,
             updatedOn: deployment.updatedOn,
             description: deployment.description,
@@ -846,6 +847,7 @@ public isolated function mapProjectsResponse(entity:ProjectsResponse response) r
             description: project.description,
             createdOn: project.createdOn,
             'type: {id: project.'type.id, label: project.'type.name},
+            hasPdpSubscription: project.hasPdpSubscription,
             hasAgent: project.hasAgent,
             hasKbReferences: project.hasKbReferences,
             activeCasesCount: project.activeCasesCount,
@@ -868,7 +870,7 @@ public isolated function mapProjectResponse(entity:ProjectResponse response) ret
     createdOn: response.createdOn,
     'type: {id: response.'type.id, label: response.'type.name},
     sfId: response.sfId,
-    hasSr: response.hasSr,
+    hasPdpSubscription: response.hasPdpSubscription,
     startDate: response.startDate,
     endDate: response.endDate,
     account: {


### PR DESCRIPTION
## Summary
This PR updates project-related responses to include PDP subscription information and enhances deployment responses with an additional `number` field.

## Changes

### 1️⃣ Project Response Update
- Replaced `hasSr` field with `hasPdpSubscription`
- Updated DTOs/records and mapping logic

### 2️⃣ Projects List Response Update
- Added `hasPdpSubscription` field to project response
- Updated response models and mappings accordingly

Reason:
`hasPdpSubscription` more accurately reflects the subscription status compared to `hasSr`, improving clarity and domain alignment.

---

### 3️⃣ Deployment Response Enhancement
- Added `number` field to deployment response
- Updated DTOs and serialization logic

Reason:
Including a `number` field provides better identification and display support for deployments in the UI.

## Impact
- `hasSr` field removed and replaced with `hasPdpSubscription`

Consumers must update usage accordingly.

## Testing
- Verified project response includes `hasPdpSubscription`
- Confirmed projects list response no longer includes `hasSr`
- Tested deployment response includes `number`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Projects now expose PDP subscription status in API responses, replacing service request status indicator.
  * Deployments now include deployment number information.

* **Improvements**
  * Account schema properties now have defined default values for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->