### PR TITLE
[Customer Portal][Webapp] Make ALLOWED_INLINE_IMAGE_EXTENSIONS immutable with as const

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -193,7 +193,12 @@ export const ALLOWED_INLINE_IMAGE_TYPES = [
 ] as const;
 
 // Allowed file extensions for inline image uploads (used in accept attribute and validation).
-export const ALLOWED_INLINE_IMAGE_EXTENSIONS = ["png", "jpeg", "jpg", "webp"];
+export const ALLOWED_INLINE_IMAGE_EXTENSIONS = [
+  "png",
+  "jpeg",
+  "jpg",
+  "webp",
+] as const;
 
 // Initial limit for case attachments list.
 export const CASE_ATTACHMENTS_INITIAL_LIMIT = 50;


### PR DESCRIPTION
## Summary
- Added `as const` assertion to `ALLOWED_INLINE_IMAGE_EXTENSIONS` in `supportConstants.ts` to match the pattern already used by `ALLOWED_INLINE_IMAGE_TYPES`.
- This infers exact string literal types (`"png" | "jpeg" | "jpg" | "webp"`) instead of the wider `string[]`, and prevents accidental runtime mutation.