### PR TITLE
[Customer Portal][FE][WEB] Increase query staleTime of recommendations API to 10 minutes

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/api/useConversationRecommendationsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useConversationRecommendationsSearch.ts
@@ -86,6 +86,6 @@ export function useConversationRecommendationsSearch(
       payload.chatHistory.length > 0 &&
       isSignedIn &&
       !isAuthLoading,
-    staleTime: 0,
+    staleTime: 10 * 60 * 1000,
   });
 }


### PR DESCRIPTION
### Description

Update useConversationRecommendationsSearch to set React Query's staleTime from 0 to 10 minutes (10 * 60 * 1000 ms). This caches conversation recommendation results longer to reduce redundant network requests and improve performance/UX when users revisit the query.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced caching efficiency for support recommendation search results, reducing repeated data requests and improving load times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/697)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->