### PR TITLE
[Customer Portal] Fix TS build error in CasesTable for optional metadataKey

### DIFF
--- a/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListFilters.tsx
@@ -105,7 +105,7 @@ export default function ListFilters({
     };
 
   return (
-    <Grid container spacing={2} sx={{ mt: 1 }}>
+    <Grid container spacing={2} sx={{ mt: 1, flexWrap: { xs: "wrap", md: "nowrap" }, overflowX: { md: "auto" } }}>
       {ALL_CASES_FILTER_DEFINITIONS.map((def) => {
         if (hideSeverityFilter && def.id === "severity") {
           return null;
@@ -177,7 +177,7 @@ export default function ListFilters({
         if (def.multiSelect) {
           const selectedValues = (filters[def.filterKey] as string[] | undefined) ?? [];
           return (
-            <Grid key={def.id} size={{ xs: 12, sm: 6, md: 3 }}>
+            <Grid key={def.id} size={{ xs: 12, sm: 6 }} sx={{ flex: { md: "1 1 0" }, minWidth: { md: 160 } }}>
               <FormControl fullWidth size="small">
                 <InputLabel id={`${def.id}-label`}>{label}</InputLabel>
                 <Select
@@ -232,7 +232,7 @@ export default function ListFilters({
         }
 
         return (
-          <Grid key={def.id} size={{ xs: 12, sm: 6, md: 3 }}>
+          <Grid key={def.id} size={{ xs: 12, sm: 6 }} sx={{ flex: { md: "1 1 0" }, minWidth: { md: 160 } }}>
             <FormControl fullWidth size="small">
               <InputLabel id={`${def.id}-label`}>{label}</InputLabel>
               <Select

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
@@ -122,7 +122,8 @@ const CasesTable = ({
       (def) =>
         def.id !== "caseType" &&
         !(restrictSeverityToLow && def.metadataKey === "severities") &&
-        (includeDeploymentFilter || def.id !== "deployment"),
+        (includeDeploymentFilter || def.id !== "deployment") &&
+        (def.id === "deployment" || !!def.metadataKey),
     ).map((def) => {
       const { label } = deriveFilterLabels(def.id);
 
@@ -140,13 +141,13 @@ const CasesTable = ({
           const metadataOptions =
             filtersMetadata?.[def.metadataKey as keyof typeof filtersMetadata];
           const filtered = filterCasesTableMetadataOptions(
-            def.metadataKey,
+            def.metadataKey!,
             metadataOptions,
             excludeS0,
             restrictSeverityToLow,
           );
           options = filtered.map((item) => ({
-            label: mapCasesTableFilterOptionLabel(def.metadataKey, item.label),
+            label: mapCasesTableFilterOptionLabel(def.metadataKey!, item.label),
             value: item.id,
           }));
         }


### PR DESCRIPTION
## Fix
  - Exclude filter definitions without a `metadataKey` from `CasesTable` dynamic filters
  - Add non-null assertions at call sites where `metadataKey` is guaranteed by the filter guard