### PR TITLE
[Customer Portal][FE][Web] Dynamic Product Categories via Project Features + UI Fixes

### DIFF
--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -111,6 +111,20 @@ export default function AnnouncementList({
                     flexWrap: "wrap",
                   }}
                 >
+                  {caseItem.internalId && (
+                    <>
+                      <Typography
+                        variant="body2"
+                        fontWeight={500}
+                        color="text.secondary"
+                      >
+                        {caseItem.internalId}
+                      </Typography>
+                      <Typography variant="body2" color="text.disabled">
+                        |
+                      </Typography>
+                    </>
+                  )}
                   <Typography
                     variant="body2"
                     fontWeight={500}

--- a/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
@@ -724,7 +724,7 @@ export default function DashboardItemsPage({
           mode === "action-required"
             ? "Action Required Items"
             : mode === "closed-last-30d"
-              ? "Closed items last (30d)"
+              ? "Closed items (last 30d)"
               : "Outstanding Items"
         }
         description={

--- a/apps/customer-portal/webapp/src/features/operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/CreateServiceRequestPage.tsx
@@ -32,7 +32,7 @@ import {
 } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePostProjectDeploymentsSearchInfinite } from "@api/usePostProjectDeploymentsSearch";
-import type { ProjectDeploymentItem } from "@features/project-details/types/deployments";
+import type { ProductCategory, ProjectDeploymentItem } from "@features/project-details/types/deployments";
 import {
   extractDeploymentProducts,
   usePostDeploymentProductsSearchInfinite,
@@ -69,7 +69,6 @@ import {
 } from "@features/operations/utils/caseRefresh";
 import {
   filterDeploymentsForCaseCreation,
-  getProductCategoriesForServiceRequest,
   getProjectPermissions,
   shouldRestrictToPrimaryProductionDeployments,
 } from "@utils/permission";
@@ -282,9 +281,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
   );
   const selectedDeploymentId = selectedDeploymentMatch?.id ?? "";
 
-  const srProductCategories = getProductCategoriesForServiceRequest(
-    projectDetails?.type?.label,
-  );
+  const srProductCategories = (projectFeatures?.srProductCategories ?? undefined) as ProductCategory[] | undefined;
   const deploymentProductsQuery = usePostDeploymentProductsSearchInfinite(
     selectedDeploymentId,
     {

--- a/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
@@ -170,6 +170,8 @@ export type ProjectFeatures = {
   hasTimeLogsReadAccess: boolean;
   hasDeploymentWriteAccess: boolean;
   hasDeploymentReadAccess: boolean;
+  defaultCaseProductCategories?: string[] | null;
+  srProductCategories?: string[] | null;
 };
 
 // Request type for patching a project.

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -74,7 +74,6 @@ import {
 import { SecurityTabId } from "@features/security/types/security";
 import {
   filterDeploymentsForCaseCreation,
-  getProductCategoriesForCaseCreation,
   getProjectSeverityPolicy,
   shouldRestrictToPrimaryProductionDeployments,
 } from "@utils/permission";
@@ -84,7 +83,7 @@ import {
 } from "@features/support/utils/richTextEditor";
 import UploadAttachmentModal from "@features/support/components/case-details/attachments-tab/UploadAttachmentModal";
 import { ROUTE_PREVIOUS_PAGE } from "@features/project-hub/constants/navigationConstants";
-import type { ProjectDeploymentItem } from "@features/project-details/types/deployments";
+import type { ProductCategory, ProjectDeploymentItem } from "@features/project-details/types/deployments";
 import type {
   RelatedCaseState,
 } from "@features/support/types/createCasePage";
@@ -198,7 +197,7 @@ export default function CreateCasePage(): JSX.Element {
     {
       pageSize: 10,
       enabled: !!selectedDeploymentId,
-      request: { filters: { productCategories: getProductCategoriesForCaseCreation(projectDetails?.type?.label) } },
+      request: { filters: { productCategories: (projectFeatures?.defaultCaseProductCategories ?? undefined) as ProductCategory[] | undefined } },
     },
   );
   const deploymentProductsLoading = deploymentProductsQuery.isLoading;


### PR DESCRIPTION
### Description

This pull request updates how product categories are determined for case and service request creation in the customer portal webapp. Instead of using utility functions to derive product categories based on project type, the code now retrieves these categories directly from the `projectFeatures` object, which can be populated from backend data. Additionally, a minor UI text change and a small display enhancement were made.

**Product category handling improvements:**

* Replaced usage of `getProductCategoriesForCaseCreation` and `getProductCategoriesForServiceRequest` utility functions with direct access to `defaultCaseProductCategories` and `srProductCategories` from the `projectFeatures` object in both `CreateCasePage` and `CreateServiceRequestPage`. This change allows product categories to be dynamically provided per project. [[1]](diffhunk://#diff-f2b4139e63cf1db309b7ada4c8f207797e4f3f88c7f0eab5aa407c8351c9e43cL72) [[2]](diffhunk://#diff-f2b4139e63cf1db309b7ada4c8f207797e4f3f88c7f0eab5aa407c8351c9e43cL285-R284) [[3]](diffhunk://#diff-77ba7db2416ae0479c6bd3f70c06ba28b4a9b6ac99f16572943de1a4cf6dbd68L77) [[4]](diffhunk://#diff-77ba7db2416ae0479c6bd3f70c06ba28b4a9b6ac99f16572943de1a4cf6dbd68L87-R86) [[5]](diffhunk://#diff-77ba7db2416ae0479c6bd3f70c06ba28b4a9b6ac99f16572943de1a4cf6dbd68L201-R200)
* Updated the `ProjectFeatures` type to include the new optional fields `defaultCaseProductCategories` and `srProductCategories` for storing product category information.

**UI improvements:**

* Added display of the `internalId` for each case item in the `AnnouncementList` component, improving traceability for users.
* Corrected the title text for closed dashboard items from "Closed items last (30d)" to "Closed items (last 30d)" for clarity.