### PR TITLE
Remove unused Typography import in CreateCasePage

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Autocomplete, Box, Button, Chip, Grid, TextField, Typography } from "@wso2/oxygen-ui";
+import { Autocomplete, Box, Button, Chip, Grid, TextField } from "@wso2/oxygen-ui";
 import { CircleCheck } from "@wso2/oxygen-ui-icons-react";
 import {
   useState,


### PR DESCRIPTION
Remove unused Typography import in CreateCasePage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**No user-visible changes.** This release contains internal code maintenance with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->