### PR TITLE
[CSM Portal] Inject next_states into GET /cases/{id} response

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -346,7 +346,12 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Unmarshal result into a typed CaseResponse and transform it
-	// to the CSM portal response shape before writing.
+	result, err = injectNextStates(result)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to inject next_states", "userID", user.UserID, "caseID", caseID, "err", err)
+		writeError(w, http.StatusInternalServerError, "Failed to process case details.")
+		return
+	}
+
 	writeJSON(w, http.StatusOK, result)
 }

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -604,12 +604,12 @@ func TestGetCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("passes case ID to upstream and returns 200 with response", func(t *testing.T) {
+	t.Run("passes case ID to upstream and returns 200 with next_states injected", func(t *testing.T) {
 		var capturedID string
 		client := &mockEntityCaseClient{
 			getCaseFn: func(_ context.Context, caseID string) ([]byte, error) {
 				capturedID = caseID
-				return []byte(`{"id":"case-42","title":"Deployment failure"}`), nil
+				return []byte(`{"id":"case-42","state":"open"}`), nil
 			},
 		}
 		h := NewCaseHandler(client)
@@ -626,6 +626,51 @@ func TestGetCase(t *testing.T) {
 		resp := decodeJSON[map[string]any](t, w)
 		if resp["id"] != "case-42" {
 			t.Errorf("response id = %v, want case-42", resp["id"])
+		}
+		ns, ok := resp["next_states"].([]any)
+		if !ok || len(ns) != 1 || ns[0] != caseStateWorkInProgress {
+			t.Errorf("next_states = %v, want [%s]", resp["next_states"], caseStateWorkInProgress)
+		}
+	})
+
+	t.Run("next_states reflects current state", func(t *testing.T) {
+		cases := []struct {
+			state    string
+			wantNext []string
+		}{
+			{caseStateOpen, []string{caseStateWorkInProgress}},
+			{caseStateWorkInProgress, []string{caseStateWaitingOnWSO2, caseStateAwaitingInfo, caseStateSolutionProposed, caseStateClosed}},
+			{caseStateWaitingOnWSO2, []string{caseStateWorkInProgress}},
+			{caseStateAwaitingInfo, []string{caseStateWaitingOnWSO2}},
+			{caseStateReopened, []string{caseStateWaitingOnWSO2}},
+			{caseStateSolutionProposed, []string{caseStateClosed, caseStateWaitingOnWSO2}},
+			{caseStateClosed, []string{}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.state, func(t *testing.T) {
+				t.Parallel()
+				body, _ := json.Marshal(map[string]string{"id": "case-1", "state": tc.state})
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) { return body, nil },
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/cases/case-1", nil))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.GetCase(w, r)
+
+				assertStatus(t, w, http.StatusOK)
+				resp := decodeJSON[map[string]any](t, w)
+				got, _ := resp["next_states"].([]any)
+				if len(got) != len(tc.wantNext) {
+					t.Fatalf("next_states = %v, want %v", got, tc.wantNext)
+				}
+				for i, v := range got {
+					if v != tc.wantNext[i] {
+						t.Errorf("next_states[%d] = %v, want %v", i, v, tc.wantNext[i])
+					}
+				}
+			})
 		}
 	})
 

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import "encoding/json"
+
+const (
+	caseStateOpen             = "open"
+	caseStateWorkInProgress   = "work_in_progress"
+	caseStateWaitingOnWSO2    = "waiting_on_wso2"
+	caseStateAwaitingInfo     = "awaiting_info"
+	caseStateReopened         = "reopened" // deprecated alias for waiting_on_wso2
+	caseStateSolutionProposed = "solution_proposed"
+	caseStateClosed           = "closed"
+)
+
+// nextStates returns the valid next states reachable from the given case state.
+// Role-gated transitions (team-lead override, auto-close) are excluded until
+// role enforcement is implemented.
+func nextStates(state string) []string {
+	switch state {
+	case caseStateOpen:
+		return []string{caseStateWorkInProgress}
+	case caseStateWorkInProgress:
+		return []string{caseStateWaitingOnWSO2, caseStateAwaitingInfo, caseStateSolutionProposed, caseStateClosed}
+	case caseStateWaitingOnWSO2:
+		return []string{caseStateWorkInProgress}
+	case caseStateAwaitingInfo:
+		return []string{caseStateWaitingOnWSO2}
+	case caseStateReopened:
+		return []string{caseStateWaitingOnWSO2}
+	case caseStateSolutionProposed:
+		return []string{caseStateClosed, caseStateWaitingOnWSO2}
+	default: // caseStateClosed and any unknown values are terminal
+		return []string{}
+	}
+}
+
+// injectNextStates parses raw case JSON returned by the entity service, derives
+// the valid next states from the "state" field, and returns the JSON with a
+// "next_states" key appended.
+func injectNextStates(data []byte) ([]byte, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	var state string
+	if raw, ok := m["state"]; ok {
+		if err := json.Unmarshal(raw, &state); err != nil {
+			return nil, err
+		}
+	}
+	ns, err := json.Marshal(nextStates(state))
+	if err != nil {
+		return nil, err
+	}
+	m["next_states"] = ns
+	return json.Marshal(m)
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -988,6 +988,18 @@ components:
         closedAt:
           type: string
           format: date-time
+        next_states:
+          type: array
+          readOnly: true
+          items:
+            type: string
+            enum:
+              - open
+              - work_in_progress
+              - waiting_on_wso2
+              - awaiting_info
+              - solution_proposed
+              - closed
 
     UpdateDescriptionRequest:
       type: object


### PR DESCRIPTION
## Summary

- Adds a read-only `next_states` field to the `GET /cases/{id}` response, computed server-side from the case's current `state` using the case state machine spec
- Introduces `apps/csm-portal/backend/internal/handler/state.go` with state constants and the `nextStates`/`injectNextStates` helpers
- Role-gated transitions (team-lead override, auto-close) are excluded until role enforcement is in place
- Updates the `Case` schema in `openapi.yaml` to document the new field

## Test plan

- [ ] `TestGetCase/passes_case_ID_to_upstream_and_returns_200_with_next_states_injected` — verifies `next_states` is present and correct for `open` state
- [ ] `TestGetCase/next_states_reflects_current_state/*` — table-driven subtests covering all 6 states (`open`, `work_in_progress`, `waiting_on_wso2`, `awaiting_info`, `solution_proposed`, `closed`)
- [ ] Existing `TestGetCase` subtests (auth, empty ID, upstream errors) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case details now display the available next status options for state transitions.

* **Documentation**
  * Updated API specification to reflect the new case status transition information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->