### PR TITLE
fix(patches-portal): Choreo build — react-app-rewired in dependencies

### DIFF
--- a/apps/security-advisory-patches-portal/webapp/package.json
+++ b/apps/security-advisory-patches-portal/webapp/package.json
@@ -21,6 +21,7 @@
     "formik": "^2.2.9",
     "notistack": "^2.0.8",
     "react": "^18.2.0",
+    "react-app-rewired": "^2.2.1",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.4.5",
@@ -47,8 +48,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "react-app-rewired": "^2.2.1"
   }
 }


### PR DESCRIPTION
## Summary

- Move **`react-app-rewired`** from `devDependencies` to **`dependencies`** in the Security Advisory Patches Portal webapp.

## Context

Choreo’s build failed with `react-app-rewired: not found` because devDependencies are omitted when the image installs dependencies for production.

## Test plan

- [ ] `cd apps/security-advisory-patches-portal/webapp && npm ci --omit=dev && npm run build` succeeds
- [ ] Choreo component build succeeds with `npm run build` and output dir `build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency configuration for internal build tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->