### PR TITLE
[Customer Portal][FE][Web] : Enhance Dashboard Cases Table with Created By Column and My Cases / All Cases Filtering

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
@@ -213,7 +213,7 @@ export default function ListCard({
               color="text.secondary"
               sx={{ lineHeight: 1, overflowWrap: "anywhere" }}
             >
-              Created {formatDateTime(caseItem.createdOn) || "--"}
+              Updated {formatDateTime(caseItem.updatedOn ?? caseItem.createdOn) || "--"}
             </Typography>
           </Box>
           {caseItem.createdBy && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -113,7 +113,7 @@ export default function AnnouncementDetailsPanel({
   const statusLabel = data.status?.label;
   const statusColorPath = getStatusColor(statusLabel ?? undefined);
   const resolvedStatusColor = resolveColorFromTheme(statusColorPath, theme);
-  const createdOnLabel = formatAnnouncementDateDisplay(data.createdOn);
+  const updatedOnLabel = formatAnnouncementDateDisplay(data.updatedOn);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -222,7 +222,7 @@ export default function AnnouncementDetailsPanel({
               aria-hidden
             />
             <Typography variant="body2" color="text.secondary">
-              {createdOnLabel}
+              {updatedOnLabel}
             </Typography>
           </Stack>
           {data.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -113,7 +113,9 @@ export default function AnnouncementDetailsPanel({
   const statusLabel = data.status?.label;
   const statusColorPath = getStatusColor(statusLabel ?? undefined);
   const resolvedStatusColor = resolveColorFromTheme(statusColorPath, theme);
-  const updatedOnLabel = formatAnnouncementDateDisplay(data.updatedOn);
+  const updatedOnLabel = formatAnnouncementDateDisplay(
+    data.updatedOn ?? data.createdOn,
+  );
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -96,7 +96,9 @@ export default function AnnouncementList({
         const statusLabel = caseItem.status?.label;
         const statusColor = getStatusColor(statusLabel);
         const resolvedStatusColor = resolveColorFromTheme(statusColor, theme);
-        const updatedOnLabel = formatAnnouncementDateDisplay(caseItem.updatedOn);
+        const updatedOnLabel = formatAnnouncementDateDisplay(
+          caseItem.updatedOn ?? caseItem.createdOn,
+        );
 
         const cardContent = (
           <>

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -96,7 +96,7 @@ export default function AnnouncementList({
         const statusLabel = caseItem.status?.label;
         const statusColor = getStatusColor(statusLabel);
         const resolvedStatusColor = resolveColorFromTheme(statusColor, theme);
-        const createdOnLabel = formatAnnouncementDateDisplay(caseItem.createdOn);
+        const updatedOnLabel = formatAnnouncementDateDisplay(caseItem.updatedOn);
 
         const cardContent = (
           <>
@@ -193,7 +193,7 @@ export default function AnnouncementList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    Created {createdOnLabel}
+                    Updated {updatedOnLabel}
                   </Typography>
                 </Box>
                 {caseItem.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/constants/announcementsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/constants/announcementsConstants.ts
@@ -38,8 +38,8 @@ export const ANNOUNCEMENTS_SEARCH_PLACEHOLDER = "Search announcements...";
 /** Entity label for results bar and pagination copy. */
 export const ANNOUNCEMENTS_LIST_ENTITY_LABEL = "announcements";
 
-/** Sort row: label for created date column. */
-export const ANNOUNCEMENTS_SORT_CREATED_LABEL = "Created date";
+/** Sort row: label for updated date column. */
+export const ANNOUNCEMENTS_SORT_UPDATED_LABEL = "Updated date";
 
 /** Sort row: label for state column. */
 export const ANNOUNCEMENTS_SORT_STATE_LABEL = "Status";
@@ -47,8 +47,8 @@ export const ANNOUNCEMENTS_SORT_STATE_LABEL = "Status";
 /** Options passed to `ListResultsBar`. */
 export const ANNOUNCEMENTS_SORT_FIELD_OPTIONS: AnnouncementSortOption[] = [
   {
-    value: AnnouncementSortField.CreatedOn,
-    label: ANNOUNCEMENTS_SORT_CREATED_LABEL,
+    value: AnnouncementSortField.UpdatedOn,
+    label: ANNOUNCEMENTS_SORT_UPDATED_LABEL,
     kind: "chronological",
   },
   {

--- a/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/pages/AnnouncementsPage.tsx
@@ -67,7 +67,7 @@ export default function AnnouncementsPage(): JSX.Element {
   const [filters, setFilters] = useSessionState<AnnouncementFilterValues>(`${sessionPrefix}-filters`, {}, undefined, { popOnly: true });
   const [sortField, setSortField] = useSessionState<AnnouncementSortField>(
     `${sessionPrefix}-sortField`,
-    AnnouncementSortField.CreatedOn,
+    AnnouncementSortField.UpdatedOn,
     isValidAnnouncementSortField,
     { popOnly: true },
   );

--- a/apps/customer-portal/webapp/src/features/announcements/types/announcements.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/types/announcements.ts
@@ -22,7 +22,7 @@ export type { AnnouncementFilterValues };
 
 /** API `sortBy.field` for announcements list. */
 export enum AnnouncementSortField {
-  CreatedOn = "createdOn",
+  UpdatedOn = "updatedOn",
   State = "state",
 }
 

--- a/apps/customer-portal/webapp/src/features/announcements/utils/__tests__/announcements.test.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/utils/__tests__/announcements.test.ts
@@ -35,7 +35,7 @@ describe("buildAnnouncementCaseSearchRequest", () => {
     expect(req.filters?.caseTypes).toEqual([CaseType.ANNOUNCEMENT]);
     expect(req.filters?.statusIds).toEqual([5]);
     expect(req.filters?.searchQuery).toBe("hello");
-    expect(req.sortBy?.field).toBe("createdOn");
+    expect(req.sortBy?.field).toBe("updatedOn");
     expect(req.sortBy?.order).toBe(SortOrder.ASC);
   });
 

--- a/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/utils/announcements.ts
@@ -47,7 +47,7 @@ export function buildAnnouncementCaseSearchRequest(
   filters: AnnouncementFilterValues,
   searchTerm: string,
   sortOrder: SortOrder,
-  sortField: AnnouncementSortField = AnnouncementSortField.CreatedOn,
+  sortField: AnnouncementSortField = AnnouncementSortField.UpdatedOn,
 ): Omit<CaseSearchRequest, "pagination"> {
   return {
     filters: {

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
@@ -63,7 +63,7 @@ const CasesList = ({
         <Table sx={{ minWidth: { xs: 480, sm: 650 } }}>
           <TableHead>
             <TableRow>
-              <TableCell>Created</TableCell>
+              <TableCell>Updated</TableCell>
               <TableCell sx={{ maxWidth: 320 }}>Details</TableCell>
               <TableCell>Severity</TableCell>
               <TableCell align="center">Assigned to</TableCell>
@@ -158,21 +158,27 @@ const CasesList = ({
                         <TableCell>
                           <Box>
                             <Typography variant="body2" color="text.primary">
-                              {formatBackendTimestampForDisplay(row.createdOn, {
-                                month: "short",
-                                day: "numeric",
-                                year: "numeric",
-                              }) ?? "--"}
+                              {formatBackendTimestampForDisplay(
+                                row.updatedOn ?? row.createdOn,
+                                {
+                                  month: "short",
+                                  day: "numeric",
+                                  year: "numeric",
+                                },
+                              ) ?? "--"}
                             </Typography>
                             <Typography
                               variant="caption"
                               color="text.secondary"
                             >
-                              {formatBackendTimestampForDisplay(row.createdOn, {
-                                hour: "numeric",
-                                minute: "2-digit",
-                                hour12: true,
-                              }) ?? ""}
+                              {formatBackendTimestampForDisplay(
+                                row.updatedOn ?? row.createdOn,
+                                {
+                                  hour: "numeric",
+                                  minute: "2-digit",
+                                  hour12: true,
+                                },
+                              ) ?? ""}
                             </Typography>
                           </Box>
                         </TableCell>

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
@@ -39,6 +39,7 @@ import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
 import CasesTableSkeleton from "@features/dashboard/components/cases-table/CasesTableSkeleton";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
 import SearchNoResultsIcon from "@components/empty-state/SearchNoResultsIcon";
+import { CASES_TABLE_HEADER_CREATED_BY } from "@features/dashboard/constants/casesTable";
 import type { CasesListProps } from "@/features/dashboard/types/casesTable";
 
 const CasesList = ({
@@ -60,14 +61,15 @@ const CasesList = ({
         elevation={0}
         sx={{ maxWidth: "100%", overflowX: "auto" }}
       >
-        <Table sx={{ minWidth: { xs: 480, sm: 650 } }}>
+        <Table sx={{ minWidth: { xs: 520, sm: 780 } }}>
           <TableHead>
             <TableRow>
               <TableCell>Updated</TableCell>
               <TableCell sx={{ maxWidth: 320 }}>Details</TableCell>
               <TableCell>Severity</TableCell>
-              <TableCell align="center">Assigned to</TableCell>
               <TableCell>Status</TableCell>
+              <TableCell>{CASES_TABLE_HEADER_CREATED_BY}</TableCell>
+              <TableCell align="center">Assigned to</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -75,7 +77,7 @@ const CasesList = ({
               <CasesTableSkeleton rowsPerPage={rowsPerPage} />
             ) : isError ? (
               <TableRow>
-                <TableCell colSpan={5} align="center">
+                <TableCell colSpan={6} align="center">
                   <Box
                     sx={{
                       display: "flex",
@@ -93,7 +95,7 @@ const CasesList = ({
               </TableRow>
             ) : data?.cases.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} align="center">
+                <TableCell colSpan={6} align="center">
                   <Box
                     sx={{
                       display: "flex",
@@ -152,6 +154,7 @@ const CasesList = ({
                         : assignedEngineerValue?.label?.trim() || "";
                     const assignedEngineerDisplay =
                       assignedEngineerName || "--";
+                    const createdByDisplay = row.createdBy?.trim() || "--";
 
                     return (
                       <>
@@ -239,11 +242,6 @@ const CasesList = ({
                             );
                           })()}
                         </TableCell>
-                        <TableCell align="center">
-                          <Typography variant="body2" color="text.primary">
-                            {assignedEngineerDisplay}
-                          </Typography>
-                        </TableCell>
                         <TableCell>
                           <Box
                             sx={{
@@ -266,6 +264,25 @@ const CasesList = ({
                               {row.status?.label || "--"}
                             </Typography>
                           </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            color="text.primary"
+                            sx={{
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                              maxWidth: 160,
+                            }}
+                          >
+                            {createdByDisplay}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="center">
+                          <Typography variant="body2" color="text.primary">
+                            {assignedEngineerDisplay}
+                          </Typography>
                         </TableCell>
                       </>
                     );

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
@@ -196,7 +196,7 @@ const CasesTable = ({
           : undefined,
       },
       sortBy: {
-        field: "createdOn",
+        field: "updatedOn",
         order: SortOrder.DESC,
       },
     };

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
@@ -35,9 +35,12 @@ import {
   countCasesTableActiveFilters,
   filterCasesTableMetadataOptions,
   mapCasesTableFilterOptionLabel,
+  parseDashboardCasesViewMode,
   resolveCasesTableDefaultStatusIds,
   resolveCasesTableSearchStatusIds,
 } from "@features/dashboard/utils/casesTable";
+import { DASHBOARD_CASES_VIEW_TABS } from "@features/dashboard/constants/casesTable";
+import { DashboardCasesViewMode } from "@features/dashboard/types/casesTable";
 import { isS0Case, deriveFilterLabels } from "@features/support/utils/support";
 import {
   CaseType,
@@ -82,6 +85,9 @@ const CasesTable = ({
   const [showAll, setShowAll] = useState(false);
   // loading all
   const [isLoadingAll, setIsLoadingAll] = useState(false);
+  const [viewMode, setViewMode] = useState<DashboardCasesViewMode>(
+    DashboardCasesViewMode.AllCases,
+  );
 
   const { data: filtersMetadata } = useGetProjectFilters(projectId);
   // deployments query
@@ -194,13 +200,15 @@ const CasesTable = ({
         deploymentId: effectiveFilters.deploymentId
           ? String(effectiveFilters.deploymentId)
           : undefined,
+        createdByMe:
+          viewMode === DashboardCasesViewMode.MyCases ? true : undefined,
       },
       sortBy: {
         field: "updatedOn",
         order: SortOrder.DESC,
       },
     };
-  }, [effectiveFilters, filtersMetadata]);
+  }, [effectiveFilters, filtersMetadata, viewMode]);
 
   // offset
   const offset = page * rowsPerPage;
@@ -318,6 +326,14 @@ const CasesTable = ({
           }
         }}
         hasAgent={hasAgent}
+        viewTabs={DASHBOARD_CASES_VIEW_TABS}
+        activeViewMode={viewMode}
+        onViewModeChange={(tabId) => {
+          setViewMode(parseDashboardCasesViewMode(tabId));
+          setPage(0);
+          setShowAll(false);
+          setIsLoadingAll(false);
+        }}
       />
 
       {isFilterOpen && (

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTableHeader.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTableHeader.tsx
@@ -15,6 +15,7 @@
 // under the License.
 
 import { Box, Typography, Button } from "@wso2/oxygen-ui";
+import TabBar from "@components/tab-bar/TabBar";
 import {
   ListFilter,
   ChevronDown,
@@ -39,6 +40,9 @@ const CasesTableHeader = ({
   activeFiltersCount,
   isFiltersOpen,
   onFilterToggle,
+  viewTabs,
+  activeViewMode,
+  onViewModeChange,
 }: CasesTableHeaderProps): JSX.Element => {
   const hasActiveFilters = activeFiltersCount > 0;
 
@@ -62,28 +66,43 @@ const CasesTableHeader = ({
             {CASES_TABLE_HEADER_SUBTITLE}
           </Typography>
         </Box>
-        <Button
-          variant="outlined"
-          color="warning"
-          size="small"
-          sx={{ flexShrink: 0 }}
-          onClick={onFilterToggle}
-          startIcon={
-            hasActiveFilters ? <X size={16} /> : <ListFilter size={16} />
-          }
-          endIcon={
-            !hasActiveFilters &&
-            (isFiltersOpen ? (
-              <ChevronUp size={16} />
-            ) : (
-              <ChevronDown size={16} />
-            ))
-          }
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            flexWrap: "wrap",
+            flexShrink: 0,
+          }}
         >
-          {hasActiveFilters
-            ? formatCasesTableClearFiltersLabel(activeFiltersCount)
-            : CASES_TABLE_BUTTON_FILTERS}
-        </Button>
+          <TabBar
+            tabs={viewTabs}
+            activeTab={activeViewMode}
+            onTabChange={onViewModeChange}
+            sx={{ mb: 0, height: 32 }}
+          />
+          <Button
+            variant="outlined"
+            color="warning"
+            size="small"
+            onClick={onFilterToggle}
+            startIcon={
+              hasActiveFilters ? <X size={16} /> : <ListFilter size={16} />
+            }
+            endIcon={
+              !hasActiveFilters &&
+              (isFiltersOpen ? (
+                <ChevronUp size={16} />
+              ) : (
+                <ChevronDown size={16} />
+              ))
+            }
+          >
+            {hasActiveFilters
+              ? formatCasesTableClearFiltersLabel(activeFiltersCount)
+              : CASES_TABLE_BUTTON_FILTERS}
+          </Button>
+        </Box>
       </Box>
     </Box>
   );

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTableSkeleton.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTableSkeleton.tsx
@@ -19,7 +19,9 @@ import { type JSX } from "react";
 import type { CasesTableSkeletonProps } from "@/features/dashboard/types/casesTable";
 
 /**
- * Skeleton rows for the cases table loading state.
+ * Skeleton rows for the dashboard outstanding cases table.
+ * Column order matches {@link CasesList}: Updated, Details, Severity, Status,
+ * Created by, Assigned to.
  *
  * @returns {JSX.Element} Table body skeleton fragment
  */
@@ -29,7 +31,10 @@ const CasesTableSkeleton = ({
   return (
     <>
       {Array.from({ length: rowsPerPage }).map((_, index) => (
-        <TableRow key={`skeleton-${index}`}>
+        <TableRow
+          key={`skeleton-${index}`}
+          data-testid={index === 0 ? "cases-skeleton" : undefined}
+        >
           <TableCell>
             <Box>
               <Skeleton variant="text" width={80} height={20} />
@@ -43,19 +48,29 @@ const CasesTableSkeleton = ({
             </Box>
           </TableCell>
           <TableCell>
-            <Skeleton variant="text" width={150} height={20} />
-          </TableCell>
-          <TableCell>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <Skeleton variant="circular" width={24} height={24} />
-              <Skeleton variant="text" width={100} height={20} />
-            </Box>
+            <Skeleton
+              variant="rounded"
+              width={56}
+              height={20}
+              sx={{ borderRadius: 0 }}
+            />
           </TableCell>
           <TableCell>
             <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
               <Skeleton variant="circular" width={8} height={8} />
-              <Skeleton variant="text" width={60} height={20} />
+              <Skeleton variant="text" width={88} height={20} />
             </Box>
+          </TableCell>
+          <TableCell>
+            <Skeleton variant="text" width={120} height={20} />
+          </TableCell>
+          <TableCell align="center">
+            <Skeleton
+              variant="text"
+              width={100}
+              height={20}
+              sx={{ mx: "auto" }}
+            />
           </TableCell>
         </TableRow>
       ))}

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesList.test.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesList.test.tsx
@@ -107,6 +107,7 @@ describe("CasesList", () => {
         title: "Test Case 1",
         number: "CS-001",
         assignedEngineer: "John Doe",
+        createdBy: "Jane Smith",
         severity: { id: 1, label: "High" },
         status: { id: 1, label: "Open" },
         project: { id: "p1", name: "Project 1" },
@@ -194,6 +195,8 @@ describe("CasesList", () => {
       />,
     );
 
+    expect(screen.getByText("Created by")).toBeInTheDocument();
+    expect(screen.getByText("Jane Smith")).toBeInTheDocument();
     expect(screen.getByText("Test Case 1")).toBeInTheDocument();
     expect(screen.getByText("ID: CS-001")).toBeInTheDocument();
     expect(screen.getByText("Test Case 2")).toBeInTheDocument();

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTable.test.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTable.test.tsx
@@ -156,7 +156,7 @@ describe("CasesTable", () => {
     expect(mockUseGetProjectCasesPage).toHaveBeenCalledWith(
       mockProjectId,
       expect.objectContaining({
-        sortBy: { field: "createdOn", order: "desc" },
+        sortBy: { field: "updatedOn", order: "desc" },
       }),
       expect.any(Number),
       expect.any(Number),

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTableHeader.test.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTableHeader.test.tsx
@@ -17,6 +17,8 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import CasesTableHeader from "@features/dashboard/components/cases-table/CasesTableHeader";
+import { DASHBOARD_CASES_VIEW_TABS } from "@features/dashboard/constants/casesTable";
+import { DashboardCasesViewMode } from "@features/dashboard/types/casesTable";
 
 const { mockNavigate, mockUseParams } = vi.hoisted(() => {
   const navigate = vi.fn();
@@ -50,28 +52,52 @@ vi.mock("@wso2/oxygen-ui-icons-react", () => ({
   ChevronUp: () => <span>ChevronUp</span>,
 }));
 
-vi.mock("@components/filter-panel/ActiveFilters", () => ({
-  default: ({ appliedFilters }: any) => (
-    <div data-testid="active-filters">
-      {Object.keys(appliedFilters).map((key) => (
-        <span key={key}>{key}</span>
+vi.mock("@features/dashboard/utils/dashboard", () => ({
+  formatCasesTableClearFiltersLabel: (count: number) => `Clear Filters (${count})`,
+}));
+
+vi.mock("@components/tab-bar/TabBar", () => ({
+  default: ({
+    tabs,
+    activeTab,
+    onTabChange,
+  }: {
+    tabs: Array<{ id: string; label: string }>;
+    activeTab: string;
+    onTabChange: (tabId: string) => void;
+  }) => (
+    <div data-testid="cases-view-tabs">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          aria-pressed={activeTab === tab.id}
+          onClick={() => onTabChange(tab.id)}
+        >
+          {tab.label}
+        </button>
       ))}
     </div>
   ),
 }));
 
 describe("CasesTableHeader", () => {
+  const onViewModeChange = vi.fn();
   const mockProps = {
     activeFiltersCount: 0,
     isFiltersOpen: false,
     onFilterToggle: vi.fn(),
+    viewTabs: DASHBOARD_CASES_VIEW_TABS,
+    activeViewMode: DashboardCasesViewMode.AllCases,
+    onViewModeChange,
   };
 
-  it("should render title and buttons", () => {
+  it("should render title, view tabs, and filters button", () => {
     render(<CasesTableHeader {...mockProps} />);
 
     expect(screen.getByText("Outstanding Support Cases")).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("My Cases")).toBeInTheDocument();
+    expect(screen.getByText("All Cases")).toBeInTheDocument();
     expect(screen.getByText("Filters")).toBeInTheDocument();
   });
 
@@ -86,5 +112,12 @@ describe("CasesTableHeader", () => {
     render(<CasesTableHeader {...mockProps} activeFiltersCount={1} />);
 
     expect(screen.getByText("Clear Filters (1)")).toBeInTheDocument();
+  });
+
+  it("should call onViewModeChange when a view tab is clicked", () => {
+    render(<CasesTableHeader {...mockProps} />);
+
+    fireEvent.click(screen.getByText("My Cases"));
+    expect(onViewModeChange).toHaveBeenCalledWith("my-cases");
   });
 });

--- a/apps/customer-portal/webapp/src/features/dashboard/constants/casesTable.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/constants/casesTable.ts
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { DashboardCasesViewMode } from "@features/dashboard/types/casesTable";
+
 // Lowercase substring for labels treated like resolved for status coloring
 export const CASE_TABLE_RESOLVED_LABEL_SUBSTRING = "resolved";
 
@@ -32,6 +34,9 @@ export const CASES_TABLE_HEADER_TITLE = "Outstanding Support Cases";
 export const CASES_TABLE_HEADER_SUBTITLE =
   "Track and manage all active support tickets";
 
+// Cases table column header for creator.
+export const CASES_TABLE_HEADER_CREATED_BY = "Created by";
+
 // Cases table button filters.
 export const CASES_TABLE_BUTTON_FILTERS = "Filters";
 
@@ -40,3 +45,9 @@ export const CASES_TABLE_BUTTON_CREATE = "Create";
 
 // Cases table clear filters label.
 export const CASES_TABLE_CLEAR_FILTERS_LABEL = "Clear Filters";
+
+// TabBar options for my vs all outstanding cases (dashboard).
+export const DASHBOARD_CASES_VIEW_TABS = [
+  { id: DashboardCasesViewMode.MyCases, label: "My Cases" },
+  { id: DashboardCasesViewMode.AllCases, label: "All Cases" },
+] as const;

--- a/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/pages/DashboardItemsPage.tsx
@@ -46,6 +46,7 @@ import {
   CaseStatus,
 } from "@features/support/constants/supportConstants";
 import { getLast30DaysUtcRange } from "@features/support/utils/support";
+import { SortOrder } from "@/types/common";
 import ListPageHeader from "@components/list-view/ListPageHeader";
 import ListItems from "@components/list-view/ListItems";
 import ChangeRequestsList from "@features/operations/components/change-requests/ChangeRequestsList";
@@ -159,6 +160,11 @@ export default function DashboardItemsPage({
     [mode],
   );
 
+  const listSortBy = useMemo(
+    () => ({ field: "updatedOn" as const, order: SortOrder.DESC }),
+    [],
+  );
+
   // --- Data fetching (10 items each — single-page query, never loads more) ---
   const {
     data: casesQueryData,
@@ -172,6 +178,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -190,6 +197,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -208,6 +216,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -226,6 +235,7 @@ export default function DashboardItemsPage({
         statusIds: apiStatusIds,
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,
@@ -243,6 +253,7 @@ export default function DashboardItemsPage({
         stateKeys: crStateKeys ?? [],
         ...closedLast30dRange,
       },
+      sortBy: listSortBy,
     },
     0,
     10,

--- a/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
@@ -58,12 +58,21 @@ export type CasesListProps = {
   hasListRefinement?: boolean;
 };
 
+/** My vs all cases on the dashboard outstanding cases table. */
+export enum DashboardCasesViewMode {
+  MyCases = "my-cases",
+  AllCases = "all-cases",
+}
+
 // Case table header props.
 export type CasesTableHeaderProps = {
   activeFiltersCount: number;
   isFiltersOpen: boolean;
   onFilterToggle: () => void;
   hasAgent?: boolean;
+  viewTabs: ReadonlyArray<{ id: string; label: string }>;
+  activeViewMode: DashboardCasesViewMode;
+  onViewModeChange: (tabId: string) => void;
 };
 
 // Case table skeleton props.

--- a/apps/customer-portal/webapp/src/features/dashboard/utils/casesTable.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/utils/casesTable.ts
@@ -181,10 +181,12 @@ export function parseDashboardCasesViewMode(
   tabId: string,
 ): DashboardCasesViewMode {
   switch (tabId) {
-    case DashboardCasesViewMode.MY:
-      return DashboardCasesViewMode.MY;
-    case DashboardCasesViewMode.ALL:
+    case DashboardCasesViewMode.MyCases:
+    case "my":
+      return DashboardCasesViewMode.MyCases;
+    case DashboardCasesViewMode.AllCases:
+    case "all":
     default:
-      return DashboardCasesViewMode.ALL;
+      return DashboardCasesViewMode.AllCases;
   }
 }

--- a/apps/customer-portal/webapp/src/features/dashboard/utils/casesTable.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/utils/casesTable.ts
@@ -31,6 +31,7 @@ import {
   CaseStatus,
 } from "@features/support/constants/supportConstants";
 import type { NavigateFunction } from "react-router";
+import { DashboardCasesViewMode } from "@features/dashboard/types/casesTable";
 
 /**
  * Returns the Oxygen ui color path for a given severity label.
@@ -168,4 +169,22 @@ export function navigateToProjectCaseDetail(
   caseId: string,
 ): void {
   navigate(`/projects/${projectId}/support/cases/${caseId}`);
+}
+
+/**
+ * Maps TabBar tab id to dashboard cases view mode.
+ *
+ * @param tabId - Tab id from `DASHBOARD_CASES_VIEW_TABS`.
+ * @returns {DashboardCasesViewMode} View mode for case search `createdByMe`.
+ */
+export function parseDashboardCasesViewMode(
+  tabId: string,
+): DashboardCasesViewMode {
+  switch (tabId) {
+    case DashboardCasesViewMode.MY:
+      return DashboardCasesViewMode.MY;
+    case DashboardCasesViewMode.ALL:
+    default:
+      return DashboardCasesViewMode.ALL;
+  }
 }

--- a/apps/customer-portal/webapp/src/features/engagements/constants/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/constants/engagements.ts
@@ -69,7 +69,7 @@ export const ENGAGEMENTS_STAT_CARDS_CONFIG: SupportStatConfig<EngagementsStatKey
 
 /** Sort dropdown options (value ↔ API field). */
 export const ENGAGEMENTS_SORT_OPTIONS: readonly EngagementsSortOption[] = [
-  { value: EngagementsSortField.CreatedOn, label: "Created on" },
   { value: EngagementsSortField.UpdatedOn, label: "Updated on" },
+  { value: EngagementsSortField.CreatedOn, label: "Created on" },
   { value: EngagementsSortField.State, label: "Status" },
 ];

--- a/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/hooks/useEngagementsPageState.ts
@@ -75,7 +75,7 @@ export function useEngagementsPageState() {
     hasListSearchOrFilters(searchTerm, filters),
   );
   const [sortField, setSortField] = useState<EngagementsSortField>(
-    EngagementsSortField.CreatedOn,
+    EngagementsSortField.UpdatedOn,
   );
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.DESC);
   const [page, setPage] = useState(1);

--- a/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
@@ -27,9 +27,9 @@ import {
 } from "@features/engagements/utils/engagements";
 
 describe("parseEngagementsSortField", () => {
-  it("returns CreatedOn for unknown values", () => {
+  it("returns UpdatedOn for unknown values", () => {
     expect(parseEngagementsSortField("unknown")).toBe(
-      EngagementsSortField.CreatedOn,
+      EngagementsSortField.UpdatedOn,
     );
   });
 
@@ -39,9 +39,9 @@ describe("parseEngagementsSortField", () => {
     );
   });
 
-  it("maps legacy Severity sort to CreatedOn", () => {
+  it("maps legacy Severity sort to UpdatedOn", () => {
     expect(parseEngagementsSortField(EngagementsSortField.Severity)).toBe(
-      EngagementsSortField.CreatedOn,
+      EngagementsSortField.UpdatedOn,
     );
   });
 });
@@ -51,11 +51,11 @@ describe("buildEngagementSearchRequest", () => {
     const req = buildEngagementSearchRequest(
       {},
       "",
-      EngagementsSortField.CreatedOn,
+      EngagementsSortField.UpdatedOn,
       SortOrder.DESC,
     );
     expect(req.filters?.caseTypes).toEqual([CaseType.ENGAGEMENT]);
-    expect(req.sortBy?.field).toBe(EngagementsSortField.CreatedOn);
+    expect(req.sortBy?.field).toBe(EngagementsSortField.UpdatedOn);
     expect(req.sortBy?.order).toBe(SortOrder.DESC);
   });
 
@@ -69,14 +69,14 @@ describe("buildEngagementSearchRequest", () => {
     expect(req.filters?.severityId).toBeUndefined();
   });
 
-  it("normalizes legacy Severity sort field to CreatedOn in API payload", () => {
+  it("normalizes legacy Severity sort field to UpdatedOn in API payload", () => {
     const req = buildEngagementSearchRequest(
       {},
       "",
       EngagementsSortField.Severity,
       SortOrder.DESC,
     );
-    expect(req.sortBy?.field).toBe(EngagementsSortField.CreatedOn);
+    expect(req.sortBy?.field).toBe(EngagementsSortField.UpdatedOn);
   });
 });
 

--- a/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
@@ -47,9 +47,9 @@ export function parseEngagementsSortField(value: string): EngagementsSortField {
     case EngagementsSortField.State:
       return value;
     case EngagementsSortField.Severity:
-      return EngagementsSortField.CreatedOn;
+      return EngagementsSortField.UpdatedOn;
     default:
-      return EngagementsSortField.CreatedOn;
+      return EngagementsSortField.UpdatedOn;
   }
 }
 
@@ -70,7 +70,7 @@ export function buildEngagementSearchRequest(
 ): Omit<CaseSearchRequest, "pagination"> {
   const normalizedSortField =
     sortField === EngagementsSortField.Severity
-      ? EngagementsSortField.CreatedOn
+      ? EngagementsSortField.UpdatedOn
       : sortField;
 
   return {

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
@@ -30,7 +30,7 @@ import {
 } from "@features/operations/utils/changeRequestUi";
 import type { ChangeRequestsListProps } from "@features/operations/types/changeRequests";
 import {
-  CHANGE_REQUESTS_LIST_CREATED_PREFIX,
+  CHANGE_REQUESTS_LIST_UPDATED_PREFIX,
   CHANGE_REQUESTS_LIST_EMPTY_DEFAULT_MESSAGE,
   CHANGE_REQUESTS_LIST_EMPTY_REFINED_MESSAGE,
   CHANGE_REQUESTS_LIST_ERROR_MESSAGE,
@@ -319,7 +319,7 @@ export default function ChangeRequestsList({
                     </Typography>
                   </Box>
                 )}
-                {item.createdOn && (
+                {(item.updatedOn ?? item.createdOn) && (
                   <Box
                     sx={{
                       display: "flex",
@@ -328,14 +328,14 @@ export default function ChangeRequestsList({
                     }}
                   >
                     <Typography variant="body2" color="text.secondary">
-                      {CHANGE_REQUESTS_LIST_CREATED_PREFIX}
+                      {CHANGE_REQUESTS_LIST_UPDATED_PREFIX}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {formatDateTime(item.createdOn)}
+                      {formatDateTime(item.updatedOn ?? item.createdOn)}
                     </Typography>
                   </Box>
                 )}
-                {item.createdOn && (item.startDate || item.endDate) && (
+                {(item.updatedOn ?? item.createdOn) && (item.startDate || item.endDate) && (
                   <Typography variant="body2" color="text.disabled">
                     |
                   </Typography>

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
@@ -232,7 +232,7 @@ export default function ServiceRequestsList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    {formatDateTime(sr.createdOn) || NULL_PLACEHOLDER}
+                    {formatDateTime(sr.updatedOn ?? sr.createdOn) || NULL_PLACEHOLDER}
                   </Typography>
                 </Box>
                 {environmentLabel && (

--- a/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
@@ -268,7 +268,7 @@ export const CHANGE_REQUESTS_LIST_PLACEHOLDER = "Not Available";
 
 export const CHANGE_REQUESTS_LIST_SR_PREFIX = "SR:";
 
-export const CHANGE_REQUESTS_LIST_CREATED_PREFIX = "Created:";
+export const CHANGE_REQUESTS_LIST_UPDATED_PREFIX = "Updated:";
 
 export const CHANGE_REQUESTS_LIST_SERVICE_OUTAGE_LABEL = "Service Outage";
 
@@ -328,13 +328,13 @@ export type ServiceRequestSortFieldOption = {
 export const SERVICE_REQUESTS_SORT_FIELD_OPTIONS: ServiceRequestSortFieldOption[] =
   [
     {
-      value: ServiceRequestCaseSortField.CreatedOn,
-      label: "Created on",
+      value: ServiceRequestCaseSortField.UpdatedOn,
+      label: "Updated on",
       kind: "chronological",
     },
     {
-      value: ServiceRequestCaseSortField.UpdatedOn,
-      label: "Updated on",
+      value: ServiceRequestCaseSortField.CreatedOn,
+      label: "Created on",
       kind: "chronological",
     },
     {

--- a/apps/customer-portal/webapp/src/features/operations/pages/OperationsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/OperationsPage.tsx
@@ -54,6 +54,7 @@ import {
   OPERATIONS_HUB_STAT_ENTITY_NAME,
 } from "@features/operations/constants/operationsConstants";
 import {
+  buildChangeRequestSearchRequest,
   formatOperationsOverviewChangeRequestsSubtitle,
   formatOperationsOverviewServiceRequestsSubtitle,
   resolveOutstandingCrStateIds,
@@ -111,6 +112,19 @@ export default function OperationsPage(): JSX.Element {
     [filterMetadata?.changeRequestStates],
   );
 
+  const changeRequestOverviewSearchRequest = useMemo(
+    () =>
+      buildChangeRequestSearchRequest(
+        {},
+        "",
+        true,
+        false,
+        false,
+        filterMetadata?.changeRequestStates,
+      ),
+    [filterMetadata?.changeRequestStates],
+  );
+
   const {
     data: srData,
     isLoading: isSrDataLoading,
@@ -122,7 +136,7 @@ export default function OperationsPage(): JSX.Element {
         caseTypes: [CaseType.SERVICE_REQUEST],
         statusIds: nonClosedStatusIds,
       },
-      sortBy: { field: "createdOn", order: SortOrder.DESC },
+      sortBy: { field: "updatedOn", order: SortOrder.DESC },
     },
     0,
     OPERATIONS_OVERVIEW_LIST_LIMIT,
@@ -144,11 +158,7 @@ export default function OperationsPage(): JSX.Element {
     isError: isCrError,
   } = useGetChangeRequests(
     projectId || "",
-    {
-      filters: {
-        stateKeys: outstandingCrStateIds ?? [],
-      },
-    },
+    changeRequestOverviewSearchRequest,
     0,
     OPERATIONS_OVERVIEW_LIST_LIMIT,
     {

--- a/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ServiceRequestsPage.tsx
@@ -100,7 +100,7 @@ export default function ServiceRequestsPage(): JSX.Element {
   const [isFiltersOpen, setIsFiltersOpen] = useState(
     () => hasListSearchOrFilters(searchTerm, filters),
   );
-  const [sortField, setSortField] = useSessionState<ServiceRequestCaseSortField>(`${sessionPrefix}-sortField`, ServiceRequestCaseSortField.CreatedOn, undefined, { popOnly: true });
+  const [sortField, setSortField] = useSessionState<ServiceRequestCaseSortField>(`${sessionPrefix}-sortField`, ServiceRequestCaseSortField.UpdatedOn, undefined, { popOnly: true });
   const [sortOrder, setSortOrder] = useSessionState<SortOrder>(`${sessionPrefix}-sortOrder`, SortOrder.DESC, undefined, { popOnly: true });
   const [page, setPage] = useSessionState<number>(`${sessionPrefix}-page`, 1, undefined, { popOnly: true });
   const [rowsPerPage, setRowsPerPage] = useSessionState<number>(`${sessionPrefix}-rowsPerPage`, OPERATIONS_LIST_PAGE_SIZE, undefined, { popOnly: true });

--- a/apps/customer-portal/webapp/src/features/operations/types/changeRequests.ts
+++ b/apps/customer-portal/webapp/src/features/operations/types/changeRequests.ts
@@ -102,6 +102,12 @@ export type ChangeRequestFilterValues = {
   impactId?: string;
 };
 
+/** Change request list sort field for search API `sortBy.field`. */
+export enum ChangeRequestSortField {
+  UpdatedOn = "updatedOn",
+  CreatedOn = "createdOn",
+}
+
 // Filter type for searching change requests.
 export type ChangeRequestSearchFilters = {
   impactKey?: number;

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
@@ -196,6 +196,12 @@ describe("buildChangeRequestSearchRequest", () => {
     expect(req.filters?.stateKeys).not.toContain(-4);
     expect(req.filters?.stateKeys).not.toContain(-3);
   });
+
+  it("sorts by updatedOn descending", () => {
+    const req = buildChangeRequestSearchRequest({}, "", false, false, false, allStates);
+    expect(req.sortBy?.field).toBe("updatedOn");
+    expect(req.sortBy?.order).toBe("desc");
+  });
 });
 
 describe("resolveChangeRequestFilterListOptions", () => {
@@ -245,12 +251,12 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
     const req = buildServiceRequestsPageCaseSearchRequest(
       {},
       "",
-      ServiceRequestCaseSortField.CreatedOn,
+      ServiceRequestCaseSortField.UpdatedOn,
       SortOrder.DESC,
       false,
     );
     expect(req.filters?.caseTypes).toEqual([CaseType.SERVICE_REQUEST]);
-    expect(req.sortBy?.field).toBe("createdOn");
+    expect(req.sortBy?.field).toBe("updatedOn");
   });
 
   it("does not send severity filter", () => {
@@ -264,7 +270,7 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
     expect(req.filters?.severityId).toBeUndefined();
   });
 
-  it("normalizes legacy Severity sort field to CreatedOn in API payload", () => {
+  it("normalizes legacy Severity sort field to UpdatedOn in API payload", () => {
     const req = buildServiceRequestsPageCaseSearchRequest(
       {},
       "",
@@ -272,7 +278,7 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
       SortOrder.DESC,
       false,
     );
-    expect(req.sortBy?.field).toBe(ServiceRequestCaseSortField.CreatedOn);
+    expect(req.sortBy?.field).toBe(ServiceRequestCaseSortField.UpdatedOn);
   });
 });
 

--- a/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
@@ -27,6 +27,7 @@ import type {
 } from "@features/operations/types/changeRequests";
 import {
   ChangeRequestFilterDefinitionId,
+  ChangeRequestSortField,
   type ChangeRequestFilterOption,
 } from "@features/operations/types/changeRequests";
 import {
@@ -34,7 +35,8 @@ import {
   ServiceRequestCaseSortField,
 } from "@features/operations/types/serviceRequests";
 import { ChangeRequestStates } from "@features/operations/constants/operationsConstants";
-import type { MetadataItem, SortOrder } from "@/types/common";
+import { SortOrder } from "@/types/common";
+import type { MetadataItem } from "@/types/common";
 
 /**
  * Resolves `operations` vs `support` from the current pathname.
@@ -222,6 +224,10 @@ export function buildChangeRequestSearchRequest(
       stateKeys,
       impactKey: filters.impactId ? Number(filters.impactId) : undefined,
     },
+    sortBy: {
+      field: ChangeRequestSortField.UpdatedOn,
+      order: SortOrder.DESC,
+    },
   };
 }
 
@@ -284,7 +290,7 @@ export function buildServiceRequestsPageCaseSearchRequest(
 ): Omit<CaseSearchRequest, "pagination"> {
   const normalizedSortField =
     sortField === ServiceRequestCaseSortField.Severity
-      ? ServiceRequestCaseSortField.CreatedOn
+      ? ServiceRequestCaseSortField.UpdatedOn
       : sortField;
 
   const resolvedStatusIds: number[] | undefined = filters.statusId

--- a/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
+++ b/apps/customer-portal/webapp/src/features/security/components/SecurityReportAnalysis.tsx
@@ -107,7 +107,7 @@ const SecurityReportAnalysis = ({ fixedStatusIds, fixedClosedDateRange }: Securi
   const [filters, setFilters] = useSessionState<AllCasesFilterValues>(`${sessionPrefix}-filters`, {}, undefined, { popOnly: true });
   const [sortField, setSortField] = useSessionState<SecurityReportCaseSortField>(
     `${sessionPrefix}-sortField`,
-    SecurityReportCaseSortField.createdOn,
+    SecurityReportCaseSortField.updatedOn,
     isValidSecuritySortField,
     { popOnly: true },
   );

--- a/apps/customer-portal/webapp/src/features/security/constants/securityConstants.ts
+++ b/apps/customer-portal/webapp/src/features/security/constants/securityConstants.ts
@@ -124,8 +124,8 @@ export const SECURITY_REPORT_VIEW_TABS = [
 ] as const;
 
 export const SECURITY_REPORT_SORT_OPTIONS = [
-  { value: "createdOn", label: "Created date", kind: "chronological" },
   { value: "updatedOn", label: "Updated date", kind: "chronological" },
+  { value: "createdOn", label: "Created date", kind: "chronological" },
   { value: "state", label: "Status", kind: "ordinal" },
 ] as const;
 

--- a/apps/customer-portal/webapp/src/features/security/utils/securityPage.ts
+++ b/apps/customer-portal/webapp/src/features/security/utils/securityPage.ts
@@ -76,6 +76,6 @@ export function parseSecurityReportCaseSortField(
     case SecurityReportCaseSortField.state:
       return SecurityReportCaseSortField.state;
     default:
-      return SecurityReportCaseSortField.createdOn;
+      return SecurityReportCaseSortField.updatedOn;
   }
 }

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
@@ -260,7 +260,7 @@ export default function OutstandingCasesList({
                   color="text.secondary"
                   sx={{ flexShrink: 0 }}
                 >
-                  {formatRelativeTime(c.createdOn ?? undefined)}
+                  {formatRelativeTime(c.updatedOn ?? undefined)}
                 </Typography>
               </Box>
             </Form.CardActions>

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
@@ -260,7 +260,7 @@ export default function OutstandingCasesList({
                   color="text.secondary"
                   sx={{ flexShrink: 0 }}
                 >
-                  {formatRelativeTime(c.updatedOn ?? undefined)}
+                  {formatRelativeTime(c.updatedOn ?? c.createdOn ?? undefined)}
                 </Typography>
               </Box>
             </Form.CardActions>

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -88,7 +88,7 @@ export default function AllCasesPage(): JSX.Element {
   const [isFiltersOpen, setIsFiltersOpen] = useState(
     () => hasListSearchOrFilters(searchTerm, filters),
   );
-  const [sortField, setSortField] = useSessionState<"createdOn" | "updatedOn" | "severity" | "state">(`${sessionPrefix}-sortField`, "createdOn", undefined, { popOnly: true });
+  const [sortField, setSortField] = useSessionState<"createdOn" | "updatedOn" | "severity" | "state">(`${sessionPrefix}-sortField`, "updatedOn", undefined, { popOnly: true });
   const [sortOrder, setSortOrder] = useSessionState<SortOrder>(`${sessionPrefix}-sortOrder`, SortOrder.DESC, undefined, { popOnly: true });
   const [page, setPage] = useSessionState<number>(`${sessionPrefix}-page`, 1, undefined, { popOnly: true });
   const [rowsPerPage, setRowsPerPage] = useSessionState<number>(`${sessionPrefix}-rowsPerPage`, 10, undefined, { popOnly: true });
@@ -369,8 +369,8 @@ export default function AllCasesPage(): JSX.Element {
         totalCount={totalItems}
         entityLabel="cases"
         sortFieldOptions={[
-          { value: "createdOn", label: "Created on" },
           { value: "updatedOn", label: "Updated on" },
+          { value: "createdOn", label: "Created on" },
           { value: "severity", label: "Severity", kind: "ordinal" as const },
           { value: "state", label: "Status", kind: "ordinal" as const },
         ]}

--- a/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
@@ -94,7 +94,7 @@ export default function SupportPage(): JSX.Element {
         caseTypes: [CaseType.DEFAULT_CASE],
         statusIds: nonClosedStatusIds,
       },
-      sortBy: { field: "createdOn", order: SortOrder.DESC },
+      sortBy: { field: "updatedOn", order: SortOrder.DESC },
     },
     0,
     SUPPORT_OVERVIEW_CASES_LIMIT,


### PR DESCRIPTION
### Description

This pull request updates the customer portal's case and announcement lists to consistently use the "Updated" date (falling back to "Created" if no update exists) instead of the "Created" date throughout the UI, sorting, and filtering logic. It also introduces a new "Created by" column to the dashboard cases table and adds support for viewing "My Cases" vs. "All Cases" via a new tab bar. Several UI elements and constants are updated for clarity and consistency.

**Announcement and Case List Date Handling**

- All announcement and case lists now display "Updated" dates instead of "Created" dates, falling back to "Created" if "Updated" is not present. This change is reflected in labels, sorting, and display logic across components such as `ListCard`, `AnnouncementList`, and `AnnouncementDetailsPanel`. [[1]](diffhunk://#diff-88f224640752ee8e725bda4ab7bec6beff12b6fc1905df6cf96aec58a414d029L216-R216) [[2]](diffhunk://#diff-c22b1772a5f43db7b9459085bc5ce8013b058e329638fd3c6502dbce10dc7cc2L116-R118) [[3]](diffhunk://#diff-c22b1772a5f43db7b9459085bc5ce8013b058e329638fd3c6502dbce10dc7cc2L225-R227) [[4]](diffhunk://#diff-8b06f4a6f812c25f1561eccc1b21d502757cabc7d30d54c6aa968858ac252f37L99-R101) [[5]](diffhunk://#diff-8b06f4a6f812c25f1561eccc1b21d502757cabc7d30d54c6aa968858ac252f37L196-R198)
- The default sort field for announcements and cases is changed from "createdOn" to "updatedOn" in types, constants, utility functions, and tests. [[1]](diffhunk://#diff-befd6535effcb3a9d86aae507cdd52d41174fa661dae300a1cdcb8192b20c36dL41-R51) [[2]](diffhunk://#diff-53faa8076743442e2deefa756c174de5697874c8e26d3c824cbef5f5b865f93aL70-R70) [[3]](diffhunk://#diff-4125893c35f32d692fee8b67b8f84c43321f82bf6f181be5594dcfb692d86774L25-R25) [[4]](diffhunk://#diff-02a782e0c737c802b7d32a1cad19ac2a2cc882036cdbba2dca18185c67430ac6L38-R38) [[5]](diffhunk://#diff-50932782d65dd33593d04c6f500b62d52300a2dd89159d9a007e5be44899d037L50-R50) [[6]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cR203-R211)

**Dashboard Cases Table Enhancements**

- Adds a new "Created by" column to the cases table, displaying the creator of each case. Adjusts table layout and skeletons to accommodate the new column. [[1]](diffhunk://#diff-2472fac5a57af1717cc0a21b184bcabe58ef428a8fa6d58c8c8cbea28e0bca92L63-R80) [[2]](diffhunk://#diff-2472fac5a57af1717cc0a21b184bcabe58ef428a8fa6d58c8c8cbea28e0bca92L96-R98) [[3]](diffhunk://#diff-2472fac5a57af1717cc0a21b184bcabe58ef428a8fa6d58c8c8cbea28e0bca92R157-R184) [[4]](diffhunk://#diff-2472fac5a57af1717cc0a21b184bcabe58ef428a8fa6d58c8c8cbea28e0bca92L236-L240) [[5]](diffhunk://#diff-2472fac5a57af1717cc0a21b184bcabe58ef428a8fa6d58c8c8cbea28e0bca92R268-R286) [[6]](diffhunk://#diff-30af3b4ece4d6facd22649a1fc3dc17b07b5ffca6904c0794922498aebf9a2c1L22-R24) [[7]](diffhunk://#diff-30af3b4ece4d6facd22649a1fc3dc17b07b5ffca6904c0794922498aebf9a2c1L32-R37)
- Table headers and column labels are updated for clarity (e.g., "Updated" instead of "Created").

**Dashboard View Mode (My Cases / All Cases)**

- Introduces a tab bar to switch between "My Cases" and "All Cases" views in the dashboard. Updates data fetching logic to filter cases accordingly. [[1]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cR38-R43) [[2]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cR88-R90) [[3]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cR203-R211) [[4]](diffhunk://#diff-47278545a84ebfb24d1b77923b8cb175e83e1acb522fe1c9534473a6f5a8b94cR329-R336) [[5]](diffhunk://#diff-7ec536e6787656650cf715338243f1a220ec5cb267ea9c045b38014c0a0a09c1R18) [[6]](diffhunk://#diff-7ec536e6787656650cf715338243f1a220ec5cb267ea9c045b38014c0a0a09c1R43-R45) [[7]](diffhunk://#diff-7ec536e6787656650cf715338243f1a220ec5cb267ea9c045b38014c0a0a09c1R69-L69) [[8]](diffhunk://#diff-7ec536e6787656650cf715338243f1a220ec5cb267ea9c045b38014c0a0a09c1R107)

**Constants and Types Updates**

- Updates constants and enums related to sorting fields and labels to reflect the switch from "Created" to "Updated". [[1]](diffhunk://#diff-befd6535effcb3a9d86aae507cdd52d41174fa661dae300a1cdcb8192b20c36dL41-R51) [[2]](diffhunk://#diff-4125893c35f32d692fee8b67b8f84c43321f82bf6f181be5594dcfb692d86774L25-R25)

These changes improve the user experience by ensuring that users see the most relevant (recently updated) information and have clearer navigation and filtering options in the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added view mode tabs ("My Cases" and "All Cases") to the dashboard cases table.
  * Added "Created by" column to the cases table.

* **Bug Fixes**
  * Updated timestamp displays to show "Updated" dates instead of "Created" dates across announcements, cases, service requests, and change requests.
  * Changed default sorting order from "Created on" to "Updated on" across cases, announcements, service requests, change requests, engagements, and security reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->