### PR TITLE
[Customer Portal][FE][Web] Update Restricted Tab Handling in Settings Page to Only Hide Registry Tokens Tab

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/pages/SettingsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/pages/SettingsPage.tsx
@@ -69,9 +69,7 @@ export default function SettingsPage(): JSX.Element {
     () =>
       hideRestrictedTabs
         ? SETTINGS_PAGE_TABS.filter(
-            (tab) =>
-              tab.id !== SettingsPageTabId.USERS &&
-              tab.id !== SettingsPageTabId.REGISTRY_TOKENS,
+            (tab) => tab.id !== SettingsPageTabId.REGISTRY_TOKENS,
           )
         : [...SETTINGS_PAGE_TABS],
     [hideRestrictedTabs],
@@ -80,8 +78,7 @@ export default function SettingsPage(): JSX.Element {
   const safeActiveTab = useMemo(() => {
     if (
       hideRestrictedTabs &&
-      (resolveSettingsPageTabId(activeTab) === SettingsPageTabId.USERS ||
-        resolveSettingsPageTabId(activeTab) === SettingsPageTabId.REGISTRY_TOKENS)
+      resolveSettingsPageTabId(activeTab) === SettingsPageTabId.REGISTRY_TOKENS
     ) {
       return SettingsPageTabId.AI;
     }


### PR DESCRIPTION
### Description

This pull request makes a small change to the logic for hiding restricted tabs in the `SettingsPage` component. Specifically, it now only hides the `REGISTRY_TOKENS` tab (and not the `USERS` tab) when `hideRestrictedTabs` is enabled, and updates the logic for determining the active tab accordingly.

- The `SETTINGS_PAGE_TABS` filtering now only excludes the `REGISTRY_TOKENS` tab when `hideRestrictedTabs` is true, allowing the `USERS` tab to remain visible.
- The logic for resetting the active tab now only checks for the `REGISTRY_TOKENS` tab, no longer redirecting away from the `USERS` tab when restricted tabs are hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Settings page tab visibility logic to ensure the Users management tab is properly displayed even when content restrictions are enabled for the account. Enhanced the tab selection fallback mechanism to gracefully handle all edge cases when certain restricted content tabs become temporarily unavailable or completely inaccessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->