### PR TITLE
[Customer Portal][Webapp] feat: enable multi-select for engagement type filter

### DIFF
--- a/apps/customer-portal/webapp/src/features/engagements/components/EngagementsListSection.tsx
+++ b/apps/customer-portal/webapp/src/features/engagements/components/EngagementsListSection.tsx
@@ -147,20 +147,42 @@ export default function EngagementsListSection({
                 <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                   <FormControl fullWidth size="small">
                     <InputLabel id="eng-type-label">Engagement Type</InputLabel>
-                    <Select
+                    <Select<string[]>
+                      multiple
                       labelId="eng-type-label"
-                      value={filters.engagementTypeKey ?? ""}
+                      value={filters.engagementTypeKey ?? []}
                       label="Engagement Type"
-                      onChange={(e: SelectChangeEvent<string>) =>
-                        onFilterChange("engagementTypeKey", e.target.value)
+                      onChange={(e: SelectChangeEvent<string[]>) =>
+                        onFilterChange("engagementTypeKey", e.target.value as string[])
                       }
+                      renderValue={(selected) => {
+                        if (!Array.isArray(selected) || selected.length === 0) return "";
+                        const labels = selected.map(
+                          (v) => engagementTypeOptions.find((o) => o.value === v)?.label ?? v,
+                        );
+                        const displayText = labels.join(", ");
+                        if (labels.length === 1) return displayText;
+                        return (
+                          <Tooltip title={displayText} placement="top">
+                            <Box
+                              component="span"
+                              sx={{
+                                display: "block",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {displayText}
+                            </Box>
+                          </Tooltip>
+                        );
+                      }}
                     >
-                      <MenuItem value="">
-                        <Typography variant="body2">All Types</Typography>
-                      </MenuItem>
                       {engagementTypeOptions.map((opt) => (
                         <MenuItem key={opt.value} value={opt.value}>
-                          <Typography variant="body2">{opt.label}</Typography>
+                          <Checkbox checked={(filters.engagementTypeKey ?? []).includes(opt.value)} size="small" />
+                          <Typography variant="body2" sx={{ ml: 1 }}>{opt.label}</Typography>
                         </MenuItem>
                       ))}
                     </Select>

--- a/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/__tests__/engagements.test.ts
@@ -91,7 +91,7 @@ describe("buildEngagementSearchRequest", () => {
 
   it("maps status and engagement type filters", () => {
     const req = buildEngagementSearchRequest(
-      { statusIds: ["1", "2"], engagementTypeKey: "10,20" },
+      { statusIds: ["1", "2"], engagementTypeKey: ["10,20"] },
       "  query ",
       EngagementsSortField.State,
       SortOrder.ASC,

--- a/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
+++ b/apps/customer-portal/webapp/src/features/engagements/utils/engagements.ts
@@ -83,8 +83,8 @@ export function buildEngagementSearchRequest(
         ? filters.deploymentIds
         : undefined,
       searchQuery: searchTerm.trim() || undefined,
-      engagementTypeKeys: filters.engagementTypeKey
-        ? filters.engagementTypeKey.split(",").map(Number).filter(Boolean)
+      engagementTypeKeys: filters.engagementTypeKey?.length
+        ? filters.engagementTypeKey.flatMap((k) => k.split(",").map(Number).filter(Boolean))
         : undefined,
     },
     sortBy: {

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -308,7 +308,7 @@ export type AllCasesFilterValues = {
   severityIds?: string[];
   issueTypes?: string[];
   deploymentIds?: string[];
-  engagementTypeKey?: string;
+  engagementTypeKey?: string[];
   createdBy?: string[];
 };
 


### PR DESCRIPTION
## Summary
- Changed `engagementTypeKey` filter from a single string to `string[]` to support multi-select
- Updated the Engagement Type dropdown to use checkboxes and tooltip rollup, matching the existing Status filter pattern
- Updated `buildEngagementSearchRequest` to flatten the array of keys when building the API request