### PR TITLE
[Customer Portal][FE][Web] Add clear (“X”) button to search inputs across portal

### DIFF
--- a/apps/customer-portal/webapp/src/components/header/SearchBar.tsx
+++ b/apps/customer-portal/webapp/src/components/header/SearchBar.tsx
@@ -16,13 +16,14 @@
 
 import {
   Box,
+  IconButton,
   InputAdornment,
   Paper,
   Stack,
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Search } from "@wso2/oxygen-ui-icons-react";
+import { Search, X } from "@wso2/oxygen-ui-icons-react";
 import {
   useState,
   useRef,
@@ -331,6 +332,20 @@ export default function SearchBar({
                 <Search size={16} />
               </InputAdornment>
             ),
+            endAdornment: searchValue ? (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  edge="end"
+                  onClick={() => {
+                    setSearchValue("");
+                    setIsDropdownOpen(false);
+                  }}
+                >
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
           },
         }}
         sx={{ "& .MuiInputBase-root": { bgcolor: "background.paper" } }}

--- a/apps/customer-portal/webapp/src/components/list-view/ListSearchBar.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListSearchBar.tsx
@@ -18,6 +18,7 @@ import {
   Box,
   Button,
   Divider,
+  IconButton,
   InputAdornment,
   Paper,
   Skeleton,
@@ -102,6 +103,13 @@ export default function ListSearchBar({
                     <Search size={16} />
                   </InputAdornment>
                 ),
+                endAdornment: searchTerm ? (
+                  <InputAdornment position="end">
+                    <IconButton size="small" edge="end" onClick={() => onSearchChange("")}>
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
               },
             }}
           />

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsSearchBar.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsSearchBar.tsx
@@ -17,10 +17,11 @@
 import {
   Box,
   Button,
+  Divider,
+  IconButton,
+  InputAdornment,
   Paper,
   TextField,
-  InputAdornment,
-  Divider,
 } from "@wso2/oxygen-ui";
 import {
   Search,
@@ -74,6 +75,13 @@ export default function ChangeRequestsSearchBar({
                     <Search size={16} />
                   </InputAdornment>
                 ),
+                endAdornment: searchTerm ? (
+                  <InputAdornment position="end">
+                    <IconButton size="small" edge="end" onClick={() => onSearchChange("")}>
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
               },
             }}
           />

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsSearchBar.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsSearchBar.tsx
@@ -17,11 +17,12 @@
 import {
   Box,
   Button,
+  IconButton,
+  InputAdornment,
   Paper,
   TextField,
-  InputAdornment,
 } from "@wso2/oxygen-ui";
-import { RotateCcw, Search } from "@wso2/oxygen-ui-icons-react";
+import { RotateCcw, Search, X } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ChangeEvent } from "react";
 
 /** Status bucket filter for the legacy Service Requests search bar (tabs). */
@@ -110,6 +111,13 @@ export default function ServiceRequestsSearchBar({
                     <Search size={16} />
                   </InputAdornment>
                 ),
+                endAdornment: searchTerm ? (
+                  <InputAdornment position="end">
+                    <IconButton size="small" edge="end" onClick={() => onSearchChange("")}>
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
               },
             }}
           />

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -16,6 +16,8 @@
 
 import {
   Box,
+  IconButton,
+  InputAdornment,
   LinearProgress,
   Skeleton,
   TextField,
@@ -35,7 +37,7 @@ import { useLoader } from "@context/linear-loader/LoaderContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import ProjectCard from "@features/project-hub/components/ProjectCard";
 import ProjectCardSkeleton from "@features/project-hub/components/project-card/ProjectCardSkeleton";
-import { FolderOpen, Search } from "@wso2/oxygen-ui-icons-react";
+import { FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useAsgardeo } from "@asgardeo/react";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
 import SearchNoResultsIcon from "@components/empty-state/SearchNoResultsIcon";
@@ -514,6 +516,13 @@ export default function ProjectHub(): JSX.Element {
                     startAdornment: (
                       <Search size={20} style={{ marginRight: 8 }} />
                     ),
+                    endAdornment: searchQuery ? (
+                      <InputAdornment position="end">
+                        <IconButton size="small" edge="end" onClick={() => setSearchQuery("")}>
+                          <X size={16} />
+                        </IconButton>
+                      </InputAdornment>
+                    ) : undefined,
                   }}
                   size="small"
                 />

