### PR TITLE
[Customer Portal][Webapp] Fix TypeScript build error in inline image extension validation

### DIFF
--- a/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
@@ -246,7 +246,7 @@ const Toolbar = ({
         !ALLOWED_INLINE_IMAGE_TYPES.includes(
           file.type as (typeof ALLOWED_INLINE_IMAGE_TYPES)[number],
         ) ||
-        !ALLOWED_INLINE_IMAGE_EXTENSIONS.includes(ext)
+        !(ALLOWED_INLINE_IMAGE_EXTENSIONS as readonly string[]).includes(ext)
       ) {
         showError(
           `Image "${file.name}" has an unsupported format. Allowed formats: ${ALLOWED_INLINE_IMAGE_EXTENSIONS.join(", ")}.`,


### PR DESCRIPTION
## Summary

- Fixed a TypeScript compile error in `ToolBar.tsx` where `string` was not assignable to the literal union type inferred from the `as const` tuple `ALLOWED_INLINE_IMAGE_EXTENSIONS`.
- Resolved by casting the array to `readonly string[]` at the `.includes()` call site, which is the standard pattern for readonly tuple membership checks.

