### PR TITLE
[Customer Portal][FE][Web] Add Multi-Select Support for Severity and Deployment Case Filters

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
@@ -29,9 +29,9 @@ export interface ListSearchPanelProps {
   onFiltersToggle: () => void;
   filters: {
     statusIds?: string[];
-    severityId?: string;
+    severityIds?: string[];
     issueTypes?: string;
-    deploymentId?: string;
+    deploymentIds?: string[];
   };
   filterMetadata: CaseMetadataResponse | undefined;
   deployments?: ProjectDeploymentItem[];
@@ -86,9 +86,9 @@ export default function ListSearchPanel({
   const excluded = Object.fromEntries(excludeFromCount.map((k) => [k, undefined]));
   const filtersForCount = {
     ...filters,
-    ...(hideSeverityFilter ? { severityId: undefined } : {}),
+    ...(hideSeverityFilter ? { severityIds: undefined } : {}),
     ...(hideStatusFilter ? { statusIds: undefined } : {}),
-    ...(hideDeploymentFilter ? { deploymentId: undefined } : {}),
+    ...(hideDeploymentFilter ? { deploymentIds: undefined } : {}),
     ...(hideCategoryFilter ? { issueTypes: undefined } : {}),
     ...excluded,
   };

--- a/apps/customer-portal/webapp/src/features/dashboard/utils/__tests__/dashboardNavigation.test.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/utils/__tests__/dashboardNavigation.test.ts
@@ -52,14 +52,14 @@ describe("buildDashboardCaseSearchFilters", () => {
     expect(
       buildDashboardCaseSearchFilters({
         statusIds: ["10"],
-        severityId: "11",
+        severityIds: ["11"],
         searchQuery: " test ",
       }),
     ).toEqual({
       statusIds: [10],
-      severityId: 11,
+      severityIds: [11],
       issueId: undefined,
-      deploymentId: undefined,
+      deploymentIds: undefined,
       searchQuery: "test",
       createdByMe: undefined,
     });
@@ -68,7 +68,7 @@ describe("buildDashboardCaseSearchFilters", () => {
   it("uses outstanding statusIds for dashboard severity navigation", () => {
     expect(
       buildDashboardCaseSearchFilters({
-        severityId: "11",
+        severityIds: ["11"],
         isDashboardSeverityNavigation: true,
         caseStates: [
           { id: "1", label: "Open" },
@@ -78,9 +78,9 @@ describe("buildDashboardCaseSearchFilters", () => {
       }),
     ).toEqual({
       statusIds: [1, 1006],
-      severityId: 11,
+      severityIds: [11],
       issueId: undefined,
-      deploymentId: undefined,
+      deploymentIds: undefined,
       searchQuery: undefined,
       createdByMe: undefined,
     });

--- a/apps/customer-portal/webapp/src/features/dashboard/utils/dashboardNavigation.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/utils/dashboardNavigation.ts
@@ -81,9 +81,9 @@ export function getDashboardOutstandingCasesDescription(
  */
 export function buildDashboardCaseSearchFilters(params: {
   statusIds?: string[];
-  severityId?: string;
+  severityIds?: string[];
   issueTypes?: string;
-  deploymentId?: string;
+  deploymentIds?: string[];
   searchQuery?: string;
   createdByMe?: boolean;
   caseStates?: MetadataItem[];
@@ -91,9 +91,9 @@ export function buildDashboardCaseSearchFilters(params: {
 }): CaseSearchFilters {
   const {
     statusIds,
-    severityId,
+    severityIds,
     issueTypes,
-    deploymentId,
+    deploymentIds,
     searchQuery,
     createdByMe,
     caseStates,
@@ -102,33 +102,35 @@ export function buildDashboardCaseSearchFilters(params: {
 
   const normalizedSearchQuery = searchQuery?.trim() || undefined;
   const explicitStatusIds = statusIds?.length ? statusIds.map(Number) : undefined;
-  const normalizedSeverityId = severityId ? Number(severityId) : undefined;
+  const normalizedSeverityIds = severityIds?.length
+    ? severityIds.map(Number)
+    : undefined;
   const normalizedIssueId = issueTypes ? Number(issueTypes) : undefined;
 
   switch (true) {
     case Boolean(explicitStatusIds?.length):
       return {
         statusIds: explicitStatusIds,
-        severityId: normalizedSeverityId,
+        severityIds: normalizedSeverityIds,
         issueId: normalizedIssueId,
-        deploymentId,
+        deploymentIds,
         searchQuery: normalizedSearchQuery,
         createdByMe,
       };
     case isDashboardSeverityNavigation:
       return {
         statusIds: resolveCasesTableDefaultStatusIds(caseStates),
-        severityId: normalizedSeverityId,
+        severityIds: normalizedSeverityIds,
         issueId: normalizedIssueId,
-        deploymentId,
+        deploymentIds,
         searchQuery: normalizedSearchQuery,
         createdByMe,
       };
     default:
       return {
-        severityId: normalizedSeverityId,
+        severityIds: normalizedSeverityIds,
         issueId: normalizedIssueId,
-        deploymentId,
+        deploymentIds,
         searchQuery: normalizedSearchQuery,
         createdByMe,
       };

--- a/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
@@ -61,12 +61,12 @@ describe("buildEngagementSearchRequest", () => {
 
   it("does not send severity filter", () => {
     const req = buildEngagementSearchRequest(
-      { severityId: "99" },
+      { severityIds: ["99"] },
       "",
       EngagementsSortField.CreatedOn,
       SortOrder.DESC,
     );
-    expect(req.filters?.severityId).toBeUndefined();
+    expect(req.filters?.severityIds).toBeUndefined();
   });
 
   it("normalizes legacy Severity sort field to UpdatedOn in API payload", () => {

--- a/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
@@ -78,7 +78,9 @@ export function buildEngagementSearchRequest(
       caseTypes: [CaseType.ENGAGEMENT],
       statusIds: filters.statusIds?.length ? filters.statusIds.map(Number) : undefined,
       issueId: filters.issueTypes ? Number(filters.issueTypes) : undefined,
-      deploymentId: filters.deploymentId || undefined,
+      deploymentIds: filters.deploymentIds?.length
+        ? filters.deploymentIds
+        : undefined,
       searchQuery: searchTerm.trim() || undefined,
       engagementTypeKeys: filters.engagementTypeKey
         ? filters.engagementTypeKey.split(",").map(Number).filter(Boolean)

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
@@ -279,13 +279,13 @@ describe("buildServiceRequestsPageCaseSearchRequest", () => {
 
   it("does not send severity filter", () => {
     const req = buildServiceRequestsPageCaseSearchRequest(
-      { severityId: "99" },
+      { severityIds: ["99"] },
       "",
       ServiceRequestCaseSortField.CreatedOn,
       SortOrder.DESC,
       false,
     );
-    expect(req.filters?.severityId).toBeUndefined();
+    expect(req.filters?.severityIds).toBeUndefined();
   });
 
   it("normalizes legacy Severity sort field to UpdatedOn in API payload", () => {

--- a/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
@@ -308,7 +308,9 @@ export function buildServiceRequestsPageCaseSearchRequest(
       caseTypes: [CaseType.SERVICE_REQUEST],
       statusIds: resolvedStatusIds,
       issueId: filters.issueTypes ? Number(filters.issueTypes) : undefined,
-      deploymentId: filters.deploymentId || undefined,
+      deploymentIds: filters.deploymentIds?.length
+        ? filters.deploymentIds
+        : undefined,
       searchQuery: searchTerm.trim() || undefined,
       createdByMe: createdByMe || undefined,
     },

--- a/apps/customer-portal/webapp/src/features/support/components/all-cases/__tests__/AllCasesFilters.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/all-cases/__tests__/AllCasesFilters.test.tsx
@@ -31,9 +31,9 @@ describe("ListFilters", () => {
   const mockOnFilterChange = vi.fn();
   const defaultFilters = {
     statusIds: [] as string[],
-    severityId: "",
+    severityIds: [] as string[],
     issueTypes: "",
-    deploymentId: "",
+    deploymentIds: [] as string[],
   };
 
   beforeEach(() => {

--- a/apps/customer-portal/webapp/src/features/support/components/all-cases/__tests__/AllCasesSearchBar.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/all-cases/__tests__/AllCasesSearchBar.test.tsx
@@ -30,9 +30,9 @@ describe("ListSearchPanel", () => {
   const mockOnClearFilters = vi.fn();
   const defaultFilters = {
     statusIds: [] as string[],
-    severityId: "",
+    severityIds: [] as string[],
     issueTypes: "",
-    deploymentId: "",
+    deploymentIds: [] as string[],
   };
 
   beforeEach(() => {

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -431,9 +431,10 @@ export const ALL_CASES_FILTER_DEFINITIONS: AllCasesFilterDefinition[] = [
     multiSelect: true,
   },
   {
-    filterKey: "severityId",
+    filterKey: "severityIds",
     id: "severity",
     metadataKey: "severities",
+    multiSelect: true,
   },
   {
     filterKey: "issueTypes",
@@ -441,9 +442,10 @@ export const ALL_CASES_FILTER_DEFINITIONS: AllCasesFilterDefinition[] = [
     metadataKey: "issueTypes",
   },
   {
-    filterKey: "deploymentId",
+    filterKey: "deploymentIds",
     id: "deployment",
     metadataKey: "deploymentTypes",
+    multiSelect: true,
   },
 ];
 

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -82,7 +82,7 @@ export default function AllCasesPage(): JSX.Element {
   const [searchTerm, setSearchTerm] = useSessionState(`${sessionPrefix}-search`, "", undefined, { popOnly: true });
   const [filters, setFilters] = useSessionState<AllCasesFilterValues>(
     `${sessionPrefix}-filters`,
-    initialSeverityId ? { severityId: initialSeverityId } : {},
+    initialSeverityId ? { severityIds: [initialSeverityId] } : {},
     undefined,
     { popOnly: true },
   );
@@ -147,17 +147,17 @@ export default function AllCasesPage(): JSX.Element {
         caseTypes: [CaseType.DEFAULT_CASE],
         ...buildDashboardCaseSearchFilters({
           statusIds: filters.statusIds as string[] | undefined,
-          severityId: filters.severityId,
+          severityIds: filters.severityIds as string[] | undefined,
           issueTypes: filters.issueTypes,
-          deploymentId: permissions.hasDeployments
-            ? filters.deploymentId || undefined
+          deploymentIds: permissions.hasDeployments
+            ? (filters.deploymentIds as string[] | undefined)
             : undefined,
           searchQuery: searchTerm,
           createdByMe: createdByMe || undefined,
           caseStates: filterMetadata?.caseStates,
           isDashboardSeverityNavigation:
             (isDashboardSeverityNavigation &&
-              filters.severityId === initialSeverityId) ||
+              filters.severityIds?.includes(initialSeverityId ?? "")) ||
             statusFilter === "active",
         }),
         ...(statusFilter === "resolved" ? getLast30DaysUtcRange() : {}),
@@ -291,7 +291,7 @@ export default function AllCasesPage(): JSX.Element {
     setPage(1);
   };
 
-  // Note: deploymentId is ignored in API request when user lacks permissions.
+  // Note: deploymentIds are ignored in API request when user lacks permissions.
 
   const listHasRefinement = hasListSearchOrFilters(searchTerm, filters);
 
@@ -378,8 +378,8 @@ export default function AllCasesPage(): JSX.Element {
           hideDeploymentFilter={!permissions.hasDeployments}
           isProjectContextLoading={isProjectContextLoading}
           excludeFromCount={
-            initialSeverityId && filters.severityId === initialSeverityId
-              ? ["severityId"]
+            initialSeverityId && filters.severityIds?.includes(initialSeverityId)
+              ? ["severityIds"]
               : []
           }
         />

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -305,9 +305,9 @@ export type CaseMetadataResponse = {
 export type AllCasesFilterValues = {
   [key: string]: string | string[] | undefined;
   statusIds?: string[];
-  severityId?: string;
+  severityIds?: string[];
   issueTypes?: string;
-  deploymentId?: string;
+  deploymentIds?: string[];
   engagementTypeKey?: string;
 };
 
@@ -359,8 +359,8 @@ export type CreateCaseResponse = AuditMetadata & {
 // Filter type for searching cases.
 export type CaseSearchFilters = {
   issueId?: number;
-  deploymentId?: string;
-  severityId?: number;
+  deploymentIds?: string[];
+  severityIds?: number[];
   statusId?: number;
   statusIds?: number[];
   searchQuery?: string;


### PR DESCRIPTION
### Description

This pull request updates the case filtering system to support multi-select for severity and deployment filters across the customer portal. The changes standardize the filter keys to plural forms (`severityIds`, `deploymentIds`) and update their types to arrays throughout the codebase, including component props, utility functions, constants, and tests. This enables users to filter cases by multiple severities and deployments simultaneously, improving the flexibility of search and filter functionality.

**Filter key and type updates:**

- Changed filter keys from `severityId` and `deploymentId` to `severityIds` and `deploymentIds` throughout the codebase, and updated their types from `string` to `string[]` in all relevant interfaces, types, and default filter values (`ListSearchPanelProps`, `AllCasesFilterValues`, `CaseSearchFilters`, etc.). [[1]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8L32-R34) [[2]](diffhunk://#diff-624c276530bd2d9bcc739ea2890edeb9311826df13dabd7a17a020bc14b50077L308-R310) [[3]](diffhunk://#diff-624c276530bd2d9bcc739ea2890edeb9311826df13dabd7a17a020bc14b50077L362-R363) [[4]](diffhunk://#diff-28f37576d44d6136f72f1089ead1444be403e21340dc4eab87059912a3542471L34-R36) [[5]](diffhunk://#diff-1a308d5767f7e45a45dd7e9d206ffb54244abbc6025eeed25ec6827e175e8453L33-R35)

- Updated the filter definitions in `ALL_CASES_FILTER_DEFINITIONS` to use the plural keys and set `multiSelect: true` for both severity and deployment filters.

**Component and page logic:**

- Refactored components and pages (`ListSearchPanel`, `AllCasesPage`) to use the new plural filter keys and array types, including handling of initial values, filter toggling, and exclusion logic. [[1]](diffhunk://#diff-62fdb53af7dce1bc712cc5f4d668f69049809e6f6ea2c83c990b4798aa1d04d8L89-R91) [[2]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L85-R85) [[3]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L150-R160) [[4]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L294-R294) [[5]](diffhunk://#diff-d30d20f430438c00e69c56fb90a8301d85e74a5206d1ce0118920c0e52df88a9L381-R382)

**Utility function updates:**

- Modified utility functions (`buildDashboardCaseSearchFilters`, `buildEngagementSearchRequest`, `buildServiceRequestsPageCaseSearchRequest`) to accept and process the new array-based filter keys, including normalization to arrays of numbers where necessary. [[1]](diffhunk://#diff-e125a4a9f60716db3fa41bc46433117af5c0ef6d73f238f483e510c0af5e3371L84-R96) [[2]](diffhunk://#diff-e125a4a9f60716db3fa41bc46433117af5c0ef6d73f238f483e510c0af5e3371L105-R133) [[3]](diffhunk://#diff-feacbcb4059727622d3882bd6fbe51920c41e4ac14ae8c9708194fb5033414ebL81-R83) [[4]](diffhunk://#diff-94f6a8a1ed1fdbada17db5f363f063a846fdd08bd092dc3a3970733c4a474d5dL311-R313)

**Test updates:**

- Updated all relevant tests to use the new plural filter keys and array values, ensuring coverage for the new multi-select behavior. [[1]](diffhunk://#diff-060af435dd58454aae85d2be252c55de6b9e0179cc50536031ca42b1c90aa628L55-R62) [[2]](diffhunk://#diff-060af435dd58454aae85d2be252c55de6b9e0179cc50536031ca42b1c90aa628L71-R71) [[3]](diffhunk://#diff-060af435dd58454aae85d2be252c55de6b9e0179cc50536031ca42b1c90aa628L81-R83) [[4]](diffhunk://#diff-732825090007ea02e2a6f86de9dbd2c347dbb1be4613af24a83d8ff37d26cc77L64-R69) [[5]](diffhunk://#diff-2ac95970e81f64fec9d4764542bf7ae312356fbf49d352b1bc684e20a467bd0cL282-R288)

These changes collectively enable multi-select filtering for severity and deployment fields, improving the user experience and aligning filter handling across the application.