### PR TITLE
[Customer Portal][FE][Web] Add .npmrc to set onlyBuiltDependencies

### DIFF
--- a/apps/customer-portal/webapp/.npmrc
+++ b/apps/customer-portal/webapp/.npmrc
@@ -1,0 +1,1 @@
+onlyBuiltDependencies=esbuild,core-js


### PR DESCRIPTION
Create apps/customer-portal/webapp/.npmrc and set onlyBuiltDependencies=esbuild,core-js to restrict which dependencies are built during install for the customer-portal webapp.
