### PR TITLE
[Customer Portal][FE][Web] Add permission-based visibility for service and change request stats/actions in Project Details

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/ProjectStatisticsCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/ProjectStatisticsCard.tsx
@@ -30,7 +30,6 @@ import type { JSX } from "react";
 import { statItems } from "@features/project-details/constants/projectDetailsConstants";
 import type { ProjectStatisticsCardProps } from "@features/project-details/types/projectDetailsComponents";
 
-const SKELETON_COUNT = 9;
 
 const StatCardSkeleton = ({ gridSize }: { gridSize: object }): JSX.Element => (
   <Grid size={gridSize} sx={{ display: "flex" }}>
@@ -91,7 +90,7 @@ const ProjectStatisticsCard = ({
 
         <Grid container spacing={2} sx={{ alignItems: "stretch" }}>
           {isStatLoading
-            ? Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+            ? Array.from({ length: visibleStats.length }).map((_, i) => (
                 <StatCardSkeleton key={i} gridSize={gridSize} />
               ))
             : visibleStats.map((stat) => {

--- a/apps/customer-portal/webapp/src/features/project-details/components/ProjectStatisticsCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/ProjectStatisticsCard.tsx
@@ -69,11 +69,16 @@ const ProjectStatisticsCard = ({
   isError,
   isSidebarOpen = false,
   showDeploymentsStat = true,
+  showServiceRequestStat = true,
+  showChangeRequestStat = true,
 }: ProjectStatisticsCardProps): JSX.Element => {
   const gridSize = isSidebarOpen ? { xs: 12, xl: 4 } : { xs: 12, sm: 6, lg: 4 };
-  const visibleStats = showDeploymentsStat
-    ? statItems
-    : statItems.filter((s) => s.key !== "deployments");
+  const visibleStats = statItems.filter((s) => {
+    if (s.key === "deployments" && !showDeploymentsStat) return false;
+    if (s.key === "outstandingServiceRequestCount" && !showServiceRequestStat) return false;
+    if (s.key === "outstandingChangeRequestCount" && !showChangeRequestStat) return false;
+    return true;
+  });
   const isStatLoading = isLoading || (!isError && !stats);
   return (
     <Card sx={{ height: "100%" }}>

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/ProjectDeployments.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/ProjectDeployments.tsx
@@ -51,6 +51,7 @@ import { isProjectRestricted } from "@utils/permission";
  */
 export default function ProjectDeployments({
   projectId,
+  showServiceRequest = true,
 }: ProjectDeploymentsProps): JSX.Element {
   const navigate = useNavigate();
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -198,7 +199,7 @@ export default function ProjectDeployments({
           </>
         ) : (
           <>
-            {!isRestricted && (
+            {!isRestricted && showServiceRequest && (
               <Button
                 variant="contained"
                 color="warning"

--- a/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
@@ -175,6 +175,8 @@ export default function ProjectDetails(): JSX.Element {
                   isLoading={(isDetailsLoading || !stats) && !statsError}
                   isError={!!statsError}
                   showDeploymentsStat={permissions.hasDeployments}
+                  showServiceRequestStat={permissions.hasSR}
+                  showChangeRequestStat={permissions.hasCR}
                 />
               </Grid>
               <Grid size={{ xs: 12, md: 5 }}>
@@ -199,7 +201,7 @@ export default function ProjectDetails(): JSX.Element {
       case ProjectDetailsTabId.DEPLOYMENTS:
         return (
           <Box>
-            <ProjectDeployments projectId={projectId ?? ""} />
+            <ProjectDeployments projectId={projectId ?? ""} showServiceRequest={permissions.hasSR} />
           </Box>
         );
       case ProjectDetailsTabId.TIME_TRACKING:

--- a/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
@@ -39,6 +39,8 @@ export type ProjectStatisticsCardProps = {
   isError?: boolean;
   isSidebarOpen?: boolean;
   showDeploymentsStat?: boolean;
+  showServiceRequestStat?: boolean;
+  showChangeRequestStat?: boolean;
 };
 
 export type ProjectNameProps = {
@@ -119,6 +121,7 @@ export type ServiceHoursStatCardsProps = {
 
 export type ProjectDeploymentsProps = {
   projectId: string;
+  showServiceRequest?: boolean;
 };
 
 export type DeploymentCardProps = {


### PR DESCRIPTION
### Description

This pull request updates the project details view to allow finer control over the visibility of service request and change request statistics and actions, based on user permissions. The changes ensure that only users with the appropriate permissions see the relevant statistics and buttons.

**Permission-based visibility for statistics and actions:**

* The `ProjectStatisticsCard` component now accepts `showServiceRequestStat` and `showChangeRequestStat` props to control the display of service request and change request statistics. The visible stats are filtered accordingly. [[1]](diffhunk://#diff-db4153d5ea2ebc38ad4ae09b1edb12c530cd78c98d23c5ac8ef4ff38f7e5f664R72-R81) [[2]](diffhunk://#diff-852b5bfbade0db0b81144fbfb8f0124887183f3ef41901ed988f6d4a8e355644R42-R43)
* The `ProjectDetails` page passes the appropriate permission flags (`permissions.hasSR` and `permissions.hasCR`) to `ProjectStatisticsCard` and `ProjectDeployments`, ensuring users only see stats and actions they are allowed to access. [[1]](diffhunk://#diff-20c141e61c462c543f2fd8b53b468e5087d0d15320415d237d35958c882048d3R178-R179) [[2]](diffhunk://#diff-20c141e61c462c543f2fd8b53b468e5087d0d15320415d237d35958c882048d3L202-R204)
* The `ProjectDeployments` component now accepts a `showServiceRequest` prop, and only renders the service request button if this prop is true and the project is not restricted. [[1]](diffhunk://#diff-af5e296c93c0f0e41d28be8901fa834a14c98d5322493c0477b3e91a6c4a2befR54) [[2]](diffhunk://#diff-af5e296c93c0f0e41d28be8901fa834a14c98d5322493c0477b3e91a6c4a2befL201-R202) [[3]](diffhunk://#diff-852b5bfbade0db0b81144fbfb8f0124887183f3ef41901ed988f6d4a8e355644R124)