### PR TITLE
[Customer Portal][FE][Web] Add permission-based visibility for security report stats and security page content

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/ProjectStatisticsCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/ProjectStatisticsCard.tsx
@@ -70,12 +70,14 @@ const ProjectStatisticsCard = ({
   showDeploymentsStat = true,
   showServiceRequestStat = true,
   showChangeRequestStat = true,
+  showSecurityReportStat = true,
 }: ProjectStatisticsCardProps): JSX.Element => {
   const gridSize = isSidebarOpen ? { xs: 12, xl: 4 } : { xs: 12, sm: 6, lg: 4 };
   const visibleStats = statItems.filter((s) => {
     if (s.key === "deployments" && !showDeploymentsStat) return false;
     if (s.key === "outstandingServiceRequestCount" && !showServiceRequestStat) return false;
     if (s.key === "outstandingChangeRequestCount" && !showChangeRequestStat) return false;
+    if (s.key === "outstandingSraCount" && !showSecurityReportStat) return false;
     return true;
   });
   const isStatLoading = isLoading || (!isError && !stats);

--- a/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
@@ -177,6 +177,7 @@ export default function ProjectDetails(): JSX.Element {
                   showDeploymentsStat={permissions.hasDeployments}
                   showServiceRequestStat={permissions.hasSR}
                   showChangeRequestStat={permissions.hasCR}
+                  showSecurityReportStat={permissions.hasSecurityReportAnalysis}
                 />
               </Grid>
               <Grid size={{ xs: 12, md: 5 }}>

--- a/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
@@ -41,6 +41,7 @@ export type ProjectStatisticsCardProps = {
   showDeploymentsStat?: boolean;
   showServiceRequestStat?: boolean;
   showChangeRequestStat?: boolean;
+  showSecurityReportStat?: boolean;
 };
 
 export type ProjectNameProps = {

--- a/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
+++ b/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
@@ -123,18 +123,24 @@ const SecurityPage = (): JSX.Element => {
     [filterMetadata, handleTabChange],
   );
 
-  const tabs = useMemo(
+  const securityPermissions = useMemo(
     () =>
       areFeaturePermissionsReady
+        ? getProjectPermissions(projectDetails?.type?.label, { projectFeatures })
+        : null,
+    [areFeaturePermissionsReady, projectDetails?.type?.label, projectFeatures],
+  );
+
+  const tabs = useMemo(
+    () =>
+      securityPermissions
         ? SECURITY_PAGE_TABS.filter((tab) =>
             tab.id === SecurityTabId.VULNERABILITIES
-              ? getProjectPermissions(projectDetails?.type?.label, {
-                  projectFeatures,
-                }).hasSecurityReportAnalysis
+              ? securityPermissions.hasSecurityReportAnalysis
               : true,
           )
         : SECURITY_PAGE_TABS,
-    [areFeaturePermissionsReady, projectDetails?.type?.label, projectFeatures],
+    [securityPermissions],
   );
   const activeTab = useMemo(() => {
     const hasRawActive = tabs.some((tab) => tab.id === rawActiveTab);
@@ -183,7 +189,9 @@ const SecurityPage = (): JSX.Element => {
           </Typography>
         </Box>
       ) : (
-        <SecurityStats onStatClick={handleStatCardClick} />
+        securityPermissions?.hasSecurityReportAnalysis && (
+          <SecurityStats onStatClick={handleStatCardClick} />
+        )
       )}
       {!isStatFiltered && (
         <TabBar

--- a/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
+++ b/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
@@ -133,13 +133,11 @@ const SecurityPage = (): JSX.Element => {
 
   const tabs = useMemo(
     () =>
-      securityPermissions
-        ? SECURITY_PAGE_TABS.filter((tab) =>
-            tab.id === SecurityTabId.VULNERABILITIES
-              ? securityPermissions.hasSecurityReportAnalysis
-              : true,
-          )
-        : SECURITY_PAGE_TABS,
+      SECURITY_PAGE_TABS.filter((tab) =>
+        tab.id === SecurityTabId.VULNERABILITIES
+          ? securityPermissions?.hasSecurityReportAnalysis ?? false
+          : true,
+      ),
     [securityPermissions],
   );
   const activeTab = useMemo(() => {


### PR DESCRIPTION
### Description

This pull request enhances the handling of security report statistics and permissions within the project details and security pages. The main changes ensure that the display of security-related statistics and tabs is properly gated by user permissions, improving both security and user experience.

**Security report statistics and permissions:**

* Added a new prop `showSecurityReportStat` to `ProjectStatisticsCardProps` and updated its usage in `ProjectStatisticsCard` and `ProjectDetails` to control the visibility of security report statistics based on the `hasSecurityReportAnalysis` permission. [[1]](diffhunk://#diff-852b5bfbade0db0b81144fbfb8f0124887183f3ef41901ed988f6d4a8e355644R44) [[2]](diffhunk://#diff-db4153d5ea2ebc38ad4ae09b1edb12c530cd78c98d23c5ac8ef4ff38f7e5f664R73-R80) [[3]](diffhunk://#diff-20c141e61c462c543f2fd8b53b468e5087d0d15320415d237d35958c882048d3R180)
* Updated the filtering logic in `ProjectStatisticsCard` to hide the security report stat item when `showSecurityReportStat` is false.

**Security page tab and stats visibility:**

* Refactored `SecurityPage` to compute `securityPermissions` once and use it to filter tabs and conditionally render the `SecurityStats` component only when the user has the `hasSecurityReportAnalysis` permission. This prevents unauthorized users from seeing security-related content. [[1]](diffhunk://#diff-92d49832ae5af5ef729c1c1310dbc371ee65b98adc3c7eb19772fa47e67307dfL126-R143) [[2]](diffhunk://#diff-92d49832ae5af5ef729c1c1310dbc371ee65b98adc3c7eb19772fa47e67307dfR192-R194)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security report statistics are now conditionally shown across the app based on user permissions—overview stats card and security page respect a user's security analysis access.
  * Security-related tabs and metrics are filtered so only authorized users see vulnerability analysis and related stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->