### PR TITLE
[Customer Portal] [Frontend] Add missing ProjectFeatures fields to permission test helper

### DIFF
--- a/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
+++ b/apps/customer-portal/webapp/src/utils/__tests__/permission.test.ts
@@ -45,6 +45,8 @@ function buildProjectFeatures(
     hasTimeLogsReadAccess: false,
     hasDeploymentWriteAccess: false,
     hasDeploymentReadAccess: false,
+    hasComponentAnalysisReadAccess: false,
+    hasUsageMetricsReadAccess: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Purpose
- Added `hasComponentAnalysisReadAccess` and `hasUsageMetricsReadAccess` to the `buildProjectFeatures` test helper defaults in `permission.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test helper to support additional permission fields for improved test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/694)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->