### PR TITLE
[Customer Portal][FE][Web] Add confirmation dialog for support case state changes

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/dialogs/CaseStateConfirmDialog.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/dialogs/CaseStateConfirmDialog.tsx
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type JSX } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+
+export interface CaseStateConfirmDialogProps {
+  open: boolean;
+  actionLabel: string;
+  isPending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function CaseStateConfirmDialog({
+  open,
+  actionLabel,
+  isPending,
+  onClose,
+  onConfirm,
+}: CaseStateConfirmDialogProps): JSX.Element {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle
+        sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+      >
+        Confirm State Change
+        <IconButton size="small" onClick={onClose} aria-label="close" disabled={isPending}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Are you sure you want to{" "}
+          <strong>{actionLabel.toLowerCase()}</strong> this case?
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={onConfirm}
+          disabled={isPending}
+          startIcon={
+            isPending ? <CircularProgress size={16} color="inherit" /> : undefined
+          }
+        >
+          {isPending ? "Updating…" : "Confirm"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/dialogs/CaseStateConfirmDialog.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/dialogs/CaseStateConfirmDialog.tsx
@@ -43,7 +43,7 @@ export default function CaseStateConfirmDialog({
   onConfirm,
 }: CaseStateConfirmDialogProps): JSX.Element {
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog open={open} onClose={isPending ? undefined : onClose} maxWidth="xs" fullWidth>
       <DialogTitle
         sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
       >

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -23,7 +23,7 @@ import {
   useTheme,
   type Theme,
 } from "@wso2/oxygen-ui";
-import CaseStateConfirmDialog from "./CaseStateConfirmDialog";
+import CaseStateConfirmDialog from "@features/support/components/case-details/dialogs/CaseStateConfirmDialog";
 import { type JSX, useState } from "react";
 import {
   CASE_STATUS_ACTIONS,

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -23,6 +23,7 @@ import {
   useTheme,
   type Theme,
 } from "@wso2/oxygen-ui";
+import CaseStateConfirmDialog from "./CaseStateConfirmDialog";
 import { type JSX, useState } from "react";
 import {
   CASE_STATUS_ACTIONS,
@@ -100,6 +101,10 @@ export default function CaseDetailsActionRow({
 
   const patchCase = usePatchCase(projectId, caseId);
   const [pendingActionLabel, setPendingActionLabel] = useState<string | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{
+    label: string;
+    stateKey: number;
+  } | null>(null);
 
   const availableActions = getAvailableCaseActions(statusLabel).filter(
     (label) => {
@@ -151,26 +156,7 @@ export default function CaseDetailsActionRow({
               isOpenRelatedCase
                 ? onOpenRelatedCase
                 : canPatch
-                  ? () => {
-                      setPendingActionLabel(label);
-                      patchCase.mutate(
-                        { stateKey: stateKey! },
-                        {
-                          onSuccess: () => {
-                            showSuccess("State updated successfully.");
-                          },
-                          onError: (err) => {
-                            showError(
-                              err?.message ??
-                                "Failed to update case status. Please try again.",
-                            );
-                          },
-                          onSettled: () => {
-                            setPendingActionLabel(null);
-                          },
-                        },
-                      );
-                    }
+                  ? () => setConfirmAction({ label, stateKey: stateKey! })
                   : undefined
             }
             sx={getActionButtonSx(theme, paletteIntent) as Record<string, unknown>}
@@ -181,6 +167,34 @@ export default function CaseDetailsActionRow({
           </Button>
         );
       })}
+      <CaseStateConfirmDialog
+        open={!!confirmAction}
+        actionLabel={confirmAction ? toPresentTenseActionLabel(confirmAction.label) : ""}
+        isPending={patchCase.isPending}
+        onClose={() => setConfirmAction(null)}
+        onConfirm={() => {
+          if (!confirmAction) return;
+          const { label, stateKey } = confirmAction;
+          setPendingActionLabel(label);
+          patchCase.mutate(
+            { stateKey },
+            {
+              onSuccess: () => {
+                showSuccess("State updated successfully.");
+              },
+              onError: (err) => {
+                showError(
+                  err?.message ?? "Failed to update case status. Please try again.",
+                );
+              },
+              onSettled: () => {
+                setPendingActionLabel(null);
+                setConfirmAction(null);
+              },
+            },
+          );
+        }}
+      />
     </Stack>
   );
 }


### PR DESCRIPTION
### Description

This pull request introduces a confirmation dialog when changing the state of a support case in the customer portal. The dialog prompts users to confirm their action before the state change is applied, improving user experience and preventing accidental changes. The main changes include the addition of a new `CaseStateConfirmDialog` component and its integration into the case details action row.

Closes (https://github.com/wso2-enterprise/digiops-cs/issues/1783)

**New confirmation dialog for case state changes:**

* Added a new `CaseStateConfirmDialog` component that displays a modal dialog to confirm state changes, including UI elements for confirmation, cancellation, and loading state. (`CaseStateConfirmDialog.tsx`)
* Integrated the `CaseStateConfirmDialog` into the `CaseDetailsActionRow` component, so that clicking a state change action now opens the confirmation dialog instead of immediately performing the action. [[1]](diffhunk://#diff-a67e5e6300c3cb0ddd28137d18c05748e3f294314086c9d8070940435b50d762R26) [[2]](diffhunk://#diff-a67e5e6300c3cb0ddd28137d18c05748e3f294314086c9d8070940435b50d762R104-R107) [[3]](diffhunk://#diff-a67e5e6300c3cb0ddd28137d18c05748e3f294314086c9d8070940435b50d762L154-R197)
* Updated the state management in `CaseDetailsActionRow` to handle dialog open/close, track the pending action, and ensure proper user feedback after confirming or canceling. [[1]](diffhunk://#diff-a67e5e6300c3cb0ddd28137d18c05748e3f294314086c9d8070940435b50d762R104-R107) [[2]](diffhunk://#diff-a67e5e6300c3cb0ddd28137d18c05748e3f294314086c9d8070940435b50d762L154-R197)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a confirmation dialog when changing support case status. Users can now review and confirm changes before they take effect.
* Loading indicator displays during status updates with real-time "Updating..." feedback.
* Users can cancel pending status changes from the confirmation dialog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->