### PR TITLE
[Customer Portal][FE][web] Hide Edit Button for CS Integration Users in User Management

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
@@ -376,17 +376,19 @@ export default function SettingsUserManagement({
                           justifyContent: "flex-end",
                         }}
                       >
-                        <Tooltip title={SETTINGS_USER_EDIT_TOOLTIP}>
-                          <span>
-                            <IconButton
-                              size="small"
-                              aria-label="Edit user"
-                              onClick={() => setEditTarget(contact)}
-                            >
-                              <PencilLine size={16} />
-                            </IconButton>
-                          </span>
-                        </Tooltip>
+                        {!contact.isCsIntegrationUser && (
+                          <Tooltip title={SETTINGS_USER_EDIT_TOOLTIP}>
+                            <span>
+                              <IconButton
+                                size="small"
+                                aria-label="Edit user"
+                                onClick={() => setEditTarget(contact)}
+                              >
+                                <PencilLine size={16} />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                        )}
                         <Tooltip title={SETTINGS_USER_REMOVE_TOOLTIP}>
                           <span>
                             <IconButton


### PR DESCRIPTION
### Description

This pull request makes a small change to the `SettingsUserManagement` component to improve the user management UI. The edit button is now hidden for users who are CS Integration Users.

* The edit icon button is conditionally rendered so that it is only shown for users who are not CS Integration Users in `SettingsUserManagement.tsx`. [[1]](diffhunk://#diff-59aa840c26f204e75529833567f1c8dd97b300aba9b4061f4ecf9f2a9572d907R379) [[2]](diffhunk://#diff-59aa840c26f204e75529833567f1c8dd97b300aba9b4061f4ecf9f2a9572d907R391)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User management settings now restrict editing capabilities for integration user accounts. The edit action has been disabled for integration users within the user management interface, preventing direct modifications to these accounts. All other management operations, including account removal and other table features, remain fully functional.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->