### PR TITLE
[Customer Portal][Frontend] Support attachment downloads up to 10MB via content endpoint

### DIFF
--- a/apps/customer-portal/webapp/src/api/__tests__/useGetAttachment.test.tsx
+++ b/apps/customer-portal/webapp/src/api/__tests__/useGetAttachment.test.tsx
@@ -22,7 +22,7 @@ import { useGetAttachment } from "@api/useGetAttachment";
 
 const mockAuthFetch = vi.fn();
 
-vi.mock("@api/useAuthApiClient", () => ({
+vi.mock("@/hooks/useAuthApiClient", () => ({
   useAuthApiClient: () => mockAuthFetch,
 }));
 
@@ -147,7 +147,7 @@ describe("useGetAttachment", () => {
     await act(async () => {
       await expect(
         result.current.downloadAttachment({ id: "att-1", name: "x" }),
-      ).rejects.toThrow(/Download failed/);
+      ).rejects.toThrow(/Not Found|Download failed/);
     });
   });
 
@@ -192,4 +192,5 @@ describe("useGetAttachment", () => {
       expect(result.current.downloadingId).toBeNull();
     });
   });
+
 });

--- a/apps/customer-portal/webapp/src/api/__tests__/useGetAttachment.test.tsx
+++ b/apps/customer-portal/webapp/src/api/__tests__/useGetAttachment.test.tsx
@@ -152,7 +152,7 @@ describe("useGetAttachment", () => {
   });
 
   it("should expose downloadingId while request is pending", async () => {
-    let resolveFetch: (value: Response) => void = () => {};
+    let resolveFetch: (value: Response) => void = () => { };
     const pending = new Promise<Response>((r) => {
       resolveFetch = r;
     });
@@ -192,5 +192,4 @@ describe("useGetAttachment", () => {
       expect(result.current.downloadingId).toBeNull();
     });
   });
-
 });

--- a/apps/customer-portal/webapp/src/api/__tests__/useGetAttachmentContent.test.tsx
+++ b/apps/customer-portal/webapp/src/api/__tests__/useGetAttachmentContent.test.tsx
@@ -1,0 +1,94 @@
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { ReactNode } from "react";
+import { useGetAttachmentContent } from "@api/useGetAttachmentContent";
+
+const mockAuthFetch = vi.fn();
+
+vi.mock("@/hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => mockAuthFetch,
+}));
+
+const testWindowConfig: Window["config"] = {
+  CUSTOMER_PORTAL_AUTH_BASE_URL: "https://auth",
+  CUSTOMER_PORTAL_AUTH_CLIENT_ID: "cid",
+  CUSTOMER_PORTAL_AUTH_SIGN_IN_REDIRECT_URL: "https://in",
+  CUSTOMER_PORTAL_AUTH_SIGN_OUT_REDIRECT_URL: "https://out",
+  CUSTOMER_PORTAL_BACKEND_BASE_URL: "https://api.example/v1.0",
+  CUSTOMER_PORTAL_THEME: "default",
+  CUSTOMER_PORTAL_LOG_LEVEL: "error",
+  CUSTOMER_PORTAL_MAINTENANCE_BANNER_VISIBLE: false,
+};
+
+describe("useGetAttachmentContent", () => {
+  let queryClient: QueryClient;
+  let prevConfig: Window["config"];
+  let openSpy: ReturnType<typeof vi.spyOn>;
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    prevConfig = window.config;
+    window.config = testWindowConfig;
+    openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    createObjectURLSpy = vi
+      .spyOn(URL as any, "createObjectURL")
+      .mockReturnValue("blob://test");
+
+    queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    window.config = prevConfig;
+    openSpy.mockRestore();
+    createObjectURLSpy.mockRestore();
+  });
+
+  it("should GET /attachments/:id/content and trigger blob download", async () => {
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click");
+    const testBlob = new Blob(["abc"], {
+      type: "application/octet-stream",
+    });
+
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) => {
+          if (name === "content-type") return "application/octet-stream";
+          if (name === "content-disposition")
+            return 'attachment; filename="downloaded.txt"';
+          return null;
+        },
+      },
+      blob: () => Promise.resolve(testBlob),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useGetAttachmentContent(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.downloadAttachment({
+        id: "att-1",
+        name: "fallback.png",
+      });
+    });
+
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "https://api.example/v1.0/attachments/att-1/content",
+      { method: "GET" },
+    );
+    expect(createObjectURLSpy).toHaveBeenCalledWith(testBlob);
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});
+

