### PR TITLE
[CSM Portal] Move deployments/search under projects/:id

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -91,7 +91,7 @@ func main() {
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
-	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
+	mux.HandleFunc("POST /projects/{id}/deployments/search", deploymentHandler.SearchDeployments)
 
 	addr := envOrDefault("PORT", ":8080")
 	slog.Info("starting csm-portal backend", "addr", addr)

--- a/apps/csm-portal/backend/internal/handler/deployments.go
+++ b/apps/csm-portal/backend/internal/handler/deployments.go
@@ -43,11 +43,17 @@ func NewDeploymentHandler(entity entityDeploymentClient) *DeploymentHandler {
 	return &DeploymentHandler{entity: entity}
 }
 
-// SearchDeployments handles POST /deployments/search.
+// SearchDeployments handles POST /projects/{id}/deployments/search.
 func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/deployments_test.go
+++ b/apps/csm-portal/backend/internal/handler/deployments_test.go
@@ -27,7 +27,8 @@ import (
 func TestSearchDeployments(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
-		r := httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(`{}`))
+		r.SetPathValue("id", "proj-1")
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -35,9 +36,20 @@ func TestSearchDeployments(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects missing project id", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/projects//deployments/search", strings.NewReader(`{}`)))
+		w := httptest.NewRecorder()
+		h.SearchDeployments(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", "proj-1")
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -47,7 +59,8 @@ func TestSearchDeployments(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`not-json`)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", "proj-1")
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -56,7 +69,7 @@ func TestSearchDeployments(t *testing.T) {
 	})
 
 	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
-		const reqPayload = `{"searchQuery":"prod","projectIds":["proj-1"],"deploymentTypeKeys":["primary_production"]}`
+		const reqPayload = `{"searchQuery":"prod","deploymentTypeKeys":["primary_production"]}`
 		var capturedBody []byte
 		client := &mockEntityDeploymentClient{
 			searchDeploymentsFn: func(_ context.Context, body []byte) ([]byte, error) {
@@ -65,7 +78,8 @@ func TestSearchDeployments(t *testing.T) {
 			},
 		}
 		h := NewDeploymentHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(reqPayload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(reqPayload)))
+		r.SetPathValue("id", "proj-1")
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 
@@ -90,7 +104,8 @@ func TestSearchDeployments(t *testing.T) {
 					},
 				}
 				h := NewDeploymentHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(`{}`)))
+				r.SetPathValue("id", "proj-1")
 				w := httptest.NewRecorder()
 				h.SearchDeployments(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -286,10 +286,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /deployments/search:
+  /projects/{id}/deployments/search:
     post:
-      summary: Search deployments.
-      operationId: postDeploymentsSearch
+      summary: Search deployments of a project.
+      operationId: postProjectsIdDeploymentsSearch
+      parameters:
+        - name: id
+          in: path
+          description: ID of the project
+          required: true
+          schema:
+            type: string
       requestBody:
         description: Deployment search payload
         content:


### PR DESCRIPTION
## Summary
- Renamed `POST /deployments/search` to `POST /projects/{id}/deployments/search` in the csm-portal backend
- Handler now extracts and validates the `id` path parameter, returning 400 if missing
- Entity client call to the upstream service remains unchanged at `POST /deployments/search`
- Updated OpenAPI spec and tests accordingly

## Test plan
- [ ] All existing handler tests pass
- [ ] New test case: `rejects missing project id` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Deployment search now operates at the project level, requiring users to specify a project when searching for deployments instead of performing global searches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->