### PR TITLE
[CSM Portal] Add products and product versions search endpoints

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -44,6 +44,7 @@ func main() {
 	caseHandler := handler.NewCaseHandler(entityClient)
 	accountHandler := handler.NewAccountHandler(entityClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
+	productHandler := handler.NewProductHandler(entityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
@@ -88,6 +89,8 @@ func main() {
 	mux.HandleFunc("POST /users/search", usersHandler.SearchUsers)
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
+	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
+	mux.HandleFunc("POST /product-versions/search", productHandler.SearchProductVersions)
 
 	addr := envOrDefault("PORT", ":8080")
 	slog.Info("starting csm-portal backend", "addr", addr)

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -90,7 +90,7 @@ func main() {
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
-	mux.HandleFunc("POST /product-versions/search", productHandler.SearchProductVersions)
+	mux.HandleFunc("POST /product/{id}/versions/search", productHandler.SearchProductVersions)
 
 	addr := envOrDefault("PORT", ":8080")
 	slog.Info("starting csm-portal backend", "addr", addr)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -58,3 +58,15 @@ func (c *Client) SearchAccounts(ctx context.Context, body []byte) ([]byte, error
 func (c *Client) SearchProjects(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/projects/search", body)
 }
+
+// SearchProducts calls POST /products/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *Client) SearchProducts(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/products/search", body)
+}
+
+// SearchProductVersions calls POST /product-versions/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *Client) SearchProductVersions(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/product-versions/search", body)
+}

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -65,8 +65,8 @@ func (c *Client) SearchProducts(ctx context.Context, body []byte) ([]byte, error
 	return c.do(ctx, http.MethodPost, "/products/search", body)
 }
 
-// SearchProductVersions calls POST /product-versions/search on the entity service.
+// SearchProductVersions calls POST /product/{id}/versions/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchProductVersions(ctx context.Context, body []byte) ([]byte, error) {
-	return c.do(ctx, http.MethodPost, "/product-versions/search", body)
+func (c *Client) SearchProductVersions(ctx context.Context, productID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/product/%s/versions/search", url.PathEscape(productID)), body)
 }

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -204,7 +204,7 @@ func (m *mockEntityProjectClient) SearchProjects(ctx context.Context, body []byt
 
 type mockEntityProductClient struct {
 	searchProductsFn        func(ctx context.Context, body []byte) ([]byte, error)
-	searchProductVersionsFn func(ctx context.Context, body []byte) ([]byte, error)
+	searchProductVersionsFn func(ctx context.Context, productID string, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityProductClient) SearchProducts(ctx context.Context, body []byte) ([]byte, error) {
@@ -214,9 +214,9 @@ func (m *mockEntityProductClient) SearchProducts(ctx context.Context, body []byt
 	return []byte(`{}`), nil
 }
 
-func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, body []byte) ([]byte, error) {
+func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, productID string, body []byte) ([]byte, error) {
 	if m.searchProductVersionsFn != nil {
-		return m.searchProductVersionsFn(ctx, body)
+		return m.searchProductVersionsFn(ctx, productID, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -199,3 +199,24 @@ func (m *mockEntityProjectClient) SearchProjects(ctx context.Context, body []byt
 	}
 	return []byte(`{}`), nil
 }
+
+// ----- mock entity product client -----
+
+type mockEntityProductClient struct {
+	searchProductsFn        func(ctx context.Context, body []byte) ([]byte, error)
+	searchProductVersionsFn func(ctx context.Context, body []byte) ([]byte, error)
+}
+
+func (m *mockEntityProductClient) SearchProducts(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchProductsFn != nil {
+		return m.searchProductsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchProductVersionsFn != nil {
+		return m.searchProductVersionsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}

--- a/apps/csm-portal/backend/internal/handler/products.go
+++ b/apps/csm-portal/backend/internal/handler/products.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -54,7 +55,8 @@ func (h *ProductHandler) SearchProducts(w http.ResponseWriter, r *http.Request) 
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		if _, ok := err.(*http.MaxBytesError); ok {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
 			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
 			return
 		}
@@ -91,7 +93,8 @@ func (h *ProductHandler) SearchProductVersions(w http.ResponseWriter, r *http.Re
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		if _, ok := err.(*http.MaxBytesError); ok {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
 			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
 			return
 		}

--- a/apps/csm-portal/backend/internal/handler/products.go
+++ b/apps/csm-portal/backend/internal/handler/products.go
@@ -30,7 +30,7 @@ import (
 // entityProductClient abstracts the entity service product operations used by ProductHandler.
 type entityProductClient interface {
 	SearchProducts(ctx context.Context, body []byte) ([]byte, error)
-	SearchProductVersions(ctx context.Context, body []byte) ([]byte, error)
+	SearchProductVersions(ctx context.Context, productID string, body []byte) ([]byte, error)
 }
 
 // ProductHandler handles HTTP requests for product operations, delegating to the
@@ -82,11 +82,17 @@ func (h *ProductHandler) SearchProducts(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, result)
 }
 
-// SearchProductVersions handles POST /product-versions/search.
+// SearchProductVersions handles POST /product/{id}/versions/search.
 func (h *ProductHandler) SearchProductVersions(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	productID := r.PathValue("id")
+	if productID == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
@@ -109,7 +115,7 @@ func (h *ProductHandler) SearchProductVersions(w http.ResponseWriter, r *http.Re
 
 	// TODO: Decode into a typed SearchProductVersionsRequest and validate fields before forwarding.
 
-	result, err := h.entity.SearchProductVersions(r.Context(), body)
+	result, err := h.entity.SearchProductVersions(r.Context(), productID, body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchProductVersions failed", "userID", user.UserID, "err", err)
 		mapUpstreamError(w, err, "Failed to search product versions.")

--- a/apps/csm-portal/backend/internal/handler/products.go
+++ b/apps/csm-portal/backend/internal/handler/products.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityProductClient abstracts the entity service product operations used by ProductHandler.
+type entityProductClient interface {
+	SearchProducts(ctx context.Context, body []byte) ([]byte, error)
+	SearchProductVersions(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// ProductHandler handles HTTP requests for product operations, delegating to the
+// entity service for data access.
+type ProductHandler struct {
+	entity entityProductClient
+}
+
+// NewProductHandler creates a ProductHandler backed by the given entity client.
+func NewProductHandler(entity entityProductClient) *ProductHandler {
+	return &ProductHandler{entity: entity}
+}
+
+// SearchProducts handles POST /products/search.
+func (h *ProductHandler) SearchProducts(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	// TODO: Decode into a typed SearchProductsRequest and validate fields before forwarding.
+
+	result, err := h.entity.SearchProducts(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProducts failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search products.")
+		return
+	}
+
+	// TODO: Unmarshal result and filter to only the fields required by the frontend.
+	writeJSON(w, http.StatusOK, result)
+}
+
+// SearchProductVersions handles POST /product-versions/search.
+func (h *ProductHandler) SearchProductVersions(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	// TODO: Decode into a typed SearchProductVersionsRequest and validate fields before forwarding.
+
+	result, err := h.entity.SearchProductVersions(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProductVersions failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search product versions.")
+		return
+	}
+
+	// TODO: Unmarshal result and filter to only the fields required by the frontend.
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/products_test.go
+++ b/apps/csm-portal/backend/internal/handler/products_test.go
@@ -104,7 +104,8 @@ func TestSearchProducts(t *testing.T) {
 func TestSearchProductVersions(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewProductHandler(&mockEntityProductClient{})
-		r := httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/product/prod-1/versions/search", strings.NewReader(`{}`))
+		r.SetPathValue("id", "prod-1")
 		w := httptest.NewRecorder()
 		h.SearchProductVersions(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -112,9 +113,20 @@ func TestSearchProductVersions(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects missing product id", func(t *testing.T) {
+		h := NewProductHandler(&mockEntityProductClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/product//versions/search", strings.NewReader(`{}`)))
+		w := httptest.NewRecorder()
+		h.SearchProductVersions(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewProductHandler(&mockEntityProductClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/product/prod-1/versions/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", "prod-1")
 		w := httptest.NewRecorder()
 		h.SearchProductVersions(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -124,7 +136,8 @@ func TestSearchProductVersions(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewProductHandler(&mockEntityProductClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(`not-json`)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/product/prod-1/versions/search", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", "prod-1")
 		w := httptest.NewRecorder()
 		h.SearchProductVersions(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -132,22 +145,28 @@ func TestSearchProductVersions(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+	t.Run("forwards product id and body to upstream and returns 200 with response", func(t *testing.T) {
 		const reqPayload = `{"searchQuery":"4.2","pagination":{"limit":10,"offset":0}}`
+		var capturedProductID string
 		var capturedBody []byte
 		client := &mockEntityProductClient{
-			searchProductVersionsFn: func(_ context.Context, body []byte) ([]byte, error) {
+			searchProductVersionsFn: func(_ context.Context, productID string, body []byte) ([]byte, error) {
+				capturedProductID = productID
 				capturedBody = body
 				return []byte(`{"productVersions":[{"id":"pv-1","version":"4.2.0"}],"total":1}`), nil
 			},
 		}
 		h := NewProductHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(reqPayload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/product/prod-1/versions/search", strings.NewReader(reqPayload)))
+		r.SetPathValue("id", "prod-1")
 		w := httptest.NewRecorder()
 		h.SearchProductVersions(w, r)
 
 		assertStatus(t, w, http.StatusOK)
 		assertContentType(t, w, "application/json")
+		if capturedProductID != "prod-1" {
+			t.Errorf("upstream received productID %q, want %q", capturedProductID, "prod-1")
+		}
 		if string(capturedBody) != reqPayload {
 			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
 		}
@@ -162,12 +181,13 @@ func TestSearchProductVersions(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				client := &mockEntityProductClient{
-					searchProductVersionsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+					searchProductVersionsFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
 						return nil, tc.err
 					},
 				}
 				h := NewProductHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/product/prod-1/versions/search", strings.NewReader(`{}`)))
+				r.SetPathValue("id", "prod-1")
 				w := httptest.NewRecorder()
 				h.SearchProductVersions(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/apps/csm-portal/backend/internal/handler/products_test.go
+++ b/apps/csm-portal/backend/internal/handler/products_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSearchProducts(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewProductHandler(&mockEntityProductClient{})
+		r := httptest.NewRequest(http.MethodPost, "/products/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchProducts(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewProductHandler(&mockEntityProductClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/products/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchProducts(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewProductHandler(&mockEntityProductClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/products/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchProducts(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"searchQuery":"wso2","pagination":{"limit":10,"offset":0}}`
+		var capturedBody []byte
+		client := &mockEntityProductClient{
+			searchProductsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"products":[{"id":"prod-1","name":"WSO2 API Manager"}],"total":1}`), nil
+			},
+		}
+		h := NewProductHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/products/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchProducts(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search products.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityProductClient{
+					searchProductsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewProductHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/products/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchProducts(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestSearchProductVersions(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewProductHandler(&mockEntityProductClient{})
+		r := httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchProductVersions(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewProductHandler(&mockEntityProductClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchProductVersions(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewProductHandler(&mockEntityProductClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchProductVersions(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"searchQuery":"4.2","pagination":{"limit":10,"offset":0}}`
+		var capturedBody []byte
+		client := &mockEntityProductClient{
+			searchProductVersionsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"productVersions":[{"id":"pv-1","version":"4.2.0"}],"total":1}`), nil
+			},
+		}
+		h := NewProductHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchProductVersions(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search product versions.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityProductClient{
+					searchProductVersionsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewProductHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/product-versions/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchProductVersions(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -350,10 +350,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /product-versions/search:
+  /product/{id}/versions/search:
     post:
-      summary: Search product versions.
+      summary: Search versions for a specific product.
       operationId: postProductVersionsSearch
+      parameters:
+        - name: id
+          in: path
+          description: ID of the product
+          required: true
+          schema:
+            type: string
       requestBody:
         description: Product version search payload
         content:
@@ -801,9 +808,6 @@ components:
                 limit:
                   default: 20
                   maximum: 100
-        productId:
-          type: string
-          description: Filter by product ID (optional)
         searchQuery:
           type: string
           description: Searches across version (case-insensitive); max 200 characters

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -311,6 +311,84 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /products/search:
+    post:
+      summary: Search products.
+      operationId: postProductsSearch
+      requestBody:
+        description: Product search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /product-versions/search:
+    post:
+      summary: Search product versions.
+      operationId: postProductVersionsSearch
+      requestBody:
+        description: Product version search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductVersionSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductVersionSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /updates/levels/search:
     post:
       summary: Search updates between update levels.
@@ -656,6 +734,116 @@ components:
           type: string
           format: date-time
         endDate:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ProductSearchPayload:
+      type: object
+      properties:
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+        searchQuery:
+          type: string
+          description: Searches across name (case-insensitive); max 200 characters
+
+    ProductSearchResponse:
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/Product'
+        total:
+          type: integer
+          description: Total number of matching products
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    Product:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        class:
+          type: string
+          enum: [software, service]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ProductVersionSearchPayload:
+      type: object
+      properties:
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+        productId:
+          type: string
+          description: Filter by product ID (optional)
+        searchQuery:
+          type: string
+          description: Searches across version (case-insensitive); max 200 characters
+
+    ProductVersionSearchResponse:
+      type: object
+      properties:
+        productVersions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductVersion'
+        total:
+          type: integer
+          description: Total number of matching product versions
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    ProductVersion:
+      type: object
+      properties:
+        id:
+          type: string
+        productId:
+          type: string
+        version:
+          type: string
+        currentSupportStatus:
+          type: string
+          enum: [available, extended, deprecated, discontinued]
+        releaseDate:
+          type: string
+          format: date-time
+        supportEolDate:
+          type: string
+          format: date-time
+        earliestPossibleSupportEolDate:
           type: string
           format: date-time
         createdAt:


### PR DESCRIPTION
## Summary

- Wires \`POST /products/search\` and \`POST /product/{id}/versions/search\` into the csm-portal backend, proxying to the entity service endpoints added in #746
- Adds \`SearchProducts\` and \`SearchProductVersions\` methods to the entity client (\`internal/entity/entity.go\`); \`SearchProductVersions\` accepts the product ID as a path segment
- Adds \`ProductHandler\` in \`internal/handler/products.go\` following the same gateway pattern as \`ProjectHandler\`; \`SearchProductVersions\` extracts \`{id}\` from the path and forwards it to the entity client
- Registers both routes in \`cmd/server/main.go\`
- Updates \`openapi.yaml\` with both new paths and their request/response schemas; \`productId\` is a path parameter on the versions endpoint, not a body field
- Adds full test coverage in \`products_test.go\` and mocks in \`helpers_test.go\`, matching the pattern used by all other handlers
- Fixes \`MaxBytesError\` detection to use \`errors.As\` instead of a direct type assertion (review feedback from @kasunsiyambalapitiya)

## Test plan

- [x] \`go test ./internal/handler/...\` passes locally
- [x] Pre-push hook ran all backend tests — all green
- [x] Verify \`POST /products/search\` proxies to entity service and returns product list
- [x] Verify \`POST /product/{id}/versions/search\` proxies to entity service and returns version list for the given product
- [x] Verify unauthenticated requests return 401
- [x] Verify missing \`{id}\` returns 400
- [x] Verify oversized / invalid JSON bodies return 413 / 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)