### PR TITLE
[Customer Portal][FE][Web] Add Payload Size Validation for Case Submission (10 MB Limit)

### DIFF
--- a/apps/customer-portal/webapp/src/features/operations/api/usePostCase.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/usePostCase.ts
@@ -68,19 +68,29 @@ export function usePostCase(): UseMutationResult<
           throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
         }
 
+        const serializedBody = JSON.stringify(body);
+        const payloadBytes = new TextEncoder().encode(serializedBody).length;
+        const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+        if (payloadBytes > MAX_PAYLOAD_BYTES) {
+          throw new Error(
+            "The case payload is larger than the 10 MB limit. Please reduce the size or number of inline images and try again.",
+          );
+        }
+
         const requestUrl = `${baseUrl}/cases`;
 
         const response = await authFetch(requestUrl, {
           method: "POST",
-
-          body: JSON.stringify(body),
+          body: serializedBody,
         });
 
         logger.debug(`[usePostCase] Response status: ${response.status}`);
 
         if (!response.ok) {
           const text = await response.text();
-          throw new Error(parseApiResponseMessage(text, response.status, response.statusText));
+          throw new Error(
+            parseApiResponseMessage(text, response.status, response.statusText),
+          );
         }
 
         const data: CreateCaseResponse = await response.json();

--- a/apps/customer-portal/webapp/src/features/operations/api/usePostCase.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/usePostCase.ts
@@ -73,7 +73,7 @@ export function usePostCase(): UseMutationResult<
         const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
         if (payloadBytes > MAX_PAYLOAD_BYTES) {
           throw new Error(
-            "The case description exceeds the 10 MB limit. Please reduce the size or number of inline images and try again.",
+            "The case description exceeds the 10 MB limit. Please reduce the size or the number of inline images and try again.",
           );
         }
 

--- a/apps/customer-portal/webapp/src/features/operations/api/usePostCase.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/usePostCase.ts
@@ -73,7 +73,7 @@ export function usePostCase(): UseMutationResult<
         const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
         if (payloadBytes > MAX_PAYLOAD_BYTES) {
           throw new Error(
-            "The case payload is larger than the 10 MB limit. Please reduce the size or number of inline images and try again.",
+            "The case description exceeds the 10 MB limit. Please reduce the size or number of inline images and try again.",
           );
         }
 


### PR DESCRIPTION
### Description 

This pull request adds a payload size check to the `usePostCase` mutation to prevent users from submitting cases with payloads larger than 10 MB. This helps avoid backend errors due to oversized requests and provides a clear error message to users.

**Validation and error handling improvements:**

* Added a check to ensure the serialized request body does not exceed 10 MB; if it does, an error is thrown with a user-friendly message about reducing the size or number of inline images. (`apps/customer-portal/webapp/src/features/operations/api/usePostCase.ts`, [apps/customer-portal/webapp/src/features/operations/api/usePostCase.tsR71-R93](diffhunk://#diff-d423e44d7b8da2e46cdfbb3235377fda702e5e32d4cb687e4b28e4af16982123R71-R93))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added payload size validation with a 10 MB limit to prevent submission of oversized requests and provide clear error messaging when the limit is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->