### PR TITLE
[Customer Portal][FE][Web] Add 10MB payload limit validation for comment posting

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/api/usePostComment.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/usePostComment.ts
@@ -67,14 +67,22 @@ export function usePostComment(): UseMutationResult<
         throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
       }
 
+      const serializedBody = JSON.stringify({
+        content: body.content,
+        type: body.type,
+      });
+      const payloadBytes = new TextEncoder().encode(serializedBody).length;
+      const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+      if (payloadBytes > MAX_PAYLOAD_BYTES) {
+        throw new Error(
+          "The comment exceeds the 10 MB limit. Please reduce the size or the number of inline images and try again.",
+        );
+      }
+
       const requestUrl = `${baseUrl}/cases/${caseId}/comments`;
       const response = await authFetch(requestUrl, {
         method: "POST",
-
-        body: JSON.stringify({
-          content: body.content,
-          type: body.type,
-        }),
+        body: serializedBody,
       });
 
       logger.debug("[usePostComment] Response status:", response.status);


### PR DESCRIPTION
### Description

This pull request introduces a safeguard to the comment posting functionality to prevent users from submitting excessively large comments. Specifically, it adds a check to ensure that the serialized comment payload does not exceed 10 MB, and provides a clear error message if the limit is breached.

Validation and error handling improvements:

* Added logic in `usePostComment` (in `usePostComment.ts`) to serialize the comment body, calculate its byte size, and throw an error if the payload exceeds 10 MB, with a user-friendly error message.