### PR TITLE
[Customer Portal][FE][Web] Download attachments via downloadUrl and blob

### DIFF
--- a/apps/customer-portal/webapp/src/api/useGetAttachment.ts
+++ b/apps/customer-portal/webapp/src/api/useGetAttachment.ts
@@ -17,10 +17,8 @@
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useAuthApiClient } from "@/hooks/useAuthApiClient";
-import type { AttachmentDownloadResponse } from "@features/support/types/attachments";
-import { parseApiResponseMessage } from "@utils/ApiError";
 
-/** Input for GET /attachments/:id or inline list payload. */
+/** Input for downloading an attachment via its download URL. */
 export interface DownloadBackendAttachmentInput {
   id: string;
   name: string;
@@ -29,83 +27,34 @@ export interface DownloadBackendAttachmentInput {
   downloadUrl?: string | null;
 }
 
-function getBackendBaseUrl(): string {
-  const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
-  if (!baseUrl) {
-    throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
-  }
-  return baseUrl.replace(/\/$/, "");
-}
-
-function triggerDownloadFromContentField(
-  content: string,
-  fileName: string,
-  mimeType?: string,
-): void {
-  const isDataUrl = content.startsWith("data:");
-  const href = isDataUrl
-    ? content
-    : `data:${mimeType ?? "application/octet-stream"};base64,${content}`;
+function triggerDownloadFromBlob(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
-  link.href = href;
+  link.href = url;
   link.download = fileName || "attachment";
-  link.target = "_blank";
-  link.rel = "noopener noreferrer";
   link.click();
+  URL.revokeObjectURL(url);
 }
 
-function openExternalDownload(url: string): void {
-  window.open(url, "_blank", "noopener,noreferrer");
-}
-
-async function downloadAttachmentThroughBackend(
+async function downloadAttachmentViaDownloadUrl(
   authFetch: (
     input: RequestInfo | URL,
     init?: RequestInit,
   ) => Promise<Response>,
   input: DownloadBackendAttachmentInput,
 ): Promise<void> {
-  if (input.content) {
-    triggerDownloadFromContentField(input.content, input.name, input.type);
-    return;
+  if (!input.downloadUrl) {
+    throw new Error("No download URL available for this attachment");
   }
 
-  const baseUrl = getBackendBaseUrl();
-  const url = `${baseUrl}/attachments/${encodeURIComponent(input.id)}`;
-  let response: Response;
-  try {
-    response = await authFetch(url, { method: "GET" });
-  } catch {
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
-    throw new Error("Network error while downloading attachment");
-  }
+  const response = await authFetch(input.downloadUrl, { method: "GET" });
 
   if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
-    throw new Error(parseApiResponseMessage(detail, response.status, response.statusText));
+    throw new Error(`Failed to download attachment: ${response.statusText}`);
   }
 
-  const data = (await response.json()) as AttachmentDownloadResponse;
-  if (!data?.content || typeof data.content !== "string") {
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
-    throw new Error("Attachment response did not include file content");
-  }
-
-  triggerDownloadFromContentField(
-    data.content,
-    data.name || input.name,
-    data.type || input.type,
-  );
+  const blob = await response.blob();
+  triggerDownloadFromBlob(blob, input.name);
 }
 
 export interface UseGetAttachmentResult {
@@ -128,7 +77,7 @@ export function useGetAttachment(): UseGetAttachmentResult {
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   const mutation = useMutation<void, Error, DownloadBackendAttachmentInput>({
-    mutationFn: (input) => downloadAttachmentThroughBackend(authFetch, input),
+    mutationFn: (input) => downloadAttachmentViaDownloadUrl(authFetch, input),
     onMutate: (variables) => {
       setDownloadingId(variables.id);
     },


### PR DESCRIPTION
### Description

This pull request refactors the attachment download logic in the `useGetAttachment` API hook to simplify the implementation and improve reliability. The main change is to always download attachments using their provided download URLs, removing the previous logic that handled content fields and fallback mechanisms.

Key changes:

**Refactoring attachment download logic:**

* Removed support for downloading attachments via a content field and now require a valid `downloadUrl` to be provided in `DownloadBackendAttachmentInput`. The function now throws an error if no download URL is available.
* Simplified the download process by fetching the attachment as a `Blob` from the `downloadUrl` and triggering the download directly, eliminating the previous logic that handled data URLs and content fields.

**Code cleanup and naming:**

* Renamed the main download function from `downloadAttachmentThroughBackend` to `downloadAttachmentViaDownloadUrl` to better reflect its purpose.
* Updated the mutation function in `useGetAttachment` to use the new download logic.