### PR TITLE
[Customer Portal][FE][Web] Refactor UpdateHistoryTab to Simplify Update Level Fetching

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/UpdateHistoryTab.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/UpdateHistoryTab.tsx
@@ -36,8 +36,7 @@ import {
 import type { ProductUpdate } from "@features/project-details/types/products";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
-import { useGetRecommendedUpdateLevels } from "@features/updates/api/useGetRecommendedUpdateLevels";
-import { usePostUpdateLevelsSearch } from "@features/updates/api/usePostUpdateLevelsSearch";
+import { useGetProductUpdateLevels } from "@features/updates/api/useGetProductUpdateLevels";
 import UpdateHistoryAddSectionSkeleton from "@features/project-details/components/deployments/update-history/UpdateHistoryAddSectionSkeleton";
 import {
   getUpdateHistoryEntryBackground,
@@ -82,66 +81,30 @@ export default function UpdateHistoryTab({
   const { showError } = useErrorBanner();
 
   const {
-    data: recommendedUpdateLevels = [],
-    isLoading: isLoadingRecommended,
-  } = useGetRecommendedUpdateLevels();
+    data: productUpdateLevels = [],
+    isLoading: isLoadingProductUpdateLevels,
+  } = useGetProductUpdateLevels();
 
-  const matchedRecommendation = useMemo(() => {
-    if (
-      !productName ||
-      !productVersion ||
-      recommendedUpdateLevels.length === 0
-    ) {
-      return null;
-    }
-
-    return recommendedUpdateLevels.find(
-      (item) =>
-        item.productName === productName &&
-        item.productBaseVersion === productVersion,
-    );
-  }, [productName, productVersion, recommendedUpdateLevels]);
-
-  const searchParams = useMemo(() => {
-    if (!productName || !productVersion || !matchedRecommendation) {
-      return null;
-    }
-
-    return {
-      productName,
-      productVersion,
-      startingUpdateLevel: matchedRecommendation.startingUpdateLevel,
-      endingUpdateLevel: matchedRecommendation.endingUpdateLevel,
-    };
-  }, [productName, productVersion, matchedRecommendation]);
-
-  const {
-    data: updateLevelsData,
-    isLoading: isLoadingUpdateLevels,
-    isFetching: isFetchingUpdateLevels,
-  } = usePostUpdateLevelsSearch(searchParams);
-
-  const showUpdateLevelDropdownSkeleton =
-    isLoadingUpdateLevels ||
-    (isFetchingUpdateLevels && updateLevelsData == null);
-
-  const isAddUpdateSectionLoading =
-    isLoadingRecommended ||
-    (searchParams != null && showUpdateLevelDropdownSkeleton);
-
-  const isEditInlineLoading =
-    isLoadingRecommended || showUpdateLevelDropdownSkeleton;
+  const showUpdateLevelDropdownSkeleton = isLoadingProductUpdateLevels;
+  const isAddUpdateSectionLoading = isLoadingProductUpdateLevels;
+  const isEditInlineLoading = isLoadingProductUpdateLevels;
 
   const availableUpdateLevels = useMemo(() => {
-    if (!updateLevelsData) return [];
+    if (!productName || !productVersion || productUpdateLevels.length === 0) {
+      return [];
+    }
 
-    const levels = Object.keys(updateLevelsData)
-      .map((key) => parseInt(key, 10))
-      .filter((level) => !isNaN(level))
-      .sort((a, b) => b - a);
+    const productItem = productUpdateLevels.find(
+      (item) => item.productName === productName,
+    );
+    if (!productItem) return [];
 
-    return levels;
-  }, [updateLevelsData]);
+    const allLevels = productItem.productUpdateLevels
+      .filter((entry) => entry.productBaseVersion === productVersion)
+      .flatMap((entry) => entry.updateLevels);
+
+    return [...new Set(allLevels)].sort((a, b) => b - a);
+  }, [productName, productVersion, productUpdateLevels]);
 
   const sortedUpdates = useMemo(() => {
     return [...updates].sort((a, b) => {


### PR DESCRIPTION
This pull request refactors the logic in the `UpdateHistoryTab` component to simplify how product update levels are fetched and processed. The main improvement is consolidating multiple API calls and memoizations into a single, more efficient data retrieval and transformation flow.

**Refactor and data fetching simplification:**

* Replaced the use of `useGetRecommendedUpdateLevels` and `usePostUpdateLevelsSearch` with a single hook, `useGetProductUpdateLevels`, to fetch all relevant update levels data in one call. [[1]](diffhunk://#diff-9e4b2e12a9f4a2f669ef765a85aadf301217df2aa49e5e2e73dee46e08e46803L39-R39) [[2]](diffhunk://#diff-9e4b2e12a9f4a2f669ef765a85aadf301217df2aa49e5e2e73dee46e08e46803L85-R107)
* Simplified the calculation of `availableUpdateLevels` by directly extracting and deduplicating update levels for the selected product and version from the fetched data, removing unnecessary intermediate memoizations and search parameter constructions.
* Streamlined loading state management by basing all related loading flags (`showUpdateLevelDropdownSkeleton`, `isAddUpdateSectionLoading`, `isEditInlineLoading`) on the loading state of the new unified data fetch.