### PR TITLE
[Customer Portal][BE] Add usage and metric stats endpoints

### DIFF
--- a/apps/customer-portal/backend/Dependencies.toml
+++ b/apps/customer-portal/backend/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -610,3 +610,25 @@ public isolated function searchCaseActivities(string idToken, IdString caseId, C
 
     return csEntityClient->/cases/[caseId]/activities/search.post(payload, generateHeaders(idToken));
 }
+
+# Search instance usage statistics by criteria.
+#
+# + idToken - ID token for authorization
+# + payload - Instance usage statistics search payload containing search criteria for instance usage statistics
+# + return - Instance usage statistics response containing matching instance usage statistics or error
+public isolated function searchInstanceUsageStats(string idToken, InstanceUsageStatsPayload payload)
+    returns InstanceUsageStatsResponse|error {
+
+    return csEntityClient->/instances/usages/stats/search.post(payload, generateHeaders(idToken));
+}
+
+# Search instance metrics statistics by criteria.
+#
+# + idToken - ID token for authorization
+# + payload - Instance metrics statistics search payload containing search criteria for instance metrics statistics
+# + return - Instance metrics statistics response containing matching instance metrics statistics or error
+public isolated function searchInstanceMetricsStats(string idToken, InstanceMetricStatsPayload payload)
+    returns InstanceMetricStatsResponse|error {
+
+    return csEntityClient->/instances/metrics/stats/search.post(payload, generateHeaders(idToken));
+}

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2276,3 +2276,78 @@ public type CaseActivitySearchResponse record {|
     int totalRecords;
     *Pagination;
 |};
+
+# Request payload for fetching instance usage statistics.
+public type InstanceUsageStatsPayload record {|
+    # Filter criteria
+    record {|
+        # Start date filter, required (format: YYYY-MM-DD)
+        Date startDate;
+        # End date filter, required (format: YYYY-MM-DD)
+        Date endDate;
+        # List of project IDs (mutually exclusive with deploymentIds and deployedProductIds)
+        IdString[] projectIds?;
+        # List of deployment IDs (mutually exclusive with projectIds and deployedProductIds)
+        IdString[] deploymentIds?;
+        # List of deployed product IDs (mutually exclusive with projectIds and deploymentIds)
+        IdString[] deployedProductIds?;
+    |} filters;
+|};
+
+# Request payload for fetching instance metrics statistics.
+public type InstanceMetricStatsPayload record {|
+    # Filter criteria
+    record {|
+        # Start date filter, required (format: YYYY-MM-DD)
+        Date startDate;
+        # End date filter, required (format: YYYY-MM-DD)
+        Date endDate;
+        # List of project IDs (mutually exclusive with deploymentIds and deployedProductIds)
+        IdString[] projectIds?;
+        # List of deployment IDs (mutually exclusive with projectIds and deployedProductIds)
+        IdString[] deploymentIds?;
+        # List of deployed product IDs (mutually exclusive with projectIds and deploymentIds)
+        IdString[] deployedProductIds?;
+    |} filters;
+|};
+
+# Instance usage statistics response.
+public type InstanceUsageStatsResponse record {|
+    # Statistics grouped by date; each date maps to metric key → value (e.g. "TRANSACTION_COUNT": 30)
+    map<map<int>> stats;
+    # Total number of data points
+    int totalRecords;
+    # Start date of the queried range
+    string startDate;
+    # End date of the queried range
+    string endDate;
+    json...;
+|};
+
+# Aggregated statistics for a metric over a time range.
+public type MetricSummary record {|
+    # Current (latest) value
+    int curr;
+    # Minimum value across the range
+    int min;
+    # Maximum value across the range
+    int max;
+    # Average value across the range
+    decimal avg;
+    json...;
+|};
+
+# Instance metrics statistics response from ServiceNow.
+public type InstanceMetricStatsResponse record {|
+    # Statistics grouped by date; each date maps to metric key → value (e.g. "TOTAL_CORES": 123)
+    map<map<int>> stats;
+    # Summary statistics across the queried date range
+    MetricSummary summary;
+    # Total number of data points
+    int totalRecords;
+    # Start date of the queried range
+    string startDate;
+    # End date of the queried range
+    string endDate;
+    json...;
+|};

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1720,3 +1720,63 @@ public type AddUsersToGroupRequest record {|
     # Array of user email addresses to add to the group
     string[] emails;
 |};
