### PR TITLE
[Customer Portal][FE][Web] Initialize All Updates Tab Filters from URL Search Params

### DIFF
--- a/apps/customer-portal/webapp/src/features/updates/components/all-updates/AllUpdatesTab.tsx
+++ b/apps/customer-portal/webapp/src/features/updates/components/all-updates/AllUpdatesTab.tsx
@@ -84,7 +84,7 @@ import {
 export default function AllUpdatesTab(): JSX.Element {
   const navigate = useNavigate();
   const { projectId } = useParams<{ projectId: string }>();
-  const [, setUrlParams] = useSearchParams();
+  const [urlParams, setUrlParams] = useSearchParams();
 
   const [filter, setFilter] = useState<AllUpdatesTabFilterState>(() => {
     const pn = urlParams.get("pn") ?? "";


### PR DESCRIPTION
### Description

This pull request makes a small update to the `AllUpdatesTab` component. The change ensures that the current URL search parameters are read and used to initialize the filter state, which improves how the component reacts to the URL.

- The `useSearchParams` hook now destructures both `urlParams` and `setUrlParams`, allowing the code to read the current search parameters for initializing the filter state.