### PR TITLE
[Customer Portal][BE] Add time cards search endpoint for project scoped to cases

### DIFF
--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -415,6 +415,17 @@ public isolated function searchTimeCards(string idToken, TimeCardSearchPayload p
     return csEntityClient->/time\-cards/search.post(payload, generateHeaders(idToken));
 }
 
+# Search case time cards grouped by case.
+#
+# + idToken - ID token for authorization
+# + payload - Payload containing search criteria for case time cards
+# + return - Response containing matching case time cards grouped by case or error
+public isolated function searchTimeCardsGroupedByCases(string idToken, TimeCardSearchPayload payload)
+    returns CaseTimeCardsSearchResponse|error {
+
+    return csEntityClient->/cases/time\-cards/search.post(payload, generateHeaders(idToken));
+}
+
 # Search conversations of a project.
 #
 # + idToken - ID token for authorization

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -1770,6 +1770,51 @@ public type TimeCardsResponse record {|
     *Pagination;
 |};
 
+# Billing summary for time cards (billable or non-billable).
+public type CaseTimeCardBillingInfo record {|
+    # Total time
+    decimal totalTime;
+    # Count of time cards
+    int count;
+    json...;
+|};
+
+# Time card summary grouped by case.
+public type CaseTimeCardSummary record {|
+    # Case information
+    record {|
+        # System ID of the case
+        IdString id;
+        # Case number
+        string number;
+        # Case name/summary
+        string name;
+        # Last updated date and time
+        string updatedOn;
+        # Associated project information
+        ReferenceTableItem? project;
+        json...;
+    |} 'case;
+    # Total time logged for this case
+    decimal totalTime;
+    # Total count of time cards
+    int totalCount;
+    # Billable time information
+    CaseTimeCardBillingInfo billable;
+    # Non-billable time information
+    CaseTimeCardBillingInfo nonBillable;
+    json...;
+|};
+
+# Cases time cards search response.
+public type CaseTimeCardsSearchResponse record {|
+    # List of case time card summaries
+    CaseTimeCardSummary[] cases;
+    # Total records count
+    int totalRecords;
+    *Pagination;
+|};
+
 # Conversation data.
 public type Conversation record {|
     # ID of the chat

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1087,7 +1087,6 @@ public type ProductVersion record {|
     string? earliestPossibleSupportEolDate;
     # Product information
     ReferenceItem? product;
-    json...;
 |};
 
 # Product versions response.
@@ -1123,7 +1122,41 @@ public type TimeCard record {|
         # Case number
         string number;
     |}? case;
-    json...;
+|};
+
+# Time card grouped by case.
+public type CaseTimeCard record {|
+    # Case information
+    record {|
+        # ID of the case
+        entity:IdString id;
+        # Case number
+        string number;
+        # Case name/summary
+        string name;
+        # Last updated date and time
+        string updatedOn;
+        # Associated project information
+        ReferenceItem? project;
+        json...;
+    |} 'case;
+    # Total time logged for this case
+    decimal totalTime;
+    # Total count of time cards
+    int totalCount;
+    # Billable time information
+    entity:CaseTimeCardBillingInfo billable;
+    # Non-billable time information
+    entity:CaseTimeCardBillingInfo nonBillable;
+|};
+
+# Cases time cards search response.
+public type CaseTimeCardsSearchResponse record {|
+    # List of case time card summaries
+    CaseTimeCard[] caseTimeCards;
+    # Total records count
+    int totalRecords;
+    *entity:Pagination;
 |};
 
 # Time cards response.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2058,6 +2058,36 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+  /projects/{id}/cases/time-cards/search:
+    post:
+      operationId: postProjectsIdCasesTimeCardsSearch
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimeCardSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
   /projects/{id}/stats/time-cards:
     get:
       summary: Get time card statistics for a project based on provided date range.

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -3821,6 +3821,72 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         };
     }
 