+
+# Request payload for fetching instance usage statistics.
+public type InstanceUsageStatsPayload record {|
+    # Filter criteria
+    record {|
+        # Start date filter, required
+        entity:Date startDate;
+        # End date filter, required
+        entity:Date endDate;
+    |} filters;
+|};
+
+# Request payload for fetching instance metrics statistics.
+public type InstanceMetricStatsPayload record {|
+    # Filter criteria
+    record {|
+        # Start date filter, required
+        entity:Date startDate;
+        # End date filter, required
+        entity:Date endDate;
+    |} filters;
+|};
+
+# Instance usage statistics response.
+public type InstanceUsageStatsResponse record {|
+    # Statistics grouped by date; each date maps to metric key → value (e.g. "TRANSACTION_COUNT": 30)
+    map<map<int>> stats;
+    # Total number of data points
+    int totalRecords;
+    # Start date of the queried range
+    string startDate;
+    # End date of the queried range
+    string endDate;
+|};
+
+# Aggregated statistics for a metric over a time range.
+public type MetricSummary record {|
+    # Current (latest) value
+    int curr;
+    # Minimum value across the range
+    int min;
+    # Maximum value across the range
+    int max;
+    # Average value across the range
+    decimal avg;
+|};
+
+# Instance metrics statistics response from ServiceNow.
+public type InstanceMetricStatsResponse record {|
+    # Statistics grouped by date; each date maps to metric key → value (e.g. "TOTAL_CORES": 123)
+    map<map<int>> stats;
+    # Summary statistics across the queried date range
+    MetricSummary summary;
+    # Total number of data points
+    int totalRecords;
+    # Start date of the queried range
+    string startDate;
+    # End date of the queried range
+    string endDate;
+|};

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2786,11 +2786,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /projects/{id}/instances/usages/stats:
+  /projects/{id}/instances/stats/usages:
     post:
       summary: Search instance usage stats for a specific project based on provided
         filters.
-      operationId: postProjectsIdInstancesUsagesStats
+      operationId: postProjectsIdInstancesStatsUsages
       parameters:
       - name: id
         in: path
@@ -2820,11 +2820,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/{id}/instances/usages/stats:
+  /deployments/{id}/instances/stats/usages:
     post:
       summary: Search instance usage stats for a specific deployment based on provided
         filters.
-      operationId: postDeploymentsIdInstancesUsagesStats
+      operationId: postDeploymentsIdInstancesStatsUsages
       parameters:
       - name: id
         in: path
@@ -2854,11 +2854,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/products/{id}/instances/usages/stats:
+  /deployments/products/{id}/instances/stats/usages:
     post:
       summary: Search instance usage stats for a specific deployed product based on
         provided filters.
-      operationId: postDeploymentsProductsIdInstancesUsagesStats
+      operationId: postDeploymentsProductsIdInstancesStatsUsages
       parameters:
       - name: id
         in: path
@@ -2888,11 +2888,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /projects/{id}/instances/metrics/stats:
+  /projects/{id}/instances/stats/metrics:
     post:
       summary: Search instance metrics stats for a specific project based on provided
         filters.
-      operationId: postProjectsIdInstancesMetricsStats
+      operationId: postProjectsIdInstancesStatsMetrics
       parameters:
       - name: id
         in: path
@@ -2922,11 +2922,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/{id}/instances/metrics/stats:
+  /deployments/{id}/instances/stats/metrics:
     post:
       summary: Search instance metrics stats for a specific deployment based on provided
         filters.
-      operationId: postDeploymentsIdInstancesMetricsStats
+      operationId: postDeploymentsIdInstancesStatsMetrics
       parameters:
       - name: id
         in: path
@@ -2956,11 +2956,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/products/{id}/instances/metrics/stats:
+  /deployments/products/{id}/instances/stats/metrics:
     post:
       summary: Search instance metrics stats for a specific deployed product based
         on provided filters.
-      operationId: postDeploymentsProductsIdInstancesMetricsStats
+      operationId: postDeploymentsProductsIdInstancesStatsMetrics
       parameters:
       - name: id
         in: path

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -10,6 +10,13 @@ servers:
     port:
       default: "9090"
 paths:
+  /health:
+    get:
+      summary: Health check endpoint.
+      operationId: getHealth
+      responses:
+        "200":
+          description: Ok
   /metadata:
     get:
       summary: Fetch metadata information for the customer portal.
