### PR TITLE
[Customer Portal][FE][Web] Refine Description Caption Rendering in CaseDetailsSection

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
@@ -244,7 +244,7 @@ export function CaseDetailsSection({
             maxHeight="210px"
           />
 
-          {!isRelatedCaseMode && (
+          {!isRelatedCaseMode && isDescriptionFromConversation && (
             <Typography
               variant="caption"
               color="text.disabled"


### PR DESCRIPTION
### Description

 This pull request makes a small adjustment to the `CaseDetailsSection` component to improve the conditional rendering of the description caption. Now, the caption is only shown when both `isRelatedCaseMode` is false and `isDescriptionFromConversation` is true.

- UI logic update:
  * The `Typography` caption in `CaseDetailsSection.tsx` is now rendered only if both `!isRelatedCaseMode` and `isDescriptionFromConversation` are true, making the display of the caption more precise.