### PR TITLE
[Customer Portal][Backend] Make watchList optional in case update response

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -359,7 +359,7 @@ public type UpdatedCase record {|
     # Case type information
     ReferenceTableItem? 'type;
     # Watch list users
-    WatchList[]? watchList;
+    WatchList[]? watchList?;
     json...;
 |};
 

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -289,7 +289,7 @@ public type UpdatedCase record {|
     # Case type information
     ReferenceItem? 'type;
     # Watch list users
-    WatchList[]? watchList;
+    WatchList[]? watchList?;
 |};
 
 # Updated user information.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -6195,7 +6195,6 @@ components:
       - type
       - updatedBy
       - updatedOn
-      - watchList
       type: object
       properties:
         id:

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1127,7 +1127,7 @@ public isolated function mapTimeCardSearchResponseGroupedByCases(entity:CaseTime
 public isolated function mapUpdatedCaseResponse(entity:UpdatedCase updatedCase) returns types:UpdatedCase {
     entity:ChoiceListItem state = updatedCase.state;
     entity:ReferenceTableItem? 'type = updatedCase.'type;
-    entity:WatchList[]? watchList = updatedCase.watchList;
+    entity:WatchList[]? watchList = updatedCase?.watchList;
     return {
         id: updatedCase.id,
         updatedOn: updatedCase.updatedOn,


### PR DESCRIPTION
## Summary
- Made `watchList` field optional (`WatchList[]? watchList?`) in `UpdatedCase` type in both `entity/types.bal` and `types/types.bal`
- Removed `watchList` from the `required` list in the `UpdatedCase` schema in `openapi.yaml`
- Fixed `utils.bal` to use optional chaining (`updatedCase?.watchList`) when accessing the now-optional field

## Reason
The case update response does not always include a `watchList`, causing binding errors when the field is absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watch list is now optional when updating cases, enabling more flexible case management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->