### PR TITLE
[CSM Portal] Add POST /cases/{id}/comments endpoint

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -81,6 +81,7 @@ func main() {
 	})
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
+	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /projects/{id}/cases/search", caseHandler.SearchProjectCases)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -41,6 +41,12 @@ func (c *Client) GetCase(ctx context.Context, caseID string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/cases/%s", url.PathEscape(caseID)), nil)
 }
 
+// CreateCaseComment calls POST /cases/{id}/comments on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/comments", url.PathEscape(caseID)), body)
+}
+
 // SearchUsers calls POST /users/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *Client) SearchUsers(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -97,6 +97,7 @@ func injectProjectID(body []byte, projectID string) ([]byte, error) {
 // allowing the handler to be tested independently of the real HTTP client.
 type entityCaseClient interface {
 	CreateCase(ctx context.Context, body []byte) ([]byte, error)
+	CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
 	SearchUsers(ctx context.Context, body []byte) ([]byte, error)
@@ -175,6 +176,64 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	if err := json.Unmarshal(result, &created); err == nil && created.ID != "" {
 		w.Header().Set("Location", "/cases/"+created.ID)
 	}
+	writeJSON(w, http.StatusCreated, result)
+}
+
+// CreateCaseComment handles POST /cases/{id}/comments.
+// createdBy is resolved server-side from the authenticated user's email.
+func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("id")
+	if caseID == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	userID, err := resolveUserID(r.Context(), h.entity, user.Email)
+	if err != nil {
+		if errors.Is(err, errUserNotFound) {
+			writeError(w, http.StatusForbidden, ErrMsgForbidden)
+			return
+		}
+		slog.ErrorContext(r.Context(), "resolveUserID failed", "email", user.Email, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+
+	entityBody, err := injectCreatedBy(body, userID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateCaseComment(r.Context(), caseID, entityBody)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCaseComment failed", "userID", userID, "caseID", caseID, "err", err)
+		mapUpstreamError(w, err, "Failed to create case comment.")
+		return
+	}
+
 	writeJSON(w, http.StatusCreated, result)
 }
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -191,6 +191,153 @@ func TestCreateCase(t *testing.T) {
 	})
 }
 
