### PR TITLE
[CSM Portal] Rename next_states to nextStates in GET /cases/{id} response

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -48,13 +48,13 @@ Follow these steps in order:
 - Error responses use `$ref: '#/components/schemas/ErrorPayload'`
 - Every endpoint must declare a `403` response
 - Path parameters that expect UUIDs must declare `format: uuid` on the schema
-- The `Case` schema includes a computed `next_states` read-only field populated server-side from `state`
+- The `Case` schema includes a computed `nextStates` read-only field populated server-side from `state`
 
 ## Response shape
 
 - For **portal-owned/transformed** responses (typed structs constructed by the portal), all JSON fields must use **camelCase** (e.g. `createdAt`, `projectId`, `issueType`); use `json:"fieldName"` struct tags to enforce this
 - **Raw passthrough** responses may retain upstream field naming as-is — do not reshape them unless there is an explicit requirement to do so
-- The `next_states` field is a documented snake_case exception where the portal constructs the field to match the upstream entity service contract
+- The `nextStates` field is portal-constructed and follows camelCase like all other portal-owned fields
 
 ## Security
 

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -355,7 +355,7 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 
 	result, err = injectNextStates(result)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to inject next_states", "userID", user.UserID, "caseID", caseID, "err", err)
+		slog.ErrorContext(r.Context(), "failed to inject nextStates", "userID", user.UserID, "caseID", caseID, "err", err)
 		writeError(w, http.StatusInternalServerError, "Failed to process case details.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -620,7 +620,7 @@ func TestGetCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("passes case ID to upstream and returns 200 with next_states injected", func(t *testing.T) {
+	t.Run("passes case ID to upstream and returns 200 with nextStates injected", func(t *testing.T) {
 		var capturedID string
 		client := &mockEntityCaseClient{
 			getCaseFn: func(_ context.Context, caseID string) ([]byte, error) {
@@ -643,13 +643,13 @@ func TestGetCase(t *testing.T) {
 		if resp["id"] != testCaseID42 {
 			t.Errorf("response id = %v, want %s", resp["id"], testCaseID42)
 		}
-		ns, ok := resp["next_states"].([]any)
+		ns, ok := resp["nextStates"].([]any)
 		if !ok || len(ns) != 1 || ns[0] != caseStateWorkInProgress {
-			t.Errorf("next_states = %v, want [%s]", resp["next_states"], caseStateWorkInProgress)
+			t.Errorf("nextStates = %v, want [%s]", resp["nextStates"], caseStateWorkInProgress)
 		}
 	})
 
-	t.Run("next_states reflects current state", func(t *testing.T) {
+	t.Run("nextStates reflects current state", func(t *testing.T) {
 		cases := []struct {
 			state    string
 			wantNext []string
@@ -677,13 +677,13 @@ func TestGetCase(t *testing.T) {
 
 				assertStatus(t, w, http.StatusOK)
 				resp := decodeJSON[map[string]any](t, w)
-				got, _ := resp["next_states"].([]any)
+				got, _ := resp["nextStates"].([]any)
 				if len(got) != len(tc.wantNext) {
-					t.Fatalf("next_states = %v, want %v", got, tc.wantNext)
+					t.Fatalf("nextStates = %v, want %v", got, tc.wantNext)
 				}
 				for i, v := range got {
 					if v != tc.wantNext[i] {
-						t.Errorf("next_states[%d] = %v, want %v", i, v, tc.wantNext[i])
+						t.Errorf("nextStates[%d] = %v, want %v", i, v, tc.wantNext[i])
 					}
 				}
 			})

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -620,6 +620,11 @@ func TestGetCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	type getCaseResp struct {
+		ID         string   `json:"id"`
+		NextStates []string `json:"nextStates"`
+	}
+
 	t.Run("passes case ID to upstream and returns 200 with nextStates injected", func(t *testing.T) {
 		var capturedID string
 		client := &mockEntityCaseClient{
@@ -639,13 +644,12 @@ func TestGetCase(t *testing.T) {
 		if capturedID != testCaseID42 {
 			t.Errorf("upstream received caseID %q, want %q", capturedID, testCaseID42)
 		}
-		resp := decodeJSON[map[string]any](t, w)
-		if resp["id"] != testCaseID42 {
-			t.Errorf("response id = %v, want %s", resp["id"], testCaseID42)
+		resp := decodeJSON[getCaseResp](t, w)
+		if resp.ID != testCaseID42 {
+			t.Errorf("response id = %v, want %s", resp.ID, testCaseID42)
 		}
-		ns, ok := resp["nextStates"].([]any)
-		if !ok || len(ns) != 1 || ns[0] != caseStateWorkInProgress {
-			t.Errorf("nextStates = %v, want [%s]", resp["nextStates"], caseStateWorkInProgress)
+		if len(resp.NextStates) != 1 || resp.NextStates[0] != caseStateWorkInProgress {
+			t.Errorf("nextStates = %v, want [%s]", resp.NextStates, caseStateWorkInProgress)
 		}
 	})
 
@@ -676,14 +680,13 @@ func TestGetCase(t *testing.T) {
 				h.GetCase(w, r)
 
 				assertStatus(t, w, http.StatusOK)
-				resp := decodeJSON[map[string]any](t, w)
-				got, _ := resp["nextStates"].([]any)
-				if len(got) != len(tc.wantNext) {
-					t.Fatalf("nextStates = %v, want %v", got, tc.wantNext)
+				resp := decodeJSON[getCaseResp](t, w)
+				if len(resp.NextStates) != len(tc.wantNext) {
+					t.Fatalf("nextStates = %v, want %v", resp.NextStates, tc.wantNext)
 				}
-				for i, v := range got {
-					if v != tc.wantNext[i] {
-						t.Errorf("nextStates[%d] = %v, want %v", i, v, tc.wantNext[i])
+				for i, got := range resp.NextStates {
+					if got != tc.wantNext[i] {
+						t.Errorf("nextStates[%d] = %v, want %v", i, got, tc.wantNext[i])
 					}
 				}
 			})

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -52,7 +52,7 @@ func nextStates(state string) []string {
 
 // injectNextStates parses raw case JSON returned by the entity service, derives
 // the valid next states from the "state" field, and returns the JSON with a
-// "next_states" key appended.
+// "nextStates" key appended.
 func injectNextStates(data []byte) ([]byte, error) {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(data, &m); err != nil {
@@ -68,6 +68,6 @@ func injectNextStates(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	m["next_states"] = ns
+	m["nextStates"] = ns
 	return json.Marshal(m)
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1019,7 +1019,7 @@ components:
         closedAt:
           type: string
           format: date-time
-        next_states:
+        nextStates:
           type: array
           readOnly: true
           items:


### PR DESCRIPTION
## Summary

- Renames the computed field `next_states` → `nextStates` in the `GET /cases/{id}` response to align with the camelCase convention used by all other portal-owned response fields
- Updates `state.go`, `cases.go`, `cases_test.go`, `openapi.yaml`, and `CLAUDE.md`

## Test plan

- [x] All `TestGetCase` subtests pass, including `nextStates reflects current state` for all 6 states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Updated case response fields: `next_states` is now `nextStates`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->