### PR TITLE
[Customer Portal]][BE] Add response interceptor to include security headers

### DIFF
--- a/apps/customer-portal/backend/modules/authorization/authorization.bal
+++ b/apps/customer-portal/backend/modules/authorization/authorization.bal
@@ -141,3 +141,17 @@ public isolated service class JwtInterceptor {
         return ctx.next();
     }
 }
+
+# Response interceptor to add security headers for the response.
+public isolated service class ResponseInterceptor {
+    *http:ResponseInterceptor;
+
+    isolated remote function interceptResponse(http:RequestContext ctx, http:Response res)
+        returns http:NextService|error? {
+
+        res.setHeader("X-Content-Type-Options", "nosniff");
+        res.setHeader("Content-Security-Policy", "upgrade-insecure-requests");
+        res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        return ctx.next();
+    }
+}

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -66,7 +66,7 @@ http:ListenerConfiguration listenerConf = {
 }
 service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     public function createInterceptors() returns http:Interceptor[] =>
-        [new authorization:JwtInterceptor(), new ErrorInterceptor(), new authorization:ResponseInterceptor()];
+        [new authorization:JwtInterceptor(), new authorization:ResponseInterceptor(), new ErrorInterceptor()];
 
     # Service init function.
     #

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -66,7 +66,7 @@ http:ListenerConfiguration listenerConf = {
 }
 service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     public function createInterceptors() returns http:Interceptor[] =>
-        [new authorization:JwtInterceptor(), new ErrorInterceptor()];
+        [new authorization:JwtInterceptor(), new ErrorInterceptor(), new authorization:ResponseInterceptor()];
 
     # Service init function.
     #


### PR DESCRIPTION
## Summary
This PR introduces a response interceptor to add standard security headers to all outgoing responses.

## Changes
- Added response interceptor/middleware
- Included the following security headers:

  - X-Content-Type-Options: nosniff  
  - Content-Security-Policy: upgrade-insecure-requests  
  - Strict-Transport-Security: max-age=31536000; includeSubDomains  

- Ensured headers are applied consistently across all endpoints

## Reason
Adding security headers improves application security by:

- Preventing MIME-type sniffing (`X-Content-Type-Options`)
- Enforcing secure resource loading (`Content-Security-Policy`)
- Enabling HTTPS enforcement via HSTS (`Strict-Transport-Security`)

This aligns the application with security best practices and helps mitigate common web vulnerabilities.

## Testing
- Verified headers are present in all API responses
- Tested across multiple endpoints
- Confirmed no impact on existing functionality
- Performed regression testing

## Impact
- Non-breaking change
- Improves security posture of the application
- No changes to API contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP responses now include security headers: Content-Security-Policy, X-Content-Type-Options, and Strict-Transport-Security are applied to all API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->