### PR TITLE
[Customer Portal][FE][Web] Show logout button on auth errors

### DIFF
--- a/apps/customer-portal/webapp/src/components/header/UserProfile.tsx
+++ b/apps/customer-portal/webapp/src/components/header/UserProfile.tsx
@@ -35,17 +35,6 @@ export default function UserProfile(): JSX.Element {
   const { data: userDetails, isLoading, isError, error } = useGetUserDetails();
   const logger = useLogger();
 
-  if (!isAuthLoading && !isSignedIn) {
-    return <></>;
-  }
-  if (
-    isError &&
-    error instanceof ApiError &&
-    (error.status === 401 || error.status === 403)
-  ) {
-    return <></>;
-  }
-
   const handleLogout = async () => {
     window.dispatchEvent(new CustomEvent("app:signing-out"));
     try {
@@ -54,6 +43,22 @@ export default function UserProfile(): JSX.Element {
       logger.error("Failed to sign out", error);
     }
   };
+
+  if (!isAuthLoading && !isSignedIn) {
+    return <></>;
+  }
+  if (
+    isError &&
+    error instanceof ApiError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    return (
+      <button onClick={handleLogout} style={{ display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", color: "inherit" }}>
+        <LogOut size={18} />
+        Log out
+      </button>
+    );
+  }
 
   const isProfilePending = isLoading || isAuthLoading;
   const useErrorFallback = isError && !userDetails;


### PR DESCRIPTION
### Description

Render a Log out button when user details API returns 401/403 instead of returning nothing. Add a shared handleLogout handler that dispatches an app:signing-out event and calls signOut(), logging any errors. This also removes the duplicated handler and provides a simple inline-styled button with an icon to allow the user to sign out on authorization failures.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication error handling by displaying a logout button when encountering session or permission-related issues, allowing users to quickly exit and re-authenticate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/691)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->