### PR TITLE
[Customer Entity] Add GET Account details and GET Project details endpoints

### DIFF
--- a/entity-service/internal/handler/account_handler.go
+++ b/entity-service/internal/handler/account_handler.go
@@ -49,3 +49,15 @@ func (h *AccountHandler) SearchAccounts(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// GetAccount handles GET /accounts/{id}.
+func (h *AccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	account, err := h.svc.GetAccountByID(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(account)
+}

--- a/entity-service/internal/handler/project_handler.go
+++ b/entity-service/internal/handler/project_handler.go
@@ -49,3 +49,15 @@ func (h *ProjectHandler) SearchProjects(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// GetProject handles GET /projects/{id}.
+func (h *ProjectHandler) GetProject(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	project, err := h.svc.GetProjectByID(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(project)
+}

--- a/entity-service/internal/repository/account_repo.go
+++ b/entity-service/internal/repository/account_repo.go
@@ -18,10 +18,13 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"golang.org/x/sync/errgroup"
 )
@@ -32,6 +35,9 @@ type AccountRepository interface {
 	// with the total count of matching rows before pagination.
 	// COUNT and SELECT are executed concurrently on separate pool connections.
 	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) ([]domain.Account, int, error)
+	// GetAccountByID returns the account with the given UUID, or a NotFoundError
+	// if no such account exists.
+	GetAccountByID(ctx context.Context, id string) (domain.Account, error)
 }
 
 type accountRepo struct {
@@ -117,4 +123,28 @@ func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccou
 	}
 
 	return accounts, total, nil
+}
+
+// GetAccountByID implements AccountRepository.
+func (r *accountRepo) GetAccountByID(ctx context.Context, id string) (domain.Account, error) {
+	var a domain.Account
+	err := r.db.QueryRow(ctx,
+		`SELECT id, sf_id, name, tier, region, activation_date, deactivation_date,
+		        owner_id, technical_owner_id, agent_enabled, kb_references_enabled,
+		        created_at, updated_at
+		 FROM accounts WHERE id = $1`, id,
+	).Scan(
+		&a.ID, &a.SfID, &a.Name, &a.Tier, &a.Region,
+		&a.ActivationDate, &a.DeactivationDate,
+		&a.OwnerID, &a.TechnicalOwnerID,
+		&a.AgentEnabled, &a.KbReferencesEnabled,
+		&a.CreatedAt, &a.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.Account{}, &apierror.NotFoundError{Msg: "account not found"}
+	}
+	if err != nil {
+		return domain.Account{}, fmt.Errorf("get account by id: %w", err)
+	}
+	return a, nil
 }

--- a/entity-service/internal/repository/project_repo.go
+++ b/entity-service/internal/repository/project_repo.go
@@ -18,10 +18,13 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"golang.org/x/sync/errgroup"
 )
@@ -32,6 +35,9 @@ type ProjectRepository interface {
 	// with the total count of matching rows before pagination.
 	// COUNT and SELECT are executed concurrently on separate pool connections.
 	SearchProjects(ctx context.Context, req domain.SearchProjectsRequest) ([]domain.Project, int, error)
+	// GetProjectByID returns the project with the given UUID, or a NotFoundError
+	// if no such project exists.
+	GetProjectByID(ctx context.Context, id string) (domain.Project, error)
 }
 
 type projectRepo struct {
@@ -117,4 +123,24 @@ func (r *projectRepo) SearchProjects(ctx context.Context, req domain.SearchProje
 	}
 
 	return projects, total, nil
+}
+
+// GetProjectByID implements ProjectRepository.
+func (r *projectRepo) GetProjectByID(ctx context.Context, id string) (domain.Project, error) {
+	var p domain.Project
+	err := r.db.QueryRow(ctx,
+		`SELECT id, account_id, sf_id, name, project_key, subscription_type,
+		        start_date, end_date, created_at, updated_at
+		 FROM projects WHERE id = $1`, id,
+	).Scan(
+		&p.ID, &p.AccountID, &p.SfID, &p.Name, &p.ProjectKey, &p.SubscriptionType,
+		&p.StartDate, &p.EndDate, &p.CreatedAt, &p.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.Project{}, &apierror.NotFoundError{Msg: "project not found"}
+	}
+	if err != nil {
+		return domain.Project{}, fmt.Errorf("get project by id: %w", err)
+	}
+	return p, nil
 }

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -69,6 +69,7 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 	mux.HandleFunc("POST /users/search", userHandler.SearchUsers)
 	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
