### PR TITLE
feat: add solution proposed case actions in microapp

### DIFF
--- a/apps/customer-portal/microapp/src/config/constants.tsx
+++ b/apps/customer-portal/microapp/src/config/constants.tsx
@@ -131,3 +131,13 @@ export const SEARCH_PLACEHOLDER_CONFIG: Record<ItemCardProps["type"], string> = 
   sra: "Search Security Report Analysis",
   engagement: "Search Engagement",
 };
+
+export const CASE_STATE_IDS = {
+  OPEN: 1,
+  WORK_IN_PROGRESS: 10,
+  AWAITING_INFO: 18,
+  WAITING_ON_WSO2: 1003,
+  SOLUTION_PROPOSED: 6,
+  CLOSED: 3,
+  REOPENED: 1006,
+} as const;

--- a/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -18,7 +18,7 @@ import ms from "ms";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { ArrowLeftRightIcon, CheckIcon, CircleX, PlusIcon, User, Users } from "@wso2/oxygen-ui-icons-react";
+import { CheckIcon, CircleX, PlusIcon, User, Users } from "@wso2/oxygen-ui-icons-react";
 import { Grid, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import {
   CommentSkeleton,
@@ -112,10 +112,6 @@ export default function CaseDetailPage() {
           editCaseMutation.mutate({ stateKey: closedStateKey });
         },
         onRejectSolution: () => {
-          if (waitingOnWso2StateKey === undefined) return;
-          editCaseMutation.mutate({ stateKey: waitingOnWso2StateKey });
-        },
-        onMarkWaiting: () => {
           if (waitingOnWso2StateKey === undefined) return;
           editCaseMutation.mutate({ stateKey: waitingOnWso2StateKey });
         },
@@ -299,7 +295,6 @@ function getCaseMenuOptions(
     onResolve: () => void;
     onAcceptSolution: () => void;
     onRejectSolution: () => void;
-    onMarkWaiting: () => void;
     onCreateRelated: () => void;
   }>,
 ): MenuOptionProps[] {
@@ -322,15 +317,8 @@ function getCaseMenuOptions(
       label: "Reject Solution",
       color: "error",
       icon: <CircleX />,
-      hidden: !isSolutionProposed,
+      hidden: !isSolutionProposed && !isAwaitingInfo,
       onClick: actions?.onRejectSolution,
-    },
-    {
-      label: "Mark as Waiting on WSO2",
-      color: "warning",
-      icon: <ArrowLeftRightIcon />,
-      hidden: !isAwaitingInfo,
-      onClick: actions?.onMarkWaiting,
     },
     {
       label: "Create Related Case",

--- a/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -18,7 +18,7 @@ import ms from "ms";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { ArrowLeftRightIcon, CheckIcon, PlusIcon, User, Users } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeftRightIcon, CheckIcon, CircleX, PlusIcon, User, Users } from "@wso2/oxygen-ui-icons-react";
 import { Grid, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import {
   CommentSkeleton,
@@ -57,7 +57,6 @@ export default function CaseDetailPage() {
   });
 
   const issueType = filters?.issueTypes.find((issueType) => issueType.id === data?.issueTypeId)?.label;
-
   const slaResponseTimeInMilliseconds = Number.isFinite(Number(data?.slaResponseTime))
     ? Number(data?.slaResponseTime)
     : undefined;
@@ -90,12 +89,42 @@ export default function CaseDetailPage() {
     onError: () => notify.error("Failed to update case. Please try again."),
   });
 
+  const getCaseStateKeyByLabel = (label: string): number | undefined => {
+    const id = filters?.caseStates.find((state) => state.label.toLowerCase() === label.toLowerCase())?.id;
+    if (!id) return undefined;
+    const value = Number(id);
+    return Number.isNaN(value) ? undefined : value;
+  };
+
+  const closedStateKey = getCaseStateKeyByLabel("Closed");
+  const waitingOnWso2StateKey = getCaseStateKeyByLabel("Waiting On WSO2");
+  const solutionProposedStateKey = getCaseStateKeyByLabel("Solution Proposed");
+  const awaitingInfoStateKey = getCaseStateKeyByLabel("Awaiting Info");
+
   const menuOptions = data
     ? getCaseMenuOptions(data.statusId, {
-        onResolve: () => {
-          editCaseMutation.mutate({ stateKey: 3 });
+        stateKeys: {
+          closed: closedStateKey,
+          waitingOnWso2: waitingOnWso2StateKey,
+          solutionProposed: solutionProposedStateKey,
+          awaitingInfo: awaitingInfoStateKey,
         },
-        onMarkWaiting: () => editCaseMutation.mutate({ stateKey: 1003 }),
+        onResolve: () => {
+          if (closedStateKey === undefined) return;
+          editCaseMutation.mutate({ stateKey: closedStateKey });
+        },
+        onAcceptSolution: () => {
+          if (closedStateKey === undefined) return;
+          editCaseMutation.mutate({ stateKey: closedStateKey });
+        },
+        onRejectSolution: () => {
+          if (waitingOnWso2StateKey === undefined) return;
+          editCaseMutation.mutate({ stateKey: waitingOnWso2StateKey });
+        },
+        onMarkWaiting: () => {
+          if (waitingOnWso2StateKey === undefined) return;
+          editCaseMutation.mutate({ stateKey: waitingOnWso2StateKey });
+        },
         onCreateRelated: () => navigate("/create", { state: { case: data } }),
       })
     : [];
@@ -264,32 +293,55 @@ export default function CaseDetailPage() {
 }
 
 function getCaseMenuOptions(
-  stateKey: string,
-  actions?: Partial<{
+  statusId: string | undefined,
+  context: {
+    stateKeys: Partial<{
+      closed: number;
+      waitingOnWso2: number;
+      solutionProposed: number;
+      awaitingInfo: number;
+    }>;
+  } & Partial<{
     onResolve: () => void;
+    onAcceptSolution: () => void;
+    onRejectSolution: () => void;
     onMarkWaiting: () => void;
     onCreateRelated: () => void;
   }>,
 ): MenuOptionProps[] {
+  const { stateKeys, ...actions } = context;
+  const currentStatusId = statusId ? Number(statusId) : undefined;
+  const isSolutionProposed = currentStatusId === stateKeys.solutionProposed;
+  const isClosed = currentStatusId === stateKeys.closed;
+  const isAwaitingInfo = currentStatusId === stateKeys.awaitingInfo;
+  const hasKnownStatus = currentStatusId !== undefined && !Number.isNaN(currentStatusId);
+
   return [
     {
-      label: "Mark as Resolved",
+      label: isSolutionProposed ? "Accept Solution" : "Mark as Resolved",
       color: "success",
       icon: <CheckIcon />,
-      hidden: !["1", "10", "1003", "6", "18", "1006"].includes(stateKey),
-      onClick: actions?.onResolve,
+      hidden: !hasKnownStatus || isClosed,
+      onClick: isSolutionProposed ? actions?.onAcceptSolution : actions?.onResolve,
+    },
+    {
+      label: "Reject Solution",
+      color: "error",
+      icon: <CircleX />,
+      hidden: !isSolutionProposed,
+      onClick: actions?.onRejectSolution,
     },
     {
       label: "Mark as Waiting on WSO2",
       color: "warning",
       icon: <ArrowLeftRightIcon />,
-      hidden: !["6", "18"].includes(stateKey),
+      hidden: !isAwaitingInfo,
       onClick: actions?.onMarkWaiting,
     },
     {
       label: "Created Related Case",
       icon: <PlusIcon />,
-      hidden: !["3"].includes(stateKey),
+      hidden: !isClosed,
       onClick: actions?.onCreateRelated,
     },
   ];

--- a/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -32,6 +32,7 @@ import { PriorityChip, StatusChip } from "@components/features/support";
 import { RichText, SectionCard } from "@components/shared";
 import { useLayout } from "@context/layout";
 import { cases } from "@src/services/cases";
+import { CASE_STATE_IDS } from "@src/config/constants";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { Comment } from "@components/features/detail";
@@ -40,16 +41,6 @@ import DOMPurify from "dompurify";
 import { useNotify } from "../context/snackbar";
 
 dayjs.extend(relativeTime);
-
-const CASE_STATE_IDS = {
-  OPEN: 1,
-  WORK_IN_PROGRESS: 10,
-  AWAITING_INFO: 18,
-  WAITING_ON_WSO2: 1003,
-  SOLUTION_PROPOSED: 6,
-  CLOSED: 3,
-  REOPENED: 1006,
-} as const;
 
 export default function CaseDetailPage() {
   const notify = useNotify();

--- a/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -41,6 +41,16 @@ import { useNotify } from "../context/snackbar";
 
 dayjs.extend(relativeTime);
 
+const CASE_STATE_IDS = {
+  OPEN: 1,
+  WORK_IN_PROGRESS: 10,
+  AWAITING_INFO: 18,
+  WAITING_ON_WSO2: 1003,
+  SOLUTION_PROPOSED: 6,
+  CLOSED: 3,
+  REOPENED: 1006,
+} as const;
+
 export default function CaseDetailPage() {
   const notify = useNotify();
   const layout = useLayout();
@@ -89,17 +99,10 @@ export default function CaseDetailPage() {
     onError: () => notify.error("Failed to update case. Please try again."),
   });
 
-  const getCaseStateKeyByLabel = (label: string): number | undefined => {
-    const id = filters?.caseStates.find((state) => state.label.toLowerCase() === label.toLowerCase())?.id;
-    if (!id) return undefined;
-    const value = Number(id);
-    return Number.isNaN(value) ? undefined : value;
-  };
-
-  const closedStateKey = getCaseStateKeyByLabel("Closed");
-  const waitingOnWso2StateKey = getCaseStateKeyByLabel("Waiting On WSO2");
-  const solutionProposedStateKey = getCaseStateKeyByLabel("Solution Proposed");
-  const awaitingInfoStateKey = getCaseStateKeyByLabel("Awaiting Info");
+  const closedStateKey = CASE_STATE_IDS.CLOSED;
+  const waitingOnWso2StateKey = CASE_STATE_IDS.WAITING_ON_WSO2;
+  const solutionProposedStateKey = CASE_STATE_IDS.SOLUTION_PROPOSED;
+  const awaitingInfoStateKey = CASE_STATE_IDS.AWAITING_INFO;
 
   const menuOptions = data
     ? getCaseMenuOptions(data.statusId, {

--- a/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -333,7 +333,7 @@ function getCaseMenuOptions(
       onClick: actions?.onMarkWaiting,
     },
     {
-      label: "Created Related Case",
+      label: "Create Related Case",
       icon: <PlusIcon />,
       hidden: !isClosed,
       onClick: actions?.onCreateRelated,


### PR DESCRIPTION
## Purpose
Enable parity with webapp case handling by replacing the generic resolved action with explicit user decisions when a case reaches the Solution Proposed state. Resolves the UX gap where users could not explicitly accept or reject a proposed solution in microapp.

## Goals
- Show `Accept Solution` and `Reject Solution` actions when the case is in Solution Proposed.
- Keep other case action flows unchanged for non-solution-proposed states.
- Use stable case state IDs to avoid label-change regressions.

## Approach
- Updated `CaseDetailPage` action menu generation to use state-id based branching.
- Added shared `CASE_STATE_IDS` in `src/config/constants.tsx` and reused it from `CaseDetailPage`.
- Mapped actions as:
  - Solution Proposed -> `Accept Solution` (to Closed), `Reject Solution` (to Waiting On WSO2)
  - Closed -> Create Related Case
  - Awaiting Info -> Mark as Waiting on WSO2
  - Other active states -> Mark as Resolved

## User stories
- As a customer user, when support proposes a solution, I can explicitly accept or reject it from the case details page.
- As a product team member, I can rely on stable backend case-state IDs instead of mutable labels.

## Release note
Microapp case details now shows `Accept Solution` and `Reject Solution` actions for Solution Proposed cases, aligned with webapp behavior.

## Documentation
N/A - UI behavior parity update; no external product documentation changes required.

## Training
N/A

## Certification
N/A - No certification exam objective impact; this is a UI action behavior alignment.

## Marketing
N/A

## Automation tests
- Unit tests 
  > N/A for this PR (no new automated unit tests added).
- Integration tests
  > Manually validated case action visibility and transitions in microapp.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- macOS (darwin 25.3.0)
- Microapp via Vite dev server in local development environment

## Learning
Used the existing webapp case-action model as reference and switched to constant-driven state-id handling in microapp to prevent regressions when backend label text changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Accept Solution" action now appears when a solution is proposed for a case
  * "Reject Solution" action available for relevant case statuses
  * "Create Related Case" shown only for closed cases
  * Case menu actions now display and behave dynamically based on the current case status, with safer no-op handling when status mappings are unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->