### PR TITLE
[Customer Portal][Frontend] Restrict inline image uploads to png, jpeg, jpg, and webp

### DIFF
--- a/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
@@ -75,6 +75,8 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import { mergeRegister } from "@lexical/utils";
 import {
+  ALLOWED_INLINE_IMAGE_EXTENSIONS,
+  ALLOWED_INLINE_IMAGE_TYPES,
   MAX_IMAGE_SIZE_BYTES,
   RICH_TEXT_BLOCK_TAGS,
 } from "@features/support/constants/supportConstants";
@@ -167,7 +169,7 @@ const Toolbar = ({
 
       const formatType =
         "getFormatType" in element &&
-        typeof element.getFormatType === "function"
+          typeof element.getFormatType === "function"
           ? (element.getFormatType() as ElementFormatType)
           : "";
       setElementAlign(formatType);
@@ -239,6 +241,19 @@ const Toolbar = ({
       const resetInput = () => {
         if (imageInputRef.current) imageInputRef.current.value = "";
       };
+      const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+      if (
+        !ALLOWED_INLINE_IMAGE_TYPES.includes(
+          file.type as (typeof ALLOWED_INLINE_IMAGE_TYPES)[number],
+        ) ||
+        !ALLOWED_INLINE_IMAGE_EXTENSIONS.includes(ext)
+      ) {
+        showError(
+          `Image "${file.name}" has an unsupported format. Allowed formats: ${ALLOWED_INLINE_IMAGE_EXTENSIONS.join(", ")}.`,
+        );
+        resetInput();
+        return;
+      }
       if (file.size > MAX_IMAGE_SIZE_BYTES) {
         showError(
           `Image "${file.name}" exceeds the maximum allowed size of ${MAX_IMAGE_SIZE_BYTES / (1024 * 1024)}MB. Please choose a smaller file.`,
@@ -776,7 +791,7 @@ const Toolbar = ({
                     ref={imageInputRef}
                     type="file"
                     hidden
-                    accept="image/*"
+                    accept={ALLOWED_INLINE_IMAGE_TYPES.join(",")}
                     onChange={onImageUpload}
                   />
                 </ToggleButton>

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -185,6 +185,16 @@ export const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
 // Maximum allowed embedded image size in bytes (10MB for base64 images in rich text).
 export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
+// Allowed MIME types for inline image uploads in the rich text editor.
+export const ALLOWED_INLINE_IMAGE_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+] as const;
+
+// Allowed file extensions for inline image uploads (used in accept attribute and validation).
+export const ALLOWED_INLINE_IMAGE_EXTENSIONS = ["png", "jpeg", "jpg", "webp"];
+
 // Initial limit for case attachments list.
 export const CASE_ATTACHMENTS_INITIAL_LIMIT = 50;
 


### PR DESCRIPTION
## Summary
- Added `ALLOWED_INLINE_IMAGE_TYPES` and `ALLOWED_INLINE_IMAGE_EXTENSIONS` constants to `supportConstants.ts` to define the permitted inline image formats.
- Updated the rich text editor toolbar's file input `accept` attribute to only show allowed image formats in the OS file picker.
- Added validation in `onImageUpload` to reject files with unsupported MIME types or extensions, displaying a descriptive error banner to the user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads in the rich text editor now validate and restrict file types to PNG, JPEG, and WebP formats. Attempts to upload unsupported file types trigger an error message, while the file input now displays only compatible format options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->