@@ -2779,6 +2786,210 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+  /projects/{id}/instances/usages/stats:
+    post:
+      summary: Search instance usage stats for a specific project based on provided
+        filters.
+      operationId: postProjectsIdInstancesUsagesStats
+      parameters:
+      - name: id
+        in: path
+        description: ID of the project
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Instance usage stats search payload containing filter criteria
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricStatsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
+  /deployments/{id}/instances/usages/stats:
+    post:
+      summary: Search instance usage stats for a specific deployment based on provided
+        filters.
+      operationId: postDeploymentsIdInstancesUsagesStats
+      parameters:
+      - name: id
+        in: path
+        description: ID of the deployment
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Instance usage stats search payload containing filter criteria
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricStatsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
+  /deployments/products/{id}/instances/usages/stats:
+    post:
+      summary: Search instance usage stats for a specific deployed product based on
+        provided filters.
+      operationId: postDeploymentsProductsIdInstancesUsagesStats
+      parameters:
+      - name: id
+        in: path
+        description: ID of the deployed product
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Instance usage stats search payload containing filter criteria
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricStatsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
+  /projects/{id}/instances/metrics/stats:
+    post:
+      summary: Search instance metrics stats for a specific project based on provided
+        filters.
+      operationId: postProjectsIdInstancesMetricsStats
+      parameters:
+      - name: id
+        in: path
+        description: ID of the project
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Instance metrics stats search payload containing filter criteria
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricStatsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
+  /deployments/{id}/instances/metrics/stats:
+    post:
+      summary: Search instance metrics stats for a specific deployment based on provided
+        filters.
+      operationId: postDeploymentsIdInstancesMetricsStats
+      parameters:
+      - name: id
+        in: path
+        description: ID of the deployment
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Instance metrics stats search payload containing filter criteria
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricStatsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
+  /deployments/products/{id}/instances/metrics/stats:
+    post:
+      summary: Search instance metrics stats for a specific deployed product based
+        on provided filters.
+      operationId: postDeploymentsProductsIdInstancesMetricsStats
+      parameters:
+      - name: id
+        in: path
+        description: ID of the deployed product
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Instance metrics stats search payload containing filter criteria
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricStatsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
   /cases/{id}/activities/search:
     post:
       summary: Search case activities for a specific case based on provided filters.
@@ -4456,6 +4667,25 @@ components:
           description: User who created
       additionalProperties: false
       description: Inline attachment.
+    InstanceMetricStatsPayload:
+      required:
+      - filters
+      type: object
+      properties:
+        filters:
+          required:
+          - endDate
+          - startDate
+          type: object
+          properties:
+            startDate:
+              $ref: '#/components/schemas/Date'
+            endDate:
+              $ref: '#/components/schemas/Date'
+          additionalProperties: false
+          description: Filter criteria
+      additionalProperties: false
+      description: Request payload for fetching instance metrics statistics.
     InstanceMetricsPayload:
       required:
       - filters

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -74,38 +74,6 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
-  /users/groups:
-    post:
-      summary: Add users to a group.
-      operationId: postUsersGroups
-      requestBody:
-        description: Add users to group request payload
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AddUsersToGroupRequest'
-        required: true
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AddUsersToGroupResponse'
-        "400":
-          description: BadRequest
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-        "404":
-          description: NotFound
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-        "500":
-          description: InternalServerError
   /projects/search:
     post:
       summary: Search projects of the logged-in user.
@@ -2786,11 +2754,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /projects/{id}/instances/stats/usages:
+  /projects/{id}/instances/stats/usages/search:
     post:
       summary: Search instance usage stats for a specific project based on provided
         filters.
-      operationId: postProjectsIdInstancesStatsUsages
+      operationId: postProjectsIdInstancesStatsUsagesSearch
       parameters:
       - name: id
         in: path
@@ -2820,11 +2788,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/{id}/instances/stats/usages:
+  /deployments/{id}/instances/stats/usages/search:
     post:
       summary: Search instance usage stats for a specific deployment based on provided
         filters.
-      operationId: postDeploymentsIdInstancesStatsUsages
+      operationId: postDeploymentsIdInstancesStatsUsagesSearch
       parameters:
       - name: id
         in: path
@@ -2854,11 +2822,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/products/{id}/instances/stats/usages:
+  /deployments/products/{id}/instances/stats/usages/search:
     post:
       summary: Search instance usage stats for a specific deployed product based on
         provided filters.
