### PR TITLE
feat(csm-portal): case management UI (cases list, detail, dashboard)

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -19,6 +19,9 @@ import { Navigate, Route, Routes } from "react-router";
 import AuthGuard from "@layouts/AuthGuard";
 import ErrorLayout from "@layouts/ErrorLayout";
 import CsmComingSoonPage from "@features/csm-coming-soon/pages/CsmComingSoonPage";
+import CsmDashboardPage from "@features/csm-dashboard/pages/CsmDashboardPage";
+import CsmCasesPage from "@features/csm-cases/pages/CsmCasesPage";
+import CsmCaseDetailPage from "@features/csm-cases/pages/CsmCaseDetailPage";
 import CsmAdminLayout from "@features/csm-admin/pages/CsmAdminLayout";
 import CsmUsersPage from "@features/csm-users/pages/CsmUsersPage";
 import CsmAccountsPage from "@features/csm-accounts/pages/CsmAccountsPage";
@@ -107,27 +110,11 @@ export default function App(): JSX.Element {
                   />
                 </Route>
 
+                <Route path="dashboard" element={<CsmDashboardPage />} />
+                <Route path="cases" element={<CsmCasesPage />} />
+                <Route path="cases/:caseId" element={<CsmCaseDetailPage />} />
+
                 {/* WIP placeholders for top-level features awaiting BFF support */}
-                <Route
-                  path="dashboard"
-                  element={
-                    <CsmComingSoonPage
-                      title="Dashboard"
-                      description="Engineer-scoped queue, recent activity, and SLA-at-risk summary across customers."
-                      blockedOn="csm-portal/backend dashboard endpoint"
-                    />
-                  }
-                />
-                <Route
-                  path="cases"
-                  element={
-                    <CsmComingSoonPage
-                      title="Cases"
-                      description="Cross-customer cases list with filters, severity, SLA timers, and comment trail."
-                      blockedOn="FE wiring for csm-portal/backend /cases endpoints"
-                    />
-                  }
-                />
                 <Route
                   path="operations"
                   element={

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Mapping helpers between backend shapes (`Be*` from `api/backend/types.ts`) and the
+ * legacy/UI shapes consumers expect. Keep mapping logic here so individual
+ * hooks stay focused on the network call.
+ */
+
+import type {
+  BeCaseComment,
+  BeCaseCommentType,
+  BeCasePriority,
+  BeCaseState,
+} from "@api/backend/types";
+import type {
+  CsmCaseComment,
+  CsmCommentAuthorRole,
+} from "@features/csm-cases/types/csmCases";
+import type {
+  CaseState,
+  Severity,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort mapping from the backend's five-step priority taxonomy onto the
+ * UI's S0-S4 severity scale. Until the BE adds explicit severity, priority
+ * doubles as the source.
+ */
+export function severityFromPriority(
+  priority: BeCasePriority | undefined,
+): Severity {
+  switch (priority) {
+    case "catastrophic":
+      return "S0";
+    case "critical":
+      return "S1";
+    case "high":
+      return "S2";
+    case "medium":
+      return "S3";
+    case "low":
+      return "S4";
+    default:
+      return "S3";
+  }
+}
+
+export function priorityFromSeverity(severity: Severity): BeCasePriority {
+  switch (severity) {
+    case "S0":
+      return "catastrophic";
+    case "S1":
+      return "critical";
+    case "S2":
+      return "high";
+    case "S3":
+      return "medium";
+    case "S4":
+      return "low";
+    default:
+      return "medium";
+  }
+}
+
+/**
+ * The backend state list and the UI state list overlap except for the trailing
+ * "ed" on `reopened`. Normalise both directions.
+ */
+export function uiStateFromBe(state: BeCaseState | undefined): CaseState {
+  switch (state) {
+    case "reopened":
+      return "reopen";
+    case "open":
+    case "work_in_progress":
+    case "waiting_on_wso2":
+    case "awaiting_info":
+    case "solution_proposed":
+    case "closed":
+      return state;
+    default:
+      return "open";
+  }
+}
+
+export function beStateFromUi(state: CaseState): BeCaseState {
+  return state === "reopen" ? "reopened" : (state as BeCaseState);
+}
+
+// ---------------------------------------------------------------------------
+// Comments
+// ---------------------------------------------------------------------------
+
+function htmlFromPlain(body: string): string {
+  const escaped = body
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\n/g, "<br/>");
+  return `<p>${escaped}</p>`;
+}
+
+export function commentTypeFromInternal(
+  internal: boolean,
+): BeCaseCommentType {
+  return internal ? "work_note" : "comment";
+}
+
+export function uiCommentFromBe(comment: BeCaseComment): CsmCaseComment {
+  const role: CsmCommentAuthorRole =
+    comment.commentType === "work_note"
+      ? "wso2_engineer"
+      : comment.commentType === "activity"
+        ? "system"
+        : "wso2_engineer";
+  return {
+    id: comment.id,
+    caseId: comment.caseId,
+    // BE returns a user id; the UI shows whatever it gets. A future user
+    // lookup can hydrate this to a display name without changing the shape.
+    authorName: comment.createdBy,
+    authorRole: role,
+    bodyHtml: htmlFromPlain(comment.body),
+    createdAt: comment.createdAt,
+    internal: comment.commentType === "work_note",
+  };
+}

--- a/apps/csm-portal/webapp/src/api/useDirectoryUsers.ts
+++ b/apps/csm-portal/webapp/src/api/useDirectoryUsers.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+
+/**
+ * Minimal user-directory entry: just what UI affordances like the cases
+ * assignee filter need. Intentionally narrower than the admin `CsmUser` so
+ * features can look up people without depending on the csm-admin module.
+ */
+export interface DirectoryUser {
+  name: string;
+  email: string;
+}
+
+const MOCK_LATENCY_MS = 150;
+
+// A small mock directory so the assignee picker is populated in mock mode
+// without coupling to the csm-admin mock data set.
+const MOCK_DIRECTORY: DirectoryUser[] = [
+  { name: "Sajith Ekanayaka", email: "sajithe@wso2.com" },
+  { name: "Renee Park", email: "renee.park@example.com" },
+  { name: "Marcus Webb", email: "marcus.webb@example.com" },
+  { name: "Lena Fischer", email: "lena.fischer@example.com" },
+  { name: "Arjun Nair", email: "arjun.nair@example.com" },
+  { name: "Priya Sharma", email: "priya.sharma@example.com" },
+];
+
+/** Raw user shape the backend may return; mapped defensively to DirectoryUser. */
+interface RawDirectoryUser {
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+}
+
+function toDirectoryUser(u: RawDirectoryUser): DirectoryUser {
+  const name =
+    u.name?.trim() ||
+    `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim();
+  return { name, email: u.email ?? "" };
+}
+
+/**
+ * Shared user-directory lookup. Backed by `POST /users/search` in live mode
+ * (the canonical backend route — there is no `GET /users`), and a small mock
+ * set under the mock toggle. Returns a lightweight {@link DirectoryUser} list.
+ */
+export function useDirectoryUsers(): UseQueryResult<DirectoryUser[], Error> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useQuery<DirectoryUser[], Error>({
+    queryKey: [ApiQueryKeys.CSM_ADMIN_USERS, "directory"],
+    queryFn: async (): Promise<DirectoryUser[]> => {
+      if (isMockMode()) {
+        logger.debug("[useDirectoryUsers] returning mock directory");
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return MOCK_DIRECTORY;
+      }
+      const res = await api.post<Record<string, never>, unknown>(
+        "/users/search",
+        {},
+      );
+      const rows: RawDirectoryUser[] = Array.isArray(res)
+        ? (res as RawDirectoryUser[])
+        : ((res as { users?: RawDirectoryUser[] })?.users ?? []);
+      return rows.map(toDirectoryUser).filter((u) => u.name);
+    },
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/components/RelativeTime.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Tooltip } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
+import { formatAbsoluteForUser } from "@utils/dateTime";
+
+interface RelativeTimeProps {
+  /** Backend timestamp string (assumed UTC if no zone is present). */
+  iso: string | null | undefined;
+  /**
+   * Optional permalink target. When provided, the time renders as an anchor
+   * (Twitter/Facebook pattern: time = permalink to the entry). May be a hash
+   * fragment (e.g. `#cmt-1001-2`) or a route.
+   */
+  href?: string;
+  /** Optional className passthrough for layout tweaks. */
+  className?: string;
+}
+
+/**
+ * Renders a relative timestamp ("7h ago") with the full absolute datetime
+ * (in the user's preferred zone) shown on hover. If `href` is provided, the
+ * text becomes a permalink to that entry.
+ */
+export default function RelativeTime({
+  iso,
+  href,
+  className,
+}: RelativeTimeProps): JSX.Element {
+  const relative = formatRelativeTime(iso);
+  const absolute = formatAbsoluteForUser(iso) ?? "Unknown time";
+
+  const inner = href ? (
+    <a
+      href={href}
+      className={className}
+      style={{
+        color: "inherit",
+        textDecoration: "none",
+        whiteSpace: "nowrap",
+        cursor: "pointer",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLAnchorElement).style.textDecoration =
+          "underline";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLAnchorElement).style.textDecoration = "none";
+      }}
+    >
+      {relative}
+    </a>
+  ) : (
+    <span className={className} style={{ whiteSpace: "nowrap" }}>
+      {relative}
+    </span>
+  );
+
+  return (
+    <Tooltip title={absolute} placement="top" arrow>
+      {inner}
+    </Tooltip>
+  );
+}

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -1,0 +1,681 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { ListPlugin } from "@lexical/react/LexicalListPlugin";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { ListItemNode, ListNode } from "@lexical/list";
+import {
+  Box,
+  Paper,
+  Typography,
+  useTheme,
+  Divider,
+  IconButton,
+  Stack,
+  Tooltip,
+} from "@wso2/oxygen-ui";
+import { Trash, ChevronLeft, ChevronRight } from "@wso2/oxygen-ui-icons-react";
+import {
+  getFileIcon,
+  scrollElement,
+  INSERT_IMAGE_COMMAND,
+} from "@components/rich-text-editor/richTextEditor";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { type ReactNode, useEffect, useState, useCallback, useMemo, useRef } from "react";
+import Toolbar, {
+  type ToolbarVariant,
+} from "@components/rich-text-editor/ToolBar";
+import type { JSX } from "react";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { ImageNode } from "@components/rich-text-editor/ImageNode";
+import ImagesPlugin from "@components/rich-text-editor/ImagesPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
+import { ClickableLinkPlugin } from "@lexical/react/LexicalClickableLinkPlugin";
+import { LinkNode } from "@lexical/link";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { CodeNode } from "@lexical/code";
+import { useLogger } from "@hooks/useLogger";
+import { $generateHtmlFromNodes, $generateNodesFromDOM } from "@lexical/html";
+import { $getRoot } from "lexical";
+import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import {
+  KEY_ENTER_COMMAND,
+  COMMAND_PRIORITY_HIGH,
+  $getSelection,
+  $isRangeSelection,
+  INSERT_PARAGRAPH_COMMAND,
+} from "lexical";
+import { $isListItemNode } from "@lexical/list";
+import { $findMatchingParent } from "@lexical/utils";
+
+/**
+ * Internal component to handle editable state changes.
+ */
+const EditableStatePlugin = ({ disabled }: { disabled: boolean }) => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    editor.setEditable(!disabled);
+  }, [editor, disabled]);
+
+  return null;
+};
+
+/**
+ * Internal component to handle initial HTML value.
+ * Injects when initialHtml is non-empty and editor root is empty (e.g. first paint or value set after mount).
+ */
+const InitialValuePlugin = ({ initialHtml }: { initialHtml?: string }) => {
+  const [editor] = useLexicalComposerContext();
+  const appliedRef = useRef(false);
+
+  useEffect(() => {
+    if (!initialHtml?.trim() || appliedRef.current) return;
+    editor.update(() => {
+      const root = $getRoot();
+      const parser = new DOMParser();
+      const dom = parser.parseFromString(initialHtml, "text/html");
+      const nodes = $generateNodesFromDOM(editor, dom);
+      root.clear();
+      root.append(...nodes);
+      appliedRef.current = true;
+    });
+  }, [editor, initialHtml]);
+
+  return null;
+};
+
+/**
+ * Internal component to handle changes and export HTML.
+ */
+const OnChangeHTMLPlugin = ({
+  onChange,
+}: {
+  onChange?: (html: string) => void;
+}) => {
+  const [editor] = useLexicalComposerContext();
+
+  return (
+    <OnChangePlugin
+      onChange={(editorState) => {
+        editorState.read(() => {
+          const html = $generateHtmlFromNodes(editor);
+          onChange?.(html);
+        });
+      }}
+    />
+  );
+};
+
+/**
+ * Plugin to handle Enter key for submit.
+ *
+ * When enterToSubmit=false (default): Ctrl+Enter / Cmd+Enter submits; plain Enter stays in editor.
+ * When enterToSubmit=true: plain Enter submits; Shift+Enter in a list inserts a new list item;
+ *   Shift+Enter outside a list passes through for a soft line break; Ctrl/Cmd+Enter is ignored.
+ */
+const EnterSubmitPlugin = ({
+  onSubmit,
+  disabled,
+  enterToSubmit = false,
+}: {
+  onSubmit?: () => void;
+  disabled?: boolean;
+  enterToSubmit?: boolean;
+}) => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (!onSubmit || disabled) return;
+
+    const unregEnter = editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (event: KeyboardEvent | null) => {
+        if (event === null) return false;
+
+        if (enterToSubmit) {
+          if (event.isComposing) return false;
+          if (event.ctrlKey || event.metaKey) return false;
+
+          if (event.shiftKey) {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              const anchorNode = selection.anchor.getNode();
+              const listItem = $findMatchingParent(anchorNode, $isListItemNode);
+              if (listItem) {
+                event.preventDefault();
+                editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+                return true;
+              }
+            }
+            return false;
+          }
+
+          event.preventDefault();
+          onSubmit();
+          return true;
+        }
+
+        if (!event.ctrlKey && !event.metaKey) return false;
+        event.preventDefault?.();
+        onSubmit();
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+
+    return unregEnter;
+  }, [editor, onSubmit, disabled, enterToSubmit]);
+
+  return null;
+};
+
+/**
+ * Internal component to handle resetting the editor.
+ */
+const ResetPlugin = ({ resetTrigger }: { resetTrigger?: number }) => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (resetTrigger !== undefined && resetTrigger > 0) {
+      editor.update(() => {
+        const root = $getRoot();
+        root.clear();
+      });
+    }
+  }, [editor, resetTrigger]);
+
+  return null;
+};
+
+/**
+ * Handles paste events containing image data (e.g. Ctrl+C from screen, then Ctrl+V).
+ * Reads the image as a data URL and inserts it via INSERT_IMAGE_COMMAND.
+ */
+const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): null => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const handlePaste = (event: ClipboardEvent) => {
+      const items = event.clipboardData?.items;
+      if (!items) return;
+
+      const MAX_PASTE_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith("image/")) {
+          const file = item.getAsFile();
+          if (!file) continue;
+
+          event.preventDefault();
+
+          if (file.size > MAX_PASTE_IMAGE_SIZE) {
+            onPasteError?.();
+            break;
+          }
+
+          const reader = new FileReader();
+          reader.onload = (e) => {
+            const src = e.target?.result;
+            if (typeof src === "string") {
+              editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+                src,
+                altText: "Pasted Image",
+              });
+            }
+          };
+          reader.readAsDataURL(file);
+          break;
+        }
+      }
+    };
+
+    return editor.registerRootListener(
+      (
+        rootElement: HTMLElement | null,
+        prevRootElement: HTMLElement | null,
+      ) => {
+        prevRootElement?.removeEventListener("paste", handlePaste);
+        rootElement?.addEventListener("paste", handlePaste);
+      },
+    );
+  }, [editor]);
+
+  return null;
+};
+
+/** Static editor config (namespace, nodes, theme). */
+const DEFAULT_EDITOR_CONFIG = {
+  namespace: "MyEditor",
+  nodes: [
+    ListNode,
+    ListItemNode,
+    ImageNode,
+    CodeNode,
+    LinkNode,
+    HeadingNode,
+    QuoteNode,
+  ],
+  theme: {
+    text: {
+      bold: "editor-text-bold",
+      italic: "editor-text-italic",
+      underline: "editor-text-underline",
+      strikethrough: "editor-text-strikethrough",
+      code: "editor-text-code",
+    },
+    list: {
+      ul: "editor-list-ul",
+      ol: "editor-list-ol",
+    },
+    link: "editor-link",
+    code: "editor-code",
+  },
+};
+
+const Editor = ({
+  onAttachmentClick,
+  attachments = [],
+  onAttachmentRemove,
+  disabled = false,
+  value,
+  onChange,
+  resetTrigger,
+  minHeight = 150,
+  showToolbar = true,
+  toolbarVariant = "full",
+  onSubmitKeyDown,
+  enterToSubmit = false,
+  placeholder = "Enter description...",
+  id,
+  showKeyboardHint = false,
+  maxHeight = "300px",
+  onFocus,
+  onBlur,
+  overlayElement,
+  onPasteError,
+}: {
+  onAttachmentClick?: () => void;
+  attachments?: File[];
+  onAttachmentRemove?: (index: number) => void;
+  disabled?: boolean;
+  value?: string;
+  onChange?: (html: string) => void;
+  resetTrigger?: number;
+  minHeight?: number | string;
+  showToolbar?: boolean;
+  toolbarVariant?: ToolbarVariant;
+  onSubmitKeyDown?: () => void;
+  enterToSubmit?: boolean;
+  placeholder?: string;
+  id?: string;
+  showKeyboardHint?: boolean;
+  maxHeight?: string | number;
+  onFocus?: () => void;
+  onBlur?: () => void;
+  /** Optional element rendered as an absolute overlay at the bottom-right inside the editor. */
+  overlayElement?: ReactNode;
+  onPasteError?: () => void;
+}): JSX.Element => {
+  const oxygenTheme = useTheme();
+  const logger = useLogger();
+
+  const memoizedEditorConfig = useMemo(
+    () => ({
+      ...DEFAULT_EDITOR_CONFIG,
+      onError: (error: Error) => {
+        logger.error("Error occurred in rich text editor", error);
+      },
+      editable: !disabled,
+    }),
+    [logger, disabled],
+  );
+
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const scrollNodeRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollRef = useCallback((node: HTMLDivElement | null) => {
+    scrollNodeRef.current = node;
+  }, []);
+
+  useEffect(() => {
+    const node = scrollNodeRef.current;
+    if (!node) return;
+    const checkScroll = () => {
+      setCanScrollLeft(node.scrollLeft > 0);
+      setCanScrollRight(
+        node.scrollLeft < node.scrollWidth - node.clientWidth - 1,
+      );
+    };
+    checkScroll();
+    node.addEventListener("scroll", checkScroll);
+    window.addEventListener("resize", checkScroll);
+    return () => {
+      node.removeEventListener("scroll", checkScroll);
+      window.removeEventListener("resize", checkScroll);
+    };
+  }, [attachments.length]);
+
+  const scrollAttachments = useCallback((direction: "left" | "right") => {
+    scrollElement(scrollNodeRef, direction);
+  }, []);
+
+  const editorInputDynamicSx = useMemo(() => {
+    const unbounded =
+      maxHeight === "none" ||
+      maxHeight === "unset" ||
+      (typeof maxHeight === "string" &&
+        maxHeight.trim().toLowerCase() === "none");
+    return {
+      maxHeight:
+        typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight,
+      overflowY: (unbounded ? "visible" : "auto") as "visible" | "auto",
+    };
+  }, [maxHeight]);
+
+  return (
+    <LexicalComposer initialConfig={memoizedEditorConfig}>
+      <Paper
+        variant="outlined"
+        sx={{
+          p: 2,
+          borderColor: disabled ? "action.disabled" : "divider",
+          transition: "border-color 0.2s",
+          "&:hover:not(:focus-within)": {
+            borderColor: disabled ? "action.disabled" : "text.primary",
+          },
+
+          "&:focus-within": {
+            borderWidth: "2px",
+            borderColor: "primary.main",
+          },
+        }}
+      >
+        <EditableStatePlugin disabled={disabled} />
+        {showToolbar && (
+          <>
+            <Toolbar
+              onAttachmentClick={onAttachmentClick}
+              disabled={disabled}
+              variant={toolbarVariant}
+              showKeyboardHint={showKeyboardHint}
+              enterToSubmit={enterToSubmit}
+            />
+            <Divider sx={{ my: 1 }} />
+          </>
+        )}
+        <Box
+          onFocus={onFocus}
+          onBlur={onBlur}
+          sx={{
+            position: "relative",
+            minHeight,
+            "& .editor-input": {
+              outline: "none",
+              minHeight:
+                typeof minHeight === "number" ? `${minHeight}px` : minHeight,
+              padding: 0,
+              ...editorInputDynamicSx,
+              ...oxygenTheme.typography.body2,
+              color: disabled ? "text.disabled" : "text.primary",
+              "& p": {
+                margin: 0,
+                padding: 0,
+              },
+              "& > p:only-child > br:only-child": {
+                display: "none",
+              },
+            },
+            "& .editor-text-bold": {
+              fontWeight: oxygenTheme.typography.fontWeightBold || "bold",
+            },
+            "& .editor-text-italic": { fontStyle: "italic" },
+            "& .editor-text-underline": { textDecoration: "underline" },
+            "& .editor-text-strikethrough": {
+              textDecoration: "line-through",
+            },
+            "& .editor-list-ul": { ml: 3, listStyleType: "disc" },
+            "& .editor-list-ol": { ml: 3, listStyleType: "decimal" },
+            "& .editor-link": {
+              color: "primary.main",
+              textDecoration: "underline",
+              "&:hover": {
+                textDecoration: "none",
+              },
+            },
+            "& .editor-code": {
+              backgroundColor: "background.default",
+              color: "text.primary",
+              fontFamily: "monospace",
+              display: "block",
+              padding: "8px 16px",
+              lineHeight: 1.5,
+              margin: "8px 0",
+              overflowX: "auto",
+              borderRadius: 1,
+              border: "1px solid",
+              borderColor: "divider",
+            },
+          }}
+        >
+          <RichTextPlugin
+            contentEditable={
+              <ContentEditable
+                id={id}
+                className="editor-input"
+                data-testid="case-description-editor"
+              />
+            }
+            placeholder={
+              <Typography
+                variant="body2"
+                sx={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  color: "text.secondary",
+                  opacity: 0.7,
+                  pointerEvents: "none",
+                  userSelect: "none",
+                  margin: 0,
+                  padding: 0,
+                  ...oxygenTheme.typography.body2,
+                }}
+              >
+                {placeholder}
+              </Typography>
+            }
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+          <HistoryPlugin />
+          <ListPlugin />
+          <ImagesPlugin />
+          <ClipboardImagePlugin onPasteError={onPasteError} />
+          <LinkPlugin />
+          <ClickableLinkPlugin />
+          <InitialValuePlugin initialHtml={value} />
+          <OnChangeHTMLPlugin onChange={onChange} />
+          <ResetPlugin resetTrigger={resetTrigger} />
+          <EnterSubmitPlugin onSubmit={onSubmitKeyDown} disabled={disabled} enterToSubmit={enterToSubmit} />
+        </Box>
+        {overlayElement && (
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              mt: 1,
+            }}
+          >
+            {overlayElement}
+          </Box>
+        )}
+        {attachments.length > 0 && (
+          <>
+            <Divider sx={{ my: 1.5 }} />
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 1,
+              }}
+            >
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 500 }}
+              >
+                Attachments ({attachments.length})
+              </Typography>
+              <Box
+                sx={{
+                  position: "relative",
+                  width: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                {canScrollLeft && (
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      mr: 0.5,
+                      flexShrink: 0,
+                    }}
+                  >
+                    <IconButton
+                      size="small"
+                      onClick={() => scrollAttachments("left")}
+                      aria-label="Scroll attachments left"
+                      sx={{
+                        color: "text.secondary",
+                        "&:hover": {
+                          color: "primary.main",
+                          bgcolor: "action.hover",
+                        },
+                      }}
+                    >
+                      <ChevronLeft size={16} />
+                    </IconButton>
+                  </Box>
+                )}
+
+                <Box
+                  ref={scrollRef}
+                  sx={{
+                    overflowX: "auto",
+                    overflowY: "hidden",
+                    width: "100%",
+                    msOverflowStyle: "none",
+                    scrollbarWidth: "none",
+                    "&::-webkit-scrollbar": {
+                      display: "none",
+                    },
+                  }}
+                >
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{
+                      flexWrap: "nowrap",
+                      gap: 1,
+                      width: "max-content",
+                    }}
+                  >
+                    {attachments.map((file, index) => (
+                      <Paper
+                        key={`${file.name}-${index}`}
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                          p: 0.75,
+                          pl: 1,
+                          pr: 0.5,
+                          transition: "all 0.2s",
+                          flexShrink: 0,
+                        }}
+                      >
+                        {getFileIcon(file, oxygenTheme)}
+                        <Tooltip title={file.name} placement="top">
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              maxWidth: 150,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                              fontWeight: 500,
+                            }}
+                          >
+                            {file.name}
+                          </Typography>
+                        </Tooltip>
+                        <IconButton
+                          size="small"
+                          onClick={() => onAttachmentRemove?.(index)}
+                          aria-label={`Remove attachment ${index + 1}`}
+                          sx={{
+                            p: 0.25,
+                            color: "text.secondary",
+                            "&:hover": { color: "error.main" },
+                          }}
+                        >
+                          <Trash size={14} />
+                        </IconButton>
+                      </Paper>
+                    ))}
+                  </Stack>
+                </Box>
+
+                {canScrollRight && (
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      ml: 0.5,
+                      flexShrink: 0,
+                    }}
+                  >
+                    <IconButton
+                      size="small"
+                      onClick={() => scrollAttachments("right")}
+                      aria-label="Scroll attachments right"
+                      sx={{
+                        color: "text.secondary",
+                        "&:hover": {
+                          color: "primary.main",
+                          bgcolor: "action.hover",
+                        },
+                      }}
+                    >
+                      <ChevronRight size={16} />
+                    </IconButton>
+                  </Box>
+                )}
+              </Box>
+            </Box>
+          </>
+        )}
+      </Paper>
+    </LexicalComposer>
+  );
+};
+
+export default Editor;

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/ImageNode.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/ImageNode.tsx
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  DecoratorNode,
+  $getNodeByKey,
+  type DOMConversionMap,
+  type EditorConfig,
+  type LexicalEditor,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from "lexical";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import type { JSX } from "react";
+import { deriveAltFromFilename, sanitizeUrl } from "@components/rich-text-editor/richTextEditor";
+
+function ImageComponent({
+  src,
+  altText,
+  nodeKey,
+}: {
+  src: string;
+  altText: string;
+  nodeKey: NodeKey;
+}): JSX.Element {
+  const [editor] = useLexicalComposerContext();
+
+  const handleRemove = () => {
+    editor.update(() => {
+      $getNodeByKey(nodeKey)?.remove();
+    });
+  };
+
+  return (
+    <span style={{ position: "relative", display: "block" }}>
+      <img
+        src={sanitizeUrl(src)}
+        alt={altText}
+        style={{ maxWidth: "100%", borderRadius: "8px", display: "block" }}
+      />
+      <button
+        type="button"
+        onClick={handleRemove}
+        aria-label="Remove image"
+        style={{
+          position: "absolute",
+          top: 4,
+          right: 4,
+          width: 22,
+          height: 22,
+          borderRadius: "50%",
+          border: "solid",
+          background: "rgba(0,0,0,0.55)",
+          color: "#fff",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 14,
+          lineHeight: 1,
+          padding: 0,
+          opacity: 1,
+          pointerEvents: "auto",
+        }}
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+export type SerializedImageNode = Spread<
+  {
+    src: string;
+    altText: string;
+  },
+  SerializedLexicalNode
+>;
+
+export class ImageNode extends DecoratorNode<JSX.Element> {
+  __src: string;
+  __altText: string;
+
+  static getType(): string {
+    return "image";
+  }
+
+  static clone(node: ImageNode): ImageNode {
+    return new ImageNode(node.__src, node.__altText, node.__key);
+  }
+
+  // 1. How Lexical turns JSON back into a Class
+  static importJSON(serializedNode: SerializedImageNode): ImageNode {
+    const { src, altText } = serializedNode;
+    return $createImageNode(sanitizeUrl(src), altText);
+  }
+
+  constructor(src: string, altText: string, key?: NodeKey) {
+    super(key);
+    this.__src = src;
+    this.__altText = altText;
+  }
+
+  exportJSON(): SerializedImageNode {
+    return {
+      type: "image",
+      version: 1,
+      src: this.__src,
+      altText: this.__altText,
+    };
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    void config;
+    const span = document.createElement("span");
+    span.style.display = "block";
+    return span;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(editor: LexicalEditor): { element: HTMLElement | null } {
+    void editor;
+    const img = document.createElement("img");
+    img.setAttribute("src", sanitizeUrl(this.__src));
+    img.setAttribute("alt", this.__altText);
+    img.style.maxWidth = "100%";
+    img.style.borderRadius = "8px";
+    img.style.display = "block";
+    return { element: img };
+  }
+
+  static importDOM(): DOMConversionMap<HTMLElement> | null {
+    return {
+      img: () => ({
+        conversion: (element: HTMLElement) => {
+          const raw = element.getAttribute("src") ?? "";
+          const src = sanitizeUrl(raw);
+          const alt =
+            element.getAttribute("alt") ?? deriveAltFromFilename(raw);
+          if (!src) return null;
+          return { node: $createImageNode(src, alt) };
+        },
+        priority: 1,
+      }),
+    };
+  }
+
+  decorate(): JSX.Element {
+    return (
+      <ImageComponent
+        src={this.__src}
+        altText={this.__altText}
+        nodeKey={this.__key}
+      />
+    );
+  }
+}
+
+export function $createImageNode(src: string, altText: string): ImageNode {
+  return new ImageNode(sanitizeUrl(src), altText);
+}

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/ImagesPlugin.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/ImagesPlugin.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  COMMAND_PRIORITY_EDITOR,
+  $insertNodes,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $createParagraphNode,
+  $isRootOrShadowRoot,
+} from "lexical";
+import { useEffect } from "react";
+import { $createImageNode } from "@components/rich-text-editor/ImageNode";
+import {
+  INSERT_IMAGE_COMMAND,
+  deriveAltFromFilename,
+  type InsertImagePayload,
+} from "@components/rich-text-editor/richTextEditor";
+
+function getPayloadSrc(payload: string | InsertImagePayload): string {
+  return typeof payload === "string" ? payload : payload.src;
+}
+
+function getPayloadAltText(payload: string | InsertImagePayload): string {
+  if (typeof payload === "string") {
+    return deriveAltFromFilename(payload) || "Uploaded Image";
+  }
+  return (
+    payload.altText || deriveAltFromFilename(payload.src) || "Uploaded Image"
+  );
+}
+
+export default function ImagesPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      INSERT_IMAGE_COMMAND,
+      (payload) => {
+        const src = getPayloadSrc(payload);
+        const altText = getPayloadAltText(payload);
+        const imageNode = $createImageNode(src, altText);
+
+        // If the editor is empty or has no range selection, move cursor to end first
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          const root = $getRoot();
+          const lastChild = root.getLastChild();
+          if (lastChild) {
+            lastChild.selectEnd();
+          } else {
+            root.selectEnd();
+          }
+        }
+
+        $insertNodes([imageNode]);
+
+        // After inserting a DecoratorNode the cursor is "at" the image and
+        // not in a text-editable position. Ensure a paragraph exists after
+        // the image and move the cursor there so the user can keep typing.
+        const parent = imageNode.getParentOrThrow();
+        if ($isRootOrShadowRoot(parent)) {
+          const nextSibling = imageNode.getNextSibling();
+          if (!nextSibling) {
+            const paragraph = $createParagraphNode();
+            imageNode.insertAfter(paragraph);
+            paragraph.select();
+          } else {
+            nextSibling.selectStart();
+          }
+        }
+
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    );
+  }, [editor]);
+
+  return null;
+}

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/ToolBar.tsx
@@ -1,0 +1,881 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  $createRangeSelection,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  FORMAT_ELEMENT_COMMAND,
+  FORMAT_TEXT_COMMAND,
+  type ElementFormatType,
+  INDENT_CONTENT_COMMAND,
+  OUTDENT_CONTENT_COMMAND,
+  SELECTION_CHANGE_COMMAND,
+  COMMAND_PRIORITY_CRITICAL,
+  UNDO_COMMAND,
+  REDO_COMMAND,
+  CAN_UNDO_COMMAND,
+  CAN_REDO_COMMAND,
+} from "lexical";
+import {
+  INSERT_ORDERED_LIST_COMMAND,
+  INSERT_UNORDERED_LIST_COMMAND,
+} from "@lexical/list";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  ToggleButton,
+  Stack,
+  Divider,
+  Tooltip,
+  Box,
+  useTheme,
+  Popover,
+  TextField,
+  Button,
+  IconButton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useEffect, useState, useCallback, useRef } from "react";
+import {
+  Bold,
+  Italic,
+  Underline,
+  Strikethrough,
+  List,
+  ListOrdered,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+  ImageIcon,
+  Code,
+  Link as LinkIcon,
+  Indent,
+  Outdent,
+  Undo as UndoIcon,
+  Redo as RedoIcon,
+  Paperclip,
+  ChevronLeft,
+  ChevronRight,
+} from "@wso2/oxygen-ui-icons-react";
+import { mergeRegister } from "@lexical/utils";
+import {
+  MAX_IMAGE_SIZE_BYTES,
+  RICH_TEXT_BLOCK_TAGS,
+} from "@components/rich-text-editor/richTextConstants";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import {
+  INSERT_IMAGE_COMMAND,
+  scrollElement,
+  sanitizeUrl,
+} from "@components/rich-text-editor/richTextEditor";
+import { $createCodeNode, $isCodeNode } from "@lexical/code";
+import { $patchStyleText, $setBlocksType } from "@lexical/selection";
+import { TOGGLE_LINK_COMMAND, $isLinkNode } from "@lexical/link";
+import {
+  $createHeadingNode,
+  $createQuoteNode,
+  $isHeadingNode,
+  $isQuoteNode,
+} from "@lexical/rich-text";
+import { $createParagraphNode } from "lexical";
+
+export type ToolbarVariant = "full" | "describeIssue";
+
+const Toolbar = ({
+  onAttachmentClick,
+  disabled = false,
+  variant = "full",
+  showKeyboardHint = false,
+  enterToSubmit = false,
+}: {
+  onAttachmentClick?: () => void;
+  disabled?: boolean;
+  variant?: ToolbarVariant;
+  showKeyboardHint?: boolean;
+  enterToSubmit?: boolean;
+}) => {
+  const isDescribeIssue = variant === "describeIssue";
+  const [editor] = useLexicalComposerContext();
+  const theme = useTheme();
+  const { showError } = useErrorBanner();
+
+  const [isBold, setIsBold] = useState(false);
+  const [isItalic, setIsItalic] = useState(false);
+  const [isUnderline, setIsUnderline] = useState(false);
+  const [isStrikethrough, setIsStrikethrough] = useState(false);
+  const [isLink, setIsLink] = useState(false);
+  const [isCode, setIsCode] = useState(false);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const [blockVariant, setBlockVariant] = useState("body1");
+  const [elementAlign, setElementAlign] = useState<ElementFormatType>("");
+  const [hasContent, setHasContent] = useState(false);
+
+  const [linkAnchorEl, setLinkAnchorEl] = useState<HTMLButtonElement | null>(
+    null,
+  );
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkText, setLinkText] = useState("");
+
+  // Focus editor helper
+  const focusEditor = useCallback(() => {
+    editor.focus();
+  }, [editor]);
+
+  const updateToolbar = useCallback(() => {
+    setHasContent($getRoot().getTextContent().length > 0);
+    const selection = $getSelection();
+    if ($isRangeSelection(selection)) {
+      setIsBold(selection.hasFormat("bold"));
+      setIsItalic(selection.hasFormat("italic"));
+      setIsUnderline(selection.hasFormat("underline"));
+      setIsStrikethrough(selection.hasFormat("strikethrough"));
+
+      const node = selection.anchor.getNode();
+      const parent = node?.getParent();
+      setIsLink($isLinkNode(parent) || $isLinkNode(node));
+
+      let element: ReturnType<typeof selection.anchor.getNode>;
+      try {
+        element =
+          selection.anchor.type === "element"
+            ? selection.anchor.getNode()
+            : selection.anchor.getNode().getTopLevelElementOrThrow();
+      } catch {
+        setBlockVariant("body1");
+        setIsCode(false);
+        setElementAlign("");
+        return;
+      }
+      setIsCode($isCodeNode(element));
+
+      const formatType =
+        "getFormatType" in element &&
+        typeof element.getFormatType === "function"
+          ? (element.getFormatType() as ElementFormatType)
+          : "";
+      setElementAlign(formatType);
+
+      if ($isHeadingNode(element)) {
+        setBlockVariant(element.getTag());
+      } else if ($isQuoteNode(element)) {
+        setBlockVariant("quote");
+      } else if ($isCodeNode(element)) {
+        setBlockVariant("body1");
+      } else {
+        setBlockVariant("body1");
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        SELECTION_CHANGE_COMMAND,
+        () => {
+          updateToolbar();
+          return false;
+        },
+        COMMAND_PRIORITY_CRITICAL,
+      ),
+      editor.registerUpdateListener(({ editorState }) => {
+        editorState.read(() => {
+          updateToolbar();
+        });
+      }),
+      editor.registerCommand(
+        CAN_UNDO_COMMAND,
+        (payload: boolean) => {
+          setCanUndo(payload);
+          return false;
+        },
+        COMMAND_PRIORITY_CRITICAL,
+      ),
+      editor.registerCommand(
+        CAN_REDO_COMMAND,
+        (payload: boolean) => {
+          setCanRedo(payload);
+          return false;
+        },
+        COMMAND_PRIORITY_CRITICAL,
+      ),
+    );
+  }, [editor, updateToolbar]);
+
+  const onFormatText = (
+    format: "bold" | "italic" | "underline" | "strikethrough",
+  ) => {
+    focusEditor();
+    editor.dispatchCommand(FORMAT_TEXT_COMMAND, format);
+  };
+
+  const onFormatAlign = (format: ElementFormatType) => {
+    focusEditor();
+    editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, format);
+  };
+
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+
+  const onImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    focusEditor();
+    const file = e.target.files?.[0];
+    if (file) {
+      const resetInput = () => {
+        if (imageInputRef.current) imageInputRef.current.value = "";
+      };
+      if (file.size > MAX_IMAGE_SIZE_BYTES) {
+        showError(
+          `Image "${file.name}" exceeds the maximum allowed size of ${MAX_IMAGE_SIZE_BYTES / (1024 * 1024)}MB. Please choose a smaller file.`,
+        );
+        resetInput();
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === "string") {
+          editor.focus(() => {
+            editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+              src: reader.result as string,
+              altText: file.name,
+            });
+          });
+        }
+        resetInput();
+      };
+      reader.onerror = () => {
+        showError(
+          `Failed to read image file "${file.name}". Please try again.`,
+        );
+        resetInput();
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const onFormatCode = () => {
+    focusEditor();
+    editor.update(() => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        if (isCode) {
+          $setBlocksType(selection, () => $createParagraphNode());
+        } else {
+          $setBlocksType(selection, () => $createCodeNode());
+        }
+      }
+    });
+  };
+
+  const onBlockChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    focusEditor();
+    const blockType = e.target.value;
+    setBlockVariant(blockType);
+    editor.update(() => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        if (blockType.startsWith("h")) {
+          const level = parseInt(blockType.substring(1)) as
+            | 1
+            | 2
+            | 3
+            | 4
+            | 5
+            | 6;
+          $setBlocksType(selection, () =>
+            $createHeadingNode(
+              `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6",
+            ),
+          );
+          $patchStyleText(selection, { "font-size": null });
+        } else if (blockType === "quote") {
+          $setBlocksType(selection, () => $createQuoteNode());
+          $patchStyleText(selection, { "font-size": null });
+        } else {
+          $setBlocksType(selection, () => $createParagraphNode());
+          const typo = theme.typography[
+            blockType as keyof typeof theme.typography
+          ] as { fontSize?: string | number };
+          const fontSize = typo?.fontSize ?? theme.typography.body1.fontSize;
+          $patchStyleText(selection, { "font-size": String(fontSize) });
+        }
+      }
+    });
+  };
+
+  const onLinkClick = (event: React.MouseEvent<HTMLElement>) => {
+    focusEditor();
+    if (isLink) {
+      editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
+    } else {
+      setLinkAnchorEl(event.currentTarget as HTMLButtonElement);
+      const selection = editor.getEditorState().read(() => $getSelection());
+      if ($isRangeSelection(selection)) {
+        setLinkText(selection.getTextContent());
+      }
+    }
+  };
+
+  const onLinkSubmit = () => {
+    focusEditor();
+    const sanitized = sanitizeUrl(linkUrl);
+    if (sanitized) {
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          if (linkText && linkText !== selection.getTextContent()) {
+            selection.insertText(linkText);
+            const afterInsert = $getSelection();
+            if ($isRangeSelection(afterInsert)) {
+              const endKey = afterInsert.anchor.key;
+              const endOffset = afterInsert.anchor.offset;
+              const startOffset = Math.max(0, endOffset - linkText.length);
+              const rangeSelection = $createRangeSelection();
+              rangeSelection.anchor.set(endKey, startOffset, "text");
+              rangeSelection.focus.set(endKey, endOffset, "text");
+              $setSelection(rangeSelection);
+            }
+          }
+          editor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitized);
+        }
+      });
+    }
+    setLinkAnchorEl(null);
+    setLinkUrl("");
+    setLinkText("");
+  };
+
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const toolbarScrollRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollRef = useCallback((node: HTMLDivElement | null) => {
+    toolbarScrollRef.current = node;
+  }, []);
+
+  useEffect(() => {
+    const node = toolbarScrollRef.current;
+    if (!node) return;
+    const checkScroll = () => {
+      setCanScrollLeft(node.scrollLeft > 0);
+      setCanScrollRight(
+        node.scrollLeft < node.scrollWidth - node.clientWidth - 1,
+      );
+    };
+    checkScroll();
+    node.addEventListener("scroll", checkScroll);
+    window.addEventListener("resize", checkScroll);
+    return () => {
+      node.removeEventListener("scroll", checkScroll);
+      window.removeEventListener("resize", checkScroll);
+    };
+  }, []);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    scrollElement(toolbarScrollRef, direction);
+  }, []);
+
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        opacity: disabled ? 0.5 : 1,
+        transition: "opacity 0.2s",
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        mb: 1, // Move margin here
+      }}
+    >
+      {canScrollLeft && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            mr: 0.5,
+            flexShrink: 0,
+          }}
+        >
+          <IconButton
+            size="small"
+            onClick={() => scroll("left")}
+            aria-label="Scroll toolbar left"
+            sx={{
+              color: "text.secondary",
+              "&:hover": { color: "primary.main", bgcolor: "action.hover" },
+            }}
+          >
+            <ChevronLeft size={16} />
+          </IconButton>
+        </Box>
+      )}
+
+      <Box
+        ref={scrollRef}
+        sx={{
+          overflowX: "auto",
+          overflowY: "hidden",
+          flex: 1,
+          minWidth: 0,
+          msOverflowStyle: "none",
+          scrollbarWidth: "none",
+          "&::-webkit-scrollbar": {
+            display: "none",
+          },
+        }}
+      >
+        <Stack
+          direction="row"
+          spacing={0.25}
+          sx={{
+            flexWrap: "nowrap",
+            gap: 0.25,
+            width: "max-content",
+            ...(disabled && { pointerEvents: "none" }),
+          }}
+        >
+          <Tooltip title="Undo">
+            <span>
+              <ToggleButton
+                size="small"
+                value="undo"
+                disabled={!canUndo}
+                onClick={() => {
+                  focusEditor();
+                  editor.dispatchCommand(UNDO_COMMAND, undefined);
+                }}
+              >
+                <UndoIcon size={16} />
+              </ToggleButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Redo">
+            <span>
+              <ToggleButton
+                size="small"
+                value="redo"
+                disabled={!canRedo}
+                onClick={() => {
+                  focusEditor();
+                  editor.dispatchCommand(REDO_COMMAND, undefined);
+                }}
+              >
+                <RedoIcon size={16} />
+              </ToggleButton>
+            </span>
+          </Tooltip>
+
+          {!isDescribeIssue && (
+            <>
+              <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+
+              <Tooltip title="Font variant">
+                <Box
+                  component="span"
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                  }}
+                >
+                  <select
+                    aria-label="Font variant"
+                    value={blockVariant}
+                    onChange={onBlockChange}
+                    onClick={(e) => e.stopPropagation()}
+                    style={{
+                      height: 28,
+                      padding: "0 4px",
+                      fontSize: theme.typography.body2.fontSize as string,
+                      border: `1px solid ${theme.palette.divider}`,
+                      borderRadius: 4,
+                      backgroundColor: "transparent",
+                      color: "inherit",
+                      cursor: "pointer",
+                      outline: "none",
+                    }}
+                  >
+                    {[
+                      ...RICH_TEXT_BLOCK_TAGS,
+                      {
+                        value: "quote",
+                        label: "Quote",
+                        variant: "quote" as const,
+                      },
+                    ].map(({ value, label }) => (
+                      <option
+                        key={value}
+                        value={value}
+                        style={{
+                          backgroundColor: theme.palette.background.paper,
+                          color: theme.palette.text.primary,
+                        }}
+                      >
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+                </Box>
+              </Tooltip>
+
+              <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+            </>
+          )}
+
+          <Tooltip title="Bold">
+            <ToggleButton
+              size="small"
+              value="bold"
+              selected={isBold}
+              onClick={() => onFormatText("bold")}
+            >
+              <Bold size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Italic">
+            <ToggleButton
+              size="small"
+              value="italic"
+              selected={isItalic}
+              onClick={() => onFormatText("italic")}
+            >
+              <Italic size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Underline">
+            <ToggleButton
+              size="small"
+              value="underline"
+              selected={isUnderline}
+              onClick={() => onFormatText("underline")}
+            >
+              <Underline size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Strikethrough">
+            <ToggleButton
+              size="small"
+              value="strikethrough"
+              selected={isStrikethrough}
+              onClick={() => onFormatText("strikethrough")}
+            >
+              <Strikethrough size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+
+          <Tooltip title="Align Left">
+            <ToggleButton
+              size="small"
+              value="left"
+              selected={
+                elementAlign === "left" || (elementAlign === "" && hasContent)
+              }
+              onClick={() => onFormatAlign("left")}
+            >
+              <AlignLeft size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Align Center">
+            <ToggleButton
+              size="small"
+              value="center"
+              selected={elementAlign === "center"}
+              onClick={() => onFormatAlign("center")}
+            >
+              <AlignCenter size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Align Right">
+            <ToggleButton
+              size="small"
+              value="right"
+              selected={elementAlign === "right"}
+              onClick={() => onFormatAlign("right")}
+            >
+              <AlignRight size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Justify">
+            <ToggleButton
+              size="small"
+              value="justify"
+              selected={elementAlign === "justify"}
+              onClick={() => onFormatAlign("justify")}
+            >
+              <AlignJustify size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+
+          <Tooltip title="Indent">
+            <ToggleButton
+              size="small"
+              value="indent"
+              onClick={() => {
+                focusEditor();
+                editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+              }}
+            >
+              <Indent size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Outdent">
+            <ToggleButton
+              size="small"
+              value="outdent"
+              onClick={() => {
+                focusEditor();
+                editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+              }}
+            >
+              <Outdent size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+
+          <Tooltip title="Bullet List">
+            <ToggleButton
+              size="small"
+              value="bullet"
+              onClick={() => {
+                focusEditor();
+                editor.dispatchCommand(
+                  INSERT_UNORDERED_LIST_COMMAND,
+                  undefined,
+                );
+              }}
+            >
+              <List size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Tooltip title="Numbered List">
+            <ToggleButton
+              size="small"
+              value="numbered"
+              onClick={() => {
+                focusEditor();
+                editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
+              }}
+            >
+              <ListOrdered size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+
+          <Tooltip title="Link">
+            <ToggleButton
+              size="small"
+              value="link"
+              selected={isLink}
+              onClick={onLinkClick}
+            >
+              <LinkIcon size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          <Popover
+            open={Boolean(linkAnchorEl)}
+            anchorEl={linkAnchorEl}
+            onClose={() => setLinkAnchorEl(null)}
+            anchorOrigin={{
+              vertical: "bottom",
+              horizontal: "left",
+            }}
+            PaperProps={{
+              sx: { borderRadius: 2, boxShadow: theme.shadows[3] },
+            }}
+          >
+            <Box
+              sx={{
+                p: 1.5,
+                display: "flex",
+                flexDirection: "column",
+                gap: 1.5,
+              }}
+            >
+              <TextField
+                label="URL"
+                size="small"
+                fullWidth
+                value={linkUrl}
+                onChange={(e) => setLinkUrl(e.target.value)}
+                autoFocus
+                slotProps={{
+                  input: { sx: { fontSize: "0.8125rem" } },
+                  inputLabel: { sx: { fontSize: "0.8125rem" } },
+                }}
+              />
+              <TextField
+                label="Text (Optional)"
+                size="small"
+                fullWidth
+                value={linkText}
+                onChange={(e) => setLinkText(e.target.value)}
+                slotProps={{
+                  input: { sx: { fontSize: "0.8125rem" } },
+                  inputLabel: { sx: { fontSize: "0.8125rem" } },
+                }}
+              />
+              <Button
+                variant="contained"
+                size="small"
+                onClick={onLinkSubmit}
+                disabled={!linkUrl}
+                fullWidth
+                sx={{ textTransform: "none", py: 0.5 }}
+              >
+                Add Link
+              </Button>
+            </Box>
+          </Popover>
+
+          <Tooltip title="Code Snippet">
+            <ToggleButton
+              size="small"
+              value="code"
+              selected={isCode}
+              onClick={onFormatCode}
+            >
+              <Code size={16} />
+            </ToggleButton>
+          </Tooltip>
+
+          {!isDescribeIssue && (
+            <>
+              <Tooltip title="Upload Image">
+                <ToggleButton size="small" component="label" value="image">
+                  <ImageIcon size={16} />
+                  <input
+                    ref={imageInputRef}
+                    type="file"
+                    hidden
+                    accept="image/*"
+                    onChange={onImageUpload}
+                  />
+                </ToggleButton>
+              </Tooltip>
+
+              {onAttachmentClick && (
+                <Tooltip title="Attach File">
+                  <ToggleButton
+                    size="small"
+                    value="attachment"
+                    onClick={() => {
+                      focusEditor();
+                      onAttachmentClick();
+                    }}
+                  >
+                    <Paperclip size={16} />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Stack>
+      </Box>
+
+      {canScrollRight && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            ml: 0.5,
+            flexShrink: 0,
+          }}
+        >
+          <IconButton
+            size="small"
+            onClick={() => scroll("right")}
+            aria-label="Scroll toolbar right"
+            sx={{
+              color: "text.secondary",
+              "&:hover": { color: "primary.main", bgcolor: "action.hover" },
+            }}
+          >
+            <ChevronRight size={16} />
+          </IconButton>
+        </Box>
+      )}
+
+      {showKeyboardHint && !disabled && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            flexShrink: 0,
+            pl: 1,
+          }}
+        >
+          {enterToSubmit ? (
+            <Typography
+              component="span"
+              variant="caption"
+              sx={{
+                color: "text.secondary",
+                whiteSpace: "nowrap",
+                lineHeight: 1.4,
+              }}
+            >
+              <Typography component="span" variant="caption" fontWeight={600}>
+                Shift+Enter
+              </Typography>
+              {" for new line and "}
+              <Typography component="span" variant="caption" fontWeight={600}>
+                Enter
+              </Typography>
+              {" to send"}
+            </Typography>
+          ) : (
+            <Typography
+              component="span"
+              variant="caption"
+              sx={{
+                color: "text.secondary",
+                whiteSpace: "nowrap",
+                lineHeight: 1.4,
+              }}
+            >
+              <Typography component="span" variant="caption" fontWeight={600}>
+                Ctrl+Enter
+              </Typography>
+              {" (or "}
+              <Typography component="span" variant="caption" fontWeight={600}>
+                ⌘+Enter
+              </Typography>
+              {") to send"}
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default Toolbar;

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/richTextConstants.ts
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/richTextConstants.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Constants for the shared rich text editor. Relocated here from the support
+// feature so the shared editor no longer imports from `@features/support`.
+
+// Maximum allowed embedded image size in bytes (10MB for base64 images).
+export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
+
+export type RichTextBlockVariant =
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "subtitle1"
+  | "subtitle2"
+  | "body1"
+  | "body2"
+  | "caption";
+
+export const RICH_TEXT_BLOCK_TAGS: Array<{
+  value: string;
+  label: string;
+  variant: RichTextBlockVariant;
+}> = [
+  { value: "h1", label: "Heading 1", variant: "h1" },
+  { value: "h2", label: "Heading 2", variant: "h2" },
+  { value: "h3", label: "Heading 3", variant: "h3" },
+  { value: "h4", label: "Heading 4", variant: "h4" },
+  { value: "h5", label: "Heading 5", variant: "h5" },
+  { value: "h6", label: "Heading 6", variant: "h6" },
+  { value: "subtitle1", label: "Subtitle 1", variant: "subtitle1" },
+  { value: "subtitle2", label: "Subtitle 2", variant: "subtitle2" },
+  { value: "body1", label: "Body 1", variant: "body1" },
+  { value: "body2", label: "Body 2", variant: "body2" },
+  { value: "caption", label: "Caption", variant: "caption" },
+];

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type ReactElement, type RefObject } from "react";
+import { type Theme } from "@wso2/oxygen-ui";
+import {
+  File as FileIcon,
+  FileArchive,
+  FileCode,
+  FileImage,
+  FileText,
+} from "@wso2/oxygen-ui-icons-react";
+import { createCommand, type LexicalCommand } from "lexical";
+
+/** Payload for `INSERT_IMAGE_COMMAND` in the shared rich text editor. */
+export type InsertImagePayload = {
+  src: string;
+  altText?: string;
+};
+
+/**
+ * Derives alt text from a URL or filename (e.g. "image.png" -> "image", "/path/to/photo.jpg" -> "photo").
+ * Handles absolute URLs, relative paths, and plain filenames.
+ */
+export function deriveAltFromFilename(src: string): string {
+  try {
+    const url = new URL(src);
+    const path = url.pathname || "";
+    const match = path.match(/\/([^/]+)$/);
+    const name = (match?.[1] ?? path) || "Image";
+    const base = name.replace(/\.[^.]+$/, "");
+    return base ? base : "Image";
+  } catch {
+    const pathOnly = src.split("?")[0].split("#")[0].trim();
+    const lastSegment = pathOnly.replace(/\/+$/, "").split("/").pop() || "";
+    const base = lastSegment.replace(/\.[^.]+$/, "");
+    return base ? base : "Image";
+  }
+}
+
+/**
+ * Converts HTML to plain text by stripping tags and decoding entities.
+ */
+export function htmlToPlainText(html: string): string {
+  if (!html || typeof html !== "string") return "";
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+  const body = parsed.body ?? parsed.documentElement;
+  return (body?.textContent ?? "").trim();
+}
+
+/**
+ * Escapes HTML entities in a string.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
+ * Sanitizes a URL by allowing only safe protocols.
+ * Rejects protocol-relative URLs (e.g. //evil.com); allows single leading slash for relative paths.
+ * Also allows data:image/* base64 URLs for inline images in the rich text editor.
+ */
+const SAFE_URL_PATTERN =
+  /^(https?:\/\/|mailto:|tel:|\/(?!\/)|#|data:image\/[a-zA-Z0-9.+-]+;base64,)/i;
+export function sanitizeUrl(url: string): string {
+  const decoded = url.replace(/&amp;/g, "&").trim();
+  return SAFE_URL_PATTERN.test(decoded) ? decoded : "";
+}
+
+/**
+ * Returns the appropriate icon for a file based on its extension or type.
+ */
+export const getFileIcon = (file: File, theme: Theme): ReactElement => {
+  const name = file.name.toLowerCase();
+  const type = file.type.toLowerCase();
+
+  if (
+    /\.(png|jpe?g|gif|webp|svg|bmp|ico)$/i.test(name) ||
+    type.startsWith("image/")
+  ) {
+    return <FileImage size={16} color={theme.palette.primary.main} />;
+  }
+  if (/\.pdf$/i.test(name) || type.includes("pdf")) {
+    return <FileText size={16} color={theme.palette.primary.main} />;
+  }
+  if (
+    /\.(zip|rar|7z|tar|gz)$/i.test(name) ||
+    type.includes("zip") ||
+    type.includes("archive")
+  ) {
+    return <FileArchive size={16} color={theme.palette.primary.main} />;
+  }
+  if (
+    /\.(js|ts|tsx|jsx|py|java|cpp|c|h|cs|go|rs|php|rb|html|css|json|md|xml|yaml|yml|sh|sql)$/i.test(
+      name,
+    ) ||
+    type.includes("code")
+  ) {
+    return <FileCode size={16} color={theme.palette.primary.main} />;
+  }
+  if (/\.(txt|log|csv)$/i.test(name) || type.startsWith("text/")) {
+    return <FileText size={16} color={theme.palette.primary.main} />;
+  }
+  return <FileIcon size={16} color={theme.palette.primary.main} />;
+};
+
+/**
+ * Scrolls an element by a given amount. Accepts either element id or ref.
+ */
+export const scrollElement = (
+  elementIdOrRef: string | RefObject<HTMLElement | null>,
+  direction: "left" | "right",
+  scrollAmount: number = 200,
+) => {
+  const container =
+    typeof elementIdOrRef === "string"
+      ? document.getElementById(elementIdOrRef)
+      : elementIdOrRef.current;
+  if (container) {
+    container.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }
+};
+
+/**
+ * Lexical Command for inserting an image.
+ */
+export const INSERT_IMAGE_COMMAND: LexicalCommand<
+  string | InsertImagePayload
+> = createCommand();

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
@@ -1,0 +1,1170 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { DashboardScope } from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  CaseAttachment,
+  CaseAuditEntry,
+  CaseCustomerContext,
+  CaseLinkedItem,
+  CaseProductContext,
+  CaseSlaClock,
+  CaseTag,
+  CaseTimeLogEntry,
+  CaseWatcher,
+  CsmCaseDetail,
+  CsmCaseRow,
+  CsmCasesListResponse,
+} from "@features/csm-cases/types/csmCases";
+
+const minutesAgo = (n: number): string =>
+  new Date(Date.now() - n * 60_000).toISOString();
+
+/**
+ * Map a case (by subject + project name) to its affected WSO2 product. The
+ * full product context (version, update level, environment) is built off this
+ * in `deriveProduct` below; the list row only carries the product name.
+ */
+function deriveProductName(subject: string, projectName: string): string {
+  const s = subject.toLowerCase();
+  const p = projectName.toLowerCase();
+  if (s.includes("identity server") || p.includes("iam"))
+    return "WSO2 Identity Server";
+  if (p.includes("asgardeo") || s.includes("asgardeo")) return "WSO2 Asgardeo";
+  if (p.includes("api manager") || s.includes("api manager"))
+    return "WSO2 API Manager";
+  if (p.includes("choreo") || s.includes("choreo")) return "WSO2 Choreo";
+  if (p.includes("integrator") || p.includes("mi") || p.includes("streaming"))
+    return "WSO2 Micro Integrator";
+  if (p.includes("open banking") || s.includes("openbanking"))
+    return "WSO2 Open Banking";
+  return "WSO2 Platform";
+}
+
+type CaseSeed = Omit<CsmCaseRow, "product" | "wso2CaseId">;
+
+const ABT_CASE_SEEDS: CaseSeed[] = [
+  {
+    id: "case-1001",
+    caseNumber: "CS-1001",
+    subject: "Identity Server token issuance latency spike",
+    customer: "Acme Financial",
+    accountId: "acc-001",
+    projectId: "prj-acme-iam-prod",
+    projectName: "IAM Production",
+    severity: "S1",
+    state: "work_in_progress",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "first_response",
+    minutesToBreach: -22,
+    createdAt: minutesAgo(60 * 8),
+    updatedAt: minutesAgo(22),
+  },
+  {
+    id: "case-1002",
+    caseNumber: "CS-1002",
+    subject: "API Manager gateway 502 during peak",
+    customer: "Initech Systems",
+    accountId: "acc-003",
+    projectId: "prj-initech-apim",
+    projectName: "API Manager",
+    severity: "S0",
+    state: "solution_proposed",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "resolution",
+    minutesToBreach: 12,
+    createdAt: minutesAgo(60 * 3),
+    updatedAt: minutesAgo(4),
+  },
+  {
+    id: "case-1003",
+    caseNumber: "CS-1003",
+    subject: "MI cluster failed to start after upgrade",
+    customer: "Initech Systems",
+    accountId: "acc-003",
+    projectId: "prj-initech-mi",
+    projectName: "Micro Integrator",
+    severity: "S1",
+    state: "solution_proposed",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "resolution",
+    minutesToBreach: 600,
+    createdAt: minutesAgo(60 * 6),
+    updatedAt: minutesAgo(60 + 30),
+  },
+  {
+    id: "case-1004",
+    caseNumber: "CS-1004",
+    subject: "OIDC userinfo claims missing groups",
+    customer: "Acme Financial",
+    accountId: "acc-001",
+    projectId: "prj-acme-iam-prod",
+    projectName: "IAM Production",
+    severity: "S2",
+    state: "work_in_progress",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "first_response",
+    minutesToBreach: 180,
+    createdAt: minutesAgo(75),
+    updatedAt: minutesAgo(60),
+  },
+  {
+    id: "case-1005",
+    caseNumber: "CS-1005",
+    subject: "Choreo deployment stuck in 'Provisioning'",
+    customer: "Umbrella Health",
+    accountId: "acc-005",
+    projectId: "prj-umbrella-choreo",
+    projectName: "Choreo Platform",
+    severity: "S2",
+    state: "closed",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "resolution",
+    minutesToBreach: 0,
+    createdAt: minutesAgo(60 * 5),
+    updatedAt: minutesAgo(60),
+  },
+  {
+    id: "case-1006",
+    caseNumber: "CS-1006",
+    subject: "SAML signature validation fails after SF cert rotation",
+    customer: "Globex Corp",
+    accountId: "acc-002",
+    projectId: "prj-globex-iam",
+    projectName: "IAM",
+    severity: "S2",
+    state: "closed",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "resolution",
+    minutesToBreach: 0,
+    createdAt: minutesAgo(60 * 12),
+    updatedAt: minutesAgo(60 * 4 + 30),
+  },
+  {
+    id: "case-1007",
+    caseNumber: "CS-1007",
+    subject: "Streaming Integrator backpressure",
+    customer: "Initech Systems",
+    accountId: "acc-003",
+    projectId: "prj-initech-si",
+    projectName: "Streaming Integrator",
+    severity: "S1",
+    state: "awaiting_info",
+    assignee: "Priya N.",
+    assigneeIsMe: false,
+    slaClockType: "resolution",
+    minutesToBreach: -180,
+    createdAt: minutesAgo(60 * 30),
+    updatedAt: minutesAgo(60 * 4),
+  },
+  {
+    id: "case-1008",
+    caseNumber: "CS-1008",
+    subject: "Asgardeo SCIM bulk import failing",
+    customer: "Umbrella Health",
+    accountId: "acc-005",
+    projectId: "prj-umbrella-asgardeo",
+    projectName: "Asgardeo Tenant",
+    severity: "S2",
+    state: "work_in_progress",
+    assignee: "Dilan W.",
+    assigneeIsMe: false,
+    slaClockType: "first_response",
+    minutesToBreach: 25,
+    createdAt: minutesAgo(60 * 4),
+    updatedAt: minutesAgo(35),
+  },
+  {
+    id: "case-1009",
+    caseNumber: "CS-1009",
+    subject: "Customer asking about FAPI conformance",
+    customer: "Acme Financial",
+    accountId: "acc-001",
+    projectId: "prj-acme-openbanking",
+    projectName: "Open Banking",
+    severity: "S3",
+    state: "open",
+    assignee: "Unassigned",
+    assigneeIsMe: false,
+    slaClockType: "ack",
+    minutesToBreach: 720,
+    createdAt: minutesAgo(60 * 2),
+    updatedAt: minutesAgo(60 * 2),
+  },
+  {
+    id: "case-1010",
+    caseNumber: "CS-1010",
+    subject: "Choreo build cache missing after region failover",
+    customer: "Globex Corp",
+    accountId: "acc-002",
+    projectId: "prj-globex-choreo",
+    projectName: "Choreo Build",
+    severity: "S2",
+    state: "solution_proposed",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "resolution",
+    minutesToBreach: 480,
+    createdAt: minutesAgo(60 * 18),
+    updatedAt: minutesAgo(60 * 2),
+  },
+  {
+    id: "case-1011",
+    caseNumber: "CS-1011",
+    subject: "Identity Server LDAP user search slow",
+    customer: "Globex Corp",
+    accountId: "acc-002",
+    projectId: "prj-globex-iam",
+    projectName: "IAM",
+    severity: "S3",
+    state: "solution_proposed",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "resolution",
+    minutesToBreach: 1200,
+    createdAt: minutesAgo(60 * 24),
+    updatedAt: minutesAgo(60 * 6),
+  },
+  {
+    id: "case-1012",
+    caseNumber: "CS-1012",
+    subject: "API Manager publisher UI 403 for tenant admin",
+    customer: "Soylent Industries",
+    accountId: "acc-004",
+    projectId: "prj-soylent-apim",
+    projectName: "API Manager",
+    severity: "S3",
+    state: "work_in_progress",
+    assignee: "Tharindu A.",
+    assigneeIsMe: false,
+    slaClockType: "first_response",
+    minutesToBreach: 360,
+    createdAt: minutesAgo(60 * 3),
+    updatedAt: minutesAgo(60),
+  },
+  {
+    id: "case-1013",
+    caseNumber: "CS-1013",
+    subject: "Update level for IS 7.1.0 — review request",
+    customer: "Acme Financial",
+    accountId: "acc-001",
+    projectId: "prj-acme-iam-prod",
+    projectName: "IAM Production",
+    severity: "S3",
+    state: "open",
+    assignee: "Unassigned",
+    assigneeIsMe: false,
+    slaClockType: "ack",
+    minutesToBreach: 1080,
+    createdAt: minutesAgo(60),
+    updatedAt: minutesAgo(60),
+  },
+  {
+    id: "case-1014",
+    caseNumber: "CS-1014",
+    subject: "Webhook signature verification failing in QA",
+    customer: "Umbrella Health",
+    accountId: "acc-005",
+    projectId: "prj-umbrella-choreo",
+    projectName: "Choreo Platform",
+    severity: "S3",
+    state: "work_in_progress",
+    assignee: "Priya N.",
+    assigneeIsMe: false,
+    slaClockType: "resolution",
+    minutesToBreach: 900,
+    createdAt: minutesAgo(60 * 36),
+    updatedAt: minutesAgo(60 * 8),
+  },
+  {
+    id: "case-1015",
+    caseNumber: "CS-1015",
+    subject: "Choreo runtime OOM under sustained load",
+    customer: "Initech Systems",
+    accountId: "acc-003",
+    projectId: "prj-initech-choreo",
+    projectName: "Choreo Runtime",
+    severity: "S2",
+    state: "work_in_progress",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "first_response",
+    minutesToBreach: 60,
+    createdAt: minutesAgo(60 * 2),
+    updatedAt: minutesAgo(15),
+  },
+  {
+    id: "case-1016",
+    caseNumber: "CS-1016",
+    subject: "How do I rotate signing keys without downtime?",
+    customer: "Soylent Industries",
+    accountId: "acc-004",
+    projectId: "prj-soylent-iam",
+    projectName: "IAM",
+    severity: "S4",
+    state: "open",
+    assignee: "Unassigned",
+    assigneeIsMe: false,
+    slaClockType: "ack",
+    minutesToBreach: 2160,
+    createdAt: minutesAgo(60 * 6),
+    updatedAt: minutesAgo(60 * 6),
+  },
+  {
+    id: "case-1017",
+    caseNumber: "CS-1017",
+    subject: "Closing: migration completed successfully",
+    customer: "Globex Corp",
+    accountId: "acc-002",
+    projectId: "prj-globex-iam",
+    projectName: "IAM",
+    severity: "S3",
+    state: "closed",
+    assignee: "Maya R.",
+    assigneeIsMe: false,
+    slaClockType: "resolution",
+    minutesToBreach: 0,
+    createdAt: minutesAgo(60 * 80),
+    updatedAt: minutesAgo(60 * 10),
+  },
+  {
+    id: "case-1018",
+    caseNumber: "CS-1018",
+    subject: "Tenant admin lost MFA device",
+    customer: "Acme Financial",
+    accountId: "acc-001",
+    projectId: "prj-acme-iam-prod",
+    projectName: "IAM Production",
+    severity: "S2",
+    state: "reopen",
+    assignee: "Sajith Ekanayaka",
+    assigneeIsMe: true,
+    slaClockType: "ack",
+    minutesToBreach: 30,
+    createdAt: minutesAgo(60 * 48),
+    updatedAt: minutesAgo(10),
+  },
+];
+
+const ALL_EXTRA_CASE_SEEDS: CaseSeed[] = [
+  {
+    id: "case-2001",
+    caseNumber: "CS-2001",
+    subject: "Open Banking sandbox cert mismatch",
+    customer: "Wayne Enterprises",
+    accountId: "acc-101",
+    projectId: "prj-wayne-openbanking",
+    projectName: "Open Banking Sandbox",
+    severity: "S1",
+    state: "work_in_progress",
+    assignee: "Tharindu A.",
+    assigneeIsMe: false,
+    slaClockType: "first_response",
+    minutesToBreach: -60,
+    createdAt: minutesAgo(60 * 10),
+    updatedAt: minutesAgo(60 * 2),
+  },
+  {
+    id: "case-2002",
+    caseNumber: "CS-2002",
+    subject: "Choreo build hanging on private dep",
+    customer: "Stark Industries",
+    accountId: "acc-102",
+    projectId: "prj-stark-choreo",
+    projectName: "Choreo CI",
+    severity: "S2",
+    state: "open",
+    assignee: "Maya R.",
+    assigneeIsMe: false,
+    slaClockType: "ack",
+    minutesToBreach: 75,
+    createdAt: minutesAgo(60 * 3),
+    updatedAt: minutesAgo(60 * 3),
+  },
+  {
+    id: "case-2003",
+    caseNumber: "CS-2003",
+    subject: "API rate limiting policy not applying",
+    customer: "Tyrell Corp",
+    accountId: "acc-103",
+    projectId: "prj-tyrell-apim",
+    projectName: "API Manager",
+    severity: "S3",
+    state: "work_in_progress",
+    assignee: "Dilan W.",
+    assigneeIsMe: false,
+    slaClockType: "resolution",
+    minutesToBreach: 600,
+    createdAt: minutesAgo(60 * 24),
+    updatedAt: minutesAgo(60 * 4),
+  },
+  {
+    id: "case-2004",
+    caseNumber: "CS-2004",
+    subject: "How to enable distributed tracing in IS?",
+    customer: "Stark Industries",
+    accountId: "acc-102",
+    projectId: "prj-stark-iam",
+    projectName: "IAM",
+    severity: "S4",
+    state: "closed",
+    assignee: "Priya N.",
+    assigneeIsMe: false,
+    slaClockType: "resolution",
+    minutesToBreach: 0,
+    createdAt: minutesAgo(60 * 100),
+    updatedAt: minutesAgo(60 * 40),
+  },
+];
+
+/**
+ * Build the project/subscription-scoped WSO2 case reference (e.g.
+ * "ACMESUB-123") from the customer name + the numeric part of the case id.
+ * Illustrative only — the real value comes from the BE `wso2Id` field.
+ */
+function deriveWso2CaseId(seed: CaseSeed): string {
+  const prefix = (seed.customer.split(/\s+/)[0] ?? "WSO2")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .slice(0, 4);
+  const num = seed.id.replace(/\D/g, "") || "0";
+  return `${prefix}SUB-${num}`;
+}
+
+function hydrate(seed: CaseSeed): CsmCaseRow {
+  return {
+    ...seed,
+    product: deriveProductName(seed.subject, seed.projectName),
+    wso2CaseId: deriveWso2CaseId(seed),
+  };
+}
+
+const ABT_CASES: CsmCaseRow[] = ABT_CASE_SEEDS.map(hydrate);
+const ALL_EXTRA_CASES: CsmCaseRow[] = ALL_EXTRA_CASE_SEEDS.map(hydrate);
+
+export function getMockCsmCases(scope: DashboardScope): CsmCasesListResponse {
+  const cases =
+    scope === "my_abt" ? ABT_CASES : [...ABT_CASES, ...ALL_EXTRA_CASES];
+  return { scope, cases };
+}
+
+const ALL_CASES_BY_ID = new Map<string, CsmCaseRow>(
+  [...ABT_CASES, ...ALL_EXTRA_CASES].map((c) => [c.id, c]),
+);
+
+const ALL_CASES_BY_NUMBER = new Map<string, CsmCaseRow>(
+  [...ABT_CASES, ...ALL_EXTRA_CASES].map((c) => [c.caseNumber, c]),
+);
+
+export function getMockCsmCaseById(
+  idOrNumber: string,
+): CsmCaseRow | undefined {
+  return ALL_CASES_BY_ID.get(idOrNumber) ?? ALL_CASES_BY_NUMBER.get(idOrNumber);
+}
+
+// ---------------------------------------------------------------------------
+// Case detail decorations: deterministic per case id, so the same case keeps
+// the same widget data across navigations.
+// ---------------------------------------------------------------------------
+
+const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
+  "acc-001": {
+    accountName: "Acme Financial",
+    tier: "managed_cloud",
+    region: "us-east-1",
+    primaryContact: "Renee Park",
+    primaryContactEmail: "renee.park@acmefinancial.com",
+    accountManager: "Lakshmi I.",
+    technicalOwner: "Chathura D.",
+    openCases: 6,
+  },
+  "acc-002": {
+    accountName: "Globex Corp",
+    tier: "subscription",
+    region: "eu-west-1",
+    primaryContact: "Helena Voss",
+    primaryContactEmail: "h.voss@globex.com",
+    accountManager: "Dilan W.",
+    openCases: 3,
+  },
+  "acc-003": {
+    accountName: "Initech Systems",
+    tier: "managed_cloud",
+    region: "ap-southeast-1",
+    primaryContact: "Peter Gibbons",
+    primaryContactEmail: "peter@initech.io",
+    accountManager: "Lakshmi I.",
+    technicalOwner: "Tharindu A.",
+    openCases: 5,
+  },
+  "acc-004": {
+    accountName: "Soylent Industries",
+    tier: "subscription",
+    region: "us-west-2",
+    primaryContact: "Marie Sandwitch",
+    primaryContactEmail: "marie@soylent.com",
+    accountManager: "Maya R.",
+    openCases: 2,
+  },
+  "acc-005": {
+    accountName: "Umbrella Health",
+    tier: "saas",
+    region: "us-east-1",
+    primaryContact: "Albert Wesker",
+    primaryContactEmail: "a.wesker@umbrella.health",
+    accountManager: "Priya N.",
+    openCases: 4,
+  },
+  "acc-101": {
+    accountName: "Wayne Enterprises",
+    tier: "subscription",
+    region: "us-east-1",
+    primaryContact: "Lucius Fox",
+    primaryContactEmail: "lfox@wayne.com",
+    accountManager: "Maya R.",
+    openCases: 1,
+  },
+  "acc-102": {
+    accountName: "Stark Industries",
+    tier: "managed_cloud",
+    region: "us-west-1",
+    primaryContact: "Pepper Potts",
+    primaryContactEmail: "pepper@stark.com",
+    accountManager: "Dilan W.",
+    technicalOwner: "Asanka R.",
+    openCases: 4,
+  },
+  "acc-103": {
+    accountName: "Tyrell Corp",
+    tier: "subscription",
+    region: "eu-central-1",
+    primaryContact: "Eldon Tyrell",
+    primaryContactEmail: "eldon@tyrell.corp",
+    accountManager: "Priya N.",
+    openCases: 1,
+  },
+};
+
+const FALLBACK_CUSTOMER: CaseCustomerContext = {
+  accountName: "Unknown Account",
+  tier: "subscription",
+  region: "unknown",
+  primaryContact: "(no primary contact)",
+  primaryContactEmail: "—",
+  accountManager: "Unassigned",
+  openCases: 1,
+};
+
+// Map the coarse environment lane to a fixed-list deployment category. Prod
+// deployments are treated as primary production in the mock.
+const CATEGORY_FROM_ENV: Record<
+  CaseProductContext["environment"],
+  NonNullable<CaseProductContext["deploymentCategory"]>
+> = {
+  prod: "primary_production",
+  staging: "staging",
+  qa: "qa",
+  dev: "development",
+};
+
+function deriveProduct(c: CsmCaseRow): CaseProductContext {
+  const base = deriveProductBase(c);
+  return { ...base, deploymentCategory: CATEGORY_FROM_ENV[base.environment] };
+}
+
+function deriveProductBase(c: CsmCaseRow): CaseProductContext {
+  const subject = c.subject.toLowerCase();
+  const project = c.projectName.toLowerCase();
+  if (subject.includes("identity server") || project.includes("iam")) {
+    return {
+      product: "WSO2 Identity Server",
+      version: "7.1.0",
+      updateLevel: "wso2is-7.1.0.42",
+      deployment: c.projectName,
+      environment: "prod",
+      region: "us-east-1",
+    };
+  }
+  if (project.includes("asgardeo") || subject.includes("asgardeo")) {
+    return {
+      product: "WSO2 Asgardeo",
+      version: "saas",
+      deployment: c.projectName,
+      environment: "prod",
+      region: "us-east-1",
+    };
+  }
+  if (project.includes("api manager") || subject.includes("api manager")) {
+    return {
+      product: "WSO2 API Manager",
+      version: "4.4.0",
+      updateLevel: "wso2am-4.4.0.18",
+      deployment: c.projectName,
+      environment: "prod",
+      region: "eu-west-1",
+    };
+  }
+  if (project.includes("choreo") || subject.includes("choreo")) {
+    return {
+      product: "WSO2 Choreo",
+      version: "saas",
+      deployment: c.projectName,
+      environment: "prod",
+      region: "us-east-1",
+    };
+  }
+  if (project.includes("integrator") || project.includes("mi") || project.includes("streaming")) {
+    return {
+      product: "WSO2 Micro Integrator",
+      version: "4.4.0",
+      updateLevel: "wso2mi-4.4.0.7",
+      deployment: c.projectName,
+      environment: "staging",
+      region: "us-east-1",
+    };
+  }
+  if (project.includes("open banking") || subject.includes("openbanking")) {
+    return {
+      product: "WSO2 Open Banking",
+      version: "4.0.0",
+      updateLevel: "wso2ob-4.0.0.21",
+      deployment: c.projectName,
+      environment: "prod",
+      region: "eu-west-1",
+    };
+  }
+  return {
+    product: "WSO2 Platform",
+    version: "n/a",
+    deployment: c.projectName,
+    environment: "prod",
+  };
+}
+
+// SLA targets vary by severity. Numbers below are illustrative for the mock.
+function deriveSlaClocks(c: CsmCaseRow): CaseSlaClock[] {
+  const ackTarget = c.severity === "S0" ? 15 : c.severity === "S1" ? 30 : c.severity === "S2" ? 60 : 240;
+  const frTarget = c.severity === "S0" ? 30 : c.severity === "S1" ? 60 : c.severity === "S2" ? 240 : 480;
+  const resTarget =
+    c.severity === "S0" ? 240 : c.severity === "S1" ? 480 : c.severity === "S2" ? 1440 : 4320;
+
+  return [
+    {
+      clockType: "ack",
+      // Ack is generally met once we've replied. Use the case's own clock
+      // to drive the active stage so the timeline matches the header chip.
+      state: c.slaClockType === "ack" ? (c.minutesToBreach < 0 ? "breached" : "running") : "met",
+      minutesToBreach: c.slaClockType === "ack" ? c.minutesToBreach : 0,
+      targetMinutes: ackTarget,
+    },
+    {
+      clockType: "first_response",
+      state:
+        c.slaClockType === "first_response"
+          ? c.minutesToBreach < 0
+            ? "breached"
+            : "running"
+          : c.slaClockType === "resolution" || c.state === "closed"
+            ? "met"
+            : "paused",
+      minutesToBreach: c.slaClockType === "first_response" ? c.minutesToBreach : 0,
+      targetMinutes: frTarget,
+    },
+    {
+      clockType: "resolution",
+      state:
+        c.state === "closed"
+          ? "met"
+          : c.slaClockType === "resolution"
+            ? c.minutesToBreach < 0
+              ? "breached"
+              : "running"
+            : "paused",
+      minutesToBreach: c.slaClockType === "resolution" ? c.minutesToBreach : resTarget,
+      targetMinutes: resTarget,
+    },
+  ];
+}
+
+const ALL_WATCHERS: CaseWatcher[] = [
+  { id: "w-1", name: "Sajith Ekanayaka", role: "wso2_engineer", isMe: true },
+  { id: "w-2", name: "Lakshmi I.", role: "manager" },
+  { id: "w-3", name: "Asanka R.", role: "wso2_engineer" },
+  { id: "w-4", name: "Priya N.", role: "wso2_engineer" },
+  { id: "w-5", name: "Renee Park", role: "customer_contact" },
+  { id: "w-6", name: "Maya R.", role: "wso2_engineer" },
+  { id: "w-7", name: "Dilan W.", role: "wso2_engineer" },
+];
+
+function deriveWatchers(c: CsmCaseRow): CaseWatcher[] {
+  // Always include the assignee if known + 2-3 more deterministically.
+  const base: CaseWatcher[] = [];
+  if (c.assigneeIsMe) base.push({ id: "w-1", name: c.assignee, role: "wso2_engineer", isMe: true });
+  else if (c.assignee !== "Unassigned")
+    base.push({ id: `w-assignee-${c.id}`, name: c.assignee, role: "wso2_engineer" });
+  const seedIdx = parseInt(c.id.replace(/\D/g, ""), 10) || 0;
+  const pool = ALL_WATCHERS.filter((w) => !base.some((b) => b.name === w.name));
+  const extras = [
+    pool[seedIdx % pool.length],
+    pool[(seedIdx + 2) % pool.length],
+    pool[(seedIdx + 3) % pool.length],
+  ];
+  const seen = new Set<string>(base.map((w) => w.name));
+  for (const w of extras) {
+    if (w && !seen.has(w.name)) {
+      base.push(w);
+      seen.add(w.name);
+    }
+  }
+  return base;
+}
+
+function deriveLinkedItems(c: CsmCaseRow): CaseLinkedItem[] {
+  const seedIdx = parseInt(c.id.replace(/\D/g, ""), 10) || 0;
+  const linked: CaseLinkedItem[] = [];
+
+  // Most cases get 1-2 related cases from the same account.
+  const sameAccount = [...ALL_CASES_BY_ID.values()].filter(
+    (other) => other.accountId === c.accountId && other.id !== c.id,
+  );
+  for (let i = 0; i < Math.min(2, sameAccount.length); i += 1) {
+    const r = sameAccount[(seedIdx + i) % sameAccount.length];
+    linked.push({
+      id: `link-${c.id}-${r.id}`,
+      kind: "case",
+      reference: r.caseNumber,
+      title: r.subject,
+      state: r.state,
+      href: `/cases/${r.id}`,
+    });
+  }
+
+  // High-severity SaaS cases get a linked incident.
+  if (
+    (c.severity === "S0" || c.severity === "S1") &&
+    (c.projectName.toLowerCase().includes("choreo") ||
+      c.projectName.toLowerCase().includes("asgardeo"))
+  ) {
+    linked.push({
+      id: `link-${c.id}-inc`,
+      kind: "incident",
+      reference: `INC-${5000 + seedIdx}`,
+      title: "Regional latency event",
+      state: "investigating",
+    });
+  }
+
+  // Breached cases get an escalation.
+  if (c.minutesToBreach < 0 || c.severity === "S0") {
+    linked.push({
+      id: `link-${c.id}-esc`,
+      kind: "escalation",
+      reference: `ESC-${300 + seedIdx}`,
+      title: "Customer-raised escalation",
+      state: "open",
+    });
+  }
+
+  // ~30% get a KB article.
+  if (seedIdx % 3 === 0) {
+    linked.push({
+      id: `link-${c.id}-kb`,
+      kind: "kb",
+      reference: `KB-${10000 + seedIdx}`,
+      title: "Troubleshooting playbook",
+      state: "published",
+    });
+  }
+  return linked;
+}
+
+function deriveTags(c: CsmCaseRow): CaseTag[] {
+  const tags: CaseTag[] = [];
+  if (c.severity === "S0" || c.severity === "S1")
+    tags.push({ id: "t-priority", label: "high-priority", color: "error" });
+  if (c.minutesToBreach < 0)
+    tags.push({ id: "t-breach", label: "sla-breached", color: "warning" });
+  if (c.state === "reopen")
+    tags.push({ id: "t-reopen", label: "reopened", color: "warning" });
+  const subjLower = c.subject.toLowerCase();
+  if (subjLower.includes("ldap")) tags.push({ id: "t-ldap", label: "ldap", color: "info" });
+  if (subjLower.includes("saml") || subjLower.includes("oidc"))
+    tags.push({ id: "t-fed", label: "federation", color: "info" });
+  if (subjLower.includes("latency") || subjLower.includes("oom"))
+    tags.push({ id: "t-perf", label: "performance", color: "primary" });
+  if (subjLower.includes("certificate") || subjLower.includes("cert"))
+    tags.push({ id: "t-pki", label: "pki", color: "primary" });
+  return tags;
+}
+
+function deriveTimeLogs(c: CsmCaseRow): CaseTimeLogEntry[] {
+  const seedIdx = parseInt(c.id.replace(/\D/g, ""), 10) || 0;
+  const assignee = c.assignee === "Unassigned" ? "Sajith Ekanayaka" : c.assignee;
+  const totalMinutes = (seedIdx * 17) % 480 + 30;
+  const logs: CaseTimeLogEntry[] = [
+    {
+      id: `tl-${c.id}-a`,
+      engineer: assignee,
+      hours: Math.round((totalMinutes / 60) * 4) / 4,
+      note: "Investigated logs, gathered customer-side traces.",
+      date: new Date(Date.now() - 60 * 60 * 1000 * 6).toISOString(),
+    },
+  ];
+  if (c.state !== "open") {
+    logs.unshift({
+      id: `tl-${c.id}-b`,
+      engineer: assignee,
+      hours: 1.5,
+      note: "Reviewed customer config and reproduction steps.",
+      date: new Date(Date.now() - 60 * 60 * 1000 * 22).toISOString(),
+    });
+  }
+  if (c.state === "solution_proposed" || c.state === "closed") {
+    logs.unshift({
+      id: `tl-${c.id}-c`,
+      engineer: assignee,
+      hours: 2,
+      note: "Drafted proposed fix and verified in staging.",
+      date: new Date(Date.now() - 60 * 60 * 1000 * 2).toISOString(),
+    });
+  }
+  return logs;
+}
+
+function deriveAudit(c: CsmCaseRow): CaseAuditEntry[] {
+  const assignee = c.assignee === "Unassigned" ? "(unassigned)" : c.assignee;
+  const created: CaseAuditEntry = {
+    id: `a-${c.id}-0`,
+    kind: "created",
+    actor: "Customer",
+    description: `Case created at severity ${c.severity}`,
+    createdAt: c.createdAt,
+  };
+  const events: CaseAuditEntry[] = [created];
+  if (c.state !== "open") {
+    events.push({
+      id: `a-${c.id}-1`,
+      kind: "assignee_change",
+      actor: "Routing",
+      description: `Assigned to ${assignee}`,
+      createdAt: new Date(new Date(c.createdAt).getTime() + 5 * 60_000).toISOString(),
+    });
+    events.push({
+      id: `a-${c.id}-2`,
+      kind: "state_change",
+      actor: assignee,
+      description: "Moved to Work in progress",
+      createdAt: new Date(new Date(c.createdAt).getTime() + 15 * 60_000).toISOString(),
+    });
+  }
+  if (c.state === "awaiting_info") {
+    events.push({
+      id: `a-${c.id}-3`,
+      kind: "state_change",
+      actor: assignee,
+      description: "Requested additional info from customer",
+      createdAt: c.updatedAt,
+    });
+  }
+  if (c.state === "waiting_on_wso2") {
+    events.push({
+      id: `a-${c.id}-3`,
+      kind: "state_change",
+      actor: assignee,
+      description: "Marked as waiting on internal WSO2 dependency",
+      createdAt: c.updatedAt,
+    });
+  }
+  if (c.state === "solution_proposed") {
+    events.push({
+      id: `a-${c.id}-3`,
+      kind: "state_change",
+      actor: assignee,
+      description: "Posted proposed solution to customer",
+      createdAt: c.updatedAt,
+    });
+  }
+  if (c.state === "closed") {
+    events.push({
+      id: `a-${c.id}-3`,
+      kind: "state_change",
+      actor: assignee,
+      description: "Case closed",
+      createdAt: c.updatedAt,
+    });
+  }
+  if (c.state === "reopen") {
+    events.push({
+      id: `a-${c.id}-3`,
+      kind: "state_change",
+      actor: "Customer",
+      description: "Customer reopened the case",
+      createdAt: c.updatedAt,
+    });
+  }
+  if (c.minutesToBreach < 0 && c.state !== "closed") {
+    events.push({
+      id: `a-${c.id}-breach`,
+      kind: "sla_breached",
+      actor: "System",
+      description: `${c.slaClockType.replace("_", " ")} SLA breached`,
+      createdAt: c.updatedAt,
+    });
+  }
+  return events;
+}
+
+const DESCRIPTIONS: Record<string, string> = {
+  "case-1001":
+    `Hi WSO2 support,
+
+Token issuance latency on our corporate IdP has spiked to ~2.5s p95 since 09:30 UTC. This is impacting workforce SSO across all internal apps — engineers can't get into Jira, GitHub, or the deployment console.
+
+What we've checked so far:
+  - Mutual TLS handshake times look normal (~40ms)
+  - JDBC userstore connection pool sits at 18/100 — not exhausted
+  - GC pauses on IS nodes are under 50ms, heap usage at 45%
+  - No deployment on our side in the last 72 hours
+  - LDAP-backed userstore latency unchanged
+
+We tried rolling restart of the IS cluster at 10:15 UTC; latency dropped for ~3 minutes then climbed back. Attaching the access log slice from 09:00–10:30 UTC and a thread dump from is-prod-2 captured during the spike.
+
+Please treat as high priority — our CISO is asking for an ETA.
+
+Thanks,
+Rohan Mehta
+Platform Engineering, Acme Financial`,
+  "case-1002":
+    `Hi WSO2 team,
+
+API Manager gateway is returning intermittent 502s to roughly 3% of traffic during our 11:00–13:00 UTC peak window. Backend services behind the gateway are healthy (5xx-free, latency normal). Looks like the gateway itself is dropping connections.
+
+Observed pattern:
+  - 5xx rate climbs starting ~11:05 UTC, peaks around 12:20 UTC
+  - Two of three gateway pods show CPU at ~85% during the spike
+  - Heap usage steady at 60%, no OOM
+  - Suspect upstream connection pool saturation but we can't see pool metrics from outside
+
+Can you take a look at the gateway pod logs and pool config? We have the change window open if you need us to apply anything.
+
+Best regards,
+Janet Park
+Initech SRE`,
+  "case-1003":
+    `Hi WSO2 support,
+
+Our Micro Integrator cluster fails to start after we applied update level wso2mi-4.4.0.7 last night. Two pods stay in CrashLoopBackOff.
+
+The carbon log shows a ClassNotFoundException on org.wso2.carbon.security.user.api.UserStoreException coming from a custom security extension we built about a year ago. The extension was working fine on wso2mi-4.4.0.4.
+
+Can you tell us what changed in 4.4.0.7 around the user-API classloader? If it's a class move or rename, we can rebuild the extension; just need to know what to retarget.
+
+We're holding the rollout to other regions until we hear back.
+
+Thanks,
+Bill Lumbergh
+Initech Platform Team`,
+  "case-1004":
+    `Hi WSO2 support,
+
+The userinfo endpoint stopped returning the "groups" claim for users authenticated via our corporate IdP. This worked last week and we haven't changed our client config.
+
+Repro:
+  1. Authenticate as bob@acmefinancial.com via the corporate IdP federation
+  2. Exchange code for tokens at /oauth2/token
+  3. Call /oauth2/userinfo with the access token
+  4. Response includes sub, email, name — but no "groups"
+
+Expected: groups should be a JSON array of LDAP DN strings.
+
+Could a federated IdP attribute mapping have been changed, or is this a known issue in 7.1.0? Happy to provide a test user account if it helps.
+
+Best regards,
+Rohan Mehta
+Acme Financial`,
+  "case-1005":
+    `Hi support,
+
+Our Choreo deployment for the "checkout-v2" component has been stuck at "Provisioning" for about 45 minutes. The component is a Go service, build succeeded, but the pod never reaches Ready.
+
+We've already tried:
+  - Deleting and redeploying — same outcome
+  - Smaller resource ask (256Mi → 128Mi) — same outcome
+  - Switching the build profile — no effect
+
+There's nothing useful in the Choreo UI beyond "Provisioning". Could you check the underlying pod state? I'll attach kubectl describe output if you can pull it from the platform side.
+
+Thanks,
+Daniel Owens
+Engineering, Acme Choreo`,
+  "case-1015":
+    `Hi WSO2 support,
+
+Our Choreo runtime is going OOM under sustained load (~120 RPS sustained, no bursts). The crash takes the whole pod down and the autoscaler can't keep up — we're seeing ~40-minute cycles of healthy / OOM / new pod.
+
+Started this morning around 05:40 UTC right after the rollout of release v4.2.1. Reverting to v4.2.0 resolves it; we've confirmed the rollback on staging.
+
+Profile so far:
+  - All pods OOM under steady-state, no specific instance pattern
+  - 2Gi memory limit, 1Gi request, 1500m CPU limit
+  - Workload is 117–122 RPS for the last 6 hours of traffic
+  - Heap dump captured (heap-prod-01.hprof, ~480MB) — attaching
+
+Need this resolved or worked around urgently — our SLO budget for the month is ~70% spent already.
+
+Thanks,
+Daniel Owens
+Engineering, Acme Choreo`,
+  "case-1006":
+    `Hi WSO2 team,
+
+We're seeing the same SAML response signature validation error on the Asgardeo tenant for our staging Salesforce SP. The error in the IS logs is:
+
+  org.wso2.carbon.identity.sso.saml.exception.IdentityException: Signature validation failed for SAML response
+
+This started after we rotated our Salesforce signing certificate yesterday. We re-uploaded the new cert into the SP configuration in Asgardeo. The new cert is RSA-2048, SHA-256 signed.
+
+Production tenant is still on the old cert and working fine; this is staging only. Can you check whether the cert metadata was actually picked up, or if there's a propagation delay we should wait through?
+
+Best regards,
+Helena Voss
+Globex IAM Team`,
+  "case-1011":
+    `Hi WSO2 support,
+
+We need help tuning the LDAP userstore for our IS deployment. Search queries against the userstore are coming back in 1.2–1.8s for queries that should be instant. We have ~85,000 user entries in the LDAP.
+
+What we've configured:
+  - ConnectionPoolingEnabled = true
+  - MaxActiveConnections = 50
+  - ConnectionPoolMinIdle = 10
+  - SearchScope = SUB on ou=people,dc=globex,dc=com
+
+Index status on the LDAP side looks fine — pres/sub/eq indexes on uid, mail, cn, member. Network RTT to the LDAP from IS pods is consistent at ~2ms.
+
+Suspect we're paginating poorly or doing redundant searches. Can you advise on the right pooling config + tracing the actual LDAP queries IS is firing?
+
+Thanks,
+Marcus Liang
+Globex Security Engineering`,
+};
+
+function describe(c: CsmCaseRow): string {
+  const seeded = DESCRIPTIONS[c.id];
+  if (seeded) return seeded;
+
+  // Fallback template: greeting + body + sign-off so every case reads like
+  // a real ticket even without a hand-written description. The greeting is
+  // intentionally generic — the customer doesn't know who will pick up the
+  // case at the time of creation.
+  const customerFirst = c.customer.split(/\s+/)[0] ?? c.customer;
+  return [
+    `Hi WSO2 support,`,
+    "",
+    `${c.subject} — reported on project ${c.projectName}.`,
+    "",
+    "What we're observing:",
+    `  - Issue first noticed earlier today during normal operations`,
+    `  - Severity ${c.severity} based on customer impact`,
+    `  - Workaround status: investigating, no permanent mitigation yet`,
+    "",
+    "Additional reproduction details and logs are captured in the comment thread below. Happy to jump on a call if it helps move things along.",
+    "",
+    "Thanks,",
+    `${customerFirst}`,
+    `${c.customer}`,
+  ].join("\n");
+}
+
+function deriveAttachments(c: CsmCaseRow): CaseAttachment[] {
+  const seedIdx = parseInt(c.id.replace(/\D/g, ""), 10) || 0;
+  const sets: Record<number, CaseAttachment[]> = {
+    0: [
+      {
+        id: `att-${c.id}-1`,
+        filename: "thread-dump.log",
+        size: 154_321,
+        contentType: "text/plain",
+        uploadedBy: c.customer.split(" ")[0],
+        uploadedAt: new Date(Date.now() - 60 * 60 * 1000 * 5).toISOString(),
+      },
+    ],
+    1: [
+      {
+        id: `att-${c.id}-1`,
+        filename: "gw-pod-metrics.csv",
+        size: 21_440,
+        contentType: "text/csv",
+        uploadedBy: c.customer.split(" ")[0],
+        uploadedAt: new Date(Date.now() - 60 * 60 * 1000 * 3).toISOString(),
+      },
+      {
+        id: `att-${c.id}-2`,
+        filename: "carbon.log",
+        size: 982_133,
+        contentType: "text/plain",
+        uploadedBy: c.assignee === "Unassigned" ? "Sajith Ekanayaka" : c.assignee,
+        uploadedAt: new Date(Date.now() - 60 * 60 * 1000 * 2).toISOString(),
+      },
+    ],
+    2: [
+      {
+        id: `att-${c.id}-1`,
+        filename: "screenshot.png",
+        size: 312_558,
+        contentType: "image/png",
+        uploadedBy: c.customer.split(" ")[0],
+        uploadedAt: new Date(Date.now() - 60 * 60 * 1000 * 1.2).toISOString(),
+      },
+    ],
+    3: [],
+  };
+  return sets[seedIdx % 4] ?? [];
+}
+
+export function getMockCsmCaseDetailById(
+  idOrNumber: string,
+): CsmCaseDetail | undefined {
+  const row = getMockCsmCaseById(idOrNumber);
+  if (!row) return undefined;
+  const customerContext = CUSTOMER_CONTEXTS[row.accountId] ?? FALLBACK_CUSTOMER;
+  return {
+    ...row,
+    description: describe(row),
+    assignmentGroup: row.projectName.toLowerCase().includes("choreo")
+      ? "grp.choreo_sre"
+      : row.projectName.toLowerCase().includes("asgardeo")
+        ? "grp.asgardeo_sre"
+        : "grp.cre_team",
+    createdBy: customerContext.primaryContact,
+    customerContext,
+    productContext: deriveProduct(row),
+    slaClocks: deriveSlaClocks(row),
+    watchers: deriveWatchers(row),
+    linkedItems: deriveLinkedItems(row),
+    tags: deriveTags(row),
+    timeLogs: deriveTimeLogs(row),
+    audit: deriveAudit(row),
+    attachments: deriveAttachments(row),
+    isWatching: row.assigneeIsMe,
+  };
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/commentsMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/commentsMocks.ts
@@ -1,0 +1,787 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+const minutesAgo = (n: number): string =>
+  new Date(Date.now() - n * 60_000).toISOString();
+
+const SEED_COMMENTS: Record<string, CsmCaseComment[]> = {
+  "case-1001": [
+    {
+      id: "cmt-1001-1",
+      caseId: "case-1001",
+      authorName: "Rohan Mehta",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi WSO2 support,</p>" +
+        "<p>P99 token issuance latency on prod jumped from <strong>~80ms</strong> to <strong>~1.2s</strong> starting around <code>09:15 UTC</code>. No deploy on our side in the last 72 hours.</p>" +
+        "<p>Quick summary of what we've ruled out:</p>" +
+        "<ul>" +
+        "<li>GC pauses on all IS nodes are under 50ms</li>" +
+        "<li>Mutual TLS handshake times look normal (~40ms)</li>" +
+        "<li>JDBC userstore pool sits at <code>18/100</code> — not exhausted</li>" +
+        "<li>LDAP-backed userstore latency unchanged</li>" +
+        "</ul>" +
+        "<p>For reference, our last green run is in this Grafana snapshot: <a href=\"https://grafana.acmefinancial.example/d/is-token-latency?from=now-7d&to=now-1d\" target=\"_blank\" rel=\"noopener\">is-token-latency (last 7d)</a>.</p>" +
+        "<p>I've attached the IS access log slice from 09:00–10:30 UTC and a thread dump captured during the spike. Treating as high priority — our CISO is asking for an ETA.</p>" +
+        "<p>Thanks,<br>Rohan Mehta<br>Platform Engineering, Acme Financial</p>",
+      createdAt: minutesAgo(60 * 7),
+    },
+    {
+      id: "cmt-1001-2",
+      caseId: "case-1001",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Rohan,</p>" +
+        "<p>Picked this up. A few clarifying questions before I dig into the thread dump:</p>" +
+        "<ol>" +
+        "<li>Does the spike show up on the LDAP-backed userstore or only the JDBC primary?</li>" +
+        "<li>Are sessions persisting across cluster nodes (sticky sessions vs. distributed cache)?</li>" +
+        "<li>Have any TLS truststore or KMS configs been updated on the load balancer in front of IS?</li>" +
+        "</ol>" +
+        "<p>While you're checking — we documented a similar token-issuance-latency investigation in <a href=\"https://docs.wso2.com/identity-server/troubleshooting/token-latency\" target=\"_blank\" rel=\"noopener\">our IS troubleshooting playbook</a>. The connection pool exhaustion section is what I'm comparing your numbers against.</p>" +
+        "<p>Will follow up with the thread-dump analysis shortly.</p>" +
+        "<p>Best regards,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 6),
+    },
+    {
+      id: "cmt-1001-3",
+      caseId: "case-1001",
+      authorName: "Rohan Mehta",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Answers:</p>" +
+        "<ol>" +
+        "<li>Only the JDBC primary. LDAP-backed userstore latency is unchanged at ~30ms.</li>" +
+        "<li>Sticky sessions on the LB; distributed cache (Hazelcast) is enabled across the cluster.</li>" +
+        "<li>No truststore or KMS changes on the LB or on IS in the last 30 days. Last network change was 2 weeks ago — added a WAF rule, nothing in the IS path.</li>" +
+        "</ol>" +
+        "<p>Two more data points we noticed:</p>" +
+        "<blockquote>Hazelcast cluster log shows ~12 partition migrations between 09:00 and 09:30 UTC. We don't usually see that during steady-state operation.</blockquote>" +
+        "<p>Could that be connected?</p>" +
+        "<p>Thanks,<br>Rohan</p>",
+      createdAt: minutesAgo(60 * 5 + 30),
+    },
+    {
+      id: "cmt-1001-4",
+      caseId: "case-1001",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Rohan,</p>" +
+        "<p>That Hazelcast detail is exactly what I needed. The thread dump confirms it — the IS auth threads are blocked on <code>HazelcastInstance.getMap(\"session-cache\")</code> waiting for partition stabilisation. Snippet from <code>is-prod-2</code>:</p>" +
+        "<pre><code>\"http-nio-9443-exec-127\" #847 daemon\n  at com.hazelcast.spi.impl.operationservice.impl.Invocation_Future.get(Invocation_Future.java:71)\n  at com.hazelcast.map.impl.proxy.MapProxyImpl.getInternal(MapProxyImpl.java:158)\n  at org.wso2.carbon.identity.session.SessionDataStore.getSessionContextData(SessionDataStore.java:412)\n  at org.wso2.carbon.identity.oauth2.token.TokenIssuanceHandler.handle(TokenIssuanceHandler.java:289)</code></pre>" +
+        "<p>The 12 partition migrations match a known Hazelcast issue when the cluster sees a transient network hiccup and re-balances under load. See <a href=\"https://github.com/wso2/product-is/issues/18234\" target=\"_blank\" rel=\"noopener\">product-is#18234</a> for the upstream context.</p>" +
+        "<p>Two paths forward:</p>" +
+        "<ul>" +
+        "<li><strong>Immediate workaround:</strong> raise <code>hazelcast.client.invocation.timeout.seconds</code> from default 120s to <code>240s</code> on the IS nodes, and increase <code>partition.migration.commit.timeout.seconds</code> to <code>60s</code>. This won't prevent migrations but it will stop them from cascading into request timeouts.</li>" +
+        "<li><strong>Permanent fix:</strong> upgrade to <code>wso2is-7.1.0.43</code> (released yesterday) which includes the Hazelcast 5.3.6 client with the fix for #18234.</li>" +
+        "</ul>" +
+        "<p>Let me know which path you want to take. Happy to hop on a call to walk through the workaround config if it helps.</p>" +
+        "<p>Best regards,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 4),
+    },
+    {
+      id: "cmt-1001-5",
+      caseId: "case-1001",
+      authorName: "Rohan Mehta",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Going with the workaround for now. Change window opens at 15:30 UTC — we'll apply the Hazelcast config bump first, monitor for an hour, then plan the .43 upgrade for next week's maintenance.</p>" +
+        "<p>Will report back. Appreciate the fast turnaround.</p>" +
+        "<p>Thanks,<br>Rohan</p>",
+      createdAt: minutesAgo(60 * 3 + 15),
+    },
+    {
+      id: "cmt-1001-6",
+      caseId: "case-1001",
+      authorName: "System",
+      authorRole: "system",
+      bodyHtml: "<p>First-response SLA breached by 22 minutes.</p>",
+      createdAt: minutesAgo(22),
+    },
+  ],
+  "case-1002": [
+    {
+      id: "cmt-1002-1",
+      caseId: "case-1002",
+      authorName: "Janet Park",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi WSO2 team,</p>" +
+        "<p>API Manager gateway is returning intermittent 502s to roughly <strong>3% of traffic</strong> during the 12:00–13:00 UTC peak window. Backend services behind the gateway are healthy:</p>" +
+        "<ul>" +
+        "<li>Upstream 5xx rate: 0.01% (unchanged)</li>" +
+        "<li>Upstream p99 latency: 180ms (normal)</li>" +
+        "<li>No backend timeouts in upstream logs</li>" +
+        "</ul>" +
+        "<p>Failure pattern on the gateway side:</p>" +
+        "<blockquote>Two of three gateway pods show CPU at ~85% during the spike. The third stays at 40%. Pod with low CPU is the newest — restarted 3 hours ago.</blockquote>" +
+        "<p>Suspect upstream connection pool saturation but we can't see pool metrics from outside. Change window is open if you need us to apply anything. Reference dashboard: <a href=\"https://grafana.initech.example/d/apim-gateway?from=now-24h\" target=\"_blank\" rel=\"noopener\">apim-gateway-24h</a>.</p>" +
+        "<p>Best regards,<br>Janet Park<br>Initech SRE</p>",
+      createdAt: minutesAgo(60 * 3),
+    },
+    {
+      id: "cmt-1002-2",
+      caseId: "case-1002",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Janet,</p>" +
+        "<p>On it. Two asks while I get our team looking at the dashboard:</p>" +
+        "<ol>" +
+        "<li>Thread dump from one of the high-CPU gateway pods captured <strong>during</strong> the spike (not after). <code>jstack &lt;pid&gt; &gt; gw-pod-dump.txt</code> works.</li>" +
+        "<li>Current values for these from the gateway deployment.toml:" +
+        "<pre><code>[transport.http.properties]\nthread.pool.size = 200\nmax.connections.per.host = 100\nconnection.keep.alive = true</code></pre>" +
+        "</li>" +
+        "</ol>" +
+        "<p>The low-CPU pod being the freshly-restarted one is a strong hint that the pool is leaking. We've seen this pattern in 4.3.x; see <a href=\"https://github.com/wso2/api-manager/issues/14087\" target=\"_blank\" rel=\"noopener\">api-manager#14087</a>.</p>" +
+        "<p>Thanks,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 2 + 20),
+    },
+    {
+      id: "cmt-1002-3",
+      caseId: "case-1002",
+      authorName: "Janet Park",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Thread dump and configs uploaded. The relevant transport block:</p>" +
+        "<pre><code>[transport.http.properties]\nthread.pool.size = 200\nmax.connections.per.host = 100\nconnection.keep.alive = true\nsocket.timeout = 60000\nconnection.timeout = 5000</code></pre>" +
+        "<p>From the thread dump on <code>apim-gw-2</code> (high CPU):</p>" +
+        "<blockquote>92 threads stuck in <code>PoolingHttpClientConnectionManager.lease()</code>. About 60 of those are blocked on <code>BlockingChannel.read()</code> waiting for a connection.</blockquote>" +
+        "<p>This matches the pool exhaustion hypothesis. Should we just bump <code>max.connections.per.host</code> or is there a smarter fix?</p>" +
+        "<p>Thanks,<br>Janet</p>",
+      createdAt: minutesAgo(60 * 1 + 50),
+    },
+    {
+      id: "cmt-1002-4",
+      caseId: "case-1002",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Janet,</p>" +
+        "<p>That's the exact pattern from #14087. Two recommended changes — both safe to apply hot:</p>" +
+        "<ol>" +
+        "<li>Raise <code>max.connections.per.host</code> from 100 to <strong>500</strong>. Your traffic profile justifies it; default of 100 was calibrated for low-RPS deployments.</li>" +
+        "<li>Set <code>connection.eviction.idle.timeout = 30000</code> to actively reap stale connections. The default leak path keeps half-open connections around for 60+s.</li>" +
+        "</ol>" +
+        "<p>After applying, restart pods one at a time and watch:</p>" +
+        "<pre><code>kubectl rollout restart deployment/apim-gateway -n apim\nkubectl logs -f -l app=apim-gateway -n apim | grep -E 'lease|eviction'</code></pre>" +
+        "<p>Marking solution_proposed once you confirm. If steady-state is still bumpy after 24h we can dig into the leak source (looks like a custom mediator holding refs, but let's see if the config fix is enough first).</p>" +
+        "<p>Best regards,<br>Sajith</p>",
+      createdAt: minutesAgo(60 + 30),
+    },
+    {
+      id: "cmt-1002-5",
+      caseId: "case-1002",
+      authorName: "Janet Park",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Applied both changes 30 minutes ago. Rolling restart complete. Gateway CPU dropped from 85% to 45% across all pods, 5xx rate at 0.02% (effectively gone). Will keep monitoring for the next peak window and report back tomorrow.</p>" +
+        "<p>Thanks,<br>Janet</p>",
+      createdAt: minutesAgo(4),
+    },
+  ],
+  "case-1003": [
+    {
+      id: "cmt-1003-1",
+      caseId: "case-1003",
+      authorName: "Bill Lumbergh",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi WSO2 support,</p>" +
+        "<p>Our MI cluster fails to start after applying update level <code>wso2mi-4.4.0.7</code> last night. Two pods stay in CrashLoopBackOff.</p>" +
+        "<p>The Carbon log shows:</p>" +
+        "<pre><code>org.osgi.framework.BundleException: Could not resolve module: com.initech.security.userstore [318]\n  Caused by: java.lang.ClassNotFoundException: \n    org.wso2.carbon.security.user.api.UserStoreException</code></pre>" +
+        "<p>This is from a custom security extension we built a year ago. It worked fine on <code>wso2mi-4.4.0.4</code> through <code>4.4.0.6</code>.</p>" +
+        "<p>What changed in 4.4.0.7 around the user-API classloader? If you can confirm a class move/rename we'll just rebuild the extension.</p>" +
+        "<p>Best regards,<br>Bill Lumbergh<br>Initech Platform Team</p>",
+      createdAt: minutesAgo(60 * 6),
+    },
+    {
+      id: "cmt-1003-wn-1",
+      caseId: "case-1003",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      internal: true,
+      bodyHtml:
+        "<p><strong>Work note:</strong> 4.4.0.7 included a JDK 17 cleanup that moved <code>org.wso2.carbon.security.user.api</code> from the old <code>org.wso2.carbon.core</code> bundle into <code>org.wso2.carbon.identity.framework</code>. Customer's extension is targeting the old import-package. Need to give them the new manifest entries.</p>",
+      createdAt: minutesAgo(60 * 5 + 30),
+    },
+    {
+      id: "cmt-1003-2",
+      caseId: "case-1003",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Bill,</p>" +
+        "<p>Confirmed — 4.4.0.7 moved the user-API classes during a JDK 17 cleanup. Your extension is importing the old bundle.</p>" +
+        "<p>Old (broken) import in your MANIFEST.MF:</p>" +
+        "<pre><code>Import-Package: org.wso2.carbon.user.api;version=\"[1.0,2)\"</code></pre>" +
+        "<p>New entry to add:</p>" +
+        "<pre><code>Import-Package: \n  org.wso2.carbon.identity.user.api;version=\"[1.0,2)\",\n  org.wso2.carbon.user.api;version=\"[1.0,2)\";resolution:=optional</code></pre>" +
+        "<p>The <code>resolution:=optional</code> on the old package keeps your extension backward-compatible with 4.4.0.6 and earlier — same JAR will load on both.</p>" +
+        "<p>Full migration notes: <a href=\"https://docs.wso2.com/mi/4.4/migration/jdk17-package-changes\" target=\"_blank\" rel=\"noopener\">MI 4.4 JDK 17 package changes</a>.</p>" +
+        "<p>Let me know when you've rebuilt and we can verify in staging.</p>" +
+        "<p>Best regards,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 5),
+    },
+    {
+      id: "cmt-1003-3",
+      caseId: "case-1003",
+      authorName: "Bill Lumbergh",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>That worked. Rebuilt the extension with the dual-import, deployed to staging on 4.4.0.7 — cluster came up clean, all health checks green. Also tested on 4.4.0.6 to confirm backward compatibility, no regression.</p>" +
+        "<p>Planning to roll to prod tonight during the change window. Thanks for the fast turnaround.</p>" +
+        "<p>Thanks,<br>Bill</p>",
+      createdAt: minutesAgo(60 * 1 + 30),
+    },
+  ],
+  "case-1004": [
+    {
+      id: "cmt-1004-1",
+      caseId: "case-1004",
+      authorName: "Rohan Mehta",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi support,</p>" +
+        "<p>The userinfo endpoint stopped returning the <code>groups</code> claim for users authenticated via our corporate IdP. Worked last week, no client config change on our side.</p>" +
+        "<p>Repro:</p>" +
+        "<ol>" +
+        "<li>Authenticate as <code>bob@acmefinancial.com</code> via the corporate IdP federation</li>" +
+        "<li>Exchange code for tokens at <code>/oauth2/token</code></li>" +
+        "<li>Call <code>/oauth2/userinfo</code> with the access token</li>" +
+        "<li>Response includes <code>sub</code>, <code>email</code>, <code>name</code> — but no <code>groups</code></li>" +
+        "</ol>" +
+        "<p>Expected: <code>groups</code> should be a JSON array of LDAP DN strings.</p>" +
+        "<p>Reference for our claim mapping: <a href=\"https://docs.wso2.com/identity-server/oidc-claims-mapping\" target=\"_blank\" rel=\"noopener\">OIDC claims mapping docs</a>.</p>" +
+        "<p>Could a federated IdP attribute mapping have been changed, or is this a known issue in 7.1.0? Test account available on request.</p>" +
+        "<p>Best regards,<br>Rohan Mehta<br>Acme Financial</p>",
+      createdAt: minutesAgo(75),
+    },
+    {
+      id: "cmt-1004-2",
+      caseId: "case-1004",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Rohan,</p>" +
+        "<p>Picked up. While I dig in, can you check whether the <code>groups</code> claim appears in the ID token vs. just the userinfo response?</p>" +
+        "<pre><code># Decode the ID token from /oauth2/token response\necho \"&lt;id_token&gt;\" | cut -d. -f2 | base64 -d | jq .</code></pre>" +
+        "<p>If <code>groups</code> shows up in the ID token but not userinfo, that's a claim-scope-mapping issue on the userinfo endpoint. If it's missing from both, it's an attribute-mapping issue on the federated authenticator.</p>" +
+        "<p>Thanks,<br>Sajith</p>",
+      createdAt: minutesAgo(60),
+    },
+  ],
+  "case-1005": [
+    {
+      id: "cmt-1005-1",
+      caseId: "case-1005",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi WSO2 team,</p>" +
+        "<p>Our Choreo deployment for the <code>checkout-v2</code> component has been stuck at \"Provisioning\" for about 45 minutes. Component is a Go service, build succeeded, but the pod never reaches Ready.</p>" +
+        "<p>Tried already:</p>" +
+        "<ul>" +
+        "<li>Deleting and redeploying — same outcome</li>" +
+        "<li>Smaller resource ask (256Mi → 128Mi) — same outcome</li>" +
+        "<li>Switching the build profile — no effect</li>" +
+        "</ul>" +
+        "<p>Nothing useful in the Choreo UI beyond \"Provisioning\". Can you check the underlying pod state from the platform side?</p>" +
+        "<p>Thanks,<br>Daniel Owens<br>Engineering, Acme Choreo</p>",
+      createdAt: minutesAgo(60 * 4),
+    },
+    {
+      id: "cmt-1005-wn-1",
+      caseId: "case-1005",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      internal: true,
+      bodyHtml:
+        "<p><strong>Work note:</strong> Suspect the new ingress controller default timeouts. Will pair with @Priya on tomorrow's call before sharing anything externally.</p>",
+      createdAt: minutesAgo(60 * 3 + 30),
+    },
+    {
+      id: "cmt-1005-2",
+      caseId: "case-1005",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Daniel,</p>" +
+        "<p>Pulled the pod state. The container is alive but failing the readiness probe — TCP check on port 8080 times out:</p>" +
+        "<pre><code>Events:\n  Warning  Unhealthy  43m (x12)  kubelet  Readiness probe failed: \n    dial tcp 10.4.7.23:8080: i/o timeout</code></pre>" +
+        "<p>What port is the Go service binding to? In the Choreo component descriptor (the <code>.choreo/component.yaml</code>), the default expected port is 8080. If your service binds to anything else (3000, 9000, etc.) the probe will never pass.</p>" +
+        "<p>Reference: <a href=\"https://wso2.com/choreo/docs/develop-components/configure-endpoints/\" target=\"_blank\" rel=\"noopener\">Choreo component endpoint config</a>.</p>" +
+        "<p>Thanks,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 2 + 50),
+    },
+    {
+      id: "cmt-1005-3",
+      caseId: "case-1005",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Found it. The service binds to <code>:9001</code> in the Go code, but our <code>component.yaml</code> still has the scaffold default:</p>" +
+        "<pre><code>endpoints:\n  - name: checkout\n    port: 8080  # &lt;-- wrong\n    type: REST</code></pre>" +
+        "<p>Updating to 9001, rebuilding. Will close this out if the next deploy succeeds.</p>" +
+        "<p>Thanks for the quick turnaround.</p>" +
+        "<p>Thanks,<br>Daniel</p>",
+      createdAt: minutesAgo(60 * 2),
+    },
+    {
+      id: "cmt-1005-4",
+      caseId: "case-1005",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Deploy succeeded with the corrected port. Component is healthy. Closing.</p>" +
+        "<p>Thanks,<br>Daniel</p>",
+      createdAt: minutesAgo(60),
+    },
+  ],
+
+  "case-1006": [
+    {
+      id: "cmt-1006-1",
+      caseId: "case-1006",
+      authorName: "Helena Voss",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi WSO2 team,</p>" +
+        "<p>SAML response signature validation is failing on our Asgardeo tenant for the staging Salesforce SP. Error from the IS logs:</p>" +
+        "<pre><code>org.wso2.carbon.identity.sso.saml.exception.IdentityException:\n  Signature validation failed for SAML response\n  at org.wso2.carbon.identity.sso.saml.processors.SPInitSSOAuthnRequestValidator\n    .validateSignature(SPInitSSOAuthnRequestValidator.java:331)</code></pre>" +
+        "<p>Started after we rotated the Salesforce signing cert yesterday. New cert is RSA-2048, SHA-256, re-uploaded to the SP config in Asgardeo. Production tenant is on the old cert and working fine; staging only.</p>" +
+        "<p>Reference: <a href=\"https://help.salesforce.com/s/articleView?id=sf.identity_saml_certificate_rotation.htm\" target=\"_blank\" rel=\"noopener\">SF cert rotation docs</a>.</p>" +
+        "<p>Best regards,<br>Helena Voss<br>Globex IAM Team</p>",
+      createdAt: minutesAgo(60 * 8),
+    },
+    {
+      id: "cmt-1006-2",
+      caseId: "case-1006",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Helena,</p>" +
+        "<p>Two things to verify:</p>" +
+        "<ol>" +
+        "<li>The cert thumbprint stored on the SP record actually matches what you uploaded. From the Asgardeo console: <em>SP &gt; Inbound auth &gt; SAML &gt; Certificate</em> — copy the displayed thumbprint.</li>" +
+        "<li>The signature algorithm on the request matches what's configured. Staging SF may be sending SHA-1 even after the rotation; the SP record needs to accept it.</li>" +
+        "</ol>" +
+        "<p>Quick check from your side — paste the relevant block from the SP record (you can redact the cert body, just keep the algorithm fields):</p>" +
+        "<pre><code>&lt;ds:SignatureMethod Algorithm=\"...\"/&gt;\n&lt;ds:DigestMethod Algorithm=\"...\"/&gt;</code></pre>" +
+        "<p>Thanks,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 7),
+    },
+    {
+      id: "cmt-1006-3",
+      caseId: "case-1006",
+      authorName: "Helena Voss",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Thumbprint on the SP record matches the new cert exactly. From the SAML config:</p>" +
+        "<pre><code>&lt;ds:SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\"/&gt;\n&lt;ds:DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\"/&gt;</code></pre>" +
+        "<p>Both SHA-256. The request from SF staging also uses SHA-256 (I checked the raw POST).</p>" +
+        "<p>One thing I noticed in the IS logs:</p>" +
+        "<blockquote>The cert thumbprint in the failed validation log shows the OLD cert thumbprint, not the new one we uploaded.</blockquote>" +
+        "<p>Cache?</p>" +
+        "<p>Thanks,<br>Helena</p>",
+      createdAt: minutesAgo(60 * 6),
+    },
+    {
+      id: "cmt-1006-4",
+      caseId: "case-1006",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Helena,</p>" +
+        "<p>Yep — Asgardeo caches the SP cert for 1 hour by default. Your upload landed but validation is still hitting the old cached cert. Two options:</p>" +
+        "<ul>" +
+        "<li><strong>Wait it out</strong> — cache TTL expires within the hour, then re-test.</li>" +
+        "<li><strong>Force refresh</strong> — toggle the SP's <em>Enable signature validation</em> off + save, then back on + save. This invalidates the cache entry.</li>" +
+        "</ul>" +
+        "<p>Production wasn't affected because cert was rotated during a window where the cache happened to be cold.</p>" +
+        "<p>Background: <a href=\"https://wso2.com/asgardeo/docs/references/sp-cert-cache\" target=\"_blank\" rel=\"noopener\">Asgardeo SP cert cache reference</a>.</p>" +
+        "<p>Best regards,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 5),
+    },
+    {
+      id: "cmt-1006-5",
+      caseId: "case-1006",
+      authorName: "Helena Voss",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Force-refreshed via the toggle. Validation works immediately. Closing this out.</p>" +
+        "<p>Thanks,<br>Helena</p>",
+      createdAt: minutesAgo(60 * 4 + 30),
+    },
+  ],
+  "case-1011": [
+    {
+      id: "cmt-1011-1",
+      caseId: "case-1011",
+      authorName: "Marcus Liang",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi WSO2 team,</p>" +
+        "<p>Need help tuning the LDAP userstore on our IS deployment. Search queries against the userstore are taking <strong>1.2–1.8s</strong> for queries that should be instant. We have ~85,000 user entries.</p>" +
+        "<p>Current config (from <code>user-mgt.xml</code>):</p>" +
+        "<pre><code>&lt;Property name=\"ConnectionPoolingEnabled\"&gt;true&lt;/Property&gt;\n&lt;Property name=\"MaxActiveConnections\"&gt;50&lt;/Property&gt;\n&lt;Property name=\"ConnectionPoolMinIdle\"&gt;10&lt;/Property&gt;\n&lt;Property name=\"SearchScope\"&gt;SUB&lt;/Property&gt;\n&lt;Property name=\"UserSearchBase\"&gt;ou=people,dc=globex,dc=com&lt;/Property&gt;</code></pre>" +
+        "<p>LDAP-side indexes look fine — pres/sub/eq on <code>uid, mail, cn, member</code>. Network RTT to LDAP is stable at ~2ms.</p>" +
+        "<p>Suspect we're paginating poorly or doing redundant searches. Reference doc we've been working from: <a href=\"https://docs.wso2.com/identity-server/userstore-tuning\" target=\"_blank\" rel=\"noopener\">userstore tuning guide</a>.</p>" +
+        "<p>Thanks,<br>Marcus Liang<br>Globex Security Engineering</p>",
+      createdAt: minutesAgo(60 * 10),
+    },
+    {
+      id: "cmt-1011-2",
+      caseId: "case-1011",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Marcus,</p>" +
+        "<p>The pool config looks fine for 85k entries. Two likely culprits:</p>" +
+        "<ol>" +
+        "<li>Group lookup amplification — IS hits the LDAP for the user, then for each group the user is in, then for each user in those groups (when role-based authorisation is enabled). Easy to verify; enable LDAP-side query logging for 5 minutes during a normal load period and count queries per login.</li>" +
+        "<li><code>SearchScope=SUB</code> from a deep base DN walks the whole subtree. If your tree has many OUs under <code>ou=people</code>, this is slow even with indexes.</li>" +
+        "</ol>" +
+        "<p>Can you share:</p>" +
+        "<ul>" +
+        "<li>A 1-min LDAP query log slice during peak (sanitised)</li>" +
+        "<li>The OU layout under <code>ou=people,dc=globex,dc=com</code></li>" +
+        "</ul>" +
+        "<p>Best regards,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 9 + 30),
+    },
+    {
+      id: "cmt-1011-3",
+      caseId: "case-1011",
+      authorName: "Marcus Liang",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>You called it. Query log shows 47 LDAP queries <em>per login</em> on average. The amplification pattern is clear:</p>" +
+        "<blockquote>1 bind + 1 user search + 3 group memberOf lookups + 12 nested group enumerations + 30 attribute fetches per nested member.</blockquote>" +
+        "<p>OU layout is flat — everyone under <code>ou=people</code> directly, no sub-OUs. So SUB scope shouldn't be the issue, but the nested group walk definitely is.</p>" +
+        "<p>How do we cut the amplification?</p>" +
+        "<p>Thanks,<br>Marcus</p>",
+      createdAt: minutesAgo(60 * 8 + 30),
+    },
+    {
+      id: "cmt-1011-4",
+      caseId: "case-1011",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Marcus,</p>" +
+        "<p>Three tweaks that compound to cut your per-login query count from ~47 to ~5:</p>" +
+        "<ol>" +
+        "<li><strong>Enable group caching</strong> on the userstore:" +
+        "<pre><code>&lt;Property name=\"GroupListCacheEnabled\"&gt;true&lt;/Property&gt;\n&lt;Property name=\"GroupListCacheTimeout\"&gt;300&lt;/Property&gt;</code></pre>" +
+        "5-minute TTL. Drops repeated group enumeration calls.</li>" +
+        "<li><strong>Cap nested group depth</strong>. Default is unlimited; for most enterprise directories depth 3 is the natural ceiling:" +
+        "<pre><code>&lt;Property name=\"MaxRoleNamesLimit\"&gt;100&lt;/Property&gt;\n&lt;Property name=\"NestedGroupSearchDepth\"&gt;3&lt;/Property&gt;</code></pre></li>" +
+        "<li><strong>Switch to memberOf-based group resolution</strong>. If your LDAP supports the <code>memberOf</code> reverse-index (RFC 4511 attribute), single-query group lookup replaces the recursive walk:" +
+        "<pre><code>&lt;Property name=\"ReadGroups\"&gt;true&lt;/Property&gt;\n&lt;Property name=\"GroupMembershipAttribute\"&gt;memberOf&lt;/Property&gt;\n&lt;Property name=\"BackLinksEnabled\"&gt;true&lt;/Property&gt;</code></pre></li>" +
+        "</ol>" +
+        "<p>Apply 1 + 2 first (safe, no LDAP-side requirements). 3 needs your AD/LDAP admin to confirm memberOf is populated — most Active Directory deployments have it on by default. OpenLDAP needs the <a href=\"https://www.openldap.org/doc/admin26/overlays.html#Reverse Group Membership Maintenance\" target=\"_blank\" rel=\"noopener\">memberof overlay</a>.</p>" +
+        "<p>Restart IS after applying. Watch <code>org.wso2.carbon.user.core.ldap</code> at DEBUG for 10 min to confirm the query count drops.</p>" +
+        "<p>Best regards,<br>Sajith</p>",
+      createdAt: minutesAgo(60 * 7),
+    },
+    {
+      id: "cmt-1011-5",
+      caseId: "case-1011",
+      authorName: "Marcus Liang",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Hi Sajith,</p>" +
+        "<p>Applied 1 + 2 in staging. Per-login query count dropped from 47 to 12. Login latency for the test users came down from 1.6s to ~280ms.</p>" +
+        "<p>Will check with our LDAP admin on memberOf overlay for #3 (we run OpenLDAP), but 280ms is already inside our SLO. Rolling 1 + 2 to prod tomorrow.</p>" +
+        "<p>Thanks for the deep dive.</p>" +
+        "<p>Thanks,<br>Marcus</p>",
+      createdAt: minutesAgo(60 * 5),
+    },
+  ],
+
+  // ------------------------------------------------------------------------
+  // case-1015: Long-running technical thread used to evaluate engineer UX on
+  // dense comment trails — Java stack traces, code blocks, config diffs,
+  // long-form work notes. Spans ~36 hours of back-and-forth.
+  // ------------------------------------------------------------------------
+  "case-1015": [
+    {
+      id: "cmt-1015-1",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Choreo runtime is going OOM under sustained load (~120 RPS sustained). The crash takes the whole pod down and the autoscaler can't keep up. Started this morning around <code>05:40 UTC</code> after the rollout of release <code>v4.2.1</code>. Reverting to <code>v4.2.0</code> resolves it.</p><p>Attaching the heap dump (<code>heap-prod-01.hprof</code>, ~480MB) and the last 2000 lines of the runtime log.</p>",
+      createdAt: minutesAgo(60 * 35),
+    },
+    {
+      id: "cmt-1015-2",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Hi Daniel — picked this up. Can you confirm:</p><ol><li>Are <strong>all</strong> pods OOMing, or just specific ones?</li><li>What's the <code>resources.limits.memory</code> on the deployment?</li><li>Is the workload steady-state ~120 RPS, or are there bursts above that?</li></ol><p>Pulling the heap dump now — will analyze with Eclipse MAT and report back.</p>",
+      createdAt: minutesAgo(60 * 34 + 40),
+    },
+    {
+      id: "cmt-1015-3",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>1) All pods, every ~40min under steady load.</p><p>2) Limits are:</p><pre><code>resources:\n  limits:\n    memory: 2Gi\n    cpu: 1500m\n  requests:\n    memory: 1Gi\n    cpu: 500m</code></pre><p>3) Steady-state, no bursts. The dashboard confirms 117–122 RPS for the last 6 hours.</p>",
+      createdAt: minutesAgo(60 * 34 + 20),
+    },
+    {
+      id: "cmt-1015-wn-1",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      internal: true,
+      bodyHtml:
+        "<p><strong>Work note:</strong> Heap dump downloaded. MAT leak suspect points at <code>io.netty.buffer.PooledByteBufAllocator</code> retaining ~1.4GB. Could be the same Netty pool leak we saw in INC-4877 (Choreo runtime 4.1.x). Will diff <code>v4.2.0</code> → <code>v4.2.1</code> for Netty config changes.</p>",
+      createdAt: minutesAgo(60 * 33 + 50),
+    },
+    {
+      id: "cmt-1015-4",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        '<p>The heap dump shows a Netty buffer pool leak. The full leak suspect from Eclipse MAT:</p><pre><code>The thread io.netty.channel.nio.NioEventLoop @ 0x7f8a2c3d4f00 NioEventLoop-3-1\nkeeps local variables with total size 1,432,891,032 (71.46%) bytes.\n\nThe memory is accumulated in one instance of\n"io.netty.buffer.PooledByteBufAllocator$PoolThreadLocalCache" loaded by\n"jdk.internal.loader.ClassLoaders$AppClassLoader @ 0x7f8a2c000028".</code></pre><p>And the suspicious thread stack from the dump:</p><pre><code>at io.netty.buffer.PoolArena.allocateNormal(PoolArena.java:241)\nat io.netty.buffer.PoolArena.allocate(PoolArena.java:215)\nat io.netty.buffer.PoolArena.allocate(PoolArena.java:147)\nat io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:393)\nat io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188)\nat io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:179)\nat io.netty.buffer.AbstractByteBufAllocator.ioBuffer(AbstractByteBufAllocator.java:140)\nat io.netty.channel.DefaultMaxMessagesRecvByteBufAllocator$MaxMessageHandle.allocate(DefaultMaxMessagesRecvByteBufAllocator.java:114)\nat io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:147)\nat io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)\nat io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)\nat io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)\nat io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)\nat io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)\nat java.base/java.lang.Thread.run(Thread.java:840)</code></pre><p>This pattern matches a known issue we fixed in <code>v4.2.2</code>: the new Netty connection-keepalive default was tuned aggressively and caused pool buffers to be cached per-thread without an eviction policy.</p>',
+      createdAt: minutesAgo(60 * 32 + 10),
+    },
+    {
+      id: "cmt-1015-5",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>That looks like exactly what we're seeing. Is <code>v4.2.2</code> available? Should we wait for the patch or is there a workaround?</p>",
+      createdAt: minutesAgo(60 * 31 + 40),
+    },
+    {
+      id: "cmt-1015-6",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        '<p>Two options:</p><p><strong>(A) Workaround (apply now, no downtime):</strong> override the Netty allocator settings via JVM args on the deployment:</p><pre><code>env:\n  - name: JAVA_OPTS\n    value: "-Dio.netty.allocator.maxOrder=9 -Dio.netty.allocator.numDirectArenas=4 -Dio.netty.allocator.cacheTrimInterval=4000"</code></pre><p>This caps the per-thread direct-buffer cache and trims it every 4s. We\'ve validated this on three customer environments — it brings the steady-state direct memory back to ~280MB.</p><p><strong>(B) Patch:</strong> <code>v4.2.2</code> is rolling out next Tuesday (full release). We can backport the fix for you to <code>v4.2.1-hotfix-3</code> today if you prefer staying on .1 line. Let me know.</p>',
+      createdAt: minutesAgo(60 * 31 + 15),
+    },
+    {
+      id: "cmt-1015-wn-2",
+      caseId: "case-1015",
+      authorName: "Lakshmi I.",
+      authorRole: "wso2_engineer",
+      internal: true,
+      bodyHtml:
+        "<p>Coordinating with R&amp;D on the hotfix release. Budhi confirmed the cherry-pick from <code>v4.2.2</code> → <code>v4.2.1-hotfix-3</code> is straightforward (single commit on the Netty allocator config).</p><p>FYI Daniel is on the Acme Choreo account, managed-cloud tier — we should prioritize hotfix path B.</p>",
+      createdAt: minutesAgo(60 * 30 + 50),
+    },
+    {
+      id: "cmt-1015-7",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Applied (A) on the staging deployment first. Direct memory steady at 240–290MB across 4 pods for the last 30 min, no OOMs. Rolling to prod in 15 min unless you say otherwise.</p>",
+      createdAt: minutesAgo(60 * 30),
+    },
+    {
+      id: "cmt-1015-8",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Looks good. Go ahead with prod rollout. Keep us posted on the first 2 hours of steady-state metrics.</p><p>Re: option B — we'll prep <code>v4.2.1-hotfix-3</code> regardless; you can take it whenever your change window allows.</p>",
+      createdAt: minutesAgo(60 * 29 + 50),
+    },
+    {
+      id: "cmt-1015-9",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Prod rollout complete. Memory profile looks flat for the last 90 min. The 40-min OOM cycle is gone.</p><p>One follow-up: we noticed a slight latency increase (p99 from 18ms → 27ms) since applying the JVM args. Is that expected? If so, we can live with it; just want to confirm.</p>",
+      createdAt: minutesAgo(60 * 28),
+    },
+    {
+      id: "cmt-1015-10",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Yes — expected. <code>cacheTrimInterval=4000</code> trims the per-thread buffer cache every 4s; that adds a small reallocation cost on the next request after each trim. Trade-off is ~5–10ms p99 bump vs ~1.2GB direct memory headroom. Most customers prefer the headroom.</p><p>You can tune via <code>cacheTrimInterval</code> if you want a different balance — e.g. <code>8000</code> halves the latency penalty but doubles peak retained memory.</p>",
+      createdAt: minutesAgo(60 * 27 + 50),
+    },
+    {
+      id: "cmt-1015-11",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Understood. We'll stick with 4000 for now. Will plan to take <code>v4.2.1-hotfix-3</code> during next Wednesday's change window.</p>",
+      createdAt: minutesAgo(60 * 27 + 40),
+    },
+    {
+      id: "cmt-1015-wn-3",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      internal: true,
+      bodyHtml:
+        "<p><strong>Work note:</strong> Linking this case to INC-5012 for the platform-wide tracker. Daniel's account is the third managed-cloud customer hitting this since the v4.2.1 rollout — pattern confirmed. R&amp;D is fast-tracking the proper fix into v4.2.2 GA next week.</p><p>Adding @Asanka as watcher since he owns the Choreo runtime SRE on-call this week.</p>",
+      createdAt: minutesAgo(60 * 26),
+    },
+    {
+      id: "cmt-1015-12",
+      caseId: "case-1015",
+      authorName: "Asanka R.",
+      authorRole: "wso2_engineer",
+      internal: true,
+      bodyHtml:
+        "<p>Thanks for the loop in. Picking up the platform-side rollout coordination — I'll make sure the v4.2.2 release notes call out this fix prominently so customers know to take it.</p>",
+      createdAt: minutesAgo(60 * 25 + 40),
+    },
+    {
+      id: "cmt-1015-13",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Update: 18 hours of steady-state production traffic with the workaround. Zero OOMs, memory profile flat, latency stable at p99=27ms. Calling this resolved on our end.</p><p>One question — for the hotfix rollout next Wednesday, do we need to revert the JVM args, or do they coexist safely with the fixed allocator?</p>",
+      createdAt: minutesAgo(60 * 9),
+    },
+    {
+      id: "cmt-1015-14",
+      caseId: "case-1015",
+      authorName: "Sajith Ekanayaka",
+      authorRole: "wso2_engineer",
+      bodyHtml:
+        "<p>Great to hear. Yes, please revert the JVM args when you apply the hotfix — the new allocator defaults in <code>v4.2.1-hotfix-3</code> are tuned to be safe out-of-the-box, and leaving the manual override on top will give you back the latency penalty without any benefit.</p><p>Suggested rollout:</p><ol><li>Apply <code>v4.2.1-hotfix-3</code> to staging, remove the <code>JAVA_OPTS</code> overrides.</li><li>Run for ~2 hours, confirm flat memory profile + p99 back to ~18ms.</li><li>Roll to prod with the same change.</li></ol><p>Marking this case as solution proposed once you confirm the hotfix path is acceptable.</p>",
+      createdAt: minutesAgo(60 * 8 + 40),
+    },
+    {
+      id: "cmt-1015-15",
+      caseId: "case-1015",
+      authorName: "Daniel Owens",
+      authorRole: "customer",
+      bodyHtml:
+        "<p>Sounds good. Hotfix path acceptable. We'll execute Wednesday change window. Thanks for the thorough investigation and fast turnaround.</p>",
+      createdAt: minutesAgo(60 * 7),
+    },
+  ],
+};
+
+// Seed a few work notes on cases that already have comment threads to make
+// the unified Activities feed look realistic out of the box.
+const WORK_NOTES: CsmCaseComment[] = [
+  {
+    id: "wn-1001-1",
+    caseId: "case-1001",
+    authorName: "Sajith Ekanayaka",
+    authorRole: "wso2_engineer",
+    internal: true,
+    bodyHtml:
+      "<p><strong>Work note:</strong> Pulled GC logs from IS node 2. Heap usage normal; suspect connection pool exhaustion on the JDBC userstore.</p>",
+    createdAt: minutesAgo(60 * 5),
+  },
+  {
+    id: "wn-1001-2",
+    caseId: "case-1001",
+    authorName: "Lakshmi I.",
+    authorRole: "wso2_engineer",
+    internal: true,
+    bodyHtml:
+      "<p>Looped in @Priya for a second look. Will reply to customer once we have a confirmed root cause.</p>",
+    createdAt: minutesAgo(60 * 4),
+  },
+  {
+    id: "wn-1002-1",
+    caseId: "case-1002",
+    authorName: "Sajith Ekanayaka",
+    authorRole: "wso2_engineer",
+    internal: true,
+    bodyHtml:
+      "<p><strong>Work note:</strong> Pod-2 thread dump shows 92 threads stuck in <code>BlockingChannel.read</code> — looks like the same pattern from INC-4877.</p>",
+    createdAt: minutesAgo(60 * 1 + 30),
+  },
+];
+for (const wn of WORK_NOTES) {
+  const bucket = SEED_COMMENTS[wn.caseId] ?? [];
+  bucket.push(wn);
+  SEED_COMMENTS[wn.caseId] = bucket;
+}
+
+const runtime: Map<string, CsmCaseComment[]> = new Map(
+  Object.entries(SEED_COMMENTS).map(([k, v]) => [k, [...v]]),
+);
+
+function ensureBucket(caseId: string): CsmCaseComment[] {
+  let bucket = runtime.get(caseId);
+  if (!bucket) {
+    bucket = [];
+    runtime.set(caseId, bucket);
+  }
+  return bucket;
+}
+
+export function getMockCsmCaseComments(caseId: string): CsmCaseComment[] {
+  // Return a fresh array so callers can't mutate our store.
+  return [...ensureBucket(caseId)].sort((a, b) =>
+    a.createdAt.localeCompare(b.createdAt),
+  );
+}
+
+export interface MockPostCsmCaseCommentInput {
+  caseId: string;
+  bodyHtml: string;
+  authorName: string;
+  authorRole: "wso2_engineer";
+  internal?: boolean;
+}
+
+export function postMockCsmCaseComment(
+  input: MockPostCsmCaseCommentInput,
+): CsmCaseComment {
+  const comment: CsmCaseComment = {
+    id: `cmt-${input.caseId}-${Date.now()}`,
+    caseId: input.caseId,
+    authorName: input.authorName,
+    authorRole: input.authorRole,
+    bodyHtml: input.bodyHtml,
+    createdAt: new Date().toISOString(),
+    internal: input.internal ?? false,
+  };
+  ensureBucket(input.caseId).push(comment);
+  return comment;
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import type {
+  BeCaseComment,
+  BeCaseCommentCreatePayload,
+  BeCaseCommentSearchPayload,
+  BeCaseCommentSearchResponse,
+} from "@api/backend/types";
+import {
+  commentTypeFromInternal,
+  uiCommentFromBe,
+} from "@api/backend/mappers";
+import {
+  getMockCsmCaseComments,
+  postMockCsmCaseComment,
+} from "@features/csm-cases/api/mocks/commentsMocks";
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+const MOCK_LATENCY_MS = 150;
+
+/** Page size used by the comments list. Capped at 100 by the BE. */
+const COMMENTS_PAGE_LIMIT = 100;
+
+/**
+ * Load all comments on a case. In LIVE mode calls
+ * `POST /cases/{id}/comments/search` with a wide page (limit=100). If a case
+ * exceeds that, switch consumers to an explicit pagination wrapper rather
+ * than chasing pages here.
+ */
+export function useGetCsmCaseComments(
+  caseId: string | undefined,
+): UseQueryResult<CsmCaseComment[], Error> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useQuery<CsmCaseComment[], Error>({
+    queryKey: [ApiQueryKeys.CSM_CASE_COMMENTS, caseId ?? ""],
+    queryFn: async (): Promise<CsmCaseComment[]> => {
+      if (!caseId) return [];
+
+      if (isMockMode()) {
+        logger.debug(
+          `[useGetCsmCaseComments] Returning mock comments for ${caseId}`,
+        );
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return getMockCsmCaseComments(caseId);
+      }
+
+      const payload: BeCaseCommentSearchPayload = {
+        pagination: { offset: 0, limit: COMMENTS_PAGE_LIMIT },
+      };
+      const response = await api.post<
+        BeCaseCommentSearchPayload,
+        BeCaseCommentSearchResponse
+      >(`/cases/${encodeURIComponent(caseId)}/comments/search`, payload);
+      return response.comments.map(uiCommentFromBe);
+    },
+    enabled: !!caseId,
+    staleTime: 10_000,
+  });
+}
+
+export interface PostCsmCaseCommentInput {
+  caseId: string;
+  /** Plain-text body. HTML is escaped on render. */
+  bodyHtml: string;
+  /** Display name of the logged-in engineer. */
+  authorName: string;
+  /** If true, the entry is an internal work note (not customer-visible). */
+  internal?: boolean;
+}
+
+/**
+ * Create a comment on a case. The backend accepts a plain-text body; the FE
+ * still passes a `bodyHtml` field for parity with the mock, but it's stored
+ * as plain text and re-rendered on read.
+ */
+export function usePostCsmCaseComment(): UseMutationResult<
+  CsmCaseComment,
+  Error,
+  PostCsmCaseCommentInput
+> {
+  const logger = useLogger();
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<CsmCaseComment, Error, PostCsmCaseCommentInput>({
+    mutationFn: async (input): Promise<CsmCaseComment> => {
+      if (isMockMode()) {
+        logger.debug(
+          `[usePostCsmCaseComment] Posting mock comment for ${input.caseId}`,
+        );
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return postMockCsmCaseComment({
+          caseId: input.caseId,
+          bodyHtml: input.bodyHtml,
+          authorName: input.authorName,
+          authorRole: "wso2_engineer",
+          internal: input.internal ?? false,
+        });
+      }
+
+      const payload: BeCaseCommentCreatePayload = {
+        commentType: commentTypeFromInternal(input.internal ?? false),
+        // BE stores plain text. Strip simple HTML so we don't double-escape on read.
+        body: input.bodyHtml.replace(/<\/?[^>]+>/g, "").trim(),
+      };
+      const created = await api.post<
+        BeCaseCommentCreatePayload,
+        BeCaseComment
+      >(`/cases/${encodeURIComponent(input.caseId)}/comments`, payload);
+      return uiCommentFromBe(created);
+    },
+    onSuccess: (newComment, variables) => {
+      queryClient.setQueryData<CsmCaseComment[] | undefined>(
+        [ApiQueryKeys.CSM_CASE_COMMENTS, variables.caseId],
+        (prev) => (prev ? [...prev, newComment] : [newComment]),
+      );
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import {
+  severityFromPriority,
+  uiStateFromBe,
+} from "@api/backend/mappers";
+import type {
+  BeAccount,
+  BeAccountSearchPayload,
+  BeAccountSearchResponse,
+  BeCase,
+  BeProject,
+  BeProjectSearchPayload,
+  BeProjectSearchResponse,
+} from "@api/backend/types";
+import { getMockCsmCaseDetailById } from "@features/csm-cases/api/mocks/casesMocks";
+import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+
+const MOCK_LATENCY_MS = 150;
+const PROJECT_PAGE_LIMIT = 100;
+const ACCOUNT_PAGE_LIMIT = 100;
+
+/**
+ * Build a thin CsmCaseDetail from the lean `BeCase` payload plus optional
+ * hydrated project/account context. Side widgets (SLA clocks, watchers, tags,
+ * time logs, attachments, linked items, customer + product context) are not
+ * yet returned by the backend, so they default to empty / placeholder values.
+ * The UI degrades gracefully — sections render empty states rather than
+ * crashing.
+ */
+function detailFromBeCase(
+  c: BeCase,
+  project?: BeProject,
+  account?: BeAccount,
+): CsmCaseDetail {
+  const customer = account?.name ?? "—";
+  return {
+    id: c.id,
+    caseNumber: c.number ?? c.id,
+    wso2CaseId: c.wso2Id ?? c.id,
+    subject: c.subject ?? "(no subject)",
+    customer,
+    accountId: project?.accountId ?? account?.id ?? "",
+    projectId: c.projectId ?? "",
+    projectName: project?.name ?? project?.projectKey ?? "—",
+    product: "—",
+    severity: severityFromPriority(c.priority),
+    state: uiStateFromBe(c.state),
+    assignee: c.createdBy ?? "Unassigned",
+    assigneeIsMe: false,
+    slaClockType: "ack",
+    minutesToBreach: 0,
+    createdAt: c.createdAt ?? "",
+    updatedAt: c.updatedAt ?? c.createdAt ?? "",
+    description: c.description ?? "",
+    assignmentGroup: "grp.cre_team",
+    createdBy: c.createdBy ?? undefined,
+    customerContext: {
+      accountName: customer,
+      tier: "subscription",
+      region: account?.region ?? "—",
+      primaryContact: "—",
+      primaryContactEmail: "—",
+      accountManager: account?.ownerId ?? "—",
+      openCases: 0,
+    },
+    productContext: {
+      product: "—",
+      version: "—",
+      deployment: "—",
+      environment: "prod",
+    },
+    slaClocks: [],
+    watchers: [],
+    linkedItems: [],
+    tags: [],
+    timeLogs: [],
+    audit: [],
+    attachments: [],
+    isWatching: false,
+  };
+}
+
+/**
+ * Look up a single CSM case by id. Returns `null` (not an error) when the
+ * id is unknown so the page can render a not-found state for that case.
+ *
+ * Calls `GET /cases/{id}` in LIVE mode and falls back to the seeded mock
+ * detail when the mock toggle is on.
+ */
+export function useGetCsmCaseDetail(
+  caseId: string | undefined,
+): UseQueryResult<CsmCaseDetail | null, Error> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useQuery<CsmCaseDetail | null, Error>({
+    queryKey: [ApiQueryKeys.CSM_CASE_DETAIL, caseId ?? ""],
+    queryFn: async (): Promise<CsmCaseDetail | null> => {
+      if (!caseId) return null;
+
+      if (isMockMode()) {
+        logger.debug(`[useGetCsmCaseDetail] Returning mock case ${caseId}`);
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return getMockCsmCaseDetailById(caseId) ?? null;
+      }
+
+      const beCase = await api.get<BeCase>(
+        `/cases/${encodeURIComponent(caseId)}`,
+      );
+      if (!beCase) return null;
+
+      // Hydrate project + account so the customer / project links in the
+      // page header are not empty strings (which would no-op the click).
+      // The BE has no by-id endpoints yet, so this falls through to the
+      // paginated search and filters client-side. Failures degrade silently
+      // — the case still renders with "—" placeholders.
+      let project: BeProject | undefined;
+      let account: BeAccount | undefined;
+      if (beCase.projectId) {
+        try {
+          const pRes = await api.post<
+            BeProjectSearchPayload,
+            BeProjectSearchResponse
+          >("/projects/search", {
+            pagination: { offset: 0, limit: PROJECT_PAGE_LIMIT },
+          });
+          project = (pRes.projects ?? []).find((p) => p.id === beCase.projectId);
+        } catch (err) {
+          logger.warn(
+            `[useGetCsmCaseDetail] project hydrate failed: ${
+              (err as Error).message
+            }`,
+          );
+        }
+      }
+      if (project?.accountId) {
+        try {
+          const aRes = await api.post<
+            BeAccountSearchPayload,
+            BeAccountSearchResponse
+          >("/accounts/search", {
+            pagination: { offset: 0, limit: ACCOUNT_PAGE_LIMIT },
+          });
+          account = (aRes.accounts ?? []).find((a) => a.id === project!.accountId);
+        } catch (err) {
+          logger.warn(
+            `[useGetCsmCaseDetail] account hydrate failed: ${
+              (err as Error).message
+            }`,
+          );
+        }
+      }
+      return detailFromBeCase(beCase, project, account);
+    },
+    enabled: !!caseId,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import {
+  severityFromPriority,
+  uiStateFromBe,
+} from "@api/backend/mappers";
+import type {
+  BeAccountSearchPayload,
+  BeAccountSearchResponse,
+  BeCaseSearchResponse,
+  BeProject,
+  BeProjectCaseSearchPayload,
+  BeProjectSearchPayload,
+  BeProjectSearchResponse,
+} from "@api/backend/types";
+import { getMockCsmCases } from "@features/csm-cases/api/mocks/casesMocks";
+import type { DashboardScope } from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  CsmCaseRow,
+  CsmCasesListResponse,
+} from "@features/csm-cases/types/csmCases";
+
+const MOCK_LATENCY_MS = 200;
+
+/** Max number of projects we fan out across to assemble the cross-project list. */
+const PROJECT_FAN_OUT_LIMIT = 20;
+/** Max cases pulled per project in the cross-project fan-out. */
+const CASES_PER_PROJECT_LIMIT = 30;
+
+/**
+ * Cross-project CSM cases list.
+ *
+ * The backend exposes only a project-scoped case search
+ * (`POST /projects/{id}/cases/search`). To preserve the cross-project list
+ * UX, LIVE mode performs a bounded fan-out: pulls the first
+ * {@link PROJECT_FAN_OUT_LIMIT} projects from `/projects/search`, then runs
+ * the case search in parallel against each (limit
+ * {@link CASES_PER_PROJECT_LIMIT}). Results are concatenated and mapped to
+ * the UI's `CsmCaseRow` shape. Note: the BE doesn't yet support filtering
+ * by assignee, so the `scope` parameter is currently a no-op in LIVE.
+ */
+export function useGetCsmCases(
+  scope: DashboardScope,
+): UseQueryResult<CsmCasesListResponse, Error> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useQuery<CsmCasesListResponse, Error>({
+    queryKey: [ApiQueryKeys.CSM_CASES, scope],
+    queryFn: async (): Promise<CsmCasesListResponse> => {
+      if (isMockMode()) {
+        logger.debug(`[useGetCsmCases] Returning mock cases for scope=${scope}`);
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return getMockCsmCases(scope);
+      }
+
+      const [projectsResponse, accountsResponse] = await Promise.all([
+        api.post<BeProjectSearchPayload, BeProjectSearchResponse>(
+          "/projects/search",
+          { pagination: { offset: 0, limit: PROJECT_FAN_OUT_LIMIT } },
+        ),
+        api
+          .post<BeAccountSearchPayload, BeAccountSearchResponse>(
+            "/accounts/search",
+            { pagination: { offset: 0, limit: PROJECT_FAN_OUT_LIMIT } },
+          )
+          .catch((err) => {
+            logger.warn(
+              `[useGetCsmCases] /accounts/search failed: ${(err as Error).message}`,
+            );
+            return {
+              accounts: [],
+              total: 0,
+              limit: 0,
+              offset: 0,
+              hasMore: false,
+            } satisfies BeAccountSearchResponse;
+          }),
+      ]);
+      const projects: BeProject[] = projectsResponse.projects ?? [];
+      const projectName = new Map<string, string>(
+        projects.map((p) => [p.id, p.name ?? p.projectKey ?? p.id]),
+      );
+      const projectAccount = new Map<string, string>(
+        projects
+          .filter((p) => p.accountId)
+          .map((p) => [p.id, p.accountId as string]),
+      );
+      const accountName = new Map<string, string>(
+        (accountsResponse.accounts ?? [])
+          .filter((a) => a.name)
+          .map((a) => [a.id, a.name as string]),
+      );
+
+      // Fan out: one search per project in parallel.
+      const perProject = await Promise.all(
+        projects.map((p) =>
+          api
+            .post<BeProjectCaseSearchPayload, BeCaseSearchResponse>(
+              `/projects/${encodeURIComponent(p.id)}/cases/search`,
+              {
+                pagination: { offset: 0, limit: CASES_PER_PROJECT_LIMIT },
+              },
+            )
+            .catch((err) => {
+              logger.warn(
+                `[useGetCsmCases] cases/search for project ${p.id} failed: ${
+                  (err as Error).message
+                }`,
+              );
+              return null;
+            }),
+        ),
+      );
+
+      const cases: CsmCaseRow[] = [];
+      for (const r of perProject) {
+        if (!r) continue;
+        for (const c of r.cases ?? []) {
+          const projectId = c.projectId ?? "";
+          const accountId = projectAccount.get(projectId) ?? "";
+          cases.push({
+            id: c.id,
+            caseNumber: c.number ?? c.id,
+            wso2CaseId: c.wso2Id ?? c.id,
+            subject: c.subject ?? "(no subject)",
+            customer: accountName.get(accountId) ?? "—",
+            accountId,
+            projectId,
+            projectName: projectName.get(projectId) ?? "—",
+            product: "—",
+            severity: severityFromPriority(c.priority),
+            state: uiStateFromBe(c.state),
+            assignee: c.createdBy ?? "Unassigned",
+            assigneeIsMe: false,
+            slaClockType: "ack",
+            minutesToBreach: 0,
+            createdAt: c.createdAt ?? "",
+            updatedAt: c.updatedAt ?? c.createdAt ?? "",
+          });
+        }
+      }
+      return { scope, cases };
+    },
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/usePostCsmCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/usePostCsmCase.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import type { BeCase, BeCaseCreatePayload } from "@api/backend/types";
+
+const MOCK_LATENCY_MS = 200;
+
+/**
+ * Create a case via `POST /cases`. Returns the created case. The mutation
+ * also invalidates project-scoped case searches so list views refresh.
+ *
+ * In MOCK mode the mutation resolves with a fabricated case using the input
+ * payload; nothing is persisted server-side.
+ */
+export function usePostCsmCase(): UseMutationResult<
+  BeCase,
+  Error,
+  BeCaseCreatePayload
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BeCase, Error, BeCaseCreatePayload>({
+    mutationFn: async (input): Promise<BeCase> => {
+      if (isMockMode()) {
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        const now = new Date().toISOString();
+        return {
+          id: `mock-${Math.random().toString(36).slice(2, 10)}`,
+          number: `CS-MOCK-${Math.floor(Math.random() * 9000) + 1000}`,
+          projectId: input.projectId,
+          deploymentId: input.deploymentId,
+          deployedProductId: input.deployedProductId,
+          subject: input.subject,
+          description: input.description,
+          priority: input.priority,
+          issueType: input.issueType,
+          state: "open",
+          createdAt: now,
+          updatedAt: now,
+        };
+      }
+      return api.post<BeCaseCreatePayload, BeCase>("/cases", input);
+    },
+    onSuccess: (created) => {
+      // Invalidate any project-scoped search for the case's project.
+      if (created.projectId) {
+        queryClient.invalidateQueries({
+          queryKey: [
+            ApiQueryKeys.BACKEND_PROJECT_CASES_SEARCH,
+            created.projectId,
+          ],
+        });
+      }
+      // And the cross-project CSM cases list (fan-out aggregation).
+      queryClient.invalidateQueries({ queryKey: [ApiQueryKeys.CSM_CASES] });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchProjectCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchProjectCases.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import type {
+  BeCaseSearchResponse,
+  BeProjectCaseSearchPayload,
+} from "@api/backend/types";
+
+/**
+ * Project-scoped case search backed by `POST /projects/{id}/cases/search`.
+ * The case ID being scoped to a project comes from the URL path, so the
+ * payload's `projectIds` is intentionally ignored by the BE.
+ *
+ * Returns the raw backend response. Callers map to UI shapes as needed.
+ *
+ * Used by:
+ *   - Project detail page → cases tab
+ *   - Cross-project fan-out aggregation in `useGetCsmCases` (LIVE mode)
+ */
+export function useSearchProjectCases(
+  projectId: string | undefined,
+  payload: BeProjectCaseSearchPayload = {},
+  options: { enabled?: boolean } = {},
+): UseQueryResult<BeCaseSearchResponse, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeCaseSearchResponse, Error>({
+    queryKey: [
+      ApiQueryKeys.BACKEND_PROJECT_CASES_SEARCH,
+      projectId ?? "",
+      payload,
+    ],
+    queryFn: async () => {
+      if (!projectId) {
+        return { cases: [], total: 0, limit: 0, offset: 0, hasMore: false };
+      }
+      if (isMockMode()) {
+        // In mock mode, callers should use `useGetCsmCases` which has a richer
+        // cross-project seed dataset. This hook is the BE-direct path; returning
+        // an empty page keeps it inert when mocks are on.
+        return { cases: [], total: 0, limit: 0, offset: 0, hasMore: false };
+      }
+      return api.post<BeProjectCaseSearchPayload, BeCaseSearchResponse>(
+        `/projects/${encodeURIComponent(projectId)}/cases/search`,
+        payload,
+      );
+    },
+    enabled: options.enabled ?? !!projectId,
+    staleTime: 15_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -1,0 +1,383 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import {
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown,
+  Clock,
+  Copy,
+  GitBranch,
+  Inbox,
+  Link as LinkIcon,
+  ListChecks,
+  PauseCircle,
+  Phone,
+  Play,
+  RotateCcw,
+  Send,
+  ShieldAlert,
+  TriangleAlert,
+  User,
+  Users,
+} from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import type {
+  CaseLifecycleAction,
+  CsmCaseDetail,
+} from "@features/csm-cases/types/csmCases";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
+
+type ActionConfirm = {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  confirmColor: "primary" | "error" | "warning";
+};
+
+type PrimaryAction = {
+  action: CaseLifecycleAction;
+  label: string;
+  color: "primary" | "success" | "warning" | "error";
+  icon: JSX.Element;
+  /** Hover hint clarifying the consequence of the transition. */
+  tooltip?: string;
+  /**
+   * When set, the action is gated behind a confirmation dialog. Used for
+   * transitions that notify the customer or are otherwise hard to undo, so a
+   * stray click in a busy queue can't silently close a case or email the
+   * customer.
+   */
+  confirm?: ActionConfirm;
+};
+
+const PRIMARY_BY_STATE: Record<CaseState, PrimaryAction[]> = {
+  // Self-assignment moves the case to WIP (ISSU-002), so "Start work" and a
+  // separate "Assign to me" were the same transition — collapsed to one.
+  open: [
+    {
+      action: "start_work",
+      label: "Start work",
+      color: "primary",
+      icon: <Play size={16} />,
+      tooltip: "Assigns this case to you and moves it to Work in progress.",
+    },
+  ],
+  work_in_progress: [
+    {
+      action: "propose_solution",
+      label: "Propose solution",
+      color: "success",
+      icon: <Send size={16} />,
+      confirm: {
+        title: "Propose solution to the customer?",
+        body: "The customer is notified that a solution has been proposed and the case moves to “Solution proposed”.",
+        confirmLabel: "Propose solution",
+        confirmColor: "primary",
+      },
+    },
+    {
+      action: "request_info",
+      label: "Request info",
+      color: "warning",
+      icon: <Inbox size={16} />,
+    },
+    {
+      action: "wait_on_wso2",
+      label: "Wait on WSO2",
+      color: "warning",
+      icon: <Clock size={16} />,
+    },
+  ],
+  // Resume work first (the safe, recoverable default); "Mark resolved" is the
+  // irreversible, customer-notifying action so it is demoted to outlined AND
+  // gated behind a confirmation.
+  solution_proposed: [
+    {
+      action: "resume_work",
+      label: "Resume work",
+      color: "primary",
+      icon: <RotateCcw size={16} />,
+    },
+    {
+      action: "close",
+      label: "Close",
+      color: "success",
+      icon: <CheckCircle size={16} />,
+      confirm: {
+        title: "Close this case?",
+        body: "The customer receives a closure notification and the case moves to “Closed”. Once closed, the case cannot be reopened.",
+        confirmLabel: "Close case",
+        confirmColor: "warning",
+      },
+    },
+  ],
+  awaiting_info: [
+    {
+      action: "resume_work",
+      label: "Resume work",
+      color: "primary",
+      icon: <Play size={16} />,
+    },
+    {
+      action: "close_no_response",
+      label: "Close (no response)",
+      color: "warning",
+      icon: <CheckCircle size={16} />,
+      confirm: {
+        title: "Close without a customer response?",
+        body: "The case is closed because the customer did not respond. They still receive a closure notification. Once closed, the case cannot be reopened.",
+        confirmLabel: "Close case",
+        confirmColor: "warning",
+      },
+    },
+  ],
+  waiting_on_wso2: [
+    {
+      action: "resume_work",
+      label: "Resume work",
+      color: "primary",
+      icon: <Play size={16} />,
+    },
+  ],
+  reopen: [
+    {
+      action: "start_work",
+      label: "Start work",
+      color: "primary",
+      icon: <Play size={16} />,
+    },
+  ],
+  // Closed is terminal for engineers and customers. Reopening is a lead-only
+  // override (see REOPEN_ACTION + the `canReopenClosed` prop) and is appended
+  // separately, so the default closed case offers no reopen path.
+  closed: [],
+};
+
+/**
+ * Lead-only override to reopen a closed case. Not part of PRIMARY_BY_STATE —
+ * it is appended for the `closed` state only when the caller grants the
+ * `canReopenClosed` capability, so normal engineers never see it.
+ */
+const REOPEN_ACTION: PrimaryAction = {
+  action: "reopen",
+  label: "Reopen",
+  color: "warning",
+  icon: <RotateCcw size={16} />,
+  tooltip: "Lead-only: reopen a closed case for an exceptional follow-up.",
+  confirm: {
+    title: "Reopen this closed case?",
+    body: "The case returns to an active state and the customer is notified.",
+    confirmLabel: "Reopen case",
+    confirmColor: "warning",
+  },
+};
+
+interface SecondaryItem {
+  key: string;
+  label: string;
+  icon: JSX.Element;
+  /** If true, render with a divider below in the menu. */
+  divider?: boolean;
+}
+
+/**
+ * The "More" overflow lists state-independent actions on a case. Items here
+ * map to documented use cases — see `UseCases.md`:
+ *   - Reassign / group               → ISSU-002 (self-assign generalised)
+ *   - Escalate / Severity change     → ISSU-006, ISSU-007
+ *   - Hold auto-closure              → ISSU-027
+ *   - Create incident / link incident → ISSU-021
+ *   - Raise Git issue                → ISSU-020
+ *   - Create task                    → ISSU-025
+ *   - Request a call                 → ISSU-008
+ *   - Log time                       → ISSU-017
+ *   - Copy case link                 → ISSU-010 (per-comment + per-case permalinks)
+ *
+ * Intentionally NOT here:
+ *   - Watch / unwatch  → managed via the Watchers widget in Details (ISSU-018)
+ *   - Open in ServiceNow → this platform replaces ServiceNow; no back-link
+ */
+function buildSecondaryItems(): SecondaryItem[] {
+  return [
+    { key: "reassign_engineer", label: "Reassign engineer…", icon: <User size={16} /> },
+    { key: "reassign_group", label: "Reassign to group…", icon: <Users size={16} />, divider: true },
+    { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} /> },
+    { key: "change_severity", label: "Request severity change…", icon: <ShieldAlert size={16} /> },
+    { key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true },
+    { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} /> },
+    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} /> },
+    { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} /> },
+    { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true },
+    { key: "request_call", label: "Request a call…", icon: <Phone size={16} /> },
+    { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },
+    { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },
+  ];
+}
+
+interface CaseActionBarProps {
+  caseDetail: CsmCaseDetail;
+  onAction: (
+    action: CaseLifecycleAction | { secondary: string },
+  ) => void | Promise<unknown>;
+  /**
+   * Grants the lead-only "Reopen" action on a closed case. Defaults to false,
+   * so a closed case is terminal unless the caller is a lead.
+   */
+  canReopenClosed?: boolean;
+}
+
+/**
+ * Lifecycle + overflow action bar for the case detail page. Primary buttons
+ * are state-driven (only valid transitions show). Secondary actions live in
+ * an overflow menu and are state-independent.
+ */
+export default function CaseActionBar({
+  caseDetail,
+  onAction,
+  canReopenClosed = false,
+}: CaseActionBarProps): JSX.Element {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [pendingConfirm, setPendingConfirm] = useState<PrimaryAction | null>(
+    null,
+  );
+  const primary = [
+    ...(PRIMARY_BY_STATE[caseDetail.state] ?? []),
+    ...(caseDetail.state === "closed" && canReopenClosed
+      ? [REOPEN_ACTION]
+      : []),
+  ];
+  const secondary = buildSecondaryItems();
+
+  const runPrimary = (p: PrimaryAction): void => {
+    if (p.confirm) {
+      setPendingConfirm(p);
+      return;
+    }
+    void onAction(p.action);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        flexWrap: "wrap",
+        justifyContent: { xs: "flex-start", md: "flex-end" },
+      }}
+    >
+      {primary.map((p, idx) => {
+        const button = (
+          <Button
+            size="small"
+            variant={idx === 0 ? "contained" : "outlined"}
+            color={p.color}
+            startIcon={p.icon}
+            onClick={() => runPrimary(p)}
+          >
+            {p.label}
+          </Button>
+        );
+        return p.tooltip ? (
+          <Tooltip key={p.action} title={p.tooltip}>
+            {button}
+          </Tooltip>
+        ) : (
+          <Box key={p.action} component="span" sx={{ display: "inline-flex" }}>
+            {button}
+          </Box>
+        );
+      })}
+
+      <Button
+        size="small"
+        variant="outlined"
+        color="primary"
+        endIcon={<ChevronDown size={16} />}
+        onClick={(e) => setMenuAnchor(e.currentTarget)}
+      >
+        More
+      </Button>
+      <Menu
+        anchorEl={menuAnchor}
+        open={!!menuAnchor}
+        onClose={() => setMenuAnchor(null)}
+      >
+        {secondary.map((item) => [
+          <MenuItem
+            key={item.key}
+            onClick={() => {
+              setMenuAnchor(null);
+              void onAction({ secondary: item.key });
+            }}
+            sx={{ gap: 1.25, minHeight: 36 }}
+          >
+            {item.icon}
+            {item.label}
+          </MenuItem>,
+          item.divider ? (
+            <Box
+              key={`${item.key}-divider`}
+              sx={{ borderTop: 1, borderColor: "divider", my: 0.25 }}
+            />
+          ) : null,
+        ])}
+      </Menu>
+
+      <Dialog
+        open={!!pendingConfirm}
+        onClose={() => setPendingConfirm(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>{pendingConfirm?.confirm?.title}</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            {pendingConfirm?.confirm?.body}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingConfirm(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color={pendingConfirm?.confirm?.confirmColor ?? "primary"}
+            startIcon={pendingConfirm?.icon}
+            onClick={() => {
+              const p = pendingConfirm;
+              setPendingConfirm(null);
+              if (p) void onAction(p.action);
+            }}
+          >
+            {pendingConfirm?.confirm?.confirmLabel ?? "Confirm"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Paper, Typography } from "@wso2/oxygen-ui";
+import {
+  Activity,
+  ArrowUpRight,
+  CheckCircle,
+  Link as LinkIcon,
+  Paperclip,
+  Plus,
+  TriangleAlert,
+  User,
+  Users,
+} from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type JSX } from "react";
+import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
+import RelativeTime from "@components/RelativeTime";
+import { formatBytes } from "@utils/formatBytes";
+import type {
+  CaseAttachment,
+  CaseAuditEntry,
+  CsmCaseComment,
+} from "@features/csm-cases/types/csmCases";
+
+type FeedEntry =
+  | { kind: "comment"; at: string; comment: CsmCaseComment }
+  | { kind: "audit"; at: string; entry: CaseAuditEntry }
+  | { kind: "attachment"; at: string; attachment: CaseAttachment };
+
+interface CaseActivitiesFeedProps {
+  comments: CsmCaseComment[];
+  audit: CaseAuditEntry[];
+  attachments: CaseAttachment[];
+}
+
+const AUDIT_ICON: Record<CaseAuditEntry["kind"], JSX.Element> = {
+  state_change: <CheckCircle size={14} />,
+  assignee_change: <User size={14} />,
+  severity_change: <TriangleAlert size={14} />,
+  linked: <LinkIcon size={14} />,
+  escalated: <ArrowUpRight size={14} />,
+  watcher_added: <Users size={14} />,
+  comment_added: <Activity size={14} />,
+  attachment_added: <Paperclip size={14} />,
+  sla_breached: <TriangleAlert size={14} />,
+  created: <Plus size={14} />,
+};
+
+export default function CaseActivitiesFeed({
+  comments,
+  audit,
+  attachments,
+}: CaseActivitiesFeedProps): JSX.Element {
+  const [showWorkNotes, setShowWorkNotes] = useState(true);
+  const [showLifecycle, setShowLifecycle] = useState(true);
+  const [showAttachments, setShowAttachments] = useState(true);
+  const [newestFirst, setNewestFirst] = useState(true);
+
+  const entries: FeedEntry[] = useMemo(() => {
+    const out: FeedEntry[] = [];
+    for (const c of comments) {
+      if (c.internal && !showWorkNotes) continue;
+      out.push({ kind: "comment", at: c.createdAt, comment: c });
+    }
+    if (showLifecycle) {
+      for (const a of audit) {
+        out.push({ kind: "audit", at: a.createdAt, entry: a });
+      }
+    }
+    if (showAttachments) {
+      for (const a of attachments) {
+        out.push({ kind: "attachment", at: a.uploadedAt, attachment: a });
+      }
+    }
+    out.sort((a, b) =>
+      newestFirst ? b.at.localeCompare(a.at) : a.at.localeCompare(b.at),
+    );
+    return out;
+  }, [
+    comments,
+    audit,
+    attachments,
+    showWorkNotes,
+    showLifecycle,
+    showAttachments,
+    newestFirst,
+  ]);
+
+  const counts = {
+    comments: comments.filter((c) => !c.internal).length,
+    workNotes: comments.filter((c) => c.internal).length,
+    lifecycle: audit.length,
+    attachments: attachments.length,
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          flexWrap: "wrap",
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          Filter:
+        </Typography>
+        <Chip
+          size="small"
+          variant={showWorkNotes ? "filled" : "outlined"}
+          color={showWorkNotes ? "primary" : "default"}
+          label={`Work notes (${counts.workNotes})`}
+          onClick={() => setShowWorkNotes((v) => !v)}
+        />
+        <Chip
+          size="small"
+          variant={showLifecycle ? "filled" : "outlined"}
+          color={showLifecycle ? "primary" : "default"}
+          label={`State changes (${counts.lifecycle})`}
+          onClick={() => setShowLifecycle((v) => !v)}
+        />
+        <Chip
+          size="small"
+          variant={showAttachments ? "filled" : "outlined"}
+          color={showAttachments ? "primary" : "default"}
+          label={`Attachments (${counts.attachments})`}
+          onClick={() => setShowAttachments((v) => !v)}
+        />
+        <Box sx={{ flex: 1 }} />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={newestFirst ? "Newest first" : "Oldest first"}
+          onClick={() => setNewestFirst((v) => !v)}
+        />
+      </Box>
+
+      {entries.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nothing to show — try widening the filters above.
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+          {entries.map((e) => {
+            if (e.kind === "comment") {
+              return (
+                <CsmCaseCommentBubble
+                  key={`c-${e.comment.id}`}
+                  comment={e.comment}
+                />
+              );
+            }
+            if (e.kind === "audit") {
+              const isBreach = e.entry.kind === "sla_breached";
+              return (
+                <Paper
+                  id={e.entry.id}
+                  key={`a-${e.entry.id}`}
+                  variant="outlined"
+                  sx={{
+                    p: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1.25,
+                    backgroundColor: isBreach ? "error.50" : "background.default",
+                    borderColor: isBreach ? "error.main" : undefined,
+                    scrollMarginTop: 96,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      color: isBreach ? "error.main" : "text.secondary",
+                      display: "flex",
+                    }}
+                  >
+                    {AUDIT_ICON[e.entry.kind]}
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="body2">
+                      {e.entry.description}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {e.entry.actor} ·{" "}
+                      <RelativeTime
+                        iso={e.entry.createdAt}
+                        href={`#${e.entry.id}`}
+                      />
+                    </Typography>
+                  </Box>
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    label="Lifecycle"
+                    color={isBreach ? "error" : "default"}
+                  />
+                </Paper>
+              );
+            }
+            // attachment
+            return (
+              <Paper
+                id={e.attachment.id}
+                key={`f-${e.attachment.id}`}
+                variant="outlined"
+                sx={{
+                  p: 1,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1.25,
+                  backgroundColor: "background.default",
+                  scrollMarginTop: 96,
+                }}
+              >
+                <Paperclip size={14} />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2">
+                    <strong>{e.attachment.filename}</strong>{" "}
+                    <Typography
+                      component="span"
+                      variant="caption"
+                      color="text.secondary"
+                    >
+                      ({formatBytes(e.attachment.size)} · {e.attachment.contentType})
+                    </Typography>
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Uploaded by {e.attachment.uploadedBy} ·{" "}
+                    <RelativeTime
+                      iso={e.attachment.uploadedAt}
+                      href={`#${e.attachment.id}`}
+                    />
+                  </Typography>
+                </Box>
+                <Chip size="small" variant="outlined" label="Attachment" />
+              </Paper>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Standalone Attachments table — used by the Attachments tab content (if any
+// surface needs the raw list separately from the unified feed).
+// ---------------------------------------------------------------------------
+
+export function AttachmentsList({
+  attachments,
+}: {
+  attachments: CaseAttachment[];
+}): JSX.Element {
+  if (attachments.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No attachments on this case.
+      </Typography>
+    );
+  }
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+      {attachments.map((a) => (
+        <Paper
+          key={a.id}
+          variant="outlined"
+          sx={{ p: 1, display: "flex", alignItems: "center", gap: 1.25 }}
+        >
+          <Paperclip size={14} />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="body2">
+              <strong>{a.filename}</strong>
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {formatBytes(a.size)} · {a.contentType} · uploaded by{" "}
+              {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />
+            </Typography>
+          </Box>
+        </Paper>
+      ))}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -1,0 +1,835 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  Chip,
+  IconButton,
+  LinearProgress,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import {
+  Activity,
+  ArrowUpRight,
+  Building,
+  CheckCircle,
+  Clock,
+  Download,
+  ExternalLink,
+  History,
+  Link as LinkIcon,
+  Mail,
+  MapPin,
+  Paperclip,
+  Plus,
+  Server,
+  Shield,
+  TriangleAlert,
+  User,
+  Users,
+} from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { Link as RouterLink } from "react-router";
+import { initialsOf } from "@utils/userClaims";
+import { formatBytes } from "@utils/formatBytes";
+import type {
+  CaseAttachment,
+  CaseAuditEntry,
+  CaseCustomerContext,
+  CaseLinkedItem,
+  CaseProductContext,
+  CaseSlaClock,
+  CaseTag,
+  CaseTimeLogEntry,
+  CaseWatcher,
+  DeploymentCategory,
+} from "@features/csm-cases/types/csmCases";
+import { TIER_COLOR, TIER_LABEL } from "@features/csm-cases/utils/caseTier";
+import {
+  SLA_CLOCK_LABEL,
+  formatTimeToBreach,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import RelativeTime from "@components/RelativeTime";
+
+// ---------------------------------------------------------------------------
+// Shared widget shell
+// ---------------------------------------------------------------------------
+
+interface WidgetCardProps {
+  title: string;
+  icon?: JSX.Element;
+  action?: JSX.Element;
+  children: React.ReactNode;
+}
+
+function WidgetCard({ title, icon, action, children }: WidgetCardProps): JSX.Element {
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+          mb: 1.25,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          {icon}
+          <Typography variant="subtitle2">{title}</Typography>
+        </Box>
+        {action}
+      </Box>
+      {children}
+    </Card>
+  );
+}
+
+function MetaRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: 1.5,
+        py: 0.5,
+        borderTop: 1,
+        borderColor: "divider",
+        "&:first-of-type": { borderTop: 0, pt: 0 },
+      }}
+    >
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ minWidth: 96, pt: 0.25 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ flex: 1, minWidth: 0, fontSize: "0.875rem" }}>{children}</Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 1. Customer / Account context
+// ---------------------------------------------------------------------------
+
+export function CustomerContextWidget({
+  ctx,
+}: {
+  ctx: CaseCustomerContext;
+}): JSX.Element {
+  return (
+    <WidgetCard
+      title="Customer"
+      icon={<Building size={16} />}
+      action={
+        <Chip
+          size="small"
+          label={TIER_LABEL[ctx.tier]}
+          color={TIER_COLOR[ctx.tier]}
+        />
+      }
+    >
+      <MetaRow label="Account">
+        <Typography variant="body2">
+          <strong>{ctx.accountName}</strong>
+        </Typography>
+      </MetaRow>
+      <MetaRow label="Primary contact">
+        <Box sx={{ display: "flex", flexDirection: "column" }}>
+          <Typography variant="body2">{ctx.primaryContact}</Typography>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
+          >
+            <Mail size={12} />
+            {ctx.primaryContactEmail}
+          </Typography>
+        </Box>
+      </MetaRow>
+      <MetaRow label="Region">
+        <Typography
+          variant="body2"
+          sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
+        >
+          <MapPin size={12} />
+          {ctx.region}
+        </Typography>
+      </MetaRow>
+      <MetaRow label="Account Manager">
+        <Typography variant="body2">{ctx.accountManager}</Typography>
+      </MetaRow>
+      {ctx.technicalOwner && (
+        <MetaRow label="Technical Owner">
+          <Typography variant="body2">{ctx.technicalOwner}</Typography>
+        </MetaRow>
+      )}
+      <MetaRow label="Open cases">
+        <Chip size="small" variant="outlined" label={`${ctx.openCases} open`} />
+      </MetaRow>
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Product / environment context
+// ---------------------------------------------------------------------------
+
+const ENV_COLOR: Record<
+  CaseProductContext["environment"],
+  "default" | "info" | "warning" | "error"
+> = {
+  dev: "default",
+  qa: "info",
+  staging: "warning",
+  prod: "error",
+};
+
+const DEPLOYMENT_CATEGORY_LABEL: Record<DeploymentCategory, string> = {
+  primary_production: "Primary Production",
+  staging: "Staging",
+  qa: "QA",
+  stress: "Stress",
+  uat: "UAT",
+  development: "Development",
+};
+
+export function ProductContextWidget({
+  ctx,
+}: {
+  ctx: CaseProductContext;
+}): JSX.Element {
+  const categoryLabel = ctx.deploymentCategory
+    ? DEPLOYMENT_CATEGORY_LABEL[ctx.deploymentCategory]
+    : null;
+  return (
+    <WidgetCard title="Deployment info" icon={<Server size={16} />}>
+      <MetaRow label="Deployment">
+        <Box
+          sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}
+        >
+          <Typography variant="body2">
+            <strong>{ctx.deployment}</strong>
+          </Typography>
+          {categoryLabel && (
+            <Chip
+              size="small"
+              variant="outlined"
+              label={categoryLabel}
+              color={ENV_COLOR[ctx.environment]}
+            />
+          )}
+        </Box>
+      </MetaRow>
+      <MetaRow label="Product">
+        <Typography variant="body2">
+          <strong>{ctx.product}</strong>
+        </Typography>
+      </MetaRow>
+      <MetaRow label="Version">
+        <Typography variant="body2">{ctx.version}</Typography>
+      </MetaRow>
+      {ctx.updateLevel && (
+        <MetaRow label="Update level">
+          <Typography variant="body2">
+            <code style={{ fontSize: "0.8rem" }}>{ctx.updateLevel}</code>
+          </Typography>
+        </MetaRow>
+      )}
+      {ctx.region && (
+        <MetaRow label="Region">
+          <Typography variant="body2">{ctx.region}</Typography>
+        </MetaRow>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. SLA timeline
+// ---------------------------------------------------------------------------
+
+function clockProgress(c: CaseSlaClock): number {
+  if (c.state === "met") return 100;
+  if (c.state === "breached") return 100;
+  const elapsed = c.targetMinutes - Math.max(0, c.minutesToBreach);
+  if (c.targetMinutes <= 0) return 0;
+  return Math.min(100, Math.max(0, (elapsed / c.targetMinutes) * 100));
+}
+
+const CLOCK_COLOR: Record<
+  CaseSlaClock["state"],
+  "primary" | "warning" | "error" | "success"
+> = {
+  running: "primary",
+  paused: "warning",
+  met: "success",
+  breached: "error",
+};
+
+export function SlaTimelineWidget({
+  clocks,
+}: {
+  clocks: CaseSlaClock[];
+}): JSX.Element {
+  return (
+    <WidgetCard title="SLA timeline" icon={<Clock size={16} />}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        {clocks.map((c) => {
+          const stateText =
+            c.state === "met"
+              ? "Met"
+              : c.state === "breached"
+                ? formatTimeToBreach(c.minutesToBreach)
+                : c.state === "paused"
+                  ? "Paused"
+                  : formatTimeToBreach(c.minutesToBreach);
+          return (
+            <Box
+              key={c.clockType}
+              sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 1,
+                }}
+              >
+                <Typography variant="body2">
+                  {SLA_CLOCK_LABEL[c.clockType]}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  color={
+                    c.state === "breached"
+                      ? "error.main"
+                      : c.state === "met"
+                        ? "success.main"
+                        : c.state === "paused"
+                          ? "warning.main"
+                          : "text.secondary"
+                  }
+                >
+                  {stateText}
+                </Typography>
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={clockProgress(c)}
+                color={CLOCK_COLOR[c.state]}
+                sx={{ height: 6, borderRadius: 1 }}
+              />
+              <Typography variant="caption" color="text.secondary">
+                Target: {formatMinutes(c.targetMinutes)}
+              </Typography>
+            </Box>
+          );
+        })}
+      </Box>
+    </WidgetCard>
+  );
+}
+
+function formatMinutes(m: number): string {
+  if (m < 60) return `${m}m`;
+  const h = m / 60;
+  if (h < 24) return `${h}h`;
+  return `${Math.round(h / 24)}d`;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Watchers
+// ---------------------------------------------------------------------------
+
+const ROLE_LABEL: Record<CaseWatcher["role"], string> = {
+  wso2_engineer: "WSO2",
+  customer_contact: "Customer",
+  manager: "Manager",
+};
+
+export function WatchersWidget({
+  watchers,
+  onAdd,
+}: {
+  watchers: CaseWatcher[];
+  onAdd?: () => void;
+}): JSX.Element {
+  return (
+    <WidgetCard
+      title="Watchers"
+      icon={<Users size={16} />}
+      action={
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<Plus size={14} />}
+          onClick={onAdd}
+        >
+          Add
+        </Button>
+      }
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+        {watchers.map((w) => (
+          <Box
+            key={w.id}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              py: 0.5,
+            }}
+          >
+            <Avatar sx={{ width: 28, height: 28, fontSize: "0.75rem" }}>
+              {initialsOf(w.name)}
+            </Avatar>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography variant="body2" sx={{ lineHeight: 1.2 }}>
+                {w.name} {w.isMe && <em>(you)</em>}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {ROLE_LABEL[w.role]}
+              </Typography>
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Linked items
+// ---------------------------------------------------------------------------
+
+const LINKED_ICON: Record<CaseLinkedItem["kind"], JSX.Element> = {
+  case: <LinkIcon size={14} />,
+  incident: <TriangleAlert size={14} />,
+  escalation: <ArrowUpRight size={14} />,
+  kb: <Shield size={14} />,
+  cr: <CheckCircle size={14} />,
+  sr: <CheckCircle size={14} />,
+};
+
+const LINKED_LABEL: Record<CaseLinkedItem["kind"], string> = {
+  case: "Case",
+  incident: "Incident",
+  escalation: "Escalation",
+  kb: "KB",
+  cr: "CR",
+  sr: "SR",
+};
+
+export function LinkedItemsWidget({
+  items,
+  onLink,
+}: {
+  items: CaseLinkedItem[];
+  onLink?: () => void;
+}): JSX.Element {
+  return (
+    <WidgetCard
+      title="Linked items"
+      icon={<LinkIcon size={16} />}
+      action={
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<Plus size={14} />}
+          onClick={onLink}
+        >
+          Link
+        </Button>
+      }
+    >
+      {items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nothing linked yet.
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+          {items.map((item) => {
+            const inner = (
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  p: 0.75,
+                  borderRadius: 1,
+                  border: 1,
+                  borderColor: "divider",
+                  "&:hover": item.href
+                    ? { backgroundColor: "action.hover", cursor: "pointer" }
+                    : undefined,
+                }}
+              >
+                {LINKED_ICON[item.kind]}
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: "block", lineHeight: 1.1 }}
+                  >
+                    {LINKED_LABEL[item.kind]} · {item.reference} · {item.state}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      lineHeight: 1.2,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {item.title}
+                  </Typography>
+                </Box>
+                {!item.href && <ExternalLink size={14} />}
+              </Box>
+            );
+            return item.href ? (
+              <RouterLink
+                key={item.id}
+                to={item.href}
+                style={{ textDecoration: "none", color: "inherit" }}
+              >
+                {inner}
+              </RouterLink>
+            ) : (
+              <Box key={item.id}>{inner}</Box>
+            );
+          })}
+        </Box>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Tags
+// ---------------------------------------------------------------------------
+
+export function TagsWidget({
+  tags,
+  onAdd,
+}: {
+  tags: CaseTag[];
+  onAdd?: () => void;
+}): JSX.Element {
+  return (
+    <WidgetCard
+      title="Tags"
+      icon={<Shield size={16} />}
+      action={
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<Plus size={14} />}
+          onClick={onAdd}
+        >
+          Tag
+        </Button>
+      }
+    >
+      {tags.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No tags applied.
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+          {tags.map((t) => (
+            <Chip
+              key={t.id}
+              size="small"
+              label={t.label}
+              color={t.color ?? "default"}
+              variant="outlined"
+            />
+          ))}
+        </Box>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Time logs
+// ---------------------------------------------------------------------------
+
+export function TimeLogsWidget({
+  logs,
+  onAdd,
+}: {
+  logs: CaseTimeLogEntry[];
+  onAdd?: () => void;
+}): JSX.Element {
+  const totalHours = logs.reduce((sum, l) => sum + l.hours, 0);
+  return (
+    <WidgetCard
+      title="Time tracked"
+      icon={<Clock size={16} />}
+      action={
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<Plus size={14} />}
+          onClick={onAdd}
+        >
+          Log time
+        </Button>
+      }
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          mb: 1,
+        }}
+      >
+        <Typography variant="h6" sx={{ lineHeight: 1 }}>
+          {totalHours.toFixed(2)}h
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          Across {logs.length} {logs.length === 1 ? "entry" : "entries"}
+        </Typography>
+      </Box>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        {logs.slice(0, 3).map((l) => (
+          <Box
+            key={l.id}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              p: 0.75,
+              borderRadius: 1,
+              border: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 1,
+              }}
+            >
+              <Typography variant="body2">{l.engineer}</Typography>
+              <Chip size="small" variant="outlined" label={`${l.hours}h`} />
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              {l.note} · <RelativeTime iso={l.date} />
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 7b. Attachments (all files on the case, newest first)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lists every attachment on the case in descending order of upload time, with
+ * a "Download all" affordance. Downloads are surfaced through the parent's
+ * action handler (mock) until the BE exposes attachment download URLs.
+ */
+export function AttachmentsWidget({
+  attachments,
+  onDownloadAll,
+  onDownload,
+}: {
+  attachments: CaseAttachment[];
+  onDownloadAll?: () => void;
+  onDownload?: (attachment: CaseAttachment) => void;
+}): JSX.Element {
+  const sorted = [...attachments].sort(
+    (a, b) =>
+      new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime(),
+  );
+  return (
+    <WidgetCard
+      title={`Attachments (${sorted.length})`}
+      icon={<Paperclip size={16} />}
+      action={
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<Download size={14} />}
+          onClick={onDownloadAll}
+          disabled={sorted.length === 0}
+        >
+          Download all
+        </Button>
+      }
+    >
+      {sorted.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No attachments on this case.
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          {sorted.map((a) => (
+            <Box
+              key={a.id}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                p: 1,
+                borderRadius: 1,
+                border: 1,
+                borderColor: "divider",
+              }}
+            >
+              <Paperclip size={16} />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                  {a.filename}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {formatBytes(a.size)} · {a.contentType} · uploaded by{" "}
+                  {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />
+                </Typography>
+              </Box>
+              <Tooltip title="Download">
+                <IconButton
+                  size="small"
+                  aria-label={`Download ${a.filename}`}
+                  onClick={() => onDownload?.(a)}
+                >
+                  <Download size={16} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Audit timeline (lifecycle events, distinct from comments)
+// ---------------------------------------------------------------------------
+
+const AUDIT_ICON: Record<CaseAuditEntry["kind"], JSX.Element> = {
+  state_change: <CheckCircle size={14} />,
+  assignee_change: <User size={14} />,
+  severity_change: <TriangleAlert size={14} />,
+  linked: <LinkIcon size={14} />,
+  escalated: <ArrowUpRight size={14} />,
+  watcher_added: <Users size={14} />,
+  comment_added: <Activity size={14} />,
+  attachment_added: <Activity size={14} />,
+  sla_breached: <TriangleAlert size={14} />,
+  created: <Plus size={14} />,
+};
+
+export function AuditTimelineWidget({
+  entries,
+}: {
+  entries: CaseAuditEntry[];
+}): JSX.Element {
+  return (
+    <WidgetCard title="Lifecycle history" icon={<History size={16} />}>
+      <Box sx={{ display: "flex", flexDirection: "column" }}>
+        {entries.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No lifecycle events yet.
+          </Typography>
+        ) : (
+          entries
+            .slice()
+            .reverse()
+            .map((e, idx, arr) => (
+              <Box
+                key={e.id}
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  position: "relative",
+                  pb: idx === arr.length - 1 ? 0 : 1.25,
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 22,
+                    flexShrink: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    color: e.kind === "sla_breached" ? "error.main" : "text.secondary",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      mt: 0.25,
+                      p: 0.25,
+                      borderRadius: "50%",
+                      border: 1,
+                      borderColor: e.kind === "sla_breached" ? "error.main" : "divider",
+                      backgroundColor: "background.paper",
+                    }}
+                  >
+                    {AUDIT_ICON[e.kind]}
+                  </Box>
+                  {idx !== arr.length - 1 && (
+                    <Box
+                      sx={{
+                        width: 1,
+                        flex: 1,
+                        borderLeft: 1,
+                        borderColor: "divider",
+                        my: 0.25,
+                      }}
+                    />
+                  )}
+                </Box>
+                <Box sx={{ flex: 1, minWidth: 0, pb: 0.25 }}>
+                  <Typography variant="body2">{e.description}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {e.actor} · <RelativeTime iso={e.createdAt} />
+                  </Typography>
+                </Box>
+              </Box>
+            ))
+        )}
+      </Box>
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Re-export: silence "Activity" reference vs `Activity` rename in lucide.
+// ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Card, Chip, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
+import type { JSX, ReactNode } from "react";
+import type { NavigateFunction } from "react-router";
+import { TIER_COLOR, TIER_LABEL } from "@features/csm-cases/utils/caseTier";
+import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+
+interface CaseMetaBandProps {
+  detail: CsmCaseDetail;
+  navigate: NavigateFunction;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}
+
+function Cell({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 0.25,
+        minWidth: 0,
+      }}
+    >
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function LinkText({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Typography
+      variant="body2"
+      noWrap
+      onClick={onClick}
+      sx={{
+        cursor: "pointer",
+        color: "primary.main",
+        "&:hover": { textDecoration: "underline" },
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+/**
+ * Always-visible facts band shown directly under the case header. Engineers
+ * see assignee, deployment/product/version, who created the case, and which
+ * account/project it belongs to without diving into a tab. The chevron in the
+ * top-right collapses the band body into a slim header strip.
+ */
+export default function CaseMetaBand({
+  detail: c,
+  navigate,
+  collapsed,
+  onToggleCollapsed,
+}: CaseMetaBandProps): JSX.Element {
+  const product = c.productContext;
+  const tier = c.customerContext.tier;
+  const versionLabel =
+    product.updateLevel && product.updateLevel.trim().length > 0
+      ? product.updateLevel
+      : product.version || "—";
+  // One-line digest shown when the band is collapsed, so collapsing doesn't
+  // hide every triage fact — account, tier, and who owns the case stay visible.
+  const collapsedSummary = [c.customer, TIER_LABEL[tier], c.assignee]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        backgroundColor: "background.default",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: 2,
+          py: collapsed ? 0.75 : 1,
+        }}
+      >
+        {collapsed ? (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            noWrap
+            sx={{ minWidth: 0, mr: 1 }}
+          >
+            {collapsedSummary}
+          </Typography>
+        ) : (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ textTransform: "uppercase", letterSpacing: 0.4, fontWeight: 600 }}
+          >
+            Overview
+          </Typography>
+        )}
+        <Tooltip title={collapsed ? "Show details" : "Hide details"}>
+          <IconButton
+            size="small"
+            onClick={onToggleCollapsed}
+            aria-label={collapsed ? "Show case details" : "Hide case details"}
+          >
+            {collapsed ? <ChevronDown size={18} /> : <ChevronUp size={18} />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+      {!collapsed && (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "1fr 1fr",
+              sm: "repeat(3, minmax(0, 1fr))",
+              md: "repeat(4, minmax(0, 1fr))",
+            },
+            gap: 2,
+            px: 2,
+            pb: 2,
+            pt: 0.5,
+            borderTop: 1,
+            borderColor: "divider",
+          }}
+        >
+          <Cell label="Tier">
+            <Box sx={{ minWidth: 0 }}>
+              <Chip
+                size="small"
+                label={TIER_LABEL[tier]}
+                color={TIER_COLOR[tier]}
+              />
+            </Box>
+          </Cell>
+          <Cell label="Assignee">
+            <Typography variant="body2" noWrap>
+              {c.assigneeIsMe ? (
+                <strong>{c.assignee}</strong>
+              ) : (
+                c.assignee
+              )}
+            </Typography>
+          </Cell>
+          <Cell label="Created by">
+            <Typography variant="body2" noWrap>
+              {c.createdBy ?? c.customerContext.primaryContact ?? "—"}
+            </Typography>
+          </Cell>
+          <Cell label="Account">
+            {c.accountId ? (
+              <LinkText onClick={() => navigate(`/accounts/${c.accountId}`)}>
+                {c.customer}
+              </LinkText>
+            ) : (
+              <Typography variant="body2" noWrap>
+                {c.customer}
+              </Typography>
+            )}
+          </Cell>
+          <Cell label="Project">
+            {c.projectId ? (
+              <LinkText onClick={() => navigate(`/projects/${c.projectId}`)}>
+                {c.projectName}
+              </LinkText>
+            ) : (
+              <Typography variant="body2" noWrap>
+                {c.projectName}
+              </Typography>
+            )}
+          </Cell>
+          <Cell label="Deployment">
+            <Typography variant="body2" noWrap>
+              {product.deployment ?? "—"}
+            </Typography>
+          </Cell>
+          <Cell label="Product">
+            <Typography variant="body2" noWrap>
+              {product.product ?? "—"}
+            </Typography>
+          </Cell>
+          <Cell label="Version">
+            <Typography variant="body2" noWrap>
+              {versionLabel}
+            </Typography>
+          </Cell>
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -1,0 +1,547 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Divider,
+  FormControl,
+  Grid,
+  IconButton,
+  InputAdornment,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import type { SelectChangeEvent } from "@wso2/oxygen-ui";
+import {
+  ChevronDown,
+  ChevronUp,
+  ListFilter,
+  Search,
+  X,
+} from "@wso2/oxygen-ui-icons-react";
+import { useMemo, type JSX } from "react";
+import type {
+  CaseState,
+  DashboardScope,
+  Severity,
+} from "@features/csm-dashboard/types/abtDashboard";
+import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+
+export type SlaFilter = "any" | "breached" | "at_risk";
+
+/** Sentinel used inside `assignees` to mean "the current user". */
+export const ASSIGNEE_ME_TOKEN = "@me";
+/** Literal assignee name used in mock data for unassigned cases. */
+export const ASSIGNEE_UNASSIGNED = "Unassigned";
+
+/**
+ * Filter state for the CSM cases list. `severities` / `states` are multi-select
+ * arrays driven by fixed enums. `assignees` / `projects` / `products` are
+ * free-form multi-selects driven by an Autocomplete with type-to-filter:
+ * options are derived from the data currently in scope. The `assignees` list
+ * accepts the sentinel `@me` (resolves against `assigneeIsMe`) and the literal
+ * "Unassigned"; any other entries are matched against `case.assignee` by name.
+ */
+export interface CasesFilters {
+  scope: DashboardScope;
+  search: string;
+  severities: Severity[];
+  states: CaseState[];
+  sla: SlaFilter;
+  assignees: string[];
+  projects: string[];
+  products: string[];
+}
+
+/**
+ * Lightweight user directory entry surfaced in the assignee picker. The
+ * filter still stores assignees as bare name strings (plus the `@me` /
+ * "Unassigned" sentinels) — `email` is only used for richer rendering.
+ */
+export interface AssigneeUser {
+  name: string;
+  email: string;
+}
+
+interface CasesFilterBarProps {
+  filters: CasesFilters;
+  onChange: (next: CasesFilters) => void;
+  onReset: () => void;
+  isFiltersOpen: boolean;
+  onFiltersToggle: () => void;
+  /** Full user directory shown in the assignee picker. */
+  availableAssigneeUsers: AssigneeUser[];
+  /** Project names seen in the current data. */
+  availableProjects: string[];
+  /** Product names seen in the current data. */
+  availableProducts: string[];
+}
+
+const ALL_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+const PRIMARY_STATES: CaseState[] = [
+  "open",
+  "work_in_progress",
+  "awaiting_info",
+  "solution_proposed",
+  "waiting_on_wso2",
+  "reopen",
+  "closed",
+];
+const SLA_OPTIONS: { value: SlaFilter; label: string }[] = [
+  { value: "any", label: "Any SLA" },
+  { value: "at_risk", label: "At risk" },
+  { value: "breached", label: "Breached" },
+];
+
+/**
+ * Count the filters that have non-default values. Search is included
+ * separately so the badge correctly reflects "search + N filters".
+ */
+function countActiveFilters(f: CasesFilters): number {
+  let n = 0;
+  if (f.search.trim()) n += 1;
+  if (f.severities.length) n += 1;
+  if (f.states.length) n += 1;
+  if (f.sla !== "any") n += 1;
+  if (f.assignees.length) n += 1;
+  if (f.projects.length) n += 1;
+  if (f.products.length) n += 1;
+  return n;
+}
+
+/** Pretty-print an assignee value (handle the @me sentinel). */
+function assigneeLabel(value: string): string {
+  return value === ASSIGNEE_ME_TOKEN ? "Me" : value;
+}
+
+interface MultiSelectFieldProps<T extends string> {
+  id: string;
+  label: string;
+  values: T[];
+  options: { value: T; label: string }[];
+  onChange: (next: T[]) => void;
+}
+
+function MultiSelectField<T extends string>({
+  id,
+  label,
+  values,
+  options,
+  onChange,
+}: MultiSelectFieldProps<T>): JSX.Element {
+  const handleChange = (event: SelectChangeEvent<string[]>): void => {
+    const val = event.target.value;
+    onChange((Array.isArray(val) ? val : [val]) as T[]);
+  };
+  return (
+    <FormControl fullWidth size="small">
+      <InputLabel id={`${id}-label`}>{label}</InputLabel>
+      <Select
+        multiple
+        labelId={`${id}-label`}
+        id={id}
+        value={values as unknown as string[]}
+        label={label}
+        onChange={handleChange}
+        renderValue={(selected) => {
+          if (!Array.isArray(selected) || selected.length === 0) return "";
+          const labels = selected.map(
+            (v) => options.find((o) => o.value === v)?.label ?? v,
+          );
+          const text = labels.join(", ");
+          if (labels.length === 1) return text;
+          return (
+            <Tooltip title={text} placement="top">
+              <Box
+                component="span"
+                sx={{
+                  display: "block",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {text}
+              </Box>
+            </Tooltip>
+          );
+        }}
+      >
+        {options.length === 0 ? (
+          <MenuItem disabled value="">
+            <em>No options</em>
+          </MenuItem>
+        ) : (
+          options.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
+              <Checkbox
+                size="small"
+                checked={values.includes(opt.value)}
+                sx={{ mr: 1, p: 0.25 }}
+              />
+              <ListItemText primary={opt.label} />
+            </MenuItem>
+          ))
+        )}
+      </Select>
+    </FormControl>
+  );
+}
+
+interface SingleSelectFieldProps<T extends string> {
+  id: string;
+  label: string;
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (next: T) => void;
+}
+
+function SingleSelectField<T extends string>({
+  id,
+  label,
+  value,
+  options,
+  onChange,
+}: SingleSelectFieldProps<T>): JSX.Element {
+  return (
+    <FormControl fullWidth size="small">
+      <InputLabel id={`${id}-label`}>{label}</InputLabel>
+      <Select
+        labelId={`${id}-label`}
+        id={id}
+        value={value as unknown as string}
+        label={label}
+        onChange={(e) => onChange(e.target.value as T)}
+      >
+        {options.map((opt) => (
+          <MenuItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+interface SearchableMultiSelectProps {
+  id: string;
+  label: string;
+  placeholder?: string;
+  values: string[];
+  options: string[];
+  /** Optional renderer for option labels (e.g. the @me sentinel → "Me"). */
+  formatOption?: (value: string) => string;
+  /** Optional secondary line shown beneath each option (e.g. email). */
+  getOptionSecondary?: (value: string) => string | undefined;
+  /** Optional filter against synthetic text (e.g. include email in the query). */
+  getOptionSearchText?: (value: string) => string;
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Multi-select autocomplete. Users type to filter the option list and
+ * select multiple. Picked values render as removable chips inside the field.
+ * Internally a thin wrapper over MUI Autocomplete so we keep oxygen-ui
+ * theming via the re-exported components.
+ */
+function SearchableMultiSelect({
+  id,
+  label,
+  placeholder,
+  values,
+  options,
+  formatOption,
+  getOptionSecondary,
+  getOptionSearchText,
+  onChange,
+}: SearchableMultiSelectProps): JSX.Element {
+  const format = formatOption ?? ((v: string) => v);
+  const searchText = getOptionSearchText ?? format;
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      id={id}
+      options={options}
+      value={values}
+      onChange={(_event, next) => onChange(next as string[])}
+      disableCloseOnSelect
+      getOptionLabel={(opt) => format(opt as string)}
+      isOptionEqualToValue={(opt, val) => opt === val}
+      filterOptions={(opts, state) => {
+        const q = state.inputValue.trim().toLowerCase();
+        if (!q) return opts;
+        return opts.filter((o) => searchText(o as string).toLowerCase().includes(q));
+      }}
+      renderTags={(value, getTagProps) =>
+        value.map((option, index) => {
+          const { key, ...tagProps } = getTagProps({ index });
+          return (
+            <Chip
+              key={key}
+              size="small"
+              label={format(option as string)}
+              {...tagProps}
+            />
+          );
+        })
+      }
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        const primary = format(option as string);
+        const secondary = getOptionSecondary?.(option as string);
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox
+              size="small"
+              checked={selected}
+              sx={{ mr: 1, p: 0.25 }}
+            />
+            <ListItemText
+              primary={primary}
+              secondary={secondary}
+              slotProps={{
+                primary: { style: { fontSize: 13 } },
+                secondary: { style: { fontSize: 11 } },
+              }}
+            />
+          </li>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={values.length ? undefined : placeholder ?? "Type to search…"}
+        />
+      )}
+    />
+  );
+}
+
+export default function CasesFilterBar({
+  filters,
+  onChange,
+  onReset,
+  isFiltersOpen,
+  onFiltersToggle,
+  availableAssigneeUsers,
+  availableProjects,
+  availableProducts,
+}: CasesFilterBarProps): JSX.Element {
+  const activeCount = countActiveFilters(filters);
+  const hasActive = activeCount > 0;
+
+  const severityOptions = useMemo(
+    () => ALL_SEVERITIES.map((s) => ({ value: s, label: s })),
+    [],
+  );
+  const stateOptions = useMemo(
+    () => PRIMARY_STATES.map((s) => ({ value: s, label: STATE_LABEL[s] })),
+    [],
+  );
+
+  // Pin "@me" and "Unassigned" to the top of the assignee option list, then
+  // every user from the directory (sorted by name, deduped). Pulling from
+  // the user directory rather than only the owners present in loaded cases
+  // means typing a name finds anyone, not just people who happen to own one
+  // of the currently-listed cases.
+  const assigneeOptions = useMemo(() => {
+    const names = Array.from(
+      new Set(availableAssigneeUsers.map((u) => u.name).filter(Boolean)),
+    ).sort();
+    return [ASSIGNEE_ME_TOKEN, ASSIGNEE_UNASSIGNED, ...names];
+  }, [availableAssigneeUsers]);
+
+  const emailByName = useMemo(() => {
+    const m = new Map<string, string>();
+    availableAssigneeUsers.forEach((u) => {
+      if (u.name) m.set(u.name, u.email);
+    });
+    return m;
+  }, [availableAssigneeUsers]);
+
+  const assigneeSecondary = (value: string): string | undefined => {
+    if (value === ASSIGNEE_ME_TOKEN || value === ASSIGNEE_UNASSIGNED) return undefined;
+    return emailByName.get(value);
+  };
+
+  const assigneeSearchText = (value: string): string => {
+    const label = assigneeLabel(value);
+    const email = emailByName.get(value);
+    return email ? `${label} ${email}` : label;
+  };
+
+  return (
+    <Paper sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+      {/* Scope + search + filters toggle. Scope buttons are CSM-specific
+          (My ABT vs All customers) and live alongside search at the top. */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+        <Box sx={{ display: "flex", gap: 0.75 }}>
+          <Button
+            size="small"
+            variant={filters.scope === "my_abt" ? "contained" : "outlined"}
+            color="primary"
+            onClick={() => onChange({ ...filters, scope: "my_abt" })}
+          >
+            My ABT
+          </Button>
+          <Button
+            size="small"
+            variant={filters.scope === "all_customers" ? "contained" : "outlined"}
+            color="primary"
+            onClick={() => onChange({ ...filters, scope: "all_customers" })}
+          >
+            All customers
+          </Button>
+        </Box>
+
+        <Box sx={{ position: "relative", flex: 1, minWidth: 240 }}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Search by case #, subject, customer, project, assignee…"
+            value={filters.search}
+            onChange={(e) => onChange({ ...filters, search: e.target.value })}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={16} />
+                  </InputAdornment>
+                ),
+                endAdornment: filters.search ? (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      edge="end"
+                      onClick={() => onChange({ ...filters, search: "" })}
+                      aria-label="Clear search"
+                    >
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+          />
+        </Box>
+
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={hasActive ? onReset : onFiltersToggle}
+          startIcon={hasActive ? <X size={16} /> : <ListFilter size={16} />}
+          endIcon={
+            !hasActive &&
+            (isFiltersOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />)
+          }
+        >
+          {hasActive ? `Clear filters (${activeCount})` : "Filters"}
+        </Button>
+      </Box>
+
+      {/* Collapsible filter grid. Severity / state stay as fixed multi-selects;
+          assignee / project / product are type-to-search Autocompletes. */}
+      {isFiltersOpen && (
+        <>
+          <Divider />
+          <Grid container spacing={2} sx={{ mt: 0 }}>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <MultiSelectField
+                id="cases-filter-severity"
+                label="Severity"
+                values={filters.severities}
+                options={severityOptions}
+                onChange={(next) => onChange({ ...filters, severities: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <MultiSelectField
+                id="cases-filter-state"
+                label="State"
+                values={filters.states}
+                options={stateOptions}
+                onChange={(next) => onChange({ ...filters, states: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <SingleSelectField
+                id="cases-filter-sla"
+                label="SLA"
+                value={filters.sla}
+                options={SLA_OPTIONS}
+                onChange={(next) => onChange({ ...filters, sla: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <SearchableMultiSelect
+                id="cases-filter-assignee"
+                label="Assignee"
+                placeholder="Search users…"
+                values={filters.assignees}
+                options={assigneeOptions}
+                formatOption={assigneeLabel}
+                getOptionSecondary={assigneeSecondary}
+                getOptionSearchText={assigneeSearchText}
+                onChange={(next) => onChange({ ...filters, assignees: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <SearchableMultiSelect
+                id="cases-filter-project"
+                label="Project"
+                placeholder="Type a project…"
+                values={filters.projects}
+                options={availableProjects}
+                onChange={(next) => onChange({ ...filters, projects: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <SearchableMultiSelect
+                id="cases-filter-product"
+                label="Product"
+                placeholder="Type a product…"
+                values={filters.products}
+                options={availableProducts}
+                onChange={(next) => onChange({ ...filters, products: next })}
+              />
+            </Grid>
+          </Grid>
+          {activeCount > 0 && (
+            <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <Typography variant="caption" color="text.secondary">
+                {activeCount} {activeCount === 1 ? "filter" : "filters"} active
+              </Typography>
+            </Box>
+          )}
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { useNavigate } from "react-router";
+import {
+  SEVERITY_COLOR,
+  SLA_CLOCK_LABEL,
+  STATE_LABEL,
+  formatTimeToBreach,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import RelativeTime from "@components/RelativeTime";
+import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+
+interface CasesListProps {
+  cases: CsmCaseRow[];
+  isLoading: boolean;
+}
+
+const HEADER_CELLS: { label: string; align?: "left" | "right" }[] = [
+  { label: "Case" },
+  { label: "Customer" },
+  { label: "Severity" },
+  { label: "State" },
+  { label: "Assignee" },
+  { label: "SLA", align: "right" },
+  { label: "Updated", align: "right" },
+];
+
+const GRID =
+  "minmax(280px, 2.5fr) minmax(140px, 1fr) auto minmax(140px, 1fr) minmax(120px, 1fr) auto auto";
+
+export default function CasesList({
+  cases,
+  isLoading,
+}: CasesListProps): JSX.Element {
+  const navigate = useNavigate();
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 1,
+        overflow: "hidden",
+        // Single grid context drives column tracks for header + every row.
+        // Each row below uses `grid-template-columns: subgrid` so columns line up.
+        display: "grid",
+        gridTemplateColumns: GRID,
+        columnGap: 2,
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          gridColumn: "1 / -1",
+          display: "grid",
+          gridTemplateColumns: "subgrid",
+          columnGap: 2,
+          alignItems: "center",
+          px: 2,
+          py: 1.25,
+          bgcolor: "action.hover",
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        {HEADER_CELLS.map((h) => (
+          <Typography
+            key={h.label}
+            variant="caption"
+            color="text.secondary"
+            sx={{ textAlign: h.align ?? "left", fontWeight: 600 }}
+          >
+            {h.label}
+          </Typography>
+        ))}
+      </Box>
+
+      {/* Rows */}
+      {isLoading &&
+        [0, 1, 2, 3, 4, 5].map((i) => (
+          <Box
+            key={i}
+            sx={{
+              gridColumn: "1 / -1",
+              px: 2,
+              py: 1.25,
+              borderBottom: 1,
+              borderColor: "divider",
+              "&:last-of-type": { borderBottom: 0 },
+            }}
+          >
+            <Skeleton variant="rectangular" height={28} />
+          </Box>
+        ))}
+
+      {!isLoading && cases.length === 0 && (
+        <Box sx={{ gridColumn: "1 / -1", px: 2, py: 4, textAlign: "center" }}>
+          <Typography variant="body2" color="text.secondary">
+            No cases match the current filters.
+          </Typography>
+        </Box>
+      )}
+
+      {!isLoading &&
+        cases.map((c) => {
+          const breached = c.minutesToBreach < 0;
+          const handleClick = () => {
+            navigate(`/cases/${c.id}`);
+          };
+          return (
+            <Box
+              key={c.id}
+              role="button"
+              tabIndex={0}
+              onClick={handleClick}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleClick();
+                }
+              }}
+              sx={{
+                gridColumn: "1 / -1",
+                display: "grid",
+                gridTemplateColumns: "subgrid",
+                columnGap: 2,
+                alignItems: "center",
+                px: 2,
+                py: 1.25,
+                borderBottom: 1,
+                borderColor: "divider",
+                cursor: "pointer",
+                "&:hover": {
+                  bgcolor: "action.hover",
+                },
+                "&:focus-visible": {
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: -2,
+                },
+                "&:last-of-type": { borderBottom: 0 },
+              }}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="body2" noWrap>
+                  <strong>{c.caseNumber}</strong> · {c.subject}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {c.projectName}
+                </Typography>
+              </Box>
+              <Typography variant="body2" noWrap>
+                {c.customer}
+              </Typography>
+              <Chip
+                size="small"
+                label={c.severity}
+                color={SEVERITY_COLOR[c.severity]}
+              />
+              <Typography variant="body2" noWrap>
+                {STATE_LABEL[c.state]}
+              </Typography>
+              <Typography variant="body2" noWrap>
+                {c.assigneeIsMe ? (
+                  <strong>{c.assignee}</strong>
+                ) : c.assignee === "Unassigned" ? (
+                  <em>Unassigned</em>
+                ) : (
+                  c.assignee
+                )}
+              </Typography>
+              <Box sx={{ textAlign: "right" }}>
+                <Typography
+                  variant="body2"
+                  color={breached ? "error" : c.minutesToBreach <= 60 ? "warning.main" : "text.primary"}
+                  noWrap
+                >
+                  {c.state === "closed"
+                    ? "—"
+                    : formatTimeToBreach(c.minutesToBreach)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {c.state === "closed" ? "Closed" : SLA_CLOCK_LABEL[c.slaClockType]}
+                </Typography>
+              </Box>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ textAlign: "right" }}
+                noWrap
+              >
+                <RelativeTime iso={c.updatedAt} />
+              </Typography>
+            </Box>
+          );
+        })}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Avatar, Box, Chip, Paper, Typography } from "@wso2/oxygen-ui";
+import DOMPurify from "dompurify";
+import type { JSX } from "react";
+import RelativeTime from "@components/RelativeTime";
+import { initialsOf } from "@utils/userClaims";
+import type {
+  CsmCaseComment,
+  CsmCommentAuthorRole,
+} from "@features/csm-cases/types/csmCases";
+
+interface CsmCaseCommentBubbleProps {
+  comment: CsmCaseComment;
+}
+
+const ROLE_LABEL: Record<CsmCommentAuthorRole, string> = {
+  customer: "Customer",
+  wso2_engineer: "WSO2",
+  system: "System",
+};
+
+const ROLE_COLOR: Record<
+  CsmCommentAuthorRole,
+  "default" | "primary" | "warning"
+> = {
+  customer: "default",
+  wso2_engineer: "primary",
+  system: "warning",
+};
+
+const PURIFY_CONFIG = {
+  ALLOWED_TAGS: [
+    "p",
+    "br",
+    "strong",
+    "b",
+    "em",
+    "i",
+    "u",
+    "s",
+    "code",
+    "pre",
+    "ul",
+    "ol",
+    "li",
+    "a",
+    "blockquote",
+    "h1",
+    "h2",
+    "h3",
+    "img",
+    "span",
+  ],
+  ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
+};
+
+export default function CsmCaseCommentBubble({
+  comment,
+}: CsmCaseCommentBubbleProps): JSX.Element {
+  const safeHtml = DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG);
+  const isSystem = comment.authorRole === "system";
+
+  if (isSystem) {
+    return (
+      <Box
+        id={comment.id}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          py: 0.5,
+          px: 1,
+          color: "text.secondary",
+          scrollMarginTop: 96,
+        }}
+      >
+        <Chip size="small" color="warning" label="System" />
+        <Box
+          sx={{
+            flex: 1,
+            "& p": { m: 0 },
+            "& a": { color: "primary.main" },
+            ...{ "& *": { fontSize: "0.875rem" } },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
+        <Typography variant="caption" color="text.secondary">
+          <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
+        </Typography>
+      </Box>
+    );
+  }
+
+  const isInternal = !!comment.internal;
+
+  return (
+    <Box
+      id={comment.id}
+      sx={{ display: "flex", gap: 1.5, alignItems: "flex-start", scrollMarginTop: 96 }}
+    >
+      <Avatar
+        sx={{
+          bgcolor:
+            comment.authorRole === "wso2_engineer"
+              ? "primary.main"
+              : "grey.500",
+          width: 32,
+          height: 32,
+          fontSize: "0.85rem",
+        }}
+      >
+        {initialsOf(comment.authorName)}
+      </Avatar>
+      <Paper
+        variant="outlined"
+        sx={{
+          p: 1.5,
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: 0.75,
+          backgroundColor: isInternal ? "warning.50" : undefined,
+          borderColor: isInternal ? "warning.main" : undefined,
+          borderLeft: isInternal ? 3 : undefined,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+          <Typography variant="subtitle2">{comment.authorName}</Typography>
+          <Chip
+            size="small"
+            label={ROLE_LABEL[comment.authorRole]}
+            color={ROLE_COLOR[comment.authorRole]}
+            variant="outlined"
+          />
+          {isInternal && (
+            <Chip
+              size="small"
+              label="Internal work note"
+              color="warning"
+              variant="filled"
+            />
+          )}
+          <Typography variant="caption" color="text.secondary">
+            <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            "& p": { m: 0 },
+            "& p + p": { mt: 0.75 },
+            "& ul, & ol": { ml: 3, my: 0.5 },
+            "& code": {
+              bgcolor: "background.default",
+              px: 0.5,
+              borderRadius: 0.5,
+              fontFamily: "monospace",
+              fontSize: "0.85em",
+            },
+            "& pre": {
+              bgcolor: "background.default",
+              p: 1,
+              borderRadius: 1,
+              overflowX: "auto",
+              fontFamily: "monospace",
+              fontSize: "0.85em",
+            },
+            "& a": { color: "primary.main" },
+            "& img": { maxWidth: "100%" },
+            "& blockquote": {
+              borderLeft: 3,
+              borderColor: "divider",
+              pl: 1.5,
+              ml: 0,
+              my: 0.75,
+              color: "text.secondary",
+              fontStyle: "italic",
+            },
+            "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
+      </Paper>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  FormControlLabel,
+  IconButton,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import {
+  Code,
+  Lock,
+  Maximize2,
+  Minimize2,
+  Send,
+} from "@wso2/oxygen-ui-icons-react";
+import { useCallback, useRef, useState, type JSX } from "react";
+import Editor from "@components/rich-text-editor/Editor";
+
+interface CsmCaseCommentInputProps {
+  onSubmit: (html: string, internal: boolean) => Promise<unknown> | void;
+  disabled?: boolean;
+}
+
+/** Strip tags + collapse whitespace to decide if the editor is effectively empty. */
+function isEmpty(html: string): boolean {
+  const text = html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim();
+  return text.length === 0;
+}
+
+export default function CsmCaseCommentInput({
+  onSubmit,
+  disabled = false,
+}: CsmCaseCommentInputProps): JSX.Element {
+  const [html, setHtml] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sourceMode, setSourceMode] = useState(false);
+  const [internal, setInternal] = useState(false);
+  const [maximized, setMaximized] = useState(false);
+
+  // Incrementing this trigger clears the editor (see Editor's ResetPlugin).
+  const resetTriggerRef = useRef(0);
+  const [resetTrigger, setResetTrigger] = useState(0);
+
+  // Bump this on every source→rich switch so the Editor remounts with the
+  // edited HTML as its new initial value (InitialValuePlugin only injects once
+  // per mount).
+  const [editorMountKey, setEditorMountKey] = useState(0);
+
+  const submit = useCallback(async () => {
+    if (submitting || disabled) return;
+    if (isEmpty(html)) {
+      setError("Comment is empty.");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(html, internal);
+      setHtml("");
+      resetTriggerRef.current += 1;
+      setResetTrigger(resetTriggerRef.current);
+      setEditorMountKey((k) => k + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to post comment.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [disabled, html, internal, onSubmit, submitting]);
+
+  const toggleSourceMode = useCallback(
+    (nextSource: boolean) => {
+      setSourceMode(nextSource);
+      // Coming back to rich mode: remount Editor so it picks up the (possibly
+      // hand-edited) HTML as its initial value.
+      if (!nextSource) setEditorMountKey((k) => k + 1);
+    },
+    [],
+  );
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        p: internal ? 1.25 : 0,
+        borderRadius: internal ? 1 : 0,
+        backgroundColor: internal ? "warning.50" : undefined,
+        border: internal ? 1 : 0,
+        borderColor: internal ? "warning.main" : undefined,
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+          flexWrap: "wrap",
+        }}
+      >
+        <Typography
+          variant="caption"
+          color={internal ? "warning.main" : "text.secondary"}
+        >
+          {internal
+            ? "Internal work note — not visible to the customer."
+            : sourceMode
+              ? "HTML source — edit raw markup directly."
+              : "Reply to this case…"}
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                color="warning"
+                checked={internal}
+                onChange={(e) => setInternal(e.target.checked)}
+                disabled={disabled || submitting}
+              />
+            }
+            label={
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  fontSize: "0.8rem",
+                }}
+              >
+                <Lock size={14} />
+                Internal note
+              </Box>
+            }
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={sourceMode}
+                onChange={(e) => toggleSourceMode(e.target.checked)}
+                disabled={disabled || submitting}
+              />
+            }
+            label={
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  fontSize: "0.8rem",
+                }}
+              >
+                <Code size={14} />
+                HTML source
+              </Box>
+            }
+          />
+          <Tooltip
+            title={maximized ? "Collapse editor" : "Maximize editor"}
+          >
+            <IconButton
+              size="small"
+              onClick={() => setMaximized((m) => !m)}
+              aria-label={
+                maximized ? "Collapse comment editor" : "Maximize comment editor"
+              }
+            >
+              {maximized ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+
+      {sourceMode ? (
+        <TextField
+          value={html}
+          onChange={(e) => setHtml(e.target.value)}
+          placeholder="<p>Type HTML here…</p>"
+          multiline
+          minRows={maximized ? 18 : 6}
+          maxRows={maximized ? 32 : 12}
+          disabled={disabled || submitting}
+          inputProps={{
+            style: {
+              fontFamily:
+                "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              fontSize: "0.825rem",
+              lineHeight: 1.45,
+            },
+            spellCheck: false,
+          }}
+          fullWidth
+          variant="outlined"
+        />
+      ) : (
+        <Editor
+          key={editorMountKey}
+          value={html}
+          onChange={setHtml}
+          resetTrigger={resetTrigger}
+          disabled={disabled || submitting}
+          placeholder="Reply to this case…"
+          minHeight={maximized ? 480 : 96}
+          maxHeight={maximized ? 720 : 260}
+          toolbarVariant="full"
+          showKeyboardHint
+          enterToSubmit={false}
+          onSubmitKeyDown={() => {
+            void submit();
+          }}
+        />
+      )}
+
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+        }}
+      >
+        <Typography
+          variant="caption"
+          color={error ? "error" : "text.secondary"}
+        >
+          {error ??
+            (sourceMode
+              ? "Output is sent as-is. Use this to fix paste-formatting or insert tables."
+              : "Ctrl/Cmd + Enter to send.")}
+        </Typography>
+        <Button
+          variant="contained"
+          color={internal ? "warning" : "primary"}
+          size="small"
+          startIcon={internal ? <Lock size={16} /> : <Send size={16} />}
+          disabled={disabled || submitting || isEmpty(html)}
+          onClick={() => {
+            void submit();
+          }}
+        >
+          {submitting
+            ? "Sending…"
+            : internal
+              ? "Save work note"
+              : "Send to customer"}
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1,0 +1,835 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Divider,
+  IconButton,
+  Skeleton,
+  Tab,
+  Tabs,
+  Typography,
+} from "@wso2/oxygen-ui";
+import {
+  Activity,
+  ArrowLeft,
+  Clock,
+  Layers,
+  ListChecks,
+  MessageSquarePlus,
+  Paperclip,
+  TriangleAlert,
+  X,
+} from "@wso2/oxygen-ui-icons-react";
+import { useCallback, useEffect, useState, type JSX } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
+import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
+import {
+  useGetCsmCaseComments,
+  usePostCsmCaseComment,
+} from "@features/csm-cases/api/useCsmCaseComments";
+import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
+import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
+import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
+import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
+import {
+  AttachmentsWidget,
+  AuditTimelineWidget,
+  CustomerContextWidget,
+  LinkedItemsWidget,
+  ProductContextWidget,
+  SlaTimelineWidget,
+  TimeLogsWidget,
+  WatchersWidget,
+} from "@features/csm-cases/components/CaseDetailWidgets";
+import { TIER_COLOR, TIER_LABEL } from "@features/csm-cases/utils/caseTier";
+import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import {
+  SEVERITY_COLOR,
+  SEVERITY_LABEL,
+  SLA_CLOCK_LABEL,
+  STATE_LABEL,
+  formatTimeToBreach,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import RelativeTime from "@components/RelativeTime";
+import type {
+  CaseLifecycleAction,
+  CsmCaseComment,
+  CsmCaseDetail,
+} from "@features/csm-cases/types/csmCases";
+
+function MetaCell({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Box>{children}</Box>
+    </Box>
+  );
+}
+
+// TODO: replace with the engineer name from useGetUserDetails once the
+// `firstName`/`lastName` shape from the CSM backend is wired.
+const CURRENT_ENGINEER_NAME = "Sajith Ekanayaka";
+
+// Reopening a closed case is a lead-only override. We match the lead role from
+// the ID-token group claims.
+// TODO(authz): confirm the exact Asgardeo group(s)/role(s) that designate a
+// "lead" with the gateway/permission model — these identifiers are provisional.
+const LEAD_REOPEN_ROLES = new Set([
+  "cre_lead",
+  "CRE_LEADS_GROUP",
+  "leadership",
+]);
+
+const LIFECYCLE_TOAST: Record<CaseLifecycleAction, string> = {
+  start_work: "Started work on this case.",
+  assign_to_me: "Assigned to you.",
+  propose_solution: "Solution proposed to the customer.",
+  request_info: "Requested additional info from the customer.",
+  wait_on_wso2: "Marked as waiting on internal WSO2 dependency.",
+  resume_work: "Resumed work on this case.",
+  close: "Case closed.",
+  close_no_response: "Closed (no response received).",
+  reopen: "Case reopened.",
+};
+
+type FeedbackSeverity = "success" | "info" | "warning" | "error";
+
+interface Feedback {
+  message: string;
+  severity: FeedbackSeverity;
+  /** Sticky feedback (state transitions) stays until dismissed; transient
+   * feedback (copy link, downloads) auto-dismisses. */
+  sticky: boolean;
+}
+
+// Lifecycle transitions carry semantic weight — closure/resolution reads as
+// success, "waiting" states as a caution. Benign/neutral moves stay info.
+const LIFECYCLE_SEVERITY: Record<CaseLifecycleAction, FeedbackSeverity> = {
+  start_work: "info",
+  assign_to_me: "info",
+  propose_solution: "success",
+  request_info: "warning",
+  wait_on_wso2: "warning",
+  resume_work: "info",
+  close: "success",
+  close_no_response: "success",
+  reopen: "info",
+};
+
+const FEEDBACK_PALETTE: Record<
+  FeedbackSeverity,
+  { bg: string; border: string; fg: string }
+> = {
+  success: { bg: "success.50", border: "success.main", fg: "success.main" },
+  info: { bg: "info.50", border: "info.main", fg: "info.main" },
+  warning: { bg: "warning.50", border: "warning.main", fg: "warning.main" },
+  error: { bg: "error.50", border: "error.main", fg: "error.main" },
+};
+
+const SECONDARY_TOAST: Record<string, string> = {
+  reassign_engineer: "Reassign engineer dialog (mock).",
+  reassign_group: "Reassign group dialog (mock).",
+  escalate: "Escalation form (mock).",
+  change_severity: "Severity change request (mock).",
+  hold_auto_close: "Hold auto-closure dialog (mock).",
+  create_incident: "Create incident from case (mock).",
+  link_case: "Link related case picker (mock).",
+  link_incident: "Link to incident picker (mock).",
+  manage_watchers: "Add/remove watcher dialog (mock).",
+  raise_git_issue: "Raise internal Git issue (mock).",
+  create_task: "Create task dialog (mock).",
+  request_call: "Request a call dialog (mock).",
+  log_time: "Log time dialog (mock).",
+  copy_link: "Case link copied to clipboard.",
+  download_all_attachments: "Preparing all attachments for download (mock).",
+  download_attachment: "Downloading attachment (mock).",
+};
+
+type CaseTabId =
+  | "activities"
+  | "details"
+  | "sla"
+  | "attachments"
+  | "time";
+
+/**
+ * Walk the parent chain to find the nearest vertically-scrollable element.
+ * Falls back to the document scrolling element if none is found.
+ */
+function findVerticalScrollAncestor(el: HTMLElement): HTMLElement {
+  let cur: HTMLElement | null = el.parentElement;
+  while (cur && cur !== document.body) {
+    const style = window.getComputedStyle(cur);
+    const overflowY = style.overflowY;
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      cur.scrollHeight > cur.clientHeight
+    ) {
+      return cur;
+    }
+    cur = cur.parentElement;
+  }
+  return (document.scrollingElement as HTMLElement | null) ?? document.documentElement;
+}
+
+/**
+ * Synthesize the case description as a virtual "first comment" so it shows up
+ * in the activity stream immediately after the `created` audit event. SN does
+ * the same thing — the customer's initial problem statement reads as the
+ * opening comment of the case.
+ *
+ * Dated 1 second after `case.createdAt` so chronological sort places it
+ * AFTER the `Case created` audit entry (which is exactly at `createdAt`).
+ */
+function buildDescriptionComment(c: CsmCaseDetail): CsmCaseComment | null {
+  if (!c.description?.trim()) return null;
+  const escaped = c.description
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\n\n+/g, "</p><p>")
+    .replace(/\n/g, "<br>");
+  const createdMs = new Date(c.createdAt).getTime();
+  const at = new Date(createdMs + 1000).toISOString();
+  return {
+    id: `description`,
+    caseId: c.id,
+    authorName:
+      c.createdBy || c.customerContext.primaryContact || c.customer,
+    authorRole: "customer",
+    bodyHtml: `<p>${escaped}</p>`,
+    createdAt: at,
+  };
+}
+
+const TAB_DEFS: Array<{
+  id: CaseTabId;
+  label: string;
+  icon: JSX.Element;
+}> = [
+  { id: "activities", label: "Activities", icon: <Activity size={16} /> },
+  { id: "details", label: "Details", icon: <ListChecks size={16} /> },
+  { id: "sla", label: "SLA", icon: <Clock size={16} /> },
+  { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
+  { id: "time", label: "Time tracking", icon: <Layers size={16} /> },
+];
+
+export default function CsmCaseDetailPage(): JSX.Element {
+  const { caseId } = useParams<{ caseId: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { data, isLoading, isError } = useGetCsmCaseDetail(caseId);
+  const {
+    data: comments,
+    isLoading: isCommentsLoading,
+    isError: isCommentsError,
+  } = useGetCsmCaseComments(caseId);
+  const postComment = usePostCsmCaseComment();
+  const recordView = useRecordRecentView();
+  const claims = useIdTokenClaims();
+  const { showError } = useErrorBanner();
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [activeTab, setActiveTab] = useState<CaseTabId>("activities");
+  const [metaCollapsed, setMetaCollapsed] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  // Twitter-style permalinks: when the URL has a fragment matching an entry id,
+  // jump to the Activities tab, scroll the entry into view vertically, and
+  // flash it. The browser's default hash-anchor `scrollIntoView` also drags
+  // ancestors horizontally if any of them is wider than the viewport (e.g.
+  // when a comment contains a wide `<pre>` block). We zero `scrollLeft` on
+  // every ancestor to undo that horizontal shift while keeping vertical
+  // scroll in place.
+  useEffect(() => {
+    const hash = location.hash?.replace(/^#/, "");
+    if (!hash) return;
+    setActiveTab("activities");
+    const timer = setTimeout(() => {
+      const target = document.getElementById(hash);
+      if (!target) return;
+
+      // Undo any horizontal scroll the browser introduced on ancestors.
+      let cur: HTMLElement | null = target.parentElement;
+      while (cur && cur !== document.body) {
+        if (cur.scrollLeft !== 0) cur.scrollLeft = 0;
+        cur = cur.parentElement;
+      }
+      if (document.documentElement.scrollLeft !== 0) {
+        document.documentElement.scrollLeft = 0;
+      }
+      if (document.body.scrollLeft !== 0) document.body.scrollLeft = 0;
+
+      const container = findVerticalScrollAncestor(target);
+      const containerTop = container === document.documentElement
+        ? 0
+        : container.getBoundingClientRect().top;
+      const targetTop = target.getBoundingClientRect().top;
+      const offset = 96;
+      const delta = targetTop - containerTop - offset;
+      container.scrollTo({
+        top: container.scrollTop + delta,
+        behavior: "smooth",
+      });
+
+      const prevTransition = target.style.transition;
+      const prevBg = target.style.backgroundColor;
+      target.style.transition = "background-color 200ms ease-out";
+      target.style.backgroundColor = "rgba(255, 213, 79, 0.35)";
+      const reset = setTimeout(() => {
+        target.style.backgroundColor = prevBg;
+        setTimeout(() => {
+          target.style.transition = prevTransition;
+        }, 350);
+      }, 1500);
+      return () => clearTimeout(reset);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [location.hash, data, comments]);
+
+  useEffect(() => {
+    // State-transition feedback is sticky (persists until dismissed) so it
+    // isn't missed; transient confirmations auto-dismiss.
+    if (!feedback || feedback.sticky) return;
+    const t = setTimeout(() => setFeedback(null), 2500);
+    return () => clearTimeout(t);
+  }, [feedback]);
+
+  useEffect(() => {
+    if (!data) return;
+    recordView({
+      kind: "case",
+      id: data.id,
+      title: `${data.caseNumber} · ${data.subject}`,
+      subtitle: `${data.customer} · ${data.projectName}`,
+      href: `/cases/${data.id}`,
+    });
+  }, [data, recordView]);
+
+  const onAction = useCallback(
+    (action: CaseLifecycleAction | { secondary: string }) => {
+      if (typeof action === "string") {
+        // Lifecycle transition: sticky, semantically-colored feedback.
+        setFeedback({
+          message: LIFECYCLE_TOAST[action],
+          severity: LIFECYCLE_SEVERITY[action],
+          sticky: true,
+        });
+        return;
+      }
+
+      setFeedback({
+        message: SECONDARY_TOAST[action.secondary] ?? `Action: ${action.secondary}`,
+        severity: "info",
+        sticky: false,
+      });
+
+      if (action.secondary === "copy_link" && data) {
+        navigator.clipboard
+          ?.writeText(`${window.location.origin}/cases/${data.id}`)
+          .catch(() => showError("Could not copy link."));
+      }
+    },
+    [data, showError],
+  );
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rectangular" height={32} width={240} />
+        <Skeleton variant="rectangular" height={200} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate("/cases")}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back to cases
+        </Button>
+        <Typography variant="body1" color="error">
+          Could not load case {caseId}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate("/cases")}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back to cases
+        </Button>
+        <Typography variant="h5">Case not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No case with id <code>{caseId}</code> in the current mock dataset.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const c = data;
+  const isClosed = c.state === "closed";
+  const breached = c.minutesToBreach < 0;
+  const canReopenClosed = (claims?.groups ?? []).some((g) =>
+    LEAD_REOPEN_ROLES.has(g),
+  );
+  const rawComments = comments ?? [];
+  // The description is the case's opening comment. It is injected into the
+  // stream dated 1s after `created`, so with the default latest-first sort it
+  // sits at the bottom as the oldest entry — read in context after the latest
+  // activity, which is how engineers actually work a case here.
+  const descriptionComment = buildDescriptionComment(c);
+  const safeComments = descriptionComment
+    ? [descriptionComment, ...rawComments]
+    : rawComments;
+
+  // SLA breach is a live condition, not a dismissible notice: surface it in a
+  // persistent banner under the header so it stays visible on every tab, not
+  // just the SLA tab.
+  const breachedClocks = c.slaClocks.filter((k) => k.state === "breached");
+  const showBreachBanner = breached || breachedClocks.length > 0;
+  const breachMessage =
+    breachedClocks.length > 0
+      ? `SLA breached — ${breachedClocks
+          .map(
+            (k) =>
+              `${SLA_CLOCK_LABEL[k.clockType]} ${formatTimeToBreach(
+                k.minutesToBreach,
+              )}`,
+          )
+          .join(", ")}`
+      : `SLA breached — ${SLA_CLOCK_LABEL[c.slaClockType]} ${formatTimeToBreach(
+          c.minutesToBreach,
+        )}`;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <Button
+        variant="text"
+        size="small"
+        startIcon={<ArrowLeft size={16} />}
+        onClick={() => navigate("/cases")}
+        sx={{ alignSelf: "flex-start" }}
+      >
+        Back to cases
+      </Button>
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+          alignItems: "flex-start",
+          flexWrap: { xs: "wrap", md: "nowrap" },
+          justifyContent: "space-between",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          {/* Case identity: project-scoped WSO2 id + case number, joined by a
+              slash and given prominence so it reads as the case's headline. */}
+          <Typography
+            variant="h6"
+            sx={{
+              fontFamily: "monospace",
+              fontWeight: 700,
+              letterSpacing: 0.2,
+              lineHeight: 1.2,
+            }}
+          >
+            <Box component="span" sx={{ color: "text.secondary" }}>
+              {c.wso2CaseId}
+            </Box>
+            <Box component="span" sx={{ color: "text.disabled", mx: 0.25 }}>
+              /
+            </Box>
+            <Box component="span" sx={{ color: "text.primary" }}>
+              {c.caseNumber}
+            </Box>
+          </Typography>
+
+          {/* Status group (severity, lifecycle state, SLA) kept visually
+              distinct from the free-form tags by a divider, so the current
+              state doesn't get lost among the tag chips. */}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            <Chip
+              size="small"
+              label={`${c.severity} — ${SEVERITY_LABEL[c.severity]}`}
+              color={SEVERITY_COLOR[c.severity]}
+            />
+            <Chip
+              size="small"
+              label={STATE_LABEL[c.state]}
+              color={isClosed ? "success" : "primary"}
+              sx={{ fontWeight: 600 }}
+            />
+            <Chip
+              size="small"
+              label={TIER_LABEL[c.customerContext.tier]}
+              color={TIER_COLOR[c.customerContext.tier]}
+            />
+            {!isClosed && (
+              <Chip
+                size="small"
+                variant="outlined"
+                color={breached ? "error" : c.minutesToBreach <= 60 ? "warning" : "default"}
+                label={`${SLA_CLOCK_LABEL[c.slaClockType]} · ${formatTimeToBreach(c.minutesToBreach)}`}
+              />
+            )}
+            {c.tags.length > 0 && (
+              <Divider orientation="vertical" flexItem sx={{ mx: 0.5, my: 0.25 }} />
+            )}
+            {c.tags.map((t) => (
+              <Chip
+                key={t.id}
+                size="small"
+                variant="outlined"
+                color={t.color ?? "default"}
+                label={t.label}
+              />
+            ))}
+          </Box>
+          <Typography variant="h5">{c.subject}</Typography>
+        </Box>
+        <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
+          <CaseActionBar
+            caseDetail={c}
+            onAction={onAction}
+            canReopenClosed={canReopenClosed}
+          />
+        </Box>
+      </Box>
+
+      <CaseMetaBand
+        detail={c}
+        navigate={navigate}
+        collapsed={metaCollapsed}
+        onToggleCollapsed={() => setMetaCollapsed((v) => !v)}
+      />
+
+      {showBreachBanner && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            p: 1.25,
+            borderRadius: 1,
+            backgroundColor: "error.50",
+            border: 1,
+            borderColor: "error.main",
+            color: "error.main",
+          }}
+        >
+          <TriangleAlert size={18} />
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {breachMessage}
+          </Typography>
+        </Box>
+      )}
+
+      {feedback && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            p: 1,
+            pl: 1.5,
+            borderRadius: 1,
+            backgroundColor: FEEDBACK_PALETTE[feedback.severity].bg,
+            border: 1,
+            borderColor: FEEDBACK_PALETTE[feedback.severity].border,
+            color: FEEDBACK_PALETTE[feedback.severity].fg,
+          }}
+        >
+          <Typography variant="body2" sx={{ flex: 1 }}>
+            {feedback.message}
+          </Typography>
+          <IconButton
+            size="small"
+            onClick={() => setFeedback(null)}
+            aria-label="Dismiss"
+            sx={{ color: "inherit" }}
+          >
+            <X size={16} />
+          </IconButton>
+        </Box>
+      )}
+
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, v) => setActiveTab(v as CaseTabId)}
+          variant="scrollable"
+          scrollButtons="auto"
+        >
+          {TAB_DEFS.map((t) => {
+            // Counts shown only where the tab IS the list (unambiguous).
+            const count =
+              t.id === "attachments"
+                ? c.attachments.length
+                : t.id === "time"
+                  ? c.timeLogs.length
+                  : undefined;
+            return (
+              <Tab
+                key={t.id}
+                value={t.id}
+                icon={t.icon}
+                iconPosition="start"
+                label={count ? `${t.label} (${count})` : t.label}
+                sx={{ minHeight: 44, textTransform: "none" }}
+              />
+            );
+          })}
+        </Tabs>
+      </Box>
+
+      {activeTab === "activities" && (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {/* Comments are latest-in-top (WSO2 convention), so the composer
+              belongs at the top. It stays collapsed behind a button to keep
+              the thread the focal point until the engineer chooses to reply. */}
+          {composerOpen ? (
+            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Typography variant="subtitle2">Reply</Typography>
+                <Button
+                  size="small"
+                  variant="text"
+                  color="inherit"
+                  onClick={() => setComposerOpen(false)}
+                >
+                  Cancel
+                </Button>
+              </Box>
+              <CsmCaseCommentInput
+                disabled={!caseId}
+                onSubmit={async (bodyHtml, internal) => {
+                  if (!caseId) return;
+                  await postComment.mutateAsync({
+                    caseId,
+                    bodyHtml,
+                    authorName: CURRENT_ENGINEER_NAME,
+                    internal,
+                  });
+                  // Collapse only on success; on error the input keeps its
+                  // draft and surfaces the failure.
+                  setComposerOpen(false);
+                }}
+              />
+            </Card>
+          ) : (
+            // Full-width collapsed composer: a faux input bar that fills the
+            // row and reads as "click to write a reply" rather than a lone
+            // button floating in empty space.
+            <Button
+              fullWidth
+              variant="outlined"
+              color="inherit"
+              startIcon={<MessageSquarePlus size={18} />}
+              onClick={() => setComposerOpen(true)}
+              sx={{
+                justifyContent: "flex-start",
+                textTransform: "none",
+                gap: 0.5,
+                py: 1.5,
+                px: 2,
+                color: "text.secondary",
+                borderColor: "divider",
+                borderStyle: "dashed",
+                "&:hover": {
+                  borderColor: "primary.main",
+                  borderStyle: "solid",
+                  backgroundColor: "action.hover",
+                },
+              }}
+            >
+              Compose a reply to the customer…
+            </Button>
+          )}
+
+          <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+              <Typography variant="subtitle2">Activity timeline</Typography>
+              {!isCommentsLoading && (
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  label={`${safeComments.length + c.audit.length + c.attachments.length} entries`}
+                />
+              )}
+            </Box>
+
+            {isCommentsLoading ? (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                {[0, 1, 2].map((i) => (
+                  <Skeleton key={i} variant="rectangular" height={56} />
+                ))}
+              </Box>
+            ) : isCommentsError ? (
+              <Typography variant="body2" color="error">
+                Could not load comments.
+              </Typography>
+            ) : (
+              <CaseActivitiesFeed
+                comments={safeComments}
+                audit={c.audit}
+                attachments={c.attachments}
+              />
+            )}
+          </Card>
+        </Box>
+      )}
+
+      {activeTab === "details" && (
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              md: "repeat(2, minmax(0, 1fr))",
+            },
+            alignItems: "start",
+          }}
+        >
+          <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Typography variant="subtitle2">Identifiers &amp; timestamps</Typography>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 2,
+              }}
+            >
+              <MetaCell label="Case ID">
+                <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                  {c.caseNumber}
+                </Typography>
+              </MetaCell>
+              <MetaCell label="WSO2 case ID">
+                <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                  {c.wso2CaseId}
+                </Typography>
+              </MetaCell>
+              <MetaCell label="Created">
+                <Typography variant="body2">
+                  <RelativeTime iso={c.createdAt} />
+                </Typography>
+              </MetaCell>
+              <MetaCell label="Last update">
+                <Typography variant="body2">
+                  <RelativeTime iso={c.updatedAt} />
+                </Typography>
+              </MetaCell>
+              <MetaCell label="Assignment group (ABT)">
+                <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                  {c.assignmentGroup}
+                </Typography>
+              </MetaCell>
+            </Box>
+          </Card>
+          <CustomerContextWidget ctx={c.customerContext} />
+          <ProductContextWidget ctx={c.productContext} />
+          <WatchersWidget
+            watchers={c.watchers}
+            onAdd={() => onAction({ secondary: "manage_watchers" })}
+          />
+          <LinkedItemsWidget
+            items={c.linkedItems}
+            onLink={() => onAction({ secondary: "link_case" })}
+          />
+        </Box>
+      )}
+
+      {activeTab === "sla" && (
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              md: "repeat(2, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <SlaTimelineWidget clocks={c.slaClocks} />
+          <AuditTimelineWidget entries={c.audit} />
+        </Box>
+      )}
+
+      {activeTab === "attachments" && (
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
+          <AttachmentsWidget
+            attachments={c.attachments}
+            onDownloadAll={() => onAction({ secondary: "download_all_attachments" })}
+            onDownload={() => onAction({ secondary: "download_attachment" })}
+          />
+        </Box>
+      )}
+
+      {activeTab === "time" && (
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
+          <TimeLogsWidget
+            logs={c.timeLogs}
+            onAdd={() => onAction({ secondary: "log_time" })}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Chip, Typography } from "@wso2/oxygen-ui";
+import { Plus } from "@wso2/oxygen-ui-icons-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import CasesFilterBar, {
+  ASSIGNEE_ME_TOKEN,
+  type CasesFilters,
+} from "@features/csm-cases/components/CasesFilterBar";
+import CasesList from "@features/csm-cases/components/CasesList";
+import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
+import { useDirectoryUsers } from "@api/useDirectoryUsers";
+import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+import {
+  DEFAULT_CASES_FILTERS,
+  readCasesFiltersFromUrl,
+  writeCasesFiltersToUrl,
+} from "@features/csm-cases/utils/casesFiltersUrl";
+
+const SLA_AT_RISK_THRESHOLD_MINUTES = 60;
+
+function applyFilters(cases: CsmCaseRow[], f: CasesFilters): CsmCaseRow[] {
+  const q = f.search.trim().toLowerCase();
+  return cases.filter((c) => {
+    if (f.severities.length && !f.severities.includes(c.severity)) return false;
+    if (f.states.length && !f.states.includes(c.state)) return false;
+    if (f.sla === "breached" && c.minutesToBreach >= 0) return false;
+    if (
+      f.sla === "at_risk" &&
+      !(c.minutesToBreach >= 0 && c.minutesToBreach <= SLA_AT_RISK_THRESHOLD_MINUTES)
+    )
+      return false;
+    if (f.assignees.length) {
+      const match = f.assignees.some((a) =>
+        a === ASSIGNEE_ME_TOKEN ? c.assigneeIsMe : a === c.assignee,
+      );
+      if (!match) return false;
+    }
+    if (f.projects.length && !f.projects.includes(c.projectName)) return false;
+    if (f.products.length && !f.products.includes(c.product)) return false;
+    if (q) {
+      const hay = `${c.caseNumber} ${c.subject} ${c.customer} ${c.projectName} ${c.assignee} ${c.product}`.toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+function sortBySlaUrgency(a: CsmCaseRow, b: CsmCaseRow): number {
+  // Closed last
+  const aClosed = a.state === "closed" ? 1 : 0;
+  const bClosed = b.state === "closed" ? 1 : 0;
+  if (aClosed !== bClosed) return aClosed - bClosed;
+  return a.minutesToBreach - b.minutesToBreach;
+}
+
+export default function CsmCasesPage(): JSX.Element {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo<CasesFilters>(
+    () => readCasesFiltersFromUrl(searchParams),
+    [searchParams],
+  );
+
+  const setFilters = useCallback(
+    (next: CasesFilters) => {
+      setSearchParams(writeCasesFiltersToUrl(next), { replace: true });
+    },
+    [setSearchParams],
+  );
+
+  const { data, isLoading, isError } = useGetCsmCases(filters.scope);
+  const { data: directoryUsers } = useDirectoryUsers();
+  const { showError } = useErrorBanner();
+  const hasShownErrorRef = useRef(false);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+
+  useEffect(() => {
+    if (isError && !hasShownErrorRef.current) {
+      hasShownErrorRef.current = true;
+      showError("Could not load cases.");
+    }
+    if (!isError) hasShownErrorRef.current = false;
+  }, [isError, showError]);
+
+  const filtered = useMemo(() => {
+    const list = data?.cases ?? [];
+    return applyFilters(list, filters).slice().sort(sortBySlaUrgency);
+  }, [data?.cases, filters]);
+
+  // Derive option lists for the searchable filters. Assignees come from the
+  // user directory (so typing finds anyone, not only owners present in the
+  // loaded cases). Projects and products are still derived from the case
+  // rows in scope. All sorted and de-duplicated; the lists are small.
+  const availableAssigneeUsers = useMemo(() => {
+    const list = (directoryUsers ?? [])
+      .filter((u) => u.name)
+      .map((u) => ({ name: u.name, email: u.email }));
+    list.sort((a, b) => a.name.localeCompare(b.name));
+    return list;
+  }, [directoryUsers]);
+
+  const availableProjects = useMemo(() => {
+    const set = new Set<string>();
+    (data?.cases ?? []).forEach((c) => {
+      if (c.projectName) set.add(c.projectName);
+    });
+    return Array.from(set).sort();
+  }, [data?.cases]);
+
+  const availableProducts = useMemo(() => {
+    const set = new Set<string>();
+    (data?.cases ?? []).forEach((c) => {
+      if (c.product) set.add(c.product);
+    });
+    return Array.from(set).sort();
+  }, [data?.cases]);
+
+  const totalAvailable = data?.cases.length ?? 0;
+  const breachedCount = filtered.filter((c) => c.minutesToBreach < 0 && c.state !== "closed").length;
+  const myCount = filtered.filter((c) => c.assigneeIsMe && c.state !== "closed").length;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          flexWrap: "wrap",
+        }}
+      >
+        <Box>
+          <Typography variant="h5">Cases</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {isLoading
+              ? "Loading…"
+              : `${filtered.length} of ${totalAvailable} shown`}
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {breachedCount > 0 && (
+            <Chip
+              size="small"
+              color="error"
+              label={`${breachedCount} breached`}
+            />
+          )}
+          {myCount > 0 && (
+            <Chip
+              size="small"
+              color="primary"
+              variant="outlined"
+              label={`${myCount} mine`}
+            />
+          )}
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            startIcon={<Plus size={16} />}
+            onClick={() => navigate("/cases/new")}
+          >
+            Create case
+          </Button>
+        </Box>
+      </Box>
+
+      <CasesFilterBar
+        filters={filters}
+        onChange={setFilters}
+        onReset={() =>
+          setFilters({ ...DEFAULT_CASES_FILTERS, scope: filters.scope })
+        }
+        isFiltersOpen={isFiltersOpen}
+        onFiltersToggle={() => setIsFiltersOpen((v) => !v)}
+        availableAssigneeUsers={availableAssigneeUsers}
+        availableProjects={availableProjects}
+        availableProducts={availableProducts}
+      />
+
+      <CasesList cases={filtered} isLoading={isLoading} />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  CaseState,
+  DashboardScope,
+  Severity,
+  SlaClockType,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+export interface CsmCaseRow {
+  id: string;
+  /**
+   * ServiceNow-style case number (e.g. "CS-1007"). The number engineers and
+   * customers quote day to day.
+   */
+  caseNumber: string;
+  /**
+   * Project/subscription-scoped WSO2 case reference (e.g. "ACMESUB-123").
+   * Distinct from {@link caseNumber}; shown alongside it as `wso2CaseId/caseNumber`.
+   * Mirrors the customer portal's `internalId` / BE `wso2Id`.
+   */
+  wso2CaseId: string;
+  subject: string;
+  customer: string;
+  accountId: string;
+  projectId: string;
+  projectName: string;
+  /** Affected WSO2 product (e.g. "WSO2 Identity Server"). Used for list filtering. */
+  product: string;
+  severity: Severity;
+  state: CaseState;
+  /** CRE / engineer working the case. "Unassigned" for cases with no one picked up yet. */
+  assignee: string;
+  assigneeIsMe: boolean;
+  slaClockType: SlaClockType;
+  // Minutes until breach (negative = already breached).
+  minutesToBreach: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CsmCasesListResponse {
+  scope: DashboardScope;
+  cases: CsmCaseRow[];
+}
+
+export type CsmCommentAuthorRole = "customer" | "wso2_engineer" | "system";
+
+export interface CsmCaseComment {
+  id: string;
+  caseId: string;
+  authorName: string;
+  authorRole: CsmCommentAuthorRole;
+  bodyHtml: string;
+  createdAt: string;
+  /**
+   * Internal work note (not visible to the customer). `false` = public comment
+   * that the customer sees in their portal. Mirrors SN's
+   * `sn_customerservice_case.work_notes` vs `comments` distinction.
+   */
+  internal?: boolean;
+}
+
+export interface CaseAttachment {
+  id: string;
+  filename: string;
+  /** File size in bytes. */
+  size: number;
+  contentType: string;
+  uploadedBy: string;
+  uploadedAt: string;
+}
+
+/** Plan/tier the customer holds for the affected product. */
+export type CustomerTier = "subscription" | "managed_cloud" | "saas" | "trial";
+
+export type SlaClockState = "running" | "paused" | "met" | "breached";
+
+export interface CaseSlaClock {
+  clockType: SlaClockType;
+  state: SlaClockState;
+  /** Minutes left until breach (negative = already breached). */
+  minutesToBreach: number;
+  /** Target SLA duration in minutes (e.g. ack target = 30 min for S1). */
+  targetMinutes: number;
+}
+
+export interface CaseWatcher {
+  id: string;
+  name: string;
+  role: "wso2_engineer" | "customer_contact" | "manager";
+  isMe?: boolean;
+}
+
+export interface CaseLinkedItem {
+  id: string;
+  kind: "case" | "incident" | "escalation" | "kb" | "cr" | "sr";
+  reference: string;
+  title: string;
+  state: string;
+  /** Optional relative URL for in-app navigation. */
+  href?: string;
+}
+
+export interface CaseTag {
+  id: string;
+  label: string;
+  color?: "default" | "primary" | "warning" | "info" | "success" | "error";
+}
+
+export interface CaseTimeLogEntry {
+  id: string;
+  engineer: string;
+  hours: number;
+  note: string;
+  date: string;
+}
+
+export type CaseAuditKind =
+  | "state_change"
+  | "assignee_change"
+  | "severity_change"
+  | "linked"
+  | "escalated"
+  | "watcher_added"
+  | "comment_added"
+  | "attachment_added"
+  | "sla_breached"
+  | "created";
+
+export interface CaseAuditEntry {
+  id: string;
+  kind: CaseAuditKind;
+  actor: string;
+  description: string;
+  createdAt: string;
+}
+
+export interface CaseCustomerContext {
+  accountName: string;
+  tier: CustomerTier;
+  region: string;
+  primaryContact: string;
+  primaryContactEmail: string;
+  accountManager: string;
+  technicalOwner?: string;
+  /** Number of currently open cases against this customer (incl. this one). */
+  openCases: number;
+}
+
+/**
+ * Deployment classification from the fixed deployment-type list. Mirrors the
+ * backend `DeploymentTypeKey` enum (`@features/support/types/case`); kept local
+ * so the case product context stays self-contained.
+ */
+export type DeploymentCategory =
+  | "primary_production"
+  | "staging"
+  | "qa"
+  | "stress"
+  | "uat"
+  | "development";
+
+export interface CaseProductContext {
+  product: string;
+  version: string;
+  updateLevel?: string;
+  /** Customer-provided deployment name (set by the customer in the project). */
+  deployment: string;
+  /** Fixed-list classification of the deployment (e.g. Primary Production). */
+  deploymentCategory?: DeploymentCategory;
+  environment: "dev" | "qa" | "staging" | "prod";
+  region?: string;
+}
+
+export type CaseLifecycleAction =
+  | "start_work"
+  | "assign_to_me"
+  | "propose_solution"
+  | "request_info"
+  | "wait_on_wso2"
+  | "resume_work"
+  | "close"
+  | "close_no_response"
+  | "reopen";
+
+/**
+ * Full case detail used by the case detail page. Extends the lightweight
+ * row type used in lists with all the side-widget data plus a curated set
+ * of state-driven primary actions.
+ */
+export interface CsmCaseDetail extends CsmCaseRow {
+  description: string;
+  assignmentGroup: string;
+  /** Customer-side person who opened the case. */
+  createdBy?: string;
+  customerContext: CaseCustomerContext;
+  productContext: CaseProductContext;
+  slaClocks: CaseSlaClock[];
+  watchers: CaseWatcher[];
+  linkedItems: CaseLinkedItem[];
+  tags: CaseTag[];
+  timeLogs: CaseTimeLogEntry[];
+  /** Lifecycle/audit entries — distinct from threaded comments. */
+  audit: CaseAuditEntry[];
+  attachments: CaseAttachment[];
+  /** Whether the current user is watching this case (controls Watch toggle). */
+  isWatching: boolean;
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CustomerTier } from "@features/csm-cases/types/csmCases";
+
+// Single source of truth for how a customer tier is labelled and coloured.
+// Lives in its own module (not a component file) so the header chip-row, the
+// meta band, and the Customer widget can all share it without tripping the
+// react-refresh "components-only export" rule.
+export const TIER_LABEL: Record<CustomerTier, string> = {
+  subscription: "Subscription",
+  managed_cloud: "Managed Cloud",
+  saas: "SaaS",
+  trial: "Trial",
+};
+
+export const TIER_COLOR: Record<
+  CustomerTier,
+  "primary" | "info" | "success" | "warning"
+> = {
+  subscription: "primary",
+  managed_cloud: "success",
+  saas: "info",
+  trial: "warning",
+};

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  CaseState,
+  DashboardScope,
+  Severity,
+} from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  CasesFilters,
+  SlaFilter,
+} from "@features/csm-cases/components/CasesFilterBar";
+
+export const DEFAULT_CASES_FILTERS: CasesFilters = {
+  scope: "my_abt",
+  search: "",
+  severities: [],
+  states: [],
+  sla: "any",
+  assignees: [],
+  projects: [],
+  products: [],
+};
+
+const VALID_SCOPES: DashboardScope[] = ["my_abt", "all_customers"];
+const VALID_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+const VALID_STATES: CaseState[] = [
+  "open",
+  "work_in_progress",
+  "solution_proposed",
+  "awaiting_info",
+  "waiting_on_wso2",
+  "reopen",
+  "closed",
+];
+const VALID_SLA: SlaFilter[] = ["any", "at_risk", "breached"];
+
+function parseCsv<T extends string>(raw: string | null, allowed: T[]): T[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is T => (allowed as string[]).includes(s));
+}
+
+/**
+ * Parse a CSV of free-form strings (used for assignee / project / product
+ * names that aren't part of a fixed enum). Empties stripped, length-capped
+ * per entry to avoid pathological URL growth.
+ */
+function parseFreeFormCsv(raw: string | null, maxEntryLen = 120): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && s.length <= maxEntryLen);
+}
+
+function parseEnum<T extends string>(
+  raw: string | null,
+  allowed: T[],
+  fallback: T,
+): T {
+  return raw && (allowed as string[]).includes(raw) ? (raw as T) : fallback;
+}
+
+export function readCasesFiltersFromUrl(
+  params: URLSearchParams,
+): CasesFilters {
+  return {
+    scope: parseEnum(params.get("scope"), VALID_SCOPES, "my_abt"),
+    search: params.get("q") ?? "",
+    severities: parseCsv(params.get("severities"), VALID_SEVERITIES),
+    states: parseCsv(params.get("states"), VALID_STATES),
+    sla: parseEnum(params.get("sla"), VALID_SLA, "any"),
+    assignees: parseFreeFormCsv(params.get("assignees")),
+    projects: parseFreeFormCsv(params.get("projects")),
+    products: parseFreeFormCsv(params.get("products")),
+  };
+}
+
+/**
+ * Build the search-params object representing these filters. Default values
+ * are omitted so the URL stays clean.
+ */
+export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
+  const out = new URLSearchParams();
+  if (f.scope !== "my_abt") out.set("scope", f.scope);
+  if (f.search) out.set("q", f.search);
+  if (f.severities.length) out.set("severities", f.severities.join(","));
+  if (f.states.length) out.set("states", f.states.join(","));
+  if (f.sla !== "any") out.set("sla", f.sla);
+  if (f.assignees.length) out.set("assignees", f.assignees.join(","));
+  if (f.projects.length) out.set("projects", f.projects.join(","));
+  if (f.products.length) out.set("products", f.products.join(","));
+  return out;
+}
+
+/**
+ * Convenience: build a `/cases?...` href from a partial filter override.
+ * Anything not specified falls back to the defaults.
+ */
+export function casesHref(overrides: Partial<CasesFilters>): string {
+  const full: CasesFilters = { ...DEFAULT_CASES_FILTERS, ...overrides };
+  const qs = writeCasesFiltersToUrl(full).toString();
+  return qs ? `/cases?${qs}` : "/cases";
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  CsmAbtDashboardData,
+  CsmCustomerSummary,
+  CsmQueueCase,
+  CsmRecentActivity,
+  CsmSlaAtRiskCase,
+  DashboardScope,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+const minutesAgo = (n: number): string =>
+  new Date(Date.now() - n * 60_000).toISOString();
+
+const ABT_CUSTOMERS: CsmCustomerSummary[] = [
+  {
+    accountId: "acc-001",
+    accountName: "Acme Financial",
+    tier: "Platinum",
+    openCaseCount: 14,
+    s0s1Count: 2,
+    breachedCount: 1,
+    lastActivityAt: minutesAgo(18),
+  },
+  {
+    accountId: "acc-002",
+    accountName: "Globex Corp",
+    tier: "Gold",
+    openCaseCount: 7,
+    s0s1Count: 0,
+    breachedCount: 0,
+    lastActivityAt: minutesAgo(95),
+  },
+  {
+    accountId: "acc-003",
+    accountName: "Initech Systems",
+    tier: "Platinum",
+    openCaseCount: 21,
+    s0s1Count: 3,
+    breachedCount: 2,
+    lastActivityAt: minutesAgo(7),
+  },
+  {
+    accountId: "acc-004",
+    accountName: "Soylent Industries",
+    tier: "Silver",
+    openCaseCount: 4,
+    s0s1Count: 0,
+    breachedCount: 0,
+    lastActivityAt: minutesAgo(240),
+  },
+  {
+    accountId: "acc-005",
+    accountName: "Umbrella Health",
+    tier: "Gold",
+    openCaseCount: 9,
+    s0s1Count: 1,
+    breachedCount: 0,
+    lastActivityAt: minutesAgo(52),
+  },
+];
+
+const ALL_EXTRA_CUSTOMERS: CsmCustomerSummary[] = [
+  {
+    accountId: "acc-101",
+    accountName: "Wayne Enterprises",
+    tier: "Platinum",
+    openCaseCount: 11,
+    s0s1Count: 1,
+    breachedCount: 0,
+    lastActivityAt: minutesAgo(33),
+  },
+  {
+    accountId: "acc-102",
+    accountName: "Stark Industries",
+    tier: "Gold",
+    openCaseCount: 6,
+    s0s1Count: 0,
+    breachedCount: 0,
+    lastActivityAt: minutesAgo(180),
+  },
+  {
+    accountId: "acc-103",
+    accountName: "Tyrell Corp",
+    tier: "Silver",
+    openCaseCount: 3,
+    s0s1Count: 0,
+    breachedCount: 0,
+    lastActivityAt: minutesAgo(420),
+  },
+];
+
+const QUEUE_TOP_CASES: CsmQueueCase[] = [
+  {
+    id: "case-1001",
+    caseNumber: "CS-1001",
+    subject: "Identity Server token issuance latency spike",
+    customer: "Acme Financial",
+    severity: "S1",
+    state: "work_in_progress",
+    slaClockType: "first_response",
+    minutesToBreach: -22,
+  },
+  {
+    id: "case-1002",
+    caseNumber: "CS-1002",
+    subject: "API Manager gateway 502 during peak",
+    customer: "Initech Systems",
+    severity: "S0",
+    state: "work_in_progress",
+    slaClockType: "resolution",
+    minutesToBreach: 12,
+  },
+  {
+    id: "case-1003",
+    caseNumber: "CS-1003",
+    subject: "MI cluster failed to start after upgrade",
+    customer: "Initech Systems",
+    severity: "S1",
+    state: "awaiting_info",
+    slaClockType: "ack",
+    minutesToBreach: 47,
+  },
+  {
+    id: "case-1004",
+    caseNumber: "CS-1004",
+    subject: "OIDC userinfo claims missing groups",
+    customer: "Acme Financial",
+    severity: "S2",
+    state: "open",
+    slaClockType: "ack",
+    minutesToBreach: 90,
+  },
+  {
+    id: "case-1005",
+    caseNumber: "CS-1005",
+    subject: "Choreo deployment stuck in 'Provisioning'",
+    customer: "Umbrella Health",
+    severity: "S2",
+    state: "work_in_progress",
+    slaClockType: "first_response",
+    minutesToBreach: 145,
+  },
+];
+
+const SLA_AT_RISK_ABT: CsmSlaAtRiskCase[] = [
+  {
+    id: "case-1001",
+    caseNumber: "CS-1001",
+    subject: "Identity Server token issuance latency spike",
+    customer: "Acme Financial",
+    severity: "S1",
+    assignee: "Me",
+    slaClockType: "first_response",
+    minutesToBreach: -22,
+    state: "work_in_progress",
+  },
+  {
+    id: "case-1002",
+    caseNumber: "CS-1002",
+    subject: "API Manager gateway 502 during peak",
+    customer: "Initech Systems",
+    severity: "S0",
+    assignee: "Me",
+    slaClockType: "resolution",
+    minutesToBreach: 12,
+    state: "work_in_progress",
+  },
+  {
+    id: "case-1007",
+    caseNumber: "CS-1007",
+    subject: "Streaming Integrator backpressure",
+    customer: "Initech Systems",
+    severity: "S1",
+    assignee: "Priya N.",
+    slaClockType: "resolution",
+    minutesToBreach: -180,
+    state: "awaiting_info",
+  },
+  {
+    id: "case-1008",
+    caseNumber: "CS-1008",
+    subject: "Asgardeo SCIM bulk import failing",
+    customer: "Umbrella Health",
+    severity: "S2",
+    assignee: "Dilan W.",
+    slaClockType: "first_response",
+    minutesToBreach: 25,
+    state: "work_in_progress",
+  },
+];
+
+const SLA_AT_RISK_ALL_EXTRA: CsmSlaAtRiskCase[] = [
+  {
+    id: "case-2001",
+    caseNumber: "CS-2001",
+    subject: "Open Banking sandbox cert mismatch",
+    customer: "Wayne Enterprises",
+    severity: "S1",
+    assignee: "Tharindu A.",
+    slaClockType: "first_response",
+    minutesToBreach: -60,
+    state: "work_in_progress",
+  },
+  {
+    id: "case-2002",
+    caseNumber: "CS-2002",
+    subject: "Choreo build hanging on private dep",
+    customer: "Stark Industries",
+    severity: "S2",
+    assignee: "Maya R.",
+    slaClockType: "ack",
+    minutesToBreach: 75,
+    state: "open",
+  },
+];
+
+const RECENT_ACTIVITY_ABT: CsmRecentActivity[] = [
+  {
+    id: "act-1",
+    caseId: "case-1002",
+    caseNumber: "CS-1002",
+    customer: "Initech Systems",
+    type: "comment",
+    who: "Customer (J. Doe)",
+    whenAt: minutesAgo(4),
+    summary: "Provided thread dump and gateway logs from peak window.",
+  },
+  {
+    id: "act-2",
+    caseId: "case-1001",
+    caseNumber: "CS-1001",
+    customer: "Acme Financial",
+    type: "sla_breach",
+    who: "System",
+    whenAt: minutesAgo(22),
+    summary: "First-response SLA breached.",
+  },
+  {
+    id: "act-3",
+    caseId: "case-1003",
+    caseNumber: "CS-1003",
+    customer: "Initech Systems",
+    type: "state_change",
+    who: "Me",
+    whenAt: minutesAgo(48),
+    summary: "Moved to awaiting_info — requested replication steps.",
+  },
+  {
+    id: "act-4",
+    caseId: "case-1004",
+    caseNumber: "CS-1004",
+    customer: "Acme Financial",
+    type: "case_created",
+    who: "Customer (R. Patel)",
+    whenAt: minutesAgo(75),
+    summary: "New case opened: OIDC userinfo claims missing groups.",
+  },
+  {
+    id: "act-5",
+    caseId: "case-1005",
+    caseNumber: "CS-1005",
+    customer: "Umbrella Health",
+    type: "comment",
+    who: "Me",
+    whenAt: minutesAgo(115),
+    summary: "Asked customer for kubectl describe output on stuck pod.",
+  },
+];
+
+const ENGINEER = {
+  name: "Sajith Ekanayaka",
+  email: "sajithe@wso2.com",
+  abtName: "ABT-IAM-East",
+};
+
+const sumQueue = (cases: CsmQueueCase[]) => {
+  let actionRequired = 0;
+  let inProgress = 0;
+  let awaitingInfo = 0;
+  for (const c of cases) {
+    if (c.state === "open" || c.state === "reopen") actionRequired += 1;
+    else if (c.state === "work_in_progress") inProgress += 1;
+    else if (c.state === "awaiting_info") awaitingInfo += 1;
+  }
+  return { actionRequired, inProgress, awaitingInfo };
+};
+
+export function getMockAbtDashboard(
+  scope: DashboardScope,
+): CsmAbtDashboardData {
+  const customers =
+    scope === "my_abt"
+      ? ABT_CUSTOMERS
+      : [...ABT_CUSTOMERS, ...ALL_EXTRA_CUSTOMERS];
+
+  const slaAtRisk =
+    scope === "my_abt"
+      ? SLA_AT_RISK_ABT
+      : [...SLA_AT_RISK_ABT, ...SLA_AT_RISK_ALL_EXTRA];
+
+  // My Queue is always "me", independent of scope.
+  const { actionRequired, inProgress, awaitingInfo } = sumQueue(QUEUE_TOP_CASES);
+  const totalOpen = actionRequired + inProgress + awaitingInfo;
+
+  return {
+    engineer: ENGINEER,
+    scope,
+    queue: {
+      actionRequiredCount: actionRequired,
+      inProgressCount: inProgress,
+      awaitingInfoCount: awaitingInfo,
+      totalOpenCount: totalOpen,
+      topCases: QUEUE_TOP_CASES,
+    },
+    slaAtRisk,
+    customers,
+    recentActivity: RECENT_ACTIVITY_ABT,
+  };
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetCsmDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetCsmDashboard.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAuthApiClient } from "@hooks/useAuthApiClient";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { getMockAbtDashboard } from "@features/csm-dashboard/api/mocks/dashboardMocks";
+import type {
+  CsmAbtDashboardData,
+  DashboardScope,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+const MOCK_LATENCY_MS = 250;
+
+/**
+ * Loads the CSM ABT dashboard payload.
+ *
+ * When `window.config.CSM_PORTAL_USE_MOCKS` is true, the hook resolves with
+ * in-memory mock data so the UI can be built ahead of csm-portal/backend.
+ * Otherwise it calls `GET ${BACKEND_BASE_URL}/csm/dashboard?scope=...`.
+ */
+export function useGetCsmDashboard(
+  scope: DashboardScope,
+): UseQueryResult<CsmAbtDashboardData, Error> {
+  const logger = useLogger();
+  const authFetch = useAuthApiClient();
+
+  return useQuery<CsmAbtDashboardData, Error>({
+    queryKey: [ApiQueryKeys.CSM_ABT_DASHBOARD, scope],
+    queryFn: async (): Promise<CsmAbtDashboardData> => {
+      if (window.config?.CSM_PORTAL_USE_MOCKS) {
+        logger.debug(
+          `[useGetCsmDashboard] Returning mock data for scope=${scope}`,
+        );
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return getMockAbtDashboard(scope);
+      }
+
+      const baseUrl = window.config?.CSM_PORTAL_BACKEND_BASE_URL;
+      if (!baseUrl) {
+        throw new Error("CSM_PORTAL_BACKEND_BASE_URL is not configured");
+      }
+
+      const url = `${baseUrl}/csm/dashboard?scope=${encodeURIComponent(scope)}`;
+      const response = await authFetch(url, { method: "GET" });
+      if (!response.ok) {
+        throw new Error(
+          `Error fetching CSM dashboard: ${response.statusText}`,
+        );
+      }
+      return (await response.json()) as CsmAbtDashboardData;
+    },
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  MenuItem,
+  Select,
+  Typography,
+} from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import {
+  DASHBOARD_OPTIONS,
+  type CsmDashboardEngineer,
+  type DashboardKey,
+  type DashboardScope,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+interface AbtDashboardHeaderProps {
+  engineer?: CsmDashboardEngineer;
+  scope: DashboardScope;
+  onScopeChange: (scope: DashboardScope) => void;
+  dashboardKey: DashboardKey;
+  onDashboardChange: (key: DashboardKey) => void;
+}
+
+export default function AbtDashboardHeader({
+  engineer,
+  scope,
+  onScopeChange,
+  dashboardKey,
+  onDashboardChange,
+}: AbtDashboardHeaderProps): JSX.Element {
+  const currentOption = DASHBOARD_OPTIONS.find((o) => o.key === dashboardKey);
+  const showScopeButtons = currentOption?.scopeBased ?? false;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 2,
+        flexWrap: "wrap",
+      }}
+    >
+      <Box>
+        <Typography variant="h5">Dashboard</Typography>
+        <Box
+          sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            {engineer ? engineer.name : "Loading engineer…"}
+          </Typography>
+          {engineer?.abtName && (
+            <Chip
+              size="small"
+              label={engineer.abtName}
+              variant="outlined"
+              color="primary"
+            />
+          )}
+        </Box>
+      </Box>
+      <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+        {showScopeButtons && (
+          <>
+            <Button
+              size="small"
+              variant={scope === "my_abt" ? "contained" : "outlined"}
+              color="primary"
+              onClick={() => onScopeChange("my_abt")}
+            >
+              My ABT
+            </Button>
+            <Button
+              size="small"
+              variant={scope === "all_customers" ? "contained" : "outlined"}
+              color="primary"
+              onClick={() => onScopeChange("all_customers")}
+            >
+              All customers
+            </Button>
+          </>
+        )}
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <Select
+            value={dashboardKey}
+            onChange={(e) => onDashboardChange(e.target.value as DashboardKey)}
+            displayEmpty
+          >
+            {DASHBOARD_OPTIONS.map((o) => (
+              <MenuItem key={o.key} value={o.key}>
+                {o.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CustomerSummarySection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CustomerSummarySection.tsx
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import SectionCard from "@features/csm-dashboard/components/SectionCard";
+import RelativeTime from "@components/RelativeTime";
+import type { CsmCustomerSummary } from "@features/csm-dashboard/types/abtDashboard";
+
+interface CustomerSummarySectionProps {
+  customers?: CsmCustomerSummary[];
+  isLoading: boolean;
+  scopeLabel: string;
+}
+
+function TierChip({ tier }: { tier: string }): JSX.Element {
+  const color =
+    tier === "Platinum"
+      ? "primary"
+      : tier === "Gold"
+        ? "warning"
+        : tier === "Silver"
+          ? "default"
+          : "default";
+  return <Chip size="small" variant="outlined" label={tier} color={color} />;
+}
+
+export default function CustomerSummarySection({
+  customers,
+  isLoading,
+  scopeLabel,
+}: CustomerSummarySectionProps): JSX.Element {
+  return (
+    <SectionCard
+      title="Customers"
+      subtitle={scopeLabel}
+      action={
+        !isLoading && customers ? (
+          <Chip
+            size="small"
+            label={`${customers.length} accounts`}
+            variant="outlined"
+          />
+        ) : undefined
+      }
+    >
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr) auto auto auto auto auto",
+          columnGap: 1.5,
+          rowGap: 1,
+          alignItems: "center",
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          Account
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          Tier
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ textAlign: "right" }}>
+          Open
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ textAlign: "right" }}>
+          S0/S1
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ textAlign: "right" }}>
+          Breached
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ textAlign: "right" }}>
+          Last activity
+        </Typography>
+
+        {isLoading &&
+          [0, 1, 2, 3, 4].map((i) => (
+            <Box key={i} sx={{ gridColumn: "1 / -1" }}>
+              <Skeleton variant="rectangular" height={32} />
+            </Box>
+          ))}
+
+        {!isLoading &&
+          customers?.map((c) => (
+            <Box
+              key={c.accountId}
+              sx={{ display: "contents" }}
+            >
+              <Typography variant="body2" noWrap>
+                {c.accountName}
+              </Typography>
+              <Box><TierChip tier={c.tier} /></Box>
+              <Typography variant="body2" sx={{ textAlign: "right" }}>
+                {c.openCaseCount}
+              </Typography>
+              <Typography
+                variant="body2"
+                color={c.s0s1Count > 0 ? "error" : "text.primary"}
+                sx={{ textAlign: "right" }}
+              >
+                {c.s0s1Count}
+              </Typography>
+              <Typography
+                variant="body2"
+                color={c.breachedCount > 0 ? "error" : "text.primary"}
+                sx={{ textAlign: "right" }}
+              >
+                {c.breachedCount}
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ textAlign: "right" }}
+              >
+                <RelativeTime iso={c.lastActivityAt} />
+              </Typography>
+            </Box>
+          ))}
+      </Box>
+    </SectionCard>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import type { JSX, KeyboardEvent } from "react";
+import { useNavigate } from "react-router";
+import SectionCard from "@features/csm-dashboard/components/SectionCard";
+import {
+  SEVERITY_COLOR,
+  SLA_CLOCK_LABEL,
+  STATE_LABEL,
+  formatTimeToBreach,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import { casesHref } from "@features/csm-cases/utils/casesFiltersUrl";
+import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/components/CasesFilterBar";
+import type { CsmQueueSummary } from "@features/csm-dashboard/types/abtDashboard";
+
+interface MyQueueSectionProps {
+  queue?: CsmQueueSummary;
+  isLoading: boolean;
+}
+
+function StatPill({
+  label,
+  value,
+  href,
+  onNavigate,
+}: {
+  label: string;
+  value: number | string;
+  href?: string;
+  onNavigate?: (href: string) => void;
+}): JSX.Element {
+  const interactive = !!href && !!onNavigate;
+  const handleKey = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!interactive) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onNavigate!(href!);
+    }
+  };
+  return (
+    <Box
+      role={interactive ? "link" : undefined}
+      tabIndex={interactive ? 0 : -1}
+      aria-label={interactive ? `${label}: ${value}` : undefined}
+      onClick={interactive ? () => onNavigate!(href!) : undefined}
+      onKeyDown={handleKey}
+      sx={{
+        flex: 1,
+        minWidth: 120,
+        p: 1.5,
+        borderRadius: 1,
+        border: 1,
+        borderColor: "divider",
+        display: "flex",
+        flexDirection: "column",
+        gap: 0.5,
+        ...(interactive && {
+          cursor: "pointer",
+          transition: "border-color 0.15s ease, background-color 0.15s ease",
+          "&:hover": {
+            borderColor: "primary.main",
+            bgcolor: "action.hover",
+          },
+        }),
+      }}
+    >
+      <Typography variant="h5">{value}</Typography>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+export default function MyQueueSection({
+  queue,
+  isLoading,
+}: MyQueueSectionProps): JSX.Element {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const go = (href: string) => navigate(href);
+
+  return (
+    <SectionCard
+      title="My queue"
+      subtitle="Cases assigned to you"
+    >
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        <StatPill
+          label="Action required"
+          value={isLoading ? "—" : (queue?.actionRequiredCount ?? 0)}
+          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN], states: ["open", "reopen"] })}
+          onNavigate={go}
+        />
+        <StatPill
+          label="In progress"
+          value={isLoading ? "—" : (queue?.inProgressCount ?? 0)}
+          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN], states: ["work_in_progress"] })}
+          onNavigate={go}
+        />
+        <StatPill
+          label="Awaiting info"
+          value={isLoading ? "—" : (queue?.awaitingInfoCount ?? 0)}
+          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN], states: ["awaiting_info"] })}
+          onNavigate={go}
+        />
+        <StatPill
+          label="Total open"
+          value={isLoading ? "—" : (queue?.totalOpenCount ?? 0)}
+          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN] })}
+          onNavigate={go}
+        />
+      </Box>
+
+      <Box sx={{ mt: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+        <Typography variant="subtitle2">Most urgent</Typography>
+        {isLoading && (
+          <>
+            <Skeleton variant="rectangular" height={48} />
+            <Skeleton variant="rectangular" height={48} />
+            <Skeleton variant="rectangular" height={48} />
+          </>
+        )}
+        {!isLoading && (queue?.topCases ?? []).length === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            Nothing in your queue.
+          </Typography>
+        )}
+        {!isLoading &&
+          queue?.topCases.map((c) => (
+            <Box
+              key={c.id}
+              role="link"
+              tabIndex={0}
+              aria-label={`${c.caseNumber} ${c.subject}`}
+              onClick={() => go(casesHref({ search: c.caseNumber }))}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  go(casesHref({ search: c.caseNumber }));
+                }
+              }}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                p: 1.25,
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+                cursor: "pointer",
+                transition: "border-color 0.15s ease, background-color 0.15s ease",
+                "&:hover": {
+                  borderColor: "primary.main",
+                  bgcolor: "action.hover",
+                },
+                "&:focus-visible": {
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: 2,
+                },
+              }}
+            >
+              <Chip
+                size="small"
+                label={c.severity}
+                color={SEVERITY_COLOR[c.severity]}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="body2" noWrap>
+                  <strong>{c.caseNumber}</strong> · {c.subject}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {c.customer} · {STATE_LABEL[c.state]}
+                </Typography>
+              </Box>
+              <Box sx={{ textAlign: "right" }}>
+                <Typography
+                  variant="body2"
+                  color={c.minutesToBreach < 0 ? "error" : "text.primary"}
+                >
+                  {formatTimeToBreach(c.minutesToBreach)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {SLA_CLOCK_LABEL[c.slaClockType]}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+      </Box>
+    </SectionCard>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/RecentActivitySection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/RecentActivitySection.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import SectionCard from "@features/csm-dashboard/components/SectionCard";
+import RelativeTime from "@components/RelativeTime";
+import type {
+  CsmRecentActivity,
+  CsmRecentActivityType,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+interface RecentActivitySectionProps {
+  activity?: CsmRecentActivity[];
+  isLoading: boolean;
+}
+
+const TYPE_LABEL: Record<CsmRecentActivityType, string> = {
+  comment: "Comment",
+  state_change: "State change",
+  case_created: "Created",
+  case_closed: "Closed",
+  sla_breach: "SLA breach",
+};
+
+const TYPE_COLOR: Record<
+  CsmRecentActivityType,
+  "default" | "primary" | "success" | "warning" | "error" | "info"
+> = {
+  comment: "info",
+  state_change: "default",
+  case_created: "primary",
+  case_closed: "success",
+  sla_breach: "error",
+};
+
+export default function RecentActivitySection({
+  activity,
+  isLoading,
+}: RecentActivitySectionProps): JSX.Element {
+  return (
+    <SectionCard title="Recent activity" subtitle="Across ABT cases">
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+        {isLoading &&
+          [0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} variant="rectangular" height={44} />
+          ))}
+        {!isLoading && (activity?.length ?? 0) === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            No recent activity.
+          </Typography>
+        )}
+        {!isLoading &&
+          activity?.map((a) => (
+            <Box
+              key={a.id}
+              sx={{
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 1.5,
+                p: 1.25,
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+              }}
+            >
+              <Chip
+                size="small"
+                color={TYPE_COLOR[a.type]}
+                label={TYPE_LABEL[a.type]}
+                sx={{ minWidth: 96 }}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="body2">
+                  <strong>{a.caseNumber}</strong> · {a.summary}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {a.customer} · {a.who} · <RelativeTime iso={a.whenAt} />
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+      </Box>
+    </SectionCard>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/SectionCard.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/SectionCard.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Card, Typography } from "@wso2/oxygen-ui";
+import type { JSX, ReactNode } from "react";
+
+interface SectionCardProps {
+  title: string;
+  subtitle?: string;
+  action?: ReactNode;
+  children: ReactNode;
+}
+
+export default function SectionCard({
+  title,
+  subtitle,
+  action,
+  children,
+}: SectionCardProps): JSX.Element {
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+        }}
+      >
+        <Box>
+          <Typography variant="h6">{title}</Typography>
+          {subtitle && (
+            <Typography variant="body2" color="text.secondary">
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+        {action}
+      </Box>
+      {children}
+    </Card>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/SlaAtRiskSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/SlaAtRiskSection.tsx
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { useNavigate } from "react-router";
+import SectionCard from "@features/csm-dashboard/components/SectionCard";
+import {
+  SEVERITY_COLOR,
+  SLA_CLOCK_LABEL,
+  STATE_LABEL,
+  formatTimeToBreach,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import { casesHref } from "@features/csm-cases/utils/casesFiltersUrl";
+import type { CsmSlaAtRiskCase } from "@features/csm-dashboard/types/abtDashboard";
+
+interface SlaAtRiskSectionProps {
+  cases?: CsmSlaAtRiskCase[];
+  isLoading: boolean;
+}
+
+export default function SlaAtRiskSection({
+  cases,
+  isLoading,
+}: SlaAtRiskSectionProps): JSX.Element {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const go = (href: string) => navigate(href);
+  const breachedCount = (cases ?? []).filter((c) => c.minutesToBreach < 0).length;
+
+  return (
+    <SectionCard
+      title="SLA at risk"
+      subtitle="Cases breaching or about to breach"
+      action={
+        !isLoading && (cases?.length ?? 0) > 0 ? (
+          <Chip
+            size="small"
+            clickable
+            color={breachedCount > 0 ? "error" : "warning"}
+            label={
+              breachedCount > 0
+                ? `${breachedCount} breached`
+                : `${cases?.length ?? 0} at risk`
+            }
+            onClick={() =>
+              go(
+                casesHref({
+                  sla: breachedCount > 0 ? "breached" : "at_risk",
+                }),
+              )
+            }
+          />
+        ) : undefined
+      }
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        {isLoading && (
+          <>
+            <Skeleton variant="rectangular" height={56} />
+            <Skeleton variant="rectangular" height={56} />
+            <Skeleton variant="rectangular" height={56} />
+          </>
+        )}
+        {!isLoading && (cases?.length ?? 0) === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            Nothing at risk right now.
+          </Typography>
+        )}
+        {!isLoading &&
+          cases?.map((c) => (
+            <Box
+              key={c.id}
+              role="link"
+              tabIndex={0}
+              aria-label={`${c.caseNumber} ${c.subject}`}
+              onClick={() => go(casesHref({ search: c.caseNumber }))}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  go(casesHref({ search: c.caseNumber }));
+                }
+              }}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                p: 1.25,
+                border: 1,
+                borderColor: c.minutesToBreach < 0 ? "error.main" : "divider",
+                borderRadius: 1,
+                cursor: "pointer",
+                transition: "border-color 0.15s ease, background-color 0.15s ease",
+                "&:hover": {
+                  bgcolor: "action.hover",
+                  ...(c.minutesToBreach >= 0 && { borderColor: "primary.main" }),
+                },
+                "&:focus-visible": {
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: 2,
+                },
+              }}
+            >
+              <Chip
+                size="small"
+                label={c.severity}
+                color={SEVERITY_COLOR[c.severity]}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="body2" noWrap>
+                  <strong>{c.caseNumber}</strong> · {c.subject}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {c.customer} · {STATE_LABEL[c.state]} · Assignee: {c.assignee}
+                </Typography>
+              </Box>
+              <Box sx={{ textAlign: "right" }}>
+                <Typography
+                  variant="body2"
+                  color={c.minutesToBreach < 0 ? "error" : "warning.main"}
+                >
+                  {formatTimeToBreach(c.minutesToBreach)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {SLA_CLOCK_LABEL[c.slaClockType]}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+      </Box>
+    </SectionCard>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Card, Chip, Typography } from "@wso2/oxygen-ui";
+import { useEffect, useRef, useState, type JSX } from "react";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import AbtDashboardHeader from "@features/csm-dashboard/components/AbtDashboardHeader";
+import MyQueueSection from "@features/csm-dashboard/components/MyQueueSection";
+import SlaAtRiskSection from "@features/csm-dashboard/components/SlaAtRiskSection";
+import CustomerSummarySection from "@features/csm-dashboard/components/CustomerSummarySection";
+import RecentActivitySection from "@features/csm-dashboard/components/RecentActivitySection";
+import { useGetCsmDashboard } from "@features/csm-dashboard/api/useGetCsmDashboard";
+import {
+  DASHBOARD_OPTIONS,
+  type DashboardKey,
+  type DashboardScope,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+/**
+ * Top-level CSM dashboard. Hosts the engineer-overview dashboard (queue +
+ * SLA + customers + activity) plus four placeholder dashboards selectable
+ * from the top-right dropdown (Operations, IAM CS, Security, Team
+ * performance). Per DashboardsAndReportsProposal.md the real tab+widget
+ * model lives behind the entity-service reports DSL; these placeholders
+ * are mocks for UX iteration only.
+ */
+export default function CsmDashboardPage(): JSX.Element {
+  const [scope, setScope] = useState<DashboardScope>("my_abt");
+  const [dashboardKey, setDashboardKey] = useState<DashboardKey>("engineer");
+  const { data, isLoading, isError } = useGetCsmDashboard(scope);
+  const { showError } = useErrorBanner();
+  const hasShownErrorRef = useRef(false);
+
+  useEffect(() => {
+    if (isError && !hasShownErrorRef.current) {
+      hasShownErrorRef.current = true;
+      showError("Could not load dashboard.");
+    }
+    if (!isError) hasShownErrorRef.current = false;
+  }, [isError, showError]);
+
+  const scopeLabel =
+    scope === "my_abt"
+      ? data?.engineer?.abtName
+        ? `In ${data.engineer.abtName}`
+        : "ABT scope"
+      : "All customers";
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <AbtDashboardHeader
+        engineer={data?.engineer}
+        scope={scope}
+        onScopeChange={setScope}
+        dashboardKey={dashboardKey}
+        onDashboardChange={setDashboardKey}
+      />
+      {dashboardKey === "engineer" ? (
+        <>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: {
+                xs: "1fr",
+                md: "repeat(2, minmax(0, 1fr))",
+              },
+            }}
+          >
+            <MyQueueSection queue={data?.queue} isLoading={isLoading} />
+            <SlaAtRiskSection cases={data?.slaAtRisk} isLoading={isLoading} />
+          </Box>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: {
+                xs: "1fr",
+                md: "minmax(0, 7fr) minmax(0, 5fr)",
+              },
+            }}
+          >
+            <CustomerSummarySection
+              customers={data?.customers}
+              isLoading={isLoading}
+              scopeLabel={scopeLabel}
+            />
+            <RecentActivitySection
+              activity={data?.recentActivity}
+              isLoading={isLoading}
+            />
+          </Box>
+        </>
+      ) : (
+        <DashboardPlaceholder dashboardKey={dashboardKey} />
+      )}
+    </Box>
+  );
+}
+
+interface DashboardPlaceholderProps {
+  dashboardKey: DashboardKey;
+}
+
+function DashboardPlaceholder({ dashboardKey }: DashboardPlaceholderProps): JSX.Element {
+  const option = DASHBOARD_OPTIONS.find((o) => o.key === dashboardKey);
+  if (!option) return <></>;
+
+  // Mock KPI tiles per dashboard. Numbers are pinned (no real query); the
+  // shape matches the v1 widget set in DashboardsAndReportsProposal.md.
+  const tiles = TILE_SETS[dashboardKey] ?? [];
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Card variant="outlined" sx={{ p: 2.5 }}>
+        <Typography variant="h6">{option.name}</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {option.description}
+        </Typography>
+        <Box sx={{ display: "flex", gap: 0.5, mt: 1 }}>
+          <Chip size="small" label="Mock" color="warning" variant="outlined" />
+          <Chip size="small" label="No widgets persisted" variant="outlined" />
+        </Box>
+      </Card>
+      <Box
+        sx={{
+          display: "grid",
+          gap: 1.5,
+          gridTemplateColumns: {
+            xs: "repeat(2, minmax(0, 1fr))",
+            sm: "repeat(3, minmax(0, 1fr))",
+            md: "repeat(4, minmax(0, 1fr))",
+            lg: "repeat(5, minmax(0, 1fr))",
+          },
+        }}
+      >
+        {tiles.map((t) => (
+          <Card key={t.label} variant="outlined" sx={{ p: 1.75 }}>
+            <Typography variant="caption" color="text.secondary">
+              {t.label}
+            </Typography>
+            <Typography
+              variant="h5"
+              sx={{
+                color:
+                  t.color === "warning"
+                    ? "warning.main"
+                    : t.color === "danger"
+                      ? "error.main"
+                      : t.color === "success"
+                        ? "success.main"
+                        : "text.primary",
+                mt: 0.5,
+              }}
+            >
+              {t.value}
+            </Typography>
+            {t.sub && (
+              <Typography variant="caption" color="text.secondary">
+                {t.sub}
+              </Typography>
+            )}
+          </Card>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+type TileColor = "neutral" | "info" | "success" | "warning" | "danger";
+interface Tile {
+  label: string;
+  value: string;
+  sub?: string;
+  color: TileColor;
+}
+
+const TILE_SETS: Record<DashboardKey, Tile[]> = {
+  engineer: [],
+  operations: [
+    { label: "Open cases", value: "287", color: "neutral" },
+    { label: "Created today", value: "34", sub: "+12% vs 7d avg", color: "info" },
+    { label: "Resolved today", value: "29", sub: "+3% vs 7d avg", color: "success" },
+    { label: "Solution proposed", value: "41", color: "neutral" },
+    { label: "Awaiting info", value: "62", color: "neutral" },
+    { label: "P0/P1 open", value: "9", color: "danger" },
+    { label: "P0/P1 breached", value: "2", color: "danger" },
+    { label: "Escalations open", value: "11", color: "warning" },
+    { label: "SLA breach 24h", value: "4", color: "warning" },
+    { label: "Time-card pending approval", value: "18", color: "neutral" },
+  ],
+  iam: [
+    { label: "IS cases open", value: "53", color: "neutral" },
+    { label: "Asgardeo cases open", value: "41", color: "neutral" },
+    { label: "IS P0/P1 open", value: "3", color: "danger" },
+    { label: "Top product: IS 7.1.0", value: "22", sub: "Open cases", color: "info" },
+    { label: "Auth-failure clusters", value: "5", color: "warning" },
+    { label: "Top account: Bank of Georgia", value: "9", sub: "Open cases", color: "info" },
+    { label: "Avg ack time", value: "22 m", sub: "Target 30 m", color: "success" },
+    { label: "Avg resolution (P2)", value: "8.4 h", sub: "Target 24 h", color: "success" },
+    { label: "Customer satisfaction", value: "4.4 / 5", sub: "Last 30d", color: "success" },
+    { label: "Vuln links to active cases", value: "7", color: "warning" },
+  ],
+  security: [
+    { label: "Critical vulns", value: "4", color: "danger" },
+    { label: "High vulns", value: "18", color: "warning" },
+    { label: "Medium vulns", value: "62", color: "neutral" },
+    { label: "Patches released 30d", value: "11", color: "success" },
+    { label: "SRA cases open", value: "6", color: "warning" },
+    { label: "Avg disclosure SLA", value: "12 d", sub: "Target 14 d", color: "success" },
+    { label: "Customers with critical exposure", value: "9", color: "danger" },
+    { label: "Affected products", value: "5", color: "neutral" },
+    { label: "Pending CVE assignments", value: "3", color: "warning" },
+    { label: "Open advisories", value: "27", color: "neutral" },
+  ],
+  team_performance: [
+    { label: "Cases per engineer (7d avg)", value: "5.2", color: "neutral" },
+    { label: "First-response within SLA", value: "94%", sub: "Last 30d", color: "success" },
+    { label: "Resolution within SLA", value: "89%", sub: "Last 30d", color: "success" },
+    { label: "On-call coverage gaps", value: "1", sub: "Bijira SRE — Sun 03:00", color: "warning" },
+    { label: "Top performer (cases closed)", value: "Priya N.", sub: "42 last 30d", color: "info" },
+    { label: "Most reassigned engineer", value: "Asanka R.", sub: "8 outbound", color: "warning" },
+    { label: "Time-card submission rate", value: "97%", color: "success" },
+    { label: "Time-card approval lag", value: "1.3 d", color: "neutral" },
+    { label: "Median ack time", value: "18 m", sub: "Across all P0–P3", color: "success" },
+    { label: "Median resolution (P2)", value: "9.6 h", color: "success" },
+  ],
+};

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export type Severity = "S0" | "S1" | "S2" | "S3" | "S4";
+
+export type CaseState =
+  | "open"
+  | "work_in_progress"
+  | "solution_proposed"
+  | "awaiting_info"
+  | "waiting_on_wso2"
+  | "reopen"
+  | "closed";
+
+export type SlaClockType = "ack" | "first_response" | "resolution";
+
+export type DashboardScope = "my_abt" | "all_customers";
+
+export interface CsmDashboardEngineer {
+  name: string;
+  email: string;
+  abtName: string;
+}
+
+export interface CsmQueueCase {
+  id: string;
+  caseNumber: string;
+  subject: string;
+  customer: string;
+  severity: Severity;
+  state: CaseState;
+  slaClockType: SlaClockType;
+  // Minutes until the active SLA clock breaches. Negative => already breached.
+  minutesToBreach: number;
+}
+
+export interface CsmQueueSummary {
+  actionRequiredCount: number;
+  inProgressCount: number;
+  awaitingInfoCount: number;
+  totalOpenCount: number;
+  topCases: CsmQueueCase[];
+}
+
+export interface CsmSlaAtRiskCase {
+  id: string;
+  caseNumber: string;
+  subject: string;
+  customer: string;
+  severity: Severity;
+  assignee: string;
+  slaClockType: SlaClockType;
+  minutesToBreach: number;
+  state: CaseState;
+}
+
+export interface CsmCustomerSummary {
+  accountId: string;
+  accountName: string;
+  tier: string;
+  openCaseCount: number;
+  s0s1Count: number;
+  breachedCount: number;
+  lastActivityAt: string;
+}
+
+export type CsmRecentActivityType =
+  | "comment"
+  | "state_change"
+  | "case_created"
+  | "case_closed"
+  | "sla_breach";
+
+export interface CsmRecentActivity {
+  id: string;
+  caseId: string;
+  caseNumber: string;
+  customer: string;
+  type: CsmRecentActivityType;
+  who: string;
+  whenAt: string;
+  summary: string;
+}
+
+export interface CsmAbtDashboardData {
+  engineer: CsmDashboardEngineer;
+  scope: DashboardScope;
+  queue: CsmQueueSummary;
+  slaAtRisk: CsmSlaAtRiskCase[];
+  customers: CsmCustomerSummary[];
+  recentActivity: CsmRecentActivity[];
+}
+
+// Multi-dashboard switcher — mirrors ServiceNow Performance Analytics where
+// engineers pivot between several dashboards (Engineer / Operations / IAM /
+// Security / Team Performance). See DashboardsAndReportsProposal.md.
+export type DashboardKey =
+  | "engineer"
+  | "operations"
+  | "iam"
+  | "security"
+  | "team_performance";
+
+export interface DashboardOption {
+  key: DashboardKey;
+  name: string;
+  description: string;
+  scopeBased: boolean;
+}
+
+export const DASHBOARD_OPTIONS: DashboardOption[] = [
+  {
+    key: "engineer",
+    name: "Engineer overview",
+    description: "Personal queue, SLA at risk, customers in scope, recent activity.",
+    scopeBased: true,
+  },
+  {
+    key: "operations",
+    name: "Operations",
+    description: "Cross-team case throughput, state distribution, escalations, SLA breach trends.",
+    scopeBased: false,
+  },
+  {
+    key: "iam",
+    name: "IAM CS",
+    description: "Identity Server / Asgardeo case posture, top accounts, vulnerability links.",
+    scopeBased: false,
+  },
+  {
+    key: "security",
+    name: "Security center",
+    description: "Vulnerability posture, security report cases, response time.",
+    scopeBased: false,
+  },
+  {
+    key: "team_performance",
+    name: "Team performance",
+    description: "Per-team throughput, time-card distribution, on-call coverage gaps.",
+    scopeBased: false,
+  },
+];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  CaseState,
+  Severity,
+  SlaClockType,
+} from "@features/csm-dashboard/types/abtDashboard";
+import { parseBackendTimestamp } from "@utils/dateTime";
+
+export const SEVERITY_COLOR: Record<
+  Severity,
+  "error" | "warning" | "info" | "success" | "default"
+> = {
+  S0: "error",
+  S1: "error",
+  S2: "warning",
+  S3: "info",
+  S4: "default",
+};
+
+export const SEVERITY_LABEL: Record<Severity, string> = {
+  S0: "Catastrophic",
+  S1: "Critical",
+  S2: "High",
+  S3: "Medium",
+  S4: "Low / Query",
+};
+
+export const STATE_LABEL: Record<CaseState, string> = {
+  open: "Open",
+  work_in_progress: "Work in progress",
+  solution_proposed: "Solution proposed",
+  awaiting_info: "Awaiting info",
+  waiting_on_wso2: "Waiting on WSO2",
+  reopen: "Reopened",
+  closed: "Closed",
+};
+
+export const SLA_CLOCK_LABEL: Record<SlaClockType, string> = {
+  ack: "Ack",
+  first_response: "First response",
+  resolution: "Resolution",
+};
+
+export function formatTimeToBreach(minutes: number): string {
+  const abs = Math.abs(minutes);
+  const h = Math.floor(abs / 60);
+  const m = abs % 60;
+  const body =
+    h > 0 && m > 0 ? `${h}h ${m}m` : h > 0 ? `${h}h` : `${m}m`;
+  return minutes < 0 ? `breached ${body} ago` : `${body} left`;
+}
+
+export function formatRelativeTime(
+  iso: string | null | undefined,
+  now: number = Date.now(),
+): string {
+  if (!iso) return "—";
+  // Backend timestamps are UTC. parseBackendTimestamp treats unzoned ISO
+  // strings (and the slash/space formats some SN APIs return) as UTC.
+  const parsed = parseBackendTimestamp(iso);
+  const epoch = parsed ? parsed.getTime() : new Date(iso).getTime();
+  if (Number.isNaN(epoch)) return "—";
+  const diffMs = now - epoch;
+  const futureSuffix = diffMs < 0 ? " from now" : " ago";
+  const abs = Math.abs(diffMs);
+  const diffMin = Math.round(abs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m${futureSuffix}`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h${futureSuffix}`;
+  const diffDay = Math.round(diffHr / 24);
+  return `${diffDay}d${futureSuffix}`;
+}

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  IconButton,
+  Paper,
+  Tooltip,
+  Typography,
+  useTheme,
+} from "@wso2/oxygen-ui";
+import {
+  Building,
+  FolderOpen,
+  Headset,
+  History,
+} from "@wso2/oxygen-ui-icons-react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+} from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router";
+import {
+  clearRecentViews,
+  useRecentViews,
+  type RecentView,
+  type RecentViewKind,
+} from "@features/csm-recent/hooks/useRecentViews";
+import RelativeTime from "@components/RelativeTime";
+
+const PANEL_WIDTH = 360;
+
+const KIND_LABEL: Record<RecentViewKind, string> = {
+  case: "Cases",
+  project: "Projects",
+  account: "Accounts",
+};
+
+const KIND_ORDER: RecentViewKind[] = ["case", "project", "account"];
+
+function kindIcon(kind: RecentViewKind): JSX.Element {
+  switch (kind) {
+    case "case":
+      return <Headset size={16} />;
+    case "project":
+      return <FolderOpen size={16} />;
+    case "account":
+      return <Building size={16} />;
+  }
+}
+
+function groupByKind(entries: RecentView[]): Record<RecentViewKind, RecentView[]> {
+  const out: Record<RecentViewKind, RecentView[]> = {
+    case: [],
+    project: [],
+    account: [],
+  };
+  for (const e of entries) out[e.kind].push(e);
+  return out;
+}
+
+export default function RecentViewsButton(): JSX.Element {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const recents = useRecentViews();
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  const updateAnchorRect = useCallback(() => {
+    if (anchorRef.current) {
+      setAnchorRect(anchorRef.current.getBoundingClientRect());
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    if (open) updateAnchorRect();
+  }, [open, updateAnchorRect]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = () => updateAnchorRect();
+    window.addEventListener("resize", handle);
+    window.addEventListener("scroll", handle, true);
+    return () => {
+      window.removeEventListener("resize", handle);
+      window.removeEventListener("scroll", handle, true);
+    };
+  }, [open, updateAnchorRect]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        panelRef.current?.contains(target) ||
+        anchorRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const grouped = useMemo(() => groupByKind(recents), [recents]);
+
+  const handleSelect = (entry: RecentView) => {
+    setOpen(false);
+    navigate(entry.href);
+  };
+
+  const panel = open && anchorRect && (
+    <Paper
+      ref={panelRef}
+      elevation={6}
+      sx={{
+        position: "fixed",
+        top: anchorRect.bottom + 6,
+        right: window.innerWidth - anchorRect.right,
+        width: PANEL_WIDTH,
+        maxHeight: 480,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+        zIndex: theme.zIndex.modal + 1,
+        border: 1,
+        borderColor: "divider",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+          px: 1.5,
+          py: 1,
+          borderBottom: 1,
+          borderColor: "divider",
+          bgcolor: "background.default",
+        }}
+      >
+        <Typography variant="subtitle2">Recently viewed</Typography>
+        {recents.length > 0 && (
+          <Button
+            size="small"
+            variant="text"
+            onClick={() => clearRecentViews()}
+          >
+            Clear
+          </Button>
+        )}
+      </Box>
+
+      <Box sx={{ overflowY: "auto", flex: 1 }}>
+        {recents.length === 0 && (
+          <Box sx={{ px: 1.5, py: 2.5, textAlign: "center" }}>
+            <Typography variant="body2" color="text.secondary">
+              No recent items. Open a case, project, or account to start tracking history.
+            </Typography>
+          </Box>
+        )}
+
+        {KIND_ORDER.map((kind) => {
+          const group = grouped[kind];
+          if (group.length === 0) return null;
+          return (
+            <Box key={kind}>
+              <Box
+                sx={{
+                  px: 1.5,
+                  py: 0.5,
+                  bgcolor: "background.default",
+                  borderBottom: 1,
+                  borderColor: "divider",
+                }}
+              >
+                <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+                  {KIND_LABEL[kind]}
+                </Typography>
+              </Box>
+              {group.map((entry) => (
+                <Box
+                  key={`${entry.kind}-${entry.id}`}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => handleSelect(entry)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleSelect(entry);
+                    }
+                  }}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1.5,
+                    px: 1.5,
+                    py: 1,
+                    cursor: "pointer",
+                    "&:hover": { bgcolor: "action.hover" },
+                  }}
+                >
+                  {kindIcon(entry.kind)}
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="body2" noWrap>
+                      {entry.title}
+                    </Typography>
+                    {entry.subtitle && (
+                      <Typography variant="caption" color="text.secondary" noWrap>
+                        {entry.subtitle}
+                      </Typography>
+                    )}
+                  </Box>
+                  <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                    <RelativeTime iso={entry.visitedAt} href={entry.href} />
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          );
+        })}
+      </Box>
+    </Paper>
+  );
+
+  return (
+    <>
+      <Tooltip title="Recently viewed">
+        <IconButton
+          ref={anchorRef}
+          size="small"
+          aria-label="Recently viewed"
+          onClick={() => setOpen((o) => !o)}
+        >
+          <History size={20} />
+        </IconButton>
+      </Tooltip>
+      {panel && createPortal(panel, document.body)}
+    </>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback, useEffect, useState } from "react";
+
+export type RecentViewKind = "case" | "project" | "account";
+
+export interface RecentView {
+  kind: RecentViewKind;
+  id: string;
+  title: string;
+  subtitle?: string;
+  href: string;
+  /** ISO timestamp of the last visit. */
+  visitedAt: string;
+}
+
+const STORAGE_KEY = "csm.recentViews.v1";
+const MAX_ENTRIES = 12;
+const STORAGE_EVENT = "csm:recent-views-changed";
+
+function readStorage(): RecentView[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Light shape guard — drop anything that doesn't look like a RecentView.
+    return parsed.filter(
+      (v): v is RecentView =>
+        typeof v === "object" &&
+        v !== null &&
+        typeof (v as RecentView).id === "string" &&
+        typeof (v as RecentView).kind === "string" &&
+        typeof (v as RecentView).title === "string" &&
+        typeof (v as RecentView).href === "string" &&
+        typeof (v as RecentView).visitedAt === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(entries: RecentView[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    // Notify other listeners in the same tab — storage events only fire
+    // across tabs, so we dispatch a CustomEvent for in-tab subscribers.
+    window.dispatchEvent(new CustomEvent(STORAGE_EVENT));
+  } catch {
+    // ignore quota errors etc.
+  }
+}
+
+/** Read-only access to the recent-views list. */
+export function useRecentViews(): RecentView[] {
+  const [entries, setEntries] = useState<RecentView[]>(() => readStorage());
+
+  useEffect(() => {
+    const sync = () => setEntries(readStorage());
+    window.addEventListener(STORAGE_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(STORAGE_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+
+  return entries;
+}
+
+/**
+ * Record a visit (call from each detail page's effect). De-dupes by `kind+id`,
+ * bumps the existing entry to the top, caps the list at {@link MAX_ENTRIES}.
+ */
+export function useRecordRecentView(): (
+  entry: Omit<RecentView, "visitedAt">,
+) => void {
+  return useCallback((entry: Omit<RecentView, "visitedAt">) => {
+    const now = new Date().toISOString();
+    const current = readStorage();
+    const filtered = current.filter(
+      (e) => !(e.kind === entry.kind && e.id === entry.id),
+    );
+    const next: RecentView[] = [
+      { ...entry, visitedAt: now },
+      ...filtered,
+    ].slice(0, MAX_ENTRIES);
+    writeStorage(next);
+  }, []);
+}
+
+export function clearRecentViews(): void {
+  writeStorage([]);
+}


### PR DESCRIPTION
  Builds on foundation PR #814 — merge that first. Net diff once #814 lands: 43 files, ~11.4k insertions.

  Implements the first real CSM-portal screens, replacing the "coming soon" placeholders for `dashboard` and `cases` in `App.tsx`, and wires the
  #814 mock-mode provider into the tree (`MockModeProvider` + `hydrateMockModeFromStorage()` in `main.tsx`). UI is testable against seeded
  mocks before backend endpoints exist.

  ### Features
  - **Cases list** (`/cases`) — cross-customer list, filter bar, severity/tier, SLA timers, URL-synced filters.
  - **Case detail** (`/cases/:caseId`) — meta band, detail widgets, activity feed, comment thread with a Lexical rich-text composer.
  - **Dashboard** (`/dashboard`) — engineer-scoped queue, SLA-at-risk, customer summary, recent activity. **Mock-only: there is no backend 
  dashboard endpoint on v2 yet.**
  - **Recently viewed** — `useRecentViews` hook + menu.

  ### Backend integration
  Live hooks call: `POST /projects/{id}/cases/search`, `GET /cases/{id}`, `POST /cases`, `POST /cases/{id}/comments` (+ `/search`), `POST
  /users/search`.
  
  ### Known limitations / follow-ups
  - **Types are stale vs the v2 `openapi.yaml`.** `GET /cases/{id}` (`CaseView`) and search (`CaseSearchView`) return nested `EntityRef`
  project/deployment objects, an object `createdBy` (`UserRef`/`UserIDEmailRef`), and `nextStates` — none modeled in #814's flat `BeCase`. This
  PR includes the regenerated types and consumes the nested refs; the previous all-projects/all-accounts client-side hydration in
  `useGetCsmCaseDetail` is removed (the names are embedded in the response, and `GET /projects/{id}` / `GET /accounts/{id}` exist).
  - **Comment author attribution:** `CaseComment` has no `authorType`, so customer-authored `comment`s cannot be distinguished from engineer
  comments; rendered neutrally pending a BE field. Tracked in PROGRESS.md.
  - **Inline images** in comments are not yet persisted (no attachment endpoint) — submit warns instead of silently dropping.
  - **Case state machine** uses BE-provided `nextStates`, not client-hardcoded transitions.
  
  ### Test plan
  - [ ] `pnpm build` / `pnpm lint` / `pnpm test`
  - [ ] Playwright nav-smoke (scaffold from the case-create branch)
  - [ ] Unit tests for `sanitizeUrl`, `htmlFromPlain`, mappers, `useRecentViews`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Case Management pages with filtering by severity, state, SLA status, assignee, project, and product
  * Added detailed case views with activity feeds displaying comments, audit history, and attachments
  * Added rich text editor for case comments with formatting and image support
  * Added SLA tracking with time-to-breach indicators and visual timeline
  * Added case action menu for lifecycle state transitions and secondary operations
  * Added recent views tracking for frequently accessed cases and accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->