### PR TITLE
[Customer Portal][FE][Web] Forbid tables and code in description HTML

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/CaseCardDescriptionClamp.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/CaseCardDescriptionClamp.tsx
@@ -52,12 +52,6 @@ const baseHtmlSx: SxProps<Theme> = {
     color: "primary.main",
     textDecoration: "underline",
   },
-  "& code": {
-    display: "inline",
-    fontSize: "0.875rem",
-    whiteSpace: "pre-wrap",
-    overflowWrap: "break-word",
-  },
   // Prevent embedded rich-text images from expanding card width.
   "& img": {
     maxWidth: "100%",
@@ -114,6 +108,10 @@ export default function CaseCardDescriptionClamp({
       dangerouslySetInnerHTML={{
         __html: DOMPurify.sanitize(
           normalizeAnnouncementDescriptionHtml(description),
+          {
+            FORBID_TAGS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
+            FORBID_CONTENTS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
+          },
         ),
       }}
     />


### PR DESCRIPTION
### Description

Remove inline code styling and tighten DOMPurify sanitization for announcement descriptions by forbidding table-related elements and code/pre tags and contents. This prevents complex table markup or code blocks from breaking card layout or rendering unwanted rich content by using FORBID_TAGS and FORBID_CONTENTS for table, code and pre elements.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated case description display styling for improved presentation.

* **Bug Fixes**
  * Refined content filtering in case descriptions to restrict certain element types from displaying.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->