### PR TITLE
[CSM Portal] Align POST /cases with entity-service CreateCase contract

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -19,12 +19,60 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 )
+
+var errUserNotFound = errors.New("authenticated user not found in entity service")
+
+// resolveUserID looks up the entity-service UUID for the given email via users/search.
+// TODO: remove once DB-level auth propagates the entity UUID directly through the token.
+func resolveUserID(ctx context.Context, entity entityCaseClient, email string) (string, error) {
+	body, err := json.Marshal(map[string]any{
+		"searchQuery": email,
+		"pagination":  map[string]any{"limit": 1, "offset": 0},
+	})
+	if err != nil {
+		return "", err
+	}
+	resp, err := entity.SearchUsers(ctx, body)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Users []struct {
+			ID string `json:"id"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return "", err
+	}
+	if len(result.Users) == 0 {
+		return "", errUserNotFound
+	}
+	return result.Users[0].ID, nil
+}
+
+// injectCreatedBy merges createdBy into a JSON request body.
+func injectCreatedBy(body []byte, userID string) ([]byte, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = make(map[string]json.RawMessage)
+	}
+	id, err := json.Marshal(userID)
+	if err != nil {
+		return nil, err
+	}
+	m["createdBy"] = id
+	return json.Marshal(m)
+}
 
 // injectProjectID merges a project ID into a JSON request body as projectIds: [id].
 func injectProjectID(body []byte, projectID string) ([]byte, error) {
@@ -49,6 +97,7 @@ type entityCaseClient interface {
 	CreateCase(ctx context.Context, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
+	SearchUsers(ctx context.Context, body []byte) ([]byte, error)
 }
 
 // CaseHandler handles HTTP requests for case operations, delegating to the
@@ -66,9 +115,10 @@ func NewCaseHandler(entity entityCaseClient) *CaseHandler {
 const maxRequestBodyBytes = 1 << 20
 
 // CreateCase handles POST /cases.
-// TODO: createdBy is currently supplied by the client. Once DB-level auth is
-// in place it will be injected server-side from the authenticated user and
-// removed from the request payload.
+// createdBy is resolved server-side by looking up the authenticated user's email
+// in the entity service and injecting the UUID into the request body.
+// TODO: remove the users/search lookup once DB-level auth propagates the entity
+// UUID directly through the token claims.
 func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -92,9 +142,26 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.entity.CreateCase(r.Context(), body)
+	userID, err := resolveUserID(r.Context(), h.entity, user.Email)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "entity CreateCase failed", "userID", user.UserID, "err", err)
+		if errors.Is(err, errUserNotFound) {
+			writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+			return
+		}
+		slog.ErrorContext(r.Context(), "resolveUserID failed", "email", user.Email, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+
+	entityBody, err := injectCreatedBy(body, userID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateCase(r.Context(), entityBody)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCase failed", "userID", userID, "err", err)
 		mapUpstreamError(w, err, "Failed to create case.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -26,6 +26,24 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 )
 
+// injectCreatedBy merges the authenticated user's ID into a JSON request body as createdBy.
+// Any caller-supplied createdBy is overridden to prevent spoofing.
+func injectCreatedBy(body []byte, userID string) ([]byte, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = make(map[string]json.RawMessage)
+	}
+	id, err := json.Marshal(userID)
+	if err != nil {
+		return nil, err
+	}
+	m["createdBy"] = id
+	return json.Marshal(m)
+}
+
 // injectProjectID merges a project ID into a JSON request body as projectIds: [id].
 func injectProjectID(body []byte, projectID string) ([]byte, error) {
 	var m map[string]json.RawMessage
@@ -66,18 +84,14 @@ func NewCaseHandler(entity entityCaseClient) *CaseHandler {
 const maxRequestBodyBytes = 1 << 20
 
 // CreateCase handles POST /cases.
+// The authenticated user's ID is injected as createdBy before forwarding to
+// the entity service; any caller-supplied createdBy is overridden.
 func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
-
-	// TODO: Decode the request body into a typed CaseCreatePayload and run
-	// field-level validation (required fields, enum values, etc.).
-
-	// TODO: Apply CSM portal business rules before forwarding to entity
-	// (e.g. restrict allowed case types, enforce project membership).
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
@@ -90,15 +104,24 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.entity.CreateCase(r.Context(), body)
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	entityBody, err := injectCreatedBy(body, user.UserID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateCase(r.Context(), entityBody)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateCase failed", "userID", user.UserID, "err", err)
 		mapUpstreamError(w, err, "Failed to create case.")
 		return
 	}
 
-	// TODO: Unmarshal result into a typed CaseCreateResponse and transform it
-	// to the CSM portal response shape before writing.
 	writeJSON(w, http.StatusCreated, result)
 }
 

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -45,13 +45,15 @@ func resolveUserID(ctx context.Context, entity entityCaseClient, email string) (
 	}
 	var result struct {
 		Users []struct {
-			ID string `json:"id"`
+			ID    string `json:"id"`
+			Email string `json:"email"`
 		} `json:"users"`
 	}
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return "", err
 	}
-	if len(result.Users) == 0 {
+	// Verify exact email match — SearchUsers may perform fuzzy/prefix search.
+	if len(result.Users) == 0 || result.Users[0].Email != email {
 		return "", errUserNotFound
 	}
 	return result.Users[0].ID, nil
@@ -145,7 +147,8 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	userID, err := resolveUserID(r.Context(), h.entity, user.Email)
 	if err != nil {
 		if errors.Is(err, errUserNotFound) {
-			writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+			// Token is valid but the entity service has no record for this user — 403, not 401.
+			writeError(w, http.StatusForbidden, ErrMsgForbidden)
 			return
 		}
 		slog.ErrorContext(r.Context(), "resolveUserID failed", "email", user.Email, "err", err)
@@ -166,6 +169,12 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(result, &created); err == nil && created.ID != "" {
+		w.Header().Set("Location", "/cases/"+created.ID)
+	}
 	writeJSON(w, http.StatusCreated, result)
 }
 

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -26,24 +26,6 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 )
 
-// injectCreatedBy merges the authenticated user's ID into a JSON request body as createdBy.
-// Any caller-supplied createdBy is overridden to prevent spoofing.
-func injectCreatedBy(body []byte, userID string) ([]byte, error) {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(body, &m); err != nil {
-		return nil, err
-	}
-	if m == nil {
-		m = make(map[string]json.RawMessage)
-	}
-	id, err := json.Marshal(userID)
-	if err != nil {
-		return nil, err
-	}
-	m["createdBy"] = id
-	return json.Marshal(m)
-}
-
 // injectProjectID merges a project ID into a JSON request body as projectIds: [id].
 func injectProjectID(body []byte, projectID string) ([]byte, error) {
 	var m map[string]json.RawMessage
@@ -84,8 +66,9 @@ func NewCaseHandler(entity entityCaseClient) *CaseHandler {
 const maxRequestBodyBytes = 1 << 20
 
 // CreateCase handles POST /cases.
-// The authenticated user's ID is injected as createdBy before forwarding to
-// the entity service; any caller-supplied createdBy is overridden.
+// TODO: createdBy is currently supplied by the client. Once DB-level auth is
+// in place it will be injected server-side from the authenticated user and
+// removed from the request payload.
 func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -109,13 +92,7 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entityBody, err := injectCreatedBy(body, user.UserID)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
-		return
-	}
-
-	result, err := h.entity.CreateCase(r.Context(), entityBody)
+	result, err := h.entity.CreateCase(r.Context(), body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateCase failed", "userID", user.UserID, "err", err)
 		mapUpstreamError(w, err, "Failed to create case.")

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -56,7 +56,7 @@ func TestCreateCase(t *testing.T) {
 	const resolvedUserID = "entity-user-uuid-42"
 
 	userSearchOK := func(_ context.Context, _ []byte) ([]byte, error) {
-		return []byte(`{"users":[{"id":"` + resolvedUserID + `"}],"total":1}`), nil
+		return []byte(`{"users":[{"id":"` + resolvedUserID + `","email":"agent@example.com"}],"total":1}`), nil
 	}
 
 	t.Run("requires authenticated user", func(t *testing.T) {
@@ -114,13 +114,17 @@ func TestCreateCase(t *testing.T) {
 		if err := json.Unmarshal(sent["createdBy"], &gotID); err != nil || gotID != resolvedUserID {
 			t.Errorf("upstream createdBy = %q, want %q", gotID, resolvedUserID)
 		}
+		var gotProjectID string
+		if err := json.Unmarshal(sent["projectId"], &gotProjectID); err != nil || gotProjectID != "proj-1" {
+			t.Errorf("upstream projectId = %q, want \"proj-1\" (original fields must be preserved)", gotProjectID)
+		}
 		resp := decodeJSON[map[string]any](t, w)
 		if resp["id"] != "case-1" {
 			t.Errorf("response id = %v, want case-1", resp["id"])
 		}
 	})
 
-	t.Run("returns 401 when user not found in entity service", func(t *testing.T) {
+	t.Run("returns 403 when user not found in entity service", func(t *testing.T) {
 		client := &mockEntityCaseClient{
 			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
 				return []byte(`{"users":[],"total":0}`), nil
@@ -130,8 +134,23 @@ func TestCreateCase(t *testing.T) {
 		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(validPayload)))
 		w := httptest.NewRecorder()
 		h.CreateCase(w, r)
-		assertStatus(t, w, http.StatusUnauthorized)
-		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgForbidden)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("returns 403 when search result email does not match token email", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
+				return []byte(`{"users":[{"id":"other-uuid","email":"alice-admin@example.com"}],"total":1}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(validPayload)))
+		w := httptest.NewRecorder()
+		h.CreateCase(w, r)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgForbidden)
 		assertContentType(t, w, "application/json")
 	})
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -51,7 +51,13 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 // ----- CreateCase -----
 
 func TestCreateCase(t *testing.T) {
-	const validPayload = `{"createdBy":"user-123","projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","priority":"high","issueType":"error"}`
+	// createdBy is NOT in the payload — it is resolved server-side via users/search.
+	const validPayload = `{"projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","priority":"high","issueType":"error"}`
+	const resolvedUserID = "entity-user-uuid-42"
+
+	userSearchOK := func(_ context.Context, _ []byte) ([]byte, error) {
+		return []byte(`{"users":[{"id":"` + resolvedUserID + `"}],"total":1}`), nil
+	}
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
@@ -83,9 +89,10 @@ func TestCreateCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
+	t.Run("resolves createdBy from users/search and injects it", func(t *testing.T) {
 		var capturedBody []byte
 		client := &mockEntityCaseClient{
+			searchUsersFn: userSearchOK,
 			createCaseFn: func(_ context.Context, body []byte) ([]byte, error) {
 				capturedBody = body
 				return []byte(`{"id":"case-1","subject":"Login failure","state":"open"}`), nil
@@ -98,8 +105,14 @@ func TestCreateCase(t *testing.T) {
 
 		assertStatus(t, w, http.StatusCreated)
 		assertContentType(t, w, "application/json")
-		if string(capturedBody) != validPayload {
-			t.Errorf("upstream received body %q, want %q", capturedBody, validPayload)
+
+		var sent map[string]json.RawMessage
+		if err := json.Unmarshal(capturedBody, &sent); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		var gotID string
+		if err := json.Unmarshal(sent["createdBy"], &gotID); err != nil || gotID != resolvedUserID {
+			t.Errorf("upstream createdBy = %q, want %q", gotID, resolvedUserID)
 		}
 		resp := decodeJSON[map[string]any](t, w)
 		if resp["id"] != "case-1" {
@@ -107,11 +120,42 @@ func TestCreateCase(t *testing.T) {
 		}
 	})
 
-	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+	t.Run("returns 401 when user not found in entity service", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
+				return []byte(`{"users":[],"total":0}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(validPayload)))
+		w := httptest.NewRecorder()
+		h.CreateCase(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("returns 500 when user lookup fails", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
+				return nil, errors.New("entity service unavailable")
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(validPayload)))
+		w := httptest.NewRecorder()
+		h.CreateCase(w, r)
+		assertStatus(t, w, http.StatusInternalServerError)
+		assertErrorMessage(t, w, ErrMsgInternal)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("upstream errors on create are mapped correctly", func(t *testing.T) {
 		for _, tc := range upstreamErrors("Failed to create case.") {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				client := &mockEntityCaseClient{
+					searchUsersFn: userSearchOK,
 					createCaseFn: func(_ context.Context, _ []byte) ([]byte, error) {
 						return nil, tc.err
 					},

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -51,9 +51,11 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 // ----- CreateCase -----
 
 func TestCreateCase(t *testing.T) {
+	const validPayload = `{"projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","priority":"high","issueType":"error"}`
+
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(validPayload))
 		w := httptest.NewRecorder()
 		h.CreateCase(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -71,28 +73,70 @@ func TestCreateCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
-		const reqPayload = `{"title":"Fix login bug","priority":"high"}`
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.CreateCase(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("injects createdBy from auth user and returns 201 with response", func(t *testing.T) {
 		var capturedBody []byte
 		client := &mockEntityCaseClient{
 			createCaseFn: func(_ context.Context, body []byte) ([]byte, error) {
 				capturedBody = body
-				return []byte(`{"id":"case-1","title":"Fix login bug"}`), nil
+				return []byte(`{"id":"case-1","subject":"Login failure","state":"open"}`), nil
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(reqPayload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(validPayload)))
 		w := httptest.NewRecorder()
 		h.CreateCase(w, r)
 
 		assertStatus(t, w, http.StatusCreated)
 		assertContentType(t, w, "application/json")
-		if string(capturedBody) != reqPayload {
-			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+
+		var sent map[string]json.RawMessage
+		if err := json.Unmarshal(capturedBody, &sent); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
+		var createdBy string
+		if err := json.Unmarshal(sent["createdBy"], &createdBy); err != nil || createdBy != testUser.UserID {
+			t.Errorf("upstream createdBy = %q, want %q", createdBy, testUser.UserID)
+		}
+
 		resp := decodeJSON[map[string]any](t, w)
 		if resp["id"] != "case-1" {
 			t.Errorf("response id = %v, want case-1", resp["id"])
+		}
+	})
+
+	t.Run("auth user id overrides any caller-supplied createdBy", func(t *testing.T) {
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			createCaseFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"id":"case-2","state":"open"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		spoofed := `{"projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"S","description":"D","priority":"low","issueType":"question","createdBy":"attacker-uuid"}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(spoofed)))
+		w := httptest.NewRecorder()
+		h.CreateCase(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+
+		var sent map[string]json.RawMessage
+		if err := json.Unmarshal(capturedBody, &sent); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		var createdBy string
+		if err := json.Unmarshal(sent["createdBy"], &createdBy); err != nil || createdBy != testUser.UserID {
+			t.Errorf("upstream createdBy = %q, want %q (auth ID must win)", createdBy, testUser.UserID)
 		}
 	})
 
@@ -106,7 +150,7 @@ func TestCreateCase(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(validPayload)))
 				w := httptest.NewRecorder()
 				h.CreateCase(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -51,7 +51,7 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 // ----- CreateCase -----
 
 func TestCreateCase(t *testing.T) {
-	const validPayload = `{"projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","priority":"high","issueType":"error"}`
+	const validPayload = `{"createdBy":"user-123","projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","priority":"high","issueType":"error"}`
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
@@ -83,7 +83,7 @@ func TestCreateCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("injects createdBy from auth user and returns 201 with response", func(t *testing.T) {
+	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
 		var capturedBody []byte
 		client := &mockEntityCaseClient{
 			createCaseFn: func(_ context.Context, body []byte) ([]byte, error) {
@@ -98,45 +98,12 @@ func TestCreateCase(t *testing.T) {
 
 		assertStatus(t, w, http.StatusCreated)
 		assertContentType(t, w, "application/json")
-
-		var sent map[string]json.RawMessage
-		if err := json.Unmarshal(capturedBody, &sent); err != nil {
-			t.Fatalf("upstream received invalid JSON: %v", err)
+		if string(capturedBody) != validPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, validPayload)
 		}
-		var createdBy string
-		if err := json.Unmarshal(sent["createdBy"], &createdBy); err != nil || createdBy != testUser.UserID {
-			t.Errorf("upstream createdBy = %q, want %q", createdBy, testUser.UserID)
-		}
-
 		resp := decodeJSON[map[string]any](t, w)
 		if resp["id"] != "case-1" {
 			t.Errorf("response id = %v, want case-1", resp["id"])
-		}
-	})
-
-	t.Run("auth user id overrides any caller-supplied createdBy", func(t *testing.T) {
-		var capturedBody []byte
-		client := &mockEntityCaseClient{
-			createCaseFn: func(_ context.Context, body []byte) ([]byte, error) {
-				capturedBody = body
-				return []byte(`{"id":"case-2","state":"open"}`), nil
-			},
-		}
-		h := NewCaseHandler(client)
-		spoofed := `{"projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"S","description":"D","priority":"low","issueType":"question","createdBy":"attacker-uuid"}`
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(spoofed)))
-		w := httptest.NewRecorder()
-		h.CreateCase(w, r)
-
-		assertStatus(t, w, http.StatusCreated)
-
-		var sent map[string]json.RawMessage
-		if err := json.Unmarshal(capturedBody, &sent); err != nil {
-			t.Fatalf("upstream received invalid JSON: %v", err)
-		}
-		var createdBy string
-		if err := json.Unmarshal(sent["createdBy"], &createdBy); err != nil || createdBy != testUser.UserID {
-			t.Errorf("upstream createdBy = %q, want %q (auth ID must win)", createdBy, testUser.UserID)
 		}
 	})
 

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -88,6 +88,7 @@ type mockEntityCaseClient struct {
 	createCaseFn  func(ctx context.Context, body []byte) ([]byte, error)
 	searchCasesFn func(ctx context.Context, body []byte) ([]byte, error)
 	getCaseFn     func(ctx context.Context, caseID string) ([]byte, error)
+	searchUsersFn func(ctx context.Context, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
@@ -109,6 +110,13 @@ func (m *mockEntityCaseClient) GetCase(ctx context.Context, caseID string) ([]by
 		return m.getCaseFn(ctx, caseID)
 	}
 	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) SearchUsers(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchUsersFn != nil {
+		return m.searchUsersFn(ctx, body)
+	}
+	return []byte(`{"users":[{"id":"user-123"}],"total":1}`), nil
 }
 
 // ----- mock updates client -----

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -65,6 +65,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -159,6 +163,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -198,6 +206,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -237,6 +249,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -276,6 +292,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -334,6 +354,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -380,6 +404,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -426,6 +454,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -465,6 +497,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -511,6 +547,10 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -542,6 +582,10 @@ paths:
           description: Unauthorized
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
 

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -561,7 +561,6 @@ components:
     CaseCreatePayload:
       type: object
       required:
-        - createdBy
         - projectId
         - deploymentId
         - deployedProductId
@@ -570,11 +569,6 @@ components:
         - priority
         - issueType
       properties:
-        createdBy:
-          type: string
-          description: >
-            UUID of the user creating the case.
-            TODO: will be removed once DB-level auth is in place and injected server-side.
         projectId:
           type: string
           description: UUID of the project this case belongs to

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -35,6 +35,10 @@ paths:
       responses:
         "201":
           description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Case'
         "400":
           description: BadRequest
           content:
@@ -43,10 +47,30 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
         "500":
           description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
 
   /cases/{id}:
     get:
@@ -537,46 +561,37 @@ components:
     CaseCreatePayload:
       type: object
       required:
-        - type
         - projectId
         - deploymentId
+        - deployedProductId
+        - subject
+        - description
+        - priority
+        - issueType
       properties:
-        type:
-          type: string
-          description: Case type (e.g. DEFAULT_CASE, SERVICE_REQUEST, SECURITY_REPORT_ANALYSIS)
         projectId:
           type: string
-          description: Project ID
+          description: UUID of the project this case belongs to
         deploymentId:
           type: string
-          description: Deployment ID
+          description: UUID of the deployment this case relates to
         deployedProductId:
           type: string
-          description: Deployed product ID
-        title:
+          description: UUID of the deployed product this case relates to
+        subject:
           type: string
-          description: Case title (required for DEFAULT_CASE and SECURITY_REPORT_ANALYSIS)
+          description: Short summary of the issue
         description:
           type: string
-          description: Case description
-        issueTypeKey:
-          type: integer
-          description: Issue type key (required for DEFAULT_CASE)
-        severityKey:
-          type: integer
-          description: Severity key (required for DEFAULT_CASE)
-        relatedCaseId:
+          description: Full description of the issue
+        priority:
           type: string
-          description: Related case ID
-        conversationId:
+          enum: [catastrophic, critical, high, medium, low]
+          description: Urgency level of the case
+        issueType:
           type: string
-          description: Conversation ID
-        catalogId:
-          type: string
-          description: Catalog ID (required for SERVICE_REQUEST)
-        catalogItemId:
-          type: string
-          description: Catalog item ID (required for SERVICE_REQUEST)
+          enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
+          description: Nature of the issue
 
     ProjectCaseSearchPayload:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -561,6 +561,7 @@ components:
     CaseCreatePayload:
       type: object
       required:
+        - createdBy
         - projectId
         - deploymentId
         - deployedProductId
@@ -569,6 +570,11 @@ components:
         - priority
         - issueType
       properties:
+        createdBy:
+          type: string
+          description: >
+            UUID of the user creating the case.
+            TODO: will be removed once DB-level auth is in place and injected server-side.
         projectId:
           type: string
           description: UUID of the project this case belongs to


### PR DESCRIPTION
## Summary

Aligns the csm-portal `POST /cases` handler and OpenAPI spec with the entity-service `CreateCase` endpoint introduced in #780.

- **`createdBy` injection** — the authenticated user's ID is now injected server-side before forwarding to the entity service; any caller-supplied `createdBy` is overridden, preventing identity spoofing
- **JSON validation** — request body is validated as valid JSON before processing (consistent with `SearchProjectCases`)
- **`CaseCreatePayload` schema updated** — removes legacy fields (`type`, `title`, integer `issueTypeKey`/`severityKey`, `relatedCaseId`, `conversationId`, `catalogId`, `catalogItemId`); replaces with the entity-service contract: `subject`, `description`, `priority` and `issueType` as string enums, all six fields required
- **`POST /cases` 201 response** — now references the `Case` response schema; also adds explicit 403/404/500 error bodies to match `mapUpstreamError` behavior

## Test plan

- [x] `TestCreateCase/requires_authenticated_user` — 401 when no user in context
- [x] `TestCreateCase/rejects_body_exceeding_1_MiB` — 413 on oversized body
- [x] `TestCreateCase/rejects_invalid_JSON_body` — 400 on malformed JSON
- [x] `TestCreateCase/injects_createdBy_from_auth_user_and_returns_201_with_response` — upstream receives correct `createdBy` from JWT, response body is forwarded
- [x] `TestCreateCase/auth_user_id_overrides_any_caller-supplied_createdBy` — spoofed `createdBy` in body is replaced by auth user ID
- [x] `TestCreateCase/upstream_errors_are_mapped_correctly` — 401/403/404/400/500 mapping for all upstream error codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Security**
  * Case creation now rejects non-JSON or invalid payloads with 400 and enforces the authenticated user as the case creator (unknown user yields 403).

* **Documentation**
  * API spec updated: POST /cases now returns a JSON Case on 201; error responses standardized to JSON; case-creation payload simplified (breaking change).

* **Tests**
  * Improved coverage for case creation, user-resolution, and error mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->