### PR TITLE
[Customer Portal][FE][Web] Enhance advisory details display on Update Level Details page

### DIFF
--- a/apps/customer-portal/webapp/src/features/updates/pages/UpdateLevelDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/updates/pages/UpdateLevelDetailsPage.tsx
@@ -391,6 +391,26 @@ function UpdateDetailCard({
                       title="Description"
                       content={advisory.description}
                     />
+                    {advisory.impact && (
+                      <Box sx={{ mt: 1.5 }}>
+                        <UpdateSection title="Impact" content={advisory.impact} />
+                      </Box>
+                    )}
+                    {advisory.solution && (
+                      <Box sx={{ mt: 1.5 }}>
+                        <UpdateSection title="Solution" content={advisory.solution} />
+                      </Box>
+                    )}
+                    {advisory.notes && (
+                      <Box sx={{ mt: 1.5 }}>
+                        <UpdateSection title="Notes" content={advisory.notes} />
+                      </Box>
+                    )}
+                    {advisory.credits && advisory.credits !== "-" && (
+                      <Box sx={{ mt: 1.5 }}>
+                        <UpdateSection title="Credits" content={advisory.credits} />
+                      </Box>
+                    )}
                   </Box>
                 ))}
               </Box>


### PR DESCRIPTION
### Description


Closes(https://github.com/wso2-enterprise/digiops-cs/issues/1702)

This pull request enhances the `UpdateLevelDetailsPage` by displaying additional advisory information when available. Specifically, it adds new sections for "Impact", "Solution", "Notes", and "Credits" to provide users with more comprehensive details about each advisory.

**Improvements to advisory detail display:**

* Added conditional rendering for the `impact`, `solution`, `notes`, and `credits` fields of each advisory, displaying them as separate sections if the data is present.
* Ensured the "Credits" section only appears if the value is not a placeholder ("-").