+    # Search time cards grouped by cases based on provided filters.
+    #
+    # + id - ID of the project
+    # + payload - Time card search payload containing filters and pagination info
+    # + return - List of time cards grouped by cases matching the criteria or an error
+    resource function post projects/[entity:IdString id]/cases/time\-cards/search(http:RequestContext ctx,
+            types:TimeCardSearchPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+        
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:CaseTimeCardsSearchResponse|error response = entity:searchTimeCardsGroupedByCases(userInfo.idToken,
+                {
+                    filters: {
+                        projectIds: [id],
+                        startDate: payload.filters?.startDate,
+                        endDate: payload.filters?.endDate,
+                        states: payload.filters?.states
+                    },
+                    pagination: payload.pagination
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching time cards grouped by cases."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access time card information!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                log:printWarn(string `Access to time card information is forbidden for user: ${userInfo.userId}`);
+                return <http:Forbidden>{
+                    body: {
+                        message: "Access to time card information is forbidden for the user!"
+                    }
+                };
+            }
+
+            string customError = "Failed to search time cards grouped by cases.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+        return <http:Ok>{
+            body: mapTimeCardSearchResponseGroupedByCases(response)
+        };
+    }
+
     # Get time card statistics for a project based on provided date range.
     #
     # + id - ID of the project

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1034,3 +1034,28 @@ public isolated function mapInstanceUsages(entity:InstanceUsageResponse response
         endDate: response.endDate
     };
 }
+
+# Map time cards search response grouped by cases to the desired structure.
+#
+# + response - Time cards search response grouped by cases from the entity service
+# + return - Mapped time cards search response grouped by cases
+public isolated function mapTimeCardSearchResponseGroupedByCases(entity:CaseTimeCardsSearchResponse response)
+    returns types:CaseTimeCardsSearchResponse {
+
+    types:CaseTimeCard[] caseTimeCards = from entity:CaseTimeCardSummary caseTimeCard in response.cases
+        let entity:ReferenceTableItem? project = caseTimeCard.case.project
+        select {
+            case: {
+                id: caseTimeCard.case.id,
+                number: caseTimeCard.case.number,
+                name: caseTimeCard.case.name,
+                updatedOn: caseTimeCard.case.updatedOn,
+                project: project != () ? {id: project.id, label: project.name} : ()
+            },
+            totalTime: caseTimeCard.totalTime,
+            totalCount: caseTimeCard.totalCount,
+            billable: caseTimeCard.billable,
+            nonBillable: caseTimeCard.nonBillable
+        };
+    return {caseTimeCards, totalRecords: response.totalRecords, 'limit: response.'limit, offset: response.offset};
+}


### PR DESCRIPTION
## Summary
This PR introduces a new endpoint to search time cards for a project, scoped to cases.

## Changes
- Added time cards search endpoint for a project:
  - POST /projects/{id}/time-cards/search
- Implemented filtering logic to fetch time cards linked to cases within the project
- Added validation for project and case associations
- Updated request/response models
- Integrated service-layer query handling

## Functionality
The new endpoint enables:
- Searching time cards within a project
- Fetching time cards associated with cases under the project
- Supporting filtering (e.g., by case, user, date range if applicable)
- Handling complex queries via POST payload

## Reason
Previously, time cards were not easily searchable at the project level when bound to cases.  
This enhancement enables:

- Better visibility into time spent per project
- Case-level time tracking within projects
- Improved reporting and dashboard capabilities
- Reduced need for frontend aggregation

## Testing
- Verified time card search scoped to project and cases
- Tested filtering with different parameters
- Confirmed behavior for invalid project/case IDs
- Tested empty result scenarios

## Impact
- New endpoint added (non-breaking enhancement)
- No changes to existing APIs
- Improves time tracking and reporting capabilities


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new search endpoint that retrieves and groups time cards by cases, including aggregated billing information (billable/non-billable hours and counts) with support for filtering and pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->