### PR TITLE
[Customer Portal][FE][Web] Enhance Deployment Matching Logic and UI Error Handling

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/DeploymentCard.tsx
@@ -34,6 +34,7 @@ import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
 import DeploymentCardLicenseFooter from "@features/project-details/components/deployments/deployment-card/DeploymentCardLicenseFooter";
 import DeploymentCardToolbar from "@features/project-details/components/deployments/deployment-card/DeploymentCardToolbar";
 import { useState, type JSX } from "react";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import DeploymentDocumentList from "@deployments/DeploymentDocumentList";
 import DeploymentProductList from "@deployments/DeploymentProductList";
 import EditDeploymentModal from "@deployments/EditDeploymentModal";
@@ -60,6 +61,7 @@ export default function DeploymentCard({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const patchDeployment = usePatchDeployment();
   const downloadLicense = useDownloadDeploymentLicense();
+  const { showError } = useErrorBanner();
 
   const createdAtStr = formatProjectDateTime(createdOn ?? "");
   const updatedAtStr = formatProjectDateTime(updatedOn ?? "");
@@ -191,6 +193,7 @@ export default function DeploymentCard({
         projectId={projectId}
         onClose={() => setIsEditModalOpen(false)}
         onSuccess={() => setIsEditModalOpen(false)}
+        onError={(message) => showError(message)}
       />
 
       <DeleteDeploymentModal
@@ -207,6 +210,10 @@ export default function DeploymentCard({
             },
             {
               onSuccess: () => setIsDeleteModalOpen(false),
+              onError: (error) => {
+                setIsDeleteModalOpen(false);
+                showError(error.message);
+              },
             },
           );
         }}

--- a/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
@@ -403,7 +403,7 @@ export function getBaseDeploymentOptions(
   projectDeployments: ProjectDeploymentOption[] | undefined,
 ): string[] {
   return (
-    projectDeployments?.map((d) => d.name || d.type?.label).filter(Boolean) ??
+    projectDeployments?.map((d) => d.name ?? d.type?.label).filter(Boolean) ??
     []
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
@@ -148,22 +148,25 @@ export function resolveDeploymentMatch(
 
   const labelLower = label.toLowerCase();
 
-  const fromProjectExact = projectDeployments?.find((d) => {
-    const typeLabel = d.type?.label?.trim();
-    const depName = d.name?.trim();
-    return typeLabel === label || depName === label;
-  });
-  if (fromProjectExact) return { id: fromProjectExact.id };
+  const fromProjectByNameExact = projectDeployments?.find(
+    (d) => d.name?.trim() === label,
+  );
+  if (fromProjectByNameExact) return { id: fromProjectByNameExact.id };
 
-  const fromProjectCaseInsensitive = projectDeployments?.find((d) => {
-    const typeLabel = d.type?.label?.trim();
-    const depName = d.name?.trim();
-    return (
-      typeLabel?.toLowerCase() === labelLower ||
-      depName?.toLowerCase() === labelLower
-    );
-  });
-  if (fromProjectCaseInsensitive) return { id: fromProjectCaseInsensitive.id };
+  const fromProjectByTypeLabelExact = projectDeployments?.find(
+    (d) => d.type?.label?.trim() === label,
+  );
+  if (fromProjectByTypeLabelExact) return { id: fromProjectByTypeLabelExact.id };
+
+  const fromProjectByNameInsensitive = projectDeployments?.find(
+    (d) => d.name?.trim().toLowerCase() === labelLower,
+  );
+  if (fromProjectByNameInsensitive) return { id: fromProjectByNameInsensitive.id };
+
+  const fromProjectByTypeLabelInsensitive = projectDeployments?.find(
+    (d) => d.type?.label?.trim().toLowerCase() === labelLower,
+  );
+  if (fromProjectByTypeLabelInsensitive) return { id: fromProjectByTypeLabelInsensitive.id };
 
   const fromFiltersExact = filterDeployments?.find(
     (d) => d.id === label || d.label === label,
@@ -400,7 +403,7 @@ export function getBaseDeploymentOptions(
   projectDeployments: ProjectDeploymentOption[] | undefined,
 ): string[] {
   return (
-    projectDeployments?.map((d) => d.name ?? d.type?.label).filter(Boolean) ??
+    projectDeployments?.map((d) => d.name || d.type?.label).filter(Boolean) ??
     []
   );
 }


### PR DESCRIPTION
### Descrption

This pull request improves error handling in the deployment card UI and refines the logic for matching deployments by name and type in the case creation utilities. The most significant changes are grouped below.

**Error Handling Improvements in Deployment UI:**

* Integrated the `useErrorBanner` context into `DeploymentCard` to display user-friendly error messages when deployment edits or deletions fail. Now, errors encountered during edit or delete actions will trigger a visible error banner for the user. [[1]](diffhunk://#diff-358bf724b95b84c856ff8a0b91d711ef61c7fb4f47459dc16b1bcdffb309c64fR37) [[2]](diffhunk://#diff-358bf724b95b84c856ff8a0b91d711ef61c7fb4f47459dc16b1bcdffb309c64fR64) [[3]](diffhunk://#diff-358bf724b95b84c856ff8a0b91d711ef61c7fb4f47459dc16b1bcdffb309c64fR196) [[4]](diffhunk://#diff-358bf724b95b84c856ff8a0b91d711ef61c7fb4f47459dc16b1bcdffb309c64fR213-R216)

**Deployment Matching Logic Enhancements:**

* Refactored the `resolveDeploymentMatch` function in `caseCreation.ts` to:
  - Separate and prioritize exact and case-insensitive matches by deployment `name` and `type.label`.
  - Ensure the matching process is more predictable and robust by checking each criterion in a specific order.

* Updated `getBaseDeploymentOptions` to use a logical OR (`||`) instead of nullish coalescing (`??`) when selecting between `name` and `type.label`, ensuring fallback to the correct value if one is falsy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages are now properly displayed when deployment edit or delete operations fail
  * Improved deployment matching accuracy with a more robust matching strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->