### PR TITLE
[Customer Entity] Implement cases search endpoint

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -312,6 +312,18 @@ type SearchDeployedProductsResponse struct {
 	HasMore          bool              `json:"hasMore"`
 }
 
+// CaseIssueType classifies the nature of a support case.
+type CaseIssueType string
+
+const (
+	CaseIssueTypeError                  CaseIssueType = "error"
+	CaseIssueTypePartialOutage          CaseIssueType = "partial_outage"
+	CaseIssueTypePerformanceDegradation CaseIssueType = "performance_degradation"
+	CaseIssueTypeQuestion               CaseIssueType = "question"
+	CaseIssueTypeSecurityOrCompliance   CaseIssueType = "security_or_compliance"
+	CaseIssueTypeTotalOutage            CaseIssueType = "total_outage"
+)
+
 // CasePriority represents the urgency level of a support case.
 type CasePriority string
 
@@ -371,8 +383,9 @@ type Case struct {
 	DeployedProductID string       `json:"deployedProductId"`
 	Subject           string       `json:"subject"`
 	Description       string       `json:"description"`
-	Priority          *CasePriority `json:"priority,omitempty"`
-	State             CaseState    `json:"state"`
+	Priority          CasePriority  `json:"priority"`
+	IssueType         CaseIssueType `json:"issueType"`
+	State             CaseState     `json:"state"`
 	CreatedAt         time.Time    `json:"createdAt"`
 	UpdatedAt         time.Time    `json:"updatedAt"`
 	ClosedAt          *time.Time   `json:"closedAt,omitempty"`
@@ -387,9 +400,10 @@ type SearchCasesRequest struct {
 	ProjectIDs          []string       `json:"projectIds"`
 	DeploymentIDs       []string       `json:"deploymentIds"`
 	DeployedProductIDs  []string       `json:"deployedProductIds"`
-	StateKeys           []CaseState    `json:"stateKeys"`
-	PriorityKeys        []CasePriority `json:"priorityKeys"`
-	SortBy              CaseSort       `json:"sortBy"`
+	StateKeys           []CaseState     `json:"stateKeys"`
+	PriorityKeys        []CasePriority  `json:"priorityKeys"`
+	IssueTypeKeys       []CaseIssueType `json:"issueTypeKeys"`
+	SortBy              CaseSort        `json:"sortBy"`
 }
 
 // SearchCasesResponse is the paginated result of a case search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -311,3 +311,93 @@ type SearchDeployedProductsResponse struct {
 	Offset           int               `json:"offset"`
 	HasMore          bool              `json:"hasMore"`
 }
