### PR TITLE
[Customer Portal][Webapp] Enable multi-select for state and impact filters on change requests page

### DIFF
--- a/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/operations/constants/operationsConstants.ts
@@ -183,16 +183,19 @@ export const CHANGE_REQUEST_FILTER_DEFINITIONS: Array<{
   filterKey: keyof ChangeRequestFilterValues;
   id: string;
   metadataKey: keyof CaseMetadataResponse;
+  multiSelect?: boolean;
 }> = [
   {
-    filterKey: "stateId",
+    filterKey: "stateIds",
     id: "state",
     metadataKey: "changeRequestStates",
+    multiSelect: true,
   },
   {
-    filterKey: "impactId",
+    filterKey: "impactIds",
     id: "impact",
     metadataKey: "changeRequestImpacts",
+    multiSelect: true,
   },
 ];
 

--- a/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/pages/ChangeRequestsPage.tsx
@@ -221,7 +221,7 @@ export default function ChangeRequestsPage(): JSX.Element {
   const handleFilterChange = (field: string, value: string | string[]) => {
     setFilters((prev) => ({
       ...prev,
-      [field]: Array.isArray(value) ? (value.length === 0 ? undefined : value[0]) : (value || undefined),
+      [field]: Array.isArray(value) ? (value.length === 0 ? undefined : value) : (value || undefined),
     }));
     setPage(1);
   };

--- a/apps/customer-portal/webapp/src/features/operations/types/changeRequests.ts
+++ b/apps/customer-portal/webapp/src/features/operations/types/changeRequests.ts
@@ -98,8 +98,8 @@ export type PatchChangeRequestResponse = AuditMetadata & {
 
 // Model type for change request filters state.
 export type ChangeRequestFilterValues = {
-  stateId?: string;
-  impactId?: string;
+  stateIds?: string[];
+  impactIds?: string[];
 };
 
 /** Change request list sort field for search API `sortBy.field`. */
@@ -110,7 +110,7 @@ export enum ChangeRequestSortField {
 
 // Filter type for searching change requests.
 export type ChangeRequestSearchFilters = {
-  impactKey?: number;
+  impactKeys?: number[];
   searchQuery?: string;
   stateKeys?: number[];
   closedStartDate?: string;
@@ -190,7 +190,7 @@ export type ChangeRequestsSearchBarProps = {
   onFiltersToggle: () => void;
   filters: ChangeRequestFilterValues;
   filterMetadata: CaseMetadataResponse | undefined;
-  onFilterChange: (field: string, value: string) => void;
+  onFilterChange: (field: string, value: string | string[]) => void;
   onClearFilters: () => void;
 };
 

--- a/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/__tests__/operationsPages.test.ts
@@ -163,13 +163,13 @@ describe("buildChangeRequestSearchRequest", () => {
 
   it("maps filters and search using allowed states from metadata", () => {
     const req = buildChangeRequestSearchRequest(
-      { stateId: "2", impactId: "1" },
+      { stateIds: ["2"], impactIds: ["1"] },
       " q ",
       false, false, false,
       allStates,
     );
     expect(req.filters?.stateKeys).toEqual([2]);
-    expect(req.filters?.impactKey).toBe(1);
+    expect(req.filters?.impactKeys).toEqual([1]);
     expect(req.filters?.searchQuery).toBe("q");
   });
 
@@ -227,7 +227,7 @@ describe("resolveChangeRequestFilterListOptions", () => {
     const options = resolveChangeRequestFilterListOptions(
       {
         id: ChangeRequestFilterDefinitionId.Impact,
-        filterKey: "impactId",
+        filterKey: "impactIds",
         metadataKey: "changeRequestImpacts",
       },
       {
@@ -242,7 +242,7 @@ describe("resolveChangeRequestFilterListOptions", () => {
     const options = resolveChangeRequestFilterListOptions(
       {
         id: ChangeRequestFilterDefinitionId.State,
-        filterKey: "stateId",
+        filterKey: "stateIds",
         metadataKey: "changeRequestStates",
       },
       {

--- a/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/operationsPages.ts
@@ -207,7 +207,7 @@ export function buildChangeRequestSearchRequest(
   sortField: ChangeRequestSortField = ChangeRequestSortField.UpdatedOn,
   sortOrder: SortOrder = SortOrder.DESC,
 ): Omit<ChangeRequestSearchRequest, "pagination"> {
-  const selectedStateId = filters.stateId ? Number(filters.stateId) : undefined;
+  const selectedStateIds = filters.stateIds?.map(Number) ?? [];
   const resolvedIds = actionRequired
     ? resolveActionRequiredCrStateIds(changeRequestStates)
     : scheduledOnly
@@ -217,17 +217,17 @@ export function buildChangeRequestSearchRequest(
         : resolveAllowedCrStateIds(changeRequestStates);
   const allowedStateIds = resolvedIds ?? [];
   const stateKeys =
-    selectedStateId === undefined
+    selectedStateIds.length === 0
       ? allowedStateIds
-      : allowedStateIds.includes(selectedStateId)
-        ? [selectedStateId]
-        : [];
+      : selectedStateIds.filter((id) => allowedStateIds.includes(id));
+
+  const selectedImpactIds = filters.impactIds?.map(Number) ?? [];
 
   return {
     filters: {
       searchQuery: searchTerm.trim() || undefined,
       stateKeys,
-      impactKey: filters.impactId ? Number(filters.impactId) : undefined,
+      impactKeys: selectedImpactIds.length > 0 ? selectedImpactIds : undefined,
     },
     sortBy: {
       field: sortField,


### PR DESCRIPTION
## Summary
- Replaces single-value `stateId`/`impactId` filter fields with `stateIds`/`impactIds` string arrays in `ChangeRequestFilterValues`
- Marks both State and Impact filter definitions as `multiSelect: true` so `ListFiltersPanel` renders checkbox-style dropdowns (matching the cases filters UX)
- Updates `ChangeRequestSearchFilters` to accept `impactKeys: number[]` (was `impactKey: number`) and `buildChangeRequestSearchRequest` to intersect selected state IDs with the allowed set and pass multiple impact IDs

