### PR TITLE
[Customer Portal][FE][Web] Add hideFiltersButton Prop to ListSearchPanel & Minor Support Import Update

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
@@ -43,6 +43,7 @@ export interface ListSearchPanelProps {
   hideStatusFilter?: boolean;
   hideDeploymentFilter?: boolean;
   hideCategoryFilter?: boolean;
+  hideFiltersButton?: boolean;
   isProjectContextLoading?: boolean;
   onLoadMoreDeployments?: () => void;
   hasMoreDeployments?: boolean;
@@ -73,6 +74,7 @@ export default function ListSearchPanel({
   hideStatusFilter = false,
   hideDeploymentFilter = false,
   hideCategoryFilter = false,
+  hideFiltersButton = false,
   isProjectContextLoading = false,
   onLoadMoreDeployments,
   hasMoreDeployments = false,

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -44,7 +44,7 @@ import {
   getDashboardOutstandingCasesDescription,
   getDashboardOutstandingCasesTitle,
 } from "@features/dashboard/utils/dashboardNavigation";
-import { CaseType } from "@features/support/constants/supportConstants";
+import { CaseStatus, CaseType } from "@features/support/constants/supportConstants";
 import { SortOrder } from "@/types/common";
 import {
   getProjectPermissions,


### PR DESCRIPTION
### Description 

This pull request introduces a minor enhancement to the `ListSearchPanel` component and a small import update in the support feature. The most significant change is the addition of a new prop to control the visibility of the filters button in the list view.

Enhancements to List View Components:

* Added a new optional boolean prop `hideFiltersButton` to the `ListSearchPanelProps` interface in `ListSearchPanel.tsx`, allowing consumers to hide the filters button if needed.
* Updated the default value for the new `hideFiltersButton` prop in the `ListSearchPanel` component to `false`.

Support Feature Import Update:

* Updated the import statement in `AllCasesPage.tsx` to include `CaseStatus` from `supportConstants`, likely for future or existing usage.