### PR TITLE
[Customer Portal] Fix image preview in Attachments tab using authenticated fetch

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
@@ -43,6 +43,7 @@ import {
   getAttachmentFileCategory,
 } from "@features/support/utils/support";
 import ImageFullscreenModal from "@case-details-activity/ImageFullscreenModal";
+import { useAttachmentPreview } from "@api/useAttachmentPreview";
 
 const PREVIEW_SKELETON_MIN_DISPLAY_MS = 4000;
 
@@ -107,7 +108,13 @@ export default function AttachmentListItem({
     attachment.name ?? "",
     attachment.type ?? "",
   );
-  const hasPreviewImage = attachmentCategory === "image" && !!attachment.previewUrl;
+  const isImageAttachment = attachmentCategory === "image";
+  const hasPreviewImage = isImageAttachment;
+
+  // Fetch authenticated image data URL only when the preview is expanded.
+  const { data: imageDataUrl, isLoading: isImageLoading } = useAttachmentPreview(
+    imageExpanded && isImageAttachment ? attachment.id : null,
+  );
 
   const deleteIconButton = onDelete ? (
     <IconButton
@@ -226,14 +233,14 @@ export default function AttachmentListItem({
 
         {hasPreviewImage && imageExpanded && (
           <Box sx={{ position: "relative", width: "100%" }}>
-            {!previewMinTimeElapsed ? (
+            {!previewMinTimeElapsed || isImageLoading ? (
               <Skeleton
                 variant="rectangular"
                 width="100%"
                 height={160}
                 sx={{ borderRadius: 1 }}
               />
-            ) : (
+            ) : imageDataUrl ? (
               <Box
                 component="button"
                 type="button"
@@ -252,7 +259,7 @@ export default function AttachmentListItem({
               >
                 <Box
                   component="img"
-                  src={attachment.previewUrl ?? undefined}
+                  src={imageDataUrl}
                   alt={attachment.name}
                   sx={{
                     display: "block",
@@ -263,7 +270,7 @@ export default function AttachmentListItem({
                   }}
                 />
               </Box>
-            )}
+            ) : null}
           </Box>
         )}
 
@@ -303,7 +310,7 @@ export default function AttachmentListItem({
 
       <ImageFullscreenModal
         open={fullscreenOpen}
-        imageSrc={attachment.previewUrl ?? null}
+        imageSrc={imageDataUrl ?? null}
         onClose={() => setFullscreenOpen(false)}
       />
     </>


### PR DESCRIPTION
This pull request updates the `AttachmentListItem` component to improve how image attachment previews are fetched and displayed. The main change is to fetch the authenticated image data URL only when the preview is expanded, ensuring better security and performance. The component also now shows a loading skeleton while the image is being loaded and uses the fetched image data for both the preview and fullscreen modal.

**Attachment preview improvements:**

* Added the `useAttachmentPreview` hook to fetch authenticated image data URLs only when the preview is expanded, instead of relying on a static `previewUrl` property. [[1]](diffhunk://#diff-e9a003e0e669c00f55946fb0a83ba11e3a514b4bdd15d62d3aaae03f668a0bf4R46) [[2]](diffhunk://#diff-e9a003e0e669c00f55946fb0a83ba11e3a514b4bdd15d62d3aaae03f668a0bf4L110-R117)
* Updated the preview logic to show a skeleton loader until both the minimum display time has elapsed and the image data is loaded, improving the user experience during loading.
* Changed the image source for both the inline preview and the fullscreen modal to use the fetched `imageDataUrl` instead of `attachment.previewUrl`, ensuring consistent and authenticated image rendering. [[1]](diffhunk://#diff-e9a003e0e669c00f55946fb0a83ba11e3a514b4bdd15d62d3aaae03f668a0bf4L255-R262) [[2]](diffhunk://#diff-e9a003e0e669c00f55946fb0a83ba11e3a514b4bdd15d62d3aaae03f668a0bf4L306-R313)
* Ensured that no image element is rendered if the image data is not yet available, preventing broken images or errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced attachment preview handling with improved loading states and more reliable preview retrieval for attachments in the support case details view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->