### PR TITLE
[Customer Portal][FE][Web] Standardize active filter count by excluding search term

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
@@ -98,7 +98,7 @@ export default function ListSearchPanel({
       isFiltersOpen={isFiltersOpen}
       onFiltersToggle={onFiltersToggle}
       activeFiltersCount={countListSearchAndFilters(
-        searchTerm,
+        "",
         filtersForCount,
       )}
       onClearFilters={onClearFilters}

--- a/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementsPage.tsx
@@ -150,7 +150,7 @@ export default function AnnouncementsPage(): JSX.Element {
         onSearchChange={handleSearchChange}
         isFiltersOpen={isFiltersOpen}
         onFiltersToggle={() => setIsFiltersOpen(!isFiltersOpen)}
-        activeFiltersCount={countListSearchAndFilters(searchTerm, filters)}
+        activeFiltersCount={countListSearchAndFilters("", filters)}
         onClearFilters={handleClearFilters}
         filtersContent={
           <ListFiltersPanel

--- a/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestsPage.tsx
@@ -325,7 +325,7 @@ export default function ChangeRequestsPage(): JSX.Element {
           onSearchChange={handleSearchChange}
           isFiltersOpen={isFiltersOpen}
           onFiltersToggle={() => setIsFiltersOpen(!isFiltersOpen)}
-          activeFiltersCount={countListSearchAndFilters(searchTerm, filters)}
+          activeFiltersCount={countListSearchAndFilters("", filters)}
           onClearFilters={handleClearFilters}
           filtersContent={
             <ListFiltersPanel

--- a/apps/customer-portal/webapp/src/features/security/components/ProductVulnerabilitiesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/ProductVulnerabilitiesTable.tsx
@@ -200,8 +200,8 @@ const ProductVulnerabilitiesTable = ({
   };
 
   const activeFilterCount = useMemo(
-    () => countProductVulnerabilityTableActiveFilters(searchInput, filters),
-    [filters, searchInput],
+    () => countProductVulnerabilityTableActiveFilters("", filters),
+    [filters],
   );
 
   // ── Render ───────────────────────────────────────────────────────────────────

--- a/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
@@ -301,7 +301,7 @@ const SecurityReportAnalysis = ({ fixedStatusIds, fixedClosedDateRange }: Securi
           onSearchChange={handleSearchChange}
           isFiltersOpen={isFiltersOpen}
           onFiltersToggle={() => setIsFiltersOpen(!isFiltersOpen)}
-          activeFiltersCount={countListSearchAndFilters(searchTerm, filters)}
+          activeFiltersCount={countListSearchAndFilters("", filters)}
           onClearFilters={handleClearFilters}
           filtersContent={
             <ListFiltersPanel

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -336,7 +336,7 @@ export default function AllCasesPage(): JSX.Element {
         }}
       />
 
-      {statusFilter ? (
+      {statusFilter || isDashboardSeverityNavigation ? (
         <Divider />
       ) : (
         <ListSearchPanel

--- a/apps/customer-portal/webapp/src/features/support/pages/AllConversationsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllConversationsPage.tsx
@@ -273,7 +273,7 @@ export default function AllConversationsPage(): JSX.Element {
           onSearchChange={handleSearchChange}
           isFiltersOpen={isFiltersOpen}
           onFiltersToggle={() => setIsFiltersOpen(!isFiltersOpen)}
-          activeFiltersCount={countListSearchAndFilters(searchTerm, filters)}
+          activeFiltersCount={countListSearchAndFilters("", filters)}
           onClearFilters={handleClearFilters}
           filtersContent={
             <ListFiltersPanel


### PR DESCRIPTION
### Description

This pull request updates how the active filter count is calculated across multiple list and table components in the customer portal webapp. Specifically, it ensures that the search term is not included when determining the number of active filters, which standardizes filter counting behavior throughout the application. Additionally, there is a small UI logic change in the support cases page to improve divider rendering.

**Standardization of active filter count calculation:**

* Updated calls to `countListSearchAndFilters` and `countProductVulnerabilityTableActiveFilters` to always pass an empty string for the search term, so only filters are counted as active, not the search input. This affects components in Announcements, Change Requests, Security Reports, Conversations, and the main ListSearchPanel. [[1]](diffhunk://#diff-53faa8076743442e2deefa756c174de5697874c8e26d3c824cbef5f5b865f93aL153-R153) [[2]](diffhunk://#diff-ddbfee321640578ea9b461da5bfcef82d7bdbdf644ee5bfe588b1644b6aafd5fL328-R328) [[3]](diffhunk://#diff-adfd2071d27be496773e2b63fe6edbdc531d8256a468c9815380e03a4e3b0b0dL304-R304) [[4]](diffhunk://#diff-5a34a806971a9775cbea6ad0795ae11aa2755494b7417a58e1751dd09bad5301L276-R276) [[5]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8L101-R101) [[6]](diffhunk://#diff-11ab0d6d2610d0338c6f0df117387b7763d0f2b5f5c8f7092403c7ee9bff4ca6L203-R204)

**UI logic improvement:**

* Modified the condition for rendering a `Divider` in the AllCasesPage to also display it when `isDashboardSeverityNavigation` is true, improving the visual separation in the UI.