### PR TITLE
[Customer Portal][FE][Web] Refactor conversation status colors to use design system tokens

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -643,17 +643,17 @@ export function getConversationStatusColor(status: string): string {
 
   switch (true) {
     case normalized.includes(ConversationStatus.ABANDONED.toLowerCase()):
-      return "error.main";
+      return colors.grey[500];
     case normalized.includes(ConversationStatus.ACTIVE.toLowerCase()):
-      return "success.main";
+      return colors.green[500];
     case normalized.includes(ConversationStatus.CONVERTED.toLowerCase()):
-      return "info.main";
+      return colors.orange[500];
     case normalized.includes(ConversationStatus.OPEN.toLowerCase()):
-      return "warning.main";
+      return colors.lightBlue[500];
     case normalized.includes(ConversationStatus.RESOLVED.toLowerCase()):
-      return "success.main";
+      return colors.purple[300];
     default:
-      return "secondary.main";
+      return colors.grey[500];
   }
 }
 


### PR DESCRIPTION
### Description

Replace palette key strings with explicit color tokens in getConversationStatusColor to align status colors with the design system. Mappings updated: ABANDONED -> colors.grey[500], ACTIVE -> colors.green[500], CONVERTED -> colors.orange[500], OPEN -> colors.lightBlue[500], RESOLVED -> colors.purple[300], default -> colors.grey[500].



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced color consistency for conversation statuses in the support portal by updating status color values to align with the design system palette.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/687)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->