### PR TITLE
[Customer Portal][FE][Web] Fix typo in Deployment field label and test cases

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
@@ -164,7 +164,7 @@ export function BasicInformationSection({
             {/* deployment field label container */}
             <Box sx={{ mb: 1, display: "flex", alignItems: "center", gap: 1 }}>
               <Typography variant="caption">
-                Deploymnet{" "}
+                Deployment{" "}
                 {!isDeploymentDisabled && (
                   <Box component="span" sx={{ color: "warning.main" }}>
                     *
@@ -202,7 +202,7 @@ export function BasicInformationSection({
                       if (showNoDeploymentsHint) {
                         return EMPTY_DROPDOWN_PLACEHOLDER;
                       }
-                      return "Select Deploymnet...";
+                      return "Select Deployment...";
                     }
                     return value;
                   }}
@@ -213,7 +213,7 @@ export function BasicInformationSection({
                   <MenuItem value="" disabled>
                     {showNoDeploymentsHint
                       ? EMPTY_DROPDOWN_PLACEHOLDER
-                    : "Select Deploymnet..."}
+                    : "Select Deployment..."}
                   </MenuItem>
                   {deploymentOptions.map((d) => (
                     <MenuItem key={d} value={d}>

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/__tests__/BasicInformationSection.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/__tests__/BasicInformationSection.test.tsx
@@ -54,9 +54,9 @@ describe("BasicInformationSection", () => {
     expect(screen.getByDisplayValue("Test Project")).toBeInTheDocument();
   });
 
-  it("should render Deploymnet and Product Version labels", () => {
+  it("should render Deployment and Product Version labels", () => {
     renderSection();
-    expect(screen.getByText("Deploymnet")).toBeInTheDocument();
+    expect(screen.getByText("Deployment")).toBeInTheDocument();
     expect(screen.getByText("Product Version")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
### Description

This pull request corrects a spelling error in the "Deployment" field across the Basic Information section of the customer portal's support case creation form. The typo "Deploymnet" has been fixed to "Deployment" in both the UI and related test cases.

UI text corrections:

* Fixed the label for the deployment field from "Deploymnet" to "Deployment" in `BasicInformationSection.tsx`.
* Updated the deployment dropdown placeholder text from "Select Deploymnet..." to "Select Deployment..." in two locations in `BasicInformationSection.tsx`. [[1]](diffhunk://#diff-2d6d529efff80d0497de406a1420b8a8a8be060ab1aa17254fd97a0e285cf0fcL205-R205) [[2]](diffhunk://#diff-2d6d529efff80d0497de406a1420b8a8a8be060ab1aa17254fd97a0e285cf0fcL216-R216)

Test updates:

* Updated the test description and expectation to match the corrected label "Deployment" in `BasicInformationSection.test.tsx`.