### PR TITLE
[CSM Portal] Add POST /cases/{id}/comments/search endpoint

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -82,6 +82,7 @@ func main() {
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
+	mux.HandleFunc("POST /cases/{id}/comments/search", caseHandler.SearchCaseComments)
 	mux.HandleFunc("POST /projects/{id}/cases/search", caseHandler.SearchProjectCases)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -47,6 +47,12 @@ func (c *Client) CreateCaseComment(ctx context.Context, caseID string, body []by
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/comments", url.PathEscape(caseID)), body)
 }
 
+// SearchCaseComments calls POST /cases/{id}/comments/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/comments/search", url.PathEscape(caseID)), body)
+}
+
 // SearchUsers calls POST /users/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *Client) SearchUsers(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -98,6 +98,7 @@ func injectProjectID(body []byte, projectID string) ([]byte, error) {
 type entityCaseClient interface {
 	CreateCase(ctx context.Context, body []byte) ([]byte, error)
 	CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
 	SearchUsers(ctx context.Context, body []byte) ([]byte, error)
@@ -235,6 +236,46 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 	}
 
 	writeJSON(w, http.StatusCreated, result)
+}
+
+// SearchCaseComments handles POST /cases/{id}/comments/search.
+func (h *CaseHandler) SearchCaseComments(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("id")
+	if caseID == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchCaseComments(r.Context(), caseID, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchCaseComments failed", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamError(w, err, "Failed to search case comments.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // SearchProjectCases handles POST /projects/{id}/cases/search.

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -338,6 +338,107 @@ func TestCreateCaseComment(t *testing.T) {
 	})
 }
 
+// ----- SearchCaseComments -----
+
+func TestSearchCaseComments(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPost, "/cases/case-1/comments/search", strings.NewReader(`{}`))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.SearchCaseComments(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty case ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases//comments/search", strings.NewReader(`{}`)))
+		w := httptest.NewRecorder()
+		h.SearchCaseComments(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.SearchCaseComments(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments/search", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.SearchCaseComments(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards case ID and body to upstream and returns 200", func(t *testing.T) {
+		var capturedCaseID string
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			searchCaseCommentsFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
+				capturedCaseID = caseID
+				capturedBody = body
+				return []byte(`{"comments":[{"id":"c-1","caseId":"case-42","commentType":"comment","body":"First comment","createdBy":"user-1","createdAt":"2026-06-03T00:00:00Z"}],"total":1,"limit":20,"offset":0,"hasMore":false}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-42/comments/search",
+			strings.NewReader(`{"pagination":{"limit":20,"offset":0}}`)))
+		r.SetPathValue("id", "case-42")
+		w := httptest.NewRecorder()
+		h.SearchCaseComments(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedCaseID != "case-42" {
+			t.Errorf("upstream received caseID %q, want %q", capturedCaseID, "case-42")
+		}
+		if !json.Valid(capturedBody) {
+			t.Errorf("upstream received invalid JSON body: %s", capturedBody)
+		}
+
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search case comments.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					searchCaseCommentsFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments/search", strings.NewReader(`{}`)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.SearchCaseComments(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 // ----- SearchProjectCases -----
 
 func TestSearchProjectCases(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -85,11 +85,12 @@ func decodeJSON[T any](t *testing.T, w *httptest.ResponseRecorder) T {
 // ----- mock entity case client -----
 
 type mockEntityCaseClient struct {
-	createCaseFn        func(ctx context.Context, body []byte) ([]byte, error)
-	createCaseCommentFn func(ctx context.Context, caseID string, body []byte) ([]byte, error)
-	searchCasesFn       func(ctx context.Context, body []byte) ([]byte, error)
-	getCaseFn           func(ctx context.Context, caseID string) ([]byte, error)
-	searchUsersFn       func(ctx context.Context, body []byte) ([]byte, error)
+	createCaseFn          func(ctx context.Context, body []byte) ([]byte, error)
+	createCaseCommentFn   func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	searchCaseCommentsFn  func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	searchCasesFn         func(ctx context.Context, body []byte) ([]byte, error)
+	getCaseFn             func(ctx context.Context, caseID string) ([]byte, error)
+	searchUsersFn         func(ctx context.Context, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
@@ -104,6 +105,13 @@ func (m *mockEntityCaseClient) CreateCaseComment(ctx context.Context, caseID str
 		return m.createCaseCommentFn(ctx, caseID, body)
 	}
 	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	if m.searchCaseCommentsFn != nil {
+		return m.searchCaseCommentsFn(ctx, caseID, body)
+	}
+	return []byte(`{"comments":[],"total":0,"limit":20,"offset":0,"hasMore":false}`), nil
 }
 
 func (m *mockEntityCaseClient) SearchCases(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -153,6 +153,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /cases/{id}/comments/search:
+    post:
+      summary: Search comments on a case.
+      operationId: postCasesIdCommentsSearch
+      parameters:
+        - name: id
+          in: path
+          description: ID of the case
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Case comment search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseCommentSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseCommentSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /updates/product-update-levels:
     get:
       summary: Get product update levels.
@@ -1351,3 +1401,33 @@ components:
         createdAt:
           type: string
           format: date-time
+
+    CaseCommentSearchPayload:
+      type: object
+      nullable: true
+      description: Payload for paginating comments on a case. The case ID is taken from the URL path.
+      properties:
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+
+    CaseCommentSearchResponse:
+      type: object
+      properties:
+        comments:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseComment'
+        total:
+          type: integer
+          description: Total number of comments on the case
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean


### PR DESCRIPTION
## Summary
- Adds `POST /cases/{id}/comments/search` to the CSM portal backend, forwarding to the entity service endpoint introduced in #791
- No server-side injection needed — the handler is a straightforward passthrough scoped to the case ID from the path
- Updates `openapi.yaml` with the new path, `CaseCommentSearchPayload`, and `CaseCommentSearchResponse` schemas

## Changes
- `internal/entity/entity.go` — new `SearchCaseComments(ctx, caseID, body)` client method
- `internal/handler/cases.go` — extended `entityCaseClient` interface + `SearchCaseComments` handler
- `cmd/server/main.go` — route registered: `POST /cases/{id}/comments/search`
- `openapi.yaml` — path + schemas added
- `internal/handler/cases_test.go` — 5 new test cases covering auth, empty case ID, body validation, upstream forwarding, and error mapping
- `internal/handler/helpers_test.go` — `mockEntityCaseClient` updated with `searchCaseCommentsFn` field and method

## Test plan
- [x] `go test ./internal/handler/` passes (all `TestSearchCaseComments` subtests green)
- [x] `go build ./...` passes with no errors
- [x] Pre-push hook ran and passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)