--- a/apps/customer-portal/webapp/src/api/__tests__/useGetAttachmentContent.test.tsx
+++ b/apps/customer-portal/webapp/src/api/__tests__/useGetAttachmentContent.test.tsx
@@ -1,3 +1,19 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import { renderHook, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
@@ -37,7 +53,7 @@ describe("useGetAttachmentContent", () => {
     openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     createObjectURLSpy = vi
-      .spyOn(URL as any, "createObjectURL")
+      .spyOn(URL, "createObjectURL")
       .mockReturnValue("blob://test");
 
     queryClient = new QueryClient({

--- a/apps/customer-portal/webapp/src/api/useAttachmentPreview.ts
+++ b/apps/customer-portal/webapp/src/api/useAttachmentPreview.ts
@@ -16,7 +16,6 @@
 
 import { useQuery, useQueries } from "@tanstack/react-query";
 import { useAuthApiClient } from "@/hooks/useAuthApiClient";
-import type { AttachmentDownloadResponse } from "@features/support/types/attachments";
 
 function getBackendBaseUrl(): string {
   const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
@@ -46,30 +45,25 @@ async function fetchAttachmentDataUrl(
 ): Promise<string | null> {
   const baseUrl = getBackendBaseUrl();
   const response = await authFetch(
-    `${baseUrl}/attachments/${encodeURIComponent(attachmentId)}`,
+    `${baseUrl}/attachments/${encodeURIComponent(attachmentId)}/content`,
     { method: "GET" },
   );
   if (!response.ok) return null;
-  const data = (await response.json()) as AttachmentDownloadResponse;
-  if (!data.content || typeof data.content !== "string") return null;
 
-  // Backend may return a data URI directly (e.g. "data:@file/image/png;base64,..." or "data:image/png;base64,...").
-  // Parse it and re-emit with a validated safe MIME type.
-  if (data.content.startsWith("data:")) {
-    // Matches both "data:image/png;base64,..." and "data:@file/image/png;base64,..."
-    const match = data.content.match(/^data:(?:@file\/)?(image\/[^;]+|[^;/]+);base64,(.+)$/s);
-    if (!match) return null;
-    const mimeType = toSafeMimeType(match[1]);
-    const stripped = match[2].replace(/\s/g, "");
-    if (!stripped || !/^[A-Za-z0-9+/]+=*$/.test(stripped)) return null;
-    return `data:${mimeType};base64,${stripped}`;
-  }
+  const blob = await response.blob();
+  const rawType = blob.type || response.headers.get("content-type") || "";
+  const mimeType = toSafeMimeType(rawType);
+  if (!mimeType.startsWith("image/")) return null;
 
-  // Raw base64 content — construct data URL using the type field.
-  const stripped = data.content.replace(/\s/g, "");
-  if (!stripped || !/^[A-Za-z0-9+/]+=*$/.test(stripped)) return null;
-  const mimeType = toSafeMimeType(typeof data.type === "string" ? data.type : "");
-  return `data:${mimeType};base64,${stripped}`;
+  return new Promise<string | null>((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result;
+      resolve(typeof result === "string" ? result : null);
+    };
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(blob);
+  });
 }
 
 /**

--- a/apps/customer-portal/webapp/src/api/useGetAttachmentContent.ts
+++ b/apps/customer-portal/webapp/src/api/useGetAttachmentContent.ts
@@ -1,3 +1,19 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useAuthApiClient } from "@/hooks/useAuthApiClient";
@@ -30,9 +46,7 @@ function getFilenameFromContentDisposition(
   if (!contentDisposition) return null;
 
   // Handles: filename="a.txt" and filename*=UTF-8''a%20b.txt
-  const utf8Star = contentDisposition.match(
-    /filename\*\s*=\s*UTF-8''([^;]+)/i,
-  );
+  const utf8Star = contentDisposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
   if (utf8Star?.[1]) {
     try {
       return decodeURIComponent(utf8Star[1].trim().replace(/^"|"$/g, ""));
@@ -154,7 +168,11 @@ export function useGetAttachmentContent(): UseGetAttachmentContentResult {
   const authFetch = useAuthApiClient();
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
-  const mutation = useMutation<void, Error, DownloadBackendAttachmentContentInput>({
+  const mutation = useMutation<
+    void,
+    Error,
+    DownloadBackendAttachmentContentInput
+  >({
     mutationFn: (input) =>
       downloadAttachmentContentThroughBackend(authFetch, input),
     onMutate: (variables) => setDownloadingId(variables.id),
@@ -167,4 +185,3 @@ export function useGetAttachmentContent(): UseGetAttachmentContentResult {
     downloadingId,
   };
 }
-

--- a/apps/customer-portal/webapp/src/api/useGetAttachmentContent.ts
+++ b/apps/customer-portal/webapp/src/api/useGetAttachmentContent.ts
@@ -1,0 +1,170 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import type { AttachmentDownloadResponse } from "@features/support/types/attachments";
+import { parseApiResponseMessage } from "@utils/ApiError";
+
+/** Input for GET /attachments/:id/content (authenticated). */
+export interface DownloadBackendAttachmentContentInput {
+  id: string;
+  name: string;
+  type?: string;
+  downloadUrl?: string | null;
+}
+
+function getBackendBaseUrl(): string {
+  const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
+  if (!baseUrl) {
+    throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
+  }
+  return baseUrl.replace(/\/$/, "");
+}
+
+function openExternalDownload(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+function getFilenameFromContentDisposition(
+  contentDisposition: string | null,
+): string | null {
+  if (!contentDisposition) return null;
+
+  // Handles: filename="a.txt" and filename*=UTF-8''a%20b.txt
+  const utf8Star = contentDisposition.match(
+    /filename\*\s*=\s*UTF-8''([^;]+)/i,
+  );
+  if (utf8Star?.[1]) {
+    try {
+      return decodeURIComponent(utf8Star[1].trim().replace(/^"|"$/g, ""));
+    } catch {
+      return utf8Star[1].trim().replace(/^"|"$/g, "");
+    }
+  }
+
+  const plain = contentDisposition.match(/filename\s*=\s*([^;]+)/i);
+  if (plain?.[1]) {
+    return plain[1].trim().replace(/^"|"$/g, "");
+  }
+
+  return null;
+}
+
+function triggerDownloadFromBlob(blob: Blob, fileName: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = objectUrl;
+  link.download = fileName || "attachment";
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.click();
+
+  // Cleanup after the click.
+  window.setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000);
+}
+
+function triggerDownloadFromContentField(
+  content: string,
+  fileName: string,
+  mimeType?: string,
+): void {
+  const isDataUrl = content.startsWith("data:");
+  const href = isDataUrl
+    ? content
+    : `data:${mimeType ?? "application/octet-stream"};base64,${content}`;
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = fileName || "attachment";
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.click();
+}
+
+async function downloadAttachmentContentThroughBackend(
+  authFetch: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>,
+  input: DownloadBackendAttachmentContentInput,
+): Promise<void> {
+  const baseUrl = getBackendBaseUrl();
+  const url = `${baseUrl}/attachments/${encodeURIComponent(input.id)}/content`;
+
+  let response: Response;
+  try {
+    response = await authFetch(url, { method: "GET" });
+  } catch {
+    if (input.downloadUrl) {
+      openExternalDownload(input.downloadUrl);
+      return;
+    }
+    throw new Error("Network error while downloading attachment");
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    if (input.downloadUrl) {
+      openExternalDownload(input.downloadUrl);
+      return;
+    }
+    throw new Error(
+      parseApiResponseMessage(detail, response.status, response.statusText),
+    );
+  }
+
+  // Some backends might still return JSON { content, name, type }.
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const data = (await response.json()) as Partial<
+      AttachmentDownloadResponse & { content?: unknown }
+    >;
+    if (typeof data?.content === "string") {
+      triggerDownloadFromContentField(
+        data.content,
+        data.name || input.name,
+        data.type || input.type,
+      );
+      return;
+    }
+
+    if (input.downloadUrl) {
+      openExternalDownload(input.downloadUrl);
+      return;
+    }
+    throw new Error("Attachment response did not include file content");
+  }
+
+  const blob = await response.blob();
+  const cd = response.headers.get("content-disposition");
+  const fileName = getFilenameFromContentDisposition(cd) ?? input.name;
+  triggerDownloadFromBlob(blob, fileName);
+}
+
+export interface UseGetAttachmentContentResult {
+  downloadAttachment: (
+    input: DownloadBackendAttachmentContentInput,
+  ) => Promise<void>;
+  isDownloading: boolean;
+  downloadingId: string | null;
+}
+
+/**
+ * Authenticated attachment download via GET /attachments/:id/content.
+ */
+export function useGetAttachmentContent(): UseGetAttachmentContentResult {
+  const authFetch = useAuthApiClient();
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const mutation = useMutation<void, Error, DownloadBackendAttachmentContentInput>({
+    mutationFn: (input) =>
+      downloadAttachmentContentThroughBackend(authFetch, input),
+    onMutate: (variables) => setDownloadingId(variables.id),
+    onSettled: () => setDownloadingId(null),
+  });
+
+  return {
+    downloadAttachment: mutation.mutateAsync,
+    isDownloading: mutation.isPending,
+    downloadingId,
+  };
+}
+

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
@@ -57,7 +57,7 @@ import DOMPurify from "dompurify";
 import { useDarkMode } from "@utils/useDarkMode";
 import ChatMessageCard from "@case-details-activity/ChatMessageCard";
 import { useResolvedInlineImageHtml } from "@features/support/hooks/useResolvedInlineImageHtml";
-import { useGetAttachment } from "@api/useGetAttachment";
+import { useGetAttachmentContent } from "@api/useGetAttachmentContent";
 import { useAttachmentPreview } from "@api/useAttachmentPreview";
 import { stripLightModeInlineStyles } from "@/utils/common";
 
@@ -85,7 +85,7 @@ export default function CommentBubble({
   const theme = useTheme();
   const isDarkMode = useDarkMode();
   const { downloadAttachment, isDownloading, downloadingId } =
-    useGetAttachment();
+    useGetAttachmentContent();
   const rawContent = comment.content ?? "";
   const isFullCodeWrap = hasSingleCodeWrapper(rawContent);
   const codeBlockCount = rawContent.match(/\[code\]/gi)?.length ?? 0;

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
@@ -26,7 +26,7 @@ import {
 } from "@features/support/api/useGetCaseAttachments";
 import type { CaseAttachment } from "@features/support/types/cases";
 import { useDeleteAttachment } from "@features/support/api/useDeleteAttachment";
-import { useGetAttachment } from "@api/useGetAttachment";
+import { useGetAttachmentContent } from "@api/useGetAttachmentContent";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 
@@ -59,7 +59,7 @@ export default function CaseDetailsAttachmentsPanel({
   const { data: userDetails } = useGetUserDetails();
   const currentUserEmail = userDetails?.email?.trim().toLowerCase() ?? "";
   const { downloadAttachment, isDownloading, downloadingId } =
-    useGetAttachment();
+    useGetAttachmentContent();
   const [uploadOpen, setUploadOpen] = useState(false);
   const [minTimeElapsed, setMinTimeElapsed] = useState(false);
   const minTimeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -144,7 +144,6 @@ export default function CaseDetailsAttachmentsPanel({
         id: att.id,
         name: att.name,
         type: att.type,
-        content: att.content,
         downloadUrl: att.downloadUrl,
       });
     } catch (error) {


### PR DESCRIPTION
## Purpose
- This PR updates the Customer Portal attachment download flow to support files up to 10MB using the dedicated attachment content endpoint.
- In addition to improving large file download support, this change also adds image previews in the Activity tab for attachments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced attachment download functionality with improved error handling and fallback support for unavailable endpoints.
  * Added support for multiple content delivery formats when retrieving attachments.

* **Tests**
  * Added test coverage for new attachment download features.
  * Updated existing tests to reflect changes in download mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/692)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->