### PR TITLE
[Customer Entity] Implement Case Comment Creation Endpoint

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -28,6 +28,8 @@ const (
 	UserTypeInternal UserType = "internal"
 	// UserTypeCustomer identifies end-customer users.
 	UserTypeCustomer UserType = "customer"
+	// UserTypeSystem identifies automated system actors.
+	UserTypeSystem UserType = "system"
 )
 
 // User represents a single user entity as stored in the database.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -428,3 +428,31 @@ type CreateCaseRequest struct {
 	Priority           CasePriority  `json:"priority"`
 	IssueType          CaseIssueType `json:"issueType"`
 }
+
+// CommentType classifies the type of a case comment.
+type CommentType string
+
+const (
+	CommentTypeWorkNote CommentType = "work_note"
+	CommentTypeComment  CommentType = "comment"
+	CommentTypeActivity CommentType = "activity"
+)
+
+// CaseComment represents a comment on a support case.
+type CaseComment struct {
+	ID          string      `json:"id"`
+	CaseID      string      `json:"caseId"`
+	CommentType CommentType `json:"commentType"`
+	Body        string      `json:"body"`
+	CreatedBy   string      `json:"createdBy"`
+	CreatedAt   time.Time   `json:"createdAt"`
+}
+
+// CreateCaseCommentRequest is the input for creating a new case comment.
+// CaseID is populated from the URL path parameter and is not part of the JSON body.
+type CreateCaseCommentRequest struct {
+	CaseID      string      `json:"-"`
+	CommentType CommentType `json:"commentType"`
+	Body        string      `json:"body"`
+	CreatedBy   string      `json:"createdBy"`
+}

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -51,6 +51,23 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(c)
 }
 
+// CreateCaseComment handles POST /cases/{id}/comments.
+func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) {
+	var req domain.CreateCaseCommentRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.CaseID = r.PathValue("id")
+	comment, err := h.svc.CreateCaseComment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(comment)
+}
+
 // SearchCases handles POST /cases/search.
 func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchCasesRequest

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -38,6 +38,8 @@ type CaseRepository interface {
 	// total count of matching rows before pagination.
 	// COUNT and SELECT are executed concurrently on separate pool connections.
 	SearchCases(ctx context.Context, req domain.SearchCasesRequest) ([]domain.Case, int, error)
+	// CreateCaseComment inserts a new comment row for the given case.
+	CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error)
 }
 
 type caseRepo struct {
@@ -84,6 +86,31 @@ func (r *caseRepo) CreateCase(ctx context.Context, req domain.CreateCaseRequest)
 			}
 		}
 		return domain.Case{}, fmt.Errorf("create case: %w", err)
+	}
+	return c, nil
+}
+
+// CreateCaseComment implements CaseRepository.
+func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+	const query = `
+		INSERT INTO case_comments (case_id, comment_type, body, created_by)
+		VALUES ($1, $2::comment_type_enum, $3, $4)
+		RETURNING id, case_id, comment_type, body, created_by, created_at`
+
+	var c domain.CaseComment
+	err := r.db.QueryRow(ctx, query,
+		req.CaseID, string(req.CommentType), req.Body, req.CreatedBy,
+	).Scan(&c.ID, &c.CaseID, &c.CommentType, &c.Body, &c.CreatedBy, &c.CreatedAt)
+	if err != nil {
+		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23503": // foreign_key_violation — case_id or created_by does not exist
+				return domain.CaseComment{}, &apierror.ValidationError{Msg: "one or more referenced IDs do not exist: " + pgErr.Detail}
+			case "P0001": // raise_exception from user-type triggers
+				return domain.CaseComment{}, &apierror.ValidationError{Msg: pgErr.Message}
+			}
+		}
+		return domain.CaseComment{}, fmt.Errorf("create case comment: %w", err)
 	}
 	return c, nil
 }

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -75,6 +75,7 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
+	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 
 	return middleware.Recovery(
 		middleware.Logger(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -101,6 +101,29 @@ func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseReque
 	return s.repo.CreateCase(ctx, req)
 }
 
+var validCommentType = map[domain.CommentType]bool{
+	domain.CommentTypeWorkNote: true,
+	domain.CommentTypeComment:  true,
+	domain.CommentTypeActivity: true,
+}
+
+// CreateCaseComment implements CaseService.
+func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+	if err := validateUUIDs("caseId", []string{req.CaseID}); err != nil {
+		return domain.CaseComment{}, err
+	}
+	if err := validateUUIDs("createdBy", []string{req.CreatedBy}); err != nil {
+		return domain.CaseComment{}, err
+	}
+	if !validCommentType[req.CommentType] {
+		return domain.CaseComment{}, &apierror.ValidationError{Msg: "commentType contains invalid value: " + string(req.CommentType)}
+	}
+	if req.Body == "" {
+		return domain.CaseComment{}, &apierror.ValidationError{Msg: "body is required"}
+	}
+	return s.repo.CreateCaseComment(ctx, req)
+}
+
 // SearchCases implements CaseService.
 func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error) {
 	if err := normalizePagination(&req.Pagination); err != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -92,4 +92,7 @@ type CaseService interface {
 	// A ValidationError is returned for invalid input; any other error indicates an
 	// infrastructure failure.
 	SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error)
+	// CreateCaseComment creates a new comment on the case identified by req.CaseID.
+	// A ValidationError is returned for invalid input or constraint violations.
+	CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error)
 }

