### PR TITLE
[Customer Portal][Backend] : Add deployment-usages endpoint to backend OpenAPI spec

### DIFF
--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2584,6 +2584,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+  /deployment-usages:
+    post:
+      summary: Import product consumption usage from a zip file.
+      operationId: postDeploymentUsages
+      requestBody:
+        description: Zip archive containing deployment usage data
+        content:
+          application/zip:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentUsageImportResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
   /projects/{id}/instances/metrics/search:
     post:
       summary: Search instance metrics for a specific project based on provided filters.
@@ -4610,6 +4637,15 @@ components:
           description: Active status (can only be set to false to deactivate deployment)
       additionalProperties: false
       description: Request payload for updating a deployment.
+    DeploymentUsageImportResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Response message
+        result:
+          description: Response result payload
+      description: Deployment usage import response.
     ErrorPayload:
       required:
       - message

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2551,7 +2551,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
+  /deployment-usages:
+    post:
+      summary: Import product consumption usage from a zip file.
+      operationId: postDeploymentUsages
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              description: Any type of entity body
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeploymentUsageImportResponse"
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorPayload"
+        "500":
+          description: InternalServerError
   /projects/{id}/stats/usage:
     get:
       summary: Get usage stats for a specific project.
@@ -2583,34 +2607,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
-  /deployment-usages:
-    post:
-      summary: Import product consumption usage from a zip file.
-      operationId: postDeploymentUsages
-      requestBody:
-        description: Zip archive containing deployment usage data
-        content:
-          application/zip:
-            schema:
-              type: string
-              format: binary
-        required: true
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeploymentUsageImportResponse'
-        "400":
-          description: BadRequest
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-        "500":
-          description: InternalServerError
+                $ref: "#/components/schemas/ErrorPayload"
   /projects/{id}/instances/metrics/search:
     post:
       summary: Search instance metrics for a specific project based on provided filters.


### PR DESCRIPTION
### Description

This pull request adds a new API endpoint for importing product consumption usage data via a zip file upload to the customer portal backend. It also introduces a corresponding response schema for this import operation.

**API Enhancements:**

* Added a new `POST /deployment-usages` endpoint to allow importing deployment usage data from a zip archive. The endpoint accepts a binary zip file and returns a structured response or error payload.

**Schema Updates:**

* Introduced a new `DeploymentUsageImportResponse` schema to standardize the API response for the deployment usage import operation. This schema includes a message and a result payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new deployment usage import feature that enables bulk importing of product consumption usage data from ZIP archive files. The import endpoint accepts binary zip file uploads and returns detailed feedback including operation status and results information, supporting improved data management and reporting capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->