-      operationId: postDeploymentsProductsIdInstancesStatsUsages
+      operationId: postDeploymentsProductsIdInstancesStatsUsagesSearch
       parameters:
       - name: id
         in: path
@@ -2888,11 +2856,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /projects/{id}/instances/stats/metrics:
+  /projects/{id}/instances/stats/metrics/search:
     post:
       summary: Search instance metrics stats for a specific project based on provided
         filters.
-      operationId: postProjectsIdInstancesStatsMetrics
+      operationId: postProjectsIdInstancesStatsMetricsSearch
       parameters:
       - name: id
         in: path
@@ -2922,11 +2890,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/{id}/instances/stats/metrics:
+  /deployments/{id}/instances/stats/metrics/search:
     post:
       summary: Search instance metrics stats for a specific deployment based on provided
         filters.
-      operationId: postDeploymentsIdInstancesStatsMetrics
+      operationId: postDeploymentsIdInstancesStatsMetricsSearch
       parameters:
       - name: id
         in: path
@@ -2956,11 +2924,11 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
-  /deployments/products/{id}/instances/stats/metrics:
+  /deployments/products/{id}/instances/stats/metrics/search:
     post:
       summary: Search instance metrics stats for a specific deployed product based
         on provided filters.
-      operationId: postDeploymentsProductsIdInstancesStatsMetrics
+      operationId: postDeploymentsProductsIdInstancesStatsMetricsSearch
       parameters:
       - name: id
         in: path
@@ -3023,6 +2991,34 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+  /users/groups:
+    post:
+      summary: Add users to a group via the SCIM operations service.
+      operationId: postUsersGroups
+      requestBody:
+        description: Request payload containing group name and user emails
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddUsersToGroupRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddUsersToGroupResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+        "404":
+          description: NotFound
 components:
   schemas:
     Account:
@@ -3038,15 +3034,50 @@ components:
           type: string
           description: Allowed domain list of the account
           nullable: true
+          default: ""
         classification:
           type: string
           description: Account classification
           nullable: true
+          default: ""
         isPartner:
           type: boolean
           description: Whether the account is a partner or not
           nullable: true
       description: Account details record
+    AddUsersToGroupRequest:
+      required:
+      - emails
+      - group
+      type: object
+      properties:
+        group:
+          type: string
+          description: Display name of the group
+        emails:
+          type: array
+          description: Array of user email addresses to add to the group
+          items:
+            type: string
+      additionalProperties: false
+      description: Request payload for adding users to a group.
+    AddUsersToGroupResponse:
+      type: object
+      properties:
+        addedUsers:
+          type: array
+          description: Users successfully added to the group
+          items:
+            type: string
+          default: []
+        failedUsers:
+          type: array
+          description: Users that failed to be added
+          items:
+            type: string
+          default: []
+      additionalProperties: false
+      description: Response payload for add-users-to-group operation.
     Attachment:
       required:
       - createdBy
@@ -6230,40 +6261,3 @@ components:
           description: Variable value
       additionalProperties: false
       description: Variable data for service request.
-    AddUsersToGroupRequest:
-      required:
-      - group
-      - emails
-      type: object
-      properties:
-        group:
-          type: string
-          description: Display name of the group
-          minLength: 1
-          pattern: "\\S+"
-        emails:
-          type: array
-          description: Array of user email addresses to add to the group
-          items:
-            type: string
-            format: email
-          minItems: 1
-      additionalProperties: false
-      description: Request payload for adding users to a group.
-    AddUsersToGroupResponse:
-      type: object
-      properties:
-        addedUsers:
-          type: array
-          description: Users successfully added to the group
-          items:
-            type: string
-          default: []
-        failedUsers:
-          type: array
-          description: Users that failed to be added
-          items:
-            type: string
-          default: []
-      additionalProperties: false
-      description: Response payload for add-users-to-group operation.

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5545,7 +5545,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the project
     # + payload - Instance usage stats search payload containing filter criteria
     # + return - List of instance usage stats matching the criteria or an error response
