### PR TITLE
[Customer Portal] Show full token name in generate/regenerate modals and add duplicate name validation

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/components/GenerateTokenModal.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/GenerateTokenModal.tsx
@@ -50,6 +50,7 @@ export default function GenerateTokenModal({
   projectId,
   tokenType,
   isAdmin,
+  existingTokenNames = [],
 }: GenerateTokenModalProps): JSX.Element {
   const [robotName, setRobotName] = useState("");
   const [robotNameError, setRobotNameError] = useState<string | null>(null);
@@ -59,6 +60,7 @@ export default function GenerateTokenModal({
   const [createdForError, setCreatedForError] = useState<string | null>(null);
 
   const [secret, setSecret] = useState<string | null>(null);
+  const [fullTokenName, setFullTokenName] = useState<string | null>(null);
   const [showSecret, setShowSecret] = useState(false);
   const [copiedSecret, setCopiedSecret] = useState(false);
   const [copiedName, setCopiedName] = useState(false);
@@ -74,6 +76,8 @@ export default function GenerateTokenModal({
     if (!value.trim()) return "Token name is required.";
     if (!REGISTRY_TOKEN_ROBOT_NAME_REGEX.test(value))
       return "Only lowercase letters, numbers, and dashes are allowed.";
+    if (existingTokenNames.some((n) => n.toLowerCase() === value.trim().toLowerCase()))
+      return "A token with this name already exists.";
     return null;
   }
 
@@ -101,6 +105,7 @@ export default function GenerateTokenModal({
       {
         onSuccess: (data) => {
           setSecret(data.secret);
+          setFullTokenName(data.name ?? null);
         },
       },
     );
@@ -113,6 +118,7 @@ export default function GenerateTokenModal({
     setSelectedUser(null);
     setCreatedForError(null);
     setSecret(null);
+    setFullTokenName(null);
     setShowSecret(false);
     setCopiedSecret(false);
     setCopiedName(false);
@@ -165,14 +171,14 @@ export default function GenerateTokenModal({
             <TextField
               label="Token Name"
               fullWidth
-              value={robotName}
+              value={fullTokenName ?? robotName}
               InputProps={{
                 readOnly: true,
                 endAdornment: (
                   <InputAdornment position="end">
                     <IconButton
                       size="small"
-                      onClick={() => handleCopy(robotName, "name")}
+                      onClick={() => handleCopy(fullTokenName ?? robotName, "name")}
                       color={copiedName ? "success" : "default"}
                       aria-label="Copy token name"
                     >
@@ -243,8 +249,7 @@ export default function GenerateTokenModal({
               onChange={(e) => {
                 const value = e.target.value.toLowerCase();
                 setRobotName(value);
-                if (robotNameError)
-                  setRobotNameError(validateRobotName(value));
+                setRobotNameError(validateRobotName(value));
               }}
               onBlur={() => setRobotNameError(validateRobotName(robotName))}
               error={!!robotNameError}
@@ -319,7 +324,7 @@ export default function GenerateTokenModal({
               variant="contained"
               color="warning"
               onClick={handleGenerate}
-              disabled={createMutation.isPending}
+              disabled={createMutation.isPending || !!robotNameError}
               startIcon={
                 createMutation.isPending ? (
                   <CircularProgress size={16} color="inherit" />

--- a/apps/customer-portal/webapp/src/features/settings/components/GenerateTokenModal.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/GenerateTokenModal.tsx
@@ -324,7 +324,7 @@ export default function GenerateTokenModal({
               variant="contained"
               color="warning"
               onClick={handleGenerate}
-              disabled={createMutation.isPending || !!robotNameError}
+              disabled={createMutation.isPending || !!robotNameError || (tokenType === RegistryTokenType.SERVICE && !selectedUser)}
               startIcon={
                 createMutation.isPending ? (
                   <CircularProgress size={16} color="inherit" />

--- a/apps/customer-portal/webapp/src/features/settings/components/RegenerateTokenModal.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/RegenerateTokenModal.tsx
@@ -46,6 +46,7 @@ export default function RegenerateTokenModal({
   token,
 }: RegenerateTokenModalProps): JSX.Element {
   const [secret, setSecret] = useState<string | null>(null);
+  const [fullTokenName, setFullTokenName] = useState<string | null>(null);
   const [showSecret, setShowSecret] = useState(false);
   const [copiedSecret, setCopiedSecret] = useState(false);
   const [copiedName, setCopiedName] = useState(false);
@@ -57,12 +58,14 @@ export default function RegenerateTokenModal({
     regenerateMutation.mutate(token.id, {
       onSuccess: (data) => {
         setSecret(data.secret);
+        setFullTokenName(data.name ?? null);
       },
     });
   }
 
   function handleClose() {
     setSecret(null);
+    setFullTokenName(null);
     setShowSecret(false);
     setCopiedSecret(false);
     setCopiedName(false);
@@ -115,7 +118,7 @@ export default function RegenerateTokenModal({
             <TextField
               label="Token Name"
               fullWidth
-              value={token?.displayName ?? token?.name}
+              value={fullTokenName ?? token?.name}
               InputProps={{
                 readOnly: true,
                 endAdornment: (
@@ -124,7 +127,7 @@ export default function RegenerateTokenModal({
                       size="small"
                       onClick={() =>
                         handleCopy(
-                          token?.displayName ?? token?.name ?? "",
+                          fullTokenName ?? token?.name ?? "",
                           "name",
                         )
                       }

--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsRegistryTokens.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsRegistryTokens.tsx
@@ -570,6 +570,7 @@ export default function SettingsRegistryTokens({
             : RegistryTokenType.USER
         }
         isAdmin={isAdmin}
+        existingTokenNames={allTokens.map((t) => t.displayName ?? t.name)}
       />
 
       <DeleteTokenModal

--- a/apps/customer-portal/webapp/src/features/settings/types/registryTokens.ts
+++ b/apps/customer-portal/webapp/src/features/settings/types/registryTokens.ts
@@ -43,6 +43,7 @@ export type RegistryToken = AuditMetadata & {
 // Response type for creating a registry token.
 export type RegistryTokenCreationResponse = {
   secret: string;
+  name?: string;
 };
 
 // Request type for creating a registry token.

--- a/apps/customer-portal/webapp/src/features/settings/types/settings.ts
+++ b/apps/customer-portal/webapp/src/features/settings/types/settings.ts
@@ -120,6 +120,7 @@ export type GenerateTokenModalProps = {
   projectId: string;
   tokenType: RegistryTokenType;
   isAdmin: boolean;
+  existingTokenNames?: string[];
 };
 
 export type DeleteTokenModalProps = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent creating tokens with case-insensitive duplicate names.
  * Require integration user selection for service tokens before generation.

* **Bug Fixes**
  * Display and copy actions now use the server-returned token name after create/regenerate.
  * Name validation errors recompute on input and disable generation while present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->