### PR TITLE
[Customer Portal][FE][Web] Hide ActivityCommentInput for closed cases

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -71,12 +71,14 @@ export default function ActivityCommentInput({
   const [isUploadingAttachments, setIsUploadingAttachments] = useState(false);
 
   const isCaseClosed = caseStatus?.toLowerCase() === "closed";
+
+  if (isCaseClosed) return null;
+
   const isDisabled =
     !isSignedIn ||
     isAuthLoading ||
     postComment.isPending ||
-    isUploadingAttachments ||
-    isCaseClosed;
+    isUploadingAttachments;
 
   const fileSignature = (f: File) => `${f.name}-${f.size}-${f.lastModified}`;
 
@@ -230,30 +232,20 @@ export default function ActivityCommentInput({
             resetTrigger={resetTrigger}
             minHeight={120}
             showToolbar={true}
-            placeholder={
-              isCaseClosed
-                ? "Commenting is disabled for closed cases"
-                : "Write a comment..."
-            }
+            placeholder="Write a comment..."
             onSubmitKeyDown={handleSend}
             enterToSubmit={false}
-            shiftEnterToSubmit={!isCaseClosed}
+            shiftEnterToSubmit={true}
             onAttachmentClick={handleAttachmentClick}
             attachments={attachments.map((a) => a.file)}
             onAttachmentRemove={handleAttachmentRemove}
-            showKeyboardHint={!isCaseClosed}
+            showKeyboardHint={true}
             maxHeight="310px"
             onPasteError={() =>
               showError("Image exceeds the maximum allowed size of 10 MB.")
             }
             overlayElement={
-              <Tooltip
-                title={
-                  isCaseClosed
-                    ? "Commenting is disabled for closed cases"
-                    : "Send comment"
-                }
-              >
+              <Tooltip title="Send comment">
                 <span>
                   <IconButton
                     disabled={

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -44,7 +44,7 @@ import { CommentType } from "@features/support/constants/supportConstants";
 export default function ActivityCommentInput({
   caseId,
   caseStatus,
-}: ActivityCommentInputProps): JSX.Element {
+}: ActivityCommentInputProps): JSX.Element | null {
   const [value, setValue] = useState("");
   const [resetTrigger, setResetTrigger] = useState(0);
   const postComment = usePostComment();


### PR DESCRIPTION
### Description

This pull request updates the `ActivityCommentInput` component to improve its behavior and user experience when a support case is closed. The main change is that the comment input is now completely hidden for closed cases, instead of being shown in a disabled state with messaging. This simplifies the UI and prevents any interaction with the comment input when commenting is not allowed.

**Behavioral and UI changes for closed cases:**

* The `ActivityCommentInput` component now returns `null` (renders nothing) if the case is closed, so users will not see the comment input at all for closed cases.
* All placeholder text, keyboard hints, and tooltips related to the closed case state have been removed. The input always shows the default placeholder and keyboard hint when rendered.
* The input is no longer disabled due to the case being closed, as it is simply not rendered in that scenario. [[1]](diffhunk://#diff-2c524159c32a2db5565c2a33ee9f17ef1c9f51fd037ec6e0111804f0bf1c086dR74-R81) [[2]](diffhunk://#diff-2c524159c32a2db5565c2a33ee9f17ef1c9f51fd037ec6e0111804f0bf1c086dL233-R248)