### PR TITLE
[Customer Portal] Add Created By filter to All Cases view

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
@@ -32,6 +32,7 @@ import type {
   AllCasesFilterValues,
 } from "@features/support/types/cases";
 import type { ProjectDeploymentItem } from "@features/project-details/types/deployments";
+import type { ProjectContact } from "@features/settings/types/users";
 import {
   SelectMenuLoadMoreRow,
   SELECT_MENU_LOAD_MORE_ROW_VALUE,
@@ -49,6 +50,8 @@ export interface ListFiltersProps {
   filters: AllCasesFilterValues;
   filterMetadata: CaseMetadataResponse | undefined;
   deployments?: ProjectDeploymentItem[];
+  contacts?: ProjectContact[];
+  isContactsLoading?: boolean;
   onFilterChange: (field: string, value: string | string[]) => void;
   excludeS0?: boolean;
   restrictSeverityToLow?: boolean;
@@ -56,6 +59,7 @@ export interface ListFiltersProps {
   hideStatusFilter?: boolean;
   hideDeploymentFilter?: boolean;
   hideCategoryFilter?: boolean;
+  hideCreatedByFilter?: boolean;
   onLoadMoreDeployments?: () => void;
   hasMoreDeployments?: boolean;
   isFetchingMoreDeployments?: boolean;
@@ -72,6 +76,8 @@ export default function ListFilters({
   filters,
   filterMetadata,
   deployments,
+  contacts,
+  isContactsLoading = false,
   onFilterChange,
   excludeS0 = false,
   restrictSeverityToLow = false,
@@ -79,6 +85,7 @@ export default function ListFilters({
   hideStatusFilter = false,
   hideDeploymentFilter = false,
   hideCategoryFilter = false,
+  hideCreatedByFilter = false,
   onLoadMoreDeployments,
   hasMoreDeployments = false,
   isFetchingMoreDeployments = false,
@@ -112,12 +119,16 @@ export default function ListFilters({
         if (hideCategoryFilter && def.id === "category") {
           return null;
         }
+        if (hideCreatedByFilter && def.id === "createdBy") {
+          return null;
+        }
         if (def.metadataKey === "severities" && restrictSeverityToLow) {
           return null;
         }
         const { label, allLabel } = deriveFilterLabels(def.id);
 
         const isDeploymentFilter = def.id === "deployment";
+        const isCreatedByFilter = def.id === "createdBy";
         const options = (() => {
           if (isDeploymentFilter) {
             return (
@@ -127,6 +138,15 @@ export default function ListFilters({
               })) ?? []
             );
           }
+          if (isCreatedByFilter) {
+            return (
+              contacts?.map((contact) => ({
+                label: `${contact.firstName} ${contact.lastName}`.trim() || contact.email,
+                value: contact.email,
+              })) ?? []
+            );
+          }
+          if (!def.metadataKey) return [];
           const metadataOptions = filterMetadata?.[def.metadataKey];
           if (!Array.isArray(metadataOptions)) return [];
           const filtered =
@@ -189,7 +209,11 @@ export default function ListFilters({
                     );
                   }}
                 >
-                  {hasNoOptions ? (
+                  {isCreatedByFilter && isContactsLoading ? (
+                    <MenuItem disabled>
+                      <Typography variant="body2">Loading...</Typography>
+                    </MenuItem>
+                  ) : hasNoOptions ? (
                     <MenuItem disabled>
                       <Typography variant="body2">{EMPTY_DROPDOWN_PLACEHOLDER}</Typography>
                     </MenuItem>

--- a/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListSearchPanel.tsx
@@ -17,6 +17,7 @@
 import type { JSX, ReactNode } from "react";
 import type { CaseMetadataResponse } from "@features/support/types/cases";
 import type { ProjectDeploymentItem } from "@features/project-details/types/deployments";
+import type { ProjectContact } from "@features/settings/types/users";
 import ListSearchBar from "@components/list-view/ListSearchBar";
 import ListFilters from "@components/list-view/ListFilters";
 import { countListSearchAndFilters } from "@features/support/utils/support";
@@ -32,9 +33,12 @@ export interface ListSearchPanelProps {
     severityIds?: string[];
     issueTypes?: string[];
     deploymentIds?: string[];
+    createdBy?: string[];
   };
   filterMetadata: CaseMetadataResponse | undefined;
   deployments?: ProjectDeploymentItem[];
+  contacts?: ProjectContact[];
+  isContactsLoading?: boolean;
   onFilterChange: (field: string, value: string | string[]) => void;
   onClearFilters: () => void;
   excludeS0?: boolean;
@@ -43,6 +47,7 @@ export interface ListSearchPanelProps {
   hideStatusFilter?: boolean;
   hideDeploymentFilter?: boolean;
   hideCategoryFilter?: boolean;
+  hideCreatedByFilter?: boolean;
   hideFiltersButton?: boolean;
   isProjectContextLoading?: boolean;
   onLoadMoreDeployments?: () => void;
@@ -67,6 +72,8 @@ export default function ListSearchPanel({
   filters,
   filterMetadata,
   deployments,
+  contacts,
+  isContactsLoading = false,
   onFilterChange,
   onClearFilters,
   excludeS0 = false,
@@ -75,6 +82,7 @@ export default function ListSearchPanel({
   hideStatusFilter = false,
   hideDeploymentFilter = false,
   hideCategoryFilter = false,
+  hideCreatedByFilter = false,
   hideFiltersButton = false,
   isProjectContextLoading = false,
   onLoadMoreDeployments,
@@ -90,6 +98,7 @@ export default function ListSearchPanel({
     ...(hideStatusFilter ? { statusIds: undefined } : {}),
     ...(hideDeploymentFilter ? { deploymentIds: undefined } : {}),
     ...(hideCategoryFilter ? { issueTypes: undefined } : {}),
+    ...(hideCreatedByFilter ? { createdBy: undefined } : {}),
     ...excluded,
   };
   return (
@@ -112,6 +121,8 @@ export default function ListSearchPanel({
           filters={filters}
           filterMetadata={filterMetadata}
           deployments={deployments}
+          contacts={contacts}
+          isContactsLoading={isContactsLoading}
           onFilterChange={onFilterChange}
           excludeS0={excludeS0}
           restrictSeverityToLow={restrictSeverityToLow}
@@ -119,6 +130,7 @@ export default function ListSearchPanel({
           hideStatusFilter={hideStatusFilter}
           hideDeploymentFilter={hideDeploymentFilter}
           hideCategoryFilter={hideCategoryFilter}
+          hideCreatedByFilter={hideCreatedByFilter}
           onLoadMoreDeployments={onLoadMoreDeployments}
           hasMoreDeployments={hasMoreDeployments}
           isFetchingMoreDeployments={isFetchingMoreDeployments}

--- a/apps/customer-portal/webapp/src/features/dashboard/utils/dashboardNavigation.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/utils/dashboardNavigation.ts
@@ -87,6 +87,7 @@ export function buildDashboardCaseSearchFilters(params: {
   deploymentIds?: string[];
   searchQuery?: string;
   createdByMe?: boolean;
+  createdBy?: string[];
   caseStates?: MetadataItem[];
   isDashboardSeverityNavigation?: boolean;
 }): CaseSearchFilters {
@@ -97,6 +98,7 @@ export function buildDashboardCaseSearchFilters(params: {
     deploymentIds,
     searchQuery,
     createdByMe,
+    createdBy,
     caseStates,
     isDashboardSeverityNavigation = false,
   } = params;
@@ -107,6 +109,7 @@ export function buildDashboardCaseSearchFilters(params: {
     ? severityIds.map(Number)
     : undefined;
   const normalizedIssueIds = normalizeCaseSearchIssueIds(issueTypes);
+  const normalizedCreatedBy = createdBy?.length ? createdBy : undefined;
 
   switch (true) {
     case Boolean(explicitStatusIds?.length):
@@ -117,6 +120,7 @@ export function buildDashboardCaseSearchFilters(params: {
         deploymentIds,
         searchQuery: normalizedSearchQuery,
         createdByMe,
+        createdBy: normalizedCreatedBy,
       };
     case isDashboardSeverityNavigation:
       return {
@@ -126,6 +130,7 @@ export function buildDashboardCaseSearchFilters(params: {
         deploymentIds,
         searchQuery: normalizedSearchQuery,
         createdByMe,
+        createdBy: normalizedCreatedBy,
       };
     default:
       return {
@@ -134,6 +139,7 @@ export function buildDashboardCaseSearchFilters(params: {
         deploymentIds,
         searchQuery: normalizedSearchQuery,
         createdByMe,
+        createdBy: normalizedCreatedBy,
       };
   }
 }

--- a/apps/customer-portal/webapp/src/features/settings/api/useGetProjectContacts.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/useGetProjectContacts.ts
@@ -70,6 +70,6 @@ export default function useGetProjectContacts(
       }
     },
     enabled: !!projectId && !!isSignedIn && !isAuthLoading,
-    staleTime: 0,
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -448,6 +448,11 @@ export const ALL_CASES_FILTER_DEFINITIONS: AllCasesFilterDefinition[] = [
     metadataKey: "deploymentTypes",
     multiSelect: true,
   },
+  {
+    filterKey: "createdBy",
+    id: "createdBy",
+    multiSelect: true,
+  },
 ];
 
 /**

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -35,6 +35,7 @@ import useGetProjectFeatures from "@api/useGetProjectFeatures";
 import useGetProjectFilters from "@api/useGetProjectFilters";
 import useGetProjectCases from "@api/useGetProjectCases";
 import { usePostProjectDeploymentsSearchInfinite } from "@api/usePostProjectDeploymentsSearch";
+import useGetProjectContacts from "@features/settings/api/useGetProjectContacts";
 import {
   hasListSearchOrFilters,
   getLast30DaysUtcRange,
@@ -141,6 +142,9 @@ export default function AllCasesPage(): JSX.Element {
   const deploymentsList =
     deploymentsQuery.data?.pages.flatMap((p) => p.deployments ?? []) ?? [];
 
+  const { data: contactsData, isLoading: isContactsLoading } = useGetProjectContacts(projectId || "");
+  const contactsList = contactsData ?? [];
+
   const caseSearchRequest = useMemo(
     () => ({
       filters: {
@@ -154,6 +158,7 @@ export default function AllCasesPage(): JSX.Element {
             : undefined,
           searchQuery: searchTerm,
           createdByMe: createdByMe || undefined,
+          createdBy: filters.createdBy as string[] | undefined,
           caseStates: filterMetadata?.caseStates,
           isDashboardSeverityNavigation:
             (isDashboardSeverityNavigation &&
@@ -178,6 +183,7 @@ export default function AllCasesPage(): JSX.Element {
       filterMetadata?.caseStates,
       isDashboardSeverityNavigation,
       initialSeverityId,
+      contactsList,
     ],
   );
 
@@ -204,7 +210,7 @@ export default function AllCasesPage(): JSX.Element {
     (!!projectId && !hasCasesResponse) ||
     isFetchingNextPage;
 
-  const isInitialPageLoading = isCasesAreaLoading;
+  const isInitialPageLoading = isCasesAreaLoading || isContactsLoading;
 
   useEffect(() => {
     if (isInitialPageLoading) {
@@ -356,6 +362,8 @@ export default function AllCasesPage(): JSX.Element {
           onFiltersToggle={() => setIsFiltersOpen(!isFiltersOpen)}
           filters={filters}
           filterMetadata={filterMetadata}
+          contacts={contactsList}
+          isContactsLoading={isContactsLoading}
           deployments={
             projectDetailsReady && permissions.hasDeployments
               ? deploymentsList

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -309,6 +309,7 @@ export type AllCasesFilterValues = {
   issueTypes?: string[];
   deploymentIds?: string[];
   engagementTypeKey?: string;
+  createdBy?: string[];
 };
 
 // Item type for a case attachment.
@@ -367,6 +368,7 @@ export type CaseSearchFilters = {
   searchQuery?: string;
   caseTypes?: string[];
   createdByMe?: boolean;
+  createdBy?: string[];
   closedStartDate?: string;
   closedEndDate?: string;
   engagementTypeKeys?: number[];

--- a/apps/customer-portal/webapp/src/features/support/types/supportUiConfig.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportUiConfig.ts
@@ -46,7 +46,7 @@ export type CaseStatusAction = {
 /** All-cases list filter field mapping. */
 export type AllCasesFilterDefinition = {
   id: string;
-  metadataKey: keyof CaseMetadataResponse;
+  metadataKey?: keyof CaseMetadataResponse;
   filterKey: string;
   useLabelAsValue?: boolean;
   multiSelect?: boolean;

--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -791,6 +791,9 @@ export function deriveFilterLabels(id: string): {
   if (id === "caseType") {
     return { label: "Case Type", allLabel: "All Case Types" };
   }
+  if (id === "createdBy") {
+    return { label: "Created By", allLabel: "All Users" };
+  }
   const label = id.charAt(0).toUpperCase() + id.slice(1);
   const allLabel = `All ${
     label.endsWith("s")


### PR DESCRIPTION
Description:

  ## Summary

  - Added a **Created By** multi-select filter to the All Cases view, consistent with existing filters (Status, Severity, Category, Deployment)
  - Populated from project contacts — same user list as **Settings > User Management**
  - Sends selected user emails as `createdBy: string[]` in the case search request body

  ## Changes

  ### Types
  - `AllCasesFilterValues` — added `createdBy?: string[]`
  - `CaseSearchFilters` — added `createdBy?: string[]`
  - `AllCasesFilterDefinition` — made `metadataKey` optional to support filters with custom data sources

  ### Filter UI
  - Added `createdBy` entry to `ALL_CASES_FILTER_DEFINITIONS` as multi-select
  - `deriveFilterLabels` — added label mapping: "Created By" / "All Users"
  - `ListFilters` — accepts `contacts` and `isContactsLoading` props; renders Created By dropdown with a "Loading..." state while contacts are in flight
  - `ListSearchPanel` — passes through `contacts`, `isContactsLoading`, and `hideCreatedByFilter`
  ### Data & API
  - `buildDashboardCaseSearchFilters` — threads `createdBy` through all three return paths
  - `AllCasesPage` — calls `useGetProjectContacts`, passes contacts to the filter panel, and includes `createdBy` in the search request
  - `useGetProjectContacts` — aligned `staleTime` to `5 * 60 * 1000` (matching `useGetProjectFilters`) so contacts are cached and load instantly on repeat visits
  - Page-level loader (`isInitialPageLoading`) now waits for both cases and contacts before dismissing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a multi-select "Created By" filter to the cases list, enabling users to filter by one or more contacts who created cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/cs-tools/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->