### PR TITLE
chore(csm-portal): clear webapp eslint errors (lint hygiene)

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -122,4 +122,13 @@ describe("uiCommentFromBe", () => {
     // No raw angle brackets survive the escape.
     expect(ui.bodyHtml).not.toContain("<script>");
   });
+
+  it("normalises CRLF/CR line endings to a single break (no \\r artifacts)", () => {
+    const ui = uiCommentFromBe({
+      ...base,
+      body: "line1\r\nline2\rline3\nline4",
+    });
+    expect(ui.bodyHtml).toBe("<p>line1<br/>line2<br/>line3<br/>line4</p>");
+    expect(ui.bodyHtml).not.toContain("\r");
+  });
 });

--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import type { BeCaseComment } from "./types";
+import {
+  beStateFromUi,
+  commentTypeFromInternal,
+  priorityFromSeverity,
+  severityFromPriority,
+  uiCommentFromBe,
+  uiStateFromBe,
+} from "./mappers";
+
+describe("severityFromPriority", () => {
+  it("maps each backend priority onto the S0-S4 scale", () => {
+    expect(severityFromPriority("catastrophic")).toBe("S0");
+    expect(severityFromPriority("critical")).toBe("S1");
+    expect(severityFromPriority("high")).toBe("S2");
+    expect(severityFromPriority("medium")).toBe("S3");
+    expect(severityFromPriority("low")).toBe("S4");
+  });
+
+  it("falls back to S3 for an unknown/undefined priority", () => {
+    expect(severityFromPriority(undefined)).toBe("S3");
+  });
+});
+
+describe("priorityFromSeverity", () => {
+  it("is the inverse of severityFromPriority for the known set", () => {
+    expect(priorityFromSeverity("S0")).toBe("catastrophic");
+    expect(priorityFromSeverity("S1")).toBe("critical");
+    expect(priorityFromSeverity("S2")).toBe("high");
+    expect(priorityFromSeverity("S3")).toBe("medium");
+    expect(priorityFromSeverity("S4")).toBe("low");
+  });
+});
+
+describe("uiStateFromBe / beStateFromUi", () => {
+  it("normalises reopened <-> reopen across the boundary", () => {
+    expect(uiStateFromBe("reopened")).toBe("reopen");
+    expect(beStateFromUi("reopen")).toBe("reopened");
+  });
+
+  it("passes through shared states unchanged", () => {
+    for (const s of [
+      "open",
+      "work_in_progress",
+      "waiting_on_wso2",
+      "awaiting_info",
+      "solution_proposed",
+      "closed",
+    ] as const) {
+      expect(uiStateFromBe(s)).toBe(s);
+      expect(beStateFromUi(s)).toBe(s);
+    }
+  });
+
+  it("defaults an unknown/undefined backend state to open", () => {
+    expect(uiStateFromBe(undefined)).toBe("open");
+  });
+});
+
+describe("commentTypeFromInternal", () => {
+  it("maps the internal flag to the backend comment type", () => {
+    expect(commentTypeFromInternal(true)).toBe("work_note");
+    expect(commentTypeFromInternal(false)).toBe("comment");
+  });
+});
+
+describe("uiCommentFromBe", () => {
+  const base: BeCaseComment = {
+    id: "c1",
+    caseId: "case1",
+    commentType: "comment",
+    body: "hello",
+    createdBy: "user-123",
+    createdAt: "2026-06-01T10:00:00Z",
+  };
+
+  it("wraps a public comment as a wso2_engineer, non-internal bubble", () => {
+    const ui = uiCommentFromBe(base);
+    expect(ui.authorRole).toBe("wso2_engineer");
+    expect(ui.internal).toBe(false);
+    expect(ui.authorName).toBe("user-123");
+    expect(ui.bodyHtml).toBe("<p>hello</p>");
+  });
+
+  it("marks a work_note as internal", () => {
+    const ui = uiCommentFromBe({ ...base, commentType: "work_note" });
+    expect(ui.authorRole).toBe("wso2_engineer");
+    expect(ui.internal).toBe(true);
+  });
+
+  it("renders an activity entry as a system author", () => {
+    const ui = uiCommentFromBe({ ...base, commentType: "activity" });
+    expect(ui.authorRole).toBe("system");
+    expect(ui.internal).toBe(false);
+  });
+
+  it("escapes HTML-special characters and converts newlines (htmlFromPlain)", () => {
+    const ui = uiCommentFromBe({
+      ...base,
+      body: 'a & b < c > d\nsecond <script>',
+    });
+    expect(ui.bodyHtml).toBe(
+      "<p>a &amp; b &lt; c &gt; d<br/>second &lt;script&gt;</p>",
+    );
+    // No raw angle brackets survive the escape.
+    expect(ui.bodyHtml).not.toContain("<script>");
+  });
+});

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -22,7 +22,7 @@
 
 import type {
   BeCaseComment,
-  BeCaseCommentType,
+  BeCreatableCommentType,
   BeCasePriority,
   BeCaseState,
 } from "@api/backend/types";
