### PR TITLE
[Customer Portal][BE] Add outstanding items count to project search results

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -127,6 +127,8 @@ public type Project record {|
     int activeChatsCount;
     # Action Required count
     int actionRequiredCount;
+    # Outstanding count (default case, SR, SRA, engagement, and CR count that are not in closed state)
+    int outstandingCount;
     # SLA status (e.g., "Needs Attention")
     string slaStatus;
     json...;

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -365,6 +365,8 @@ public type Project record {|
     int activeChatsCount;
     # Action Required count
     int actionRequiredCount;
+    # Outstanding count (default case, SR, SRA, engagement, and CR count that are not in closed state)
+    int outstandingCount;
     # SLA status (e.g., "Needs Attention")
     string slaStatus;
 |};

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2795,10 +2795,12 @@ components:
           type: string
           description: Allowed domain list of the account
           nullable: true
+          default: ""
         classification:
           type: string
           description: Account classification
           nullable: true
+          default: ""
         isPartner:
           type: boolean
           description: Whether the account is a partner or not

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -912,6 +912,7 @@ public isolated function mapProjectsResponse(entity:ProjectsResponse response) r
             'type: {id: project.'type.id, label: project.'type.name},
             hasPdpSubscription: project.hasPdpSubscription,
             actionRequiredCount: project.actionRequiredCount,
+            outstandingCount: project.outstandingCount,
             hasAgent: project.hasAgent,
             hasKbReferences: project.hasKbReferences,
             activeCasesCount: project.activeCasesCount,


### PR DESCRIPTION
## Description
- Add outstanding items count to project search results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Project details now include an outstanding count metric, providing visibility into non-closed items across all request categories.
* Account schema fields have been updated with default empty-string values to ensure consistent data handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->