### PR TITLE
[Customer Portal][FE][Web] Remove Frontend File Type Validation for Attachments and Inline Images

### DIFF
--- a/apps/customer-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -36,7 +36,6 @@ import {
   scrollElement,
   INSERT_IMAGE_COMMAND,
 } from "@features/support/utils/richTextEditor";
-import { ALLOWED_INLINE_IMAGE_MIME_TYPES } from "@features/support/constants/supportConstants";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { type ReactNode, useEffect, useState, useCallback, useMemo, useRef } from "react";
 import Toolbar, {
@@ -218,13 +217,7 @@ const ResetPlugin = ({ resetTrigger }: { resetTrigger?: number }) => {
  * Handles paste events containing image data (e.g. Ctrl+C from screen, then Ctrl+V).
  * Reads the image as a data URL and inserts it via INSERT_IMAGE_COMMAND.
  */
-const ClipboardImagePlugin = ({
-  onPasteError,
-  onImageTypeError,
-}: {
-  onPasteError?: () => void;
-  onImageTypeError?: () => void;
-}): null => {
+const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): null => {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -239,11 +232,6 @@ const ClipboardImagePlugin = ({
           if (!file) continue;
 
           event.preventDefault();
-
-          if (!ALLOWED_INLINE_IMAGE_MIME_TYPES.has(item.type)) {
-            onImageTypeError?.();
-            break;
-          }
 
           if (file.size > MAX_PASTE_IMAGE_SIZE) {
             onPasteError?.();
@@ -331,7 +319,6 @@ const Editor = ({
   onBlur,
   overlayElement,
   onPasteError,
-  onInlineImageTypeError,
 }: {
   onAttachmentClick?: () => void;
   attachments?: File[];
@@ -355,7 +342,6 @@ const Editor = ({
   /** Optional element rendered as an absolute overlay at the bottom-right inside the editor. */
   overlayElement?: ReactNode;
   onPasteError?: () => void;
-  onInlineImageTypeError?: () => void;
 }): JSX.Element => {
   const oxygenTheme = useTheme();
   const logger = useLogger();
@@ -531,7 +517,7 @@ const Editor = ({
           <HistoryPlugin />
           <ListPlugin />
           <ImagesPlugin />
-          <ClipboardImagePlugin onPasteError={onPasteError} onImageTypeError={onInlineImageTypeError} />
+          <ClipboardImagePlugin onPasteError={onPasteError} />
           <LinkPlugin />
           <ClickableLinkPlugin />
           <InitialValuePlugin initialHtml={value} />

--- a/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
@@ -77,8 +77,6 @@ import { mergeRegister } from "@lexical/utils";
 import {
   MAX_IMAGE_SIZE_BYTES,
   RICH_TEXT_BLOCK_TAGS,
-  ALLOWED_INLINE_IMAGE_MIME_TYPES,
-  ALLOWED_INLINE_IMAGE_ACCEPT,
 } from "@features/support/constants/supportConstants";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import {
@@ -241,13 +239,6 @@ const Toolbar = ({
       const resetInput = () => {
         if (imageInputRef.current) imageInputRef.current.value = "";
       };
-      if (!ALLOWED_INLINE_IMAGE_MIME_TYPES.has(file.type)) {
-        showError(
-          `Image "${file.name}" is not a supported type. Only jpg, jpeg, png, and webp images can be inserted inline.`,
-        );
-        resetInput();
-        return;
-      }
       if (file.size > MAX_IMAGE_SIZE_BYTES) {
         showError(
           `Image "${file.name}" exceeds the maximum allowed size of ${MAX_IMAGE_SIZE_BYTES / (1024 * 1024)}MB. Please choose a smaller file.`,
@@ -596,7 +587,8 @@ const Toolbar = ({
               size="small"
               value="left"
               selected={
-                elementAlign === "left" || (elementAlign === "" && hasContent)
+                elementAlign === "left" ||
+                (elementAlign === "" && hasContent)
               }
               onClick={() => onFormatAlign("left")}
             >
@@ -785,7 +777,7 @@ const Toolbar = ({
                     ref={imageInputRef}
                     type="file"
                     hidden
-                    accept={ALLOWED_INLINE_IMAGE_ACCEPT}
+                    accept="image/*"
                     onChange={onImageUpload}
                   />
                 </ToggleButton>
@@ -846,11 +838,7 @@ const Toolbar = ({
             <Typography
               component="span"
               variant="caption"
-              sx={{
-                color: "text.secondary",
-                whiteSpace: "nowrap",
-                lineHeight: 1.4,
-              }}
+              sx={{ color: "text.secondary", whiteSpace: "nowrap", lineHeight: 1.4 }}
             >
               <Typography component="span" variant="caption" fontWeight={600}>
                 Shift+Enter
@@ -865,11 +853,7 @@ const Toolbar = ({
             <Typography
               component="span"
               variant="caption"
-              sx={{
-                color: "text.secondary",
-                whiteSpace: "nowrap",
-                lineHeight: 1.4,
-              }}
+              sx={{ color: "text.secondary", whiteSpace: "nowrap", lineHeight: 1.4 }}
             >
               <Typography component="span" variant="caption" fontWeight={600}>
                 Shift+Enter

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
@@ -28,11 +28,6 @@ import {
 } from "@wso2/oxygen-ui";
 import { Upload, X } from "@wso2/oxygen-ui-icons-react";
 import { useEffect, useMemo, type JSX } from "react";
-import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
-import {
-  ALLOWED_ATTACHMENT_ACCEPT,
-  isAllowedAttachment,
-} from "@features/support/constants/supportConstants";
 import type { CatalogItemVariable } from "@features/operations/types/serviceRequests";
 import {
   isAttachmentField,
@@ -79,10 +74,7 @@ function parseRequiredLabel(questionText: string): { label: string } {
 
 function isTitleField(questionText: string): boolean {
   return (
-    questionText
-      .replace(/^\s*\*?\s*/, "")
-      .trim()
-      .toLowerCase() === "title"
+    questionText.replace(/^\s*\*?\s*/, "").trim().toLowerCase() === "title"
   );
 }
 
@@ -217,12 +209,8 @@ export default function VariableFormFields({
   onAttachmentAdd,
   userTimeZone,
 }: VariableFormFieldsProps): JSX.Element {
-  const { showError } = useErrorBanner();
   const effectiveTimeZone = userTimeZone ?? resolveDisplayTimeZone();
-  const minDatetime = computeMinScheduleDatetimeLocalForTimeZone(
-    0,
-    effectiveTimeZone,
-  );
+  const minDatetime = computeMinScheduleDatetimeLocalForTimeZone(0, effectiveTimeZone);
   const sortedVariables = useMemo(
     () => (variables ? [...variables].sort((a, b) => a.order - b.order) : []),
     [variables],
@@ -362,11 +350,6 @@ export default function VariableFormFields({
             onAttachmentClick={onAttachmentClick}
             attachments={attachments.map((a) => a.file)}
             onAttachmentRemove={onAttachmentRemove}
-            onInlineImageTypeError={() =>
-              showError(
-                "Only jpg, jpeg, png, and webp images can be inserted inline.",
-              )
-            }
           />
         </Grid>
       );
@@ -437,20 +420,16 @@ export default function VariableFormFields({
                   type="file"
                   hidden
                   multiple
-                  accept={ALLOWED_ATTACHMENT_ACCEPT}
                   onChange={(e) => {
                     const files = e.target.files;
                     if (files?.length) {
                       for (let i = 0; i < files.length; i++) {
                         const f = files[i];
-                        if (!f) continue;
-                        if (!isAllowedAttachment(f)) {
-                          showError(
-                            `"${f.name}" is not supported. Only pdf, doc, docx, xls, xlsx, ppt, pptx, zip, json, xml, txt, csv, jpg, jpeg, png, webp, sh, and har file types are supported.`,
+                        if (f)
+                          onAttachmentAdd(
+                            f,
+                            variable.questionText ?? undefined,
                           );
-                          continue;
-                        }
-                        onAttachmentAdd(f, variable.questionText ?? undefined);
                       }
                       e.target.value = "";
                     }
@@ -544,11 +523,7 @@ export default function VariableFormFields({
           onChange={(e) => onChange(variable.id, e.target.value)}
           disabled={isContext}
           error={isTitleTooLong}
-          helperText={
-            isTitleTooLong
-              ? "Title must be 160 characters or fewer."
-              : undefined
-          }
+          helperText={isTitleTooLong ? "Title must be 160 characters or fewer." : undefined}
         />
         {isTitle && (
           <Typography

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
@@ -29,15 +29,8 @@ import {
 } from "@wso2/oxygen-ui";
 import { File, Sparkles, Upload, X } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
-import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
-import {
-  CaseSeverity,
-  CaseSeverityLevel,
-} from "@features/support/constants/supportConstants";
-import {
-  isS0SeverityLabel,
-  getSeverityLegendColor,
-} from "@features/dashboard/utils/dashboard";
+import { CaseSeverity, CaseSeverityLevel } from "@features/support/constants/supportConstants";
+import { isS0SeverityLabel, getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import Editor from "@components/rich-text-editor/Editor";
 
 /**
@@ -69,7 +62,6 @@ export function CaseDetailsSection({
   excludeS0 = false,
   isSeverityDisabled = false,
 }: CaseDetailsSectionProps): JSX.Element {
-  const { showError } = useErrorBanner();
   const titleReadOnly = isTitleDisabled;
   const titleLength = title.trim().length;
   const isTitleTooLong = titleLength > 160;
@@ -197,9 +189,7 @@ export function CaseDetailsSection({
               disabled={isLoading || titleReadOnly}
               error={isTitleTooLong}
               helperText={
-                isTitleTooLong
-                  ? "Title must be 160 characters or fewer."
-                  : undefined
+                isTitleTooLong ? "Title must be 160 characters or fewer." : undefined
               }
             />
             <Typography
@@ -248,11 +238,6 @@ export function CaseDetailsSection({
             value={description}
             onChange={setDescription}
             maxHeight="210px"
-            onInlineImageTypeError={() =>
-              showError(
-                "Only jpg, jpeg, png, and webp images can be inserted inline.",
-              )
-            }
           />
 
           {!isRelatedCaseMode && (
@@ -496,9 +481,7 @@ export function CaseDetailsSection({
                           width: 10,
                           height: 10,
                           borderRadius: "50%",
-                          bgcolor:
-                            selectedLevel?.color ??
-                            getSeverityLegendColor(CaseSeverityLevel.S4),
+                          bgcolor: selectedLevel?.color ?? getSeverityLegendColor(CaseSeverityLevel.S4),
                           flexShrink: 0,
                         }}
                       />
@@ -527,11 +510,7 @@ export function CaseDetailsSection({
                       }
                       return (
                         <Box
-                          sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 1.5,
-                          }}
+                          sx={{ display: "flex", alignItems: "center", gap: 1.5 }}
                         >
                           <Box
                             sx={{
@@ -555,11 +534,7 @@ export function CaseDetailsSection({
                     {severityLevels.map((lvl) => (
                       <MenuItem key={lvl.id} value={lvl.id}>
                         <Box
-                          sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 1.5,
-                          }}
+                          sx={{ display: "flex", alignItems: "center", gap: 1.5 }}
                         >
                           <Box
                             sx={{

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -244,11 +244,6 @@ export default function ActivityCommentInput({
             onPasteError={() =>
               showError("Image exceeds the maximum allowed size of 10 MB.")
             }
-            onInlineImageTypeError={() =>
-              showError(
-                "Only jpg, jpeg, png, and webp images can be inserted inline.",
-              )
-            }
             overlayElement={
               <Tooltip title="Send comment">
                 <span>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/UploadAttachmentModal.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/UploadAttachmentModal.tsx
@@ -30,11 +30,7 @@ import { X } from "@wso2/oxygen-ui-icons-react";
 import { useCallback, useRef, useState, type JSX } from "react";
 import { usePostAttachments } from "@features/support/api/usePostAttachments";
 import { usePostDeploymentAttachment } from "@features/project-details/api/usePostDeploymentAttachment";
-import {
-  MAX_ATTACHMENT_SIZE_BYTES,
-  ALLOWED_ATTACHMENT_ACCEPT,
-  isAllowedAttachment,
-} from "@features/support/constants/supportConstants";
+import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/support/constants/supportConstants";
 import UploadAttachmentDropZone from "@case-details-attachments/UploadAttachmentDropZone";
 import SelectedFileDisplay from "@case-details-attachments/SelectedFileDisplay";
 
@@ -93,7 +89,6 @@ export default function UploadAttachmentModal({
   const [description, setDescription] = useState("");
   const [dragOver, setDragOver] = useState(false);
   const [fileSizeErrorVisible, setFileSizeErrorVisible] = useState(false);
-  const [fileTypeErrorVisible, setFileTypeErrorVisible] = useState(false);
   const [readErrorVisible, setReadErrorVisible] = useState(false);
 
   const fileTooLarge = file ? file.size > MAX_ATTACHMENT_SIZE_BYTES : false;
@@ -109,7 +104,6 @@ export default function UploadAttachmentModal({
     setName("");
     setDescription("");
     setFileSizeErrorVisible(false);
-    setFileTypeErrorVisible(false);
     setReadErrorVisible(false);
   }, []);
 
@@ -120,13 +114,6 @@ export default function UploadAttachmentModal({
 
   const setFileWithValidation = useCallback(
     (selected: File | null) => {
-      if (selected && !isAllowedAttachment(selected)) {
-        setFileTypeErrorVisible(true);
-        setFileSizeErrorVisible(false);
-        setFile(null);
-        return;
-      }
-      setFileTypeErrorVisible(false);
       setFile(selected);
       if (selected && selected.size > MAX_ATTACHMENT_SIZE_BYTES) {
         setFileSizeErrorVisible(true);
@@ -265,17 +252,6 @@ export default function UploadAttachmentModal({
         </IconButton>
       </DialogTitle>
       <DialogContent sx={{ pt: 1 }}>
-        {fileTypeErrorVisible && (
-          <Alert
-            severity="error"
-            onClose={() => setFileTypeErrorVisible(false)}
-            sx={{ mb: 2 }}
-          >
-            This file type is not supported. Supported types: pdf, doc, docx,
-            xls, xlsx, ppt, pptx, zip, json, xml, txt, csv, jpg, jpeg, png,
-            webp, sh, har.
-          </Alert>
-        )}
         {fileSizeErrorVisible && (
           <Alert
             severity="error"
@@ -297,7 +273,7 @@ export default function UploadAttachmentModal({
         <input
           ref={fileInputRef}
           type="file"
-          accept={ALLOWED_ATTACHMENT_ACCEPT}
+          accept="*/*"
           onChange={handleFileChange}
           style={{ display: "none" }}
           aria-hidden

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -511,55 +511,6 @@ export type CommentType = (typeof CommentType)[keyof typeof CommentType];
 // Line count threshold for showing expand button in support activity section.
 export const COLLAPSE_LINE_THRESHOLD = 4;
 
-// Allowed MIME types for attachment file uploads.
-export const ALLOWED_ATTACHMENT_MIME_TYPES: ReadonlySet<string> = new Set([
-  "application/pdf",
-  "application/msword",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  "application/vnd.ms-excel",
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-  "application/vnd.ms-powerpoint",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  "application/zip",
-  "application/json",
-  "application/xml",
-  "text/plain",
-  "text/csv",
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "application/x-sh",
-  "application/x-har",
-]);
-
-// Allowed file extensions for attachment uploads (fallback when MIME type is empty or unreliable).
-export const ALLOWED_ATTACHMENT_EXTENSIONS: ReadonlySet<string> = new Set([
-  "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx",
-  "zip", "json", "xml", "txt", "csv",
-  "jpg", "jpeg", "png", "webp", "sh", "har",
-]);
-
-// accept attribute value for the attachment file input element.
-export const ALLOWED_ATTACHMENT_ACCEPT =
-  ".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.zip,.json,.xml,.txt,.csv,.jpg,.jpeg,.png,.webp,.sh,.har";
-
-// Allowed MIME types for inline images in the rich text editor.
-export const ALLOWED_INLINE_IMAGE_MIME_TYPES: ReadonlySet<string> = new Set([
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-]);
-
-// accept attribute value for the inline image file input element.
-export const ALLOWED_INLINE_IMAGE_ACCEPT = ".jpg,.jpeg,.png,.webp";
-
-/** Returns true if the file is an allowed attachment type (checks MIME type then extension). */
-export function isAllowedAttachment(file: File): boolean {
-  if (ALLOWED_ATTACHMENT_MIME_TYPES.has(file.type)) return true;
-  const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
-  return ALLOWED_ATTACHMENT_EXTENSIONS.has(ext);
-}
-
 // Case type input.
 export type CaseTypeInput = CaseTypeObject | string | null | undefined;
 


### PR DESCRIPTION
### Description

This pull request removes file type validation for inline images and attachments in the customer portal's rich text editor and related forms, shifting responsibility for file type checks to the backend. The changes simplify the frontend code by eliminating references to allowed MIME types and file extensions, and by removing error handling related to unsupported file types. Only file size validation remains on the frontend for images and attachments.

**Rich Text Editor and Toolbar:**

- Removed all frontend validation of inline image MIME types and accepted file extensions, including the use of `ALLOWED_INLINE_IMAGE_MIME_TYPES` and `ALLOWED_INLINE_IMAGE_ACCEPT`. The editor and toolbar now accept all image types via `accept="image/*"`, and no longer show errors for unsupported image types. [[1]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L39) [[2]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L221-R220) [[3]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L243-L247) [[4]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L80-L81) [[5]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L244-L250) [[6]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L788-R780)
- Removed the `onInlineImageTypeError` prop and related error handling from the `Editor` and all consuming components. [[1]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L334) [[2]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L358) [[3]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L534-R520) [[4]](diffhunk://#diff-8fd436212309fa48e15e09bef0ea2e5946850847dea455e6cd821547d43808dcL365-L369) [[5]](diffhunk://#diff-a1aaf4aba8863f59244132243c9aee4a621bd673c68642ae900434b23c28d972L251-L255) [[6]](diffhunk://#diff-2c524159c32a2db5565c2a33ee9f17ef1c9f51fd037ec6e0111804f0bf1c086dL247-L251)

**Attachment Handling in Forms:**

- Removed frontend file type validation and accepted file extension restrictions for attachments in service request and case creation forms. The frontend now passes all selected files to the backend for validation, and related error banners for unsupported types have been eliminated. [[1]](diffhunk://#diff-8fd436212309fa48e15e09bef0ea2e5946850847dea455e6cd821547d43808dcL31-L35) [[2]](diffhunk://#diff-8fd436212309fa48e15e09bef0ea2e5946850847dea455e6cd821547d43808dcL440-L453) [[3]](diffhunk://#diff-5b90605b012f82cfd981b084917e9f8bb6f2a470074bd47820d34f0416946561L33-R33) [[4]](diffhunk://#diff-5b90605b012f82cfd981b084917e9f8bb6f2a470074bd47820d34f0416946561L96)

**General Code Simplification:**

- Cleaned up code by removing unused imports, props, and error handling functions related to file type validation, and simplified some style and helper text expressions. [[1]](diffhunk://#diff-8fd436212309fa48e15e09bef0ea2e5946850847dea455e6cd821547d43808dcL82-R77) [[2]](diffhunk://#diff-8fd436212309fa48e15e09bef0ea2e5946850847dea455e6cd821547d43808dcL220-R213) [[3]](diffhunk://#diff-8fd436212309fa48e15e09bef0ea2e5946850847dea455e6cd821547d43808dcL547-R526) [[4]](diffhunk://#diff-a1aaf4aba8863f59244132243c9aee4a621bd673c68642ae900434b23c28d972L32-R33) [[5]](diffhunk://#diff-a1aaf4aba8863f59244132243c9aee4a621bd673c68642ae900434b23c28d972L72) [[6]](diffhunk://#diff-a1aaf4aba8863f59244132243c9aee4a621bd673c68642ae900434b23c28d972L200-R192) [[7]](diffhunk://#diff-a1aaf4aba8863f59244132243c9aee4a621bd673c68642ae900434b23c28d972L499-R484) [[8]](diffhunk://#diff-a1aaf4aba8863f59244132243c9aee4a621bd673c68642ae900434b23c28d972L530-R513) [[9]](diffhunk://#diff-a1aaf4aba8863f59244132243c9aee4a621bd673c68642ae900434b23c28d972L558-R537) [[10]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L599-R591) [[11]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L849-R841) [[12]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L868-R856)

These changes ensure that file type validation is consistently handled by the backend, reducing duplication and potential mismatches between frontend and backend validation logic.