### PR TITLE
[Customer Portal][FE][Web] Improve Editor Image Layout and Add Production Version to Case Details

### DIFF
--- a/apps/customer-portal/webapp/src/components/rich-text-editor/ImageNode.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/ImageNode.tsx
@@ -46,7 +46,7 @@ function ImageComponent({
   };
 
   return (
-    <span style={{ position: "relative", display: "inline-block" }}>
+    <span style={{ position: "relative", display: "block" }}>
       <img
         src={sanitizeUrl(src)}
         alt={altText}
@@ -126,7 +126,9 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
 
   createDOM(config: EditorConfig): HTMLElement {
     void config;
-    return document.createElement("span");
+    const span = document.createElement("span");
+    span.style.display = "block";
+    return span;
   }
 
   updateDOM(): false {

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -429,6 +429,14 @@ export default function CaseDetailsDetailsPanel({
                 {formatValue(productDisplayName)}
               </Typography>
             </Box>
+            {data?.deployedProduct?.version ? (
+              <Box>
+                <Typography {...labelSx}>Production Version</Typography>
+                <Typography {...valueSx}>
+                  {data.deployedProduct.version}
+                </Typography>
+              </Box>
+            ) : null}
             <Box>
               <Typography {...labelSx}>Environment Type</Typography>
               <Typography {...valueSx}>


### PR DESCRIPTION
### Description

This pull request introduces improvements to the display of images in the rich text editor and adds a new production version field to the case details panel. The changes focus on enhancing the layout and user experience in the UI.

**Rich Text Editor Image Display Improvements:**

* Changed the container of images in `ImageComponent` from `inline-block` to `block` display for better layout consistency. (`ImageNode.tsx`, [apps/customer-portal/webapp/src/components/rich-text-editor/ImageNode.tsxL49-R49](diffhunk://#diff-20aabf60f7c683d898445a8fb62dcfc59b09c3ec6b4bf944ebaac0ef4f9d71f2L49-R49))
* Updated the `createDOM` method in the `ImageNode` class to set the `span`'s display style to `block`, aligning the DOM structure with the React component. (`ImageNode.tsx`, [apps/customer-portal/webapp/src/components/rich-text-editor/ImageNode.tsxL129-R131](diffhunk://#diff-20aabf60f7c683d898445a8fb62dcfc59b09c3ec6b4bf944ebaac0ef4f9d71f2L129-R131))

**Case Details Panel Enhancement:**

* Added a "Production Version" field to the case details panel, displaying the deployed product's version when available. (`CaseDetailsDetailsPanel.tsx`, [apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsxR432-R439](diffhunk://#diff-315c8c98952805057dc9c2645745ed059602f597a0d00fd723a73953d722cda5R432-R439))