### PR TITLE
[Customer Portal][FE][Web] Redirect ServiceNow Case Errors to 404 Page

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ServiceNowCaseRedirectPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ServiceNowCaseRedirectPage.tsx
@@ -48,7 +48,7 @@ export default function ServiceNowCaseRedirectPage(): JSX.Element {
   useEffect(() => {
     if (!caseId) {
       showError(SERVICENOW_REDIRECT_NO_CASE_ID);
-      void navigate("/", { replace: true });
+      void navigate("/404", { replace: true });
       return;
     }
     if (isLoading) {
@@ -60,7 +60,7 @@ export default function ServiceNowCaseRedirectPage(): JSX.Element {
   useEffect(() => {
     if (isError || (!isLoading && data && !data.project?.id)) {
       showError(SERVICENOW_REDIRECT_RESOLVE_ERROR);
-      void navigate("/", { replace: true });
+      void navigate("/404", { replace: true });
       return;
     }
 


### PR DESCRIPTION
### Description

This pull request updates the redirect behavior in the `ServiceNowCaseRedirectPage` component to improve error handling. Instead of redirecting users to the homepage on certain errors, users are now redirected to a dedicated 404 error page, providing clearer feedback when a ServiceNow case cannot be found or resolved.

**Error handling improvements:**

* Updated redirects in `ServiceNowCaseRedirectPage.tsx` to send users to `/404` instead of `/` when a case ID is missing or when case resolution fails. [[1]](diffhunk://#diff-e6ed9047c2ff41547eab6426cfc12ef993b49188008f9200ad8d3553385eb1f6L51-R51) [[2]](diffhunk://#diff-e6ed9047c2ff41547eab6426cfc12ef993b49188008f9200ad8d3553385eb1f6L63-R63)