+	mux.HandleFunc("GET /projects/{id}", projectHandler.GetProject)
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productVersionHandler.SearchProductVersions)

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -67,6 +67,7 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 
 	mux.HandleFunc("GET /health", handler.HealthCheck)
 	mux.HandleFunc("POST /users/search", userHandler.SearchUsers)
+	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)

--- a/entity-service/internal/service/account_service.go
+++ b/entity-service/internal/service/account_service.go
@@ -54,3 +54,11 @@ func (s *accountService) SearchAccounts(ctx context.Context, req domain.SearchAc
 		HasMore:  req.Pagination.Offset+len(accounts) < total,
 	}, nil
 }
+
+// GetAccountByID implements AccountService.
+func (s *accountService) GetAccountByID(ctx context.Context, id string) (domain.Account, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.Account{}, err
+	}
+	return s.repo.GetAccountByID(ctx, id)
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -51,6 +51,9 @@ type ProjectService interface {
 	// in req. A ValidationError is returned for invalid input; any other error
 	// indicates an infrastructure failure.
 	SearchProjects(ctx context.Context, req domain.SearchProjectsRequest) (domain.SearchProjectsResponse, error)
+	// GetProjectByID returns the project with the given UUID. A ValidationError is
+	// returned for a malformed UUID; a NotFoundError if no project matches.
+	GetProjectByID(ctx context.Context, id string) (domain.Project, error)
 }
 
 // ProductService defines the operations available on the product entity.

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -40,6 +40,9 @@ type AccountService interface {
 	// in req. A ValidationError is returned for invalid input; any other error
 	// indicates an infrastructure failure.
 	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchAccountsResponse, error)
+	// GetAccountByID returns the account with the given UUID. A ValidationError is
+	// returned for a malformed UUID; a NotFoundError if no account matches.
+	GetAccountByID(ctx context.Context, id string) (domain.Account, error)
 }
 
 // ProjectService defines the operations available on the project entity.

--- a/entity-service/internal/service/project_service.go
+++ b/entity-service/internal/service/project_service.go
@@ -55,3 +55,11 @@ func (s *projectService) SearchProjects(ctx context.Context, req domain.SearchPr
 		HasMore:  req.Pagination.Offset+len(projects) < total,
 	}, nil
 }
+
+// GetProjectByID implements ProjectService.
+func (s *projectService) GetProjectByID(ctx context.Context, id string) (domain.Project, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.Project{}, err
+	}
+	return s.repo.GetProjectByID(ctx, id)
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -49,6 +49,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /accounts/{id}:
+    get:
+      summary: Get an account by ID.
+      operationId: getAccount
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The account with the given ID.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Account not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /accounts/search:
     post:
       summary: Search accounts by name or Salesforce ID.
@@ -68,6 +105,43 @@ paths:
                 $ref: '#/components/schemas/SearchAccountsResponse'
         "400":
           description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /projects/{id}:
+    get:
+      summary: Get a project by ID.
+      operationId: getProject
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The project with the given ID.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- Add `GET /accounts/{id}` endpoint to fetch a single account by UUID
- Add `GET /projects/{id}` endpoint to fetch a single project by UUID
- Returns `404` if the resource does not exist, `400` for an invalid UUID

## Changes
- **Repository** — `GetAccountByID` / `GetProjectByID` using a single `QueryRow`, returning `NotFoundError` on no rows
- **Service** — UUID validation before delegating to the repository
- **Handler** — reads `{id}` path param, delegates to service, writes JSON response
- **Router** — registered `GET /accounts/{id}` and `GET /projects/{id}` routes
- **OpenAPI** — added both endpoint definitions with `200`, `400`, `404`, and `500` responses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GET /accounts/{id}` endpoint to retrieve individual account details
  * Added `GET /projects/{id}` endpoint to retrieve individual project details
  * Updated API specification with endpoint definitions and error handling documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->