### PR TITLE
[Customer Portal][FE][Web] Fix white background issues in dark mode comment rendering

### DIFF
--- a/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
@@ -32,6 +32,7 @@ import {
   ANNOUNCEMENTS_CLEAR_FILTERS_LABEL,
 } from "@features/announcements/constants/announcementsConstants";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { stripLightModeInlineStyles } from "@/utils/common";
 
 /**
  * Builds the case search payload for the announcements list (announcement case type only).
@@ -168,30 +169,6 @@ export function formatAnnouncementsClearFiltersButtonLabel(
 }
 
 /**
- * Strips pure-white inline background declarations from style attributes so
- * dark-mode containers no longer render white boxes on a dark background.
- * Everything else (code-block backgrounds, borders, shadows, text colors) is
- * intentionally left untouched so light-mode and structural styling stay intact.
- *
- * @param html - Raw HTML string.
- * @returns HTML with pure-white background declarations removed.
- */
-function stripLightModeInlineStyles(html: string): string {
-  return html.replace(/style\s*=\s*"([^"]*)"/gi, (_match, styleContent: string) => {
-    const declarations = styleContent.split(";");
-    const filtered = declarations.filter((decl) => {
-      const normalized = decl.toLowerCase().replace(/\s+/g, " ").trim();
-      if (!normalized) return false;
-      if (/^background(-color)?\s*:\s*(#fff(fff)?|white|#f4f4f4|#f5f5f5|#f0f0f0|#f9f9f9|#f8f8f8|#fafafa|#e9e9e9)\s*$/.test(normalized)) return false;
-      return true;
-    });
-    const cleaned = filtered.join(";").replace(/;+$/, "").trim();
-    if (!cleaned) return "";
-    return `style="${cleaned}"`;
-  });
-}
-
-/**
  * Normalizes announcement HTML:
  * - Strips pure-white inline backgrounds in dark mode so containers don't clash.
  * - Converts empty `<code>` blocks to a newline (`<br />`) so we do not render useless whitespace.
@@ -201,7 +178,10 @@ function stripLightModeInlineStyles(html: string): string {
  * @param isDarkMode - When true, strips pure-white inline backgrounds.
  * @returns Normalized HTML.
  */
