### PR TITLE
[Customer Portal][Webapp] Block unsupported image formats from inline paste in rich text editor

### DIFF
--- a/apps/customer-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/customer-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -208,7 +208,7 @@ const ResetPlugin = ({ resetTrigger }: { resetTrigger?: number }) => {
  * Handles paste events containing image data (e.g. Ctrl+C from screen, then Ctrl+V).
  * Reads the image as a data URL and inserts it via INSERT_IMAGE_COMMAND.
  */
-const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): null => {
+const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: (reason: "size" | "type") => void }): null => {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -216,16 +216,22 @@ const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): 
       const items = event.clipboardData?.items;
       if (!items) return;
 
+      const ALLOWED_PASTE_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
       const MAX_PASTE_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
       for (const item of Array.from(items)) {
-        if (item.type.startsWith("image/")) {
+        if (item.type.startsWith("image/") && !ALLOWED_PASTE_IMAGE_TYPES.has(item.type)) {
+          event.preventDefault();
+          onPasteError?.("type");
+          break;
+        }
+        if (ALLOWED_PASTE_IMAGE_TYPES.has(item.type)) {
           const file = item.getAsFile();
           if (!file) continue;
 
           event.preventDefault();
 
           if (file.size > MAX_PASTE_IMAGE_SIZE) {
-            onPasteError?.();
+            onPasteError?.("size");
             break;
           }
 
@@ -330,7 +336,7 @@ const Editor = ({
   onBlur?: () => void;
   /** Optional element rendered as an absolute overlay at the bottom-right inside the editor. */
   overlayElement?: ReactNode;
-  onPasteError?: () => void;
+  onPasteError?: (reason: "size" | "type") => void;
 }): JSX.Element => {
   const oxygenTheme = useTheme();
   const logger = useLogger();

--- a/apps/customer-portal/webapp/src/constants/common.ts
+++ b/apps/customer-portal/webapp/src/constants/common.ts
@@ -43,3 +43,7 @@ export const BANNER_HEADER_GAP_PX = 24;
 
 // Horizontal gap in pixels.
 export const BANNER_RIGHT_GAP_PX = 24;
+
+export const ERROR_UNSUPPORTED_TYPE =
+  "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment.";
+export const ERROR_SIZE_EXCEEDED = "Image exceeds the maximum allowed size of 10 MB.";

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestDetailContent.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestDetailContent.tsx
@@ -659,6 +659,13 @@ export default function ServiceRequestDetailContent({
                 showToolbar
                 placeholder="Add a comment..."
                 onSubmitKeyDown={handleAddComment}
+                onPasteError={(reason) =>
+                  showError(
+                    reason === "type"
+                      ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
+                      : "Image exceeds the maximum allowed size of 10 MB.",
+                  )
+                }
               />
               <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
                 <Button

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestDetailContent.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestDetailContent.tsx
@@ -42,6 +42,10 @@ import {
 import useGetProjectFilters from "@api/useGetProjectFilters";
 import { usePatchCase } from "@features/support/api/usePatchCase";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import {
+  ERROR_UNSUPPORTED_TYPE,
+  ERROR_SIZE_EXCEEDED,
+} from "@constants/common";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
 import useGetCaseCommentsInfinite from "@features/support/api/useGetCaseCommentsInfinite";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
@@ -662,8 +666,8 @@ export default function ServiceRequestDetailContent({
                 onPasteError={(reason) =>
                   showError(
                     reason === "type"
-                      ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
-                      : "Image exceeds the maximum allowed size of 10 MB.",
+                      ? ERROR_UNSUPPORTED_TYPE
+                      : ERROR_SIZE_EXCEEDED,
                   )
                 }
               />

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
@@ -38,6 +38,7 @@ import {
 import { computeMinScheduleDatetimeLocalForTimeZone } from "@features/support/utils/support";
 import { resolveDisplayTimeZone } from "@utils/dateTime";
 import Editor from "@components/rich-text-editor/Editor";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 
 export interface VariableFormFieldsProps {
   variables: CatalogItemVariable[] | undefined;
@@ -209,6 +210,7 @@ export default function VariableFormFields({
   onAttachmentAdd,
   userTimeZone,
 }: VariableFormFieldsProps): JSX.Element {
+  const { showError } = useErrorBanner();
   const effectiveTimeZone = userTimeZone ?? resolveDisplayTimeZone();
   const minDatetime = computeMinScheduleDatetimeLocalForTimeZone(0, effectiveTimeZone);
   const sortedVariables = useMemo(
@@ -350,6 +352,13 @@ export default function VariableFormFields({
             onAttachmentClick={onAttachmentClick}
             attachments={attachments.map((a) => a.file)}
             onAttachmentRemove={onAttachmentRemove}
+            onPasteError={(reason) =>
+              showError(
+                reason === "type"
+                  ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
+                  : "Image exceeds the maximum allowed size of 10 MB.",
+              )
+            }
           />
         </Grid>
       );

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
@@ -39,6 +39,10 @@ import { computeMinScheduleDatetimeLocalForTimeZone } from "@features/support/ut
 import { resolveDisplayTimeZone } from "@utils/dateTime";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import {
+  ERROR_UNSUPPORTED_TYPE,
+  ERROR_SIZE_EXCEEDED,
+} from "@constants/common";
 
 export interface VariableFormFieldsProps {
   variables: CatalogItemVariable[] | undefined;
@@ -355,8 +359,8 @@ export default function VariableFormFields({
             onPasteError={(reason) =>
               showError(
                 reason === "type"
-                  ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
-                  : "Image exceeds the maximum allowed size of 10 MB.",
+                  ? ERROR_UNSUPPORTED_TYPE
+                  : ERROR_SIZE_EXCEEDED,
               )
             }
           />

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
@@ -32,6 +32,7 @@ import { type JSX } from "react";
 import { CaseSeverity, CaseSeverityLevel } from "@features/support/constants/supportConstants";
 import { isS0SeverityLabel, getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import Editor from "@components/rich-text-editor/Editor";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 
 /**
  * Renders the Case Details section for case creation.
@@ -66,6 +67,7 @@ export function CaseDetailsSection({
   isTitleFromChat = false,
   isDescriptionFromConversation = false,
 }: CaseDetailsSectionProps): JSX.Element {
+  const { showError } = useErrorBanner();
   const titleReadOnly = isTitleDisabled;
   const titleLength = title.trim().length;
   const isTitleTooLong = titleLength > 160;
@@ -242,6 +244,13 @@ export function CaseDetailsSection({
             value={description}
             onChange={setDescription}
             maxHeight="210px"
+            onPasteError={(reason) =>
+              showError(
+                reason === "type"
+                  ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
+                  : "Image exceeds the maximum allowed size of 10 MB.",
+              )
+            }
           />
 
           {!isRelatedCaseMode && isDescriptionFromConversation && (

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
@@ -33,6 +33,10 @@ import { CaseSeverity, CaseSeverityLevel } from "@features/support/constants/sup
 import { isS0SeverityLabel, getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import {
+  ERROR_UNSUPPORTED_TYPE,
+  ERROR_SIZE_EXCEEDED,
+} from "@constants/common";
 
 /**
  * Renders the Case Details section for case creation.
@@ -247,8 +251,8 @@ export function CaseDetailsSection({
             onPasteError={(reason) =>
               showError(
                 reason === "type"
-                  ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
-                  : "Image exceeds the maximum allowed size of 10 MB.",
+                  ? ERROR_UNSUPPORTED_TYPE
+                  : ERROR_SIZE_EXCEEDED,
               )
             }
           />

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -33,11 +33,10 @@ import Editor from "@components/rich-text-editor/Editor";
 import UploadAttachmentModal from "@case-details-attachments/UploadAttachmentModal";
 import type { JSX } from "react";
 import { CommentType } from "@features/support/constants/supportConstants";
-
-const PASTE_ERROR_UNSUPPORTED_TYPE =
-  "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment.";
-const PASTE_ERROR_SIZE_EXCEEDED =
-  "Image exceeds the maximum allowed size of 10 MB.";
+import {
+  ERROR_UNSUPPORTED_TYPE,
+  ERROR_SIZE_EXCEEDED,
+} from "@constants/common";
 
 /**
  * Input row with rich-text editor and send button.
@@ -248,8 +247,8 @@ export default function ActivityCommentInput({
             onPasteError={(reason) =>
               showError(
                 reason === "type"
-                  ? PASTE_ERROR_UNSUPPORTED_TYPE
-                  : PASTE_ERROR_SIZE_EXCEEDED,
+                  ? ERROR_UNSUPPORTED_TYPE
+                  : ERROR_SIZE_EXCEEDED,
               )
             }
             overlayElement={

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -240,8 +240,12 @@ export default function ActivityCommentInput({
             onAttachmentRemove={handleAttachmentRemove}
             showKeyboardHint={true}
             maxHeight="310px"
-            onPasteError={() =>
-              showError("Image exceeds the maximum allowed size of 10 MB.")
+            onPasteError={(reason) =>
+              showError(
+                reason === "type"
+                  ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
+                  : "Image exceeds the maximum allowed size of 10 MB.",
+              )
             }
             overlayElement={
               <Tooltip title="Send comment">

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -34,6 +34,11 @@ import UploadAttachmentModal from "@case-details-attachments/UploadAttachmentMod
 import type { JSX } from "react";
 import { CommentType } from "@features/support/constants/supportConstants";
 
+const PASTE_ERROR_UNSUPPORTED_TYPE =
+  "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment.";
+const PASTE_ERROR_SIZE_EXCEEDED =
+  "Image exceeds the maximum allowed size of 10 MB.";
+
 /**
  * Input row with rich-text editor and send button.
  * Uses the shared Editor component and posts comments via usePostComment; on success invalidates and refetches comments.
@@ -243,8 +248,8 @@ export default function ActivityCommentInput({
             onPasteError={(reason) =>
               showError(
                 reason === "type"
-                  ? "This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."
-                  : "Image exceeds the maximum allowed size of 10 MB.",
+                  ? PASTE_ERROR_UNSUPPORTED_TYPE
+                  : PASTE_ERROR_SIZE_EXCEEDED,
               )
             }
             overlayElement={


### PR DESCRIPTION
## Changes
- **Restrict paste to JPEG, PNG, and WebP only** — SVG and all other image formats are now blocked at the clipboard paste handler in `ClipboardImagePlugin`
- **User-facing warning** — when a blocked format is pasted, an error banner is shown: *"This image format can't be pasted inline. Only JPEG, PNG, and WebP images support inline display. You can still upload this file as an attachment."*
- **Extended `onPasteError` callback** — now receives a `reason` (`"type"` | `"size"`) so callers can show distinct messages for format vs size violations
- **Wired up across all Editor usages** — `CaseDetailsSection`, `ActivityCommentInput`, `ServiceRequestDetailContent`, `VariableFormFields`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich-text editor validates pasted images and only accepts JPEG, PNG, and WebP inline.
  * Provides distinct error notifications for unsupported formats vs images over the 10 MB limit.

* **Bug Fixes**
  * Paste error feedback is now shown consistently across all forms that include the rich-text editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->