### PR TITLE
[Customer Portal][Webapp] fix: correct registry tokens description

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
@@ -270,7 +270,7 @@ export const REGISTRY_ADMIN_ALERT_BODY =
 export const REGISTRY_PAGE_TITLE = "Registry Tokens";
 
 export const REGISTRY_PAGE_DESCRIPTION =
-  "Manage registry tokens for WSO2 Updates 2.0. User tokens are for individual access, while service tokens are for automation and CI/CD pipelines.";
+  "Manage tokens for the WSO2 container registry. User tokens are for individual access to pull Docker images, while service tokens are for automation and CI/CD pipelines.";
 
 export const REGISTRY_SUBTAB_USER_BASE = "User Tokens";
 


### PR DESCRIPTION
## Summary
- The Registry Tokens settings page describes the tokens as being for "WSO2 Updates 2.0", but these tokens authenticate against the WSO2 container registry to pull product Docker images.
- Updates the description string in `settingsConstants.ts` accordingly.

Reference: https://updates.docs.wso2.com/en/latest/updates/registry-token-management/

## Test plan
- [ ] Open the customer portal → Settings → Registry Tokens and confirm the new description renders correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description text in the registry token management settings to provide clearer guidance when managing WSO2 container registry tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->