### PR TITLE
[Backend] Add 'pc' product category to enums and OpenAPI

### DIFF
--- a/apps/customer-portal/backend/modules/entity/enums.bal
+++ b/apps/customer-portal/backend/modules/entity/enums.bal
@@ -75,5 +75,6 @@ public enum ProductClass {
 public enum ProductCategory {
     PRIVATE_DATA_PLANE = "pdp",
     CLOUD = "cl",
-    MS = "ms"
+    MS = "ms",
+    PC = "pc"
 }

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -4578,6 +4578,7 @@ components:
       - ms
       - cl
       - pdp
+      - pc
     ProductClass:
       type: string
       description: Valid product class values.


### PR DESCRIPTION
This pull request adds support for a new product class, "pc", across both the backend enums and the OpenAPI specification. This ensures the new product class is recognized and validated throughout the system.

Product class support:

* Added `PC` to the `ProductClass` enum in `enums.bal`, enabling backend support for the new product class.
* Updated the allowed values for `ProductClass` in the OpenAPI specification to include `pc`, ensuring API validation and documentation reflect the new option.