+// ----- CreateCaseComment -----
+
+func TestCreateCaseComment(t *testing.T) {
+	const validPayload = `{"commentType":"comment","body":"Looking into this now."}`
+	const resolvedUserID = "entity-user-uuid-42"
+
+	userSearchOK := func(_ context.Context, _ []byte) ([]byte, error) {
+		return []byte(`{"users":[{"id":"` + resolvedUserID + `","email":"agent@example.com"}],"total":1}`), nil
+	}
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty case ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases//comments", strings.NewReader(validPayload)))
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("resolves createdBy server-side and forwards to upstream", func(t *testing.T) {
+		var capturedCaseID string
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			searchUsersFn: userSearchOK,
+			createCaseCommentFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
+				capturedCaseID = caseID
+				capturedBody = body
+				return []byte(`{"id":"comment-1","caseId":"case-1","commentType":"comment","body":"Looking into this now.","createdBy":"` + resolvedUserID + `","createdAt":"2026-06-03T00:00:00Z"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+		assertContentType(t, w, "application/json")
+
+		if capturedCaseID != "case-1" {
+			t.Errorf("upstream received caseID %q, want %q", capturedCaseID, "case-1")
+		}
+
+		var sent map[string]json.RawMessage
+		if err := json.Unmarshal(capturedBody, &sent); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		var gotID string
+		if err := json.Unmarshal(sent["createdBy"], &gotID); err != nil || gotID != resolvedUserID {
+			t.Errorf("upstream createdBy = %q, want %q", gotID, resolvedUserID)
+		}
+
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["id"] != "comment-1" {
+			t.Errorf("response id = %v, want comment-1", resp["id"])
+		}
+	})
+
+	t.Run("returns 403 when user not found in entity service", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
+				return []byte(`{"users":[],"total":0}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgForbidden)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("returns 500 when user lookup fails", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
+				return nil, errors.New("entity service unavailable")
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusInternalServerError)
+		assertErrorMessage(t, w, ErrMsgInternal)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to create case comment.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					searchUsersFn: userSearchOK,
+					createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.CreateCaseComment(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 // ----- SearchProjectCases -----
 
 func TestSearchProjectCases(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -85,15 +85,23 @@ func decodeJSON[T any](t *testing.T, w *httptest.ResponseRecorder) T {
 // ----- mock entity case client -----
 
 type mockEntityCaseClient struct {
-	createCaseFn  func(ctx context.Context, body []byte) ([]byte, error)
-	searchCasesFn func(ctx context.Context, body []byte) ([]byte, error)
-	getCaseFn     func(ctx context.Context, caseID string) ([]byte, error)
-	searchUsersFn func(ctx context.Context, body []byte) ([]byte, error)
+	createCaseFn        func(ctx context.Context, body []byte) ([]byte, error)
+	createCaseCommentFn func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	searchCasesFn       func(ctx context.Context, body []byte) ([]byte, error)
+	getCaseFn           func(ctx context.Context, caseID string) ([]byte, error)
+	searchUsersFn       func(ctx context.Context, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
 	if m.createCaseFn != nil {
 		return m.createCaseFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	if m.createCaseCommentFn != nil {
+		return m.createCaseCommentFn(ctx, caseID, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -97,6 +97,62 @@ paths:
         "500":
           description: InternalServerError
 
+  /cases/{id}/comments:
+    post:
+      summary: Create a comment on a case.
+      operationId: postCasesIdComments
+      parameters:
+        - name: id
+          in: path
+          description: ID of the case
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Case comment creation payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseCommentCreatePayload'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseComment'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /updates/product-update-levels:
     get:
       summary: Get product update levels.
@@ -1263,3 +1319,35 @@ components:
           type: integer
           minimum: 1
           default: 10
+
+    CaseCommentCreatePayload:
+      type: object
+      required:
+        - commentType
+        - body
+      properties:
+        commentType:
+          type: string
+          enum: [work_note, comment, activity]
+          description: work_note is restricted to internal users; activity to internal and system users
+        body:
+          type: string
+          description: Comment text
+
+    CaseComment:
+      type: object
+      properties:
+        id:
+          type: string
+        caseId:
+          type: string
+        commentType:
+          type: string
+          enum: [work_note, comment, activity]
+        body:
+          type: string
+        createdBy:
+          type: string
+        createdAt:
+          type: string
+          format: date-time


### PR DESCRIPTION
## Summary
- Adds `POST /cases/{id}/comments` to the CSM portal backend, forwarding to the entity service endpoint introduced in #790
- `createdBy` is resolved server-side from the authenticated user's JWT email (same pattern as `POST /cases`)
- Updates `openapi.yaml` with the new path, `CaseCommentCreatePayload`, and `CaseComment` schemas

## Changes
- `internal/entity/entity.go` — new `CreateCaseComment(ctx, caseID, body)` client method
- `internal/handler/cases.go` — extended `entityCaseClient` interface + `CreateCaseComment` handler
- `cmd/server/main.go` — route registered: `POST /cases/{id}/comments`
- `openapi.yaml` — path + schemas added
- `internal/handler/cases_test.go` — 8 new test cases covering auth, body validation, server-side createdBy injection, and upstream error mapping
- `internal/handler/helpers_test.go` — `mockEntityCaseClient` updated to implement the new interface method

## Test plan
- [x] `go test ./internal/handler/` passes (all 8 new `TestCreateCaseComment` subtests green)
- [x] `go build ./...` passes with no errors
- [x] Pre-push hook ran and passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now add comments to cases with automatic creator tracking and timestamps.
  * Supports multiple comment types: work notes, comments, and activities.

* **Tests**
  * Added test coverage for case comment creation functionality.

* **Documentation**
  * Updated API specification with case comment endpoint and schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->