### PR TITLE
[Customer Portal] Fix chat card navigation, cache KB recommendations, and cap chat history payload

### DIFF
--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTable.test.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/__tests__/CasesTable.test.tsx
@@ -31,6 +31,40 @@ vi.mock("react-router", () => ({
 
 vi.mock("@api/useGetProjectCasesPage");
 vi.mock("@api/useGetProjectFilters");
+vi.mock("@api/useGetProjectCases", () => ({
+  default: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+vi.mock("@api/usePostProjectDeploymentsSearch", () => ({
+  usePostProjectDeploymentsSearchInfinite: () => ({
+    data: undefined,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+vi.mock("@features/settings/api/useGetProjectContacts", () => ({
+  default: () => ({ data: [], isLoading: false }),
+}));
+vi.mock("@api/usePostProjectDeploymentsSearch", () => ({
+  usePostProjectDeploymentsSearchInfinite: () => ({
+    data: undefined,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+vi.mock("@features/settings/api/useGetProjectContacts", () => ({
+  default: () => ({ data: [], isLoading: false }),
+}));
 
 vi.mock("@asgardeo/react", () => ({
   useAsgardeo: () => ({

--- a/apps/customer-portal/webapp/src/features/support/api/useConversationRecommendationsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useConversationRecommendationsSearch.ts
@@ -34,21 +34,16 @@ import type {
 export function useConversationRecommendationsSearch(
   payload: RecommendationSearchRequest | null,
   enabled: boolean,
+  conversationId?: string,
 ): UseQueryResult<RecommendationSearchResponse, Error> {
   const logger = useLogger();
   const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
   const authFetch = useAuthApiClient();
 
-  const msgCount = payload?.chatHistory.length ?? 0;
-  const firstTs = payload?.chatHistory[0]?.timestamp ?? "";
-  const lastTs = payload?.chatHistory[msgCount - 1]?.timestamp ?? "";
-
   return useQuery<RecommendationSearchResponse, Error>({
     queryKey: [
       ApiQueryKeys.CONVERSATION_RECOMMENDATIONS_SEARCH,
-      msgCount,
-      firstTs,
-      lastTs,
+      conversationId ?? payload?.chatHistory[0]?.timestamp ?? "",
     ],
     queryFn: async (): Promise<RecommendationSearchResponse> => {
       if (!payload) {
@@ -86,6 +81,6 @@ export function useConversationRecommendationsSearch(
       payload.chatHistory.length > 0 &&
       isSignedIn &&
       !isAuthLoading,
-    staleTime: 10 * 60 * 1000,
+    staleTime: 45 * 60 * 1000,
   });
 }

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryCard.tsx
@@ -55,7 +55,7 @@ export default function ChatHistoryCard({
 
   return (
     <Form.CardButton
-      onClick={() => onItemAction?.(item.chatId, ChatAction.VIEW)}
+      onClick={() => onItemAction?.(item.chatId, action)}
       sx={{
         p: 2,
         width: "100%",

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/caseCreation.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/caseCreation.test.ts
@@ -26,7 +26,9 @@ import {
   getBaseProductOptions,
   isUnknownPlaceholderProductLabel,
   getBaseDeploymentOptions,
+  formatChatHistoryForClassification,
 } from "@features/support/utils/caseCreation";
+import { ChatSender } from "@features/support/types/conversations";
 import type { DeploymentProductItem } from "@features/project-details/types/deployments";
 
 describe("caseCreation utils", () => {
@@ -411,6 +413,31 @@ describe("caseCreation utils", () => {
       expect(getBaseProductOptions(products)).toEqual([
         { id: "2", label: "WSO2 API Manager 4.2.0" },
       ]);
+    });
+  });
+
+  describe("formatChatHistoryForClassification", () => {
+    it("truncates message text to last 150 chars", () => {
+      const longText = "a".repeat(200);
+      const result = formatChatHistoryForClassification([
+        { text: longText, sender: ChatSender.USER },
+      ]);
+      expect(result).toBe(`User: ${"a".repeat(150)}`);
+    });
+
+    it("does not truncate messages under 150 chars", () => {
+      const result = formatChatHistoryForClassification([
+        { text: "short message", sender: ChatSender.USER },
+      ]);
+      expect(result).toBe("User: short message");
+    });
+
+    it("keeps the last 150 chars of a long message", () => {
+      const text = "start" + "b".repeat(200);
+      const result = formatChatHistoryForClassification([
+        { text, sender: ChatSender.BOT },
+      ]);
+      expect(result).toBe(`Assistant: ${"b".repeat(150)}`);
     });
   });
 

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/recommendations.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/recommendations.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildRecommendationRequestFromCase,
+  buildRecommendationRequestFromConversationMessages,
   recommendationScoreToPercent,
 } from "@features/support/utils/recommendations";
 import type { CaseDetails } from "@features/support/types/cases";
@@ -30,6 +31,36 @@ describe("recommendationScoreToPercent", () => {
 
   it("should treat values above 1 as already being percent-like", () => {
     expect(recommendationScoreToPercent(94)).toBe(94);
+  });
+});
+
+describe("buildRecommendationRequestFromConversationMessages", () => {
+  it("returns null for empty messages", () => {
+    expect(buildRecommendationRequestFromConversationMessages([])).toBeNull();
+  });
+
+  const makeMsg = (content: string) => ({
+    id: "1",
+    content,
+    type: "user",
+    createdOn: "2026-01-01T00:00:00Z",
+    isEscalated: false,
+    hasInlineAttachments: false,
+    inlineAttachments: [],
+  });
+
+  it("truncates message content to last 150 chars", () => {
+    const req = buildRecommendationRequestFromConversationMessages([
+      makeMsg("x".repeat(200)),
+    ]);
+    expect(req?.chatHistory[0].content).toBe("x".repeat(150));
+  });
+
+  it("does not truncate messages under 150 chars", () => {
+    const req = buildRecommendationRequestFromConversationMessages([
+      makeMsg("short message"),
+    ]);
+    expect(req?.chatHistory[0].content).toBe("short message");
   });
 });
 

--- a/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
@@ -376,7 +376,7 @@ export function formatChatHistoryForClassification(
 ): string {
   return messages
     .map((m) => {
-      const text = (m.text || "").trim();
+      const text = (m.text || "").trim().slice(-150);
       if (!text) return "";
       const role = m.sender === ChatSender.USER ? "User" : "Assistant";
       return `${role}: ${text}`;

--- a/apps/customer-portal/webapp/src/features/support/utils/recommendations.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/recommendations.ts
@@ -166,7 +166,7 @@ export function buildRecommendationRequestFromConversationMessages(
 
   const chatHistory: RecommendationApiMessage[] = [];
   for (const m of sorted) {
-    const content = m.content?.trim() ?? "";
+    const content = (m.content?.trim() ?? "").slice(-150);
     if (!content) continue;
     const isBot =
       m.type?.toLowerCase() === "bot" ||


### PR DESCRIPTION
Description:

  ## Summary

  - Fix chat card click on active/open/abandoned chats to navigate to the live chat page (same as the Resume button), enabling the "Create Case" button
  - Cache KB article recommendation API calls once per conversation instead of re-firing on every new message; increase staleTime to 45 minutes
  - Cap each message's text to the last 150 characters when building the chat history payload for both the classification and recommendation endpoints

  ## Changes

  - **`ChatHistoryCard.tsx`** — card-level click now uses `getChatStatusAction(item.status)` instead of hardcoded `ChatAction.VIEW`
  - **`useConversationRecommendationsSearch.ts`** — query key uses `conversationId`, staleTime bumped from 10min → 45min
  - **`caseCreation.ts`** — `formatChatHistoryForClassification` truncates each message to last 150 chars
  - **`recommendations.ts`** — `buildRecommendationRequestFromConversationMessages` truncates each message to last 150 chars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat history card button action to respond correctly based on conversation status.

* **Improvements**
  * Optimized message text handling with character truncation for improved performance.
  * Increased cache duration for conversation recommendations from 10 to 45 minutes.

* **Tests**
  * Added test coverage for message formatting and recommendation request building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->