### PR TITLE
[Customer Portal][Fe][Web] Remove excludeS0 Flag and Simplify Case Filtering & Pagination

### DIFF
--- a/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
@@ -24,7 +24,6 @@ import useGetProjectCases from "@api/useGetProjectCases";
 import { useGetProjectCasesStats } from "@features/dashboard/api/useGetProjectCasesStats";
 import { useLoader } from "@context/linear-loader/LoaderContext";
 import { getProjectSeverityPolicy } from "@utils/permission";
-import { isS0Case } from "@features/support/utils/support";
 import { hasListSearchOrFilters } from "@features/support/utils/support";
 import { normalizeEngagementLabel } from "@features/dashboard/utils/dashboard";
 import type { AllCasesFilterValues } from "@features/support/types/cases";
@@ -99,7 +98,7 @@ export function useEngagementsPageState() {
   const severityPolicy = areFeaturePermissionsReady
     ? getProjectSeverityPolicy(project?.type?.label, { projectFeatures })
     : { excludeS0: false, restrictSeverityToLow: false };
-  const { excludeS0, restrictSeverityToLow } = severityPolicy;
+  const { restrictSeverityToLow } = severityPolicy;
 
   const { data: filterMetadata } = useGetProjectFilters(projectId || "");
 
@@ -239,11 +238,8 @@ export function useEngagementsPageState() {
   const apiTotalRecords = data?.pages?.[0]?.totalRecords ?? 0;
 
   const filteredCases = useMemo(
-    () =>
-      excludeS0
-        ? currentPageCases.filter((c) => !isS0Case(c))
-        : currentPageCases,
-    [currentPageCases, excludeS0],
+    () => currentPageCases,
+    [currentPageCases],
   );
 
   const totalItems = computeEngagementsTotalItems(
@@ -365,7 +361,6 @@ export function useEngagementsPageState() {
   return {
     projectId,
     projectReady,
-    excludeS0,
     restrictSeverityToLow,
     filterMetadata,
     stats,

--- a/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
@@ -237,16 +237,11 @@ export function useEngagementsPageState() {
 
   const apiTotalRecords = data?.pages?.[0]?.totalRecords ?? 0;
 
-  const filteredCases = useMemo(
-    () => currentPageCases,
-    [currentPageCases],
-  );
-
   const totalItems = computeEngagementsTotalItems(
     apiTotalRecords,
-    filteredCases.length,
+    currentPageCases.length,
   );
-  const paginatedCases = filteredCases;
+  const paginatedCases = currentPageCases;
 
   const handlePageChange = (_e: ChangeEvent<unknown>, value: number) => {
     setPage(value);

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
@@ -227,13 +227,8 @@ export default function ServiceRequestsPage(): JSX.Element {
 
   const apiTotalRecords = data?.pages?.[0]?.totalRecords ?? 0;
 
-  const filteredAndSearchedCases = useMemo(
-    () => currentPageCases,
-    [currentPageCases],
-  );
-
-  const totalItems = apiTotalRecords || filteredAndSearchedCases.length;
-  const paginatedCases = filteredAndSearchedCases;
+  const totalItems = apiTotalRecords || currentPageCases.length;
+  const paginatedCases = currentPageCases;
 
   const handlePageChange = (_event: ChangeEvent<unknown>, value: number) => {
     setPage(value);

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
@@ -38,7 +38,6 @@ import useGetProjectCases from "@api/useGetProjectCases";
 import { usePostProjectDeploymentsSearchInfinite } from "@api/usePostProjectDeploymentsSearch";
 import {
   hasListSearchOrFilters,
-  isS0Case,
 } from "@features/support/utils/support";
 import {
   getProjectPermissions,
@@ -128,7 +127,7 @@ export default function ServiceRequestsPage(): JSX.Element {
         : { excludeS0: false, restrictSeverityToLow: false },
     [projectDetailsReady, project, projectFeatures],
   );
-  const { excludeS0, restrictSeverityToLow } = severityPolicy;
+  const { restrictSeverityToLow } = severityPolicy;
 
   const { data: filterMetadata } = useGetProjectFilters(projectId || "");
   const deploymentsQuery = usePostProjectDeploymentsSearchInfinite(
@@ -229,11 +228,8 @@ export default function ServiceRequestsPage(): JSX.Element {
   const apiTotalRecords = data?.pages?.[0]?.totalRecords ?? 0;
 
   const filteredAndSearchedCases = useMemo(
-    () =>
-      excludeS0
-        ? currentPageCases.filter((c) => !isS0Case(c))
-        : currentPageCases,
-    [currentPageCases, excludeS0],
+    () => currentPageCases,
+    [currentPageCases],
   );
 
   const totalItems = apiTotalRecords || filteredAndSearchedCases.length;
@@ -408,7 +404,6 @@ export default function ServiceRequestsPage(): JSX.Element {
           isFetchingMoreDeployments={deploymentsQuery.isFetchingNextPage}
           onFilterChange={handleFilterChange}
           onClearFilters={handleClearFilters}
-          excludeS0={excludeS0}
           restrictSeverityToLow={restrictSeverityToLow}
           hideSeverityFilter
           hideDeploymentFilter={!permissions.hasDeployments}

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -37,7 +37,6 @@ import useGetProjectCases from "@api/useGetProjectCases";
 import { usePostProjectDeploymentsSearchInfinite } from "@api/usePostProjectDeploymentsSearch";
 import {
   hasListSearchOrFilters,
-  isS0Case,
   getLast30DaysUtcRange,
 } from "@features/support/utils/support";
 import {
@@ -114,7 +113,7 @@ export default function AllCasesPage(): JSX.Element {
         : { excludeS0: false, restrictSeverityToLow: false },
     [projectDetailsReady, project, projectFeatures],
   );
-  const { excludeS0, restrictSeverityToLow } = severityPolicy;
+  const { restrictSeverityToLow } = severityPolicy;
 
   // Fetch filter metadata first to get Incident and Query IDs for stats API
   const { data: filterMetadata } = useGetProjectFilters(projectId || "");
@@ -234,16 +233,11 @@ export default function AllCasesPage(): JSX.Element {
   const apiTotalRecords = data?.pages?.[0]?.totalRecords ?? 0;
 
   const filteredAndSearchedCases = useMemo(
-    () =>
-      excludeS0
-        ? currentPageCases.filter((c) => !isS0Case(c))
-        : currentPageCases,
-    [currentPageCases, excludeS0],
+    () => currentPageCases,
+    [currentPageCases],
   );
 
-  const totalItems = excludeS0
-    ? filteredAndSearchedCases.length
-    : (apiTotalRecords || filteredAndSearchedCases.length);
+  const totalItems = apiTotalRecords || filteredAndSearchedCases.length;
 
   const paginatedCases = filteredAndSearchedCases;
 
@@ -363,7 +357,6 @@ export default function AllCasesPage(): JSX.Element {
           isFetchingMoreDeployments={deploymentsQuery.isFetchingNextPage}
           onFilterChange={handleFilterChange}
           onClearFilters={handleClearFilters}
-          excludeS0={excludeS0}
           restrictSeverityToLow={restrictSeverityToLow}
           hideSeverityFilter={isDashboardSeverityNavigation}
           hideDeploymentFilter={!permissions.hasDeployments}

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -232,14 +232,9 @@ export default function AllCasesPage(): JSX.Element {
 
   const apiTotalRecords = data?.pages?.[0]?.totalRecords ?? 0;
 
-  const filteredAndSearchedCases = useMemo(
-    () => currentPageCases,
-    [currentPageCases],
-  );
+  const totalItems = apiTotalRecords || currentPageCases.length;
 
-  const totalItems = apiTotalRecords || filteredAndSearchedCases.length;
-
-  const paginatedCases = filteredAndSearchedCases;
+  const paginatedCases = currentPageCases;
 
   const handlePageChange = (_event: ChangeEvent<unknown>, value: number) => {
     setPage(value);


### PR DESCRIPTION
### Description

This pull request removes all logic related to the `excludeS0` flag across the `AllCasesPage`, `ServiceRequestsPage`, and `useEngagementsPageState` hooks and pages. The `excludeS0` flag and its related filtering (which excluded S0 cases from results) are no longer used, simplifying the code and ensuring that all cases are now included in the lists by default. Only the `restrictSeverityToLow` flag remains relevant for severity filtering.

Key changes by theme:

**Removal of S0 Case Filtering Logic:**

* Removed all usage of the `excludeS0` flag, including destructuring, passing as props, and related filtering logic from `useEngagementsPageState`, `AllCasesPage`, and `ServiceRequestsPage`. This includes deleting the `isS0Case` import and all `filteredCases`/`filteredAndSearchedCases` logic that depended on `excludeS0`. [[1]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL27) [[2]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL102-R101) [[3]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL241-R244) [[4]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL368) [[5]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L41) [[6]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L131-R130) [[7]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L231-R231) [[8]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L411) [[9]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L40) [[10]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L117-R116) [[11]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L236-R237) [[12]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L366)

**Simplification of Case Pagination and Counting:**

* Updated all relevant pages and hooks to use the full `currentPageCases` array for pagination and total item counting, instead of filtered versions that excluded S0 cases. [[1]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL241-R244) [[2]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L231-R231) [[3]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L236-R237)

**Prop Cleanup:**

* Removed the `excludeS0` prop from components where it was previously passed, as it is no longer needed. [[1]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL368) [[2]](diffhunk://#diff-9a6094dda58967a8cb9a6dc3265f076b9f61fceb3a1eaa9fc849dcbea2677d40L411) [[3]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L366)

These changes streamline the codebase by removing unnecessary complexity related to S0 case exclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where S0 severity cases were being filtered out from engagement lists, service request pages, and all cases views. These cases now display correctly with accurate item counts across all affected features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->