### PR TITLE
[Customer Portal][FE][Web] Swap dashboard stat icons and remove unused prop

### DIFF
--- a/apps/customer-portal/webapp/src/features/dashboard/constants/dashboard.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/constants/dashboard.ts
@@ -67,14 +67,14 @@ export const DASHBOARD_STATS: StatConfigItem[] = [
   {
     id: "totalCases",
     label: "Action Required",
-    icon: Clock,
+    icon: AlertCircle,
     iconColor: "primary",
     tooltipText: "Total number of cases reported for this project",
   },
   {
     id: "openCases",
     label: "Outstanding",
-    icon: AlertCircle,
+    icon: Clock,
     iconColor: "warning",
     tooltipText: "Currently active and unresolved cases",
   },

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -88,7 +88,6 @@ export default function CaseDetailsActionRow({
   caseId = "",
   isLoading = false,
   showOnlyEngineer = false,
-  hideAssignedEngineer = false,
 }: CaseDetailsActionRowProps): JSX.Element {
   void assignedEngineer;
   void engineerInitials;


### PR DESCRIPTION
## Description

This pull request includes minor UI and code cleanup changes to the customer portal dashboard and case details components.

Dashboard UI improvements:
* Swapped the icons for the "Action Required" (`totalCases`) and "Outstanding" (`openCases`) dashboard stats: "Action Required" now uses `AlertCircle` and "Outstanding" uses `Clock` for clearer visual representation.

Code cleanup:
* Removed the unused `hideAssignedEngineer` prop from the `CaseDetailsActionRow` component, simplifying its interface.