### PR TITLE
[Customer Portal][FE][Web] : Add pnpm onlyBuiltDependencies config

### DIFF
--- a/apps/customer-portal/webapp/package.json
+++ b/apps/customer-portal/webapp/package.json
@@ -63,5 +63,11 @@
     "typescript-eslint": "8.46.4",
     "vite": "7.2.4",
     "vitest": "4.0.18"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "core-js",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
Adds a pnpm.onlyBuiltDependencies section to apps/customer-portal/webapp/package.json listing core-js and esbuild. This ensures pnpm treats these packages as built dependencies during installation, avoiding unnecessary rebuilds or install-time compilation for them.
