### PR TITLE
[Customer Portal][Webapp] fix: sign out when SDK token refresh fails

### DIFF
--- a/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -18,7 +18,7 @@ import { useAsgardeo } from "@asgardeo/react";
 
 // A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
-  const { getIdToken, signOut } = useAsgardeo();
+  const { getIdToken, signInSilently, signOut } = useAsgardeo();
 
   /**
    * Builds request headers with auth and payload defaults.
@@ -63,18 +63,30 @@ export function useAuthApiClient() {
     input: RequestInfo | URL,
     options?: RequestInit,
   ): Promise<Response> => {
+    // SDK throws SPA-AUTH_CLIENT-VM-IV02 from getIdToken once the access token's
+    // lifetime is up — it checks isSignedIn() and rejects without ever attempting
+    // a refresh. periodicTokenRefresh is a timer scheduled around the original
+    // expiry, so on a long-idle tab (or background-throttled timer) we land here
+    // with an expired access token but a still-valid IdP session.
+    // Fix: on that specific code, attempt silent re-auth, then retry. Only if
+    // the silent re-auth also fails do we sign out — letting ProtectedRoute
+    // bounce the user through the IdP rather than surfacing a 500 page.
     let token: string | undefined | null;
     try {
       token = await getIdToken();
     } catch (err) {
-      // SDK throws SPA-AUTH_CLIENT-VM-IV02 when token refresh fails (e.g. the
-      // refresh token has expired after a long-idle tab). Sign out so the
-      // existing ProtectedRoute bounces the user through the IdP to re-acquire
-      // a token, rather than letting the error surface as a 500 in every view.
-      if ((err as { code?: string } | null)?.code === "SPA-AUTH_CLIENT-VM-IV02") {
-        void signOut();
+      const isAuthDead =
+        (err as { code?: string } | null)?.code === "SPA-AUTH_CLIENT-VM-IV02";
+      if (!isAuthDead) {
+        throw err;
       }
-      throw err;
+      try {
+        await signInSilently();
+        token = await getIdToken();
+      } catch {
+        void signOut();
+        throw err;
+      }
     }
     if (!token) {
       throw new Error("Unable to retrieve ID token");

--- a/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -18,7 +18,7 @@ import { useAsgardeo } from "@asgardeo/react";
 
 // A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
-  const { getIdToken } = useAsgardeo();
+  const { getIdToken, signOut } = useAsgardeo();
 
   /**
    * Builds request headers with auth and payload defaults.
@@ -63,7 +63,19 @@ export function useAuthApiClient() {
     input: RequestInfo | URL,
     options?: RequestInit,
   ): Promise<Response> => {
-    const token = await getIdToken();
+    let token: string | undefined | null;
+    try {
+      token = await getIdToken();
+    } catch (err) {
+      // SDK throws SPA-AUTH_CLIENT-VM-IV02 when token refresh fails (e.g. the
+      // refresh token has expired after a long-idle tab). Sign out so the
+      // existing ProtectedRoute bounces the user through the IdP to re-acquire
+      // a token, rather than letting the error surface as a 500 in every view.
+      if ((err as { code?: string } | null)?.code === "SPA-AUTH_CLIENT-VM-IV02") {
+        void signOut();
+      }
+      throw err;
+    }
     if (!token) {
       throw new Error("Unable to retrieve ID token");
     }


### PR DESCRIPTION
## Summary

When a customer-portal tab sits past the access token's TTL and the user then clicks anything that fetches, the Asgardeo SDK throws `SPA-AUTH_CLIENT-VM-IV02` ("The user is not authenticated.") from `getIdToken()`. That error propagates through every React Query hook and `ApiErrorState`'s default branch renders the **Error500 page** — the user is stuck with no path to re-authenticate.

This PR adds an inline recovery in `useAuthApiClient`:

1. On `SPA-AUTH_CLIENT-VM-IV02`, call `signInSilently()` (the SDK's silent OIDC re-auth via `prompt=none`).
2. If that succeeds, retry `getIdToken()` and continue the request — **no UX disruption**.
3. Only if silent re-auth also fails do we `signOut()`, letting the existing `ProtectedRoute` bounce the user through the IdP. Matches the recovery pattern already used by `IdleTimeoutProvider` and the user-profile sign-out.

## Why the SDK falls into this state

The SDK's `isSignedIn()` returns `false` the moment the access token's lifetime is up, **without consulting the refresh token** (`@asgardeo/javascript:1893-1905`). `_validateMethod` then rejects `getIdToken()` with `SPA-AUTH_CLIENT-VM-IV02` and never attempts a refresh on demand.

The `periodicTokenRefresh` flag is a **timer** scheduled around the original expiry — on a long-idle tab where browser throttling has frozen the timer, or where the original lifetime has simply elapsed without the timer running, we land in this state. This PR is the application-side workaround.

## Scope

Intentionally minimal — single file, one hunk. No new providers, no global error handlers, no changes to `ApiErrorState`, `QueryClient`, or `AppWithConfig`. Only the exact failure path described above is handled.

## How to reproduce

Pick any of the three; they all converge on the same code path (access token expired, click triggers a fetch, `getIdToken()` throws).

### Option 1 — Natural flow (slow)

1. Sign in to the customer portal.
2. Leave the tab open and idle for at least the access token's default lifetime (~1 hour for the WSO2 Asgardeo tenant).
3. Come back and click any nav item that fetches data (e.g. open a project, change a filter).

### Option 2 — Shorten the access token TTL in Asgardeo (medium)

1. In the Asgardeo console, edit the customer-portal SPA application and reduce the access token user-access-token expiry to e.g. 60 seconds.
2. Sign in to the customer portal.
3. Wait ~60s without interacting, then click any nav item.

### Option 3 — Force expiry in 10s from the browser console (fast)

1. Sign in to the customer portal.
2. In DevTools Console, paste:
   ```js
   const k = Object.keys(sessionStorage).find(k => k.startsWith('session_data-'));
   const s = JSON.parse(sessionStorage.getItem(k));
   s.created_at = Date.now();   // anchor lifetime to "now"
   s.expires_in = '10';         // 10 seconds of validity
   sessionStorage.setItem(k, JSON.stringify(s));
   ```
3. Wait ~11 seconds (the SDK's `periodicTokenRefresh` timer was scheduled around the **original** expiry, so it won't fire in this window — exactly the gap the bug lives in).
4. Click any nav item that fetches data.

### What you should see

**Before this PR:** every hook logs `SPA-AUTH_CLIENT-VM-IV02` and the page renders the Error500 illustration. The user is stuck.

**After this PR (best case — IdP session still alive):** `signInSilently()` succeeds in an iframe, fresh tokens land in storage, the original request completes. User sees no disruption.

**After this PR (worst case — IdP session also dead, e.g. user signed out elsewhere):** `signInSilently()` fails, `signOut()` fires, the IdP logout + auth-code flow runs, user lands back signed in.

## Test plan

- [ ] Run one of the repro options above on a local build of `main` to confirm the Error500 baseline.
- [ ] Switch to this branch (Vite hot-reloads). Repeat Option 3. Expected: no Error500; on the click after 11s, the request either completes silently or you see a brief IdP bounce.
- [ ] Also reproduce with the refresh token additionally corrupted (`s.refresh_token = 'BROKEN-' + s.refresh_token;`) on top of the expiry — verify the silent-then-signOut fallback path works end-to-end.
- [ ] Verify a normal sign-out (header menu) and idle-timeout sign-out still work unchanged.
- [ ] Sanity-check that an authenticated 401 from the BFF is still surfaced through `ApiErrorState` as `Error401Page` — this PR does not change that path.

## Out of scope

- 401 from the BFF being treated as session-lost — leave to a follow-up if it shows up in practice.
- Preserving the exact URL across the fallback bounce — `signOut()` lands the user on `afterSignOutUrl`.