### PR TITLE
[Customer Portal][FE][web] Refactor Project Hub Stats to Outstanding Count and Simplify Project Hub UI Logic

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectCard.tsx
@@ -37,7 +37,6 @@ export default function ProjectCard({
   projectKey,
   title,
   date,
-  activeCasesCount,
   activeChatsCount,
   actionRequiredCount,
   outstandingCount,

--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectCard.tsx
@@ -40,6 +40,7 @@ export default function ProjectCard({
   activeCasesCount,
   activeChatsCount,
   actionRequiredCount,
+  outstandingCount,
   closureState,
   onViewDashboard,
 }: ProjectCardProps): JSX.Element {
@@ -81,7 +82,7 @@ export default function ProjectCard({
       <ProjectCardStats
         activeChatsCount={activeChatsCount}
         date={date}
-        activeCasesCount={activeCasesCount}
+        outstandingCount={outstandingCount ?? 0}
         actionRequiredCount={actionRequiredCount}
       />
       {/* project card actions */}

--- a/apps/customer-portal/webapp/src/features/project-hub/components/project-card/ProjectCardStats.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/project-card/ProjectCardStats.tsx
@@ -41,7 +41,7 @@ import type { ProjectCardStatsProps } from "@features/project-hub/types/projectH
  * @returns {JSX.Element} The rendered stats section.
  */
 export default function ProjectCardStats({
-  activeCasesCount,
+  outstandingCount,
   activeChatsCount,
   actionRequiredCount,
   isError,
@@ -101,7 +101,7 @@ export default function ProjectCardStats({
             />
           ) : (
             <Typography variant="body2" color="primary">
-              {activeCasesCount ?? PROJECT_CARD_STATS_NULL_PLACEHOLDER}
+              {outstandingCount ?? PROJECT_CARD_STATS_NULL_PLACEHOLDER}
             </Typography>
           )}
         </Box>

--- a/apps/customer-portal/webapp/src/features/project-hub/components/project-card/__tests__/ProjectCardStats.test.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/project-card/__tests__/ProjectCardStats.test.tsx
@@ -54,7 +54,7 @@ vi.mock("@components/error-indicator/ErrorIndicator", () => ({
 describe("ProjectCardStats", () => {
   it("should render counts and formatted date", () => {
     const props = {
-      activeCasesCount: 10,
+      outstandingCount: 10,
       activeChatsCount: 5,
       actionRequiredCount: 0,
       date: "2025-07-17",
@@ -69,7 +69,7 @@ describe("ProjectCardStats", () => {
 
   it("should render icons", () => {
     const props = {
-      activeCasesCount: 0,
+      outstandingCount: 0,
       activeChatsCount: 0,
       actionRequiredCount: 0,
       date: "2025-07-17",
@@ -84,7 +84,7 @@ describe("ProjectCardStats", () => {
 
   it("should render error indicators when isError is true", () => {
     const props = {
-      activeCasesCount: 0,
+      outstandingCount: 0,
       activeChatsCount: 0,
       actionRequiredCount: 0,
       date: "2025-07-17",
@@ -102,7 +102,7 @@ describe("ProjectCardStats", () => {
 
   it("should render skeletons when isLoading is true", () => {
     const props = {
-      activeCasesCount: 0,
+      outstandingCount: 0,
       activeChatsCount: 0,
       actionRequiredCount: 0,
       date: "2025-07-17",

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -91,13 +91,7 @@ export default function ProjectHub(): JSX.Element {
   const totalRecords = getTotalRecords(data);
 
   useEffect(() => {
-    if (
-      debouncedSearchQuery &&
-      hasNextPage &&
-      !isFetchingNextPage &&
-      !isLoading &&
-      !isError
-    ) {
+    if (hasNextPage && !isFetchingNextPage && !isLoading && !isError) {
       fetchNextPage();
     }
   }, [
@@ -346,6 +340,7 @@ export default function ProjectHub(): JSX.Element {
                   activeCasesCount={project.activeCasesCount}
                   activeChatsCount={project.activeChatsCount}
                   actionRequiredCount={project.actionRequiredCount ?? 0}
+                  outstandingCount={project.outstandingCount ?? 0}
                   closureState={project.closureState}
                 />
               </Box>

--- a/apps/customer-portal/webapp/src/features/project-hub/types/projectHub.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/types/projectHub.ts
@@ -37,6 +37,7 @@ export type ProjectCardProps = {
   activeCasesCount: number;
   activeChatsCount: number;
   actionRequiredCount: number;
+  outstandingCount?: number | null;
   closureState?: string | null;
   onViewDashboard?: () => void;
   projectKey: string;
@@ -51,7 +52,7 @@ export type ProjectCardBadgesProps = {
 export type ProjectCardStatsProps = {
   activeChatsCount: number | undefined;
   date: string;
-  activeCasesCount: number | undefined;
+  outstandingCount: number | undefined;
   actionRequiredCount: number | undefined;
   isError?: boolean;
   isLoading?: boolean;

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/projectHub.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/projectHub.ts
@@ -56,12 +56,6 @@ export function resolveProjectHubContentView(
   if (isError) {
     return ProjectHubContentView.ERROR;
   }
-  if (
-    totalRecords > PROJECT_HUB_MIN_PROJECTS_FOR_SEARCH &&
-    !searchQuery.trim()
-  ) {
-    return ProjectHubContentView.NO_GRID;
-  }
   if (projectsLength === 0) {
     return ProjectHubContentView.EMPTY_STATE;
   }
@@ -132,19 +126,13 @@ export function shouldShowProjectHubSearchBar(
  * @param isError - Query error.
  */
 export function shouldShowProjectHubSearchOnlyLayout(
-  totalRecords: number,
-  searchQuery: string,
-  isLoading: boolean,
-  isAuthLoading: boolean,
-  isError: boolean,
+  _totalRecords: number,
+  _searchQuery: string,
+  _isLoading: boolean,
+  _isAuthLoading: boolean,
+  _isError: boolean,
 ): boolean {
-  return (
-    totalRecords > PROJECT_HUB_MIN_PROJECTS_FOR_SEARCH &&
-    !searchQuery.trim() &&
-    !isLoading &&
-    !isAuthLoading &&
-    !isError
-  );
+  return false;
 }
 
 /**

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/projectHub.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/projectHub.ts
@@ -40,8 +40,8 @@ export function resolveProjectHubContentView(
   isAuthLoading: boolean,
   isLoading: boolean,
   isError: boolean,
-  totalRecords: number,
-  searchQuery: string,
+  _totalRecords: number,
+  _searchQuery: string,
   projectsLength: number,
 ): ProjectHubContentView {
   if (isRedirectingToSingleProject) {

--- a/apps/customer-portal/webapp/src/features/support/pages/DescribeIssuePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/DescribeIssuePage.tsx
@@ -243,17 +243,6 @@ export default function DescribeIssuePage(): JSX.Element {
                 }}
               >
                 <Button
-                  variant="outlined"
-                  onClick={() =>
-                    navigate(
-                      `/projects/${projectId}/support/chat/create-case`,
-                    )
-                  }
-                  sx={{ py: 0.5 }}
-                >
-                  Create Case
-                </Button>
-                <Button
                   variant="contained"
                   color="warning"
                   startIcon={<Send size={18} />}


### PR DESCRIPTION
### Description|

This pull request updates the Project Hub UI and logic to consolidate the "active cases" count into a new "outstanding" count, removes some unused UI flows, and simplifies search-related logic. The changes affect component props, type definitions, tests, and utility logic, aiming to streamline the project card statistics and improve maintainability.

**Project Card and Stats Refactor:**

- Replaced the `activeCasesCount` prop with `outstandingCount` in `ProjectCard`, `ProjectCardStats`, their props, and all related usages and tests. This change ensures that the statistics displayed on project cards now use the new outstanding count metric. [[1]](diffhunk://#diff-69dc5fada8c0c8c349c3e5b08499f21fe4166d8744ae70874265310504997767L40-R42) [[2]](diffhunk://#diff-69dc5fada8c0c8c349c3e5b08499f21fe4166d8744ae70874265310504997767L84-R84) [[3]](diffhunk://#diff-05594630148f5f343e4fadc0a22ffce9d5f0e23b0b02eb21fe2f419b58777d73L44-R44) [[4]](diffhunk://#diff-05594630148f5f343e4fadc0a22ffce9d5f0e23b0b02eb21fe2f419b58777d73L104-R104) [[5]](diffhunk://#diff-cba5519a48fcf5e9f1ba737f974a4ae770dd22e7bb8be96ba5d8ead4191d1c14L57-R57) [[6]](diffhunk://#diff-cba5519a48fcf5e9f1ba737f974a4ae770dd22e7bb8be96ba5d8ead4191d1c14L72-R72) [[7]](diffhunk://#diff-cba5519a48fcf5e9f1ba737f974a4ae770dd22e7bb8be96ba5d8ead4191d1c14L87-R87) [[8]](diffhunk://#diff-cba5519a48fcf5e9f1ba737f974a4ae770dd22e7bb8be96ba5d8ead4191d1c14L105-R105) [[9]](diffhunk://#diff-5c90d4f9c9bed251e7429b45747963321ea21ddbe8362f7b288cb3bd736da6fcR40) [[10]](diffhunk://#diff-5c90d4f9c9bed251e7429b45747963321ea21ddbe8362f7b288cb3bd736da6fcL54-R55) [[11]](diffhunk://#diff-d88902c7dfaf68b0857f424d1a40d4c26da78ca0f11b6881d490300d4129f121R343)

**Project Hub Page and Logic Simplification:**

- Simplified the infinite scrolling logic in `ProjectHub.tsx` by removing the dependency on `debouncedSearchQuery` for fetching the next page, making the effect trigger only on pagination and loading state.
- Removed the logic that displayed a "no grid" state when there were more than a certain number of projects and no search query, ensuring the grid is always shown unless there are truly no projects.
- Updated `shouldShowProjectHubSearchOnlyLayout` utility to always return false, effectively removing the "search only" layout logic.

**UI Cleanup in Support Pages:**

- Removed the "Create Case" outlined button from the support issue description page, leaving only the "Chat" button for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination to trigger based on data availability status only, removing unnecessary dependencies.
  * Simplified project hub view logic to improve consistency.

* **Refactor**
  * Renamed internal tracking metric from active cases to outstanding count across project cards.
  * Removed "Create Case" button from the issue description page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->