+
+// CasePriority represents the urgency level of a support case.
+type CasePriority string
+
+const (
+	CasePriorityCatastrophic CasePriority = "catastrophic"
+	CasePriorityCritical     CasePriority = "critical"
+	CasePriorityHigh         CasePriority = "high"
+	CasePriorityMedium       CasePriority = "medium"
+	CasePriorityLow          CasePriority = "low"
+)
+
+// CaseState represents the current workflow state of a support case.
+type CaseState string
+
+const (
+	CaseStateOpen             CaseState = "open"
+	CaseStateWorkInProgress   CaseState = "work_in_progress"
+	CaseStateWaitingOnWSO2    CaseState = "waiting_on_wso2"
+	CaseStateAwaitingInfo     CaseState = "awaiting_info"
+	CaseStateReopened         CaseState = "reopened"
+	CaseStateSolutionProposed CaseState = "solution_proposed"
+	CaseStateClosed           CaseState = "closed"
+)
+
+// CaseSortField enumerates the columns available for sorting case search results.
+type CaseSortField string
+
+const (
+	CaseSortFieldCreatedAt CaseSortField = "created_at"
+	CaseSortFieldUpdatedAt CaseSortField = "updated_at"
+	CaseSortFieldClosedAt  CaseSortField = "closed_at"
+)
+
+// CaseSortOrder controls the sort direction.
+type CaseSortOrder string
+
+const (
+	CaseSortOrderAsc  CaseSortOrder = "asc"
+	CaseSortOrderDesc CaseSortOrder = "desc"
+)
+
+// CaseSort specifies the sort field and direction for case search results.
+type CaseSort struct {
+	Field CaseSortField `json:"field"`
+	Order CaseSortOrder `json:"order"`
+}
+
+// Case represents a customer support case as stored in the database.
+// Priority and ClosedAt are optional and omitted from JSON when absent.
+type Case struct {
+	ID                string       `json:"id"`
+	Number            string       `json:"number"`
+	Wso2ID            string       `json:"wso2Id"`
+	CreatedBy         string       `json:"createdBy"`
+	ProjectID         string       `json:"projectId"`
+	DeploymentID      string       `json:"deploymentId"`
+	DeployedProductID string       `json:"deployedProductId"`
+	Subject           string       `json:"subject"`
+	Description       string       `json:"description"`
+	Priority          *CasePriority `json:"priority,omitempty"`
+	State             CaseState    `json:"state"`
+	CreatedAt         time.Time    `json:"createdAt"`
+	UpdatedAt         time.Time    `json:"updatedAt"`
+	ClosedAt          *time.Time   `json:"closedAt,omitempty"`
+}
+
+// SearchCasesRequest is the input for a case search operation.
+// SearchQuery is matched case-insensitively against subject, number, and wso2_id.
+// All filter slices are optional. SortBy defaults to created_at.
+type SearchCasesRequest struct {
+	Pagination          Pagination     `json:"pagination"`
+	SearchQuery         string         `json:"searchQuery"`
+	ProjectIDs          []string       `json:"projectIds"`
+	DeploymentIDs       []string       `json:"deploymentIds"`
+	DeployedProductIDs  []string       `json:"deployedProductIds"`
+	StateKeys           []CaseState    `json:"stateKeys"`
+	PriorityKeys        []CasePriority `json:"priorityKeys"`
+	SortBy              CaseSort       `json:"sortBy"`
+}
+
+// SearchCasesResponse is the paginated result of a case search.
+// HasMore is true when additional pages are available beyond the current offset.
+type SearchCasesResponse struct {
+	Cases   []Case `json:"cases"`
+	Total   int    `json:"total"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	HasMore bool   `json:"hasMore"`
+}

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package handler is declared in user_handler.go.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// CaseHandler handles HTTP requests for the case resource.
+type CaseHandler struct {
+	svc service.CaseService
+}
+
+// NewCaseHandler constructs a CaseHandler with the given service.
+func NewCaseHandler(svc service.CaseService) *CaseHandler {
+	return &CaseHandler{svc: svc}
+}
+
+// SearchCases handles POST /cases/search.
+func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchCasesRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchCases(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -88,6 +88,16 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
+	if len(req.IssueTypeKeys) > 0 {
+		issueTypeStrings := make([]string, len(req.IssueTypeKeys))
+		for i, it := range req.IssueTypeKeys {
+			issueTypeStrings[i] = string(it)
+		}
+		where += fmt.Sprintf(" AND issue_type = ANY($%d::case_issue_type_enum[])", argIdx)
+		filterArgs = append(filterArgs, issueTypeStrings)
+		argIdx++
+	}
+
 	if req.SearchQuery != "" {
 		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.SearchQuery)
 		pattern := "%" + escaped + "%"
@@ -103,7 +113,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 
 	dataQuery := fmt.Sprintf(
 		`SELECT id, number, wso2_id, created_by, project_id, deployment_id, deployed_product_id,
-		        subject, description, priority, state, created_at, updated_at, closed_at
+		        subject, description, priority, issue_type, state, created_at, updated_at, closed_at
 		 FROM cases %s
 		 ORDER BY %s %s NULLS LAST, id
 		 LIMIT $%d OFFSET $%d`,
@@ -136,7 +146,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 			if err := rows.Scan(
 				&c.ID, &c.Number, &c.Wso2ID, &c.CreatedBy,
 				&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
-				&c.Subject, &c.Description, &c.Priority, &c.State,
+				&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State,
 				&c.CreatedAt, &c.UpdatedAt, &c.ClosedAt,
 			); err != nil {
 				return fmt.Errorf("scan case: %w", err)

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"golang.org/x/sync/errgroup"
+)
+
+// CaseRepository defines the persistence operations for the cases table.
+type CaseRepository interface {
+	// SearchCases returns a filtered, paginated slice of cases together with the
+	// total count of matching rows before pagination.
+	// COUNT and SELECT are executed concurrently on separate pool connections.
+	SearchCases(ctx context.Context, req domain.SearchCasesRequest) ([]domain.Case, int, error)
+}
+
+type caseRepo struct {
+	db *pgxpool.Pool
+}
+
+// NewCaseRepository constructs a CaseRepository backed by the given connection pool.
+func NewCaseRepository(db *pgxpool.Pool) CaseRepository {
+	return &caseRepo{db: db}
+}
+
+// SearchCases implements CaseRepository.
+func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesRequest) ([]domain.Case, int, error) {
+	filterArgs := []any{}
+	argIdx := 1
+
+	where := "WHERE 1=1"
+
+	if len(req.ProjectIDs) > 0 {
+		where += fmt.Sprintf(" AND project_id = ANY($%d::uuid[])", argIdx)
+		filterArgs = append(filterArgs, req.ProjectIDs)
+		argIdx++
+	}
+
+	if len(req.DeploymentIDs) > 0 {
+		where += fmt.Sprintf(" AND deployment_id = ANY($%d::uuid[])", argIdx)
+		filterArgs = append(filterArgs, req.DeploymentIDs)
+		argIdx++
+	}
+
+	if len(req.DeployedProductIDs) > 0 {
+		where += fmt.Sprintf(" AND deployed_product_id = ANY($%d::uuid[])", argIdx)
+		filterArgs = append(filterArgs, req.DeployedProductIDs)
+		argIdx++
+	}
+
+	if len(req.StateKeys) > 0 {
+		stateStrings := make([]string, len(req.StateKeys))
+		for i, s := range req.StateKeys {
+			stateStrings[i] = string(s)
+		}
+		where += fmt.Sprintf(" AND state = ANY($%d::case_state_enum[])", argIdx)
+		filterArgs = append(filterArgs, stateStrings)
+		argIdx++
+	}
+
+	if len(req.PriorityKeys) > 0 {
+		priorityStrings := make([]string, len(req.PriorityKeys))
+		for i, p := range req.PriorityKeys {
+			priorityStrings[i] = string(p)
+		}
+		where += fmt.Sprintf(" AND priority = ANY($%d::case_priority_enum[])", argIdx)
+		filterArgs = append(filterArgs, priorityStrings)
+		argIdx++
+	}
+
+	if req.SearchQuery != "" {
+		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.SearchQuery)
+		pattern := "%" + escaped + "%"
+		where += fmt.Sprintf(` AND (subject ILIKE $%d ESCAPE '\' OR number ILIKE $%d ESCAPE '\' OR wso2_id ILIKE $%d ESCAPE '\')`, argIdx, argIdx, argIdx)
+		filterArgs = append(filterArgs, pattern)
+		argIdx++
+	}
+
+	sortCol := string(req.SortBy.Field)
+	sortDir := string(req.SortBy.Order)
+
+	countQuery := "SELECT COUNT(*) FROM cases " + where
+
+	dataQuery := fmt.Sprintf(
+		`SELECT id, number, wso2_id, created_by, project_id, deployment_id, deployed_product_id,
+		        subject, description, priority, state, created_at, updated_at, closed_at
+		 FROM cases %s
+		 ORDER BY %s %s NULLS LAST, id
+		 LIMIT $%d OFFSET $%d`,
+		where, sortCol, sortDir, argIdx, argIdx+1,
+	)
+	dataArgs := append(append([]any{}, filterArgs...), req.Pagination.Limit, req.Pagination.Offset)
+
+	var total int
+	var cases []domain.Case
+
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		if err := r.db.QueryRow(egCtx, countQuery, filterArgs...).Scan(&total); err != nil {
+			return fmt.Errorf("count cases: %w", err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		rows, err := r.db.Query(egCtx, dataQuery, dataArgs...)
+		if err != nil {
+			return fmt.Errorf("query cases: %w", err)
+		}
+		defer rows.Close()
+
+		result := make([]domain.Case, 0, req.Pagination.Limit)
+		for rows.Next() {
+			var c domain.Case
+			if err := rows.Scan(
+				&c.ID, &c.Number, &c.Wso2ID, &c.CreatedBy,
+				&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
+				&c.Subject, &c.Description, &c.Priority, &c.State,
+				&c.CreatedAt, &c.UpdatedAt, &c.ClosedAt,
+			); err != nil {
+				return fmt.Errorf("scan case: %w", err)
+			}
+			result = append(result, c)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate cases: %w", err)
+		}
+		cases = result
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, 0, err
+	}
+
+	return cases, total, nil
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -59,6 +59,10 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 	deployedProductSvc := service.NewDeployedProductService(deployedProductRepo)
 	deployedProductHandler := handler.NewDeployedProductHandler(deployedProductSvc)
 
+	caseRepo := repository.NewCaseRepository(db)
+	caseSvc := service.NewCaseService(caseRepo)
+	caseHandler := handler.NewCaseHandler(caseSvc)
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /health", handler.HealthCheck)
@@ -69,6 +73,7 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 	mux.HandleFunc("POST /products/{id}/versions/search", productVersionHandler.SearchProductVersions)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
+	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 
 	return middleware.Recovery(
 		middleware.Logger(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -63,6 +63,15 @@ var validCasePriority = map[domain.CasePriority]bool{
 	domain.CasePriorityLow:          true,
 }
 
+var validCaseIssueType = map[domain.CaseIssueType]bool{
+	domain.CaseIssueTypeError:                  true,
+	domain.CaseIssueTypePartialOutage:          true,
+	domain.CaseIssueTypePerformanceDegradation: true,
+	domain.CaseIssueTypeQuestion:               true,
+	domain.CaseIssueTypeSecurityOrCompliance:   true,
+	domain.CaseIssueTypeTotalOutage:            true,
+}
+
 // SearchCases implements CaseService.
 func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error) {
 	if err := normalizePagination(&req.Pagination); err != nil {
@@ -89,6 +98,11 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	for _, p := range req.PriorityKeys {
 		if !validCasePriority[p] {
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "priorityKeys contains invalid value: " + string(p)}
+		}
+	}
+	for _, it := range req.IssueTypeKeys {
+		if !validCaseIssueType[it] {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "issueTypeKeys contains invalid value: " + string(it)}
 		}
 	}
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package service is declared in interfaces.go.
+package service
+
+import (
+	"context"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/repository"
+)
+
+type caseService struct {
+	repo repository.CaseRepository
+}
+
+// NewCaseService constructs a CaseService backed by the given repository.
+func NewCaseService(repo repository.CaseRepository) CaseService {
+	return &caseService{repo: repo}
+}
+
+var validCaseSortField = map[domain.CaseSortField]bool{
+	domain.CaseSortFieldCreatedAt: true,
+	domain.CaseSortFieldUpdatedAt: true,
+	domain.CaseSortFieldClosedAt:  true,
+}
+
+var validCaseSortOrder = map[domain.CaseSortOrder]bool{
+	domain.CaseSortOrderAsc:  true,
+	domain.CaseSortOrderDesc: true,
+}
+
+var validCaseState = map[domain.CaseState]bool{
+	domain.CaseStateOpen:             true,
+	domain.CaseStateWorkInProgress:   true,
+	domain.CaseStateWaitingOnWSO2:    true,
+	domain.CaseStateAwaitingInfo:     true,
+	domain.CaseStateReopened:         true,
+	domain.CaseStateSolutionProposed: true,
+	domain.CaseStateClosed:           true,
+}
+
+var validCasePriority = map[domain.CasePriority]bool{
+	domain.CasePriorityCatastrophic: true,
+	domain.CasePriorityCritical:     true,
+	domain.CasePriorityHigh:         true,
+	domain.CasePriorityMedium:       true,
+	domain.CasePriorityLow:          true,
+}
+
+// SearchCases implements CaseService.
+func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+	if err := validateSearchQuery(req.SearchQuery); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+	if err := validateUUIDs("projectIds", req.ProjectIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+	if err := validateUUIDs("deploymentIds", req.DeploymentIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+	if err := validateUUIDs("deployedProductIds", req.DeployedProductIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+
+	for _, s := range req.StateKeys {
+		if !validCaseState[s] {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "stateKeys contains invalid value: " + string(s)}
+		}
+	}
+	for _, p := range req.PriorityKeys {
+		if !validCasePriority[p] {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "priorityKeys contains invalid value: " + string(p)}
+		}
+	}
+
+	if req.SortBy.Field == "" {
+		req.SortBy.Field = domain.CaseSortFieldCreatedAt
+	} else if !validCaseSortField[req.SortBy.Field] {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "sortBy.field must be one of: created_at, updated_at, closed_at"}
+	}
+	if req.SortBy.Order == "" {
+		req.SortBy.Order = domain.CaseSortOrderDesc
+	} else if !validCaseSortOrder[req.SortBy.Order] {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "sortBy.order must be one of: asc, desc"}
+	}
+
+	cases, total, err := s.repo.SearchCases(ctx, req)
+	if err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+
+	return domain.SearchCasesResponse{
+		Cases:   cases,
+		Total:   total,
+		Limit:   req.Pagination.Limit,
+		Offset:  req.Pagination.Offset,
+		HasMore: req.Pagination.Offset+len(cases) < total,
+	}, nil
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -81,3 +81,12 @@ type DeployedProductService interface {
 	// error indicates an infrastructure failure.
 	SearchDeployedProducts(ctx context.Context, req domain.SearchDeployedProductsRequest) (domain.SearchDeployedProductsResponse, error)
 }
+
+// CaseService defines the operations available on the cases entity.
+type CaseService interface {
+	// SearchCases returns a paginated list of cases filtered by optional project IDs,
+	// deployment IDs, deployed product IDs, state keys, priority keys, and search query.
+	// A ValidationError is returned for invalid input; any other error indicates an
+	// infrastructure failure.
+	SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error)
+}

--- a/entity-service/migrations/000008_create_cases.down.sql
+++ b/entity-service/migrations/000008_create_cases.down.sql
@@ -1,6 +1,7 @@
 DROP TABLE IF EXISTS cases;
 DROP TYPE IF EXISTS case_state_enum;
 DROP TYPE IF EXISTS case_priority_enum;
+DROP TYPE IF EXISTS case_issue_type_enum;
 DROP FUNCTION IF EXISTS check_case_deployment_belongs_to_project();
 DROP FUNCTION IF EXISTS check_case_deployed_product_belongs_to_deployment();
 DROP FUNCTION IF EXISTS check_case_catastrophic_priority();

--- a/entity-service/migrations/000008_create_cases.down.sql
+++ b/entity-service/migrations/000008_create_cases.down.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS cases;
+DROP TYPE IF EXISTS case_state_enum;
+DROP TYPE IF EXISTS case_priority_enum;
+DROP FUNCTION IF EXISTS check_case_deployment_belongs_to_project();
+DROP FUNCTION IF EXISTS check_case_deployed_product_belongs_to_deployment();
+DROP FUNCTION IF EXISTS check_case_catastrophic_priority();

--- a/entity-service/migrations/000008_create_cases.down.sql
+++ b/entity-service/migrations/000008_create_cases.down.sql
@@ -4,3 +4,4 @@ DROP TYPE IF EXISTS case_priority_enum;
 DROP FUNCTION IF EXISTS check_case_deployment_belongs_to_project();
 DROP FUNCTION IF EXISTS check_case_deployed_product_belongs_to_deployment();
 DROP FUNCTION IF EXISTS check_case_catastrophic_priority();
+DROP EXTENSION IF EXISTS pg_trgm;

--- a/entity-service/migrations/000008_create_cases.up.sql
+++ b/entity-service/migrations/000008_create_cases.up.sql
@@ -16,6 +16,15 @@ CREATE TYPE case_state_enum AS ENUM (
   'closed'
 );
 
+CREATE TYPE case_issue_type_enum AS ENUM (
+  'error',
+  'partial_outage',
+  'performance_degradation',
+  'question',
+  'security_or_compliance',
+  'total_outage'
+);
+
 CREATE TABLE cases (
   id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   number              VARCHAR UNIQUE NOT NULL,
@@ -26,7 +35,8 @@ CREATE TABLE cases (
   deployed_product_id UUID NOT NULL REFERENCES deployed_products(id),
   subject             VARCHAR NOT NULL,
   description         TEXT NOT NULL,
-  priority            case_priority_enum,
+  priority            case_priority_enum NOT NULL,
+  issue_type          case_issue_type_enum NOT NULL,
   state               case_state_enum NOT NULL,
   created_at          TIMESTAMP DEFAULT NOW(),
   updated_at          TIMESTAMP DEFAULT NOW(),
@@ -106,6 +116,7 @@ CREATE INDEX idx_cases_deployment_id       ON cases(deployment_id);
 CREATE INDEX idx_cases_deployed_product_id ON cases(deployed_product_id);
 CREATE INDEX idx_cases_priority            ON cases(priority);
 CREATE INDEX idx_cases_state               ON cases(state);
+CREATE INDEX idx_cases_issue_type          ON cases(issue_type);
 
 -- Sort indexes
 CREATE INDEX idx_cases_created_at          ON cases(created_at);
@@ -113,8 +124,9 @@ CREATE INDEX idx_cases_updated_at          ON cases(updated_at);
 CREATE INDEX idx_cases_closed_at           ON cases(closed_at);
 
 -- Composite indexes
-CREATE INDEX idx_cases_project_state       ON cases(project_id, state);
-CREATE INDEX idx_cases_priority_state      ON cases(priority, state);
+CREATE INDEX idx_cases_project_state         ON cases(project_id, state);
+CREATE INDEX idx_cases_priority_state        ON cases(priority, state);
+CREATE INDEX idx_cases_priority_issue_type   ON cases(priority, issue_type);
 
 -- Trigram indexes for ILIKE search on subject, number, wso2_id
 CREATE INDEX idx_cases_subject_trgm  ON cases USING GIN (subject  gin_trgm_ops);

--- a/entity-service/migrations/000008_create_cases.up.sql
+++ b/entity-service/migrations/000008_create_cases.up.sql
@@ -96,13 +96,27 @@ CREATE TRIGGER trg_case_catastrophic_priority
   BEFORE INSERT OR UPDATE ON cases
   FOR EACH ROW EXECUTE FUNCTION check_case_catastrophic_priority();
 
+-- Enable trigram extension for ILIKE '%...%' support
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- FK / equality indexes
 CREATE INDEX idx_cases_created_by          ON cases(created_by);
 CREATE INDEX idx_cases_project_id          ON cases(project_id);
 CREATE INDEX idx_cases_deployment_id       ON cases(deployment_id);
 CREATE INDEX idx_cases_deployed_product_id ON cases(deployed_product_id);
 CREATE INDEX idx_cases_priority            ON cases(priority);
 CREATE INDEX idx_cases_state               ON cases(state);
+
+-- Sort indexes
 CREATE INDEX idx_cases_created_at          ON cases(created_at);
+CREATE INDEX idx_cases_updated_at          ON cases(updated_at);
 CREATE INDEX idx_cases_closed_at           ON cases(closed_at);
+
+-- Composite indexes
 CREATE INDEX idx_cases_project_state       ON cases(project_id, state);
 CREATE INDEX idx_cases_priority_state      ON cases(priority, state);
+
+-- Trigram indexes for ILIKE search on subject, number, wso2_id
+CREATE INDEX idx_cases_subject_trgm  ON cases USING GIN (subject  gin_trgm_ops);
+CREATE INDEX idx_cases_number_trgm   ON cases USING GIN (number   gin_trgm_ops);
+CREATE INDEX idx_cases_wso2_id_trgm  ON cases USING GIN (wso2_id  gin_trgm_ops);

--- a/entity-service/migrations/000008_create_cases.up.sql
+++ b/entity-service/migrations/000008_create_cases.up.sql
@@ -1,0 +1,108 @@
+CREATE TYPE case_priority_enum AS ENUM (
+  'catastrophic',
+  'critical',
+  'high',
+  'medium',
+  'low'
+);
+
+CREATE TYPE case_state_enum AS ENUM (
+  'open',
+  'work_in_progress',
+  'waiting_on_wso2',
+  'awaiting_info',
+  'reopened',
+  'solution_proposed',
+  'closed'
+);
+
+CREATE TABLE cases (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  number              VARCHAR UNIQUE NOT NULL,
+  wso2_id             VARCHAR UNIQUE NOT NULL,
+  created_by          UUID NOT NULL REFERENCES users(id),
+  project_id          UUID NOT NULL REFERENCES projects(id),
+  deployment_id       UUID NOT NULL REFERENCES deployments(id),
+  deployed_product_id UUID NOT NULL REFERENCES deployed_products(id),
+  subject             VARCHAR NOT NULL,
+  description         TEXT NOT NULL,
+  priority            case_priority_enum,
+  state               case_state_enum NOT NULL,
+  created_at          TIMESTAMP DEFAULT NOW(),
+  updated_at          TIMESTAMP DEFAULT NOW(),
+  closed_at           TIMESTAMP,
+
+  CONSTRAINT chk_closed_at_on_closed
+    CHECK (state != 'closed' OR closed_at IS NOT NULL),
+
+  CONSTRAINT chk_closed_at_not_on_open
+    CHECK (closed_at IS NULL OR state = 'closed')
+);
+
+CREATE OR REPLACE FUNCTION check_case_deployment_belongs_to_project()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM deployments
+    WHERE id         = NEW.deployment_id
+      AND project_id = NEW.project_id
+  ) THEN
+    RAISE EXCEPTION
+      'deployment_id % does not belong to project_id %.', NEW.deployment_id, NEW.project_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_case_deployment_belongs_to_project
+  BEFORE INSERT OR UPDATE ON cases
+  FOR EACH ROW EXECUTE FUNCTION check_case_deployment_belongs_to_project();
+
+CREATE OR REPLACE FUNCTION check_case_deployed_product_belongs_to_deployment()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM deployed_products
+    WHERE id            = NEW.deployed_product_id
+      AND deployment_id = NEW.deployment_id
+  ) THEN
+    RAISE EXCEPTION
+      'deployed_product_id % does not belong to deployment_id %.', NEW.deployed_product_id, NEW.deployment_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_case_deployed_product_belongs_to_deployment
+  BEFORE INSERT OR UPDATE ON cases
+  FOR EACH ROW EXECUTE FUNCTION check_case_deployed_product_belongs_to_deployment();
+
+CREATE OR REPLACE FUNCTION check_case_catastrophic_priority()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.priority = 'catastrophic' AND NOT EXISTS (
+    SELECT 1 FROM projects
+    WHERE id                = NEW.project_id
+      AND subscription_type = 'managed_cloud_subscription'
+  ) THEN
+    RAISE EXCEPTION
+      'catastrophic priority is only allowed for managed_cloud_subscription projects. project_id % has a different subscription type.', NEW.project_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_case_catastrophic_priority
+  BEFORE INSERT OR UPDATE ON cases
+  FOR EACH ROW EXECUTE FUNCTION check_case_catastrophic_priority();
+
+CREATE INDEX idx_cases_created_by          ON cases(created_by);
+CREATE INDEX idx_cases_project_id          ON cases(project_id);
+CREATE INDEX idx_cases_deployment_id       ON cases(deployment_id);
+CREATE INDEX idx_cases_deployed_product_id ON cases(deployed_product_id);
+CREATE INDEX idx_cases_priority            ON cases(priority);
+CREATE INDEX idx_cases_state               ON cases(state);
+CREATE INDEX idx_cases_created_at          ON cases(created_at);
+CREATE INDEX idx_cases_closed_at           ON cases(closed_at);
+CREATE INDEX idx_cases_project_state       ON cases(project_id, state);
+CREATE INDEX idx_cases_priority_state      ON cases(priority, state);

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -206,6 +206,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/search:
+    post:
+      summary: Search support cases.
+      operationId: searchCases
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCasesRequest'
+      responses:
+        "200":
+          description: Cases matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCasesResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /deployed-products/search:
     post:
       summary: Search deployed products by deployment IDs.
@@ -634,6 +664,108 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DeployedProduct'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    SearchCasesRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        searchQuery:
+          type: string
+          description: Case-insensitive match against subject, number, and wso2_id.
+        projectIds:
+          type: array
+          items:
+            type: string
+          description: Filter by project UUIDs.
+        deploymentIds:
+          type: array
+          items:
+            type: string
+          description: Filter by deployment UUIDs.
+        deployedProductIds:
+          type: array
+          items:
+            type: string
+          description: Filter by deployed product UUIDs.
+        stateKeys:
+          type: array
+          items:
+            type: string
+            enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          description: Filter by case states.
+        priorityKeys:
+          type: array
+          items:
+            type: string
+            enum: [catastrophic, critical, high, medium, low]
+          description: Filter by case priorities.
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [created_at, updated_at, closed_at]
+              description: Column to sort by. Defaults to created_at.
+            order:
+              type: string
+              enum: [asc, desc]
+              description: Sort direction. Defaults to desc.
+
+    Case:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        wso2Id:
+          type: string
+        createdBy:
+          type: string
+        projectId:
+          type: string
+        deploymentId:
+          type: string
+        deployedProductId:
+          type: string
+        subject:
+          type: string
+        description:
+          type: string
+        priority:
+          type: string
+          nullable: true
+          enum: [catastrophic, critical, high, medium, low]
+        state:
+          type: string
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        closedAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    SearchCasesResponse:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/Case'
         total:
           type: integer
         limit:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -708,6 +708,12 @@ components:
             type: string
             enum: [catastrophic, critical, high, medium, low]
           description: Filter by case priorities.
+        issueTypeKeys:
+          type: array
+          items:
+            type: string
+            enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
+          description: Filter by case issue types.
         sortBy:
           type: object
           properties:
@@ -743,8 +749,10 @@ components:
           type: string
         priority:
           type: string
-          nullable: true
           enum: [catastrophic, critical, high, medium, low]
+        issueType:
+          type: string
+          enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]


### PR DESCRIPTION
## Purpose
- Add `cases` table migration with `case_priority_enum` and `case_state_enum` types, referential integrity triggers (deployment → project, deployed product → deployment, catastrophic priority → managed_cloud_subscription only), and covering indexes
- Add `Case` domain types with `CasePriority`, `CaseState`, and `CaseSort` (field + order) enums
- Implement cases search repository with concurrent COUNT/SELECT, dynamic WHERE clause for project, deployment, deployed product, state, and priority filters, plus ILIKE search across subject, number, and wso2_id
- Implement cases search service with UUID, enum, sort field/order validation and defaults
- Register `POST /cases/search` handler and route
- Add `/cases/search` path and request/response schemas to OpenAPI spec

## Request payload

```json
{
  "pagination": { "limit": 20, "offset": 0 },
  "searchQuery": "gateway",
  "projectIds": ["..."],
  "deploymentIds": ["..."],
  "deployedProductIds": ["..."],
  "stateKeys": ["open", "work_in_progress"],
  "priorityKeys": ["critical", "high"],
  "sortBy": { "field": "created_at", "order": "desc" }
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added comprehensive case search capability with filtering by project, deployment, deployed product, state, and priority. Search results can be sorted by creation date, last update, or closure date with full pagination support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->