### PR TITLE
[Customer Portal] Add Created By filter to dashboard Outstanding Support Cases

### DIFF
--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesFilters.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesFilters.tsx
@@ -104,7 +104,11 @@ export default function CasesFilters({
                     );
                   }}
                 >
-                  {hasNoOptions ? (
+                  {field.isLoading ? (
+                    <MenuItem disabled>
+                      <Typography variant="body2">Loading...</Typography>
+                    </MenuItem>
+                  ) : hasNoOptions ? (
                     <MenuItem disabled>
                       <Typography variant="body2">{EMPTY_DROPDOWN_PLACEHOLDER}</Typography>
                     </MenuItem>

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
@@ -28,6 +28,7 @@ import useGetProjectCases from "@api/useGetProjectCases";
 import { useGetProjectCasesPage } from "@api/useGetProjectCasesPage";
 import useGetProjectFilters from "@api/useGetProjectFilters";
 import { usePostProjectDeploymentsSearchInfinite } from "@api/usePostProjectDeploymentsSearch";
+import useGetProjectContacts from "@features/settings/api/useGetProjectContacts";
 import CasesTableHeader from "@features/dashboard/components/cases-table/CasesTableHeader";
 import CasesFilters from "@features/dashboard/components/cases-table/CasesFilters";
 import CasesList from "@features/dashboard/components/cases-table/CasesList";
@@ -107,6 +108,10 @@ const CasesTable = ({
     [deploymentsQuery.data],
   );
 
+  // contacts for created by filter
+  const { data: contactsData, isLoading: isContactsLoading } = useGetProjectContacts(projectId);
+  const contactsList = useMemo(() => contactsData ?? [], [contactsData]);
+
   // effective filters
   const effectiveFilters: CasesTableFilterValues = useMemo(
     () =>
@@ -123,34 +128,36 @@ const CasesTable = ({
         def.id !== "caseType" &&
         !(restrictSeverityToLow && def.metadataKey === "severities") &&
         (includeDeploymentFilter || def.id !== "deployment") &&
-        (def.id === "deployment" || !!def.metadataKey),
+        (def.id === "deployment" || def.id === "createdBy" || !!def.metadataKey),
     ).map((def) => {
       const { label } = deriveFilterLabels(def.id);
 
       const isDeploymentFilter = def.id === "deployment";
+      const isCreatedByFilter = def.id === "createdBy";
       let options: { label: string; value: string }[];
-      switch (isDeploymentFilter) {
-        case true:
-          options =
-            deploymentsList.map((deployment) => ({
-              label: deployment.type?.label || deployment.name,
-              value: deployment.id,
-            })) ?? [];
-          break;
-        default: {
-          const metadataOptions =
-            filtersMetadata?.[def.metadataKey as keyof typeof filtersMetadata];
-          const filtered = filterCasesTableMetadataOptions(
-            def.metadataKey!,
-            metadataOptions,
-            excludeS0,
-            restrictSeverityToLow,
-          );
-          options = filtered.map((item) => ({
-            label: mapCasesTableFilterOptionLabel(def.metadataKey!, item.label),
-            value: item.id,
-          }));
-        }
+      if (isDeploymentFilter) {
+        options = deploymentsList.map((deployment) => ({
+          label: deployment.type?.label || deployment.name,
+          value: deployment.id,
+        }));
+      } else if (isCreatedByFilter) {
+        options = contactsList.map((contact) => ({
+          label: `${contact.firstName} ${contact.lastName}`.trim() || contact.email,
+          value: contact.email,
+        }));
+      } else {
+        const metadataOptions =
+          filtersMetadata?.[def.metadataKey as keyof typeof filtersMetadata];
+        const filtered = filterCasesTableMetadataOptions(
+          def.metadataKey!,
+          metadataOptions,
+          excludeS0,
+          restrictSeverityToLow,
+        );
+        options = filtered.map((item) => ({
+          label: mapCasesTableFilterOptionLabel(def.metadataKey!, item.label),
+          value: item.id,
+        }));
       }
 
       return {
@@ -159,6 +166,7 @@ const CasesTable = ({
         type: "select" as const,
         options,
         ...(def.multiSelect ? { multiSelect: true } : null),
+        ...(isCreatedByFilter ? { isLoading: isContactsLoading } : null),
         ...(isDeploymentFilter
           ? {
               onLoadMore: () => {
@@ -178,6 +186,8 @@ const CasesTable = ({
   }, [
     filtersMetadata,
     deploymentsList,
+    contactsList,
+    isContactsLoading,
     excludeS0,
     restrictSeverityToLow,
     includeDeploymentFilter,
@@ -208,6 +218,10 @@ const CasesTable = ({
           : undefined,
         createdByMe:
           viewMode === DashboardCasesViewMode.MyCases ? true : undefined,
+        createdBy:
+          (effectiveFilters.createdBy as string[] | undefined)?.length
+            ? (effectiveFilters.createdBy as string[])
+            : undefined,
       },
       sortBy: {
         field: "updatedOn",

--- a/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
@@ -33,6 +33,7 @@ export type TableFilter = {
   options?: string[] | SelectOption[];
   placeholder?: string;
   multiSelect?: boolean;
+  isLoading?: boolean;
   onLoadMore?: () => void;
   hasMore?: boolean;
   isFetchingMore?: boolean;
@@ -97,6 +98,7 @@ export type CasesTableFilterValues = {
   severityId?: string | number;
   issueTypes?: string | string[] | number;
   deploymentId?: string | number;
+  createdBy?: string[];
 };
 
 // Route params used by cases table header when `projectId` is read from the URL.

--- a/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
@@ -97,7 +97,6 @@ export type CasesTableFilterValues = {
   statusIds?: string[];
   severityIds?: string[];
   issueTypes?: string | string[] | number;
-  deploymentId?: string | number;
   createdBy?: string[];
   deploymentIds?: string[];
 };


### PR DESCRIPTION
Summary

  - Added a Created By multi-select filter to the dashboard's Outstanding Support Cases table, consistent with the existing filter in the All Cases view
  - Fetches project contacts via useGetProjectContacts and populates the dropdown with contact names/emails
  - Passes the selected createdBy values to the case search API to filter results accordingly
  - Shows a loading state in the dropdown while contacts are being fetched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-select filter behavior by showing a disabled "Loading..." item while options load.

* **New Features**
  * Added a "Created By" filter to the cases table, populated from project contacts and surfaces its loading state while options are fetched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->