### PR TITLE
[Customer Portal][FE][Web] Replace createdOn with updatedOn for Sorting, Labels, and UI Display

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
@@ -213,7 +213,7 @@ export default function ListCard({
               color="text.secondary"
               sx={{ lineHeight: 1, overflowWrap: "anywhere" }}
             >
-              Created {formatDateTime(caseItem.createdOn) || "--"}
+              Updated {formatDateTime(caseItem.updatedOn ?? caseItem.createdOn) || "--"}
             </Typography>
           </Box>
           {caseItem.createdBy && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -113,7 +113,7 @@ export default function AnnouncementDetailsPanel({
   const statusLabel = data.status?.label;
   const statusColorPath = getStatusColor(statusLabel ?? undefined);
   const resolvedStatusColor = resolveColorFromTheme(statusColorPath, theme);
-  const createdOnLabel = formatAnnouncementDateDisplay(data.createdOn);
+  const updatedOnLabel = formatAnnouncementDateDisplay(data.updatedOn);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -222,7 +222,7 @@ export default function AnnouncementDetailsPanel({
               aria-hidden
             />
             <Typography variant="body2" color="text.secondary">
-              {createdOnLabel}
+              {updatedOnLabel}
             </Typography>
           </Stack>
           {data.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -113,7 +113,9 @@ export default function AnnouncementDetailsPanel({
   const statusLabel = data.status?.label;
   const statusColorPath = getStatusColor(statusLabel ?? undefined);
   const resolvedStatusColor = resolveColorFromTheme(statusColorPath, theme);
-  const updatedOnLabel = formatAnnouncementDateDisplay(data.updatedOn);
+  const updatedOnLabel = formatAnnouncementDateDisplay(
+    data.updatedOn ?? data.createdOn,
+  );
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -96,7 +96,9 @@ export default function AnnouncementList({
         const statusLabel = caseItem.status?.label;
         const statusColor = getStatusColor(statusLabel);
         const resolvedStatusColor = resolveColorFromTheme(statusColor, theme);
-        const updatedOnLabel = formatAnnouncementDateDisplay(caseItem.updatedOn);
+        const updatedOnLabel = formatAnnouncementDateDisplay(
+          caseItem.updatedOn ?? caseItem.createdOn,
+        );
 
         const cardContent = (
           <>

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -96,7 +96,7 @@ export default function AnnouncementList({
         const statusLabel = caseItem.status?.label;
         const statusColor = getStatusColor(statusLabel);
         const resolvedStatusColor = resolveColorFromTheme(statusColor, theme);
-        const createdOnLabel = formatAnnouncementDateDisplay(caseItem.createdOn);
+        const updatedOnLabel = formatAnnouncementDateDisplay(caseItem.updatedOn);
 
         const cardContent = (
           <>
@@ -193,7 +193,7 @@ export default function AnnouncementList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    Created {createdOnLabel}
+                    Updated {updatedOnLabel}
                   </Typography>
                 </Box>
                 {caseItem.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/constants/announcementsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/constants/announcementsConstants.ts
@@ -38,8 +38,8 @@ export const ANNOUNCEMENTS_SEARCH_PLACEHOLDER = "Search announcements...";
 /** Entity label for results bar and pagination copy. */
 export const ANNOUNCEMENTS_LIST_ENTITY_LABEL = "announcements";
 
-/** Sort row: label for created date column. */
-export const ANNOUNCEMENTS_SORT_CREATED_LABEL = "Created date";
+/** Sort row: label for updated date column. */
+export const ANNOUNCEMENTS_SORT_UPDATED_LABEL = "Updated date";
 
 /** Sort row: label for state column. */
 export const ANNOUNCEMENTS_SORT_STATE_LABEL = "Status";
@@ -47,8 +47,8 @@ export const ANNOUNCEMENTS_SORT_STATE_LABEL = "Status";
 /** Options passed to `ListResultsBar`. */
 export const ANNOUNCEMENTS_SORT_FIELD_OPTIONS: AnnouncementSortOption[] = [
   {
-    value: AnnouncementSortField.CreatedOn,
-    label: ANNOUNCEMENTS_SORT_CREATED_LABEL,
+    value: AnnouncementSortField.UpdatedOn,
+    label: ANNOUNCEMENTS_SORT_UPDATED_LABEL,
     kind: "chronological",
   },
   {

--- a/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementsPage.tsx
@@ -67,7 +67,7 @@ export default function AnnouncementsPage(): JSX.Element {
   const [filters, setFilters] = useSessionState<AnnouncementFilterValues>(`${sessionPrefix}-filters`, {}, undefined, { popOnly: true });
   const [sortField, setSortField] = useSessionState<AnnouncementSortField>(
     `${sessionPrefix}-sortField`,
-    AnnouncementSortField.CreatedOn,
+    AnnouncementSortField.UpdatedOn,
     isValidAnnouncementSortField,
     { popOnly: true },
   );

--- a/apps/customer-portal/webapp/src/features/announcements/types/announcements.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/types/announcements.ts
@@ -22,7 +22,7 @@ export type { AnnouncementFilterValues };
 
 /** API `sortBy.field` for announcements list. */
 export enum AnnouncementSortField {
-  CreatedOn = "createdOn",
+  UpdatedOn = "updatedOn",
   State = "state",
 }
 

--- a/apps/customer-portal/webapp/src/features/announcements/utils/__tests__/announcements.test.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/utils/__tests__/announcements.test.ts
@@ -35,7 +35,7 @@ describe("buildAnnouncementCaseSearchRequest", () => {
     expect(req.filters?.caseTypes).toEqual([CaseType.ANNOUNCEMENT]);
     expect(req.filters?.statusIds).toEqual([5]);
     expect(req.filters?.searchQuery).toBe("hello");
-    expect(req.sortBy?.field).toBe("createdOn");
+    expect(req.sortBy?.field).toBe("updatedOn");
     expect(req.sortBy?.order).toBe(SortOrder.ASC);
   });
 

--- a/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
@@ -47,7 +47,7 @@ export function buildAnnouncementCaseSearchRequest(
   filters: AnnouncementFilterValues,
   searchTerm: string,
   sortOrder: SortOrder,
-  sortField: AnnouncementSortField = AnnouncementSortField.CreatedOn,
+  sortField: AnnouncementSortField = AnnouncementSortField.UpdatedOn,
 ): Omit<CaseSearchRequest, "pagination"> {
   return {
     filters: {

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
@@ -63,7 +63,7 @@ const CasesList = ({
         <Table sx={{ minWidth: { xs: 480, sm: 650 } }}>
           <TableHead>
             <TableRow>
-              <TableCell>Created</TableCell>
+              <TableCell>Updated</TableCell>
               <TableCell sx={{ maxWidth: 320 }}>Details</TableCell>
               <TableCell>Severity</TableCell>
               <TableCell align="center">Assigned to</TableCell>
@@ -158,21 +158,27 @@ const CasesList = ({
                         <TableCell>
                           <Box>
                             <Typography variant="body2" color="text.primary">
-                              {formatBackendTimestampForDisplay(row.createdOn, {
-                                month: "short",
-                                day: "numeric",
-                                year: "numeric",
-                              }) ?? "--"}
+                              {formatBackendTimestampForDisplay(
+                                row.updatedOn ?? row.createdOn,
+                                {
+                                  month: "short",
+                                  day: "numeric",
+                                  year: "numeric",
+                                },
+                              ) ?? "--"}
                             </Typography>
                             <Typography
                               variant="caption"
                               color="text.secondary"
                             >
-                              {formatBackendTimestampForDisplay(row.createdOn, {
-                                hour: "numeric",
-                                minute: "2-digit",
-                                hour12: true,
-                              }) ?? ""}
+                              {formatBackendTimestampForDisplay(
+                                row.updatedOn ?? row.createdOn,
+                                {
+                                  hour: "numeric",
+                                  minute: "2-digit",
+                                  hour12: true,
+                                },
+                              ) ?? ""}
                             </Typography>
                           </Box>
                         </TableCell>

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
@@ -196,7 +196,7 @@ const CasesTable = ({
           : undefined,
       },
       sortBy: {
-        field: "createdOn",
+        field: "updatedOn",
         order: SortOrder.DESC,
       },
     };

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTable.test.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTable.test.tsx
@@ -156,7 +156,7 @@ describe("CasesTable", () => {
     expect(mockUseGetProjectCasesPage).toHaveBeenCalledWith(
       mockProjectId,
       expect.objectContaining({
-        sortBy: { field: "createdOn", order: "desc" },
+        sortBy: { field: "updatedOn", order: "desc" },
       }),
       expect.any(Number),
       expect.any(Number),

--- a/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
@@ -46,6 +46,7 @@ import {
   CaseStatus,
 } from "@features/support/constants/supportConstants";
 import { getLast30DaysUtcRange } from "@features/support/utils/support";
+import { SortOrder } from "@/types/common";
 import ListPageHeader from "@components/list-view/ListPageHeader";
 import ListItems from "@components/list-view/ListItems";
 import ChangeRequestsList from "@features/operations/components/change-requests/ChangeRequestsList";
@@ -159,6 +160,11 @@ export default function DashboardItemsPage({
     [mode],
   );
 
+  const listSortBy = useMemo(
+    () => ({ field: "updatedOn" as const, order: SortOrder.DESC }),
+    [],
+  );
+
   // --- Data fetching (10 items each — single-page query, never loads more) ---
   const {
     data: casesQueryData,
@@ -172,6 +178,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -190,6 +197,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -208,6 +216,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -226,6 +235,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -243,6 +253,7 @@ export default function DashboardItemsPage({
         stateKeys: crStateKeys ?? [],
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,

--- a/apps/customer-portal/webapp/src/features/engagements/constants/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/constants/engagements.ts
@@ -69,7 +69,7 @@ export const ENGAGEMENTS_STAT_CARDS_CONFIG: SupportStatConfig<EngagementsStatKey
 
 /** Sort dropdown options (value ↔ API field). */
 export const ENGAGEMENTS_SORT_OPTIONS: readonly EngagementsSortOption[] = [
-  { value: EngagementsSortField.CreatedOn, label: "Created on" },
   { value: EngagementsSortField.UpdatedOn, label: "Updated on" },
+  { value: EngagementsSortField.CreatedOn, label: "Created on" },
   { value: EngagementsSortField.State, label: "Status" },
 ];

--- a/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
@@ -75,7 +75,7 @@ export function useEngagementsPageState() {
     hasListSearchOrFilters(searchTerm, filters),
   );
   const [sortField, setSortField] = useState<EngagementsSortField>(
-    EngagementsSortField.CreatedOn,
+    EngagementsSortField.UpdatedOn,
   );
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.DESC);
   const [page, setPage] = useState(1);

--- a/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
@@ -27,9 +27,9 @@ import {
 } from "@features/engagements/utils/engagements";
 
 describe("parseEngagementsSortField", () => {
-  it("returns CreatedOn for unknown values", () => {
+  it("returns UpdatedOn for unknown values", () => {
     expect(parseEngagementsSortField("unknown")).toBe(
-      EngagementsSortField.CreatedOn,
+      EngagementsSortField.UpdatedOn,
     );
   });
 
@@ -39,9 +39,9 @@ describe("parseEngagementsSortField", () => {
     );
   });
 
-  it("maps legacy Severity sort to CreatedOn", () => {
+  it("maps legacy Severity sort to UpdatedOn", () => {
     expect(parseEngagementsSortField(EngagementsSortField.Severity)).toBe(
-      EngagementsSortField.CreatedOn,
+      EngagementsSortField.UpdatedOn,
     );
   });
 });
@@ -51,11 +51,11 @@ describe("buildEngagementSearchRequest", () => {
     const req = buildEngagementSearchRequest(
       {},
       "",
-      EngagementsSortField.CreatedOn,
+      EngagementsSortField.UpdatedOn,
       SortOrder.DESC,
     );
     expect(req.filters?.caseTypes).toEqual([CaseType.ENGAGEMENT]);
-    expect(req.sortBy?.field).toBe(EngagementsSortField.CreatedOn);
+    expect(req.sortBy?.field).toBe(EngagementsSortField.UpdatedOn);
     expect(req.sortBy?.order).toBe(SortOrder.DESC);
   });
 
@@ -69,14 +69,14 @@ describe("buildEngagementSearchRequest", () => {
     expect(req.filters?.severityId).toBeUndefined();
   });
 
-  it("normalizes legacy Severity sort field to CreatedOn in API payload", () => {
+  it("normalizes legacy Severity sort field to UpdatedOn in API payload", () => {
     const req = buildEngagementSearchRequest(
       {},
       "",
       EngagementsSortField.Severity,
       SortOrder.DESC,
     );
-    expect(req.sortBy?.field).toBe(EngagementsSortField.CreatedOn);
+    expect(req.sortBy?.field).toBe(EngagementsSortField.UpdatedOn);
   });
 });
 

--- a/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
@@ -47,9 +47,9 @@ export function parseEngagementsSortField(value: string): EngagementsSortField {
     case EngagementsSortField.State:
       return value;
     case EngagementsSortField.Severity:
-      return EngagementsSortField.CreatedOn;
+      return EngagementsSortField.UpdatedOn;
     default:
-      return EngagementsSortField.CreatedOn;
+      return EngagementsSortField.UpdatedOn;
   }
 }
 
@@ -70,7 +70,7 @@ export function buildEngagementSearchRequest(
 ): Omit<CaseSearchRequest, "pagination"> {
   const normalizedSortField =
     sortField === EngagementsSortField.Severity
-      ? EngagementsSortField.CreatedOn
+      ? EngagementsSortField.UpdatedOn
       : sortField;
 
   return {

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
@@ -30,7 +30,7 @@ import {
 } from "@features/operations/utils/changeRequestUi";
 import type { ChangeRequestsListProps } from "@features/operations/types/changeRequests";
 import {
-  CHANGE_REQUESTS_LIST_CREATED_PREFIX,
+  CHANGE_REQUESTS_LIST_UPDATED_PREFIX,
   CHANGE_REQUESTS_LIST_EMPTY_DEFAULT_MESSAGE,
   CHANGE_REQUESTS_LIST_EMPTY_REFINED_MESSAGE,
   CHANGE_REQUESTS_LIST_ERROR_MESSAGE,
@@ -319,7 +319,7 @@ export default function ChangeRequestsList({
                     </Typography>
                   </Box>
                 )}
-                {item.createdOn && (
+                {(item.updatedOn ?? item.createdOn) && (
                   <Box
                     sx={{
                       display: "flex",
@@ -328,14 +328,14 @@ export default function ChangeRequestsList({
                     }}
                   >
                     <Typography variant="body2" color="text.secondary">
-                      {CHANGE_REQUESTS_LIST_CREATED_PREFIX}
+                      {CHANGE_REQUESTS_LIST_UPDATED_PREFIX}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {formatDateTime(item.createdOn)}
+                      {formatDateTime(item.updatedOn ?? item.createdOn)}
                     </Typography>
                   </Box>
                 )}
-                {item.createdOn && (item.startDate || item.endDate) && (
+                {(item.updatedOn ?? item.createdOn) && (item.startDate || item.endDate) && (
                   <Typography variant="body2" color="text.disabled">
                     |
                   </Typography>

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
@@ -232,7 +232,7 @@ export default function ServiceRequestsList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    {formatDateTime(sr.createdOn) || NULL_PLACEHOLDER}
+                    {formatDateTime(sr.updatedOn ?? sr.createdOn) || NULL_PLACEHOLDER}
                   </Typography>
                 </Box>
                 {environmentLabel && (

--- a/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
@@ -268,7 +268,7 @@ export const CHANGE_REQUESTS_LIST_PLACEHOLDER = "Not Available";
 
 export const CHANGE_REQUESTS_LIST_SR_PREFIX = "SR:";
 
-export const CHANGE_REQUESTS_LIST_CREATED_PREFIX = "Created:";
+export const CHANGE_REQUESTS_LIST_UPDATED_PREFIX = "Updated:";
 
 export const CHANGE_REQUESTS_LIST_SERVICE_OUTAGE_LABEL = "Service Outage";
 
@@ -328,13 +328,13 @@ export type ServiceRequestSortFieldOption = {
 export const SERVICE_REQUESTS_SORT_FIELD_OPTIONS: ServiceRequestSortFieldOption[] =
   [
     {
-      value: ServiceRequestCaseSortField.CreatedOn,
-      label: "Created on",
+      value: ServiceRequestCaseSortField.UpdatedOn,
+      label: "Updated on",
       kind: "chronological",
     },
     {
-      value: ServiceRequestCaseSortField.UpdatedOn,
-      label: "Updated on",
+      value: ServiceRequestCaseSortField.CreatedOn,
+      label: "Created on",
       kind: "chronological",
     },
     {

--- a/apps/customer-portal/webapp/src/features/operations/pages/OperationsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/OperationsPage.tsx
@@ -54,6 +54,7 @@ import {
   OPERATIONS_HUB_STAT_ENTITY_NAME,
 } from "@features/operations/constants/operationsConstants";
 import {
+  buildChangeRequestSearchRequest,
   formatOperationsOverviewChangeRequestsSubtitle,
   formatOperationsOverviewServiceRequestsSubtitle,
   resolveOutstandingCrStateIds,
@@ -111,6 +112,19 @@ export default function OperationsPage(): JSX.Element {
     [filterMetadata?.changeRequestStates],
   );
 
+  const changeRequestOverviewSearchRequest = useMemo(
+    () =>
+      buildChangeRequestSearchRequest(
+        {},
+        "",
+        true,
+        false,
+        false,
+        filterMetadata?.changeRequestStates,
+      ),
+    [filterMetadata?.changeRequestStates],
+  );
+
   const {
     data: srData,
     isLoading: isSrDataLoading,
@@ -122,7 +136,7 @@ export default function OperationsPage(): JSX.Element {
         caseTypes: [CaseType.SERVICE_REQUEST],
         statusIds: nonClosedStatusIds,
       },
-      sortBy: { field: "createdOn", order: SortOrder.DESC },
+      sortBy: { field: "updatedOn", order: SortOrder.DESC },
     },
     0,
     OPERATIONS_OVERVIEW_LIST_LIMIT,
@@ -144,11 +158,7 @@ export default function OperationsPage(): JSX.Element {
     isError: isCrError,
   } = useGetChangeRequests(
     projectId || "",
-    {
-      filters: {
-        stateKeys: outstandingCrStateIds ?? [],
-      },
-    },
+    changeRequestOverviewSearchRequest,
     0,
     OPERATIONS_OVERVIEW_LIST_LIMIT,
     {

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
@@ -100,7 +100,7 @@ export default function ServiceRequestsPage(): JSX.Element {
   const [isFiltersOpen, setIsFiltersOpen] = useState(
     () => hasListSearchOrFilters(searchTerm, filters),
   );
-  const [sortField, setSortField] = useSessionState<ServiceRequestCaseSortField>(`${sessionPrefix}-sortField`, ServiceRequestCaseSortField.CreatedOn, undefined, { popOnly: true });
+  const [sortField, setSortField] = useSessionState<ServiceRequestCaseSortField>(`${sessionPrefix}-sortField`, ServiceRequestCaseSortField.UpdatedOn, undefined, { popOnly: true });
   const [sortOrder, setSortOrder] = useSessionState<SortOrder>(`${sessionPrefix}-sortOrder`, SortOrder.DESC, undefined, { popOnly: true });
   const [page, setPage] = useSessionState<number>(`${sessionPrefix}-page`, 1, undefined, { popOnly: true });
   const [rowsPerPage, setRowsPerPage] = useSessionState<number>(`${sessionPrefix}-rowsPerPage`, OPERATIONS_LIST_PAGE_SIZE, undefined, { popOnly: true });

--- a/apps/customer-portal/webapp/src/features/operations/types/changeRequests.ts
+++ b/apps/customer-portal/webapp/src/features/operations/types/changeRequests.ts
@@ -102,6 +102,12 @@ export type ChangeRequestFilterValues = {
   impactId?: string;
 };
 
+/** Change request list sort field for search API `sortBy.field`. */
+export enum ChangeRequestSortField {
+  UpdatedOn = "updatedOn",
+  CreatedOn = "createdOn",
+}
+
 // Filter type for searching change requests.
 export type ChangeRequestSearchFilters = {
   impactKey?: number;

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
@@ -196,6 +196,12 @@ describe("buildChangeRequestSearchRequest", () => {
     expect(req.filters?.stateKeys).not.toContain(-4);
     expect(req.filters?.stateKeys).not.toContain(-3);
   });
+
+  it("sorts by updatedOn descending", () => {
+    const req = buildChangeRequestSearchRequest({}, "", false, false, false, allStates);
+    expect(req.sortBy?.field).toBe("updatedOn");
+    expect(req.sortBy?.order).toBe("desc");
+  });
 });
 
 describe("resolveChangeRequestFilterListOptions", () => {
@@ -245,12 +251,12 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
     const req = buildServiceRequestsPageCaseSearchRequest(
       {},
       "",
-      ServiceRequestCaseSortField.CreatedOn,
+      ServiceRequestCaseSortField.UpdatedOn,
       SortOrder.DESC,
       false,
     );
     expect(req.filters?.caseTypes).toEqual([CaseType.SERVICE_REQUEST]);
-    expect(req.sortBy?.field).toBe("createdOn");
+    expect(req.sortBy?.field).toBe("updatedOn");
   });
 
   it("does not send severity filter", () => {
@@ -264,7 +270,7 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
     expect(req.filters?.severityId).toBeUndefined();
   });
 
-  it("normalizes legacy Severity sort field to CreatedOn in API payload", () => {
+  it("normalizes legacy Severity sort field to UpdatedOn in API payload", () => {
     const req = buildServiceRequestsPageCaseSearchRequest(
       {},
       "",
@@ -272,7 +278,7 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
       SortOrder.DESC,
       false,
     );
-    expect(req.sortBy?.field).toBe(ServiceRequestCaseSortField.CreatedOn);
+    expect(req.sortBy?.field).toBe(ServiceRequestCaseSortField.UpdatedOn);
   });
 });
 

--- a/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
@@ -27,6 +27,7 @@ import type {
 } from "@features/operations/types/changeRequests";
 import {
   ChangeRequestFilterDefinitionId,
+  ChangeRequestSortField,
   type ChangeRequestFilterOption,
 } from "@features/operations/types/changeRequests";
 import {
@@ -34,7 +35,8 @@ import {
   ServiceRequestCaseSortField,
 } from "@features/operations/types/serviceRequests";
 import { ChangeRequestStates } from "@features/operations/constants/operationsConstants";
-import type { MetadataItem, SortOrder } from "@/types/common";
+import { SortOrder } from "@/types/common";
+import type { MetadataItem } from "@/types/common";
 
 /**
  * Resolves `operations` vs `support` from the current pathname.
@@ -222,6 +224,10 @@ export function buildChangeRequestSearchRequest(
       stateKeys,
       impactKey: filters.impactId ? Number(filters.impactId) : undefined,
     },
+    sortBy: {
+      field: ChangeRequestSortField.UpdatedOn,
+      order: SortOrder.DESC,
+    },
   };
 }
 
@@ -284,7 +290,7 @@ export function buildServiceRequestsPageCaseSearchRequest(
 ): Omit<CaseSearchRequest, "pagination"> {
   const normalizedSortField =
     sortField === ServiceRequestCaseSortField.Severity
-      ? ServiceRequestCaseSortField.CreatedOn
+      ? ServiceRequestCaseSortField.UpdatedOn
       : sortField;
 
   const resolvedStatusIds: number[] | undefined = filters.statusId

--- a/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
@@ -107,7 +107,7 @@ const SecurityReportAnalysis = ({ fixedStatusIds, fixedClosedDateRange }: Securi
   const [filters, setFilters] = useSessionState<AllCasesFilterValues>(`${sessionPrefix}-filters`, {}, undefined, { popOnly: true });
   const [sortField, setSortField] = useSessionState<SecurityReportCaseSortField>(
     `${sessionPrefix}-sortField`,
-    SecurityReportCaseSortField.createdOn,
+    SecurityReportCaseSortField.updatedOn,
     isValidSecuritySortField,
     { popOnly: true },
   );

--- a/apps/customer-portal/webapp/src/features/security/constants/securityConstants.ts
+++ b/apps/customer-portal/webapp/src/features/security/constants/securityConstants.ts
@@ -124,8 +124,8 @@ export const SECURITY_REPORT_VIEW_TABS = [
 ] as const;
 
 export const SECURITY_REPORT_SORT_OPTIONS = [
-  { value: "createdOn", label: "Created date", kind: "chronological" },
   { value: "updatedOn", label: "Updated date", kind: "chronological" },
+  { value: "createdOn", label: "Created date", kind: "chronological" },
   { value: "state", label: "Status", kind: "ordinal" },
 ] as const;
 

--- a/apps/customer-portal/webapp/src/features/security/utils/securityPage.ts
+++ b/apps/customer-portal/webapp/src/features/security/utils/securityPage.ts
@@ -76,6 +76,6 @@ export function parseSecurityReportCaseSortField(
     case SecurityReportCaseSortField.state:
       return SecurityReportCaseSortField.state;
     default:
-      return SecurityReportCaseSortField.createdOn;
+      return SecurityReportCaseSortField.updatedOn;
   }
 }

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
@@ -260,7 +260,7 @@ export default function OutstandingCasesList({
                   color="text.secondary"
                   sx={{ flexShrink: 0 }}
                 >
-                  {formatRelativeTime(c.createdOn ?? undefined)}
+                  {formatRelativeTime(c.updatedOn ?? undefined)}
                 </Typography>
               </Box>
             </Form.CardActions>

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
@@ -260,7 +260,7 @@ export default function OutstandingCasesList({
                   color="text.secondary"
                   sx={{ flexShrink: 0 }}
                 >
-                  {formatRelativeTime(c.updatedOn ?? undefined)}
+                  {formatRelativeTime(c.updatedOn ?? c.createdOn ?? undefined)}
                 </Typography>
               </Box>
             </Form.CardActions>

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -88,7 +88,7 @@ export default function AllCasesPage(): JSX.Element {
   const [isFiltersOpen, setIsFiltersOpen] = useState(
     () => hasListSearchOrFilters(searchTerm, filters),
   );
-  const [sortField, setSortField] = useSessionState<"createdOn" | "updatedOn" | "severity" | "state">(`${sessionPrefix}-sortField`, "createdOn", undefined, { popOnly: true });
+  const [sortField, setSortField] = useSessionState<"createdOn" | "updatedOn" | "severity" | "state">(`${sessionPrefix}-sortField`, "updatedOn", undefined, { popOnly: true });
   const [sortOrder, setSortOrder] = useSessionState<SortOrder>(`${sessionPrefix}-sortOrder`, SortOrder.DESC, undefined, { popOnly: true });
   const [page, setPage] = useSessionState<number>(`${sessionPrefix}-page`, 1, undefined, { popOnly: true });
   const [rowsPerPage, setRowsPerPage] = useSessionState<number>(`${sessionPrefix}-rowsPerPage`, 10, undefined, { popOnly: true });
@@ -369,8 +369,8 @@ export default function AllCasesPage(): JSX.Element {
         totalCount={totalItems}
         entityLabel="cases"
         sortFieldOptions={[
-          { value: "createdOn", label: "Created on" },
           { value: "updatedOn", label: "Updated on" },
+          { value: "createdOn", label: "Created on" },
           { value: "severity", label: "Severity", kind: "ordinal" as const },
           { value: "state", label: "Status", kind: "ordinal" as const },
         ]}

--- a/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
@@ -94,7 +94,7 @@ export default function SupportPage(): JSX.Element {
         caseTypes: [CaseType.DEFAULT_CASE],
         statusIds: nonClosedStatusIds,
       },
-      sortBy: { field: "createdOn", order: SortOrder.DESC },
+      sortBy: { field: "updatedOn", order: SortOrder.DESC },
     },
     0,
     SUPPORT_OVERVIEW_CASES_LIMIT,


### PR DESCRIPTION
### Description

This pull request updates the customer portal to consistently use "updated on" (last modified date) instead of "created on" (creation date) as the primary sort field, display label, and default for cases, announcements, and engagements. This change impacts UI labels, sorting logic, API requests, and test cases to ensure users see the most recently updated items first and that all relevant components reflect this updated behavior.

Key changes include:

**UI and Display Updates:**
* All relevant labels and table headers in the UI now display "Updated" or "Updated date" instead of "Created" or "Created date" for cases, announcements, and engagements. [[1]](diffhunk://#diff-2472fac5a57af1717cc0a21b184bcabe58ef428a8fa6d58c8c8cbea28e0bca92L66-R66) [[2]](diffhunk://#diff-8b06f4a6f812c25f1561eccc1b21d502757cabc7d30d54c6aa968858ac252f37L196-R196) [[3]](diffhunk://#diff-befd6535effcb3a9d86aae507cdd52d41174fa661dae300a1cdcb8192b20c36dL41-R51) [[4]](diffhunk://#diff-1971d0cad75b493093dc45879afda9b302cfdcefa872b69c29181bbc35cdade7L72-R73)
* Updated date values (`updatedOn ?? createdOn`) are now shown in list cards, tables, and detail panels for cases and announcements. [[1]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029L216-R216) [[2]](diffhunk://#diff-8b06f4a6f812c25f1561eccc1b21d502757cabc7d30d54c6aa968858ac252f37L196-R196) [[3]](diffhunk://#diff-c22b1772a5f43db7b9459085bc5ce8013b058e329638fd3c6502dbce10dc7cc2L225-R225) [[4]](diffhunk://#diff-2472fac5a57af1717cc0a21b184bcabe58ef428a8fa6d58c8c8cbea28e0bca92L161-R181) [[5]](diffhunk://#diff-4e57ef6a36604b02bea328a8860c0fc5951345d1ee5fecb12c51ddd0066d2e85L322-R322)

**Sorting and Default Behavior:**
* The default sort field for announcements, cases, and engagements is now `updatedOn` instead of `createdOn`, both in UI state and API request payloads. [[1]](diffhunk://#diff-53faa8076743442e2deefa756c174de5697874c8e26d3c824cbef5f5b865f93aL70-R70) [[2]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cL199-R199) [[3]](diffhunk://#diff-26a2c2a9f0ea16955b11c20612f66aac8a4c7044371ff95e04c374393eb9e76fL78-R78) [[4]](diffhunk://#diff-8b06f4a6f812c25f1561eccc1b21d502757cabc7d30d54c6aa968858ac252f37L99-R99) [[5]](diffhunk://#diff-50932782d65dd33593d04c6f500b62d52300a2dd89159d9a007e5be44899d037L50-R50) [[6]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77L54-R58) [[7]](diffhunk://#diff-feacbcb4059727622d3882bd6fbe51920c41e4ac14ae8c9708194fb5033414ebL73-R73) [[8]](diffhunk://#diff-cda7965095932ea3788027824b371a97c999333cb8b66e0963e987de7d2598c8R163-R167)
* All API requests and hooks that previously sent or expected `createdOn` as the sort field now use `updatedOn`. [[1]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cL199-R199) [[2]](diffhunk://#diff-cda7965095932ea3788027824b371a97c999333cb8b66e0963e987de7d2598c8R181) [[3]](diffhunk://#diff-cda7965095932ea3788027824b371a97c999333cb8b66e0963e987de7d2598c8R200) [[4]](diffhunk://#diff-cda7965095932ea3788027824b371a97c999333cb8b66e0963e987de7d2598c8R219) [[5]](diffhunk://#diff-cda7965095932ea3788027824b371a97c999333cb8b66e0963e987de7d2598c8R238) [[6]](diffhunk://#diff-cda7965095932ea3788027824b371a97c999333cb8b66e0963e987de7d2598c8R256)

**Constants and Types:**
* Renamed constants and enum values from "CreatedOn" to "UpdatedOn" throughout the codebase for announcements and engagements. [[1]](diffhunk://#diff-4125893c35f32d692fee8b67b8f84c43321f82bf6f181be5594dcfb692d86774L25-R25) [[2]](diffhunk://#diff-befd6535effcb3a9d86aae507cdd52d41174fa661dae300a1cdcb8192b20c36dL41-R51) [[3]](diffhunk://#diff-1971d0cad75b493093dc45879afda9b302cfdcefa872b69c29181bbc35cdade7L72-R73)

**Tests and Utilities:**
* Updated tests and utility functions to reflect the new default sort field and label, ensuring correct expectations and coverage. [[1]](diffhunk://#diff-02a782e0c737c802b7d32a1cad19ac2a2cc882036cdbba2dca18185c67430ac6L38-R38) [[2]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77L30-R32) [[3]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77L42-R44) [[4]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77L54-R58) [[5]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77L72-R79) [[6]](diffhunk://#diff-b0a9ec54ba556c2066e76499827b4a8a16c1bf3d10eb6e0b4186414158756754L159-R159) [[7]](diffhunk://#diff-feacbcb4059727622d3882bd6fbe51920c41e4ac14ae8c9708194fb5033414ebL50-R52)

**Change Requests and Miscellaneous:**
* Change request lists and related UI now show "updated on" dates and use the new constant names. [[1]](diffhunk://#diff-4e57ef6a36604b02bea328a8860c0fc5951345d1ee5fecb12c51ddd0066d2e85L33-R33) [[2]](diffhunk://#diff-4e57ef6a36604b02bea328a8860c0fc5951345d1ee5fecb12c51ddd0066d2e85L322-R322)

These changes ensure a consistent experience across the portal, prioritizing recently updated items and clarifying date fields for users.