### PR TITLE
[Customer Portal][FE][web] Add Silent Sign-In Recovery and Proactive Token Refresh for Session Stability

### DIFF
--- a/apps/customer-portal/webapp/src/AppWithConfig.tsx
+++ b/apps/customer-portal/webapp/src/AppWithConfig.tsx
@@ -70,7 +70,6 @@ export default function AppWithConfig(): JSX.Element {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       periodicTokenRefresh
-      storage="localStorage"
       scopes={["openid", "email", "groups"]}
       preferences={{
         theme: {

--- a/apps/customer-portal/webapp/src/constants/authConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/authConstants.ts
@@ -22,3 +22,5 @@ export const IDLE_PROMPT_BEFORE_MS = 4_000;
 
 // Throttle for idle timer updates (ms).
 export const IDLE_THROTTLE_MS = 500;
+
+export const HIDDEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;

--- a/apps/customer-portal/webapp/src/constants/authConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/authConstants.ts
@@ -24,3 +24,5 @@ export const IDLE_PROMPT_BEFORE_MS = 4_000;
 export const IDLE_THROTTLE_MS = 500;
 
 export const HIDDEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+
+export const SILENT_RECOVERY_TIMEOUT_MS = 15_000;

--- a/apps/customer-portal/webapp/src/hooks/authRecovery.ts
+++ b/apps/customer-portal/webapp/src/hooks/authRecovery.ts
@@ -14,12 +14,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { SILENT_RECOVERY_TIMEOUT_MS } from "@constants/authConstants";
 import type { useAsgardeo } from "@asgardeo/react";
 import type { useLogger } from "@hooks/useLogger";
 
 type SignInSilently = ReturnType<typeof useAsgardeo>["signInSilently"];
 type Logger = ReturnType<typeof useLogger>;
+
 let pendingSilentRecovery: Promise<boolean> | null = null;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      reject(new Error("Silent sign-in timed out"));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        window.clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
 
 export function recoverViaSilentSignIn(
   signInSilently: SignInSilently,
@@ -27,7 +47,7 @@ export function recoverViaSilentSignIn(
 ): Promise<boolean> {
   if (!pendingSilentRecovery) {
     pendingSilentRecovery = Promise.resolve()
-      .then(() => signInSilently())
+      .then(() => withTimeout(signInSilently(), SILENT_RECOVERY_TIMEOUT_MS))
       .then((result) => result !== false)
       .catch((error) => {
         logger.warn("[authRecovery] silent-signin-failed", { error });

--- a/apps/customer-portal/webapp/src/hooks/authRecovery.ts
+++ b/apps/customer-portal/webapp/src/hooks/authRecovery.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { useAsgardeo } from "@asgardeo/react";
+import type { useLogger } from "@hooks/useLogger";
+
+type SignInSilently = ReturnType<typeof useAsgardeo>["signInSilently"];
+type Logger = ReturnType<typeof useLogger>;
+let pendingSilentRecovery: Promise<boolean> | null = null;
+
+export function recoverViaSilentSignIn(
+  signInSilently: SignInSilently,
+  logger: Logger,
+): Promise<boolean> {
+  if (!pendingSilentRecovery) {
+    pendingSilentRecovery = Promise.resolve()
+      .then(() => signInSilently())
+      .then((result) => result !== false)
+      .catch((error) => {
+        logger.warn("[authRecovery] silent-signin-failed", { error });
+        return false;
+      })
+      .finally(() => {
+        pendingSilentRecovery = null;
+      });
+  }
+  return pendingSilentRecovery;
+}

--- a/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -21,6 +21,7 @@ import {
 } from "@constants/apiConstants";
 import { useAsgardeo } from "@asgardeo/react";
 import { useLogger } from "@hooks/useLogger";
+import { recoverViaSilentSignIn } from "@hooks/authRecovery";
 
 // Waits for the provided duration.
 function sleep(delayMs: number): Promise<void> {
@@ -54,20 +55,30 @@ function isNonReplayableBody(body: unknown): boolean {
 
 // A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
-  const { getIdToken } = useAsgardeo();
+  const { getIdToken, signInSilently } = useAsgardeo();
   const logger = useLogger();
+
+  const tryGetToken = async (): Promise<{
+    token?: string;
+    error?: unknown;
+  }> => {
+    try {
+      const token = await getIdToken();
+      return { token: token || undefined };
+    } catch (error) {
+      return { error };
+    }
+  };
 
   const resolveIdTokenWithRetry = async (): Promise<string> => {
     let lastError: unknown;
     const delays = TOKEN_RETRY_DELAYS_MS;
     for (let attempt = 0; attempt < delays.length; attempt += 1) {
-      try {
-        const token = await getIdToken();
-        if (token) {
-          return token;
-        }
-        logger.warn("[authFetch] token-unavailable", { attempt: attempt + 1 });
-      } catch (error) {
+      const { token, error } = await tryGetToken();
+      if (token) {
+        return token;
+      }
+      if (error !== undefined) {
         lastError = error;
         if (isAsgardeoUnauthenticatedError(error)) {
           logger.warn("[authFetch] token-unavailable", {
@@ -80,10 +91,25 @@ export function useAuthApiClient() {
             error,
           });
         }
+      } else {
+        logger.warn("[authFetch] token-unavailable", { attempt: attempt + 1 });
       }
 
       if (attempt < delays.length - 1) {
         await sleep(delays[attempt]);
+      }
+    }
+
+    logger.warn("[authFetch] attempting-silent-recovery");
+    const recovered = await recoverViaSilentSignIn(signInSilently, logger);
+    if (recovered) {
+      const { token, error } = await tryGetToken();
+      if (token) {
+        logger.info("[authFetch] silent-recovery-succeeded");
+        return token;
+      }
+      if (error !== undefined) {
+        lastError = error;
       }
     }
 
@@ -164,6 +190,8 @@ export function useAuthApiClient() {
         url: urlLabel,
         method: options?.method ?? "GET",
       });
+
+      await recoverViaSilentSignIn(signInSilently, logger);
       const retryToken = await resolveIdTokenWithRetry();
       response = await fetch(input, {
         ...options,

--- a/apps/customer-portal/webapp/src/hooks/useProactiveTokenRefresh.ts
+++ b/apps/customer-portal/webapp/src/hooks/useProactiveTokenRefresh.ts
@@ -31,6 +31,10 @@ export function useProactiveTokenRefresh(): void {
       return;
     }
 
+    if (document.visibilityState === "hidden" && hiddenAtRef.current === null) {
+      hiddenAtRef.current = Date.now();
+    }
+
     const handleVisibilityChange = (): void => {
       if (document.visibilityState === "hidden") {
         hiddenAtRef.current = Date.now();

--- a/apps/customer-portal/webapp/src/hooks/useProactiveTokenRefresh.ts
+++ b/apps/customer-portal/webapp/src/hooks/useProactiveTokenRefresh.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { useLogger } from "@hooks/useLogger";
+import { recoverViaSilentSignIn } from "@hooks/authRecovery";
+import { HIDDEN_REFRESH_THRESHOLD_MS } from "@constants/authConstants";
+
+export function useProactiveTokenRefresh(): void {
+  const { isSignedIn, signInSilently } = useAsgardeo();
+  const logger = useLogger();
+  const hiddenAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isSignedIn) {
+      hiddenAtRef.current = null;
+      return;
+    }
+
+    const handleVisibilityChange = (): void => {
+      if (document.visibilityState === "hidden") {
+        hiddenAtRef.current = Date.now();
+        return;
+      }
+
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+      if (hiddenAt === null) {
+        return;
+      }
+
+      const hiddenDuration = Date.now() - hiddenAt;
+      if (hiddenDuration < HIDDEN_REFRESH_THRESHOLD_MS) {
+        return;
+      }
+
+      logger.info("[proactiveRefresh] tab-returned-after-idle", {
+        hiddenDurationMs: hiddenDuration,
+      });
+      void recoverViaSilentSignIn(signInSilently, logger);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [isSignedIn, signInSilently, logger]);
+}

--- a/apps/customer-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/customer-portal/webapp/src/layouts/AppLayout.tsx
@@ -27,6 +27,7 @@ import { useAsgardeo } from "@asgardeo/react";
 import { useLoader } from "@context/linear-loader/LoaderContext";
 import { useLocation, Outlet } from "react-router";
 import IdleTimeoutProvider from "@providers/IdleTimeoutProvider";
+import { useProactiveTokenRefresh } from "@hooks/useProactiveTokenRefresh";
 import GlobalNotificationBanner from "@components/notification-banner/GlobalNotificationBanner";
 import TopBanner from "@components/top-banner/TopBanner";
 import Footer from "@components/footer/Footer";
@@ -55,6 +56,8 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
   const location = useLocation();
   const mainContentRef = useRef<HTMLDivElement>(null);
   const { isLoading: isAuthLoading } = useAsgardeo();
+
+  useProactiveTokenRefresh();
 
   // Scroll to top on route change
   useEffect(() => {


### PR DESCRIPTION
### Description

This pull request introduces a set of improvements to authentication reliability and user experience in the customer portal webapp. The main focus is on proactively handling token expiration and recovery, especially after periods of inactivity or when the browser tab is hidden and then revisited. It does this by adding silent sign-in recovery logic, a new proactive token refresh hook, and integrating these mechanisms into the authentication flow and main layout.

**Authentication recovery and proactive token refresh:**

* Added a new `recoverViaSilentSignIn` utility in `authRecovery.ts` to centralize and deduplicate logic for silent authentication recovery, with logging and error handling.
* Implemented `useProactiveTokenRefresh` hook to trigger a silent sign-in when the user returns to the tab after being hidden for a configurable period, improving session continuity.
* Integrated `useProactiveTokenRefresh` into the main `AppLayout`, ensuring all users benefit from proactive token refresh on tab visibility changes. [[1]](diffhunk://#diff-c2a3e50fb8a2a610c4442f7249a91c71d014d37bbd0c114c18eb513e04232ec7R30) [[2]](diffhunk://#diff-c2a3e50fb8a2a610c4442f7249a91c71d014d37bbd0c114c18eb513e04232ec7R60-R61)

**Enhancements to authentication API client:**

* Updated `useAuthApiClient` to use the new silent recovery logic if fetching a token fails, and to attempt silent recovery before retrying failed requests, reducing user disruptions due to session timeouts. [[1]](diffhunk://#diff-cac52d2fa2bef66d482b899571745fd94b0312d5df4547b0e9d98d8df075e3dcR24) [[2]](diffhunk://#diff-cac52d2fa2bef66d482b899571745fd94b0312d5df4547b0e9d98d8df075e3dcL57-R81) [[3]](diffhunk://#diff-cac52d2fa2bef66d482b899571745fd94b0312d5df4547b0e9d98d8df075e3dcR94-R115) [[4]](diffhunk://#diff-cac52d2fa2bef66d482b899571745fd94b0312d5df4547b0e9d98d8df075e3dcR193-R194)

**Configuration and minor changes:**

* Added `HIDDEN_REFRESH_THRESHOLD_MS` constant to control how long a tab must be hidden before triggering a proactive token refresh.
* Removed the `storage="localStorage"` prop from the Asgardeo provider in `AppWithConfig`, possibly to use default or alternative storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proactive token refresh that automatically refreshes authentication tokens when your browser tab becomes active after extended inactivity.
  * Enhanced authentication reliability with automatic silent sign-in recovery to handle token acquisition failures gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->