### PR TITLE
[Customer Portal][FE][Web] Initialize Filters from URL Params for All Updates Tab (Deep Linking Support)

### DIFF
--- a/apps/customer-portal/webapp/src/features/updates/components/all-updates/AllUpdatesTab.tsx
+++ b/apps/customer-portal/webapp/src/features/updates/components/all-updates/AllUpdatesTab.tsx
@@ -86,12 +86,30 @@ export default function AllUpdatesTab(): JSX.Element {
   const { projectId } = useParams<{ projectId: string }>();
   const [urlParams, setUrlParams] = useSearchParams();
 
-  const [filter, setFilter] = useState<AllUpdatesTabFilterState>(
-    ALL_UPDATES_TAB_INITIAL_FILTER,
-  );
+  const [filter, setFilter] = useState<AllUpdatesTabFilterState>(() => {
+    const pn = urlParams.get("pn") ?? "";
+    const pv = urlParams.get("pv") ?? "";
+    const sl = urlParams.get("sl") ?? "";
+    const el = urlParams.get("el") ?? "";
+    return pn || pv || sl || el
+      ? { productName: pn, productVersion: pv, startLevel: sl, endLevel: el }
+      : ALL_UPDATES_TAB_INITIAL_FILTER;
+  });
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
-  const [searchParams, setSearchParams] =
-    useState<AllUpdatesTabSearchParams | null>(null);
+  const [searchParams, setSearchParams] = useState<AllUpdatesTabSearchParams | null>(() => {
+    const pn = urlParams.get("pn");
+    const pv = urlParams.get("pv");
+    const sl = urlParams.get("sl");
+    const el = urlParams.get("el");
+    if (pn && pv && sl && el) {
+      const start = Number(sl);
+      const end = Number(el);
+      if (Number.isFinite(start) && Number.isFinite(end)) {
+        return { productName: pn, productVersion: pv, startingUpdateLevel: start, endingUpdateLevel: end };
+      }
+    }
+    return null;
+  });
 
   const {
     data: productLevelsData,


### PR DESCRIPTION
### Description

This pull request updates the initialization logic for the filter and search parameter state in the `AllUpdatesTab` component, making it responsive to URL parameters on first render. This ensures that the component can be correctly pre-populated based on the current URL, improving usability and supporting deep linking.

**State initialization improvements:**

* The `filter` state is now initialized based on URL parameters (`pn`, `pv`, `sl`, `el`), falling back to the default filter only if none are present.
* The `searchParams` state is now initialized via a function that parses and validates URL parameters, ensuring both `sl` and `el` are finite numbers before setting the state; otherwise, it defaults to `null`.