### PR TITLE
Expand UserManagementMembership record

### DIFF
--- a/apps/customer-portal/backend/modules/user_management/types.bal
+++ b/apps/customer-portal/backend/modules/user_management/types.bal
@@ -124,9 +124,15 @@ public type Membership record {|
 
 # Membership details returned by the user management service.
 type UserManagementMembership record {|
-    *Membership;
+    # ID
+    string id;
+    # State of the Membership
+    string state;
     # Role of the Membership
     string? role;
+    # Contact details
+    ContactMinimal contact?;
+    json...;
 |};
 
 # ContactMinimal Details.


### PR DESCRIPTION
Add explicit id and state fields, an optional contact (ContactMinimal), and a json... spread to the UserManagementMembership record to mirror additional membership details returned by the user management service. Also refined inline comments for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Membership API responses have been restructured with explicit contact information now available and clearly defined core fields.
  * Core membership fields (ID, state, and role) are consistently defined across all responses.
  * Optional contact details are now included in membership queries for enhanced user visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->