-export function normalizeAnnouncementDescriptionHtml(html: string, isDarkMode = false): string {
+export function normalizeAnnouncementDescriptionHtml(
+  html: string,
+  isDarkMode = false,
+): string {
   let normalized = isDarkMode ? stripLightModeInlineStyles(html) : html;
 
   normalized = normalized.replace(

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
@@ -54,12 +54,12 @@ import {
   isNoveraOrBotSender,
 } from "@features/support/utils/support";
 import DOMPurify from "dompurify";
-import { stripLightModeInlineStyles } from "@features/announcements/utils/announcements";
 import { useDarkMode } from "@utils/useDarkMode";
 import ChatMessageCard from "@case-details-activity/ChatMessageCard";
 import { useResolvedInlineImageHtml } from "@features/support/hooks/useResolvedInlineImageHtml";
 import { useGetAttachment } from "@api/useGetAttachment";
 import { useAttachmentPreview } from "@api/useAttachmentPreview";
+import { stripLightModeInlineStyles } from "@/utils/common";
 
 function commentAuthorDisplayName(comment: CaseComment): string {
   if (comment.createdByFullName?.trim()) {
@@ -84,7 +84,8 @@ export default function CommentBubble({
 }: CommentBubbleProps): import("react").JSX.Element {
   const theme = useTheme();
   const isDarkMode = useDarkMode();
-  const { downloadAttachment, isDownloading, downloadingId } = useGetAttachment();
+  const { downloadAttachment, isDownloading, downloadingId } =
+    useGetAttachment();
   const rawContent = comment.content ?? "";
   const isFullCodeWrap = hasSingleCodeWrapper(rawContent);
   const codeBlockCount = rawContent.match(/\[code\]/gi)?.length ?? 0;
@@ -100,8 +101,13 @@ export default function CommentBubble({
     comment.inlineAttachments,
   );
   const renderAsMarkdown = isNoveraOrBotSender(comment.createdBy, comment.type);
-  const darkModeHtml = isDarkMode ? stripLightModeInlineStyles(withImages) : withImages;
-  const sanitizedHtml = DOMPurify.sanitize(darkModeHtml, INLINE_COMMENT_HTML_PURIFY);
+  const darkModeHtml = isDarkMode
+    ? stripLightModeInlineStyles(withImages)
+    : withImages;
+  const sanitizedHtml = DOMPurify.sanitize(
+    darkModeHtml,
+    INLINE_COMMENT_HTML_PURIFY,
+  );
   const { resolvedHtml: htmlContent, isLoading: isImagesLoading } =
     useResolvedInlineImageHtml(sanitizedHtml, comment.inlineAttachments);
   const displayName = useMemo(() => {
@@ -143,7 +149,9 @@ export default function CommentBubble({
     comment.contentType ?? "",
   );
   const { data: imageDataUrl, isLoading: isImagePreviewLoading } =
-    useAttachmentPreview(isAttachmentEntry && attachmentCategory === "image" ? comment.id : null);
+    useAttachmentPreview(
+      isAttachmentEntry && attachmentCategory === "image" ? comment.id : null,
+    );
 
   const renderAttachmentIcon = () => {
     switch (attachmentCategory) {
@@ -299,40 +307,86 @@ export default function CommentBubble({
                 </span>
               </Tooltip>
             </Box>
-            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-              <Typography variant="caption" color="text.secondary" component="span">
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              flexWrap="wrap"
+            >
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                component="span"
+              >
                 {formatFileSize(comment.sizeBytes)}
               </Typography>
-              <Typography variant="caption" color="text.secondary" component="span">
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                component="span"
+              >
                 •
               </Typography>
-              <Typography variant="caption" color="text.secondary" component="span">
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                component="span"
+              >
                 Uploaded by {comment.createdBy}
               </Typography>
-              <Typography variant="caption" color="text.secondary" component="span">
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                component="span"
+              >
                 •
               </Typography>
-              <Typography variant="caption" color="text.secondary" component="span">
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                component="span"
+              >
                 {formatCommentDate(comment.createdOn)}
               </Typography>
             </Stack>
-            {attachmentCategory === "image" && (
-              isImagePreviewLoading ? (
-                <Skeleton variant="rectangular" width="100%" height={160} sx={{ borderRadius: 1 }} />
+            {attachmentCategory === "image" &&
+              (isImagePreviewLoading ? (
+                <Skeleton
+                  variant="rectangular"
+                  width="100%"
+                  height={160}
+                  sx={{ borderRadius: 1 }}
+                />
               ) : imageDataUrl ? (
                 <Box
                   component="img"
                   src={imageDataUrl}
                   alt={comment.fileName ?? "Image attachment"}
-                  sx={{ maxWidth: "100%", borderRadius: 1, display: "block", cursor: "pointer" }}
+                  sx={{
+                    maxWidth: "100%",
+                    borderRadius: 1,
+                    display: "block",
+                    cursor: "pointer",
+                  }}
                   onClick={() => onImageClick?.(imageDataUrl)}
                 />
-              ) : null
-            )}
+              ) : null)}
           </Paper>
         ) : isImagesLoading ? (
-          <Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 0.75 }}>
-            <Skeleton variant="rectangular" width="100%" height={160} sx={{ borderRadius: 1 }} />
+          <Box
+            sx={{
+              width: "100%",
+              display: "flex",
+              flexDirection: "column",
+              gap: 0.75,
+            }}
+          >
+            <Skeleton
+              variant="rectangular"
+              width="100%"
+              height={160}
+              sx={{ borderRadius: 1 }}
+            />
           </Box>
         ) : (
           <ChatMessageCard

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
@@ -54,6 +54,8 @@ import {
   isNoveraOrBotSender,
 } from "@features/support/utils/support";
 import DOMPurify from "dompurify";
+import { stripLightModeInlineStyles } from "@features/announcements/utils/announcements";
+import { useDarkMode } from "@utils/useDarkMode";
 import ChatMessageCard from "@case-details-activity/ChatMessageCard";
 import { useResolvedInlineImageHtml } from "@features/support/hooks/useResolvedInlineImageHtml";
 import { useGetAttachment } from "@api/useGetAttachment";
@@ -81,6 +83,7 @@ export default function CommentBubble({
   userDetails,
 }: CommentBubbleProps): import("react").JSX.Element {
   const theme = useTheme();
+  const isDarkMode = useDarkMode();
   const { downloadAttachment, isDownloading, downloadingId } = useGetAttachment();
   const rawContent = comment.content ?? "";
   const isFullCodeWrap = hasSingleCodeWrapper(rawContent);
@@ -97,7 +100,8 @@ export default function CommentBubble({
     comment.inlineAttachments,
   );
   const renderAsMarkdown = isNoveraOrBotSender(comment.createdBy, comment.type);
-  const sanitizedHtml = DOMPurify.sanitize(withImages, INLINE_COMMENT_HTML_PURIFY);
+  const darkModeHtml = isDarkMode ? stripLightModeInlineStyles(withImages) : withImages;
+  const sanitizedHtml = DOMPurify.sanitize(darkModeHtml, INLINE_COMMENT_HTML_PURIFY);
   const { resolvedHtml: htmlContent, isLoading: isImagesLoading } =
     useResolvedInlineImageHtml(sanitizedHtml, comment.inlineAttachments);
   const displayName = useMemo(() => {

--- a/apps/customer-portal/webapp/src/utils/common.ts
+++ b/apps/customer-portal/webapp/src/utils/common.ts
@@ -37,3 +37,35 @@ export function paginatedSelectMenuListProps(
     },
   };
 }
+
+/**
+ * Strips pure-white inline background declarations from style attributes so
+ * dark-mode containers no longer render white boxes on a dark background.
+ * Everything else (code-block backgrounds, borders, shadows, text colors) is
+ * intentionally left untouched so light-mode and structural styling stay intact.
+ *
+ * @param html - Raw HTML string.
+ * @returns HTML with pure-white background declarations removed.
+ */
+export function stripLightModeInlineStyles(html: string): string {
+  return html.replace(
+    /style\s*=\s*"([^"]*)"/gi,
+    (_match, styleContent: string) => {
+      const declarations = styleContent.split(";");
+      const filtered = declarations.filter((decl) => {
+        const normalized = decl.toLowerCase().replace(/\s+/g, " ").trim();
+        if (!normalized) return false;
+        if (
+          /^background(-color)?\s*:\s*(#fff(fff)?|white|#f4f4f4|#f5f5f5|#f0f0f0|#f9f9f9|#f8f8f8|#fafafa|#e9e9e9)\s*$/.test(
+            normalized,
+          )
+        )
+          return false;
+        return true;
+      });
+      const cleaned = filtered.join(";").replace(/;+$/, "").trim();
+      if (!cleaned) return "";
+      return `style="${cleaned}"`;
+    },
+  );
+}


### PR DESCRIPTION
### Description

This pull request refactors how the utility function for removing light-mode inline background styles from HTML is organized and used. The `stripLightModeInlineStyles` function is moved from the announcements feature to a shared utilities file, and its usage is expanded to also sanitize support case comment bubbles in dark mode. Additionally, some formatting improvements are made for better code readability.

**Refactoring and code organization:**

* Moved the `stripLightModeInlineStyles` function from `@features/announcements/utils/announcements.ts` to the shared utility file `@/utils/common`, making it available for use across the application. [[1]](diffhunk://#diff-50932782d65dd33593d04c6f500b62d52300a2dd89159d9a007e5be44899d037R35) [[2]](diffhunk://#diff-50932782d65dd33593d04c6f500b62d52300a2dd89159d9a007e5be44899d037L170-L193) [[3]](diffhunk://#diff-bb4a0715388d13c36f0f24335e4c7771837098e22232d4b8cc99c9acfe34a40eR40-R71)

**Dark mode support improvements:**

* Updated the support case comment bubble component (`CommentBubble.tsx`) to use `stripLightModeInlineStyles` when rendering HTML in dark mode, ensuring white backgrounds are removed from comment content for better dark mode compatibility. [[1]](diffhunk://#diff-792e3bfc8d32232c36aa834a2f7f90ce44ccf2d06273eddf2da0d934112f539fR57-R62) [[2]](diffhunk://#diff-792e3bfc8d32232c36aa834a2f7f90ce44ccf2d06273eddf2da0d934112f539fL84-R88) [[3]](diffhunk://#diff-792e3bfc8d32232c36aa834a2f7f90ce44ccf2d06273eddf2da0d934112f539fL100-R110)

**Formatting and readability:**

* Improved code formatting in the `CommentBubble.tsx` component, especially for JSX blocks and function arguments, to enhance readability and maintainability. [[1]](diffhunk://#diff-792e3bfc8d32232c36aa834a2f7f90ce44ccf2d06273eddf2da0d934112f539fL142-R154) [[2]](diffhunk://#diff-792e3bfc8d32232c36aa834a2f7f90ce44ccf2d06273eddf2da0d934112f539fL298-R389)

**Other usage updates:**

* Updated the `normalizeAnnouncementDescriptionHtml` function to use the relocated `stripLightModeInlineStyles` from the shared utilities file.