### PR TITLE
[Customer Portal][BE] Move releasedOn and endOfLifeOn fields to reference table response

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -406,6 +406,10 @@ public type ReferenceTableItem record {|
     int count?;
     # Abbreviation
     string? abbreviation?;
+    # Release date (for product versions)
+    Date? releasedOn?;
+    # End of life date (for product versions)
+    Date? endOfLifeOn?;
     json...;
 |};
 
@@ -889,10 +893,6 @@ public type DeployedProduct record {|
     int? cores;
     # TPS allocated for the product
     decimal? tps;
-    # Release date of the product
-    string? releasedOn;
-    # End of life date of the product
-    string? endOfLifeOn;
     json...;
 |};
 

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -187,6 +187,10 @@ public type ReferenceItem record {|
     string? number?;
     # Abbreviation
     string? abbreviation?;
+    # Release date (for product versions)
+    entity:Date? releasedOn?;
+    # End of life date (for product versions)
+    entity:Date? endOfLifeOn?;
 |};
 
 # Case metadata information.
@@ -642,10 +646,6 @@ public type DeployedProduct record {|
     int? cores;
     # TPS allocated for the product
     decimal? tps;
-    # Release date of the product
-    string? releasedOn;
-    # End of life date of the product
-    string? endOfLifeOn;
 |};
 
 # Instance search filters.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2695,12 +2695,10 @@ components:
           type: string
           description: Allowed domain list of the account
           nullable: true
-          default: ""
         classification:
           type: string
           description: Account classification
           nullable: true
-          default: ""
         isPartner:
           type: boolean
           description: Whether the account is a partner or not

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2695,10 +2695,12 @@ components:
           type: string
           description: Allowed domain list of the account
           nullable: true
+          default: ""
         classification:
           type: string
           description: Account classification
           nullable: true
+          default: ""
         isPartner:
           type: boolean
           description: Whether the account is a partner or not
@@ -5226,6 +5228,16 @@ components:
           type: string
           description: Abbreviation
           nullable: true
+        releasedOn:
+          description: Release date (for product versions)
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/Date'
+        endOfLifeOn:
+          description: End of life date (for product versions)
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/Date'
       additionalProperties: false
       description: Reference item.
     ReferenceTableItem:
@@ -5252,6 +5264,16 @@ components:
           type: string
           description: Abbreviation
           nullable: true
+        releasedOn:
+          description: Release date (for product versions)
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/Date'
+        endOfLifeOn:
+          description: End of life date (for product versions)
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/Date'
       description: Basic table information.
     RegistryTokenCreatePayload:
       required:

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -290,12 +290,15 @@ public isolated function mapDeployedProducts(entity:DeployedProductsResponse res
             product: associatedProduct != () ? {
                     id: associatedProduct.id,
                     label: associatedProduct.name,
-                    abbreviation: associatedProduct?.abbreviation,
+                    abbreviation: associatedProduct?.abbreviation
+                } : (),
+            deployment: deployment != () ? {id: deployment.id, label: deployment.name} : (),
+            version: version != () ? {
+                    id: version.id,
+                    label: version.name,
                     releasedOn: associatedProduct?.releasedOn,
                     endOfLifeOn: associatedProduct?.endOfLifeOn
                 } : (),
-            deployment: deployment != () ? {id: deployment.id, label: deployment.name} : (),
-            version: version != () ? {id: version.id, label: version.name} : (),
             category: category != () ? {id: category.id, label: category.name} : ()
         };
 

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -286,13 +286,13 @@ public isolated function mapDeployedProducts(entity:DeployedProductsResponse res
             description: product.description,
             cores: product.cores,
             tps: product.tps,
-            releasedOn: product.releasedOn,
-            endOfLifeOn: product.endOfLifeOn,
             updates: product.updates,
             product: associatedProduct != () ? {
                     id: associatedProduct.id,
                     label: associatedProduct.name,
-                    abbreviation: associatedProduct?.abbreviation
+                    abbreviation: associatedProduct?.abbreviation,
+                    releasedOn: associatedProduct?.releasedOn,
+                    endOfLifeOn: associatedProduct?.endOfLifeOn
                 } : (),
             deployment: deployment != () ? {id: deployment.id, label: deployment.name} : (),
             version: version != () ? {id: version.id, label: version.name} : (),


### PR DESCRIPTION
## Summary
This PR refactors the placement of lifecycle fields by moving `releasedOn` and `endOfLifeOn` from the deployed product response to the reference table response.

## Changes

### 1️⃣ Reference Table Response Enhancement
- Added fields:
  - releasedOn
  - endOfLifeOn
- Updated DTOs/records and mapping logic
- Ensured proper serialization

### 2️⃣ Deployed Product Response Cleanup
- Removed:
  - releasedOn
  - endOfLifeOn
- Updated response models accordingly

## Reason
Lifecycle fields such as `releasedOn` and `endOfLifeOn` are more appropriately associated with product reference data rather than deployed product instances.

This change:
- Improves data normalization
- Avoids duplication across responses
- Aligns fields with their correct domain context
- Simplifies deployed product response

## Impact
⚠ Potential breaking change:
- Fields removed from deployed product response
- Consumers must fetch these values from the reference table response

## Testing
- Verified reference table response includes lifecycle fields
- Confirmed deployed product response no longer includes these fields
- Tested mapping and serialization logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved product release and end-of-life dates from deployed product entries into shared reference items and changed them to proper date types.
  * API schemas updated to expose these nullable date fields on reference entities.
  * Data mapping adjusted so version objects carry the release/EOL dates instead of top-level deployed product records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->