### PR TITLE
Enrich conversations/search response with chatbot stats

### DIFF
--- a/apps/customer-portal/backend/modules/ai_chat_agent/ai_chat_agent.bal
+++ b/apps/customer-portal/backend/modules/ai_chat_agent/ai_chat_agent.bal
@@ -79,7 +79,7 @@ public isolated function getRecommendation(RecommendationRequest payload) return
 }
 
 # Get summary for a conversation.
-# 
+#
 # + projectId - Project ID
 # + conversationId - Conversation ID
 # + return - Summary response or error

--- a/apps/customer-portal/backend/modules/ai_chat_agent/client.bal
+++ b/apps/customer-portal/backend/modules/ai_chat_agent/client.bal
@@ -40,7 +40,7 @@ final http:Client aiChatAgentClient = check new (aiChatAgentBaseUrl, {
 });
 
 isolated function createAiChatAgentWsClient(string sessionId) returns websocket:Client|error {
-    return new (string `${aiChatAgentWsBaseUrl}/ws?sessionId=${sessionId}`, {
+    return new (string `${aiChatAgentWsBaseUrl}/ws/${sessionId}`, {
         auth: {
             ...clientCredentialsOauth2ConfigWs
         }

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1043,6 +1043,12 @@ public type Conversation record {|
     ReferenceItem? case;
     # State information
     ReferenceItem? state;
+    # Total messages exchanged in the chatbot conversation
+    int messagesExchanged?;
+    # Number of troubleshooting tool invocations in the chatbot conversation
+    int troubleshootingAttempts?;
+    # Number of unique KB articles surfaced in the chatbot conversation
+    int kbArticlesReviewed?;
     json...;
 |};
 

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -1371,11 +1371,18 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
 
         types:ConversationSearchResponse baseResponse = mapConversationSearchResponse(conversationResponse);
 
-        // Enrich each conversation with chatbot stats from the AI chat agent.
-        types:Conversation[] enrichedConversations = [];
+        // Fan-out: fire all summary calls in parallel to avoid N serial round-trips.
+        future<ai_chat_agent:ConversationSummaryResponse|error>[] summaryFutures = [];
         foreach types:Conversation conv in baseResponse.conversations {
-            types:Conversation enriched = conv.clone();
-            ai_chat_agent:ConversationSummaryResponse|error summary = ai_chat_agent:getSummary(id, conv.id);
+            future<ai_chat_agent:ConversationSummaryResponse|error> f = start ai_chat_agent:getSummary(id, conv.id);
+            summaryFutures.push(f);
+        }
+
+        // Fan-in: collect results and enrich each conversation.
+        types:Conversation[] enrichedConversations = [];
+        foreach int i in 0 ..< baseResponse.conversations.length() {
+            types:Conversation enriched = baseResponse.conversations[i].clone();
+            ai_chat_agent:ConversationSummaryResponse|error summary = wait summaryFutures[i];
             if summary is ai_chat_agent:ConversationSummaryResponse {
                 enriched.messagesExchanged = summary.messagesExchanged;
                 enriched.troubleshootingAttempts = summary.troubleshootingAttempts;

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -83,7 +83,6 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         log:printInfo("Customer Portal backend started.");
     }
 
-    # Fetch metadata information for the customer portal.
     #
     # + return - Metadata information or error response
     resource function get metadata(http:RequestContext ctx)
@@ -1370,8 +1369,32 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
+        types:ConversationSearchResponse baseResponse = mapConversationSearchResponse(conversationResponse);
+
+        // Enrich each conversation with chatbot stats from the AI chat agent.
+        types:Conversation[] enrichedConversations = [];
+        foreach types:Conversation conv in baseResponse.conversations {
+            types:Conversation enriched = conv.clone();
+            ai_chat_agent:ConversationSummaryResponse|error summary = ai_chat_agent:getSummary(id, conv.id);
+            if summary is ai_chat_agent:ConversationSummaryResponse {
+                enriched.messagesExchanged = summary.messagesExchanged;
+                enriched.troubleshootingAttempts = summary.troubleshootingAttempts;
+                enriched.kbArticlesReviewed = summary.kbArticlesReviewed;
+            } else {
+                enriched.messagesExchanged = 0;
+                enriched.troubleshootingAttempts = 0;
+                enriched.kbArticlesReviewed = 0;
+            }
+            enrichedConversations.push(enriched);
+        }
+
         return <http:Ok>{
-            body: mapConversationSearchResponse(conversationResponse)
+            body: {
+                conversations: enrichedConversations,
+                totalRecords: baseResponse.totalRecords,
+                'limit: baseResponse.'limit,
+                offset: baseResponse.offset
+            }
         };
     }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                    
                                                                                                                                                                                                
  - Enrich the `POST /projects/{id}/conversations/search` response with chatbot conversation stats from the AI chat agent                                                                       
  - Each conversation in the response now includes `messagesExchanged`, `troubleshootingAttempts`, and `kbArticlesReviewed`                                                                     
  - Stats default to `0` when the AI chat agent is unavailable or returns an error (never omitted)                                                                                              
                                                                                                                                                                                                
  ## Changes                                                
                                                                                                                                                                                                
  ### `apps/customer-portal/backend/modules/types/types.bal`                                                                                                                                    
  - Added 3 optional fields to the `Conversation` type:
    - `messagesExchanged` — total messages exchanged in the chatbot session
    - `troubleshootingAttempts` — number of troubleshooting tool invocations
    - `kbArticlesReviewed` — number of unique KB articles surfaced

  ### `apps/customer-portal/backend/service.bal`
  - Updated `POST /projects/{id}/conversations/search` to enrich each conversation with stats fetched via `ai_chat_agent:getSummary(projectId, conversationId)`
  - Falls back to `0` for all stat fields if the chatbot call fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation analytics added: message count, troubleshooting attempts, and KB articles reviewed.
  * Search now returns conversations enriched with analytics plus totalRecords/limit/offset metadata.

* **Chores**
  * Minor formatting and comment cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->