### PR TITLE
[Customer Portal][FE][Web] support engagement type rendering in lists and details

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
@@ -41,6 +41,7 @@ export interface ListCardProps {
   caseItem: CaseListItem;
   onClick?: (caseItem: CaseListItem) => void;
   hideSeverity?: boolean;
+  showEngagementType?: boolean;
 }
 
 /**
@@ -54,6 +55,7 @@ export default function ListCard({
   caseItem,
   onClick,
   hideSeverity = false,
+  showEngagementType = false,
 }: ListCardProps): JSX.Element {
   const theme = useTheme();
   const colorPath = getStatusColor(caseItem.status?.label);
@@ -142,14 +144,23 @@ export default function ListCard({
                 {caseItem.status?.label || "--"}
               </Typography>
             </Stack>
-            {caseItem.issueType?.label && (
-              <Chip
-                size="small"
-                label={caseItem.issueType.label}
-                variant="outlined"
-                sx={{ height: 20, fontSize: "0.75rem" }}
-              />
-            )}
+            {showEngagementType
+              ? caseItem.engagementType?.label && (
+                  <Chip
+                    size="small"
+                    label={caseItem.engagementType.label}
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: "0.75rem" }}
+                  />
+                )
+              : caseItem.issueType?.label && (
+                  <Chip
+                    size="small"
+                    label={caseItem.issueType.label}
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: "0.75rem" }}
+                  />
+                )}
           </Stack>
         }
       />

--- a/apps/customer-portal/webapp/src/components/list-view/ListItems.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListItems.tsx
@@ -31,6 +31,7 @@ export interface ListItemsProps {
   onCaseClick?: (caseItem: CaseListItem) => void;
   entityName?: string;
   hideSeverity?: boolean;
+  showEngagementType?: boolean;
 }
 
 /**
@@ -47,6 +48,7 @@ export default function ListItems({
   onCaseClick,
   entityName = "items",
   hideSeverity = false,
+  showEngagementType = false,
 }: ListItemsProps): JSX.Element {
   if (isLoading) {
     return <ListSkeleton />;
@@ -120,6 +122,7 @@ export default function ListItems({
           caseItem={caseItem}
           onClick={onCaseClick}
           hideSeverity={hideSeverity}
+          showEngagementType={showEngagementType}
         />
       ))}
     </Box>

--- a/apps/customer-portal/webapp/src/features/engagements/components/EngagementsListSection.tsx
+++ b/apps/customer-portal/webapp/src/features/engagements/components/EngagementsListSection.tsx
@@ -165,6 +165,7 @@ export default function EngagementsListSection({
         entityName={ENGAGEMENTS_LIST_ENTITY_LABEL}
         onCaseClick={onCaseClick}
         hideSeverity
+        showEngagementType
       />
 
       <ListPagination

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -312,6 +312,11 @@ export default function CaseDetailsContent({
                     assignedEngineerLabel={
                       hideAssignedEngineer ? null : assignedEngineerLabel
                     }
+                    engagementTypeLabel={
+                      isEngagementRoute
+                        ? (data?.engagementType?.label ?? null)
+                        : null
+                    }
                     statusChipIcon={statusChipIcon}
                     statusChipSx={statusChipSx}
                     isLoading={isLoading}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -216,20 +216,38 @@ export default function CaseDetailsDetailsPanel({
               />
             </Box>
           )}
-          {(!isServiceRequest || data?.issueType) && (
-            <Box>
-              <Typography {...labelSx}>Category</Typography>
-              <Stack direction="row" alignItems="center" spacing={1}>
-                <Tag
-                  size={16}
-                  color={theme.palette.text.secondary}
-                  aria-hidden
-                />
-                <Typography {...valueSx}>
-                  {formatValue(data?.issueType)}
-                </Typography>
-              </Stack>
-            </Box>
+          {isEngagement ? (
+            data?.engagementType && (
+              <Box>
+                <Typography {...labelSx}>Engagement Type</Typography>
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <Tag
+                    size={16}
+                    color={theme.palette.text.secondary}
+                    aria-hidden
+                  />
+                  <Typography {...valueSx}>
+                    {formatValue(data.engagementType)}
+                  </Typography>
+                </Stack>
+              </Box>
+            )
+          ) : (
+            (!isServiceRequest || data?.issueType) && (
+              <Box>
+                <Typography {...labelSx}>Category</Typography>
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <Tag
+                    size={16}
+                    color={theme.palette.text.secondary}
+                    aria-hidden
+                  />
+                  <Typography {...valueSx}>
+                    {formatValue(data?.issueType)}
+                  </Typography>
+                </Stack>
+              </Box>
+            )
           )}
           {data?.createdBy ? (
             <Box>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsHeader.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsHeader.tsx
@@ -46,6 +46,7 @@ export default function CaseDetailsHeader({
   severityLabel,
   statusLabel,
   assignedEngineerLabel,
+  engagementTypeLabel,
   statusChipSx,
   isLoading = false,
   showSeverityChip = true,
@@ -96,6 +97,14 @@ export default function CaseDetailsHeader({
         <Typography variant="body2" fontWeight={500} color="text.primary">
           {formatValue(caseNumber)}
         </Typography>
+        {engagementTypeLabel && (
+          <Chip
+            label={engagementTypeLabel}
+            size="small"
+            variant="outlined"
+            sx={{ height: 20, fontSize: "0.75rem" }}
+          />
+        )}
         {showStatusChip && (
           <Stack direction="row" spacing={0.75} alignItems="center">
             <Box

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -155,6 +155,7 @@ export type CaseListItem = AuditMetadata & {
   assignedEngineer: string | IdLabelRef | null;
   project: IdLabelRef;
   issueType: IdLabelRef | null;
+  engagementType?: IdLabelRef | null;
   deployedProduct: IdLabelRef | null;
   deployment: IdLabelRef | null;
   severity: IdLabelRef | null;
@@ -219,6 +220,7 @@ export type CaseDetails = AuditMetadata & {
   relatedCase: IdLabelRef | null;
   conversation: IdLabelRef | null;
   issueType: IdLabelRef | null;
+  engagementType?: IdLabelRef | null;
   catalog?: IdLabelRef | null;
   catalogItem?: IdLabelRef | null;
   variables?: CaseVariable[];

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -49,6 +49,7 @@ export type CaseDetailsHeaderProps = {
   severityLabel: string | null | undefined;
   statusLabel: string | null | undefined;
   assignedEngineerLabel?: string | null;
+  engagementTypeLabel?: string | null;
   statusChipIcon: ReactNode;
   statusChipSx: Record<string, unknown>;
   isLoading?: boolean;


### PR DESCRIPTION
### Description

This pull request adds support for displaying the engagement type for cases and engagements throughout the customer portal UI. The main changes include updating types to include `engagementType`, updating list and detail components to show the engagement type when relevant, and passing the necessary props through the component hierarchy.

Closes(https://github.com/wso2-enterprise/digiops-cs/issues/1656)

**Type and Data Model Updates:**
- Added optional `engagementType` field to both `CaseListItem` and `CaseDetails` types to support engagement type data. [[1]](diffhunk://#diff-624c276530bd2d9bcc739ea2890edeb9311826df13dabd7a17a020bc14b50077R158) [[2]](diffhunk://#diff-624c276530bd2d9bcc739ea2890edeb9311826df13dabd7a17a020bc14b50077R223)

**List View Enhancements:**
- Updated `ListCard` and `ListItems` components to accept a new `showEngagementType` prop and conditionally display an engagement type chip instead of the issue type chip. [[1]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R44) [[2]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029R58) [[3]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029L145-R156) [[4]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271R34) [[5]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271R51) [[6]](diffhunk://#diff-c441200289b0df3452005bbaa344b848579dbedc426005f2f0ef2dac7d004271R125)
- Modified `EngagementsListSection` to enable `showEngagementType` when rendering engagement lists.

**Case Details Enhancements:**
- Updated `CaseDetailsHeader` and its props to support and display an engagement type chip. [[1]](diffhunk://#diff-b970ff3cd18f85aa8cbd1f6e3c5eda04e05a86e9f6d3db9b209ab331b0bda7b0R49) [[2]](diffhunk://#diff-b970ff3cd18f85aa8cbd1f6e3c5eda04e05a86e9f6d3db9b209ab331b0bda7b0R100-R107) [[3]](diffhunk://#diff-a1ce9daab3a74b8369f989255d631191ba17536b5bfb2e46711ace456783c1b7R52)
- Updated `CaseDetailsContent` to pass the engagement type label to the header when on an engagement route.
- Modified `CaseDetailsDetailsPanel` to show the engagement type field instead of the category when viewing an engagement. [[1]](diffhunk://#diff-315c8c98952805057dc9c2645745ed059602f597a0d00fd723a73953d722cda5L219-R236) [[2]](diffhunk://#diff-315c8c98952805057dc9c2645745ed059602f597a0d00fd723a73953d722cda5R250)