### PR TITLE
[Customer Portal][FE][Web] Refactor case details components by removing engineer-only display logic

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -65,7 +65,6 @@ export default function CaseDetailsContent({
   onOpenRelatedCase,
   projectId = "",
   hideActionRow = false,
-  showEngineerOnly = false,
   isServiceRequest = false,
 }: CaseDetailsContentProps): JSX.Element {
   const theme = useTheme();
@@ -230,7 +229,6 @@ export default function CaseDetailsContent({
           />
           <CaseDetailsSkeleton
             hideActionRow={hideActionRow}
-            showEngineerOnly={showEngineerOnly}
             hideAssignedEngineer={hideAssignedEngineer}
             headerVariant={headerVariant}
           />
@@ -331,7 +329,7 @@ export default function CaseDetailsContent({
                   />
                 </Box>
 
-                {!isEngagementRoute && (!hideActionRow || showEngineerOnly) && (
+                {!hideActionRow && (
                   <CaseDetailsActionRow
                     assignedEngineer={assignedEngineer}
                     engineerInitials=""
@@ -341,7 +339,6 @@ export default function CaseDetailsContent({
                     projectId={resolvedProjectId}
                     caseId={caseId}
                     isLoading={isLoading}
-                    showOnlyEngineer={showEngineerOnly}
                     hideAssignedEngineer={hideAssignedEngineer}
                   />
                 )}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -87,7 +87,6 @@ export default function CaseDetailsActionRow({
   projectId = "",
   caseId = "",
   isLoading = false,
-  showOnlyEngineer = false,
 }: CaseDetailsActionRowProps): JSX.Element {
   void assignedEngineer;
   void engineerInitials;
@@ -111,10 +110,6 @@ export default function CaseDetailsActionRow({
       return true;
     },
   );
-
-  if (showOnlyEngineer) {
-    return <></>;
-  }
 
   return (
     <Stack

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsSkeleton.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsSkeleton.tsx
@@ -80,7 +80,6 @@ export function CaseDetailsHeaderSkeleton({
  */
 export default function CaseDetailsSkeleton({
   hideActionRow = false,
-  showEngineerOnly = false,
   hideAssignedEngineer = false,
   headerVariant = "default",
 }: CaseDetailsSkeletonProps = {}): JSX.Element {
@@ -101,19 +100,16 @@ export default function CaseDetailsSkeleton({
         </Box>
 
         {/* Action buttons area (right side) */}
-        {!hideActionRow && !showEngineerOnly && (
+        {!hideActionRow && (
           <Stack direction="row" spacing={1} alignItems="center" sx={{ flexShrink: 0 }}>
             <Skeleton variant="rounded" width={88} height={30} sx={{ borderRadius: "4px" }} />
             <Skeleton variant="rounded" width={96} height={30} sx={{ borderRadius: "4px" }} />
           </Stack>
         )}
-        {showEngineerOnly && (
-          <Skeleton variant="circular" width={32} height={32} sx={{ flexShrink: 0 }} />
-        )}
       </Box>
 
       {/* Security Report Analysis progress bar — shown instead of action row */}
-      {hideActionRow && !showEngineerOnly && (
+      {hideActionRow && (
         <Paper
           variant="outlined"
           sx={{

--- a/apps/customer-portal/webapp/src/features/support/pages/CaseDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CaseDetailsPage.tsx
@@ -151,7 +151,6 @@ export default function CaseDetailsPage(): JSX.Element {
       onBack={handleBack}
       onOpenRelatedCase={handleOpenRelatedCase}
       hideActionRow={false}
-      showEngineerOnly={isEngagementRoute}
     />
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -370,7 +370,6 @@ export type CaseDetailsContentProps = {
   onOpenRelatedCase?: () => void;
   projectId?: string;
   hideActionRow?: boolean;
-  showEngineerOnly?: boolean;
   isServiceRequest?: boolean;
 };
 
@@ -413,7 +412,6 @@ export type CaseDetailsTabPanelsProps = {
 
 export type CaseDetailsSkeletonProps = {
   hideActionRow?: boolean;
-  showEngineerOnly?: boolean;
   hideAssignedEngineer?: boolean;
   headerVariant?: CaseDetailsHeaderVariant;
 };
@@ -432,7 +430,6 @@ export type CaseDetailsActionRowProps = {
   projectId?: string;
   caseId?: string;
   isLoading?: boolean;
-  showOnlyEngineer?: boolean;
   hideAssignedEngineer?: boolean;
   restrictToCloseOnly?: boolean;
 };


### PR DESCRIPTION
### Description

This pull request removes the `showEngineerOnly` and `showOnlyEngineer` props from several case details components and their associated logic. The main goal is to simplify the rendering logic for the case details header and action row by eliminating this conditional display mode, which previously showed only the assigned engineer instead of the full action row. The changes touch both the component implementations and their TypeScript prop definitions.

**Component and Prop Cleanup:**

* Removed the `showEngineerOnly` and `showOnlyEngineer` props from `CaseDetailsContent`, `CaseDetailsActionRow`, and `CaseDetailsSkeleton` components, as well as their TypeScript prop types. [[1]](diffhunk://#diff-38d5813f6b5bfcef204f8a451ae8956be7f2c8a1fcb1824e57118246bfc1adaeL68) [[2]](diffhunk://#diff-a67e5e6300c3cb0ddd28137d18c05748e3f294314086c9d8070940435b50d762L90) [[3]](diffhunk://#diff-16c21b3ada415a179bf8ce1af8e8b4d08e40d9c325404a918117fbff58c8e93bL83) [[4]](diffhunk://#diff-a1ce9daab3a74b8369f989255d631191ba17536b5bfb2e46711ace456783c1b7L373) [[5]](diffhunk://#diff-a1ce9daab3a74b8369f989255d631191ba17536b5bfb2e46711ace456783c1b7L416) [[6]](diffhunk://#diff-a1ce9daab3a74b8369f989255d631191ba17536b5bfb2e46711ace456783c1b7L435)

**Rendering Logic Simplification:**

* Updated the rendering logic in `CaseDetailsContent`, `CaseDetailsActionRow`, and `CaseDetailsSkeleton` to remove all branches and conditions related to `showEngineerOnly` or `showOnlyEngineer`, ensuring that the action row and skeletons are shown or hidden based solely on the `hideActionRow` prop. [[1]](diffhunk://#diff-38d5813f6b5bfcef204f8a451ae8956be7f2c8a1fcb1824e57118246bfc1adaeL233) [[2]](diffhunk://#diff-38d5813f6b5bfcef204f8a451ae8956be7f2c8a1fcb1824e57118246bfc1adaeL334-R332) [[3]](diffhunk://#diff-38d5813f6b5bfcef204f8a451ae8956be7f2c8a1fcb1824e57118246bfc1adaeL344) [[4]](diffhunk://#diff-a67e5e6300c3cb0ddd28137d18c05748e3f294314086c9d8070940435b50d762L115-L118) [[5]](diffhunk://#diff-16c21b3ada415a179bf8ce1af8e8b4d08e40d9c325404a918117fbff58c8e93bL104-R112)

**Usage Cleanup:**

* Removed all usages of the `showEngineerOnly` prop from component calls, including in `CaseDetailsPage`.

These changes make the codebase easier to maintain and reduce unnecessary complexity related to conditional UI rendering for the case details header and action row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed engineer-only conditional display logic from case details components, including the action row, skeleton loader, and content areas
  * Simplified action row rendering to depend on visibility settings only, eliminating alternate control flow paths
  * Updated component type definitions and props to reflect the streamlined UI logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->