### PR TITLE
[Customer Portal][FE][Web] Append Default Update Level 0 to Product Version Update Levels

### DIFF
--- a/apps/customer-portal/webapp/src/features/updates/utils/__tests__/allUpdatesTab.test.ts
+++ b/apps/customer-portal/webapp/src/features/updates/utils/__tests__/allUpdatesTab.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { getUpdateLevelsForProductVersion } from "@features/updates/utils/allUpdatesTab";
+
+describe("getUpdateLevelsForProductVersion", () => {
+  it("always includes 0 in returned level options", () => {
+    const data = [
+      {
+        productName: "WSO2 API Manager",
+        productUpdateLevels: [
+          {
+            productBaseVersion: "4.2.0",
+            channel: "full",
+            updateLevels: [3, 5, 7],
+          },
+        ],
+      },
+    ];
+
+    expect(getUpdateLevelsForProductVersion(data, "WSO2 API Manager", "4.2.0")).toEqual([
+      0, 3, 5, 7,
+    ]);
+  });
+
+  it("returns only 0 when update levels are unavailable", () => {
+    expect(getUpdateLevelsForProductVersion(undefined, "WSO2 API Manager", "4.2.0")).toEqual([0]);
+  });
+});
+

--- a/apps/customer-portal/webapp/src/features/updates/utils/allUpdatesTab.ts
+++ b/apps/customer-portal/webapp/src/features/updates/utils/allUpdatesTab.ts
@@ -133,6 +133,6 @@ export function getUpdateLevelsForProductVersion(
 ): number[] {
   const entries = getVersionEntriesForProduct(data, productName);
   const entry = entries.find((e) => e.productBaseVersion === productVersion);
-  if (!entry?.updateLevels?.length) return [];
-  return [...entry.updateLevels].sort((a, b) => a - b);
+  if (!entry?.updateLevels?.length) return [0];
+  return [...new Set([0, ...entry.updateLevels])].sort((a, b) => a - b);
 }


### PR DESCRIPTION
### Description

This pull request improves the handling of update levels in the `getUpdateLevelsForProductVersion` utility and adds corresponding unit tests to ensure correct behavior. The main changes ensure that the returned update levels always include `0`, even when no update levels are available, and that the function is now properly tested.

### Update logic improvements
* Modified `getUpdateLevelsForProductVersion` in `allUpdatesTab.ts` to always include `0` in the returned update levels. If no update levels are available for a product version, it now returns `[0]` instead of an empty array.

### Testing enhancements
* Added a new test file `allUpdatesTab.test.ts` with unit tests for `getUpdateLevelsForProductVersion`, verifying that `0` is always included and that `[0]` is returned when update levels are unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update level selection now consistently includes a baseline option and prevents empty results when no custom levels are configured.

* **Tests**
  * Added test coverage for update level retrieval functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->