### PR TITLE
[Customer Portal][Webapp] Show server-returned watch list after update

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -116,7 +116,7 @@ export default function CaseDetailsDetailsPanel({
   const handleSaveWatchList = () => {
     patchCase({ watchList: pendingWatchList }, {
       onSuccess: () => {
-        setSavedWatchList(pendingWatchList);
+        setSavedWatchList(null);
         setIsEditingWatchList(false);
         showSuccess("Watch list updated successfully");
       },


### PR DESCRIPTION
## Summary
- After saving the watch list, the UI was displaying only the locally selected emails (`pendingWatchList`) instead of the actual server response
- This caused backend-managed entries (e.g. auto-added watchers) to be missing until a page reload
- Fix: clear `savedWatchList` on successful save so the display falls back to the refetched `data?.watchList` from the server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed watch list behavior in case details to properly clear saved watch list information after successful updates. Previously, stale data could persist after saving. Now the state is properly reset, ensuring the interface displays accurate and current watch list information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->