### PR TITLE
[Customer Portal][Webapp] Restrict attachment and inline image previews to png, jpeg, jpg, and webp only

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/CommentBubble.tsx
@@ -109,7 +109,7 @@ export default function CommentBubble({
     INLINE_COMMENT_HTML_PURIFY,
   );
   const { resolvedHtml: htmlContent, isLoading: isImagesLoading } =
-    useResolvedInlineImageHtml(sanitizedHtml, comment.inlineAttachments);
+    useResolvedInlineImageHtml(sanitizedHtml);
   const displayName = useMemo(() => {
     if (isCurrentUser && userDetails) {
       const { firstName, lastName, email } = userDetails;
@@ -148,9 +148,12 @@ export default function CommentBubble({
     comment.fileName ?? "",
     comment.contentType ?? "",
   );
+  const isPreviewableImage =
+    attachmentCategory === "image" &&
+    /\.(png|jpe?g|webp)$/i.test(comment.fileName ?? "");
   const { data: imageDataUrl, isLoading: isImagePreviewLoading } =
     useAttachmentPreview(
-      isAttachmentEntry && attachmentCategory === "image" ? comment.id : null,
+      isAttachmentEntry && isPreviewableImage ? comment.id : null,
     );
 
   const renderAttachmentIcon = () => {
@@ -349,7 +352,7 @@ export default function CommentBubble({
                 {formatCommentDate(comment.createdOn)}
               </Typography>
             </Stack>
-            {attachmentCategory === "image" &&
+            {isPreviewableImage &&
               (isImagePreviewLoading ? (
                 <Skeleton
                   variant="rectangular"

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/AttachmentListItem.tsx
@@ -89,7 +89,6 @@ export default function AttachmentListItem({
 
   useEffect(() => {
     if (imageExpanded) {
-      setPreviewMinTimeElapsed(false);
       previewTimerRef.current = setTimeout(
         () => setPreviewMinTimeElapsed(true),
         PREVIEW_SKELETON_MIN_DISPLAY_MS,
@@ -99,7 +98,6 @@ export default function AttachmentListItem({
         clearTimeout(previewTimerRef.current);
         previewTimerRef.current = null;
       }
-      setPreviewMinTimeElapsed(false);
     }
     return () => {
       if (previewTimerRef.current) clearTimeout(previewTimerRef.current);
@@ -109,7 +107,9 @@ export default function AttachmentListItem({
     attachment.name ?? "",
     attachment.type ?? "",
   );
-  const isImageAttachment = attachmentCategory === "image";
+  const isImageAttachment =
+    attachmentCategory === "image" &&
+    /\.(png|jpe?g|webp)$/i.test(attachment.name ?? "");
   const hasPreviewImage = isImageAttachment;
 
   // Fetch authenticated image data URL only when the preview is expanded.
@@ -195,7 +195,10 @@ export default function AttachmentListItem({
                 size="small"
                 aria-label={imageExpanded ? "Collapse image" : "Expand image"}
                 sx={{ color: "text.secondary" }}
-                onClick={() => setImageExpanded((prev) => !prev)}
+                onClick={() => {
+                  setPreviewMinTimeElapsed(false);
+                  setImageExpanded((prev) => !prev);
+                }}
               >
                 {imageExpanded ? (
                   <ChevronUp size={16} aria-hidden />

--- a/apps/customer-portal/webapp/src/features/support/hooks/useResolvedInlineImageHtml.ts
+++ b/apps/customer-portal/webapp/src/features/support/hooks/useResolvedInlineImageHtml.ts
@@ -17,7 +17,6 @@
 import { useMemo } from "react";
 import { useAttachmentPreviews } from "@api/useAttachmentPreview";
 import { extractInlineImageRefId } from "@features/support/utils/support";
-import type { InlineAttachment } from "@features/support/utils/support";
 
 /**
  * Extracts all `.iix`-style attachment IDs referenced in img src attributes within HTML.
@@ -42,12 +41,10 @@ function extractIixAttachmentIds(html: string): string[] {
  * Fetches images via the authenticated backend and replaces src attributes with data URLs.
  *
  * @param html - Sanitized HTML string potentially containing `.iix` img src URLs.
- * @param inlineAttachments - Inline attachment metadata list from the comment.
  * @returns `{ resolvedHtml: string, isLoading: boolean }`
  */
 export function useResolvedInlineImageHtml(
   html: string,
-  _inlineAttachments?: InlineAttachment[] | null,
 ): { resolvedHtml: string; isLoading: boolean } {
   const idsFromHtml = useMemo(() => extractIixAttachmentIds(html), [html]);
 


### PR DESCRIPTION
## Summary
- Restrict attachment previews in the Attachments tab and Activity tab to only render inline previews for `png`, `jpg`/`jpeg`, and `webp` files; other types (e.g. SVG) are shown as file entries without a preview
- Filter inline images embedded in rich text comments by MIME type, blocking non-previewable formats (e.g. `image/svg+xml`) from rendering in the activity feed
- Hide blocked inline images and their wrapper elements (`<figure>`, `<p>`) via CSS to prevent empty white boxes
- Remove unused `_inlineAttachments` parameter from `useResolvedInlineImageHtml`
- Fix React lint warning: move synchronous `setState` out of `useEffect` body into the click event handler in `AttachmentListItem`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image previews now display only for standard image formats (.png, .jpg, .jpeg, .webp)
  * Improved inline image resolution and loading behavior in comments
  * Enhanced attachment preview timing for better responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->