@@ -113,13 +113,15 @@ function htmlFromPlain(body: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/\n/g, "<br/>");
+    // Normalise CRLF/CR to a single break so Windows line endings don't leave
+    // stray \r artifacts in the rendered HTML.
+    .replace(/\r\n?|\n/g, "<br/>");
   return `<p>${escaped}</p>`;
 }
 
 export function commentTypeFromInternal(
   internal: boolean,
-): BeCaseCommentType {
+): BeCreatableCommentType {
   return internal ? "work_note" : "comment";
 }
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -135,8 +135,11 @@ export interface BeCaseComment {
   createdAt: string;
 }
 
+/** Comment types a client may create. `activity` is system-generated only. */
+export type BeCreatableCommentType = Exclude<BeCaseCommentType, "activity">;
+
 export interface BeCaseCommentCreatePayload {
-  commentType: BeCaseCommentType;
+  commentType: BeCreatableCommentType;
   body: string;
 }
 

--- a/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
+++ b/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
@@ -76,6 +76,9 @@ export default function UserProfileModal({
 
   useEffect(() => {
     if (open && userMe) {
+      // Seed the editable draft from the latest server value each time the
+      // dialog opens (the accepted "reset form state on open" pattern).
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- form reset on dialog open
       setPhoneDraft(userMe.phoneNumber ?? "");
       setIsPhoneEditing(false);
     }

--- a/apps/csm-portal/webapp/src/components/notification-banner/GlobalNotificationBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/notification-banner/GlobalNotificationBanner.tsx
@@ -38,6 +38,7 @@ export default function GlobalNotificationBanner({
   // Reset the dismissed state when the visibility configuration changes to true.
   useEffect(() => {
     if (visible) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset dismissal when banner is re-shown
       setDismissed(false);
     }
   }, [visible]);

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -211,6 +211,13 @@ const ResetPlugin = ({ resetTrigger }: { resetTrigger?: number }) => {
 const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): null => {
   const [editor] = useLexicalComposerContext();
 
+  // Keep the latest callback in a ref so the paste listener (registered once
+  // per editor) always calls the current onPasteError without re-registering.
+  const onPasteErrorRef = useRef(onPasteError);
+  useEffect(() => {
+    onPasteErrorRef.current = onPasteError;
+  }, [onPasteError]);
+
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       const items = event.clipboardData?.items;
@@ -225,7 +232,7 @@ const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): 
           event.preventDefault();
 
           if (file.size > MAX_PASTE_IMAGE_SIZE) {
-            onPasteError?.();
+            onPasteErrorRef.current?.();
             break;
           }
 

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/ImageNode.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/ImageNode.tsx
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/* eslint-disable react-refresh/only-export-components -- Lexical node class and its render component are colocated by design (fast-refresh DX only) */
+
 import {
   DecoratorNode,
   $getNodeByKey,

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/ImagesPlugin.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/ImagesPlugin.tsx
@@ -29,6 +29,7 @@ import { $createImageNode } from "@components/rich-text-editor/ImageNode";
 import {
   INSERT_IMAGE_COMMAND,
   deriveAltFromFilename,
+  sanitizeUrl,
   type InsertImagePayload,
 } from "@components/rich-text-editor/richTextEditor";
 
@@ -53,6 +54,11 @@ export default function ImagesPlugin(): null {
       INSERT_IMAGE_COMMAND,
       (payload) => {
         const src = getPayloadSrc(payload);
+        // Blocked/invalid URLs sanitize to "" — skip insertion rather than
+        // commit an image node with an empty src (broken editor content).
+        if (!sanitizeUrl(src)) {
+          return true;
+        }
         const altText = getPayloadAltText(payload);
         const imageNode = $createImageNode(src, altText);
 

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
@@ -36,17 +36,26 @@ export type InsertImagePayload = {
  * Handles absolute URLs, relative paths, and plain filenames.
  */
 export function deriveAltFromFilename(src: string): string {
+  // Percent-encoded names (e.g. "screen%20shot") read poorly as alt text;
+  // decode them, but fall back to the raw value if it isn't valid encoding.
+  const decode = (s: string): string => {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  };
   try {
     const url = new URL(src);
     const path = url.pathname || "";
     const match = path.match(/\/([^/]+)$/);
     const name = (match?.[1] ?? path) || "Image";
-    const base = name.replace(/\.[^.]+$/, "");
+    const base = decode(name).replace(/\.[^.]+$/, "");
     return base ? base : "Image";
   } catch {
     const pathOnly = src.split("?")[0].split("#")[0].trim();
     const lastSegment = pathOnly.replace(/\/+$/, "").split("/").pop() || "";
-    const base = lastSegment.replace(/\.[^.]+$/, "");
+    const base = decode(lastSegment).replace(/\.[^.]+$/, "");
     return base ? base : "Image";
   }
 }

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/sanitizeUrl.test.ts
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/sanitizeUrl.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { deriveAltFromFilename, sanitizeUrl } from "./richTextEditor";
+
+describe("sanitizeUrl", () => {
+  it("allows safe protocols and anchors", () => {
+    expect(sanitizeUrl("https://wso2.com")).toBe("https://wso2.com");
+    expect(sanitizeUrl("http://example.com")).toBe("http://example.com");
+    expect(sanitizeUrl("mailto:support@wso2.com")).toBe(
+      "mailto:support@wso2.com",
+    );
+    expect(sanitizeUrl("tel:+15551234")).toBe("tel:+15551234");
+    expect(sanitizeUrl("#section")).toBe("#section");
+  });
+
+  it("allows single-slash relative paths but rejects protocol-relative URLs", () => {
+    expect(sanitizeUrl("/cases/123")).toBe("/cases/123");
+    expect(sanitizeUrl("//evil.com")).toBe("");
+  });
+
+  it("allows base64 inline images", () => {
+    const data = "data:image/png;base64,iVBORw0KGgo=";
+    expect(sanitizeUrl(data)).toBe(data);
+  });
+
+  it("rejects dangerous protocols", () => {
+    expect(sanitizeUrl("javascript:alert(1)")).toBe("");
+    expect(sanitizeUrl("vbscript:msgbox(1)")).toBe("");
+    expect(sanitizeUrl("data:text/html;base64,PHNjcmlwdD4=")).toBe("");
+  });
+
+  it("decodes &amp; and trims before testing", () => {
+    expect(sanitizeUrl("  https://a.com/?x=1&amp;y=2  ")).toBe(
+      "https://a.com/?x=1&y=2",
+    );
+  });
+});
+
+describe("deriveAltFromFilename", () => {
+  it("extracts the base filename from an absolute URL", () => {
+    expect(deriveAltFromFilename("https://cdn.example.com/img/diagram.png")).toBe(
+      "diagram",
+    );
+  });
+
+  it("strips query and hash for non-URL paths", () => {
+    expect(deriveAltFromFilename("/uploads/screen-shot.jpeg?v=2")).toBe(
+      "screen-shot",
+    );
+  });
+
+  it("falls back to Image when no usable name is present", () => {
+    expect(deriveAltFromFilename("")).toBe("Image");
+  });
+});

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/sanitizeUrl.test.ts
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/sanitizeUrl.test.ts
@@ -67,4 +67,18 @@ describe("deriveAltFromFilename", () => {
   it("falls back to Image when no usable name is present", () => {
     expect(deriveAltFromFilename("")).toBe("Image");
   });
+
+  it("decodes percent-encoded filenames", () => {
+    expect(
+      deriveAltFromFilename("https://cdn.example.com/img/screen%20shot.png"),
+    ).toBe("screen shot");
+    expect(deriveAltFromFilename("/uploads/my%2Bfile.jpeg")).toBe("my+file");
+  });
+
+  it("falls back to the raw segment when decoding fails", () => {
+    // A malformed percent-escape must not throw.
+    expect(deriveAltFromFilename("/uploads/bad%E0%A4name.png")).toBe(
+      "bad%E0%A4name",
+    );
+  });
 });

--- a/apps/csm-portal/webapp/src/config/loggerConfig.ts
+++ b/apps/csm-portal/webapp/src/config/loggerConfig.ts
@@ -17,5 +17,5 @@
 // Configuration for the Logger service.
 export const loggerConfig = {
   level: window.config?.CSM_PORTAL_LOG_LEVEL || "ERROR",
-  prefix: "CustomerPortal",
+  prefix: "CSMPortal",
 };

--- a/apps/csm-portal/webapp/src/context/error-banner/ErrorBannerContext.tsx
+++ b/apps/csm-portal/webapp/src/context/error-banner/ErrorBannerContext.tsx
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/* eslint-disable react-refresh/only-export-components -- Provider component and its useXxx hook are colocated per the repo's context idiom (fast-refresh DX only) */
+
 import ErrorBanner from "@components/error-banner/ErrorBanner";
 import {
   createContext,

--- a/apps/csm-portal/webapp/src/context/error-page/ErrorPageContext.tsx
+++ b/apps/csm-portal/webapp/src/context/error-page/ErrorPageContext.tsx
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/* eslint-disable react-refresh/only-export-components -- Provider component and its useXxx hook are colocated per the repo's context idiom (fast-refresh DX only) */
+
 import {
   createContext,
   useContext,

--- a/apps/csm-portal/webapp/src/context/linear-loader/LoaderContext.tsx
+++ b/apps/csm-portal/webapp/src/context/linear-loader/LoaderContext.tsx
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/* eslint-disable react-refresh/only-export-components -- Provider component and its useXxx hook are colocated per the repo's context idiom (fast-refresh DX only) */
+
 import {
   createContext,
   useContext,

--- a/apps/csm-portal/webapp/src/context/mock-mode/MockModeContext.tsx
+++ b/apps/csm-portal/webapp/src/context/mock-mode/MockModeContext.tsx
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/* eslint-disable react-refresh/only-export-components -- Provider component and its useXxx hook are colocated per the repo's context idiom (fast-refresh DX only) */
+
 import { useQueryClient } from "@tanstack/react-query";
 import {
   createContext,

--- a/apps/csm-portal/webapp/src/context/success-banner/SuccessBannerContext.tsx
+++ b/apps/csm-portal/webapp/src/context/success-banner/SuccessBannerContext.tsx
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/* eslint-disable react-refresh/only-export-components -- Provider component and its useXxx hook are colocated per the repo's context idiom (fast-refresh DX only) */
+
 import SuccessBanner from "@components/success-banner/SuccessBanner";
 import {
   createContext,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -24,19 +24,13 @@ import {
 } from "@api/backend/mappers";
 import type {
   BeAccount,
-  BeAccountSearchPayload,
-  BeAccountSearchResponse,
   BeCase,
   BeProject,
-  BeProjectSearchPayload,
-  BeProjectSearchResponse,
 } from "@api/backend/types";
 import { getMockCsmCaseDetailById } from "@features/csm-cases/api/mocks/casesMocks";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 
 const MOCK_LATENCY_MS = 150;
-const PROJECT_PAGE_LIMIT = 100;
-const ACCOUNT_PAGE_LIMIT = 100;
 
 /**
  * Build a thin CsmCaseDetail from the lean `BeCase` payload plus optional
@@ -64,7 +58,9 @@ function detailFromBeCase(
     product: "—",
     severity: severityFromPriority(c.priority),
     state: uiStateFromBe(c.state),
-    assignee: c.createdBy ?? "Unassigned",
+    // The backend has no assignee field yet; `createdBy` is the reporter, not
+    // the assigned engineer, so don't surface it here as the assignee.
+    assignee: "Unassigned",
     assigneeIsMe: false,
     slaClockType: "ack",
     minutesToBreach: 0,
@@ -129,21 +125,19 @@ export function useGetCsmCaseDetail(
       if (!beCase) return null;
 
       // Hydrate project + account so the customer / project links in the
-      // page header are not empty strings (which would no-op the click).
-      // The BE has no by-id endpoints yet, so this falls through to the
-      // paginated search and filters client-side. Failures degrade silently
-      // — the case still renders with "—" placeholders.
+      // page header are not empty strings (which would no-op the click). Use
+      // the by-id endpoints (GET /projects/{id}, GET /accounts/{id}) so this is
+      // exact rather than search-and-filter, which silently missed records
+      // outside the first page. `get` resolves 404/204 to null; failures
+      // degrade gracefully — the case still renders with "—" placeholders.
       let project: BeProject | undefined;
       let account: BeAccount | undefined;
       if (beCase.projectId) {
         try {
-          const pRes = await api.post<
-            BeProjectSearchPayload,
-            BeProjectSearchResponse
-          >("/projects/search", {
-            pagination: { offset: 0, limit: PROJECT_PAGE_LIMIT },
-          });
-          project = (pRes.projects ?? []).find((p) => p.id === beCase.projectId);
+          project =
+            (await api.get<BeProject>(
+              `/projects/${encodeURIComponent(beCase.projectId)}`,
+            )) ?? undefined;
         } catch (err) {
           logger.warn(
             `[useGetCsmCaseDetail] project hydrate failed: ${
@@ -154,13 +148,10 @@ export function useGetCsmCaseDetail(
       }
       if (project?.accountId) {
         try {
-          const aRes = await api.post<
-            BeAccountSearchPayload,
-            BeAccountSearchResponse
-          >("/accounts/search", {
-            pagination: { offset: 0, limit: ACCOUNT_PAGE_LIMIT },
-          });
-          account = (aRes.accounts ?? []).find((a) => a.id === project!.accountId);
+          account =
+            (await api.get<BeAccount>(
+              `/accounts/${encodeURIComponent(project.accountId)}`,
+            )) ?? undefined;
         } catch (err) {
           logger.warn(
             `[useGetCsmCaseDetail] account hydrate failed: ${

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -511,7 +511,7 @@ export function LinkedItemsWidget({
                     {item.title}
                   </Typography>
                 </Box>
-                {!item.href && <ExternalLink size={14} />}
+                {item.href && <ExternalLink size={14} />}
               </Box>
             );
             return item.href ? (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -65,13 +65,30 @@ function LinkText({
 }): JSX.Element {
   return (
     <Typography
+      component="span"
+      role="link"
+      tabIndex={0}
       variant="body2"
       noWrap
       onClick={onClick}
+      onKeyDown={(e) => {
+        // Keyboard activation: Enter/Space mirror the click so the link is
+        // reachable without a pointer.
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       sx={{
         cursor: "pointer",
         color: "primary.main",
         "&:hover": { textDecoration: "underline" },
+        "&:focus-visible": {
+          outline: "2px solid",
+          outlineColor: "primary.main",
+          outlineOffset: 2,
+          borderRadius: 0.5,
+        },
       }}
     >
       {children}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -270,6 +270,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
   useEffect(() => {
     const hash = location.hash?.replace(/^#/, "");
     if (!hash) return;
+    // Permalink: a URL fragment forces the Activities tab. Effect-driven so it
+    // also fires when the hash changes while already on the page.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs active tab to URL hash
     setActiveTab("activities");
     // Track every timer (outer + both nested resets) so the cleanup can cancel
     // all of them on unmount / hash change — the inner resets were previously

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -271,6 +271,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
     const hash = location.hash?.replace(/^#/, "");
     if (!hash) return;
     setActiveTab("activities");
+    // Track every timer (outer + both nested resets) so the cleanup can cancel
+    // all of them on unmount / hash change — the inner resets were previously
+    // leaked.
+    const timers: ReturnType<typeof setTimeout>[] = [];
     const timer = setTimeout(() => {
       const target = document.getElementById(hash);
       if (!target) return;
@@ -304,13 +308,16 @@ export default function CsmCaseDetailPage(): JSX.Element {
       target.style.backgroundColor = "rgba(255, 213, 79, 0.35)";
       const reset = setTimeout(() => {
         target.style.backgroundColor = prevBg;
-        setTimeout(() => {
-          target.style.transition = prevTransition;
-        }, 350);
+        timers.push(
+          setTimeout(() => {
+            target.style.transition = prevTransition;
+          }, 350),
+        );
       }, 1500);
-      return () => clearTimeout(reset);
+      timers.push(reset);
     }, 250);
-    return () => clearTimeout(timer);
+    timers.push(timer);
+    return () => timers.forEach(clearTimeout);
   }, [location.hash, data, comments]);
 
   useEffect(() => {
@@ -344,17 +351,32 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Copy-link is async: only confirm success once the clipboard write
+      // actually resolves, otherwise a failure shows both a false "copied"
+      // toast and an error.
+      if (action.secondary === "copy_link") {
+        if (data && navigator.clipboard) {
+          navigator.clipboard
+            .writeText(`${window.location.origin}/cases/${data.id}`)
+            .then(() =>
+              setFeedback({
+                message: SECONDARY_TOAST.copy_link,
+                severity: "success",
+                sticky: false,
+              }),
+            )
+            .catch(() => showError("Could not copy link."));
+        } else {
+          showError("Could not copy link.");
+        }
+        return;
+      }
+
       setFeedback({
         message: SECONDARY_TOAST[action.secondary] ?? `Action: ${action.secondary}`,
         severity: "info",
         sticky: false,
       });
-
-      if (action.secondary === "copy_link" && data) {
-        navigator.clipboard
-          ?.writeText(`${window.location.origin}/cases/${data.id}`)
-          .catch(() => showError("Could not copy link."));
-      }
     },
     [data, showError],
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import {
+  casesHref,
+  DEFAULT_CASES_FILTERS,
+  readCasesFiltersFromUrl,
+  writeCasesFiltersToUrl,
+} from "./casesFiltersUrl";
+
+describe("readCasesFiltersFromUrl", () => {
+  it("returns the defaults for an empty query string", () => {
+    expect(readCasesFiltersFromUrl(new URLSearchParams())).toEqual(
+      DEFAULT_CASES_FILTERS,
+    );
+  });
+
+  it("parses a fully-populated query string", () => {
+    const params = new URLSearchParams(
+      "scope=all_customers&q=timeout&severities=S0,S2&states=open,closed&sla=at_risk&assignees=alice,bob&projects=apim&products=mi",
+    );
+    expect(readCasesFiltersFromUrl(params)).toEqual({
+      scope: "all_customers",
+      search: "timeout",
+      severities: ["S0", "S2"],
+      states: ["open", "closed"],
+      sla: "at_risk",
+      assignees: ["alice", "bob"],
+      projects: ["apim"],
+      products: ["mi"],
+    });
+  });
+
+  it("drops values outside the allowed enums", () => {
+    const params = new URLSearchParams(
+      "scope=bogus&severities=S0,S9,wat&states=open,nonsense&sla=invalid",
+    );
+    const f = readCasesFiltersFromUrl(params);
+    expect(f.scope).toBe("my_abt"); // fallback
+    expect(f.severities).toEqual(["S0"]);
+    expect(f.states).toEqual(["open"]);
+    expect(f.sla).toBe("any"); // fallback
+  });
+
+  it("strips empties and over-long free-form entries", () => {
+    const long = "x".repeat(121);
+    const params = new URLSearchParams();
+    params.set("assignees", `alice, ,${long}`);
+    expect(readCasesFiltersFromUrl(params).assignees).toEqual(["alice"]);
+  });
+});
+
+describe("writeCasesFiltersToUrl", () => {
+  it("omits default-valued fields to keep the URL clean", () => {
+    expect(writeCasesFiltersToUrl(DEFAULT_CASES_FILTERS).toString()).toBe("");
+  });
+
+  it("round-trips a non-default filter set", () => {
+    const filters: CasesFilters = {
+      scope: "all_customers",
+      search: "disk full",
+      severities: ["S1"],
+      states: ["work_in_progress"],
+      sla: "breached",
+      assignees: ["carol"],
+      projects: ["streaming"],
+      products: ["si"],
+    };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round).toEqual(filters);
+  });
+});
+
+describe("casesHref", () => {
+  it("returns the bare path when overrides reduce to defaults", () => {
+    expect(casesHref({})).toBe("/cases");
+  });
+
+  it("builds a query string from a partial override", () => {
+    expect(casesHref({ scope: "all_customers" })).toBe(
+      "/cases?scope=all_customers",
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
@@ -315,7 +315,9 @@ export function getMockAbtDashboard(
 
   // My Queue is always "me", independent of scope.
   const { actionRequired, inProgress, awaitingInfo } = sumQueue(QUEUE_TOP_CASES);
-  const totalOpen = actionRequired + inProgress + awaitingInfo;
+  // Count every non-closed case, not just the three display buckets, so the
+  // total doesn't drop states like solution_proposed / waiting_on_wso2.
+  const totalOpen = QUEUE_TOP_CASES.filter((c) => c.state !== "closed").length;
 
   return {
     engineer: ENGINEER,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
@@ -78,11 +78,13 @@ export function formatRelativeTime(
   const diffMs = now - epoch;
   const futureSuffix = diffMs < 0 ? " from now" : " ago";
   const abs = Math.abs(diffMs);
-  const diffMin = Math.round(abs / 60_000);
+  // Floor each unit so we don't round up across a boundary (e.g. show "1h ago"
+  // at 30 minutes, or "1d ago" at 12 hours).
+  const diffMin = Math.floor(abs / 60_000);
   if (diffMin < 1) return "just now";
   if (diffMin < 60) return `${diffMin}m${futureSuffix}`;
-  const diffHr = Math.round(diffMin / 60);
+  const diffHr = Math.floor(diffMin / 60);
   if (diffHr < 24) return `${diffHr}h${futureSuffix}`;
-  const diffDay = Math.round(diffHr / 24);
+  const diffDay = Math.floor(diffHr / 24);
   return `${diffDay}d${futureSuffix}`;
 }

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRecentViews,
+  useRecentViews,
+  useRecordRecentView,
+  type RecentView,
+} from "./useRecentViews";
+
+const entry = (id: string): Omit<RecentView, "visitedAt"> => ({
+  kind: "case",
+  id,
+  title: `Case ${id}`,
+  href: `/cases/${id}`,
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useRecentViews + useRecordRecentView", () => {
+  it("starts empty", () => {
+    const { result } = renderHook(() => useRecentViews());
+    expect(result.current).toEqual([]);
+  });
+
+  it("records a visit and exposes it to readers in the same tab", () => {
+    const reader = renderHook(() => useRecentViews());
+    const recorder = renderHook(() => useRecordRecentView());
+
+    act(() => recorder.result.current(entry("1")));
+
+    expect(reader.result.current).toHaveLength(1);
+    expect(reader.result.current[0].id).toBe("1");
+    expect(reader.result.current[0].visitedAt).toBeTruthy();
+  });
+
+  it("de-dupes by kind+id and bumps the entry to the top", () => {
+    const reader = renderHook(() => useRecentViews());
+    const recorder = renderHook(() => useRecordRecentView());
+
+    act(() => recorder.result.current(entry("1")));
+    act(() => recorder.result.current(entry("2")));
+    act(() => recorder.result.current(entry("1")));
+
+    expect(reader.result.current.map((v) => v.id)).toEqual(["1", "2"]);
+  });
+
+  it("caps the list at 12 entries, keeping the most recent", () => {
+    const recorder = renderHook(() => useRecordRecentView());
+    for (let i = 0; i < 15; i++) {
+      act(() => recorder.result.current(entry(String(i))));
+    }
+    const reader = renderHook(() => useRecentViews());
+    expect(reader.result.current).toHaveLength(12);
+    // Most recent first: 14 down to 3.
+    expect(reader.result.current[0].id).toBe("14");
+    expect(reader.result.current.at(-1)?.id).toBe("3");
+  });
+
+  it("clearRecentViews empties the list", () => {
+    const reader = renderHook(() => useRecentViews());
+    const recorder = renderHook(() => useRecordRecentView());
+    act(() => recorder.result.current(entry("1")));
+    expect(reader.result.current).toHaveLength(1);
+
+    act(() => clearRecentViews());
+    expect(reader.result.current).toEqual([]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
@@ -40,6 +40,18 @@ describe("useRecentViews + useRecordRecentView", () => {
     expect(result.current).toEqual([]);
   });
 
+  it("drops persisted entries with an unknown kind", () => {
+    localStorage.setItem(
+      "csm.recentViews.v1",
+      JSON.stringify([
+        { kind: "case", id: "1", title: "Case 1", href: "/cases/1", visitedAt: "t" },
+        { kind: "bogus", id: "2", title: "X", href: "/x", visitedAt: "t" },
+      ]),
+    );
+    const { result } = renderHook(() => useRecentViews());
+    expect(result.current.map((v) => v.id)).toEqual(["1"]);
+  });
+
   it("records a visit and exposes it to readers in the same tab", () => {
     const reader = renderHook(() => useRecentViews());
     const recorder = renderHook(() => useRecordRecentView());

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
@@ -18,6 +18,19 @@ import { useCallback, useEffect, useState } from "react";
 
 export type RecentViewKind = "case" | "project" | "account";
 
+const RECENT_VIEW_KINDS: readonly RecentViewKind[] = [
+  "case",
+  "project",
+  "account",
+];
+
+function isRecentViewKind(v: unknown): v is RecentViewKind {
+  return (
+    typeof v === "string" &&
+    (RECENT_VIEW_KINDS as readonly string[]).includes(v)
+  );
+}
+
 export interface RecentView {
   kind: RecentViewKind;
   id: string;
@@ -44,7 +57,9 @@ function readStorage(): RecentView[] {
         typeof v === "object" &&
         v !== null &&
         typeof (v as RecentView).id === "string" &&
-        typeof (v as RecentView).kind === "string" &&
+        // Validate kind against the known set so a malformed entry can't later
+        // crash consumers that index by kind.
+        isRecentViewKind((v as RecentView).kind) &&
         typeof (v as RecentView).title === "string" &&
         typeof (v as RecentView).href === "string" &&
         typeof (v as RecentView).visitedAt === "string",

--- a/apps/csm-portal/webapp/src/hooks/logger.ts
+++ b/apps/csm-portal/webapp/src/hooks/logger.ts
@@ -26,10 +26,10 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 
 // Interface for the Logger service.
 export interface ILogger {
-  debug(message: string, ...args: any[]): void;
-  info(message: string, ...args: any[]): void;
-  warn(message: string, ...args: any[]): void;
-  error(message: string, ...args: any[]): void;
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
 }
 
 // Logger service that handles application-wide logging.
@@ -53,7 +53,7 @@ export class Logger implements ILogger {
     level: LogLevel,
     levelName: string,
     message: string,
-    ...args: any[]
+    ...args: unknown[]
   ): void {
     if (level >= this.level) {
       const formattedMessage = this.formatMessage(levelName, message);
@@ -77,19 +77,19 @@ export class Logger implements ILogger {
     }
   }
 
-  debug(message: string, ...args: any[]): void {
+  debug(message: string, ...args: unknown[]): void {
     this.log(LogLevel.DEBUG, "DEBUG", message, ...args);
   }
 
-  info(message: string, ...args: any[]): void {
+  info(message: string, ...args: unknown[]): void {
     this.log(LogLevel.INFO, "INFO", message, ...args);
   }
 
-  warn(message: string, ...args: any[]): void {
+  warn(message: string, ...args: unknown[]): void {
     this.log(LogLevel.WARN, "WARN", message, ...args);
   }
 
-  error(message: string, ...args: any[]): void {
+  error(message: string, ...args: unknown[]): void {
     this.log(LogLevel.ERROR, "ERROR", message, ...args);
   }
 

--- a/apps/csm-portal/webapp/src/hooks/useIdTokenClaims.ts
+++ b/apps/csm-portal/webapp/src/hooks/useIdTokenClaims.ts
@@ -38,6 +38,9 @@ export function useIdTokenClaims(): IdTokenClaims | undefined {
 
   useEffect(() => {
     if (!isSignedIn) {
+      // Clear claims when signed out; the async branch below subscribes to the
+      // external Asgardeo token and setStates from its callback.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs to external auth state
       setClaims(undefined);
       return;
     }

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -85,6 +85,9 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
 
   useEffect(() => {
     if (!isAuthLoading) {
+      // One-way init latch: flips to true once auth settles and stays there.
+      // Effect-driven by design (must re-render on the transition).
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional init latch
       setHasInitialized(true);
     }
   }, [isAuthLoading]);
@@ -92,6 +95,9 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
   useEffect(() => {
     if (!isAuthLoading || !isLoginCallback) return;
 
+    // Re-asserts the message when the callback effect (re)runs; the staged
+    // timers below legitimately setState from async callbacks.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs message to auth/callback state
     setLoadingMessage("Authenticating…");
     const t1 = setTimeout(() => setLoadingMessage("Fetching user info…"), 1500);
     const t2 = setTimeout(() => setLoadingMessage("Please wait…"), 3000);

--- a/apps/csm-portal/webapp/src/utils/formatBytes.test.ts
+++ b/apps/csm-portal/webapp/src/utils/formatBytes.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { formatBytes } from "./formatBytes";
+
+describe("formatBytes", () => {
+  it("renders sub-KB values as bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1)).toBe("1 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("renders KB with one decimal", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(1024 * 1024 - 1)).toBe("1024.0 KB");
+  });
+
+  it("renders MB with two decimals", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.00 MB");
+    expect(formatBytes(5 * 1024 * 1024 + 512 * 1024)).toBe("5.50 MB");
+  });
+});


### PR DESCRIPTION
Top of the CSM-portal case-management stack. **Merge order: #814 → #815 → this.** Until the two below land, this PR's diff shows their changes too; the net diff once #815 lands is the 12 files below.

### What's here
Brings `pnpm lint` on the csm-portal webapp from **22 errors to 0**. These were pre-existing baseline errors from a strict `eslint-plugin-react-hooks` v7 / `react-refresh` upgrade that was never enforced (there is no CI step running lint), firing on intentional patterns across the app — not regressions from the feature PRs.

- **`logger.ts` — proper fix.** `...args: any[]` → `unknown[]` at all 9 sites. Console forwarding is unaffected; this is a real type tightening, not a suppression.
- **`react-hooks/set-state-in-effect` (6) — scoped, justified disables.** Init latch (`AppLayout`), timed loading messages (`AppLayout`), form-reset-on-open (`UserProfileModal`), banner reset-on-reshow (`GlobalNotificationBanner`), auth-state sync (`useIdTokenClaims`), URL-hash permalink (`CsmCaseDetailPage`). In each the synchronous `setState` is the intended behavior; refactoring untested shared infra to satisfy a brand-new rule would risk regressions for no functional gain.
- **`react-refresh/only-export-components` (7) — file-level disables.** The five context provider+hook files and the Lexical `ImageNode`. This is a fast-refresh DX rule, not correctness; provider+hook colocation is the repo idiom (see `caseTier.ts`'s comment).

### Not done here (deliberate)
- One non-failing `react-hooks/exhaustive-deps` **warning** remains in `Editor.tsx`. `pnpm lint` passes (warnings don't fail `eslint .`). Forcing the missing dep changes the effect's cadence; out of scope for a hygiene PR.

### Verification
- `pnpm lint` → 0 errors (1 pre-existing warning)
- `pnpm build` → green
- `pnpm test` → 35 passing (the unit tests added in #815)
