### PR TITLE
[CSM Portal] Add deployments search; fix product versions route; remove unused endpoint

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -154,7 +154,6 @@ backend/
 
 ### Updates
 
-- `GET /updates/recommended-update-levels` — Get recommended update levels (user email sourced from JWT)
 - `GET /updates/product-update-levels` — Get product update levels
 - `POST /updates/levels/search` — Search updates between update levels
 
@@ -195,9 +194,6 @@ curl -X PATCH http://localhost:8080/users/me \
   -H "x-jwt-assertion: $JWT" \
   -H "Content-Type: application/json" \
   -d '{"phoneNumber":"+94771234567"}'
-
-# Get recommended update levels (user email is read from the JWT)
-curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/recommended-update-levels
 
 # Get product update levels
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/product-update-levels

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -45,6 +45,7 @@ func main() {
 	accountHandler := handler.NewAccountHandler(entityClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
 	productHandler := handler.NewProductHandler(entityClient)
+	deploymentHandler := handler.NewDeploymentHandler(entityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
@@ -91,6 +92,7 @@ func main() {
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /product/{id}/versions/search", productHandler.SearchProductVersions)
+	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 
 	addr := envOrDefault("PORT", ":8080")
 	slog.Info("starting csm-portal backend", "addr", addr)

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -91,7 +91,7 @@ func main() {
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
-	mux.HandleFunc("POST /product/{id}/versions/search", productHandler.SearchProductVersions)
+	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 
 	addr := envOrDefault("PORT", ":8080")

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -82,7 +82,6 @@ func main() {
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
-	mux.HandleFunc("GET /updates/recommended-update-levels", updatesHandler.GetRecommendedUpdateLevels)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)
 	mux.HandleFunc("GET /users/me", usersHandler.GetMe)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -70,3 +70,9 @@ func (c *Client) SearchProducts(ctx context.Context, body []byte) ([]byte, error
 func (c *Client) SearchProductVersions(ctx context.Context, productID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/product/%s/versions/search", url.PathEscape(productID)), body)
 }
+
+// SearchDeployments calls POST /deployments/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *Client) SearchDeployments(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/deployments/search", body)
+}

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -65,10 +65,10 @@ func (c *Client) SearchProducts(ctx context.Context, body []byte) ([]byte, error
 	return c.do(ctx, http.MethodPost, "/products/search", body)
 }
 
-// SearchProductVersions calls POST /product/{id}/versions/search on the entity service.
+// SearchProductVersions calls POST /products/{id}/versions/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *Client) SearchProductVersions(ctx context.Context, productID string, body []byte) ([]byte, error) {
-	return c.do(ctx, http.MethodPost, fmt.Sprintf("/product/%s/versions/search", url.PathEscape(productID)), body)
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/products/%s/versions/search", url.PathEscape(productID)), body)
 }
 
 // SearchDeployments calls POST /deployments/search on the entity service.

--- a/apps/csm-portal/backend/internal/handler/deployments.go
+++ b/apps/csm-portal/backend/internal/handler/deployments.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityDeploymentClient abstracts the entity service deployment operations used by DeploymentHandler.
+type entityDeploymentClient interface {
+	SearchDeployments(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// DeploymentHandler handles HTTP requests for deployment operations, delegating to the
+// entity service for data access.
+type DeploymentHandler struct {
+	entity entityDeploymentClient
+}
+
+// NewDeploymentHandler creates a DeploymentHandler backed by the given entity client.
+func NewDeploymentHandler(entity entityDeploymentClient) *DeploymentHandler {
+	return &DeploymentHandler{entity: entity}
+}
+
+// SearchDeployments handles POST /deployments/search.
+func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	// TODO: Decode into a typed SearchDeploymentsRequest and validate fields before forwarding.
+
+	result, err := h.entity.SearchDeployments(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchDeployments failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search deployments.")
+		return
+	}
+
+	// TODO: Unmarshal result and filter to only the fields required by the frontend.
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/deployments_test.go
+++ b/apps/csm-portal/backend/internal/handler/deployments_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSearchDeployments(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchDeployments(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchDeployments(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchDeployments(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"searchQuery":"prod","projectIds":["proj-1"],"deploymentTypeKeys":["primary_production"]}`
+		var capturedBody []byte
+		client := &mockEntityDeploymentClient{
+			searchDeploymentsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"deployments":[{"id":"dep-1","name":"Production"}],"total":1}`), nil
+			},
+		}
+		h := NewDeploymentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchDeployments(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search deployments.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityDeploymentClient{
+					searchDeploymentsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewDeploymentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchDeployments(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -220,3 +220,16 @@ func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, pro
 	}
 	return []byte(`{}`), nil
 }
+
+// ----- mock entity deployment client -----
+
+type mockEntityDeploymentClient struct {
+	searchDeploymentsFn func(ctx context.Context, body []byte) ([]byte, error)
+}
+
+func (m *mockEntityDeploymentClient) SearchDeployments(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchDeploymentsFn != nil {
+		return m.searchDeploymentsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -114,16 +114,8 @@ func (m *mockEntityCaseClient) GetCase(ctx context.Context, caseID string) ([]by
 // ----- mock updates client -----
 
 type mockUpdatesClient struct {
-	recommendedFn func(ctx context.Context, email string) ([]updates.RecommendedUpdateLevel, error)
-	productFn     func(ctx context.Context) ([]updates.ProductUpdateLevel, error)
-	searchFn      func(ctx context.Context, payload updates.SearchPayload, email string) (map[string]updates.UpdateLevelGroup, error)
-}
-
-func (m *mockUpdatesClient) GetRecommendedUpdateLevels(ctx context.Context, email string) ([]updates.RecommendedUpdateLevel, error) {
-	if m.recommendedFn != nil {
-		return m.recommendedFn(ctx, email)
-	}
-	return []updates.RecommendedUpdateLevel{}, nil
+	productFn func(ctx context.Context) ([]updates.ProductUpdateLevel, error)
+	searchFn  func(ctx context.Context, payload updates.SearchPayload, email string) (map[string]updates.UpdateLevelGroup, error)
 }
 
 func (m *mockUpdatesClient) GetProductUpdateLevels(ctx context.Context) ([]updates.ProductUpdateLevel, error) {

--- a/apps/csm-portal/backend/internal/handler/products.go
+++ b/apps/csm-portal/backend/internal/handler/products.go
@@ -82,7 +82,7 @@ func (h *ProductHandler) SearchProducts(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, result)
 }
 
-// SearchProductVersions handles POST /product/{id}/versions/search.
+// SearchProductVersions handles POST /products/{id}/versions/search.
 func (h *ProductHandler) SearchProductVersions(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {

--- a/apps/csm-portal/backend/internal/handler/updates.go
+++ b/apps/csm-portal/backend/internal/handler/updates.go
@@ -30,7 +30,6 @@ import (
 // updatesClient abstracts the updates service operations used by UpdatesHandler,
 // allowing the handler to be tested independently of the real HTTP client.
 type updatesClient interface {
-	GetRecommendedUpdateLevels(ctx context.Context, userEmail string) ([]updates.RecommendedUpdateLevel, error)
 	GetProductUpdateLevels(ctx context.Context) ([]updates.ProductUpdateLevel, error)
 	SearchUpdatesBetweenUpdateLevels(ctx context.Context, payload updates.SearchPayload, userEmail string) (map[string]updates.UpdateLevelGroup, error)
 }
@@ -44,25 +43,6 @@ type UpdatesHandler struct {
 // NewUpdatesHandler creates an UpdatesHandler backed by the given updates client.
 func NewUpdatesHandler(updates updatesClient) *UpdatesHandler {
 	return &UpdatesHandler{updates: updates}
-}
-
-// GetRecommendedUpdateLevels handles GET /updates/recommended-update-levels.
-// The user email is sourced from the JWT claims, not a query parameter.
-func (h *UpdatesHandler) GetRecommendedUpdateLevels(w http.ResponseWriter, r *http.Request) {
-	user := middleware.UserInfoFromContext(r.Context())
-	if user == nil {
-		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
-		return
-	}
-
-	result, err := h.updates.GetRecommendedUpdateLevels(r.Context(), user.Email)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "updates GetRecommendedUpdateLevels failed", "userID", user.UserID, "err", err)
-		mapUpstreamError(w, err, "Failed to get recommended update levels.")
-		return
-	}
-
-	writeJSONValue(w, http.StatusOK, result)
 }
 
 // GetProductUpdateLevels handles GET /updates/product-update-levels.

--- a/apps/csm-portal/backend/internal/handler/updates_test.go
+++ b/apps/csm-portal/backend/internal/handler/updates_test.go
@@ -26,66 +26,6 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/updates"
 )
 
-// ----- GetRecommendedUpdateLevels -----
-
-func TestGetRecommendedUpdateLevels(t *testing.T) {
-	t.Run("requires authenticated user", func(t *testing.T) {
-		h := NewUpdatesHandler(&mockUpdatesClient{})
-		r := httptest.NewRequest(http.MethodGet, "/updates/recommended-update-levels", nil)
-		w := httptest.NewRecorder()
-		h.GetRecommendedUpdateLevels(w, r)
-		assertStatus(t, w, http.StatusUnauthorized)
-		assertErrorMessage(t, w, ErrMsgUnauthorized)
-		assertContentType(t, w, "application/json")
-	})
-
-	t.Run("passes JWT email to upstream and returns 200 with levels", func(t *testing.T) {
-		var capturedEmail string
-		client := &mockUpdatesClient{
-			recommendedFn: func(_ context.Context, email string) ([]updates.RecommendedUpdateLevel, error) {
-				capturedEmail = email
-				return []updates.RecommendedUpdateLevel{
-					{ProductName: "wso2am", ProductBaseVersion: "4.3.0", RecommendedUpdateLevel: 10},
-				}, nil
-			},
-		}
-		h := NewUpdatesHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodGet, "/updates/recommended-update-levels", nil))
-		w := httptest.NewRecorder()
-		h.GetRecommendedUpdateLevels(w, r)
-
-		assertStatus(t, w, http.StatusOK)
-		assertContentType(t, w, "application/json")
-		if capturedEmail != testUser.Email {
-			t.Errorf("upstream called with email %q, want %q", capturedEmail, testUser.Email)
-		}
-		resp := decodeJSON[[]updates.RecommendedUpdateLevel](t, w)
-		if len(resp) != 1 || resp[0].ProductName != "wso2am" {
-			t.Errorf("unexpected response: %+v", resp)
-		}
-	})
-
-	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
-		for _, tc := range upstreamErrors("Failed to get recommended update levels.") {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				client := &mockUpdatesClient{
-					recommendedFn: func(_ context.Context, _ string) ([]updates.RecommendedUpdateLevel, error) {
-						return nil, tc.err
-					},
-				}
-				h := NewUpdatesHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodGet, "/updates/recommended-update-levels", nil))
-				w := httptest.NewRecorder()
-				h.GetRecommendedUpdateLevels(w, r)
-				assertStatus(t, w, tc.wantCode)
-				assertErrorMessage(t, w, tc.wantMsg)
-				assertContentType(t, w, "application/json")
-			})
-		}
-	})
-}
-
 // ----- GetProductUpdateLevels -----
 
 func TestGetProductUpdateLevels(t *testing.T) {

--- a/apps/csm-portal/backend/internal/updates/mapper.go
+++ b/apps/csm-portal/backend/internal/updates/mapper.go
@@ -18,28 +18,6 @@ package updates
 
 import "strconv"
 
-// mapRecommendedUpdateLevels converts the upstream snake-case response to the
-// portal camelCase response shape, mirroring processRecommendedUpdateLevels in utils.bal.
-func mapRecommendedUpdateLevels(src []upstreamRecommendedUpdateLevel) []RecommendedUpdateLevel {
-	out := make([]RecommendedUpdateLevel, len(src))
-	for i, s := range src {
-		out[i] = RecommendedUpdateLevel{
-			ProductName:                   s.ProductName,
-			ProductBaseVersion:            s.ProductBaseVersion,
-			Channel:                       s.Channel,
-			StartingUpdateLevel:           s.StartingUpdateLevel,
-			EndingUpdateLevel:             s.EndingUpdateLevel,
-			InstalledUpdatesCount:         s.InstalledUpdatesCount,
-			InstalledSecurityUpdatesCount: s.InstalledSecurityUpdatesCount,
-			Timestamp:                     s.Timestamp,
-			RecommendedUpdateLevel:        s.RecommendedUpdateLevel,
-			AvailableUpdatesCount:         s.AvailableUpdatesCount,
-			AvailableSecurityUpdatesCount: s.AvailableSecurityUpdatesCount,
-		}
-	}
-	return out
-}
-
 // mapProductUpdateLevels converts the upstream snake-case response to the
 // portal camelCase response shape, mirroring processProductUpdateLevels in utils.bal.
 func mapProductUpdateLevels(src []upstreamProductUpdateLevel) []ProductUpdateLevel {

--- a/apps/csm-portal/backend/internal/updates/types.go
+++ b/apps/csm-portal/backend/internal/updates/types.go
@@ -26,20 +26,6 @@ const updateTypeRegular = "regular"
 // ---- upstream (snake-case) types ----
 // These mirror the record types defined in modules/updates/types.bal.
 
-type upstreamRecommendedUpdateLevel struct {
-	ProductName                   string `json:"product-name"`
-	ProductBaseVersion            string `json:"product-base-version"`
-	Channel                       string `json:"channel"`
-	StartingUpdateLevel           int    `json:"starting-update-level"`
-	EndingUpdateLevel             int    `json:"ending-update-level"`
-	InstalledUpdatesCount         int    `json:"installed-updates-count"`
-	InstalledSecurityUpdatesCount int    `json:"installed-security-updates-count"`
-	Timestamp                     int64  `json:"timestamp"`
-	RecommendedUpdateLevel        int    `json:"recommended-update-level"`
-	AvailableUpdatesCount         int    `json:"available-updates-count"`
-	AvailableSecurityUpdatesCount int    `json:"available-security-updates-count"`
-}
-
 type upstreamProductUpdateLevel struct {
 	ProductName         string               `json:"product-name"`
 	ProductUpdateLevels []upstreamUpdateLevel `json:"product-update-levels"`
@@ -98,21 +84,6 @@ type upstreamSecurityAdvisory struct {
 // ---- portal (camelCase) types ----
 // These mirror the types defined in modules/types/types.bal and are what the
 // CSM portal returns to its callers.
-
-// RecommendedUpdateLevel is the portal response shape for a recommended update level.
-type RecommendedUpdateLevel struct {
-	ProductName                   string `json:"productName"`
-	ProductBaseVersion            string `json:"productBaseVersion"`
-	Channel                       string `json:"channel"`
-	StartingUpdateLevel           int    `json:"startingUpdateLevel"`
-	EndingUpdateLevel             int    `json:"endingUpdateLevel"`
-	InstalledUpdatesCount         int    `json:"installedUpdatesCount"`
-	InstalledSecurityUpdatesCount int    `json:"installedSecurityUpdatesCount"`
-	Timestamp                     int64  `json:"timestamp"`
-	RecommendedUpdateLevel        int    `json:"recommendedUpdateLevel"`
-	AvailableUpdatesCount         int    `json:"availableUpdatesCount"`
-	AvailableSecurityUpdatesCount int    `json:"availableSecurityUpdatesCount"`
-}
 
 // ProductUpdateLevel is the portal response shape for a product's update levels.
 type ProductUpdateLevel struct {

--- a/apps/csm-portal/backend/internal/updates/updates.go
+++ b/apps/csm-portal/backend/internal/updates/updates.go
@@ -23,24 +23,6 @@ import (
 	"net/http"
 )
 
-// GetRecommendedUpdateLevels fetches recommended update levels for the given user
-// and returns them mapped to the portal camelCase response shape.
-func (c *Client) GetRecommendedUpdateLevels(ctx context.Context, userEmail string) ([]RecommendedUpdateLevel, error) {
-	raw, err := c.do(ctx, http.MethodGet, "/updates/recommended-update-levels", nil, map[string]string{
-		"user": userEmail,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var upstream []upstreamRecommendedUpdateLevel
-	if err := json.Unmarshal(raw, &upstream); err != nil {
-		return nil, fmt.Errorf("updates: decode recommended update levels: %w", err)
-	}
-
-	return mapRecommendedUpdateLevels(upstream), nil
-}
-
 // GetProductUpdateLevels fetches all product update levels and returns them
 // mapped to the portal camelCase response shape.
 func (c *Client) GetProductUpdateLevels(ctx context.Context) ([]ProductUpdateLevel, error) {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -311,6 +311,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /deployments/search:
+    post:
+      summary: Search deployments.
+      operationId: postDeploymentsSearch
+      requestBody:
+        description: Deployment search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeploymentSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /products/search:
     post:
       summary: Search products.
@@ -743,6 +782,83 @@ components:
         endDate:
           type: string
           format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    DeploymentSearchPayload:
+      type: object
+      properties:
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+        searchQuery:
+          type: string
+          description: Searches across name (case-insensitive); max 200 characters
+        projectIds:
+          type: array
+          items:
+            type: string
+          description: Filter by project IDs (optional)
+        deploymentTypeKeys:
+          type: array
+          items:
+            type: string
+            enum:
+              - primary_production
+              - staging
+              - qa
+              - stress
+              - uat
+              - development
+          description: Filter by deployment type (optional)
+
+    DeploymentSearchResponse:
+      type: object
+      properties:
+        deployments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Deployment'
+        total:
+          type: integer
+          description: Total number of matching deployments
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    Deployment:
+      type: object
+      properties:
+        id:
+          type: string
+        projectId:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum:
+            - primary_production
+            - staging
+            - qa
+            - stress
+            - uat
+            - development
+        description:
+          type: string
+        createdBy:
+          type: string
         createdAt:
           type: string
           format: date-time

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -389,7 +389,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /product/{id}/versions/search:
+  /products/{id}/versions/search:
     post:
       summary: Search versions for a specific product.
       operationId: postProductVersionsSearch

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -96,31 +96,6 @@ paths:
         "500":
           description: InternalServerError
 
-  /updates/recommended-update-levels:
-    get:
-      summary: Get recommended update levels for a user.
-      operationId: getUpdatesRecommendedUpdateLevels
-      parameters:
-        - name: user
-          in: query
-          description: Email of the user
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Ok
-        "400":
-          description: BadRequest
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-        "401":
-          description: Unauthorized
-        "500":
-          description: InternalServerError
-
   /updates/product-update-levels:
     get:
       summary: Get product update levels.


### PR DESCRIPTION
## Summary

- Adds `POST /deployments/search` endpoint proxying to the entity service, with `DeploymentHandler`, entity client method, route registration, OpenAPI schema, and full test coverage
- Renames `/product/{id}/versions/search` to `/products/{id}/versions/search` for consistency with other resource routes
- Removes unused `GET /updates/recommended-update-levels` endpoint and all related types, mapper, client method, tests, and OpenAPI path

## Test plan

- [x] `go test ./...` passes locally
- [x] Pre-push hook ran all backend tests — all green
- [x] Verify `POST /deployments/search` proxies to entity service and returns deployment list
- [x] Verify filtering by `projectIds` and `deploymentTypeKeys` works end-to-end
- [x] Verify `POST /products/{id}/versions/search` still resolves correctly with the renamed route
- [x] Verify unauthenticated requests return 401
- [x] Verify oversized / invalid JSON bodies return 413 / 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)