### PR TITLE
[Customer Portal Frontend] Hide security center and usage metrics nav items based on project feature flags

### DIFF
--- a/apps/customer-portal/webapp/src/components/side-nav-bar/SideBar.tsx
+++ b/apps/customer-portal/webapp/src/components/side-nav-bar/SideBar.tsx
@@ -80,7 +80,7 @@ export default function SideBar({
   const navItems = useMemo(() => {
     let items = APP_SHELL_NAV_ITEMS;
 
-    if (!usageMetricsEnabled) {
+    if (!usageMetricsEnabled || !permissions.hasUsageMetrics) {
       items = items.filter((item: AppShellNavItem) => item.id !== "usage-metrics");
     }
 
@@ -100,6 +100,10 @@ export default function SideBar({
       items = items.filter((item: AppShellNavItem) => item.id !== "updates");
     }
 
+    if (!permissions.hasSecurityReportAnalysis && !permissions.hasComponentAnalysis) {
+      items = items.filter((item: AppShellNavItem) => item.id !== "security-center");
+    }
+
     return items;
   }, [
     isProjectTypeResolved,
@@ -108,6 +112,9 @@ export default function SideBar({
     permissions.hasCR,
     permissions.hasEngagements,
     permissions.hasUpdates,
+    permissions.hasSecurityReportAnalysis,
+    permissions.hasComponentAnalysis,
+    permissions.hasUsageMetrics,
     usageMetricsEnabled,
   ]);
 

--- a/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
@@ -172,6 +172,8 @@ export type ProjectFeatures = {
   hasTimeLogsReadAccess: boolean;
   hasDeploymentWriteAccess: boolean;
   hasDeploymentReadAccess: boolean;
+  hasComponentAnalysisReadAccess: boolean;
+  hasUsageMetricsReadAccess: boolean;
   defaultCaseProductCategories?: string[] | null;
   srProductCategories?: string[] | null;
 };

--- a/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
+++ b/apps/customer-portal/webapp/src/features/security/pages/SecurityPage.tsx
@@ -133,11 +133,15 @@ const SecurityPage = (): JSX.Element => {
 
   const tabs = useMemo(
     () =>
-      SECURITY_PAGE_TABS.filter((tab) =>
-        tab.id === SecurityTabId.VULNERABILITIES
-          ? securityPermissions?.hasSecurityReportAnalysis ?? false
-          : true,
-      ),
+      SECURITY_PAGE_TABS.filter((tab) => {
+        if (tab.id === SecurityTabId.VULNERABILITIES) {
+          return securityPermissions?.hasSecurityReportAnalysis ?? false;
+        }
+        if (tab.id === SecurityTabId.COMPONENTS) {
+          return securityPermissions?.hasComponentAnalysis ?? false;
+        }
+        return true;
+      }),
     [securityPermissions],
   );
   const activeTab = useMemo(() => {

--- a/apps/customer-portal/webapp/src/types/permission.ts
+++ b/apps/customer-portal/webapp/src/types/permission.ts
@@ -54,6 +54,8 @@ export type ProjectPermissions = {
   showServiceHoursAllocationsCard: boolean;
   hasEngagements: boolean;
   hasUpdates: boolean;
+  hasComponentAnalysis: boolean;
+  hasUsageMetrics: boolean;
 };
 
 /** Aggregated operation counts for dashboard and related UI. */

--- a/apps/customer-portal/webapp/src/utils/permission.ts
+++ b/apps/customer-portal/webapp/src/utils/permission.ts
@@ -67,6 +67,8 @@ function restrictivePermissions(): ProjectPermissions {
     showServiceHoursAllocationsCard: false,
     hasEngagements: false,
     hasUpdates: false,
+    hasComponentAnalysis: false,
+    hasUsageMetrics: false,
   };
 }
 
@@ -110,6 +112,8 @@ export function getProjectPermissions(
     showServiceHoursAllocationsCard: hasTimeLogs,
     hasEngagements: features.hasEngagementsReadAccess,
     hasUpdates: features.hasUpdatesReadAccess,
+    hasComponentAnalysis: features.hasComponentAnalysisReadAccess,
+    hasUsageMetrics: features.hasUsageMetricsReadAccess,
   };
 }
 


### PR DESCRIPTION
## Purpose
- Hide the Security Center sidebar item when both `hasSraReadAccess` and `hasComponentAnalysisReadAccess` are `false`. 
- Hide the Component Analysis tab within Security Center when `hasComponentAnalysisReadAccess` is `false`.
- Show Usage & Metrics only when both the global `usageMetricsEnabled` flag and the project-level `hasUsageMetricsReadAccess` flag are `true`.