### PR TITLE
[Customer Portal][FE][WEB][ Refactor HTML Sanitization to Use Shared Description Purify Config

### DIFF
--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
 import { ArrowLeft, Calendar, FileText } from "@wso2/oxygen-ui-icons-react";
+import { DESCRIPTION_PURIFY_CONFIG } from "@utils/common";
 import type { JSX } from "react";
 import CaseDetailsActionRow from "@features/support/components/case-details/header/CaseDetailsActionRow";
 import {
@@ -287,7 +288,7 @@ export default function AnnouncementDetailsPanel({
                 }}
                 // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized with DOMPurify
                 dangerouslySetInnerHTML={{
-                  __html: DOMPurify.sanitize(normalizedHtml),
+                  __html: DOMPurify.sanitize(normalizedHtml, DESCRIPTION_PURIFY_CONFIG),
                 }}
               />
             );

--- a/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestDetailsPage.tsx
@@ -17,6 +17,7 @@
 import { useParams, useNavigate, useLocation } from "react-router";
 import { type JSX, useMemo, useState } from "react";
 import DOMPurify from "dompurify";
+import { DESCRIPTION_PURIFY_CONFIG } from "@utils/common";
 import {
   Box,
   Button,
@@ -272,7 +273,7 @@ export default function ChangeRequestDetailsPage(): JSX.Element {
           "& p:last-child": { mb: 0 },
         }}
         // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized backend HTML content
-        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html, DESCRIPTION_PURIFY_CONFIG) }}
       />
     );
   };

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/conversation-summary-section/RelatedCaseSummary.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/conversation-summary-section/RelatedCaseSummary.tsx
@@ -19,6 +19,7 @@ import { Box, Divider, Paper, Typography } from "@wso2/oxygen-ui";
 import { FileText } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import DOMPurify from "dompurify";
