### PR TITLE
[Customer Portal][Webapp] Watch list edit mode improvements for non-project watchers

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -649,55 +649,81 @@ export default function CaseDetailsDetailsPanel({
           )
         }
       >
-        {isEditingWatchList ? (
-          <Autocomplete
-            multiple
-            disableCloseOnSelect
-            loading={isContactsLoading}
-            loadingText="Loading..."
-            options={contactOptions}
-            getOptionLabel={(option) => option.label}
-            value={pendingWatchList
-                  .map((email) => contactOptions.find((o) => o.value === email))
-                  .filter((o): o is { label: string; value: string } => o !== undefined)}
-            onChange={(_event, newValue) => {
-              const hiddenWatchers = pendingWatchList.filter(
-                (email) => !contactOptions.some((o) => o.value === email),
-              );
-              setPendingWatchList([...newValue.map((o) => o.value), ...hiddenWatchers]);
-            }}
-            isOptionEqualToValue={(option, val) => option.value === val.value}
-            renderOption={(props, option, { selected }) => {
-              const { key, ...rest } = props;
-              return (
-                <li key={key} {...rest}>
-                  <Checkbox
-                    size="small"
-                    checked={selected}
-                    sx={{ mr: 1, p: 0.5 }}
-                  />
-                  {option.label}
-                </li>
-              );
-            }}
-            renderTags={(tagValue, getTagProps) =>
-              tagValue.map((option, index) => {
-                const { key, ...tagProps } = getTagProps({ index });
-                return <Chip key={key} label={option.label} size="small" {...tagProps} />;
-              })
-            }
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Watch List"
-                placeholder="Add watchers..."
-                size="small"
-                error={isContactsError}
-                helperText={isContactsError ? "Could not load users. Please refresh and try again." : undefined}
-              />
-            )}
-          />
-        ) : (() => {
+        {isEditingWatchList ? (() => {
+          type WatchOption = { label: string; value: string; readonly?: boolean };
+          const hiddenWatcherOptions: WatchOption[] = pendingWatchList
+            .filter((email) => !contactOptions.some((o) => o.value === email))
+            .map((email) => ({
+              label:
+                data?.watchList?.find((w) => w.email === email || w.userName === email)?.name ??
+                email,
+              value: email,
+              readonly: true,
+            }));
+          const editableValue: WatchOption[] = pendingWatchList
+            .filter((email) => contactOptions.some((o) => o.value === email))
+            .map((email) => contactOptions.find((o) => o.value === email)!);
+          return (
+            <Autocomplete<WatchOption, true>
+              multiple
+              disableCloseOnSelect
+              loading={isContactsLoading}
+              loadingText="Loading..."
+              options={contactOptions}
+              getOptionLabel={(option) => option.label}
+              value={[...hiddenWatcherOptions, ...editableValue]}
+              onChange={(_event, newValue) => {
+                const visibleEmails = newValue
+                  .filter((o) => !o.readonly)
+                  .map((o) => o.value);
+                const hiddenEmails = pendingWatchList.filter(
+                  (email) => !contactOptions.some((o) => o.value === email),
+                );
+                setPendingWatchList([...visibleEmails, ...hiddenEmails]);
+              }}
+              isOptionEqualToValue={(option, val) => option.value === val.value}
+              renderOption={(props, option, { selected }) => {
+                const { key, ...rest } = props;
+                return (
+                  <li key={key} {...rest}>
+                    <Checkbox
+                      size="small"
+                      checked={selected}
+                      sx={{ mr: 1, p: 0.5 }}
+                    />
+                    {option.label}
+                  </li>
+                );
+              }}
+              renderTags={(tagValue, getTagProps) =>
+                tagValue.map((option, index) => {
+                  const { key, onDelete, ...tagProps } = getTagProps({ index });
+                  return option.readonly ? (
+                    <Chip
+                      key={key}
+                      label={option.label}
+                      size="small"
+                      {...tagProps}
+                      sx={{ opacity: 0.7 }}
+                    />
+                  ) : (
+                    <Chip key={key} label={option.label} size="small" onDelete={onDelete} {...tagProps} />
+                  );
+                })
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Watch List"
+                  placeholder="Add watchers..."
+                  size="small"
+                  error={isContactsError}
+                  helperText={isContactsError ? "Could not load users. Please refresh and try again." : undefined}
+                />
+              )}
+            />
+          );
+        })() : (() => {
           const displayItems = savedWatchList
             ? savedWatchList.map((email) => ({
                 key: email,

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -701,7 +701,10 @@ export default function CaseDetailsDetailsPanel({
           const displayItems = savedWatchList
             ? savedWatchList.map((email) => ({
                 key: email,
-                label: contactOptions.find((o) => o.value === email)?.label ?? email,
+                label:
+                  contactOptions.find((o) => o.value === email)?.label ??
+                  data?.watchList?.find((w) => w.email === email || w.userName === email)?.name ??
+                  email,
               }))
             : (data?.watchList ?? [])
                 .filter((w) => w.email ?? w.userName ?? w.name)

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -624,29 +624,7 @@ export default function CaseDetailsDetailsPanel({
             >
               Edit
             </Button>
-          ) : (
-            <Stack direction="row" spacing={1}>
-              <Button
-                variant="text"
-                size="small"
-                onClick={() => setIsEditingWatchList(false)}
-                sx={{ minHeight: "unset", p: 0, textTransform: "none" }}
-                disabled={isPatchPending}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="text"
-                size="small"
-                color="primary"
-                onClick={handleSaveWatchList}
-                sx={{ minHeight: "unset", p: 0, textTransform: "none" }}
-                loading={isPatchPending}
-              >
-                Save
-              </Button>
-            </Stack>
-          )
+          ) : null
         }
       >
         {isEditingWatchList ? (() => {
@@ -664,6 +642,7 @@ export default function CaseDetailsDetailsPanel({
             .filter((email) => contactOptions.some((o) => o.value === email))
             .map((email) => contactOptions.find((o) => o.value === email)!);
           return (
+            <Box>
             <Autocomplete<WatchOption, true>
               multiple
               disableCloseOnSelect
@@ -722,6 +701,28 @@ export default function CaseDetailsDetailsPanel({
                 />
               )}
             />
+            <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 1 }}>
+              <Button
+                variant="text"
+                size="small"
+                onClick={() => setIsEditingWatchList(false)}
+                sx={{ minHeight: "unset", textTransform: "none" }}
+                disabled={isPatchPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="text"
+                size="small"
+                color="primary"
+                onClick={handleSaveWatchList}
+                sx={{ minHeight: "unset", textTransform: "none" }}
+                loading={isPatchPending}
+              >
+                Save
+              </Button>
+            </Stack>
+            </Box>
           );
         })() : (() => {
           const displayItems = savedWatchList


### PR DESCRIPTION
## Summary

- **Show non-editable watchers as read-only chips** — watchers not available in the project contacts dropdown (e.g. WSO2 internal users) are now displayed as non-removable chips at the front of the list in edit mode, preventing them from being silently dropped on save
- **Fix name display for non-project watchers** — watchers outside the contacts list (e.g. imedya, suhanr) now correctly show their name instead of falling back to the email address in view mode
- **Improved edit mode layout** — Cancel and Save buttons moved below the watch list input field, right-aligned, for a cleaner editing experience
