### PR TITLE
[Customer Portal][FE][Web] Refactor ProjectSwitcher with Custom Popover-Based Dropdown

### DIFF
--- a/apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx
+++ b/apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx
@@ -16,20 +16,23 @@
 
 import {
   Box,
-  ComplexSelect,
   Header as HeaderUI,
+  MenuItem,
+  Paper,
+  Popover,
   Skeleton,
   TextField,
   Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import { FolderOpen, Search } from "@wso2/oxygen-ui-icons-react";
+import { ChevronDown, ChevronUp, FolderOpen, Search } from "@wso2/oxygen-ui-icons-react";
 import {
   useCallback,
   useMemo,
   useRef,
   useState,
   type JSX,
+  type MouseEvent,
   type UIEvent,
 } from "react";
 import useInfiniteProjects, {
@@ -71,7 +74,9 @@ export default function ProjectSwitcher({
   isAuthLoading = false,
 }: ProjectSwitcherProps): JSX.Element {
   const [searchQuery, setSearchQuery] = useState("");
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const isMenuOpen = Boolean(anchorEl);
+
   const debouncedSearchQuery = useDebouncedValue(
     searchQuery,
     PROJECT_HUB_SEARCH_DEBOUNCE_MS,
@@ -134,9 +139,12 @@ export default function ProjectSwitcher({
     [hasNextPage, isFetchingNextPage, fetchNextPage],
   );
 
-  const handleOpen = useCallback(() => setIsMenuOpen(true), []);
+  const handleOpen = useCallback((event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
   const handleClose = useCallback(() => {
-    setIsMenuOpen(false);
+    setAnchorEl(null);
     setSearchQuery("");
   }, []);
 
@@ -240,75 +248,79 @@ export default function ProjectSwitcher({
 
   return (
     <HeaderUI.Switchers showDivider={false}>
-      <ComplexSelect
-        value={projectId || ""}
-        onChange={(event: any) => onProjectChange(event.target.value)}
-        onOpen={handleOpen}
-        onClose={handleClose}
-        size="small"
+      {/* Trigger button — styled to match the other switcher states */}
+      <Paper
+        onClick={handleOpen}
         sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          height: 40,
           minWidth: 200,
-          "& .MuiOutlinedInput-root": {
-            "& fieldset": { borderColor: "divider" },
-            "&:hover fieldset": { borderColor: "action.active" },
-            "&.Mui-focused fieldset": { borderColor: "primary.main" },
-          },
+          px: 1.5,
+          cursor: "pointer",
+          border: "1px solid",
+          borderColor: isMenuOpen ? "primary.main" : "divider",
+          userSelect: "none",
+          "&:hover": { borderColor: "action.active" },
         }}
-        MenuProps={{
-          PaperProps: {
-            sx: { overflow: "hidden" },
-          },
-          MenuListProps: {
-            sx: {
-              p: 0,
-              maxHeight: PAGINATED_SELECT_MENU_MAX_HEIGHT_PX,
-              overflowY: "auto",
-            },
-            onScroll: handleMenuScroll as any,
-          },
-        }}
-        renderValue={() => (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            <FolderOpen size={16} />
-            <Tooltip title={displayName}>
-              <Typography
-                variant="body2"
-                noWrap
-                sx={{
-                  maxWidth: 220,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
-              >
-                {displayName}
-              </Typography>
-            </Tooltip>
-          </Box>
-        )}
       >
-        {/* Search box — sticky header, only shown when project count exceeds the minimum threshold */}
+        <FolderOpen size={16} />
+        <Tooltip title={displayName}>
+          <Typography
+            variant="body2"
+            noWrap
+            sx={{
+              flex: 1,
+              maxWidth: 220,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {displayName}
+          </Typography>
+        </Tooltip>
+        {isMenuOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+      </Paper>
+
+      {/* Dropdown — Popover gives us full layout control: fixed search bar + scrollable items */}
+      <Popover
+        open={isMenuOpen}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        disableAutoFocus
+        disableEnforceFocus
+        slotProps={{
+          paper: {
+            sx: {
+              minWidth: anchorEl ? anchorEl.offsetWidth : 200,
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+              mt: 0.5,
+            },
+          },
+        }}
+      >
+        {/* Fixed search bar — never scrolls */}
         {unfilteredTotalRef.current > PROJECT_HUB_MIN_PROJECTS_FOR_SEARCH && (
           <Box
-            component="li"
             sx={{
-              position: "sticky",
-              top: 0,
-              zIndex: 1,
-              bgcolor: "background.paper",
+              flexShrink: 0,
               px: 1,
               pt: 1,
               pb: 0.5,
               borderBottom: "1px solid",
               borderColor: "divider",
-              listStyle: "none",
+              bgcolor: "background.paper",
             }}
-            onKeyDown={(e) => e.stopPropagation()}
-            onMouseDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
           >
             <TextField
               size="small"
               fullWidth
+              autoFocus
               placeholder={PROJECT_HUB_SEARCH_PLACEHOLDER}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -321,44 +333,58 @@ export default function ProjectSwitcher({
           </Box>
         )}
 
-        {/* Skeleton items shown while a new search query loads (keeps dropdown open) */}
-        {isLoading &&
-          [...Array(DROPDOWN_SKELETON_COUNT)].map((_, i) => (
-            <Box component="li" key={`skel-${i}`} sx={{ px: 2, py: 0.75, width: "100%", listStyle: "none" }}>
-              <Skeleton variant="rounded" width="100%" height={40} />
-            </Box>
-          ))}
+        {/* Scrollable items container — sits below the search bar */}
+        <Box
+          sx={{ maxHeight: PAGINATED_SELECT_MENU_MAX_HEIGHT_PX, overflowY: "auto" }}
+          onScroll={handleMenuScroll}
+        >
+          {/* Skeleton items shown while a new search query loads */}
+          {isLoading &&
+            [...Array(DROPDOWN_SKELETON_COUNT)].map((_, i) => (
+              <Box key={`skel-${i}`} sx={{ px: 2, py: 0.75, width: "100%" }}>
+                <Skeleton variant="rounded" width="100%" height={40} />
+              </Box>
+            ))}
 
-        {/* Project list items — direct children so MUI wires up click handlers */}
-        {!isLoading &&
-          projects.map((project) => (
-            <ComplexSelect.MenuItem key={project.id} value={project.id}>
-              <ComplexSelect.MenuItem.Text
-                primary={project.name}
-                secondary={project.key}
-              />
-            </ComplexSelect.MenuItem>
-          ))}
+          {/* Project list items */}
+          {!isLoading &&
+            projects.map((project) => (
+              <MenuItem
+                key={project.id}
+                selected={project.id === projectId}
+                onClick={() => {
+                  onProjectChange(project.id);
+                  handleClose();
+                }}
+                sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}
+              >
+                <Typography variant="body2">{project.name}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {project.key}
+                </Typography>
+              </MenuItem>
+            ))}
 
-        {/* Spinner row while the next page loads on scroll */}
-        {!isLoading && (
-          <SelectMenuLoadMoreRow
-            visible={Boolean(isFetchingNextPage && projects.length > 0)}
-          />
-        )}
-
-        {/* Empty search result */}
-        {!isLoading &&
-          !isFetchingNextPage &&
-          projects.length === 0 &&
-          Boolean(debouncedSearchQuery) && (
-            <Box component="li" sx={{ px: 2, py: 1.5, textAlign: "center", listStyle: "none" }}>
-              <Typography variant="body2" color="text.secondary">
-                No projects found
-              </Typography>
-            </Box>
+          {/* Spinner row while the next page loads on scroll */}
+          {!isLoading && (
+            <SelectMenuLoadMoreRow
+              visible={Boolean(isFetchingNextPage && projects.length > 0)}
+            />
           )}
-      </ComplexSelect>
+
+          {/* Empty search result */}
+          {!isLoading &&
+            !isFetchingNextPage &&
+            projects.length === 0 &&
+            Boolean(debouncedSearchQuery) && (
+              <Box sx={{ px: 2, py: 1.5, textAlign: "center" }}>
+                <Typography variant="body2" color="text.secondary">
+                  No projects found
+                </Typography>
+              </Box>
+            )}
+        </Box>
+      </Popover>
     </HeaderUI.Switchers>
   );
 }

--- a/apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx
+++ b/apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx
@@ -28,8 +28,8 @@ import {
 import { ChevronDown, ChevronUp, FolderOpen, Search } from "@wso2/oxygen-ui-icons-react";
 import {
   useCallback,
+  useEffect,
   useMemo,
-  useRef,
   useState,
   type JSX,
   type MouseEvent,
@@ -98,18 +98,24 @@ export default function ProjectSwitcher({
   const totalRecords = getTotalRecords(data);
 
   // Track the true unfiltered total so the single-project check isn't misled by a search-filtered count.
-  const unfilteredTotalRef = useRef(0);
-  if (!debouncedSearchQuery) {
-    unfilteredTotalRef.current = totalRecords;
-  }
+  const [unfilteredTotal, setUnfilteredTotal] = useState(0);
+  useEffect(() => {
+    if (!debouncedSearchQuery && !isLoading) {
+      setUnfilteredTotal(totalRecords);
+    }
+  }, [debouncedSearchQuery, isLoading, totalRecords]);
 
   // Persist the last known selected project name across search queries (projects list empties while loading)
-  const lastFoundRef = useRef<{ id: string; name: string } | undefined>(undefined);
-  const selectedProject = useMemo(() => {
+  const [lastFound, setLastFound] = useState<{ id: string; name: string } | undefined>(undefined);
+  useEffect(() => {
     const found = projects.find((p) => p.id === projectId);
-    if (found) lastFoundRef.current = { id: found.id, name: found.name };
-    return found;
+    if (found) setLastFound({ id: found.id, name: found.name });
   }, [projects, projectId]);
+
+  const selectedProject = useMemo(
+    () => projects.find((p) => p.id === projectId),
+    [projects, projectId],
+  );
 
   // Project details from React Query cache — populated by the dashboard's useGetProjectDetails call
   const { data: projectDetails } = useGetProjectDetails(projectId || "");
@@ -117,9 +123,7 @@ export default function ProjectSwitcher({
   // Best display name: live list → last found while searching → project details API → fallback
   const displayName =
     selectedProject?.name ??
-    (lastFoundRef.current?.id === projectId
-      ? lastFoundRef.current?.name
-      : undefined) ??
+    (lastFound?.id === projectId ? lastFound?.name : undefined) ??
     projectDetails?.name ??
     "Select Project";
 
@@ -208,7 +212,7 @@ export default function ProjectSwitcher({
     );
   }
 
-  if (!isMenuOpen && !isLoading && unfilteredTotalRef.current <= 1) {
+  if (!isMenuOpen && !isLoading && unfilteredTotal <= 1) {
     const project = selectedProject ?? projects[0];
 
     return (
@@ -305,7 +309,7 @@ export default function ProjectSwitcher({
         }}
       >
         {/* Fixed search bar — never scrolls */}
-        {unfilteredTotalRef.current > PROJECT_HUB_MIN_PROJECTS_FOR_SEARCH && (
+        {unfilteredTotal > PROJECT_HUB_MIN_PROJECTS_FOR_SEARCH && (
           <Box
             sx={{
               flexShrink: 0,

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -296,6 +296,30 @@ export default function ProjectHub(): JSX.Element {
       case ProjectHubContentView.AUTH_PENDING:
         return null;
       case ProjectHubContentView.LOADING_SKELETONS:
+        if (debouncedSearchQuery) {
+          return (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: {
+                  xs: "repeat(3, 1fr)",
+                  lg: "repeat(4, 1fr)",
+                  xl: "repeat(5, 1fr)",
+                },
+                gap: 3,
+                width: "100%",
+                py: 1,
+              }}
+            >
+              {[...Array(colsPerRow)].map((_, i) => (
+                <ProjectCardSkeleton key={`skeleton-search-${i}`} />
+              ))}
+              {[...Array(GRID_GHOST_COUNT)].map((_, i) => (
+                <Box key={`ghost-search-${i}`} aria-hidden="true" sx={gridGhostSx} />
+              ))}
+            </Box>
+          );
+        }
         return (
           <Box
             sx={{
@@ -452,7 +476,7 @@ export default function ProjectHub(): JSX.Element {
               component="div"
               sx={{ display: "flex", alignItems: "center" }}
             >
-              {isLoading ? (
+              {isLoading && !debouncedSearchQuery ? (
                 <>
                   Your Projects&nbsp;(
                   <Skeleton
@@ -477,8 +501,8 @@ export default function ProjectHub(): JSX.Element {
           </Typography>
 
           {showSearchBar && (
-            <Box sx={{ mt: 2, width: "100%", maxWidth: isLoading ? 700 : 500 }}>
-              {isLoading ? (
+            <Box sx={{ mt: 2, width: "100%", maxWidth: 500 }}>
+              {isLoading && !debouncedSearchQuery ? (
                 <Skeleton variant="rounded" height={40} width="100%" />
               ) : (
                 <TextField

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/projectHub.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/projectHub.ts
@@ -84,9 +84,10 @@ export function shouldHideProjectHubHeaderBlock(
   projectsLength: number,
   searchQuery: string,
 ): boolean {
+  const trimmedSearch = searchQuery.trim();
   return (
     isError ||
-    isLoading ||
-    (!isAuthLoading && projectsLength === 0 && !searchQuery.trim())
+    (isLoading && !trimmedSearch) ||
+    (!isAuthLoading && projectsLength === 0 && !trimmedSearch)
   );
 }


### PR DESCRIPTION
### Description

This pull request refactors the `ProjectSwitcher` component to replace the `ComplexSelect` dropdown with a custom implementation using `Paper`, `Popover`, and `MenuItem` from the Oxygen UI library. This change provides greater control over the dropdown's layout, appearance, and behavior, especially for handling search and infinite scrolling.

**Component refactor and UI improvements:**

* Replaced the `ComplexSelect` component with a custom dropdown using `Paper` as the trigger and `Popover` for the dropdown, allowing for a fixed search bar and a scrollable list of projects. (`apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx` [[1]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L19-R35) [[2]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L243-R274) [[3]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L286-R323) [[4]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L324-R365) [[5]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L355-R387)
* Updated the dropdown trigger to display the current project name and a chevron icon that reflects the open/closed state. (`apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx` [[1]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L243-R274) [[2]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L286-R323)
* Implemented a fixed search bar at the top of the dropdown, which remains visible while scrolling through the project list. (`apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx` [apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsxL286-R323](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L286-R323))
* Improved handling of loading and empty states, showing skeletons while loading and a "No projects found" message when appropriate. (`apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx` [[1]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L324-R365) [[2]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L355-R387)

**State management changes:**

* Switched from a boolean `isMenuOpen` state to using an anchor element (`anchorEl`) for managing the dropdown's open/close state, aligning with how `Popover` components are typically controlled. (`apps/customer-portal/webapp/src/components/header/ProjectSwitcher.tsx` [[1]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L74-R79) [[2]](diffhunk://#diff-88aeb917309767820633c5ca9b8034a38cf2f37a7086b965230d78ac254c67d4L137-R147)