### PR TITLE
[Customer Portal][FE][Web] Customer Portal: Disable Chat Input on Solution Completion and Refactor Comment Rendering

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
@@ -45,13 +45,6 @@ function commentAuthorDisplayName(comment: CaseComment): string {
   return comment.createdBy?.trim() || "Unknown";
 }
 
-function shouldRenderCommentAsMarkdown(comment: CaseComment): boolean {
-  return (
-    comment.type?.toLowerCase() === "bot" ||
-    comment.createdBy?.trim().toLowerCase() === "novera"
-  );
-}
-
 /**
  * Single comment bubble: avatar, display name, date, and ChatMessageCard.
  *
@@ -67,7 +60,6 @@ export default function CommentBubble({
 }: CommentBubbleProps): import("react").JSX.Element {
   const theme = useTheme();
   const rawContent = comment.content ?? "";
-  const renderAsMarkdown = shouldRenderCommentAsMarkdown(comment);
   const isFullCodeWrap = hasSingleCodeWrapper(rawContent);
   const codeBlockCount = rawContent.match(/\[code\]/gi)?.length ?? 0;
   const afterCode = isFullCodeWrap

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatInput.tsx
@@ -45,7 +45,8 @@ export default function ChatInput({
   isCreateCaseLoading = false,
   resetTrigger = 0,
   forceRichText = false,
-}: ChatInputProps): JSX.Element {
+  disabled = false,
+}: ChatInputProps): JSX.Element | null {
   const plainText = htmlToPlainText(inputValue).trim();
   const isSendDisabled = !plainText || isSending;
   const [showToolbar, setShowToolbar] = useState(forceRichText);
@@ -59,6 +60,10 @@ export default function ChatInput({
   const maxLinesHeight = 120;
   const BUTTON_TOP_WITHOUT_TOOLBAR = 8;
   const BUTTON_TOP_WITH_TOOLBAR = 56;
+
+  if (disabled) {
+    return null;
+  }
 
   return (
     <Box sx={{ flexShrink: 0 }}>

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -314,6 +314,7 @@ export default function NoveraChatPage(): JSX.Element {
     }
   }, [isWaitingForClassification, isAllProductsLoading, performClassification]);
   const [showRichText, setShowRichText] = useState(false);
+  const [isInputDisabled, setIsInputDisabled] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputValueRef = useRef("");
   const [resetTrigger, setResetTrigger] = useState(0);
@@ -388,13 +389,15 @@ export default function NoveraChatPage(): JSX.Element {
     });
     if (appliedFinal) {
       setIsSending(false);
-      const hasSolutionProposed =
-        pending?.payload &&
-        Array.isArray(pending.payload.actions) &&
-        (pending.payload.actions as NoveraAction[]).some(
-          (a) => a.type === NoveraActionType.SolutionProposed,
-        );
-      if (hasSolutionProposed) setShowRichText(true);
+      const actions = Array.isArray(pending?.payload?.actions)
+        ? (pending.payload.actions as NoveraAction[])
+        : [];
+      if (actions.some((a) => a.type === NoveraActionType.SolutionProposed)) {
+        setShowRichText(true);
+      }
+      if (actions.some((a) => a.type === NoveraActionType.SolutionWorked)) {
+        setIsInputDisabled(true);
+      }
     }
   }, [setShowRichText]);
 
@@ -702,6 +705,7 @@ export default function NoveraChatPage(): JSX.Element {
             isSending={isSending}
             resetTrigger={resetTrigger}
             forceRichText={showRichText}
+            disabled={isInputDisabled}
           />
         </Paper>
       </Box>

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -450,6 +450,7 @@ export type ChatInputProps = {
   isCreateCaseLoading?: boolean;
   resetTrigger?: number;
   forceRichText?: boolean;
+  disabled?: boolean;
 };
 
 export type ChatHeaderProps = {


### PR DESCRIPTION
### Description

This pull request updates the Novera AI chat experience in the customer portal, primarily by adding logic to disable the chat input when a solution has been marked as "worked" and by cleaning up some comment rendering logic. The changes improve the user experience by preventing further input when appropriate and simplify the codebase by removing unused logic.

**Novera Chat Input Disablement and State Management:**
- Added an `isInputDisabled` state to `NoveraChatPage`, which is set to `true` when a `SolutionWorked` action is detected in the conversation actions. This disables the chat input when the solution is marked as worked. [[1]](diffhunk://#diff-2fc3f15354c4c50e3fc4255f18bc674ac774683dae876e9db06a34372dcde809R317) [[2]](diffhunk://#diff-2fc3f15354c4c50e3fc4255f18bc674ac774683dae876e9db06a34372dcde809L391-R400)
- Updated the `ChatInput` component and its props to accept a `disabled` flag. When `disabled` is true, the input returns `null` and is not rendered, effectively disabling user input. [[1]](diffhunk://#diff-11d11e6030b34cae79782629fb33ba9008380f62f221a82fa32876e3bcd55e06L48-R49) [[2]](diffhunk://#diff-11d11e6030b34cae79782629fb33ba9008380f62f221a82fa32876e3bcd55e06R64-R67) [[3]](diffhunk://#diff-a1ce9daab3a74b8369f989255d631191ba17536b5bfb2e46711ace456783c1b7R453) [[4]](diffhunk://#diff-2fc3f15354c4c50e3fc4255f18bc674ac774683dae876e9db06a34372dcde809R708)

**Comment Rendering Logic Cleanup:**
- Removed the unused `shouldRenderCommentAsMarkdown` function from `CommentBubble.tsx`, simplifying the comment rendering logic. [[1]](diffhunk://#diff-792e3bfc8d32232c36aa834a2f7f90ce44ccf2d06273eddf2da0d934112f539fL48-L54) [[2]](diffhunk://#diff-792e3bfc8d32232c36aa834a2f7f90ce44ccf2d06273eddf2da0d934112f539fL70)