### PR TITLE
[Customer Portal][FE][Web] Add Comprehensive Change Requests API Hook and Component Test Coverage

### DIFF
--- a/apps/customer-portal/webapp/src/features/operations/api/__tests__/fetchChangeRequestSearchResults.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/api/__tests__/fetchChangeRequestSearchResults.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchChangeRequestSearchResults } from "@features/operations/api/fetchChangeRequestSearchResults";
+import { SortOrder } from "@/types/common";
+import { ChangeRequestSortField } from "@features/operations/types/changeRequests";
+
+describe("fetchChangeRequestSearchResults", () => {
+  beforeEach(() => {
+    (
+      window as unknown as { config?: { CUSTOMER_PORTAL_BACKEND_BASE_URL?: string } }
+    ).config = { CUSTOMER_PORTAL_BACKEND_BASE_URL: "https://api.test" };
+  });
+
+  it("aggregates paginated change request search results", async () => {
+    const authFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          changeRequests: [{ id: "1", number: "CHG1" }],
+          totalRecords: 2,
+          offset: 0,
+          limit: 1,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          changeRequests: [{ id: "2", number: "CHG2" }],
+          totalRecords: 2,
+          offset: 1,
+          limit: 1,
+        }),
+      });
+
+    const results = await fetchChangeRequestSearchResults(
+      authFetch,
+      "proj-1",
+      {
+        sortBy: { field: ChangeRequestSortField.CREATED_ON, order: SortOrder.DESC },
+      },
+      1,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(authFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when response is not ok", async () => {
+    const authFetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      text: async () => "failed",
+    });
+
+    await expect(
+      fetchChangeRequestSearchResults(authFetch, "proj-1", {
+        sortBy: { field: ChangeRequestSortField.CREATED_ON, order: SortOrder.DESC },
+      }),
+    ).rejects.toThrow("failed");
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/api/__tests__/operationsApiHooks.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/api/__tests__/operationsApiHooks.test.tsx
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useGetChangeRequests, {
+  useGetChangeRequestsInfinite,
+} from "@features/operations/api/useGetChangeRequests";
+import useGetChangeRequestDetails from "@features/operations/api/useGetChangeRequestDetails";
+import { useGetProjectChangeRequestStats } from "@features/operations/api/useGetProjectChangeRequestStats";
+import { usePatchChangeRequest } from "@features/operations/api/usePatchChangeRequest";
+import { usePostCase } from "@features/operations/api/usePostCase";
+import { useSearchCatalogs } from "@features/operations/api/useSearchCatalogs";
+import { useGetCatalogItemVariables } from "@features/operations/api/useGetCatalogItemVariables";
+import { SortOrder } from "@/types/common";
+import { ChangeRequestSortField } from "@features/operations/types/changeRequests";
+
+const mockAuthFetch = vi.fn();
+let mockIsSignedIn = true;
+let mockIsAuthLoading = false;
+
+vi.mock("@/hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => mockAuthFetch,
+}));
+vi.mock("@asgardeo/react", () => ({
+  useAsgardeo: () => ({
+    isSignedIn: mockIsSignedIn,
+    isLoading: mockIsAuthLoading,
+    getIdToken: vi.fn().mockResolvedValue("mock-token"),
+  }),
+}));
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ debug: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const baseSearchRequest = {
+  sortBy: { field: ChangeRequestSortField.CREATED_ON, order: SortOrder.DESC },
+};
+
+describe("operations API hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSignedIn = true;
+    mockIsAuthLoading = false;
+    (
+      window as unknown as { config?: { CUSTOMER_PORTAL_BACKEND_BASE_URL?: string } }
+    ).config = { CUSTOMER_PORTAL_BACKEND_BASE_URL: "https://api.test" };
+  });
+
+  it("useGetChangeRequests posts paginated search", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ changeRequests: [], totalRecords: 0, offset: 0, limit: 10 }),
+    });
+
+    const { result } = renderHook(
+      () => useGetChangeRequests("proj-1", baseSearchRequest, 0, 10),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "https://api.test/projects/proj-1/change-requests/search",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("useGetChangeRequestsInfinite fetches first page", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        changeRequests: [{ id: "cr-1" }],
+        totalRecords: 1,
+        offset: 0,
+        limit: 10,
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useGetChangeRequestsInfinite("proj-1", baseSearchRequest),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/projects/proj-1/change-requests/search"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("useGetChangeRequestDetails fetches by id", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "cr-1", number: "CHG001" }),
+    });
+
+    const { result } = renderHook(() => useGetChangeRequestDetails("cr-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "https://api.test/change-requests/cr-1",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("useGetProjectChangeRequestStats fetches mapped stats", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stateCount: [], totalRecords: 0 }),
+    });
+
+    const { result } = renderHook(() => useGetProjectChangeRequestStats("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/projects/proj-1/stats/change-requests"),
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("useSearchCatalogs posts catalog search", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ catalogs: [] }),
+    });
+
+    const { result } = renderHook(() => useSearchCatalogs("dp-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "https://api.test/deployments/products/dp-1/catalogs/search",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("useGetCatalogItemVariables fetches variables", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ variables: [] }),
+    });
+
+    const { result } = renderHook(
+      () => useGetCatalogItemVariables("cat-1", "item-1"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "https://api.test/catalogs/cat-1/items/item-1",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("usePatchChangeRequest patches change request", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "cr-1" }),
+    });
+
+    const { result } = renderHook(() => usePatchChangeRequest("cr-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({ plannedStartOn: "2026-06-01 10:00:00" });
+
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "https://api.test/change-requests/cr-1",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("usePostCase creates a case", async () => {
+    mockAuthFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "case-1", number: "CS001" }),
+    });
+
+    const { result } = renderHook(() => usePostCase(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      projectId: "proj-1",
+      deploymentId: "dep-1",
+      deployedProductId: "dp-1",
+      description: "Need help",
+    } as never);
+
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/cases"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestDetailsLoadingSkeleton.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestDetailsLoadingSkeleton.test.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestDetailsLoadingSkeleton from "@features/operations/components/change-requests/ChangeRequestDetailsLoadingSkeleton";
+
+describe("ChangeRequestDetailsLoadingSkeleton", () => {
+  it("renders loading placeholders", () => {
+    const { container } = render(<ChangeRequestDetailsLoadingSkeleton />);
+    expect(container.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsCalendarSkeleton.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsCalendarSkeleton.test.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestsCalendarSkeleton from "@features/operations/components/change-requests/ChangeRequestsCalendarSkeleton";
+
+describe("ChangeRequestsCalendarSkeleton", () => {
+  it("renders calendar skeleton", () => {
+    const { container } = render(<ChangeRequestsCalendarSkeleton />);
+    expect(container.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsCalendarView.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsCalendarView.test.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestsCalendarView from "@features/operations/components/change-requests/ChangeRequestsCalendarView";
+
+describe("ChangeRequestsCalendarView", () => {
+  it("renders calendar skeleton while loading", () => {
+    const { container } = render(
+      <ChangeRequestsCalendarView changeRequests={[]} isLoading />,
+    );
+    expect(container.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsCsvExportButton.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsCsvExportButton.test.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ChangeRequestsCsvExportButton from "@features/operations/components/change-requests/ChangeRequestsCsvExportButton";
+import { SortOrder } from "@/types/common";
+import { ChangeRequestSortField } from "@features/operations/types/changeRequests";
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+describe("ChangeRequestsCsvExportButton", () => {
+  it("renders download results button", () => {
+    render(
+      <ChangeRequestsCsvExportButton
+        projectId="proj-1"
+        searchRequest={{
+          sortBy: { field: ChangeRequestSortField.CREATED_ON, order: SortOrder.DESC },
+        }}
+        prefetchedItems={[]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^export$/i })).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsFilters.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsFilters.test.tsx
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestsFilters from "@features/operations/components/change-requests/ChangeRequestsFilters";
+
+describe("ChangeRequestsFilters", () => {
+  it("renders state filter label", () => {
+    render(
+      <ChangeRequestsFilters
+        filters={{}}
+        filterMetadata={undefined}
+        onFilterChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByText("State").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsList.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsList.test.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestsList from "@features/operations/components/change-requests/ChangeRequestsList";
+import { CHANGE_REQUESTS_LIST_EMPTY_DEFAULT_MESSAGE } from "@features/operations/constants/operationsConstants";
+
+describe("ChangeRequestsList", () => {
+  it("renders empty state when there are no change requests", () => {
+    render(
+      <ChangeRequestsList changeRequests={[]} isLoading={false} isError={false} />,
+    );
+    expect(screen.getByText(CHANGE_REQUESTS_LIST_EMPTY_DEFAULT_MESSAGE)).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsListSkeleton.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsListSkeleton.test.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestsListSkeleton from "@features/operations/components/change-requests/ChangeRequestsListSkeleton";
+
+describe("ChangeRequestsListSkeleton", () => {
+  it("renders skeleton cards", () => {
+    const { container } = render(<ChangeRequestsListSkeleton />);
+    expect(container.querySelectorAll("button").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsSearchBar.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsSearchBar.test.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestsSearchBar from "@features/operations/components/change-requests/ChangeRequestsSearchBar";
+import { CHANGE_REQUESTS_SEARCH_PLACEHOLDER } from "@features/operations/constants/operationsConstants";
+
+describe("ChangeRequestsSearchBar", () => {
+  it("renders search placeholder", () => {
+    render(
+      <ChangeRequestsSearchBar
+        searchTerm=""
+        onSearchChange={() => {}}
+        isFiltersOpen={false}
+        onFiltersToggle={() => {}}
+        filters={{}}
+        filterMetadata={undefined}
+        onFilterChange={() => {}}
+        onClearFilters={() => {}}
+      />,
+    );
+    expect(screen.getByPlaceholderText(CHANGE_REQUESTS_SEARCH_PLACEHOLDER)).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsStatCards.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ChangeRequestsStatCards.test.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ChangeRequestsStatCards from "@features/operations/components/change-requests/ChangeRequestsStatCards";
+import { CHANGE_REQUEST_STAT_CONFIGS } from "@features/operations/constants/operationsConstants";
+
+describe("ChangeRequestsStatCards", () => {
+  it("renders stat card labels", () => {
+    render(
+      <ChangeRequestsStatCards
+        isLoading={false}
+        stats={{
+          totalRequests: 10,
+          awaitingYourAction: 2,
+          ongoing: 5,
+          completed: 3,
+        }}
+      />,
+    );
+    expect(screen.getByText(CHANGE_REQUEST_STAT_CONFIGS[0].label)).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ProposeNewImplementationTimeModal.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/__tests__/ProposeNewImplementationTimeModal.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ProposeNewImplementationTimeModal from "@features/operations/components/change-requests/ProposeNewImplementationTimeModal";
+
+vi.mock("@features/operations/api/usePatchChangeRequest", () => ({
+  usePatchChangeRequest: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+vi.mock("@context/success-banner/SuccessBannerContext", () => ({
+  useSuccessBanner: () => ({ showSuccess: vi.fn() }),
+}));
+
+const changeRequest = {
+  id: "cr-1",
+  number: "CHG001",
+  startDate: "2026-06-01 10:00:00",
+  endDate: "2026-06-01 12:00:00",
+} as never;
+
+describe("ProposeNewImplementationTimeModal", () => {
+  it("renders dialog when open", () => {
+    render(
+      <ProposeNewImplementationTimeModal
+        open
+        onClose={() => {}}
+        changeRequest={changeRequest}
+      />,
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/CatalogSelector.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/CatalogSelector.test.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CatalogSelector from "@features/operations/components/service-requests/CatalogSelector";
+
+describe("CatalogSelector", () => {
+  it("renders catalog accordion when data is loaded", () => {
+    render(
+      <CatalogSelector
+        catalogs={[
+          {
+            id: "cat-1",
+            name: "Configuration",
+            catalogItems: [{ id: "item-1", label: "Update SSL cert" }],
+          },
+        ]}
+        isLoading={false}
+        selectedCatalogId=""
+        selectedCatalogItemId=""
+        onSelectCatalogItem={() => {}}
+      />,
+    );
+    expect(screen.getByText("Configuration")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestDetailContent.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestDetailContent.test.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ServiceRequestDetailContent from "@features/operations/components/service-requests/ServiceRequestDetailContent";
+
+vi.mock("@api/useGetProjectFilters", () => ({
+  default: () => ({ data: {}, isLoading: false }),
+}));
+
+vi.mock("@features/support/api/usePatchCase", () => ({
+  usePatchCase: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+vi.mock("@context/success-banner/SuccessBannerContext", () => ({
+  useSuccessBanner: () => ({ showSuccess: vi.fn() }),
+}));
+
+vi.mock("@features/settings/api/useGetUserDetails", () => ({
+  default: () => ({ data: { email: "user@test.dev" }, isLoading: false }),
+}));
+
+vi.mock("@features/support/api/useGetCaseCommentsInfinite", () => ({
+  default: () => ({
+    data: { pages: [] },
+    isLoading: false,
+    isError: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+
+vi.mock("@features/support/api/usePostComment", () => ({
+  usePostComment: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock("@case-details-attachments/CaseDetailsAttachmentsPanel", () => ({
+  default: () => <div data-testid="attachments-panel" />,
+}));
+
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: () => <div data-testid="comment-editor" />,
+}));
+
+const caseDetails = {
+  id: "case-1",
+  number: "SR100",
+  title: "Renew certificate",
+  description: "Details",
+  status: { id: "1", label: "Open" },
+  severity: { id: "3", label: "S3" },
+  createdOn: "2026-01-01",
+} as never;
+
+describe("ServiceRequestDetailContent", () => {
+  it("renders service request title", () => {
+    render(
+      <ServiceRequestDetailContent
+        data={caseDetails}
+        isLoading={false}
+        isError={false}
+        caseId="case-1"
+        projectId="proj-1"
+        onBack={() => {}}
+      />,
+    );
+    expect(screen.getByText("Renew certificate")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestsList.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestsList.test.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ServiceRequestsList from "@features/operations/components/service-requests/ServiceRequestsList";
+import { SERVICE_REQUESTS_LIST_EMPTY_DEFAULT_MESSAGE } from "@features/operations/constants/operationsConstants";
+
+describe("ServiceRequestsList", () => {
+  it("renders empty state when there are no service requests", () => {
+    render(
+      <ServiceRequestsList serviceRequests={[]} isLoading={false} isError={false} />,
+    );
+    expect(screen.getByText(SERVICE_REQUESTS_LIST_EMPTY_DEFAULT_MESSAGE)).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestsListSkeleton.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestsListSkeleton.test.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ServiceRequestsListSkeleton from "@features/operations/components/service-requests/ServiceRequestsListSkeleton";
+
+describe("ServiceRequestsListSkeleton", () => {
+  it("renders skeleton cards", () => {
+    const { container } = render(<ServiceRequestsListSkeleton />);
+    expect(container.querySelectorAll("button").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestsSearchBar.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/ServiceRequestsSearchBar.test.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ServiceRequestsSearchBar from "@features/operations/components/service-requests/ServiceRequestsSearchBar";
+
+describe("ServiceRequestsSearchBar", () => {
+  it("renders status filter tabs", () => {
+    render(
+      <ServiceRequestsSearchBar
+        searchTerm=""
+        onSearchChange={() => {}}
+        statusFilter="all"
+        onStatusFilterChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/VariableFormFields.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/__tests__/VariableFormFields.test.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import VariableFormFields from "@features/operations/components/service-requests/VariableFormFields";
+
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: () => <div data-testid="rich-text-editor" />,
+}));
+
+describe("VariableFormFields", () => {
+  it("renders variable field label", () => {
+    render(
+      <VariableFormFields
+        variables={[{ id: "v1", questionText: "Summary", type: "text" } as never]}
+        isLoading={false}
+        values={{}}
+        onChange={() => {}}
+        contextValues={{
+          projectDisplay: "Proj",
+          deploymentDisplay: "Dep",
+          productDisplay: "Prod",
+        }}
+      />,
+    );
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/constants/__tests__/operationsConstants.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/constants/__tests__/operationsConstants.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  CHANGE_REQUEST_BULLET_ITEMS,
+  CHANGE_REQUEST_STAT_CONFIGS,
+  CHANGE_REQUEST_FILTER_DEFINITIONS,
+  ChangeRequestStatus,
+} from "@features/operations/constants/operationsConstants";
+
+describe("operationsConstants", () => {
+  it("exports change request marketing bullets", () => {
+    expect(CHANGE_REQUEST_BULLET_ITEMS.length).toBeGreaterThan(0);
+  });
+
+  it("exports stat configs and filter definitions", () => {
+    expect(CHANGE_REQUEST_STAT_CONFIGS.length).toBeGreaterThan(0);
+    expect(CHANGE_REQUEST_FILTER_DEFINITIONS.length).toBeGreaterThan(0);
+  });
+
+  it("exports change request status constants", () => {
+    expect(ChangeRequestStatus.SCHEDULED).toBe("Scheduled");
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ChangeRequestDetailsPage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ChangeRequestDetailsPage.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import ChangeRequestDetailsPage from "@features/operations/pages/ChangeRequestDetailsPage";
+
+vi.mock("@features/operations/api/useGetChangeRequestDetails", () => ({
+  default: () => ({
+    data: {
+      id: "cr-1",
+      number: "CHG001",
+      title: "Deploy patch",
+      state: { id: "-2", label: "Scheduled" },
+      type: { id: "normal", label: "Normal" },
+      project: { id: "p1", label: "Proj", number: null },
+      case: null,
+      deployment: null,
+      deployedProduct: null,
+      product: null,
+      assignedEngineer: null,
+      assignedTeam: null,
+      startDate: null,
+      endDate: null,
+      createdOn: "2026-01-01",
+      updatedOn: "2026-01-02",
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+vi.mock("@context/success-banner/SuccessBannerContext", () => ({
+  useSuccessBanner: () => ({ showSuccess: vi.fn() }),
+}));
+
+vi.mock("@features/operations/api/usePatchChangeRequest", () => ({
+  usePatchChangeRequest: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+describe("ChangeRequestDetailsPage", () => {
+  it("renders change request number when loaded", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/p1/operations/change-requests/cr-1"]}>
+        <Routes>
+          <Route
+            path="/projects/:projectId/operations/change-requests/:changeRequestId"
+            element={<ChangeRequestDetailsPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("CHG001")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ChangeRequestsPage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ChangeRequestsPage.test.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import ChangeRequestsPage from "@features/operations/pages/ChangeRequestsPage";
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useParams: () => ({ projectId: "proj-1" }),
+    useLocation: () => ({ pathname: "/projects/proj-1/operations/change-requests", state: null }),
+  };
+});
+
+vi.mock("@hooks/useModifierAwareNavigate", () => ({
+  useModifierAwareNavigate: () => vi.fn(),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+vi.mock("@api/useGetProjectDetails", () => ({
+  default: () => ({ data: { name: "Demo" }, isLoading: false }),
+}));
+
+vi.mock("@api/useGetProjectFilters", () => ({
+  default: () => ({ data: { severities: [], statuses: [] }, isLoading: false }),
+}));
+
+vi.mock("@hooks/useSessionState", () => ({
+  useSessionState: (key: string, initial: unknown) => {
+    if (key.includes("search")) return ["", vi.fn()];
+    if (key.includes("page")) return [1, vi.fn()];
+    if (key.includes("rowsPerPage")) return [10, vi.fn()];
+    if (key.includes("sortField")) return ["updatedOn", vi.fn()];
+    if (key.includes("sortOrder")) return ["desc", vi.fn()];
+    if (key.includes("filters")) return [{}, vi.fn()];
+    return [initial, vi.fn()];
+  },
+}));
+
+vi.mock("@features/operations/api/useGetChangeRequests", () => ({
+  default: () => ({
+    data: { changeRequests: [], totalRecords: 0 },
+    isLoading: false,
+    isError: false,
+  }),
+  useGetChangeRequestsInfinite: () => ({
+    data: { pages: [{ changeRequests: [], totalRecords: 0 }] },
+    isLoading: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+  }),
+}));
+
+describe("ChangeRequestsPage", () => {
+  it("renders change requests page header", () => {
+    render(
+      <MemoryRouter>
+        <ChangeRequestsPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("All Change Requests")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/pages/__tests__/CreateServiceRequestPage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/__tests__/CreateServiceRequestPage.test.tsx
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import CreateServiceRequestPage from "@features/operations/pages/CreateServiceRequestPage";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useParams: () => ({ projectId: "proj-1" }),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+    useLocation: () => ({ pathname: "/projects/proj-1/operations/service-requests/create", state: null }),
+  };
+});
+
+vi.mock("@hooks/useModifierAwareNavigate", () => ({
+  useModifierAwareNavigate: () => vi.fn(),
+}));
+
+vi.mock("@api/useGetProjectDetails", () => ({
+  default: () => ({ data: { name: "Demo", account: { name: "Acct" } }, isLoading: false }),
+}));
+
+vi.mock("@api/useGetProjectFilters", () => ({
+  default: () => ({
+    data: { deployments: [{ id: "d1", label: "Prod" }], products: [] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@features/operations/api/useSearchCatalogs", () => ({
+  useSearchCatalogs: () => ({ data: { catalogs: [] }, isLoading: false }),
+}));
+
+vi.mock("@features/operations/api/useGetCatalogItemVariables", () => ({
+  useGetCatalogItemVariables: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock("@features/operations/api/usePostCase", () => ({
+  usePostCase: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+vi.mock("@context/linear-loader/LoaderContext", () => ({
+  useLoader: () => ({ showLoader: vi.fn(), hideLoader: vi.fn() }),
+}));
+
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock("@api/useGetProjectFeatures", () => ({
+  default: () => ({
+    data: { hasServiceRequestReadAccess: true, acceptedSeverityValues: [] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@api/usePostProjectDeploymentsSearch", () => ({
+  usePostProjectDeploymentsSearchInfinite: () => ({
+    data: { pages: [] },
+    isLoading: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+
+vi.mock("@features/project-details/api/usePostDeploymentProductsSearch", () => ({
+  usePostDeploymentProductsSearchInfinite: () => ({
+    data: { pages: [] },
+    isLoading: false,
+    isError: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+  extractDeploymentProducts: () => [],
+}));
+
+vi.mock("@features/settings/api/useGetUserDetails", () => ({
+  default: () => ({ data: { email: "user@test.dev" }, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+vi.mock("@context/success-banner/SuccessBannerContext", () => ({
+  useSuccessBanner: () => ({ showSuccess: vi.fn() }),
+}));
+
+describe("CreateServiceRequestPage", () => {
+  it("renders create service request heading", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CreateServiceRequestPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText(/Create Service Request/i)).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/pages/__tests__/OperationsPage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/__tests__/OperationsPage.test.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import OperationsPage from "@features/operations/pages/OperationsPage";
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useParams: () => ({ projectId: "proj-1" }),
+  };
+});
+
+vi.mock("@hooks/useModifierAwareNavigate", () => ({
+  useModifierAwareNavigate: () => vi.fn(),
+}));
+
+vi.mock("@api/useGetProjectDetails", () => ({
+  default: () => ({ data: { name: "Demo Project" }, isLoading: false }),
+}));
+
+vi.mock("@api/useGetProjectFeatures", () => ({
+  default: () => ({
+    data: {
+      hasServiceRequestReadAccess: true,
+      hasChangeRequestReadAccess: true,
+      acceptedSeverityValues: [],
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@api/useGetProjectFilters", () => ({
+  default: () => ({ data: {}, isLoading: false }),
+}));
+
+vi.mock("@api/useGetProjectCasesPage", () => ({
+  useGetProjectCasesPage: () => ({ data: { cases: [] }, isLoading: false }),
+}));
+
+vi.mock("@features/operations/api/useGetChangeRequests", () => ({
+  default: () => ({ data: { changeRequests: [] }, isLoading: false }),
+  useGetChangeRequestsInfinite: () => ({ data: { pages: [] }, isLoading: false }),
+}));
+
+vi.mock("@features/dashboard/api/useGetProjectCasesStats", () => ({
+  useGetProjectCasesStats: () => ({ data: {}, isLoading: false }),
+}));
+
+vi.mock("@features/dashboard/api/useGetProjectChangeRequestsStats", () => ({
+  useGetProjectChangeRequestsStats: () => ({ data: {}, isLoading: false }),
+}));
+
+vi.mock("@utils/permission", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@utils/permission")>();
+  return {
+    ...actual,
+    isProjectRestricted: () => false,
+  };
+});
+
+describe("OperationsPage", () => {
+  it("renders operations overview stat grid", () => {
+    render(
+      <MemoryRouter>
+        <OperationsPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Outstanding service requests")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ServiceRequestDetailsPage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ServiceRequestDetailsPage.test.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import ServiceRequestDetailsPage from "@features/operations/pages/ServiceRequestDetailsPage";
+
+vi.mock("@features/support/api/useGetCaseDetails", () => ({
+  default: () => ({
+    data: {
+      id: "case-1",
+      number: "SR001",
+      title: "Certificate renewal",
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("@case-details-details/CaseDetailsContent", () => ({
+  default: ({ data }: { data?: { number: string } }) => (
+    <div>case:{data?.number}</div>
+  ),
+}));
+
+vi.mock("@context/linear-loader/LoaderContext", () => ({
+  useLoader: () => ({ showLoader: vi.fn(), hideLoader: vi.fn() }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+describe("ServiceRequestDetailsPage", () => {
+  it("renders service request details content", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/p1/operations/service-requests/case-1"]}>
+        <Routes>
+          <Route
+            path="/projects/:projectId/operations/service-requests/:serviceRequestId"
+            element={<ServiceRequestDetailsPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("case:SR001")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ServiceRequestsPage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/__tests__/ServiceRequestsPage.test.tsx
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import ServiceRequestsPage from "@features/operations/pages/ServiceRequestsPage";
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useParams: () => ({ projectId: "proj-1" }),
+    useLocation: () => ({ pathname: "/projects/proj-1/operations/service-requests", state: null }),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+vi.mock("@hooks/useModifierAwareNavigate", () => ({
+  useModifierAwareNavigate: () => vi.fn(),
+}));
+
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock("@context/linear-loader/LoaderContext", () => ({
+  useLoader: () => ({ showLoader: vi.fn(), hideLoader: vi.fn() }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+vi.mock("@api/usePostProjectDeploymentsSearch", () => ({
+  usePostProjectDeploymentsSearchInfinite: () => ({
+    data: { pages: [] },
+    isLoading: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+  }),
+}));
+
+vi.mock("@api/useGetProjectDetails", () => ({
+  default: () => ({ data: { name: "Demo" }, isLoading: false }),
+}));
+
+vi.mock("@api/useGetProjectFilters", () => ({
+  default: () => ({ data: { severities: [], statuses: [] }, isLoading: false }),
+}));
+
+vi.mock("@api/useGetProjectCases", () => ({
+  default: () => ({
+    data: { pages: [{ cases: [], totalRecords: 0 }] },
+    isLoading: false,
+    isError: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    isFetchingNextPage: false,
+  }),
+}));
+
+vi.mock("@api/useGetProjectFeatures", () => ({
+  default: () => ({
+    data: {
+      hasServiceRequestReadAccess: true,
+      acceptedSeverityValues: [],
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@hooks/useSessionState", () => ({
+  useSessionState: (key: string, initial: unknown) => {
+    if (key.includes("search")) return ["", vi.fn()];
+    if (key.includes("page")) return [1, vi.fn()];
+    if (key.includes("rowsPerPage")) return [10, vi.fn()];
+    if (key.includes("sortField")) return ["updatedOn", vi.fn()];
+    if (key.includes("sortOrder")) return ["desc", vi.fn()];
+    if (key.includes("filters")) return [{}, vi.fn()];
+    return [initial, vi.fn()];
+  },
+}));
+
+describe("ServiceRequestsPage", () => {
+  it("renders service requests page header", () => {
+    render(
+      <MemoryRouter>
+        <ServiceRequestsPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("All Service Requests")).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/caseRefresh.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/caseRefresh.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+  refreshCaseQueriesAfterCreation,
+  triggerPostCreationApiCalls,
+} from "@features/operations/utils/caseRefresh";
+import { CaseType } from "@features/support/constants/supportConstants";
+import { ApiQueryKeys } from "@constants/apiConstants";
+
+describe("caseRefresh", () => {
+  it("triggerPostCreationApiCalls hits stats and search endpoints", async () => {
+    (
+      window as unknown as { config?: { CUSTOMER_PORTAL_BACKEND_BASE_URL?: string } }
+    ).config = { CUSTOMER_PORTAL_BACKEND_BASE_URL: "https://api.test" };
+
+    const authFetch = vi.fn().mockResolvedValue({ ok: true });
+    await triggerPostCreationApiCalls(authFetch, "proj-1", CaseType.SERVICE_REQUEST);
+
+    expect(authFetch).toHaveBeenCalledTimes(3);
+    expect(authFetch.mock.calls[2][0]).toContain("/cases/search");
+  });
+
+  it("refreshCaseQueriesAfterCreation invalidates case-related queries", async () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+
+    await refreshCaseQueriesAfterCreation(
+      queryClient,
+      "proj-1",
+      CaseType.DEFAULT_CASE,
+    );
+
+    expect(invalidateSpy).toHaveBeenCalled();
+    expect(refetchSpy).toHaveBeenCalledWith({
+      queryKey: [ApiQueryKeys.CASES_STATS, "proj-1"],
+    });
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/changeRequests.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/changeRequests.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  changeRequestToApiDatetime,
+  changeRequestToDatetimeLocal,
+  formatChangeRequestDuration,
+  formatDuration,
+  getChangeRequestDecisionMode,
+  mapChangeRequestStats,
+  stripChangeRequestCustomTags,
+  sumChangeRequestStateCount,
+  AWAITING_YOUR_ACTION_STATE_IDS,
+  AWAITING_LABELS,
+} from "@features/operations/utils/changeRequests";
+import { ChangeRequestDecisionMode } from "@features/operations/types/changeRequests";
+
+describe("changeRequests utils", () => {
+  it("sumChangeRequestStateCount sums by id and label", () => {
+    const total = sumChangeRequestStateCount(
+      [
+        { id: "5", label: "Customer Approval", count: 2 },
+        { id: "", label: "Customer Review", count: 1 },
+        { id: "9", label: "Other", count: 99 },
+      ],
+      AWAITING_YOUR_ACTION_STATE_IDS,
+      AWAITING_LABELS,
+    );
+    expect(total).toBe(3);
+  });
+
+  it("mapChangeRequestStats maps API payload to card stats", () => {
+    const stats = mapChangeRequestStats({
+      stateCount: [{ id: "5", label: "Customer Approval", count: 4 }],
+      totalCount: 10,
+    });
+    expect(stats.awaitingYourAction).toBe(4);
+    expect(stats.totalRequests).toBe(10);
+  });
+
+  it("formatChangeRequestDuration formats minutes", () => {
+    expect(formatChangeRequestDuration(90)).toBe("1 hour 30 minutes");
+    expect(formatChangeRequestDuration(45)).toBe("45 minutes");
+  });
+
+  it("formatDuration handles hour and minute segments", () => {
+    expect(formatDuration(90)).toBe("1h 30m");
+  });
+
+  it("changeRequest datetime helpers round-trip wall time", () => {
+    const api = changeRequestToApiDatetime("2026-06-01T10:30");
+    expect(api).toMatch(/2026-06-01 10:30:00/);
+    expect(changeRequestToDatetimeLocal(api)).toBe("2026-06-01T10:30");
+  });
+
+  it("stripChangeRequestCustomTags removes custom tags", () => {
+    expect(stripChangeRequestCustomTags("[code]hello[/code]")).toBe("hello");
+  });
+
+  it("getChangeRequestDecisionMode detects customer approval state", () => {
+    expect(
+      getChangeRequestDecisionMode({
+        state: { id: "5", label: "Customer Approval" },
+      } as never),
+    ).toBe(ChangeRequestDecisionMode.CUSTOMER_APPROVAL);
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/changeRequestsSchedulePdf.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/changeRequestsSchedulePdf.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it, vi } from "vitest";
+import { generateChangeRequestsSchedulePdf } from "@features/operations/utils/changeRequestsSchedulePdf";
+
+const saveMock = vi.fn();
+const textMock = vi.fn();
+const autoTableMock = vi.fn();
+
+vi.mock("jspdf", () => ({
+  jsPDF: vi.fn().mockImplementation(function MockJsPDF(this: {
+    setFontSize: ReturnType<typeof vi.fn>;
+    text: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+    getNumberOfPages: ReturnType<typeof vi.fn>;
+    setPage: ReturnType<typeof vi.fn>;
+    getTextWidth: ReturnType<typeof vi.fn>;
+    internal: {
+      pageSize: { getWidth: ReturnType<typeof vi.fn>; getHeight: ReturnType<typeof vi.fn> };
+    };
+  }) {
+    this.setFontSize = vi.fn();
+    this.text = textMock;
+    this.save = saveMock;
+    this.getNumberOfPages = vi.fn(() => 1);
+    this.setPage = vi.fn();
+    this.getTextWidth = vi.fn(() => 40);
+    this.internal = {
+      pageSize: { getWidth: vi.fn(() => 210), getHeight: vi.fn(() => 297) },
+    };
+  }),
+}));
+
+vi.mock("jspdf-autotable", () => ({
+  default: (...args: unknown[]) => autoTableMock(...args),
+}));
+
+describe("generateChangeRequestsSchedulePdf", () => {
+  it("builds schedule PDF and saves", () => {
+    generateChangeRequestsSchedulePdf(
+      [
+        {
+          number: "CHG1",
+          title: "Patch",
+          startDate: "2026-06-01 10:00:00",
+          endDate: "2026-06-01 12:00:00",
+          state: { id: "1", label: "Scheduled" },
+          impact: { id: "3", label: "3 - Low" },
+        } as never,
+      ],
+      {
+        awaitingYourAction: 1,
+        ongoing: 2,
+        completed: 3,
+        totalRequests: 6,
+      },
+    );
+
+    expect(textMock).toHaveBeenCalledWith("Change Requests Schedule", 14, 20);
+    expect(autoTableMock).toHaveBeenCalled();
+    expect(saveMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^Change-Requests-Schedule-\d{4}-\d{2}-\d{2}\.pdf$/),
+    );
+  });
+});

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
@@ -180,7 +180,7 @@ describe("buildChangeRequestSearchRequest", () => {
 
   it("resolves outstanding state IDs from metadata when outstandingOnly is true", () => {
     const req = buildChangeRequestSearchRequest({}, "", true, false, false, allStates);
-    expect(req.filters?.stateKeys).toEqual([5, -2, -1, 0, 1]);
+    expect(req.filters?.stateKeys).toEqual([-5, -4, -3, 5, -2, -1, 0, 1]);
   });
 
   it("resolves action-required state IDs from metadata", () => {

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/serviceRequestValidation.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/serviceRequestValidation.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  getFirstEmptyRequiredField,
+  getUserEditableVariables,
+  isAttachmentField,
+  isDescriptionField,
+  isFileCopyPathField,
+} from "@features/operations/utils/serviceRequestValidation";
+
+describe("serviceRequestValidation", () => {
+  it("detects description field", () => {
+    expect(isDescriptionField("Description")).toBe(true);
+    expect(isDescriptionField("* Summary")).toBe(false);
+  });
+
+  it("detects attachment and file copy path fields", () => {
+    expect(
+      isAttachmentField({ questionText: "Upload vulnerability scan report", type: "Single Line Text" }),
+    ).toBe(true);
+    expect(
+      isFileCopyPathField({ questionText: "File Copy Path", type: "text" }),
+    ).toBe(true);
+  });
+
+  it("filters user-editable variables", () => {
+    const contextValues = {
+      projectDisplay: "Proj",
+      deploymentDisplay: "Dep",
+      productDisplay: "Prod",
+    };
+    const editable = getUserEditableVariables(
+      [
+        { id: "1", questionText: "Project", type: "text" } as never,
+        { id: "2", questionText: "Notes", type: "text" } as never,
+      ],
+      contextValues,
+    );
+    expect(editable).toHaveLength(1);
+    expect(editable[0].questionText).toBe("Notes");
+  });
+
+  it("returns first empty required field label", () => {
+    const contextValues = {
+      projectDisplay: "Proj",
+      deploymentDisplay: "Dep",
+      productDisplay: "Prod",
+    };
+    const label = getFirstEmptyRequiredField(
+      [{ id: "v1", questionText: "Required field", type: "text" } as never],
+      contextValues,
+      {},
+    );
+    expect(label).toBe("Required field");
+  });
+});


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the change requests feature in the customer portal webapp. The new tests cover API hooks, utility functions, and UI components related to change requests, improving test coverage and ensuring the reliability of core operations functionality.

**API and Hook Testing:**

* Added tests for the API utility `fetchChangeRequestSearchResults`, verifying correct aggregation of paginated results and error handling.
* Added tests for all major React Query hooks in `@features/operations/api`, including `useGetChangeRequests`, `useGetChangeRequestsInfinite`, `useGetChangeRequestDetails`, `useGetProjectChangeRequestStats`, `usePatchChangeRequest`, `usePostCase`, `useSearchCatalogs`, and `useGetCatalogItemVariables`. These tests mock authentication and API responses to validate correct network calls and state handling.

**Component Testing:**

* Added unit tests for UI components in `@features/operations/components/change-requests`, specifically:
  - `ChangeRequestDetailsLoadingSkeleton`
  - `ChangeRequestsCalendarSkeleton`
  - `ChangeRequestsCalendarView`
  - `ChangeRequestsCsvExportButton`
  - `ChangeRequestsFilters`
  - `ChangeRequestsList`
  - `ChangeRequestsListSkeleton`
  - `ChangeRequestsSearchBar`
  - `ChangeRequestsStatCards`
* These tests verify correct rendering of placeholders, skeletons, empty states, labels, and button presence for each component.

Overall, this PR significantly improves the test coverage and reliability of the change requests domain in the customer portal frontend.