+import { DESCRIPTION_PURIFY_CONFIG } from "@utils/common";
 
 /**
  * Sidebar component showing related case details when creating a case from "Open Related Case".
@@ -31,7 +32,7 @@ export function RelatedCaseSummary({
   title,
   description,
 }: RelatedCaseSummaryProps): JSX.Element {
-  const sanitizedDescription = DOMPurify.sanitize(description ?? "");
+  const sanitizedDescription = DOMPurify.sanitize(description ?? "", DESCRIPTION_PURIFY_CONFIG);
 
   return (
     <Paper sx={{ p: 3, position: "sticky", top: 3 }}>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -39,6 +39,7 @@ import {
 import { type JSX } from "react";
 import { Link, useLocation, useParams } from "react-router";
 import DOMPurify from "dompurify";
+import { DESCRIPTION_PURIFY_CONFIG } from "@utils/common";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import AssignedEngineerDisplay from "@case-details-details/AssignedEngineerDisplay";
 import CaseDetailsCard from "@case-details-details/CaseDetailsCard";
@@ -394,7 +395,7 @@ export default function CaseDetailsDetailsPanel({
               }}
               // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized with DOMPurify
               dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(data.description),
+                __html: DOMPurify.sanitize(data.description, DESCRIPTION_PURIFY_CONFIG),
               }}
             />
           ) : (

--- a/apps/customer-portal/webapp/src/features/updates/components/HtmlOrText.tsx
+++ b/apps/customer-portal/webapp/src/features/updates/components/HtmlOrText.tsx
@@ -17,7 +17,7 @@
 import { Box } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
 import type { JSX } from "react";
-import { stripLightModeInlineStyles } from "@utils/common";
+import { DESCRIPTION_PURIFY_CONFIG, stripLightModeInlineStyles } from "@utils/common";
 
 // Matches actual HTML formatting tags — not XML/config tag-like strings e.g. <Product_Home>.
 export const HTML_FORMAT_RE =
@@ -63,7 +63,7 @@ export function HtmlOrText({
     const stripped = isDark ? stripLightModeInlineStyles(content) : content;
     return (
       <Box
-        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(stripped) }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(stripped, DESCRIPTION_PURIFY_CONFIG) }}
         sx={HTML_CONTENT_SX}
       />
     );

--- a/apps/customer-portal/webapp/src/utils/common.ts
+++ b/apps/customer-portal/webapp/src/utils/common.ts
@@ -72,6 +72,12 @@ export function stripLightModeInlineStyles(html: string): string {
   );
 }
 
+/** DOMPurify config for backend description/body HTML: strips tables and code blocks. */
+export const DESCRIPTION_PURIFY_CONFIG = {
+  FORBID_TAGS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
+  FORBID_CONTENTS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
+};
+
 function isDarkColor(colorDecl: string): boolean {
   // Named dark colors
   if (/^color\s*:\s*(black|#000(000)?|#1[0-9a-f]{5}|#2[0-9a-f]{5})\s*$/.test(colorDecl))

--- a/apps/customer-portal/webapp/src/utils/common.ts
+++ b/apps/customer-portal/webapp/src/utils/common.ts
@@ -15,7 +15,18 @@
 // under the License.
 
 import type { UIEvent } from "react";
+import DOMPurify from "dompurify";
 import { PAGINATED_SELECT_MENU_MAX_HEIGHT_PX } from "@constants/common";
+
+// Harden all sanitized <a target="_blank"> links against reverse tabnabbing.
+// Registered once at module load; applies to every DOMPurify.sanitize() call in the app.
+if (typeof window !== "undefined") {
+  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    if (node.tagName === "A" && node.getAttribute("target") === "_blank") {
+      node.setAttribute("rel", "noopener noreferrer");
+    }
+  });
+}
 
 /**
  * MenuList props for paginated selects: fixed max height + optional scroll handler.


### PR DESCRIPTION
### Description

This pull request updates the way backend-provided HTML descriptions are sanitized throughout the customer portal webapp. It introduces a shared DOMPurify configuration, `DESCRIPTION_PURIFY_CONFIG`, which strips table and code block elements from HTML content. All components that render backend HTML now use this stricter configuration, improving security and consistency.

Closes(https://github.com/wso2-enterprise/digiops-cs/issues/1797)

**Sanitization improvements**

* Added `DESCRIPTION_PURIFY_CONFIG` to `@utils/common`, which configures DOMPurify to remove table and code block tags and their contents from HTML.
* Updated all usages of `DOMPurify.sanitize` in components rendering backend HTML (`AnnouncementDetailsPanel.tsx`, `ChangeRequestDetailsPage.tsx`, `RelatedCaseSummary.tsx`, `CaseDetailsDetailsPanel.tsx`, `HtmlOrText.tsx`) to use the new configuration. [[1]](diffhunk://#diff-c22b1772a5f43db7b9459085bc5ce8013b058e329638fd3c6502dbce10dc7cc2L290-R291) [[2]](diffhunk://#diff-32c6a03f9d2ecb2cbe28f75e6f50f136ecbc7727922c03ad3850472a1cf8bebbL275-R276) [[3]](diffhunk://#diff-fbbb93577db33c7db7e6680ad7fe139d5c1e606c2fefb80f03f91dab6e7a9e61L34-R35) [[4]](diffhunk://#diff-315c8c98952805057dc9c2645745ed059602f597a0d00fd723a73953d722cda5L397-R398) [[5]](diffhunk://#diff-f6c6dde3101545e894d03421d84b55f01d7e2d34f78cb2f620dae8f85161d4cbL66-R66)

**Imports and code organization**

* Added imports of `DESCRIPTION_PURIFY_CONFIG` to relevant files to support the new sanitization approach. [[1]](diffhunk://#diff-c22b1772a5f43db7b9459085bc5ce8013b058e329638fd3c6502dbce10dc7cc2R28) [[2]](diffhunk://#diff-32c6a03f9d2ecb2cbe28f75e6f50f136ecbc7727922c03ad3850472a1cf8bebbR20) [[3]](diffhunk://#diff-fbbb93577db33c7db7e6680ad7fe139d5c1e606c2fefb80f03f91dab6e7a9e61R22) [[4]](diffhunk://#diff-315c8c98952805057dc9c2645745ed059602f597a0d00fd723a73953d722cda5R42) [[5]](diffhunk://#diff-f6c6dde3101545e894d03421d84b55f01d7e2d34f78cb2f620dae8f85161d4cbL20-R20)