### PR TITLE
[Customer Portal][Webapp] populate default watch list on case creation

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/watch-list-section/WatchListSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/watch-list-section/WatchListSection.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Autocomplete,
+  Box,
+  Checkbox,
+  Chip,
+  Paper,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useMemo, type JSX } from "react";
+import type { ProjectContact } from "@features/settings/types/users";
+
+type ContactOption = {
+  label: string;
+  value: string;
+};
+
+type WatchListSectionProps = {
+  contacts: ProjectContact[];
+  selectedEmails: string[];
+  onChange: (emails: string[]) => void;
+  isLoading?: boolean;
+};
+
+/**
+ * Renders the Watch List section for case creation.
+ * Only contacts with Admin or Portal User roles are shown as options.
+ *
+ * @returns {JSX.Element} The Watch List section.
+ */
+export function WatchListSection({
+  contacts,
+  selectedEmails,
+  onChange,
+  isLoading = false,
+}: WatchListSectionProps): JSX.Element {
+  const options: ContactOption[] = useMemo(
+    () =>
+      contacts.map((c) => ({
+        label: `${c.firstName} ${c.lastName}`.trim() || c.email,
+        value: c.email,
+      })),
+    [contacts],
+  );
+
+  const selectedOptions = options.filter((o) => selectedEmails.includes(o.value));
+
+  return (
+    <Paper sx={{ p: 3 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 3,
+        }}
+      >
+        <Typography variant="h6">Watch List</Typography>
+      </Box>
+
+      <Box>
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="caption">
+            Watchers{" "}
+            <Typography variant="caption" color="text.secondary">
+              (users who will receive case notifications)
+            </Typography>
+          </Typography>
+        </Box>
+        <Autocomplete
+          multiple
+          loading={isLoading}
+          loadingText="Loading..."
+          options={options}
+          getOptionLabel={(option) => option.label}
+          value={selectedOptions}
+          onChange={(_event, newValue) => {
+            onChange(newValue.map((o) => o.value));
+          }}
+          disableCloseOnSelect
+          isOptionEqualToValue={(option, val) => option.value === val.value}
+          renderOption={(props, option, { selected }) => {
+            const { key, ...rest } = props;
+            return (
+              <li key={key} {...rest}>
+                <Checkbox
+                  size="small"
+                  checked={selected}
+                  sx={{ mr: 1, p: 0.5 }}
+                />
+                {option.label}
+              </li>
+            );
+          }}
+          renderTags={(tagValue, getTagProps) =>
+            tagValue.map((option, index) => {
+              const { key, ...tagProps } = getTagProps({ index });
+              return (
+                <Chip key={key} label={option.label} size="small" {...tagProps} />
+              );
+            })
+          }
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              size="small"
+              placeholder={selectedOptions.length === 0 ? "Add watchers..." : ""}
+            />
+          )}
+        />
+      </Box>
+    </Paper>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -19,6 +19,7 @@ import {
   Autocomplete,
   Box,
   Button,
+  Checkbox,
   Chip,
   Stack,
   TextField,
@@ -90,10 +91,13 @@ export default function CaseDetailsDetailsPanel({
 
   const { data: contactsData, isLoading: isContactsLoading, isError: isContactsError } = useGetProjectContacts(projectId);
   const contactOptions = useMemo(
-    () => (contactsData ?? []).map((c) => ({
-      label: `${c.firstName} ${c.lastName}`.trim() || c.email,
-      value: c.email,
-    })),
+    () =>
+      (contactsData ?? [])
+        .filter((c) => c.isCsAdmin || c.isCsIntegrationUser || c.isPortalUser || !c.isSecurityContact)
+        .map((c) => ({
+          label: `${c.firstName} ${c.lastName}`.trim() || c.email,
+          value: c.email,
+        })),
     [contactsData],
   );
 
@@ -645,6 +649,7 @@ export default function CaseDetailsDetailsPanel({
         {isEditingWatchList ? (
           <Autocomplete
             multiple
+            disableCloseOnSelect
             loading={isContactsLoading}
             loadingText="Loading..."
             options={contactOptions}
@@ -654,6 +659,19 @@ export default function CaseDetailsDetailsPanel({
               setPendingWatchList(newValue.map((o) => o.value));
             }}
             isOptionEqualToValue={(option, val) => option.value === val.value}
+            renderOption={(props, option, { selected }) => {
+              const { key, ...rest } = props;
+              return (
+                <li key={key} {...rest}>
+                  <Checkbox
+                    size="small"
+                    checked={selected}
+                    sx={{ mr: 1, p: 0.5 }}
+                  />
+                  {option.label}
+                </li>
+              );
+            }}
             renderTags={(tagValue, getTagProps) =>
               tagValue.map((option, index) => {
                 const { key, ...tagProps } = getTagProps({ index });

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Autocomplete, Box, Button, Chip, Grid, TextField } from "@wso2/oxygen-ui";
+import { Box, Button, Grid } from "@wso2/oxygen-ui";
 import { CircleCheck } from "@wso2/oxygen-ui-icons-react";
 import {
   useState,
@@ -46,8 +46,10 @@ import type { CreateCaseRequest } from "@features/support/types/cases";
 import { BasicInformationSection } from "@features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection";
 import { CaseCreationHeader } from "@features/support/components/case-creation-layout/header/CaseCreationHeader";
 import { CaseDetailsSection } from "@features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection";
+import { WatchListSection } from "@features/support/components/case-creation-layout/form-sections/watch-list-section/WatchListSection";
 import { ConversationSummary } from "@features/support/components/case-creation-layout/form-sections/conversation-summary-section/ConversationSummary";
 import { RelatedCaseSummary } from "@features/support/components/case-creation-layout/form-sections/conversation-summary-section/RelatedCaseSummary";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import {
   buildClassificationProductLabel,
   findMatchingDeploymentLabel,
@@ -147,6 +149,9 @@ export default function CreateCasePage(): JSX.Element {
   const { data: filters, isLoading: isFiltersLoading } = useGetProjectFilters(
     projectId || "",
   );
+  const { data: projectContacts, isLoading: isContactsLoading } =
+    useGetProjectContacts(projectId || "");
+  const { data: currentUser } = useGetUserDetails();
   const [title, setTitle] = useState(() => relatedCase?.title ?? "");
   const [description, setDescription] = useState(() =>
     relatedCase ? buildRelatedCaseDescriptionHtml(relatedCase.description) : "",
@@ -155,11 +160,11 @@ export default function CreateCasePage(): JSX.Element {
   const [product, setProduct] = useState("");
   const [deployment, setDeployment] = useState("");
   const [severity, setSeverity] = useState("");
+  const [watchList, setWatchList] = useState<string[]>([]);
   const [classificationProductLabel, setClassificationProductLabel] =
     useState("");
   type AttachmentItem = { id: string; file: File };
   const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
-  const [watchList, setWatchList] = useState<string[]>([]);
   const attachmentNamesRef = useRef<Map<string, string>>(new Map());
   const attachmentIdCounterRef = useRef(0);
   const [isPreparingAttachments, setIsPreparingAttachments] = useState(false);
@@ -232,16 +237,6 @@ export default function CreateCasePage(): JSX.Element {
     });
   }, [baseProductOptions]);
 
-  const { data: contactsData, isLoading: isContactsLoading, isError: isContactsError } = useGetProjectContacts(projectId || "");
-  const contactOptions = useMemo(
-    () =>
-      (contactsData ?? []).map((c) => ({
-        label: `${c.firstName} ${c.lastName}`.trim() || c.email,
-        value: c.email,
-      })),
-    [contactsData],
-  );
-
   const { showError } = useErrorBanner();
   const { showSuccess } = useSuccessBanner();
   const { mutate: postCase, isPending: isCreatePending } = usePostCase();
@@ -256,6 +251,18 @@ export default function CreateCasePage(): JSX.Element {
       );
     }
   }, [deploymentProductsError, showError]);
+
+  useEffect(() => {
+    if (!projectContacts) return;
+    const eligibleEmails = projectContacts
+      .filter((c) => c.isCsAdmin || c.isCsIntegrationUser || c.isPortalUser || !c.isSecurityContact)
+      .map((c) => c.email);
+    const creatorEmail = currentUser?.email;
+    const merged = creatorEmail
+      ? Array.from(new Set([creatorEmail, ...eligibleEmails]))
+      : Array.from(new Set(eligibleEmails));
+    setWatchList(merged);
+  }, [projectContacts, currentUser?.email]);
 
   const hasInitializedRef = useRef(false);
   const hasClassificationAppliedRef = useRef(false);
@@ -1175,38 +1182,16 @@ export default function CreateCasePage(): JSX.Element {
             isSecurityReport={isSecurityReport}
             excludeS0={excludeS0}
             isSeverityDisabled={forceSeverityS4}
-          >
-            <Autocomplete
-              multiple
-              loading={isContactsLoading}
-              loadingText="Loading..."
-              options={contactOptions}
-              getOptionLabel={(option) => option.label}
-              value={contactOptions.filter((o) => watchList.includes(o.value))}
-              onChange={(_event, newValue) => {
-                setWatchList(newValue.map((o) => o.value));
-              }}
-              isOptionEqualToValue={(option, val) => option.value === val.value}
-              renderTags={(tagValue, getTagProps) =>
-                tagValue.map((option, index) => {
-                  const { key, ...tagProps } = getTagProps({ index });
-                  return (
-                    <Chip key={key} label={option.label} size="small" {...tagProps} />
-                  );
-                })
-              }
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Watch List"
-                  placeholder="Add watchers..."
-                  size="small"
-                  error={isContactsError}
-                  helperText={isContactsError ? "Could not load users. Please refresh and try again." : undefined}
-                />
-              )}
-            />
-          </CaseDetailsSection>
+          />
+
+          <WatchListSection
+            contacts={(projectContacts ?? []).filter(
+              (c) => c.isCsAdmin || c.isCsIntegrationUser || c.isPortalUser || !c.isSecurityContact,
+            )}
+            selectedEmails={watchList}
+            onChange={setWatchList}
+            isLoading={isContactsLoading}
+          />
 
           {/* form actions container */}
           <Box sx={{ display: "flex", justifyContent: "right" }}>


### PR DESCRIPTION
## Summary
- Pre-populate watch list on case creation with all eligible project contacts (Admin, Portal User, System User) excluding security-only users, with the creator always included
- Add a dedicated Watch List section with checkbox multi-select on the create case form
- Add checkbox multi-select to the watch list edit mode on the case details page, with the same role-based filtering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a watch list section for case creation with improved contact selection UI featuring checkboxes and a dropdown that stays open during selection.
  * Enhanced contact filtering to automatically include the current user in watch list options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->