### PR TITLE
Hide project dropdown icon when only one project exists

### DIFF
--- a/apps/customer-portal/microapp/src/components/core/AppBar.tsx
+++ b/apps/customer-portal/microapp/src/components/core/AppBar.tsx
@@ -36,7 +36,7 @@ import { useProject } from "@context/project";
 import { APP_BAR_CONFIG } from "@components/layout/config";
 import { PROJECT_STATUS_META } from "@config/constants";
 import { ArrowLeft, ChevronDown, Folder, Grip } from "@wso2/oxygen-ui-icons-react";
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { projects } from "@src/services/projects";
 import { goToMyAppsScreen } from "../microapp-bridge";
 import { useThemeMode } from "@root/src/context/theme";
@@ -49,9 +49,9 @@ export function AppBar() {
     useLayout();
   const config = APP_BAR_CONFIG[appBarVariant];
   const { projectId } = useProject();
-  const projectsData = useQuery(projects.all()).data;
+  const { data: projectsData } = useSuspenseQuery(projects.all());
   const project = projectsData?.find((project) => project.id === projectId);
-  const hasMultipleProjects = (projectsData?.length ?? 0) > 1;
+  const hasMultipleProjects = projectsData.length > 1;
 
   const [projectSelectorAnchor, setProjectSelectorAnchor] = useState<HTMLButtonElement | null>(null);
   const isProjectSelectorOpen = Boolean(projectSelectorAnchor);

--- a/apps/customer-portal/microapp/src/components/core/AppBar.tsx
+++ b/apps/customer-portal/microapp/src/components/core/AppBar.tsx
@@ -49,7 +49,9 @@ export function AppBar() {
     useLayout();
   const config = APP_BAR_CONFIG[appBarVariant];
   const { projectId } = useProject();
-  const project = useQuery(projects.all()).data?.find((project) => project.id === projectId);
+  const projectsData = useQuery(projects.all()).data;
+  const project = projectsData?.find((project) => project.id === projectId);
+  const hasMultipleProjects = (projectsData?.length ?? 0) > 1;
 
   const [projectSelectorAnchor, setProjectSelectorAnchor] = useState<HTMLButtonElement | null>(null);
   const isProjectSelectorOpen = Boolean(projectSelectorAnchor);
@@ -70,6 +72,7 @@ export function AppBar() {
   const navigateBack = () => navigate(-1);
 
   const openProjectSelector = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!hasMultipleProjects) return;
     event.preventDefault();
     setProjectSelectorAnchor(event.currentTarget);
   };
@@ -135,7 +138,7 @@ export function AppBar() {
                 {project.name}
               </Typography>
             </Stack>
-            <ChevronDown color={theme.palette.text.secondary} size={pxToRem(18)} />
+            {hasMultipleProjects && <ChevronDown color={theme.palette.text.secondary} size={pxToRem(18)} />}
           </Button>
         )}
 
@@ -162,7 +165,9 @@ export function AppBar() {
       </MuiAppBar>
 
       {/* Popovers */}
-      <ProjectSelector anchorEl={projectSelectorAnchor} open={isProjectSelectorOpen} onClose={closeProjectSelector} />
+      {hasMultipleProjects && (
+        <ProjectSelector anchorEl={projectSelectorAnchor} open={isProjectSelectorOpen} onClose={closeProjectSelector} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Purpose
Improve microapp app-bar UX by removing the project-switch dropdown affordance when a user has only one available project.

## Goals
- Avoid showing a non-actionable dropdown icon for single-project users.
- Preserve current project selector behavior for users with multiple projects.

## Approach
- Updated `AppBar` to derive `hasMultipleProjects` from the loaded project list.
- Render chevron icon and `ProjectSelector` popover only when `hasMultipleProjects` is true.
- Added guard in `openProjectSelector` to no-op when only one project is available.

## User stories
- As a single-project user, I should not see a misleading project-switch dropdown icon.
- As a multi-project user, I should still be able to switch projects from the app bar.

## Release note
Refined microapp project selector UX by hiding dropdown affordance when only one project is available.

## Documentation
N/A - small UI behavior improvement without doc-impacting flow changes.

## Training
N/A

## Certification
N/A - no certification impact.

## Marketing
N/A

## Automation tests
- Unit tests
  > Not added in this PR.
- Integration tests
  > Manually verified single-project and multi-project app bar behavior.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
No migration required.

## Test environment
- macOS (Darwin)
- Customer portal microapp local dev environment

## Learning
- Conditional rendering was preferred over disabled affordances to reduce false interactivity and visual noise for single-project contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Project selector now intelligently displays only when multiple projects are available, streamlining the interface for single-project scenarios. The selector button remains inactive and the dropdown indicator appears conditionally, reducing unnecessary UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->