### PR TITLE
feat(customer-portal): Add endpoint to add users to external group via SCIM

### DIFF
--- a/apps/customer-portal/backend/modules/scim/scim.bal
+++ b/apps/customer-portal/backend/modules/scim/scim.bal
@@ -47,13 +47,13 @@ public isolated function updateUser(UserUpdatePayload payload, string email, str
     string organization = isWso2Email(email) ? ORGANIZATION_INTERNAL : ORGANIZATION_EXTERNAL;
     return scimOperationsClient->/organizations/[organization]/users/[uuid].patch(payload);
 }
-
+x
 # Adds users to an external group via the SCIM operations service.
 #
 # + group - The display name of the external group
 # + payload - The request payload containing user emails
 # + return - The response with added/failed users, or an error if the operation fails
-public isolated function addUsersToExternalGroup(string group, AddUsersToGroupRequest payload)
+public isolated function addUsersToExternalGroup(string group, AddUsersToGroupPayload payload)
         returns AddUsersToGroupResponse|error {
     return scimOperationsClient->/organizations/[ORGANIZATION_EXTERNAL]/groups/[group]/users.post(payload);
 }

--- a/apps/customer-portal/backend/modules/scim/scim.bal
+++ b/apps/customer-portal/backend/modules/scim/scim.bal
@@ -47,3 +47,13 @@ public isolated function updateUser(UserUpdatePayload payload, string email, str
     string organization = isWso2Email(email) ? ORGANIZATION_INTERNAL : ORGANIZATION_EXTERNAL;
     return scimOperationsClient->/organizations/[organization]/users/[uuid].patch(payload);
 }
+
+# Adds users to an external group via the SCIM operations service.
+#
+# + group - The display name of the external group
+# + payload - The request payload containing user emails
+# + return - The response with added/failed users, or an error if the operation fails
+public isolated function addUsersToExternalGroup(string group, AddUsersToGroupRequest payload)
+        returns AddUsersToGroupResponse|error {
+    return scimOperationsClient->/organizations/[ORGANIZATION_EXTERNAL]/groups/[group]/users.post(payload);
+}

--- a/apps/customer-portal/backend/modules/scim/scim.bal
+++ b/apps/customer-portal/backend/modules/scim/scim.bal
@@ -47,7 +47,7 @@ public isolated function updateUser(UserUpdatePayload payload, string email, str
     string organization = isWso2Email(email) ? ORGANIZATION_INTERNAL : ORGANIZATION_EXTERNAL;
     return scimOperationsClient->/organizations/[organization]/users/[uuid].patch(payload);
 }
-x
+
 # Adds users to an external group via the SCIM operations service.
 #
 # + group - The display name of the external group
@@ -55,5 +55,6 @@ x
 # + return - The response with added/failed users, or an error if the operation fails
 public isolated function addUsersToExternalGroup(string group, AddUsersToGroupPayload payload)
         returns AddUsersToGroupResponse|error {
+
     return scimOperationsClient->/organizations/[ORGANIZATION_EXTERNAL]/groups/[group]/users.post(payload);
 }

--- a/apps/customer-portal/backend/modules/scim/types.bal
+++ b/apps/customer-portal/backend/modules/scim/types.bal
@@ -80,8 +80,16 @@ public type Phone record {|
     string mobile?;
 |};
 
-# Request payload for adding users to an external group.
+# Request payload for adding users to a group.
 public type AddUsersToGroupRequest record {|
+    # Display name of the group
+    string group;
+    # Array of user email addresses to add to the group
+    string[] emails;
+|};
+
+# Payload for the SCIM add-users-to-group operation.
+public type AddUsersToGroupPayload record {|
     # Array of user email addresses to add to the group
     string[] emails;
 |};

--- a/apps/customer-portal/backend/modules/scim/types.bal
+++ b/apps/customer-portal/backend/modules/scim/types.bal
@@ -79,3 +79,17 @@ public type Phone record {|
     # Mobile number
     string mobile?;
 |};
+
+# Request payload for adding users to an external group.
+public type AddUsersToGroupRequest record {|
+    # Array of user email addresses to add to the group
+    string[] emails;
+|};
+
+# Response payload for add-users-to-group operation.
+public type AddUsersToGroupResponse record {|
+    # Users successfully added to the group
+    string[] addedUsers = [];
+    # Users that failed to be added
+    string[] failedUsers = [];
+|};

