### PR TITLE
[Customer Portal][FE][Web] Format Attachment Created Date

### DIFF
--- a/apps/customer-portal/webapp/src/components/access-control/ProjectSuspendedNoticePage.tsx
+++ b/apps/customer-portal/webapp/src/components/access-control/ProjectSuspendedNoticePage.tsx
@@ -26,7 +26,7 @@ import {
 import { AlertCircle, Info } from "@wso2/oxygen-ui-icons-react";
 import suspensionIllustration from "@assets/access-control/project-suspended.svg";
 import type { ProjectDetails } from "@features/project-hub/types/projects";
-import { parseBackendTimestamp } from "@utils/dateTime";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 
 type ProjectSuspendedNoticePageProps = {
   project: ProjectDetails;
@@ -34,28 +34,7 @@ type ProjectSuspendedNoticePageProps = {
 
 function formatDateLabel(raw: string | null | undefined): string {
   if (!raw) return "—";
-  // date-only strings like "2023-10-03"
-  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
-  if (dateOnlyMatch) {
-    const [, yyyy, mm, dd] = dateOnlyMatch;
-    const date = new Date(`${yyyy}-${mm}-${dd}T00:00:00`);
-    if (!Number.isNaN(date.getTime())) {
-      return new Intl.DateTimeFormat("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      }).format(date);
-    }
-  }
-  const parsed = parseBackendTimestamp(raw);
-  if (parsed) {
-    return new Intl.DateTimeFormat("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    }).format(parsed);
-  }
-  return raw;
+  return formatBackendTimestampForDisplay(raw, { year: "numeric", month: "short", day: "numeric" }) ?? raw;
 }
 
 type InfoRowProps = {

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
@@ -30,6 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { type JSX } from "react";
 import { getStatusColor, mapSeverityToDisplay } from "@features/support/utils/support";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import CasesTableSkeleton from "@features/dashboard/components/cases-table/CasesTableSkeleton";
@@ -149,10 +150,10 @@ const CasesList = ({
                   <TableCell>
                     <Box>
                       <Typography variant="body2" color="text.primary">
-                        {row.createdOn ? row.createdOn.split(" ")[0] : "--"}
+                        {formatBackendTimestampForDisplay(row.createdOn, { month: "short", day: "numeric", year: "numeric" }) ?? "--"}
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
-                        {row.createdOn ? row.createdOn.split(" ")[1] || "" : ""}
+                        {formatBackendTimestampForDisplay(row.createdOn, { hour: "numeric", minute: "2-digit", hour12: true }) ?? ""}
                       </Typography>
                     </Box>
                   </TableCell>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
@@ -308,7 +308,7 @@ export default function CommentBubble({
                 •
               </Typography>
               <Typography variant="caption" color="text.secondary" component="span">
-                {comment.createdOn}
+                {formatCommentDate(comment.createdOn)}
               </Typography>
             </Stack>
             {attachmentCategory === "image" && (

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
@@ -39,6 +39,7 @@ import {
 import { useEffect, useRef, useState, type JSX } from "react";
 import type { CaseAttachment } from "@features/support/types/cases";
 import {
+  formatDateTime,
   formatFileSize,
   getAttachmentFileCategory,
 } from "@features/support/utils/support";
@@ -303,7 +304,7 @@ export default function AttachmentListItem({
             •
           </Typography>
           <Typography variant="caption" color="text.secondary" component="span">
-            {attachment.createdOn}
+            {formatDateTime(attachment.createdOn)}
           </Typography>
         </Stack>
       </Paper>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/calls-tab/CallRequestCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/calls-tab/CallRequestCard.tsx
@@ -30,7 +30,6 @@ import {
 import { Clock, ExternalLink, Phone } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
 import {
-  formatCallRequestBackendDateTimeShort,
   formatUtcToLocal,
   getCallRequestStatusColor,
   resolveColorFromTheme,
@@ -175,7 +174,7 @@ export default function CallRequestCard({
               )}
               <Typography variant="caption" color="text.secondary">
                 Requested on{" "}
-                {formatCallRequestBackendDateTimeShort(call.createdOn)}
+                {call.createdOn ?? "--"}
               </Typography>
             </Box>
           </Stack>


### PR DESCRIPTION
### Description

This pull request updates the way attachment creation dates are displayed in the `AttachmentListItem` component. Instead of showing the raw date string, it now formats the date for improved readability.

Formatting improvements:

* The `formatDateTime` utility is now imported and used to display the `createdOn` date for each attachment in the `AttachmentListItem` component, replacing the previous unformatted output. [[1]](diffhunk://#diff-e9a003e0e669c00f55946fb0a83ba11e3a514b4bdd15d62d3aaae03f668a0bf4R42) [[2]](diffhunk://#diff-e9a003e0e669c00f55946fb0a83ba11e3a514b4bdd15d62d3aaae03f668a0bf4L306-R307)