### PR TITLE
[Customer Portal][Frontend] Hide Get Help button on Portal Access Required page

### DIFF
--- a/apps/customer-portal/webapp/src/components/header/Actions.tsx
+++ b/apps/customer-portal/webapp/src/components/header/Actions.tsx
@@ -28,6 +28,7 @@ import { useErrorPageContext } from "@context/error-page/ErrorPageContext";
 
 interface ActionsProps {
   showUserProfile?: boolean;
+  hideGetHelp?: boolean;
 }
 
 /**
@@ -38,6 +39,7 @@ interface ActionsProps {
  */
 export default function Actions({
   showUserProfile = true,
+  hideGetHelp = false,
 }: ActionsProps): JSX.Element {
   const location = useLocation();
   const { isProjectSuspended } = useErrorPageContext();
@@ -46,8 +48,8 @@ export default function Actions({
 
   return (
     <HeaderUI.Actions>
-      {/* Get Help dropdown (before theme switcher, not on project hub, public landing page, or suspended project) */}
-      {!isProjectHub && !isPublicLandingPage && !isProjectSuspended && <GetHelpDropdown />}
+      {/* Get Help dropdown (before theme switcher, not on project hub, public landing page, suspended project, or portal access error) */}
+      {!isProjectHub && !isPublicLandingPage && !isProjectSuspended && !hideGetHelp && <GetHelpDropdown />}
       {/* theme switcher */}
       <ColorSchemeToggle />
       {/* header action divider */}

--- a/apps/customer-portal/webapp/src/components/header/Header.tsx
+++ b/apps/customer-portal/webapp/src/components/header/Header.tsx
@@ -138,7 +138,7 @@ export default function Header({ onToggleSidebar, hideProjectControls = false }:
       {/* header spacer */}
       <HeaderUI.Spacer />
       {/* header action buttons */}
-      <Actions />
+      <Actions hideGetHelp={hideProjectControls} />
     </HeaderUI>
   );
 }


### PR DESCRIPTION
## Purpose
Hide Get Help button on Portal Access Required page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The "Get Help" dropdown in the header now has configurable visibility based on application context. This allows the help feature to be hidden when not needed, providing a cleaner, more contextual user interface. The feature now intelligently adapts to different views and project states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/696)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->