-    resource function post projects/[entity:IdString id]/instances/usages/stats(http:RequestContext ctx,
+    resource function post projects/[entity:IdString id]/instances/stats/usages(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5608,7 +5608,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployment
     # + payload - Instance usage stats search payload containing filter criteria
     # + return - List of instance usage stats matching the criteria or an error response
-    resource function post deployments/[entity:IdString id]/instances/usages/stats(http:RequestContext ctx,
+    resource function post deployments/[entity:IdString id]/instances/stats/usages(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5671,7 +5671,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployed product
     # + payload - Instance usage stats search payload containing filter criteria
     # + return - List of instance usage stats matching the criteria or an error response
-    resource function post deployments/products/[entity:IdString id]/instances/usages/stats(http:RequestContext ctx,
+    resource function post deployments/products/[entity:IdString id]/instances/stats/usages(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5734,7 +5734,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the project
     # + payload - Instance metrics stats search payload containing filter criteria
     # + return - List of instance metrics stats matching the criteria or an error response
-    resource function post projects/[entity:IdString id]/instances/metrics/stats(http:RequestContext ctx,
+    resource function post projects/[entity:IdString id]/instances/stats/metrics(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5797,7 +5797,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployment
     # + payload - Instance metrics stats search payload containing filter criteria
     # + return - List of instance metrics stats matching the criteria or an error response
-    resource function post deployments/[entity:IdString id]/instances/metrics/stats(http:RequestContext ctx,
+    resource function post deployments/[entity:IdString id]/instances/stats/metrics(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5860,7 +5860,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployed product
     # + payload - Instance metrics stats search payload containing filter criteria
     # + return - List of instance metrics stats matching the criteria or an error response
-    resource function post deployments/products/[entity:IdString id]/instances/metrics/stats(http:RequestContext ctx,
+    resource function post deployments/products/[entity:IdString id]/instances/stats/metrics(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5540,6 +5540,384 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return <http:Ok>{body: mapInstanceUsages(response)};
     }
 
+    # Search instance usage stats for a specific project based on provided filters.
+    #
+    # + id - ID of the project
+    # + payload - Instance usage stats search payload containing filter criteria
+    # + return - List of instance usage stats matching the criteria or an error response
+    resource function post projects/[entity:IdString id]/instances/usages/stats(http:RequestContext ctx,
+            types:InstanceMetricStatsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:InstanceUsageStatsResponse|error response = entity:searchInstanceUsageStats(userInfo.idToken,
+                {
+                    filters: {
+                        projectIds: [id],
+                        startDate: payload.filters.startDate,
+                        endDate: payload.filters.endDate
+                    }
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching instance usage stats for the project."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                logForbiddenProjectAccess(id, userInfo.userId);
+                return <http:Forbidden>{
+                    body: {
+                        message: ERR_MSG_PROJECT_ACCESS_FORBIDDEN
+                    }
+                };
+            }
+
+            string customError = "Failed to search instance usage stats for the project.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapInstanceUsageStats(response)};
+    }
+
+    # Search instance usage stats for a specific deployment based on provided filters.
+    #
+    # + id - ID of the deployment
+    # + payload - Instance usage stats search payload containing filter criteria
+    # + return - List of instance usage stats matching the criteria or an error response
+    resource function post deployments/[entity:IdString id]/instances/usages/stats(http:RequestContext ctx,
+            types:InstanceMetricStatsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:InstanceUsageStatsResponse|error response = entity:searchInstanceUsageStats(userInfo.idToken,
+                {
+                    filters: {
+                        deploymentIds: [id],
+                        startDate: payload.filters.startDate,
+                        endDate: payload.filters.endDate
+                    }
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching instance usage stats for the deployment."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                logForbiddenProjectAccess(id, userInfo.userId);
+                return <http:Forbidden>{
+                    body: {
+                        message: ERR_MSG_PROJECT_ACCESS_FORBIDDEN
+                    }
+                };
+            }
+
+            string customError = "Failed to search instance usage stats for the deployment.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapInstanceUsageStats(response)};
+    }
+
+    # Search instance usage stats for a specific deployed product based on provided filters.
+    #
+    # + id - ID of the deployed product
+    # + payload - Instance usage stats search payload containing filter criteria
+    # + return - List of instance usage stats matching the criteria or an error response
+    resource function post deployments/products/[entity:IdString id]/instances/usages/stats(http:RequestContext ctx,
+            types:InstanceMetricStatsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:InstanceUsageStatsResponse|error response = entity:searchInstanceUsageStats(userInfo.idToken,
+                {
+                    filters: {
+                        deployedProductIds: [id],
+                        startDate: payload.filters.startDate,
+                        endDate: payload.filters.endDate
+                    }
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching instance usage stats for the deployed product."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                logForbiddenProjectAccess(id, userInfo.userId);
+                return <http:Forbidden>{
+                    body: {
+                        message: ERR_MSG_PROJECT_ACCESS_FORBIDDEN
+                    }
+                };
+            }
+
+            string customError = "Failed to search instance usage stats for the deployed product.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapInstanceUsageStats(response)};
+    }
+
+    # Search instance metrics stats for a specific project based on provided filters.
+    #
+    # + id - ID of the project
+    # + payload - Instance metrics stats search payload containing filter criteria
+    # + return - List of instance metrics stats matching the criteria or an error response
+    resource function post projects/[entity:IdString id]/instances/metrics/stats(http:RequestContext ctx,
+            types:InstanceMetricStatsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:InstanceMetricStatsResponse|error response = entity:searchInstanceMetricsStats(userInfo.idToken,
+                {
+                    filters: {
+                        projectIds: [id],
+                        startDate: payload.filters.startDate,
+                        endDate: payload.filters.endDate
+                    }
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching instance metric stats for the project."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                logForbiddenProjectAccess(id, userInfo.userId);
+                return <http:Forbidden>{
+                    body: {
+                        message: ERR_MSG_PROJECT_ACCESS_FORBIDDEN
+                    }
+                };
+            }
+
+            string customError = "Failed to search instance metric stats for the project.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapInstanceMetricStats(response)};
+    }
+
+    # Search instance metrics stats for a specific deployment based on provided filters.
+    #
+    # + id - ID of the deployment
+    # + payload - Instance metrics stats search payload containing filter criteria
+    # + return - List of instance metrics stats matching the criteria or an error response
+    resource function post deployments/[entity:IdString id]/instances/metrics/stats(http:RequestContext ctx,
+            types:InstanceMetricStatsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:InstanceMetricStatsResponse|error response = entity:searchInstanceMetricsStats(userInfo.idToken,
+                {
+                    filters: {
+                        deploymentIds: [id],
+                        startDate: payload.filters.startDate,
+                        endDate: payload.filters.endDate
+                    }
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching instance metric stats for the deployment."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                logForbiddenProjectAccess(id, userInfo.userId);
+                return <http:Forbidden>{
+                    body: {
+                        message: ERR_MSG_PROJECT_ACCESS_FORBIDDEN
+                    }
+                };
+            }
+
+            string customError = "Failed to search instance metric stats for the deployment.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapInstanceMetricStats(response)};
+    }
+
+    # Search instance metrics stats for a specific deployed product based on provided filters.
+    #
+    # + id - ID of the deployed product
+    # + payload - Instance metrics stats search payload containing filter criteria
+    # + return - List of instance metrics stats matching the criteria or an error response
+    resource function post deployments/products/[entity:IdString id]/instances/metrics/stats(http:RequestContext ctx,
+            types:InstanceMetricStatsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:InstanceMetricStatsResponse|error response = entity:searchInstanceMetricsStats(userInfo.idToken,
+                {
+                    filters: {
+                        deployedProductIds: [id],
+                        startDate: payload.filters.startDate,
+                        endDate: payload.filters.endDate
+                    }
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching instance metric stats for the deployed product."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                logForbiddenProjectAccess(id, userInfo.userId);
+                return <http:Forbidden>{
+                    body: {
+                        message: ERR_MSG_PROJECT_ACCESS_FORBIDDEN
+                    }
+                };
+            }
+
+            string customError = "Failed to search instance metric stats for the deployed product.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapInstanceMetricStats(response)};
+    }
+
     # Search case activities for a specific case based on provided filters.
     #
     # + id - ID of the case

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5545,7 +5545,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the project
     # + payload - Instance usage stats search payload containing filter criteria
     # + return - List of instance usage stats matching the criteria or an error response
-    resource function post projects/[entity:IdString id]/instances/stats/usages(http:RequestContext ctx,
+    resource function post projects/[entity:IdString id]/instances/stats/usages/search(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5608,7 +5608,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployment
     # + payload - Instance usage stats search payload containing filter criteria
     # + return - List of instance usage stats matching the criteria or an error response
-    resource function post deployments/[entity:IdString id]/instances/stats/usages(http:RequestContext ctx,
+    resource function post deployments/[entity:IdString id]/instances/stats/usages/search(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5671,8 +5671,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployed product
     # + payload - Instance usage stats search payload containing filter criteria
     # + return - List of instance usage stats matching the criteria or an error response
-    resource function post deployments/products/[entity:IdString id]/instances/stats/usages(http:RequestContext ctx,
-            types:InstanceMetricStatsPayload payload)
+    resource function post deployments/products/[entity:IdString id]/instances/stats/usages/search(
+            http:RequestContext ctx, types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
@@ -5734,7 +5734,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the project
     # + payload - Instance metrics stats search payload containing filter criteria
     # + return - List of instance metrics stats matching the criteria or an error response
-    resource function post projects/[entity:IdString id]/instances/stats/metrics(http:RequestContext ctx,
+    resource function post projects/[entity:IdString id]/instances/stats/metrics/search(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5797,7 +5797,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployment
     # + payload - Instance metrics stats search payload containing filter criteria
     # + return - List of instance metrics stats matching the criteria or an error response
-    resource function post deployments/[entity:IdString id]/instances/stats/metrics(http:RequestContext ctx,
+    resource function post deployments/[entity:IdString id]/instances/stats/metrics/search(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 
@@ -5860,7 +5860,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the deployed product
     # + payload - Instance metrics stats search payload containing filter criteria
     # + return - List of instance metrics stats matching the criteria or an error response
-    resource function post deployments/products/[entity:IdString id]/instances/stats/metrics(http:RequestContext ctx,
+    resource function post deployments/products/[entity:IdString id]/instances/stats/metrics/search(http:RequestContext ctx,
             types:InstanceMetricStatsPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
 

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1137,3 +1137,33 @@ public isolated function mapCaseActivitySummaryResponse(entity:CaseActivitySearc
         };
     return {activities, totalRecords: response.totalRecords, 'limit: response.'limit, offset: response.offset};
 }
+
+# Map instance usage stats response to the desired structure.
+#
+# + response - Instance usage stats response from the entity service
+# + return - Mapped instance usage stats response
+public isolated function mapInstanceUsageStats(entity:InstanceUsageStatsResponse response)
+    returns types:InstanceUsageStatsResponse => {
+    stats: response.stats,
+    totalRecords: response.totalRecords,
+    startDate: response.startDate,
+    endDate: response.endDate
+};
+
+# Map instance metric stats response to the desired structure.
+#
+# + response - Instance metric stats response from the entity service
+# + return - Mapped instance metric stats response
+public isolated function mapInstanceMetricStats(entity:InstanceMetricStatsResponse response)
+    returns types:InstanceMetricStatsResponse => {
+    stats: response.stats,
+    summary: {
+        curr: response.summary.curr,
+        avg: response.summary.avg,
+        min: response.summary.min,
+        max: response.summary.max
+    },
+    totalRecords: response.totalRecords,
+    startDate: response.startDate,
+    endDate: response.endDate
+};


### PR DESCRIPTION
## Description
Introduced new **usage** and **metrics** statistics endpoints for enhanced analytics.

These endpoints are implemented for:
- Projects
- Deployments
- Deployment Products

The APIs provide aggregated statistical data including:
- Minimum (min)
- Maximum (max)
- Average (avg)
- Total (sum)

---

## Endpoints (Examples)
- `/projects/{projectId}/stats/usage`
- `/projects/{projectId}/stats/metrics`
- `/deployments/{deploymentId}/stats/usage`
- `/deployments/{deploymentId}/stats/metrics`
- `/deployments/products/{deploymentId}/stats/usage`
- `/deployments/products/{deploymentId}/stats/metrics`
---

## Functionality
- Returns aggregated statistics for usage and metrics data
- Supports multiple entity levels (project, deployment, product)
- Optimized for dashboard/stat card consumption

---

## Improvements
- Enables better insights into system usage patterns
- Standardized stats response across entities
- Improves frontend data visualization capabilities

---

## Testing
- Verified responses for all entity types
- Validated min, max, avg, and total calculations
- Tested with different data ranges and edge cases

## Related Issues
- https://github.com/wso2-enterprise/wso2-digital-team-project-management/issues/90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Six authenticated POST endpoints to retrieve instance usage and metric statistics for projects, deployments, and deployed products.
  * Date-range filtering for stats queries; responses include date-grouped statistics, total counts, and aggregated metric summaries (current, min, max, avg).
  * Added a health-check GET endpoint.

* **Chores**
  * Bumped HTTP library version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/680)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->