### PR TITLE
[CSM-Portal][BE] Add user search functionality

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -61,7 +61,7 @@ func main() {
 		Scopes:       splitComma(os.Getenv("SCIM_SCOPES")),
 	}
 	scimClient := scim.NewClient(scimCfg)
-	usersHandler := handler.NewUsersHandler(scimClient)
+	usersHandler := handler.NewUsersHandler(scimClient, entityClient)
 
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
@@ -83,6 +83,7 @@ func main() {
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)
 	mux.HandleFunc("GET /users/me", usersHandler.GetMe)
 	mux.HandleFunc("PATCH /users/me", usersHandler.PatchMe)
+	mux.HandleFunc("POST /users/search", usersHandler.SearchUsers)
 
 	addr := envOrDefault("PORT", ":8080")
 	slog.Info("starting csm-portal backend", "addr", addr)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -40,3 +40,9 @@ func (c *Client) SearchCases(ctx context.Context, body []byte) ([]byte, error) {
 func (c *Client) GetCase(ctx context.Context, caseID string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/cases/%s", url.PathEscape(caseID)), nil)
 }
+
+// SearchUsers calls POST /users/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *Client) SearchUsers(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/users/search", body)
+}

--- a/apps/csm-portal/backend/internal/handler/users.go
+++ b/apps/csm-portal/backend/internal/handler/users.go
@@ -35,14 +35,20 @@ type scimClient interface {
 	UpdateUserPhone(ctx context.Context, userID, mobile string) (*string, error)
 }
 
-// UsersHandler handles HTTP requests for user-related operations.
-type UsersHandler struct {
-	scim scimClient
+// entityUserClient abstracts the entity service user operations used by UsersHandler.
+type entityUserClient interface {
+	SearchUsers(ctx context.Context, body []byte) ([]byte, error)
 }
 
-// NewUsersHandler creates a UsersHandler backed by the given SCIM client.
-func NewUsersHandler(scim scimClient) *UsersHandler {
-	return &UsersHandler{scim: scim}
+// UsersHandler handles HTTP requests for user-related operations.
+type UsersHandler struct {
+	scim   scimClient
+	entity entityUserClient
+}
+
+// NewUsersHandler creates a UsersHandler backed by the given SCIM and entity clients.
+func NewUsersHandler(scim scimClient, entity entityUserClient) *UsersHandler {
+	return &UsersHandler{scim: scim, entity: entity}
 }
 
 // userMeResponse is the GET /users/me response shape.
@@ -150,4 +156,36 @@ func (h *UsersHandler) PatchMe(w http.ResponseWriter, r *http.Request) {
 	// TODO: update timeZone via entity once available.
 
 	writeJSONValue(w, http.StatusOK, resp)
+}
+
+// SearchUsers handles POST /users/search.
+func (h *UsersHandler) SearchUsers(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	// TODO: Decode and validate the request body before forwarding.
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	result, err := h.entity.SearchUsers(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchUsers failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search users.")
+		return
+	}
+
+	// TODO: Unmarshal result and filter to only the fields required by the frontend.
+	writeJSON(w, http.StatusOK, result)
 }

--- a/apps/csm-portal/backend/internal/handler/users.go
+++ b/apps/csm-portal/backend/internal/handler/users.go
@@ -166,8 +166,6 @@ func (h *UsersHandler) SearchUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Decode and validate the request body before forwarding.
-
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -178,6 +176,13 @@ func (h *UsersHandler) SearchUsers(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errMsgReadBody)
 		return
 	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	// TODO: Decode into a typed SearchUsersRequest and validate fields before forwarding.
 
 	result, err := h.entity.SearchUsers(r.Context(), body)
 	if err != nil {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -194,6 +194,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /users/search:
+    post:
+      summary: Search users.
+      operationId: postUsersSearch
+      requestBody:
+        description: User search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /updates/levels/search:
     post:
       summary: Search updates between update levels.
@@ -354,6 +393,63 @@ components:
         phoneNumber:
           type: string
         # TODO: timeZone — requires entity
+
+    UserSearchPayload:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        searchQuery:
+          type: string
+          description: Searches across firstName, lastName, userName, and email (case-insensitive)
+        userType:
+          type: string
+          enum: [internal, customer]
+          description: Filter by user type
+
+    UserSearchResponse:
+      type: object
+      properties:
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        total:
+          type: integer
+          description: Total number of matching users
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        userName:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        phone:
+          type: string
+        timezone:
+          type: string
+        userType:
+          type: string
+          enum: [internal, customer]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 
     Pagination:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -398,7 +398,12 @@ components:
       type: object
       properties:
         pagination:
-          $ref: '#/components/schemas/Pagination'
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
         searchQuery:
           type: string
           description: Searches across firstName, lastName, userName, and email (case-insensitive)


### PR DESCRIPTION
## Summary
- Adds SearchUsers method to the entity client in internal/entity/entity.go, proxying POST /users/search to the entity service
- Extends UsersHandler with an entityUserClient interface and a SearchUsers HTTP handler (POST /users/search), following the same pattern as CaseHandler
- Wires the entity client into NewUsersHandler in main.go and registers the route
- Documents the endpoint in `openapi.yaml` with UserSearchPayload, UserSearchResponse, and User schemas matching the entity service contract

## Notes
- The response currently proxies all fields from the entity service. Field filtering to a frontend-specific shape is left as a TODO, consistent with how case endpoints are handled today.
- `UserSearchPayload.pagination` reuses the existing Pagination schema (limit, offset).
- The entity service applies a default limit of 20 and a cap of 100 — validation is handled upstream; the portal layer adds no additional pagination constraints for now.

## Test plan
 - POST /users/search with a valid JWT returns 200 and a paginated user list
 - Request without a JWT returns 401
 - Request body exceeding 1 MiB returns 413
 - `searchQuery` filters results by firstName, lastName, userName, email
 - `userType` filter (`internal` / `customer`) scopes results correctly
 - `hasMore` is `true` when more pages exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new user search endpoint enabling authenticated users to search and discover other users with support for filtering by search query, user type, and pagination controls (limit, offset, hasMore).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->