--- a/apps/customer-portal/backend/modules/scim/types.bal
+++ b/apps/customer-portal/backend/modules/scim/types.bal
@@ -80,14 +80,6 @@ public type Phone record {|
     string mobile?;
 |};
 
-# Request payload for adding users to a group.
-public type AddUsersToGroupRequest record {|
-    # Display name of the group
-    string group;
-    # Array of user email addresses to add to the group
-    string[] emails;
-|};
-
 # Payload for the SCIM add-users-to-group operation.
 public type AddUsersToGroupPayload record {|
     # Array of user email addresses to add to the group

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1712,3 +1712,11 @@ public type CaseActivitySearchResponse record {|
     int totalRecords;
     *entity:Pagination;
 |};
+
+# Request payload for adding users to a group.
+public type AddUsersToGroupRequest record {|
+    # Display name of the group
+    string group;
+    # Array of user email addresses to add to the group
+    string[] emails;
+|};

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -67,6 +67,38 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
+  /users/groups:
+    post:
+      summary: Add users to a group.
+      operationId: postUsersGroups
+      requestBody:
+        description: Add users to group request payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddUsersToGroupRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddUsersToGroupResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
   /projects/search:
     post:
       summary: Search projects of the logged-in user.
@@ -5968,3 +6000,37 @@ components:
           description: Variable value
       additionalProperties: false
       description: Variable data for service request.
+    AddUsersToGroupRequest:
+      required:
+      - group
+      - emails
+      type: object
+      properties:
+        group:
+          type: string
+          description: Display name of the group
+        emails:
+          type: array
+          description: Array of user email addresses to add to the group
+          items:
+            type: string
+          minItems: 1
+      additionalProperties: false
+      description: Request payload for adding users to a group.
+    AddUsersToGroupResponse:
+      type: object
+      properties:
+        addedUsers:
+          type: array
+          description: Users successfully added to the group
+          items:
+            type: string
+          default: []
+        failedUsers:
+          type: array
+          description: Users that failed to be added
+          items:
+            type: string
+          default: []
+      additionalProperties: false
+      description: Response payload for add-users-to-group operation.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -6009,11 +6009,14 @@ components:
         group:
           type: string
           description: Display name of the group
+          minLength: 1
+          pattern: "\\S+"
         emails:
           type: array
           description: Array of user email addresses to add to the group
           items:
             type: string
+            format: email
           minItems: 1
       additionalProperties: false
       description: Request payload for adding users to a group.

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5641,20 +5641,21 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         if response is error {
             int statusCode = getStatusCode(response);
             if statusCode == http:STATUS_NOT_FOUND {
-                string notFoundMsg = string `Group '${payload.group}' is not found.`;
-                log:printWarn(notFoundMsg);
+                string customError = string `Group '${payload.group}' is not found.`;
+                log:printWarn(customError);
                 return <http:NotFound>{
                     body: {
-                        message: notFoundMsg
+                        message: customError
                     }
                 };
             }
             if statusCode == http:STATUS_BAD_REQUEST {
-                log:printWarn(string `Invalid request while adding users to the provided group. ${
-                        extractErrorMessage(response)}`);
+                string customError = string `Invalid request while adding users to the provided group. ${
+                        extractErrorMessage(response)}`;
+                log:printWarn(customError);
                 return <http:BadRequest>{
                     body: {
-                        message: extractErrorMessage(response)
+                        message: customError
                     }
                 };
             }

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5595,14 +5595,12 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return <http:Ok>{body: mapCaseActivitySummaryResponse(response)};
     }
 
-    # Add users to an external group via the SCIM operations service.
+    # Add users to a group via the SCIM operations service.
     #
-    # + group - Display name of the external group
-    # + payload - Request payload containing user emails
+    # + payload - Request payload containing group name and user emails
     # + return - Response with added/failed users or error response
-    resource function post groups/[string group]/users(http:RequestContext ctx, scim:AddUsersToGroupRequest payload)
-        returns scim:AddUsersToGroupResponse|http:BadRequest|http:NotFound|http:Unauthorized|http:Forbidden|
-        http:InternalServerError {
+    resource function post users/groups(http:RequestContext ctx, scim:AddUsersToGroupRequest payload)
+        returns scim:AddUsersToGroupResponse|http:BadRequest|http:NotFound|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -5630,26 +5628,13 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
-        scim:AddUsersToGroupResponse|error response = scim:addUsersToExternalGroup(group, payload);
+        string group = payload.group;
+        scim:AddUsersToGroupPayload scimPayload = {emails: payload.emails};
+        scim:AddUsersToGroupResponse|error response = scim:addUsersToExternalGroup(group, scimPayload);
         if response is error {
             int statusCode = getStatusCode(response);
-            if statusCode == http:STATUS_UNAUTHORIZED {
-                log:printWarn(string `User: ${userInfo.userId} is not authorized to add users to group: ${group}`);
-                return <http:Unauthorized>{
-                    body: {
-                        message: ERR_MSG_UNAUTHORIZED_ACCESS
-                    }
-                };
-            }
-            if statusCode == http:STATUS_FORBIDDEN {
-                log:printWarn(string `User: ${userInfo.userId} is forbidden from adding users to group: ${group}`);
-                return <http:Forbidden>{
-                    body: {
-                        message: "You do not have permission to add users to this group."
-                    }
-                };
-            }
             if statusCode == http:STATUS_NOT_FOUND {
+                log:printWarn(string `Group '${group}' was not found.`);
                 return <http:NotFound>{
                     body: {
                         message: string `Group '${group}' was not found.`

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5611,6 +5611,14 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
+        if payload.group.trim().length() == 0 {
+            return <http:BadRequest>{
+                body: {
+                    message: "Group name must be provided."
+                }
+            };
+        }
+
         if payload.emails.length() == 0 {
             return <http:BadRequest>{
                 body: {

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5599,7 +5599,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     #
     # + payload - Request payload containing group name and user emails
     # + return - Response with added/failed users or error response
-    resource function post users/groups(http:RequestContext ctx, scim:AddUsersToGroupRequest payload)
+    resource function post users/groups(http:RequestContext ctx, types:AddUsersToGroupRequest payload)
         returns scim:AddUsersToGroupResponse|http:BadRequest|http:NotFound|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
@@ -5636,21 +5636,21 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
-        string group = payload.group;
-        scim:AddUsersToGroupPayload scimPayload = {emails: payload.emails};
-        scim:AddUsersToGroupResponse|error response = scim:addUsersToExternalGroup(group, scimPayload);
+        scim:AddUsersToGroupResponse|error response = scim:addUsersToExternalGroup(payload.group,
+                {emails: payload.emails});
         if response is error {
             int statusCode = getStatusCode(response);
             if statusCode == http:STATUS_NOT_FOUND {
-                log:printWarn(string `Group '${group}' was not found.`);
+                string notFoundMsg = string `Group '${payload.group}' is not found.`;
+                log:printWarn(notFoundMsg);
                 return <http:NotFound>{
                     body: {
-                        message: string `Group '${group}' was not found.`
+                        message: notFoundMsg
                     }
                 };
             }
             if statusCode == http:STATUS_BAD_REQUEST {
-                log:printWarn(string `Bad request while adding users to group: ${group}. ${
+                log:printWarn(string `Invalid request while adding users to the provided group. ${
                         extractErrorMessage(response)}`);
                 return <http:BadRequest>{
                     body: {
@@ -5659,7 +5659,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                 };
             }
 
-            string customError = string `Failed to add users to group: ${group}.`;
+            string customError = "Failed to add users to group.";
             log:printError(customError, response);
             return <http:InternalServerError>{
                 body: {

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5594,6 +5594,79 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         }
         return <http:Ok>{body: mapCaseActivitySummaryResponse(response)};
     }
+
+    # Add users to an external group via the SCIM operations service.
+    #
+    # + group - Display name of the external group
+    # + payload - Request payload containing user emails
+    # + return - Response with added/failed users or error response
+    resource function post groups/[string group]/users(http:RequestContext ctx, scim:AddUsersToGroupRequest payload)
+        returns scim:AddUsersToGroupResponse|http:BadRequest|http:NotFound|http:Unauthorized|http:Forbidden|
+        http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        if payload.emails.length() == 0 {
+            return <http:BadRequest>{
+                body: {
+                    message: "At least one user email must be provided."
+                }
+            };
+        }
+
+        scim:AddUsersToGroupResponse|error response = scim:addUsersToExternalGroup(group, payload);
+        if response is error {
+            int statusCode = getStatusCode(response);
+            if statusCode == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to add users to group: ${group}`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if statusCode == http:STATUS_FORBIDDEN {
+                log:printWarn(string `User: ${userInfo.userId} is forbidden from adding users to group: ${group}`);
+                return <http:Forbidden>{
+                    body: {
+                        message: "You do not have permission to add users to this group."
+                    }
+                };
+            }
+            if statusCode == http:STATUS_NOT_FOUND {
+                return <http:NotFound>{
+                    body: {
+                        message: string `Group '${group}' was not found.`
+                    }
+                };
+            }
+            if statusCode == http:STATUS_BAD_REQUEST {
+                log:printWarn(string `Bad request while adding users to group: ${group}. ${
+                        extractErrorMessage(response)}`);
+                return <http:BadRequest>{
+                    body: {
+                        message: extractErrorMessage(response)
+                    }
+                };
+            }
+
+            string customError = string `Failed to add users to group: ${group}.`;
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+        return response;
+    }
 }
 
 # WebSocket service to proxy messages between the browser and the upstream Python AI chat agent for real-time communication in chat sessions.

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5621,6 +5621,15 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
+        boolean hasInvalidEmail = payload.emails.some(email => email.trim().length() == 0);
+        if hasInvalidEmail {
+            return <http:BadRequest>{
+                body: {
+                    message: "Email list contains empty or whitespace-only values."
+                }
+            };
+        }
+
         scim:AddUsersToGroupResponse|error response = scim:addUsersToExternalGroup(group, payload);
         if response is error {
             int statusCode = getStatusCode(response);


### PR DESCRIPTION
## Purpose
> Introduces a new endpoint in the customer portal backend that allows adding users to an external group via the SCIM operations service. Resolves #678

## Goals
> Enable the customer portal to call the SCIM operations service's "Add users to external group" endpoint, providing a clean API surface for group user management from the frontend.

## Approach
> - Added `AddUsersToGroupRequest` and `AddUsersToGroupResponse` types in `modules/scim/types.bal`
> - Added `addUsersToExternalGroup` function in `modules/scim/scim.bal` that delegates to the SCIM operations service endpoint `POST /organizations/external/groups/{group}/users`
> - Added `POST /groups/{group}/users` resource endpoint in `service.bal` following existing authorization, error handling, and logging conventions

## User stories
> As a portal administrator, I want to add users to an external group so that they can be granted the appropriate access permissions in the external organization.

## Release note
> Added a new POST /groups/{group}/users endpoint to the customer portal backend for adding users to external groups via the SCIM operations service.

## Documentation
> N/A — Internal API endpoint, documentation will be updated as part of the broader user management feature rollout.

## Training
> N/A

## Certification
> N/A — Internal tooling change with no certification exam impact.

## Marketing
> N/A

## Automation tests
- Unit tests
  > To be added in a follow-up PR once integration testing environment is configured.
- Integration tests
  > Manual testing against the SCIM operations service on Choreo dev environment.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Ballerina project)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Request:
> ```json
> POST /groups/my-external-group/users
> { "emails": ["user1@example.com", "user2@example.com"] }
> ```
> Response:
> ```json
> { "addedUsers": ["user1@example.com"], "failedUsers": ["user2@example.com"] }
> ```

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
> Ballerina Swan Lake, macOS, Choreo dev environment

## Learning
> Referenced the existing SCIM operations service implementation at `digiops-infra/operations/scim-operations-service` to understand the upstream API contract and aligned the customer portal integration accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /users/groups to add users to external groups; validates group and non-empty/non-whitespace emails and returns added/failed email lists.
  * Provides clear error responses: 404 for group not found, 400 for bad request (with error details), and 500 for internal failures; OpenAPI updated to document request/response schemas.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/679)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->