--- a/apps/customer-portal/webapp/src/features/security/components/ProductVulnerabilitiesTableHeader.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/ProductVulnerabilitiesTableHeader.tsx
@@ -16,10 +16,11 @@
 
 import {
   Box,
-  Typography,
-  TextField,
-  InputAdornment,
   Button,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Typography,
 } from "@wso2/oxygen-ui";
 import {
   Search,
@@ -105,6 +106,13 @@ const ProductVulnerabilitiesTableHeader = ({
                       <Search size={16} />
                     </InputAdornment>
                   ),
+                  endAdornment: searchValue ? (
+                    <InputAdornment position="end">
+                      <IconButton size="small" edge="end" onClick={() => onSearchChange("")}>
+                        <X size={16} />
+                      </IconButton>
+                    </InputAdornment>
+                  ) : undefined,
                 },
               }}
             />

--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsRegistryTokens.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsRegistryTokens.tsx
@@ -47,6 +47,7 @@ import {
   Server,
   Trash2,
   User,
+  X,
 } from "@wso2/oxygen-ui-icons-react";
 import TabBar from "@components/tab-bar/TabBar";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
@@ -227,6 +228,13 @@ export default function SettingsRegistryTokens({
                 <Search size={18} color={theme.palette.text.secondary} />
               </InputAdornment>
             ),
+            endAdornment: searchQuery ? (
+              <InputAdornment position="end">
+                <IconButton size="small" edge="end" onClick={() => setSearchQuery("")}>
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
           }}
         />
         {/* Generate button: user token for all, service token for admins only */}

--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
@@ -43,6 +43,7 @@ import {
   Search,
   Shield,
   Trash2,
+  X,
 } from "@wso2/oxygen-ui-icons-react";
 import useGetProjectContacts from "@features/settings/api/useGetProjectContacts";
 import { usePostProjectContact } from "@features/settings/api/usePostProjectContact";