--- a/entity-service/migrations/000001_create_users.up.sql
+++ b/entity-service/migrations/000001_create_users.up.sql
@@ -1,4 +1,4 @@
-CREATE TYPE user_type AS ENUM ('internal', 'customer', 'system');
+CREATE TYPE user_type_enum AS ENUM ('internal', 'customer', 'system');
 
 CREATE TABLE IF NOT EXISTS users (
     id          TEXT        PRIMARY KEY,
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS users (
     email       TEXT        NOT NULL UNIQUE,
     phone       TEXT,
     timezone    TEXT,
-    user_type   user_type   NOT NULL,
+    user_type   user_type_enum   NOT NULL,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/entity-service/migrations/000001_create_users.up.sql
+++ b/entity-service/migrations/000001_create_users.up.sql
@@ -1,4 +1,4 @@
-CREATE TYPE user_type AS ENUM ('internal', 'customer');
+CREATE TYPE user_type AS ENUM ('internal', 'customer', 'system');
 
 CREATE TABLE IF NOT EXISTS users (
     id          TEXT        PRIMARY KEY,

--- a/entity-service/migrations/000009_create_case_comments.down.sql
+++ b/entity-service/migrations/000009_create_case_comments.down.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS case_comments;
 DROP FUNCTION IF EXISTS check_activity_creator();
 DROP FUNCTION IF EXISTS check_work_note_creator();
-DROP FUNCTION IF EXISTS assert_user_type(UUID, user_type_enum[], TEXT);
+DROP FUNCTION IF EXISTS assert_user_type(TEXT, user_type_enum[], TEXT);
 DROP TYPE IF EXISTS comment_type_enum;

--- a/entity-service/migrations/000009_create_case_comments.down.sql
+++ b/entity-service/migrations/000009_create_case_comments.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS case_comments;
+DROP FUNCTION IF EXISTS check_activity_creator();
+DROP FUNCTION IF EXISTS check_work_note_creator();
+DROP FUNCTION IF EXISTS assert_user_type(UUID, user_type_enum[], TEXT);
+DROP TYPE IF EXISTS comment_type_enum;

--- a/entity-service/migrations/000009_create_case_comments.up.sql
+++ b/entity-service/migrations/000009_create_case_comments.up.sql
@@ -15,24 +15,24 @@ CREATE TABLE case_comments (
 
 -- This function checks if a user has one of the allowed user types. It can be used in triggers or other functions to enforce access control based on user type.
 
-CREATE OR REPLACE FUNCTION assert_user_type(
+CREATE OR REPLACE FUNCTION assert_user_type_enum(
   p_user_id   TEXT,
   p_allowed   user_type_enum[],
   p_context   TEXT
 )
 RETURNS VOID AS $$
 DECLARE
-  v_user_type user_type_enum;
+  v_user_type_enum user_type_enum;
 BEGIN
-  SELECT user_type INTO v_user_type
+  SELECT user_type_enum INTO v_user_type_enum
   FROM users WHERE id = p_user_id;
 
-  IF v_user_type != ALL(p_allowed) THEN
+  IF v_user_type_enum != ALL(p_allowed) THEN
     RAISE EXCEPTION '% requires user type to be one of (%). user_id % has type %.',
       p_context,
       array_to_string(p_allowed::text[], ', '),
       p_user_id,
-      v_user_type;
+      v_user_type_enum;
   END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -43,7 +43,7 @@ CREATE OR REPLACE FUNCTION check_work_note_creator()
 RETURNS TRIGGER AS $$
 BEGIN
   IF NEW.comment_type = 'work_note' THEN
-    PERFORM assert_user_type(
+    PERFORM assert_user_type_enum(
       NEW.created_by,
       ARRAY['internal']::user_type_enum[],
       'work_note comment'
@@ -57,7 +57,7 @@ CREATE OR REPLACE FUNCTION check_activity_creator()
 RETURNS TRIGGER AS $$
 BEGIN
   IF NEW.comment_type = 'activity' THEN
-    PERFORM assert_user_type(
+    PERFORM assert_user_type_enum(
       NEW.created_by,
       ARRAY['internal', 'system']::user_type_enum[],
       'activity comment'

--- a/entity-service/migrations/000009_create_case_comments.up.sql
+++ b/entity-service/migrations/000009_create_case_comments.up.sql
@@ -1,0 +1,86 @@
+CREATE TYPE comment_type_enum AS ENUM (
+  'work_note',
+  'comment',
+  'activity'
+);
+
+CREATE TABLE case_comments (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id      UUID NOT NULL REFERENCES cases(id),
+  comment_type comment_type_enum NOT NULL,
+  body         TEXT NOT NULL,
+  created_by   UUID NOT NULL REFERENCES users(id),
+  created_at   TIMESTAMP DEFAULT NOW()
+);
+
+-- This function checks if a user has one of the allowed user types. It can be used in triggers or other functions to enforce access control based on user type.
+
+CREATE OR REPLACE FUNCTION assert_user_type(
+  p_user_id   UUID,
+  p_allowed   user_type_enum[],
+  p_context   TEXT
+)
+RETURNS VOID AS $$
+DECLARE
+  v_user_type user_type_enum;
+BEGIN
+  SELECT user_type INTO v_user_type
+  FROM users WHERE id = p_user_id;
+
+  IF v_user_type != ALL(p_allowed) THEN
+    RAISE EXCEPTION '% requires user type to be one of (%). user_id % has type %.',
+      p_context,
+      array_to_string(p_allowed::text[], ', '),
+      p_user_id,
+      v_user_type;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Triggers to enforce that only internal users can create work notes, and only internal or system users can create activity comments.
+
+CREATE OR REPLACE FUNCTION check_work_note_creator()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.comment_type = 'work_note' THEN
+    PERFORM assert_user_type(
+      NEW.created_by,
+      ARRAY['internal']::user_type_enum[],
+      'work_note comment'
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION check_activity_creator()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.comment_type = 'activity' THEN
+    PERFORM assert_user_type(
+      NEW.created_by,
+      ARRAY['internal', 'system']::user_type_enum[],
+      'activity comment'
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create triggers to enforce the creator restrictions on case_comments.
+
+CREATE TRIGGER trg_check_work_note_creator
+  BEFORE INSERT OR UPDATE ON case_comments
+  FOR EACH ROW EXECUTE FUNCTION check_work_note_creator();
+
+CREATE TRIGGER trg_check_activity_creator
+  BEFORE INSERT OR UPDATE ON case_comments
+  FOR EACH ROW EXECUTE FUNCTION check_activity_creator();
+
+-- Indexes to optimize queries on case_comments by case_id, created_by, comment_type, and combinations of these fields.
+
+CREATE INDEX idx_case_comments_case_id    ON case_comments(case_id);
+CREATE INDEX idx_case_comments_created_by ON case_comments(created_by);
+CREATE INDEX idx_case_comments_type       ON case_comments(comment_type);
+CREATE INDEX idx_case_comments_case_time  ON case_comments(case_id, created_at DESC);
+CREATE INDEX idx_case_comments_case_type  ON case_comments(case_id, comment_type);

--- a/entity-service/migrations/000009_create_case_comments.up.sql
+++ b/entity-service/migrations/000009_create_case_comments.up.sql
@@ -9,14 +9,14 @@ CREATE TABLE case_comments (
   case_id      UUID NOT NULL REFERENCES cases(id),
   comment_type comment_type_enum NOT NULL,
   body         TEXT NOT NULL,
-  created_by   UUID NOT NULL REFERENCES users(id),
+  created_by   TEXT NOT NULL REFERENCES users(id),
   created_at   TIMESTAMP DEFAULT NOW()
 );
 
 -- This function checks if a user has one of the allowed user types. It can be used in triggers or other functions to enforce access control based on user type.
 
 CREATE OR REPLACE FUNCTION assert_user_type(
-  p_user_id   UUID,
+  p_user_id   TEXT,
   p_allowed   user_type_enum[],
   p_context   TEXT
 )

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -266,6 +266,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/{id}/comments:
+    post:
+      summary: Create a comment on a support case.
+      operationId: createCaseComment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCaseCommentRequest'
+      responses:
+        "201":
+          description: Comment created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseComment'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /deployed-products/search:
     post:
       summary: Search deployed products by deployment IDs.
@@ -338,7 +375,7 @@ components:
           nullable: true
         userType:
           type: string
-          enum: [internal, customer]
+          enum: [internal, customer, system]
         createdAt:
           type: string
           format: date-time
@@ -836,6 +873,38 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    CreateCaseCommentRequest:
+      type: object
+      required: [commentType, body, createdBy]
+      properties:
+        commentType:
+          type: string
+          enum: [work_note, comment, activity]
+          description: work_note is restricted to internal users; activity to internal and system users.
+        body:
+          type: string
+        createdBy:
+          type: string
+          description: UUID of the user creating the comment.
+
+    CaseComment:
+      type: object
+      properties:
+        id:
+          type: string
+        caseId:
+          type: string
+        commentType:
+          type: string
+          enum: [work_note, comment, activity]
+        body:
+          type: string
+        createdBy:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
## Summary
- Adds `comment_type_enum` (`work_note`, `comment`, `activity`) and `case_comments` table with DB-enforced triggers: only internal users may create work notes, only internal/system users may create activity comments
- Introduces `CaseComment` and `CreateCaseCommentRequest` domain types, wired through repository → service → handler following existing case patterns
- Extends `user_type_enum` with `system` to support activity comment authorship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added case commenting capability—users can now create and attach comments to cases. Three comment types are supported: work notes, general comments, and activity notes. Comments are tracked with creator information and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->