### PR TITLE
[Customer Portal][Webapp] Watch list UX improvements and data integrity fixes

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/api/usePatchCase.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/usePatchCase.ts
@@ -76,7 +76,7 @@ export function usePatchCase(
       logger.debug("[usePatchCase] Case updated:", data);
       return data;
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: () => {
       const matchesProjectCases = (queryKey: readonly unknown[]): boolean => {
         if (queryKey[0] !== ApiQueryKeys.PROJECT_CASES) return false;
         if (queryKey[1] === "page") return queryKey[2] === projectId;
@@ -86,14 +86,10 @@ export function usePatchCase(
       const isCaseDetailsQuery = (queryKey: readonly unknown[]) =>
         queryKey[0] === ApiQueryKeys.CASE_DETAILS && queryKey[2] === caseId;
 
-      queryClient.invalidateQueries({ predicate: (q) => isCaseDetailsQuery(q.queryKey) });
-
-      if (variables.watchList !== undefined) {
-        void queryClient.refetchQueries({
-          predicate: (q) => isCaseDetailsQuery(q.queryKey),
-          type: "active",
-        });
-      }
+      void queryClient.refetchQueries({
+        predicate: (q) => isCaseDetailsQuery(q.queryKey),
+        type: "active",
+      });
       queryClient.invalidateQueries({
         queryKey: [ApiQueryKeys.CASES_STATS, projectId],
       });

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/watch-list-section/WatchListSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/watch-list-section/WatchListSection.tsx
@@ -52,14 +52,18 @@ export function WatchListSection({
 }: WatchListSectionProps): JSX.Element {
   const options: ContactOption[] = useMemo(
     () =>
-      contacts.map((c) => ({
-        label: `${c.firstName} ${c.lastName}`.trim() || c.email,
-        value: c.email,
-      })),
+      contacts
+        .map((c) => ({
+          label: `${c.firstName} ${c.lastName}`.trim() || c.email,
+          value: c.email,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
     [contacts],
   );
 
-  const selectedOptions = options.filter((o) => selectedEmails.includes(o.value));
+  const selectedOptions = selectedEmails
+    .map((email) => options.find((o) => o.value === email))
+    .filter((o): o is ContactOption => o !== undefined);
 
   return (
     <Paper sx={{ p: 3 }}>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -97,7 +97,8 @@ export default function CaseDetailsDetailsPanel({
         .map((c) => ({
           label: `${c.firstName} ${c.lastName}`.trim() || c.email,
           value: c.email,
-        })),
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
     [contactsData],
   );
 
@@ -114,13 +115,15 @@ export default function CaseDetailsDetailsPanel({
   };
 
   const handleSaveWatchList = () => {
-    patchCase({ watchList: pendingWatchList }, {
+    const optimisticList = [...pendingWatchList];
+    setSavedWatchList(optimisticList);
+    patchCase({ watchList: optimisticList }, {
       onSuccess: () => {
-        setSavedWatchList(null);
         setIsEditingWatchList(false);
         showSuccess("Watch list updated successfully");
       },
       onError: () => {
+        setSavedWatchList(null);
         showError("Failed to update watch list. Please try again.");
       },
     });
@@ -654,9 +657,14 @@ export default function CaseDetailsDetailsPanel({
             loadingText="Loading..."
             options={contactOptions}
             getOptionLabel={(option) => option.label}
-            value={contactOptions.filter((o) => pendingWatchList.includes(o.value))}
+            value={pendingWatchList
+                  .map((email) => contactOptions.find((o) => o.value === email))
+                  .filter((o): o is { label: string; value: string } => o !== undefined)}
             onChange={(_event, newValue) => {
-              setPendingWatchList(newValue.map((o) => o.value));
+              const hiddenWatchers = pendingWatchList.filter(
+                (email) => !contactOptions.some((o) => o.value === email),
+              );
+              setPendingWatchList([...newValue.map((o) => o.value), ...hiddenWatchers]);
             }}
             isOptionEqualToValue={(option, val) => option.value === val.value}
             renderOption={(props, option, { selected }) => {
@@ -690,16 +698,22 @@ export default function CaseDetailsDetailsPanel({
             )}
           />
         ) : (() => {
-          const displayEmails = savedWatchList ?? (data?.watchList ?? []).map(
-            (w) => w.email ?? w.userName ?? w.name ?? ""
-          ).filter(Boolean);
-          return displayEmails.length > 0 ? (
+          const displayItems = savedWatchList
+            ? savedWatchList.map((email) => ({
+                key: email,
+                label: contactOptions.find((o) => o.value === email)?.label ?? email,
+              }))
+            : (data?.watchList ?? [])
+                .filter((w) => w.email ?? w.userName ?? w.name)
+                .map((w) => ({
+                  key: w.email ?? w.userName ?? w.name ?? "",
+                  label: w.name ?? w.userName ?? w.email ?? "",
+                }));
+          return displayItems.length > 0 ? (
             <Stack direction="row" flexWrap="wrap" gap={1}>
-              {displayEmails.map((email) => {
-                const label = contactOptions.find((o) => o.value === email)?.label ?? email;
-                return (
+              {displayItems.map(({ key, label }) => (
                   <Chip
-                    key={email}
+                    key={key}
                     label={label}
                     size="small"
                     variant="outlined"
@@ -710,8 +724,7 @@ export default function CaseDetailsDetailsPanel({
                       fontSize: "0.75rem",
                     }}
                   />
-                );
-              })}
+              ))}
             </Stack>
           ) : (
             <Typography variant="body2" color="text.secondary">No watchers added</Typography>


### PR DESCRIPTION
## Summary

- **Display names instead of emails** in the watch list view on case details — uses the `name` field from the API response directly rather than looking up from project contacts, so all watchers (including those outside the contacts list) show correctly
- **Preserve insertion order** for watch list selections — newly added contacts now appear at the end of the chip list instead of being reordered alphabetically
- **Sort dropdown options alphabetically** in both case creation and case update watch list pickers
- **Prevent unlisted watchers from being dropped** on save — watchers not available in the contacts dropdown (e.g. WSO2 internal users) are now preserved when the user edits and saves the watch list
- **Optimistic UI update** on save — the updated watch list is shown immediately instead of briefly flashing the stale list while the refetch completes
- **Fix duplicate API calls** — removed redundant `invalidateQueries` + `refetchQueries` pair that was triggering the same case details endpoint 2–3 times on every patch