@@ -204,6 +205,13 @@ export default function SettingsUserManagement({
                 <Search size={18} color={theme.palette.text.secondary} />
               </InputAdornment>
             ),
+            endAdornment: searchQuery ? (
+              <InputAdornment position="end">
+                <IconButton size="small" edge="end" onClick={() => setSearchQuery("")}>
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
           }}
         />
         {canAddOrRemoveUsers && (

--- a/apps/customer-portal/webapp/src/features/support/components/all-conversations/AllConversationsSearchBar.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/all-conversations/AllConversationsSearchBar.tsx
@@ -18,10 +18,11 @@ import type { AllConversationsSearchBarProps } from "@features/support/types/sup
 import {
   Box,
   Button,
+  Divider,
+  IconButton,
+  InputAdornment,
   Paper,
   TextField,
-  InputAdornment,
-  Divider,
 } from "@wso2/oxygen-ui";
 import {
   Search,
@@ -74,6 +75,13 @@ export default function AllConversationsSearchBar({
                     <Search size={16} />
                   </InputAdornment>
                 ),
+                endAdornment: searchTerm ? (
+                  <InputAdornment position="end">
+                    <IconButton size="small" edge="end" onClick={() => onSearchChange("")}>
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
               },
             }}
           />


### PR DESCRIPTION
### Description

This pull request improves the user experience across multiple search bars in the customer portal webapp by adding a clear ("X") button to each search input. This allows users to quickly clear their search queries with a single click. The change is applied consistently to all major search bars throughout the application.

**Enhancements to Search Bars:**

* Added a clear ("X") button to the end of search inputs in the following components:
  - `SearchBar` in the header (`SearchBar.tsx`) [[1]](diffhunk://#diff-d4393d033b635189c87f9fc33507e3b38a7649b1fbd2931c250bf264aac8453eR19-R26) [[2]](diffhunk://#diff-d4393d033b635189c87f9fc33507e3b38a7649b1fbd2931c250bf264aac8453eR335-R348)
  - List view search bar (`ListSearchBar.tsx`) [[1]](diffhunk://#diff-c07227d7cf147a665d0790d61bcd4730f4fa1b3755d9888f4ca4bfce954c3c82R21) [[2]](diffhunk://#diff-c07227d7cf147a665d0790d61bcd4730f4fa1b3755d9888f4ca4bfce954c3c82R106-R112)
  - Change Requests search bar (`ChangeRequestsSearchBar.tsx`) [[1]](diffhunk://#diff-8b11367c86e1b1872f4f503020fc6c87bd12379b956a29f121e24f77819efb7aR20-L23) [[2]](diffhunk://#diff-8b11367c86e1b1872f4f503020fc6c87bd12379b956a29f121e24f77819efb7aR78-R84)
  - Service Requests search bar (`ServiceRequestsSearchBar.tsx`) [[1]](diffhunk://#diff-47005aaf84d46d3f5dcb754b4aceed9b8ac0dd0a279725d732e86dcd2607b3e2R20-R25) [[2]](diffhunk://#diff-47005aaf84d46d3f5dcb754b4aceed9b8ac0dd0a279725d732e86dcd2607b3e2R114-R120)
  - Project Hub search bar (`ProjectHub.tsx`) [[1]](diffhunk://#diff-d88902c7dfaf68b0857f424d1a40d4c26da78ca0f11b6881d490300d4129f121R19-R20) [[2]](diffhunk://#diff-d88902c7dfaf68b0857f424d1a40d4c26da78ca0f11b6881d490300d4129f121L38-R40) [[3]](diffhunk://#diff-d88902c7dfaf68b0857f424d1a40d4c26da78ca0f11b6881d490300d4129f121R519-R525)
  - Product Vulnerabilities Table Header (`ProductVulnerabilitiesTableHeader.tsx`) [[1]](diffhunk://#diff-904a56fd258decf42be692cf09768c67854f0810e4eb5068a2d58ad0e1541445L19-R23) [[2]](diffhunk://#diff-904a56fd258decf42be692cf09768c67854f0810e4eb5068a2d58ad0e1541445R109-R115)
  - Settings Registry Tokens search bar (`SettingsRegistryTokens.tsx`) [[1]](diffhunk://#diff-015bdfb7ee492faf8f0bb31f63e21fcd02d94b05a7340514ca686254abcb66bdR50) [[2]](diffhunk://#diff-015bdfb7ee492faf8f0bb31f63e21fcd02d94b05a7340514ca686254abcb66bdR231-R237)
  - Settings User Management search bar (`SettingsUserManagement.tsx`) [[1]](diffhunk://#diff-59aa840c26f204e75529833567f1c8dd97b300aba9b4061f4ecf9f2a9572d907R46) [[2]](diffhunk://#diff-59aa840c26f204e75529833567f1c8dd97b300aba9b4061f4ecf9f2a9572d907R208-R214)
  - All Conversations search bar (`AllConversationsSearchBar.tsx`) [[1]](diffhunk://#diff-5bc6dc9b5bebbc32a708cbcb5830795dc0589d1d8141c0f52a137fbab1d735c4R21-L24) [[2]](diffhunk://#diff-5bc6dc9b5bebbc32a708cbcb5830795dc0589d1d8141c0f52a137fbab1d735c4R78-R84)

**Icon Imports and Cleanup:**

* Updated imports to include the new `X` icon and reorganized imports for consistency across affected files. (All references above)

These changes ensure a consistent and user-friendly search experience throughout the portal.