### PR TITLE
[Customer Portal][Webapp] Enable multi-select for severity and deployment filters on dashboard cases table

### DIFF
--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesTable.tsx
@@ -197,15 +197,17 @@ const CasesTable = ({
           defaultStatusIds,
         ),
         caseTypes: [CaseType.DEFAULT_CASE],
-        severityId: effectiveFilters.severityId
-          ? Number(effectiveFilters.severityId)
-          : undefined,
+        severityIds:
+          (effectiveFilters.severityIds as string[] | undefined)?.length
+            ? (effectiveFilters.severityIds as string[]).map(Number)
+            : undefined,
         issueIds: normalizeCaseSearchIssueIds(
           effectiveFilters.issueTypes as string | string[] | undefined,
         ),
-        deploymentId: effectiveFilters.deploymentId
-          ? String(effectiveFilters.deploymentId)
-          : undefined,
+        deploymentIds:
+          (effectiveFilters.deploymentIds as string[] | undefined)?.length
+            ? (effectiveFilters.deploymentIds as string[])
+            : undefined,
         createdByMe:
           viewMode === DashboardCasesViewMode.MyCases ? true : undefined,
       },

--- a/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
+++ b/apps/customer-portal/webapp/src/features/dashboard/types/casesTable.ts
@@ -94,9 +94,9 @@ export type CasesTableProps = {
 export type CasesTableFilterValues = {
   [key: string]: string | string[] | number | undefined;
   statusIds?: string[];
-  severityId?: string | number;
+  severityIds?: string[];
   issueTypes?: string | string[] | number;
-  deploymentId?: string | number;
+  deploymentIds?: string[];
 };
 
 // Route params used by cases table header when `projectId` is read from the URL.


### PR DESCRIPTION
## Purpose
- Enable multi-select for severity and deployment filters on dashboard cases table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cases table filtering to support selecting multiple severities and deployments simultaneously, allowing users to create more comprehensive filters when viewing and managing cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->