### PR TITLE
Revert "[Customer Portal][FE][Web] Allow .log and .toml attachments"

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -530,10 +530,6 @@ export const ALLOWED_ATTACHMENT_MIME_TYPES: ReadonlySet<string> = new Set([
   "image/webp",
   "application/x-sh",
   "application/x-har",
-  "text/x-log",
-  "application/x-log",
-  "application/toml",
-  "text/x-toml",
 ]);
 
 // Allowed file extensions for attachment uploads (fallback when MIME type is empty or unreliable).
@@ -541,12 +537,11 @@ export const ALLOWED_ATTACHMENT_EXTENSIONS: ReadonlySet<string> = new Set([
   "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx",
   "zip", "json", "xml", "txt", "csv",
   "jpg", "jpeg", "png", "webp", "sh", "har",
-  "log", "toml",
 ]);
 
 // accept attribute value for the attachment file input element.
 export const ALLOWED_ATTACHMENT_ACCEPT =
-  ".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.zip,.json,.xml,.txt,.csv,.jpg,.jpeg,.png,.webp,.sh,.har,.log,.toml";
+  ".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.zip,.json,.xml,.txt,.csv,.jpg,.jpeg,.png,.webp,.sh,.har";
 
 // Allowed MIME types for inline images in the rich text editor.
 export const ALLOWED_INLINE_IMAGE_MIME_TYPES: ReadonlySet<string> = new Set([


### PR DESCRIPTION
Reverts wso2-open-operations/cs-tools#655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for .log and .toml file attachments in support requests. Users can no longer upload these file types when submitting support tickets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->