### PR TITLE
[Customer Portal][FE][Web] Enhance engagement filtering with interactive stat cards and improved dashboard UX

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListStatGrid.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListStatGrid.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, StatCard, Skeleton } from "@wso2/oxygen-ui";
+import { Box, StatCard, Skeleton, useTheme } from "@wso2/oxygen-ui";
 import { type JSX } from "react";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import { type SupportStatConfig } from "@features/support/constants/supportConstants";
@@ -65,6 +65,7 @@ export default function ListStatGrid<T extends string>({
   valueFormatter,
   onStatClick,
 }: ListStatGridProps<T>): JSX.Element {
+  const theme = useTheme();
   const xs = itemSize.xs ?? 12;
   const sm = itemSize.sm ?? 6;
   const md = itemSize.md ?? 3;
@@ -110,6 +111,17 @@ export default function ListStatGrid<T extends string>({
               position: "relative",
               minWidth: 0,
               cursor: onStatClick ? "pointer" : undefined,
+              borderRadius: 1,
+              transition: onStatClick ? "box-shadow 0.2s ease, transform 0.15s ease" : undefined,
+              "&:hover": onStatClick
+                ? {
+                    boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
+                    transform: "translateY(-2px)",
+                  }
+                : undefined,
+              "&:focus-visible": onStatClick
+                ? { outline: "2px solid", outlineOffset: 2 }
+                : undefined,
             }}
           >
             {SecondaryIcon && (

--- a/apps/customer-portal/webapp/src/features/dashboard/components/charts/ActiveCasesChart.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/charts/ActiveCasesChart.tsx
@@ -150,11 +150,10 @@ export const ActiveCasesChart = ({
               "& *:focus": { outline: "none" },
               ...(onSliceClick && !isError && {
                 "& .recharts-pie-sector": { cursor: "pointer" },
-                cursor: "pointer",
-                transition: "box-shadow 0.2s ease, transform 0.15s ease",
-                "&:hover": {
-                  boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
-                  transform: "translateY(-2px)",
+                "& .recharts-pie-sector:hover path": {
+                  stroke: theme.palette.primary.main,
+                  strokeWidth: 2,
+                  filter: "drop-shadow(0 2px 8px rgba(0,0,0,0.18))",
                 },
               }),
             }}

--- a/apps/customer-portal/webapp/src/features/dashboard/components/charts/ActiveCasesChart.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/charts/ActiveCasesChart.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Card, Typography, Box, Skeleton, colors, alpha } from "@wso2/oxygen-ui";
+import { Card, Typography, Box, Skeleton, colors, alpha, useTheme } from "@wso2/oxygen-ui";
 import { Inbox } from "@wso2/oxygen-ui-icons-react";
 import {
   PieChart,
@@ -64,6 +64,7 @@ export const ActiveCasesChart = ({
   onSliceClick,
 }: ActiveCasesChartProps): JSX.Element => {
   const isDarkMode = useDarkMode();
+  const theme = useTheme();
   // safe data
   const safeData = data ?? EMPTY_ACTIVE_CASES_DATA;
   // series config
@@ -147,7 +148,15 @@ export const ActiveCasesChart = ({
               opacity: isError ? 0.3 : 1,
               filter: isError ? "grayscale(1)" : "none",
               "& *:focus": { outline: "none" },
-              ...(onSliceClick && !isError && { "& .recharts-pie-sector": { cursor: "pointer" } }),
+              ...(onSliceClick && !isError && {
+                "& .recharts-pie-sector": { cursor: "pointer" },
+                cursor: "pointer",
+                transition: "box-shadow 0.2s ease, transform 0.15s ease",
+                "&:hover": {
+                  boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
+                  transform: "translateY(-2px)",
+                },
+              }),
             }}
           >
             <ResponsiveContainer width="100%" height="100%">

--- a/apps/customer-portal/webapp/src/features/dashboard/components/charts/OutstandingIncidentsChart.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/charts/OutstandingIncidentsChart.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Card, Typography, Box, Skeleton, colors, alpha } from "@wso2/oxygen-ui";
+import { Card, Typography, Box, Skeleton, colors, alpha, useTheme } from "@wso2/oxygen-ui";
 import { Inbox } from "@wso2/oxygen-ui-icons-react";
 import {
   PieChart,
@@ -64,6 +64,7 @@ export const OutstandingIncidentsChart = ({
   onSeverityClick,
 }: OutstandingIncidentsChartProps): JSX.Element => {
   const isDarkMode = useDarkMode();
+  const theme = useTheme();
   // safe data
   const safeData = data ?? EMPTY_OUTSTANDING_INCIDENTS_DATA;
   const displayedData = restrictSeverityToLow
@@ -176,7 +177,15 @@ export const OutstandingIncidentsChart = ({
               opacity: isError ? 0.3 : 1,
               filter: isError ? "grayscale(1)" : "none",
               "& *:focus": { outline: "none" },
-              ...(onSeverityClick && !isError && { "& .recharts-pie-sector": { cursor: "pointer" } }),
+              ...(onSeverityClick && !isError && {
+                "& .recharts-pie-sector": { cursor: "pointer" },
+                cursor: "pointer",
+                transition: "box-shadow 0.2s ease, transform 0.15s ease",
+                "&:hover": {
+                  boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
+                  transform: "translateY(-2px)",
+                },
+              }),
             }}
           >
             <ResponsiveContainer width="100%" height="100%">

--- a/apps/customer-portal/webapp/src/features/dashboard/components/charts/OutstandingIncidentsChart.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/charts/OutstandingIncidentsChart.tsx
@@ -179,11 +179,10 @@ export const OutstandingIncidentsChart = ({
               "& *:focus": { outline: "none" },
               ...(onSeverityClick && !isError && {
                 "& .recharts-pie-sector": { cursor: "pointer" },
-                cursor: "pointer",
-                transition: "box-shadow 0.2s ease, transform 0.15s ease",
-                "&:hover": {
-                  boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
-                  transform: "translateY(-2px)",
+                "& .recharts-pie-sector:hover path": {
+                  stroke: theme.palette.primary.main,
+                  strokeWidth: 2,
+                  filter: "drop-shadow(0 2px 8px rgba(0,0,0,0.18))",
                 },
               }),
             }}

--- a/apps/customer-portal/webapp/src/features/dashboard/components/stats/StatCard.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/stats/StatCard.tsx
@@ -77,6 +77,11 @@ export const StatCard = ({
         height: "100%",
         ...(onClick && {
           cursor: "pointer",
+          transition: "box-shadow 0.2s ease, transform 0.15s ease",
+          "&:hover": {
+            boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
+            transform: "translateY(-2px)",
+          },
           "&:focus-visible": {
             outline: `2px solid ${theme.palette.primary.main}`,
             outlineOffset: 2,

--- a/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
@@ -421,7 +421,7 @@ export default function DashboardItemsPage({
             ? "Review items that require your attention"
             : "View all currently active and unresolved interactions"
         }
-        backLabel="Back to Dashboard"
+        backLabel="Back"
         onBack={() => navigate(returnTo ?? "..")}
       />
 

--- a/apps/customer-portal/webapp/src/features/engagements/components/EngagementsStatCards.tsx
+++ b/apps/customer-portal/webapp/src/features/engagements/components/EngagementsStatCards.tsx
@@ -36,6 +36,7 @@ export default function EngagementsStatCards({
   stats,
   isLoading,
   isError,
+  onStatClick,
 }: EngagementsStatCardsProps): JSX.Element {
   const flattened = useMemo(() => computeEngagementsStatValues(stats), [stats]);
 
@@ -47,6 +48,7 @@ export default function EngagementsStatCards({
       isError={isError}
       entityName={ENGAGEMENTS_STAT_GRID_ENTITY_NAME}
       itemSize={{ xs: 12, sm: 4, md: 4 }}
+      onStatClick={onStatClick}
     />
   );
 }

--- a/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
@@ -26,10 +26,10 @@ import { getProjectSeverityPolicy } from "@utils/permission";
 import { isS0Case } from "@features/support/utils/support";
 import { hasListSearchOrFilters } from "@features/support/utils/support";
 import type { AllCasesFilterValues } from "@features/support/types/cases";
-import { CaseType } from "@features/support/constants/supportConstants";
+import { CaseStatus, CaseType } from "@features/support/constants/supportConstants";
 import { SortOrder } from "@/types/common";
 import { ENGAGEMENTS_PAGE_SIZE } from "@/features/engagements/constants/engagements";
-import { EngagementsSortField } from "@features/engagements/types/engagements";
+import { EngagementsSortField, type EngagementsStatKey } from "@features/engagements/types/engagements";
 import {
   buildEngagementSearchRequest,
   buildEngagementDetailPath,
@@ -65,6 +65,8 @@ export function useEngagementsPageState() {
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.DESC);
   const [page, setPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(ENGAGEMENTS_PAGE_SIZE);
+  const [fixedStatusIds, setFixedStatusIds] = useState<number[] | undefined>(undefined);
+  const [activeStatKey, setActiveStatKey] = useState<EngagementsStatKey | undefined>(undefined);
 
   const { data: project, isLoading: isProjectLoading } = useGetProjectDetails(
     projectId || "",
@@ -97,11 +99,19 @@ export function useEngagementsPageState() {
     projectId,
   );
 
-  const engagementSearchRequest = useMemo(
-    () =>
-      buildEngagementSearchRequest(filters, searchTerm, sortField, sortOrder),
-    [filters, searchTerm, sortField, sortOrder],
-  );
+  const engagementSearchRequest = useMemo(() => {
+    const base = buildEngagementSearchRequest(filters, searchTerm, sortField, sortOrder);
+    if (fixedStatusIds !== undefined) {
+      return {
+        ...base,
+        filters: {
+          ...base.filters,
+          statusIds: fixedStatusIds.length > 0 ? fixedStatusIds : undefined,
+        },
+      };
+    }
+    return base;
+  }, [filters, searchTerm, sortField, sortOrder, fixedStatusIds]);
 
   const {
     data,
@@ -183,6 +193,43 @@ export function useEngagementsPageState() {
   const handleClearFilters = () => {
     setFilters({});
     setSearchTerm("");
+    setFixedStatusIds(undefined);
+    setActiveStatKey(undefined);
+    setPage(1);
+  };
+
+  const handleStatCardClick = (key: EngagementsStatKey) => {
+    if (!filterMetadata?.caseStates) return;
+    const getStateId = (label: string): number | null => {
+      const s = filterMetadata.caseStates!.find((st) => st.label === label);
+      return s != null ? Number(s.id) : null;
+    };
+    let ids: number[] | undefined;
+    switch (key) {
+      case "active": {
+        const closedId = getStateId(CaseStatus.CLOSED);
+        ids = filterMetadata.caseStates
+          .map((s) => Number(s.id))
+          .filter((id) => id !== closedId);
+        break;
+      }
+      case "completed": {
+        const id = getStateId(CaseStatus.CLOSED);
+        ids = id != null ? [id] : undefined;
+        break;
+      }
+      case "onHold": {
+        const awaitingId = getStateId(CaseStatus.AWAITING_INFO);
+        const waitingId = getStateId(CaseStatus.WAITING_ON_WSO2);
+        ids = [awaitingId, waitingId].filter((id): id is number => id != null);
+        break;
+      }
+      default:
+        ids = undefined;
+    }
+    setFixedStatusIds(ids);
+    setActiveStatKey(key);
+    setFilters((prev) => ({ ...prev, statusId: undefined }));
     setPage(1);
   };
 
@@ -241,6 +288,10 @@ export function useEngagementsPageState() {
     handleSortChange,
     handleSortFieldUiChange,
     handleSearchChange,
+    handleStatCardClick,
+    isStatFiltered: fixedStatusIds !== undefined,
+    activeStatKey,
+    clearStatFilter: () => { setFixedStatusIds(undefined); setActiveStatKey(undefined); setPage(1); },
     onCaseClick,
   };
 }

--- a/apps/customer-portal/webapp/src/features/engagements/pages/EngagementsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/engagements/pages/EngagementsPage.tsx
@@ -16,11 +16,19 @@
 
 import type { JSX } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { Box, Button, Stack } from "@wso2/oxygen-ui";
+import { Box, Button, Stack, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import type { EngagementsStatKey } from "@features/engagements/types/engagements";
 import EngagementsListSection from "@features/engagements/components/EngagementsListSection";
 import EngagementsStatCards from "@features/engagements/components/EngagementsStatCards";
 import { useEngagementsPageState } from "@features/engagements/hooks/useEngagementsPageState";
+
+const ENGAGEMENT_STAT_FILTER_INFO: Record<EngagementsStatKey, { title: string; subtitle: string }> = {
+  total: { title: "All Engagements", subtitle: "All engagement cases" },
+  active: { title: "Outstanding Engagements", subtitle: "Active engagements without closed state" },
+  completed: { title: "Completed Engagements", subtitle: "Engagements in closed state" },
+  onHold: { title: "On Hold Engagements", subtitle: "Engagements awaiting info or action" },
+};
 
 /**
  * Engagements list: stats, search, filters, sort, and paginated cases.
@@ -60,27 +68,49 @@ export default function EngagementsPage(): JSX.Element {
     handleSortChange,
     handleSortFieldUiChange,
     handleSearchChange,
+    handleStatCardClick,
+    isStatFiltered,
+    activeStatKey,
+    clearStatFilter,
     onCaseClick,
   } = useEngagementsPageState();
 
   return (
     <Stack spacing={3}>
-      {returnTo && (
+      {(returnTo || isStatFiltered) && (
         <Box>
           <Button
             startIcon={<ArrowLeft size={16} />}
-            onClick={() => navigate(returnTo)}
+            onClick={() => {
+              if (isStatFiltered) {
+                clearStatFilter();
+              } else if (returnTo) {
+                navigate(returnTo);
+              }
+            }}
             variant="text"
           >
-            Back to Dashboard
+            Back
           </Button>
         </Box>
       )}
-      <EngagementsStatCards
-        stats={stats}
-        isLoading={isStatsLoading}
-        isError={isStatsError}
-      />
+      {isStatFiltered ? (
+        <Box>
+          <Typography variant="h5" color="text.primary" sx={{ mb: 0.5 }}>
+            {activeStatKey ? ENGAGEMENT_STAT_FILTER_INFO[activeStatKey].title : ""}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {activeStatKey ? ENGAGEMENT_STAT_FILTER_INFO[activeStatKey].subtitle : ""}
+          </Typography>
+        </Box>
+      ) : (
+        <EngagementsStatCards
+          stats={stats}
+          isLoading={isStatsLoading}
+          isError={isStatsError}
+          onStatClick={handleStatCardClick}
+        />
+      )}
       <EngagementsListSection
         searchTerm={searchTerm}
         onSearchChange={handleSearchChange}

--- a/apps/customer-portal/webapp/src/features/engagements/types/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/types/engagements.ts
@@ -38,6 +38,7 @@ export type EngagementsStatCardsProps = {
   stats?: ProjectCasesStats;
   isLoading: boolean;
   isError: boolean;
+  onStatClick?: (key: EngagementsStatKey) => void;
 };
 
 export type EngagementsSortOption = {

--- a/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestsPage.tsx
@@ -302,7 +302,7 @@ export default function ChangeRequestsPage(): JSX.Element {
             ? CHANGE_REQUESTS_PAGE_DESCRIPTION_OUTSTANDING
             : CHANGE_REQUESTS_PAGE_DESCRIPTION
         }
-        backLabel={returnTo ? "Back to Dashboard" : OPERATIONS_LIST_BACK_LABEL}
+        backLabel={OPERATIONS_LIST_BACK_LABEL}
         onBack={() => (returnTo ? navigate(returnTo) : navigate(".."))}
         actions={exportButton}
       />

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
@@ -312,7 +312,7 @@ export default function ServiceRequestsPage(): JSX.Element {
             sx={{ mb: 2 }}
             variant="text"
           >
-            {returnTo ? "Back to Dashboard" : OPERATIONS_LIST_BACK_LABEL}
+            {OPERATIONS_LIST_BACK_LABEL}
           </Button>
           <Typography variant="body2" color="text.secondary">
             Service requests are not available for this project.
@@ -332,7 +332,7 @@ export default function ServiceRequestsPage(): JSX.Element {
             sx={{ mb: 2 }}
             variant="text"
           >
-            {returnTo ? "Back to Dashboard" : OPERATIONS_LIST_BACK_LABEL}
+            {OPERATIONS_LIST_BACK_LABEL}
           </Button>
           <ErrorIndicator entityName={SERVICE_REQUESTS_ERROR_ENTITY_NAME} size="medium" />
         </Box>
@@ -373,7 +373,7 @@ export default function ServiceRequestsPage(): JSX.Element {
             ? SERVICE_REQUESTS_PAGE_DESCRIPTION_MINE
             : SERVICE_REQUESTS_PAGE_DESCRIPTION_ALL
         }
-        backLabel={returnTo ? "Back to Dashboard" : OPERATIONS_LIST_BACK_LABEL}
+        backLabel={OPERATIONS_LIST_BACK_LABEL}
         onBack={() => (returnTo ? navigate(returnTo) : navigate(".."))}
         actions={newRequestButton}
       />

--- a/apps/customer-portal/webapp/src/features/project-hub/components/project-card/ProjectCardActions.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/project-card/ProjectCardActions.tsx
@@ -42,6 +42,14 @@ export default function ProjectCardActions({
             e.stopPropagation();
             onViewDashboard?.();
           }}
+          sx={{
+            transition: "color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease",
+            "&:hover": {
+              color: "primary.contrastText",
+              backgroundColor: "primary.main",
+              borderColor: "primary.main",
+            },
+          }}
         >
           {PROJECT_CARD_VIEW_DASHBOARD_LABEL}
         </Button>

--- a/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
@@ -65,12 +65,16 @@ import {
 } from "@features/security/utils/securityPage";
 import { getProjectPermissions, isProjectRestricted } from "@utils/permission";
 
+type SecurityReportAnalysisProps = {
+  fixedStatusIds?: number[];
+};
+
 /**
  * SecurityReportAnalysis displays security vulnerability reports uploaded for analysis.
  *
  * @returns {JSX.Element}
  */
-const SecurityReportAnalysis = (): JSX.Element => {
+const SecurityReportAnalysis = ({ fixedStatusIds }: SecurityReportAnalysisProps): JSX.Element => {
   const navigate = useNavigate();
   const { projectId } = useParams<{ projectId: string }>();
   const { data: projectDetails, isLoading: isProjectLoading } =
@@ -115,7 +119,9 @@ const SecurityReportAnalysis = (): JSX.Element => {
         caseTypes: [CaseType.SECURITY_REPORT_ANALYSIS],
         createdByMe:
           viewMode === SecurityReportViewMode.MY ? true : undefined,
-        statusIds: filters.statusId ? [Number(filters.statusId)] : undefined,
+        statusIds: fixedStatusIds !== undefined
+          ? (fixedStatusIds.length > 0 ? fixedStatusIds : undefined)
+          : (filters.statusId ? [Number(filters.statusId)] : undefined),
         severityId: filters.severityId ? Number(filters.severityId) : undefined,
         issueId: filters.issueTypes ? Number(filters.issueTypes) : undefined,
         deploymentId: filters.deploymentId || undefined,
@@ -126,7 +132,7 @@ const SecurityReportAnalysis = (): JSX.Element => {
         order: sortOrder,
       },
     }),
-    [filters, searchTerm, sortField, sortOrder, viewMode],
+    [filters, searchTerm, sortField, sortOrder, viewMode, fixedStatusIds],
   );
 
   const { data, isLoading, hasNextPage, fetchNextPage } = useGetProjectCases(

--- a/apps/customer-portal/webapp/src/features/security/components/SecurityStats.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/SecurityStats.tsx
@@ -26,12 +26,16 @@ import {
 } from "@features/security/constants/securityConstants";
 import { SecurityStatKey } from "@features/security/types/security";
 
+type SecurityStatsProps = {
+  onStatClick?: (key: SecurityStatKey) => void;
+};
+
 /**
  * SecurityStats component displays security-related statistics cards.
  *
  * @returns {JSX.Element} The rendered SecurityStats component.
  */
-export default function SecurityStats(): JSX.Element {
+export default function SecurityStats({ onStatClick }: SecurityStatsProps): JSX.Element {
   const { projectId } = useParams<{ projectId: string }>();
 
   const {
@@ -59,6 +63,7 @@ export default function SecurityStats(): JSX.Element {
         stats={stats}
         configs={SECURITY_STAT_CONFIGS}
         itemSize={{ xs: 12, sm: 4, md: 4 }}
+        onStatClick={onStatClick}
       />
     </Box>
   );

--- a/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
+++ b/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
@@ -14,19 +14,37 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useCallback, useMemo, type JSX } from "react";
+import { useCallback, useMemo, useState, type JSX } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
-import { Box } from "@wso2/oxygen-ui";
+import { Box, Button, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import useGetProjectDetails from "@api/useGetProjectDetails";
 import useGetProjectFeatures from "@api/useGetProjectFeatures";
+import useGetProjectFilters from "@api/useGetProjectFilters";
 import SecurityStats from "@features/security/components/SecurityStats";
 import TabBar from "@components/tab-bar/TabBar";
 import ProductVulnerabilitiesTable from "@features/security/components/ProductVulnerabilitiesTable";
 import SecurityReportAnalysis from "@features/security/components/SecurityReportAnalysis";
 import { SECURITY_PAGE_TABS } from "@features/security/constants/securityConstants";
-import { SecurityTabId } from "@features/security/types/security";
+import { SecurityStatKey, SecurityTabId } from "@features/security/types/security";
 import { parseSecurityTabQueryParam } from "@features/security/utils/securityPage";
 import { getProjectPermissions } from "@utils/permission";
+import { CaseStatus } from "@features/support/constants/supportConstants";
+
+const SECURITY_STAT_FILTER_INFO: Record<SecurityStatKey, { title: string; subtitle: string }> = {
+  [SecurityStatKey.activeSecurityReports]: {
+    title: "Outstanding Security Reports",
+    subtitle: "Security reports without closed state",
+  },
+  [SecurityStatKey.resolvedSecurityReports]: {
+    title: "Resolved Security Reports (Last 30d)",
+    subtitle: "Security reports in closed state",
+  },
+  [SecurityStatKey.totalVulnerabilities]: {
+    title: "All Security Reports",
+    subtitle: "All security reports",
+  },
+};
 
 const SecurityPage = (): JSX.Element => {
   const navigate = useNavigate();
@@ -35,6 +53,16 @@ const SecurityPage = (): JSX.Element => {
   const { data: projectDetails } = useGetProjectDetails(projectId || "");
   const { data: projectFeatures, isLoading: isProjectFeaturesLoading } =
     useGetProjectFeatures(projectId || "");
+  const { data: filterMetadata } = useGetProjectFilters(projectId || "");
+  const [fixedStatusIds, setFixedStatusIds] = useState<number[] | undefined>(undefined);
+  const [activeStatKey, setActiveStatKey] = useState<SecurityStatKey | undefined>(undefined);
+
+  const isStatFiltered = fixedStatusIds !== undefined;
+
+  const clearStatFilter = () => {
+    setFixedStatusIds(undefined);
+    setActiveStatKey(undefined);
+  };
 
   const tabParam = searchParams.get("tab");
   const rawActiveTab = parseSecurityTabQueryParam(tabParam);
@@ -55,6 +83,35 @@ const SecurityPage = (): JSX.Element => {
       navigate(`/projects/${projectId}/security-center/${vulnerability.id}`);
     },
     [navigate, projectId],
+  );
+
+  const handleStatCardClick = useCallback(
+    (key: SecurityStatKey) => {
+      if (!filterMetadata?.caseStates) return;
+      const getStateId = (label: string): number | null => {
+        const s = filterMetadata.caseStates!.find((st) => st.label === label);
+        return s != null ? Number(s.id) : null;
+      };
+      let ids: number[] | undefined;
+      switch (key) {
+        case SecurityStatKey.activeSecurityReports: {
+          const closedId = getStateId(CaseStatus.CLOSED);
+          ids = filterMetadata.caseStates.map((s) => Number(s.id)).filter((id) => id !== closedId);
+          break;
+        }
+        case SecurityStatKey.resolvedSecurityReports: {
+          const id = getStateId(CaseStatus.CLOSED);
+          ids = id != null ? [id] : undefined;
+          break;
+        }
+        default:
+          ids = undefined;
+      }
+      setFixedStatusIds(ids);
+      setActiveStatKey(key);
+      handleTabChange(SecurityTabId.VULNERABILITIES);
+    },
+    [filterMetadata, handleTabChange],
   );
 
   const tabs = useMemo(
@@ -87,7 +144,7 @@ const SecurityPage = (): JSX.Element => {
           />
         );
       case SecurityTabId.VULNERABILITIES:
-        return <SecurityReportAnalysis />;
+        return <SecurityReportAnalysis fixedStatusIds={fixedStatusIds} />;
       default:
         return (
           <ProductVulnerabilitiesTable
@@ -99,7 +156,26 @@ const SecurityPage = (): JSX.Element => {
 
   return (
     <Box>
-      <SecurityStats />
+      {isStatFiltered ? (
+        <Box sx={{ mb: 3 }}>
+          <Button
+            startIcon={<ArrowLeft size={16} />}
+            onClick={clearStatFilter}
+            variant="text"
+            sx={{ mb: 1 }}
+          >
+            Back
+          </Button>
+          <Typography variant="h5" color="text.primary" sx={{ mb: 0.5 }}>
+            {activeStatKey ? SECURITY_STAT_FILTER_INFO[activeStatKey].title : ""}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {activeStatKey ? SECURITY_STAT_FILTER_INFO[activeStatKey].subtitle : ""}
+          </Typography>
+        </Box>
+      ) : (
+        <SecurityStats onStatClick={handleStatCardClick} />
+      )}
       <TabBar
         tabs={tabs}
         activeTab={activeTab}

--- a/apps/customer-portal/webapp/src/features/support/hooks/useResolvedInlineImageHtml.ts
+++ b/apps/customer-portal/webapp/src/features/support/hooks/useResolvedInlineImageHtml.ts
@@ -47,28 +47,9 @@ function extractIixAttachmentIds(html: string): string[] {
  */
 export function useResolvedInlineImageHtml(
   html: string,
-  inlineAttachments?: InlineAttachment[] | null,
+  _inlineAttachments?: InlineAttachment[] | null,
 ): { resolvedHtml: string; isLoading: boolean } {
   const idsFromHtml = useMemo(() => extractIixAttachmentIds(html), [html]);
-
-  // Map each iix ref id to the attachment id (from inlineAttachments) or use directly.
-  const attachmentIds = useMemo(() => {
-    return idsFromHtml.map((refId) => {
-      if (inlineAttachments?.length) {
-        const match = inlineAttachments.find(
-          (a) =>
-            (a.id && (a.id === refId || a.id.includes(refId) || refId.includes(a.id))) ||
-            (a.sys_id &&
-              (a.sys_id === refId ||
-                a.sys_id.includes(refId) ||
-                refId.includes(a.sys_id))),
-        );
-        if (match?.id) return match.id;
-        if (match?.sys_id) return match.sys_id;
-      }
-      return refId;
-    });
-  }, [idsFromHtml, inlineAttachments]);
 
   const { dataUrls, isLoading } = useAttachmentPreviews([]);
 

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -320,11 +320,7 @@ export default function AllCasesPage(): JSX.Element {
           })()
         }
         backLabel={
-          returnTo?.endsWith("/support")
-            ? "Back to Support Center"
-            : returnTo && (initialSeverityId || statusFilter !== null)
-              ? "Back to Dashboard"
-              : "Back to Support Center"
+          returnTo?.endsWith("/support") ? "Back to Support Center" : "Back"
         }
         onBack={() => {
           if (returnTo) {


### PR DESCRIPTION
### Description

This pull request primarily improves the interactivity and filtering of engagement stat cards, enhances UI feedback for clickable dashboard elements, and standardizes back button labels across dashboard-related pages. The most notable changes are the addition of stat-based filtering for engagements, visual enhancements for interactive cards and chart elements, and UI consistency improvements.

**Engagements Stat Card Filtering and State Management:**

* Added click-to-filter functionality on engagement stat cards, allowing users to filter the engagements list by clicking a stat card (e.g., Active, Completed, On Hold). This includes new state management for filtered status IDs and active stat key, as well as logic to update the search request and clear filters. [[1]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL29-R32) [[2]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fR68-R69) [[3]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL100-R114) [[4]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fR196-R232) [[5]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fR291-R294) [[6]](diffhunk://#diff-8a652c1a7dbb5bd0ae0b9d0922aa67187ddc57533af3a5c966f6bb0c7fe0c5cfR41) [[7]](diffhunk://#diff-7eee47c5fc401ca37a181d01bfcbea103096584be46a4194991d2dc35e534f92R39) [[8]](diffhunk://#diff-7eee47c5fc401ca37a181d01bfcbea103096584be46a4194991d2dc35e534f92R51) [[9]](diffhunk://#diff-c21dfe6027e75870a77189d04edb70dabfb3b1b8b1c9c77534d6feef786f6e45L19-R32) [[10]](diffhunk://#diff-c21dfe6027e75870a77189d04edb70dabfb3b1b8b1c9c77534d6feef786f6e45R71-R113)

**UI/UX Enhancements for Interactive Elements:**

* Improved visual feedback for clickable stat cards and chart sectors: added hover and focus styles (e.g., box-shadow, transform, outline) to `StatCard`, `ListStatGrid`, and pie chart sectors to make interactivity clearer and more accessible. [[1]](diffhunk://#diff-c4ca918173bf2fb2f7fb2f1a7486247ae0e8cf8cc2f3a2f62f57f5899f03224cL17-R17) [[2]](diffhunk://#diff-c4ca918173bf2fb2f7fb2f1a7486247ae0e8cf8cc2f3a2f62f57f5899f03224cR68) [[3]](diffhunk://#diff-c4ca918173bf2fb2f7fb2f1a7486247ae0e8cf8cc2f3a2f62f57f5899f03224cR114-R124) [[4]](diffhunk://#diff-acfc751c15fd1a9e6072a555c4ab11a7dc75336f0e656dcfe1106939e2f87ab0R80-R84) [[5]](diffhunk://#diff-172aafc5d4310ebffe97d577913444411e6c548b0a966b7b4a3b0d5166eb4c6fL17-R17) [[6]](diffhunk://#diff-172aafc5d4310ebffe97d577913444411e6c548b0a966b7b4a3b0d5166eb4c6fR67) [[7]](diffhunk://#diff-172aafc5d4310ebffe97d577913444411e6c548b0a966b7b4a3b0d5166eb4c6fL150-R158) [[8]](diffhunk://#diff-a6922fdddd1612531f29be29338d5fd36721e0ee7ee40b1c50b1f39f54ada728L17-R17) [[9]](diffhunk://#diff-a6922fdddd1612531f29be29338d5fd36721e0ee7ee40b1c50b1f39f54ada728R67) [[10]](diffhunk://#diff-a6922fdddd1612531f29be29338d5fd36721e0ee7ee40b1c50b1f39f54ada728L179-R187) [[11]](diffhunk://#diff-5de15c1018fc7adbfa30496b133e1a1da42e8c922492f39bf0c592dcd6f9a458R45-R52)

**UI Consistency and Label Updates:**

* Standardized the "Back" button label across dashboard and operations pages, replacing "Back to Dashboard" with "Back" or a consistent label for improved clarity and consistency. [[1]](diffhunk://#diff-cda7965095932ea3788027824b371a97c999333cb8b66e0963e987de7d2598c8L424-R424) [[2]](diffhunk://#diff-ddbfee321640578ea9b461da5bfcef82d7bdbdf644ee5bfe588b1644b6aafd5fL305-R305) [[3]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L315-R315) [[4]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L335-R335) [[5]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L376-R376)

These changes collectively make the dashboard more interactive, visually responsive, and user-friendly, especially when navigating and filtering engagement cases.