### PR TITLE
[Customer Entity] Add Case Comments Search Endpoint to OpenAPI Spec

### DIFF
--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -303,6 +303,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/{id}/comments/search:
+    post:
+      summary: Search comments on a support case.
+      operationId: searchCaseComments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCaseCommentsRequest'
+      responses:
+        "200":
+          description: Comments for the case, ordered by created_at DESC.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCaseCommentsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /deployed-products/search:
     post:
       summary: Search deployed products by deployment IDs.
@@ -905,6 +942,28 @@ components:
         createdAt:
           type: string
           format: date-time
+
+    SearchCaseCommentsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    SearchCaseCommentsResponse:
+      type: object
+      properties:
+        comments:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseComment'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
## Purpose
- Adds the `POST /cases/{id}/comments/search` endpoint to the OpenAPI specification for Case Comments.
- Defines request and response structure for searching case comments.