### PR TITLE
[Customer Portal][BE] Add watch list for case update

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -333,7 +333,9 @@ public type CreatedCase record {|
 # Request payload for updating a case.
 public type CaseUpdatePayload record {|
     # State key to update
-    int stateKey;
+    int stateKey?;
+    # Watch list user emails to update on the case
+    Email[] watchList?;
 |};
 
 # Response from updating a case.
@@ -356,6 +358,8 @@ public type UpdatedCase record {|
     ChoiceListItem state;
     # Case type information
     ReferenceTableItem? 'type;
+    # Watch list users
+    WatchList[]? watchList;
     json...;
 |};
 

--- a/apps/customer-portal/backend/modules/entity/utils.bal
+++ b/apps/customer-portal/backend/modules/entity/utils.bal
@@ -168,6 +168,13 @@ public isolated function validateDeploymentUpdatePayload(DeploymentUpdatePayload
 # + payload - Case update payload
 # + return - Error message if validation fails, nil otherwise
 public isolated function validateCaseUpdatePayload(CaseUpdatePayload payload) returns string? {
+    boolean hasStateKey = payload.stateKey !is ();
+    boolean hasWatchList = payload.watchList !is ();
+
+    if !hasStateKey && !hasWatchList {
+        return "Invalid payload. At least one of status or watch list should be provided for case update.";
+    }
+
     if payload.stateKey != caseStateIds.closed && payload.stateKey != caseStateIds.reopened &&
     payload.stateKey != caseStateIds.waitingOnWso2 {
         return "Invalid status. Allowed values are Waiting on WSO2, Closed, or Reopened.";

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -288,6 +288,8 @@ public type UpdatedCase record {|
     ReferenceItem state;
     # Case type information
     ReferenceItem? 'type;
+    # Watch list users
+    WatchList[]? watchList;
 |};
 
 # Updated user information.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -3777,14 +3777,17 @@ components:
       - service_request
       - default_case
     CaseUpdatePayload:
-      required:
-      - stateKey
       type: object
       properties:
         stateKey:
           type: integer
           description: State key to update
           format: int64
+        watchList:
+          type: array
+          description: Watch list user emails to update on the case
+          items:
+            $ref: '#/components/schemas/Email'
       additionalProperties: false
       description: Request payload for updating a case.
     CasesTrend:
@@ -6192,6 +6195,7 @@ components:
       - type
       - updatedBy
       - updatedOn
+      - watchList
       type: object
       properties:
         id:
@@ -6209,6 +6213,12 @@ components:
           nullable: true
           allOf:
           - $ref: '#/components/schemas/ReferenceItem'
+        watchList:
+          type: array
+          description: Watch list users
+          nullable: true
+          items:
+            $ref: '#/components/schemas/WatchList'
       additionalProperties: false
       description: Updated case details.
     UpdatedChangeRequest:

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1127,12 +1127,15 @@ public isolated function mapTimeCardSearchResponseGroupedByCases(entity:CaseTime
 public isolated function mapUpdatedCaseResponse(entity:UpdatedCase updatedCase) returns types:UpdatedCase {
     entity:ChoiceListItem state = updatedCase.state;
     entity:ReferenceTableItem? 'type = updatedCase.'type;
+    entity:WatchList[]? watchList = updatedCase.watchList;
     return {
         id: updatedCase.id,
         updatedOn: updatedCase.updatedOn,
         state: {id: state.id.toString(), label: state.label},
         'type: 'type != () ? {id: 'type.id, label: 'type.name} : (),
-        updatedBy: updatedCase.updatedBy
+        updatedBy: updatedCase.updatedBy,
+        watchList: watchList != () ? from entity:WatchList user in watchList
+            select {id: user.id, userName: user.userName, name: user.name, email: user.email} : ()
     };
 }
 


### PR DESCRIPTION
## Description
- Add `watchList` field to case update payload allowing users to update the watch list on a case.
- Extended case updated response to include the watchList array.
- Updated `openapi.yaml` spec to reflect the new payload field and response shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced watch list functionality to track case observers. Users can now view and update the list of people monitoring a case.

* **Changes**
  * Case status updates are no longer required. Updates must include at least one change: either a status modification or a watch list change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->