### PR TITLE
[Customer Portal][FE][Web] Remove Shift+Enter Submission Support from Rich Text Editor

### DIFF
--- a/apps/customer-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -134,12 +134,10 @@ const EnterSubmitPlugin = ({
   onSubmit,
   disabled,
   enterToSubmit = false,
-  shiftEnterToSubmit = false,
 }: {
   onSubmit?: () => void;
   disabled?: boolean;
   enterToSubmit?: boolean;
-  shiftEnterToSubmit?: boolean;
 }) => {
   const [editor] = useLexicalComposerContext();
 
@@ -174,13 +172,6 @@ const EnterSubmitPlugin = ({
           return true;
         }
 
-        if (shiftEnterToSubmit && event.shiftKey && !event.ctrlKey && !event.metaKey) {
-          if (event.isComposing) return false;
-          event.preventDefault();
-          onSubmit();
-          return true;
-        }
-
         if (!event.ctrlKey && !event.metaKey) return false;
         event.preventDefault?.();
         onSubmit();
@@ -190,7 +181,7 @@ const EnterSubmitPlugin = ({
     );
 
     return unregEnter;
-  }, [editor, onSubmit, disabled, enterToSubmit, shiftEnterToSubmit]);
+  }, [editor, onSubmit, disabled, enterToSubmit]);
 
   return null;
 };
@@ -310,7 +301,6 @@ const Editor = ({
   toolbarVariant = "full",
   onSubmitKeyDown,
   enterToSubmit = false,
-  shiftEnterToSubmit = false,
   placeholder = "Enter description...",
   id,
   showKeyboardHint = false,
@@ -332,7 +322,6 @@ const Editor = ({
   toolbarVariant?: ToolbarVariant;
   onSubmitKeyDown?: () => void;
   enterToSubmit?: boolean;
-  shiftEnterToSubmit?: boolean;
   placeholder?: string;
   id?: string;
   showKeyboardHint?: boolean;
@@ -523,7 +512,7 @@ const Editor = ({
           <InitialValuePlugin initialHtml={value} />
           <OnChangeHTMLPlugin onChange={onChange} />
           <ResetPlugin resetTrigger={resetTrigger} />
-          <EnterSubmitPlugin onSubmit={onSubmitKeyDown} disabled={disabled} enterToSubmit={enterToSubmit} shiftEnterToSubmit={shiftEnterToSubmit} />
+          <EnterSubmitPlugin onSubmit={onSubmitKeyDown} disabled={disabled} enterToSubmit={enterToSubmit} />
         </Box>
         {overlayElement && (
           <Box

--- a/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
@@ -587,8 +587,7 @@ const Toolbar = ({
               size="small"
               value="left"
               selected={
-                elementAlign === "left" ||
-                (elementAlign === "" && hasContent)
+                elementAlign === "left" || (elementAlign === "" && hasContent)
               }
               onClick={() => onFormatAlign("left")}
             >
@@ -838,7 +837,11 @@ const Toolbar = ({
             <Typography
               component="span"
               variant="caption"
-              sx={{ color: "text.secondary", whiteSpace: "nowrap", lineHeight: 1.4 }}
+              sx={{
+                color: "text.secondary",
+                whiteSpace: "nowrap",
+                lineHeight: 1.4,
+              }}
             >
               <Typography component="span" variant="caption" fontWeight={600}>
                 Shift+Enter
@@ -853,12 +856,12 @@ const Toolbar = ({
             <Typography
               component="span"
               variant="caption"
-              sx={{ color: "text.secondary", whiteSpace: "nowrap", lineHeight: 1.4 }}
+              sx={{
+                color: "text.secondary",
+                whiteSpace: "nowrap",
+                lineHeight: 1.4,
+              }}
             >
-              <Typography component="span" variant="caption" fontWeight={600}>
-                Shift+Enter
-              </Typography>
-              {" or "}
               <Typography component="span" variant="caption" fontWeight={600}>
                 Ctrl+Enter
               </Typography>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -235,7 +235,6 @@ export default function ActivityCommentInput({
             placeholder="Write a comment..."
             onSubmitKeyDown={handleSend}
             enterToSubmit={false}
-            shiftEnterToSubmit={true}
             onAttachmentClick={handleAttachmentClick}
             attachments={attachments.map((a) => a.file)}
             onAttachmentRemove={handleAttachmentRemove}


### PR DESCRIPTION
### Description

This pull request simplifies the keyboard submission logic in the rich text editor component by removing the `shiftEnterToSubmit` prop and its associated functionality. Now, only the `enterToSubmit` and Ctrl/Cmd+Enter key combinations are supported for submitting content, leading to a more streamlined and predictable user experience. Additionally, some minor code formatting improvements are included in the toolbar component.

**Rich Text Editor Submission Logic:**

* Removed the `shiftEnterToSubmit` prop and all related logic from the `Editor` and `EnterSubmitPlugin` components, so Shift+Enter no longer submits content and is no longer configurable. Submission is now handled only via Enter (if enabled) or Ctrl/Cmd+Enter. [[1]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L137-L142) [[2]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L177-L183) [[3]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L193-R184) [[4]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L313) [[5]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L335) [[6]](diffhunk://#diff-239321e2d673618cb8acbedb7bfe7ddf25bea286b603203b4a35a7a7b9b018c6L526-R515) [[7]](diffhunk://#diff-2c524159c32a2db5565c2a33ee9f17ef1c9f51fd037ec6e0111804f0bf1c086dL238)

**Toolbar UI and Code Formatting:**

* Improved code formatting in the `ToolBar` component for better readability, and updated the keyboard hint to remove the Shift+Enter shortcut, reflecting the updated submission logic. [[1]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L590-R590) [[2]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L841-R844) [[3]](diffhunk://#diff-bfc716b98ab446c23c894db716067215272106523a54cacb8c825953e43bf4f5L856-L861)