### PR TITLE
[Customer Entity] implement PATCH /cases/{id} to update case state

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -487,6 +487,13 @@ type SearchCasesResponse struct {
 	HasMore bool             `json:"hasMore"`
 }
 
+// UpdateCaseStateRequest is the input for PATCH /cases/{id}.
+// Only State may be changed through this endpoint.
+type UpdateCaseStateRequest struct {
+	ID    string    `json:"-"`
+	State CaseState `json:"state"`
+}
+
 // CreateCaseRequest is the input for creating a new case.
 // id, number, and wso2_id are auto-generated; state defaults to open.
 type CreateCaseRequest struct {

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -63,6 +63,22 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(c)
 }
 
+// PatchCase handles PATCH /cases/{id} and allows updating the case state.
+func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
+	var req domain.UpdateCaseStateRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.ID = r.PathValue("id")
+	c, err := h.svc.UpdateCaseState(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(c)
+}
+
 // CreateCaseComment handles POST /cases/{id}/comments.
 func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) {
 	var req domain.CreateCaseCommentRequest

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -220,7 +220,7 @@ func (r *caseRepo) UpdateCaseState(ctx context.Context, req domain.UpdateCaseSta
 		UPDATE cases
 		SET state      = $2::case_state_enum,
 		    updated_at = NOW(),
-		    closed_at  = CASE WHEN $2 = 'closed' THEN NOW() ELSE NULL END
+		    closed_at  = CASE WHEN state <> 'closed'::case_state_enum AND $2 = 'closed' THEN NOW() ELSE closed_at END
 		WHERE id = $1
 		RETURNING id, number, wso2_id, created_by, project_id, deployment_id, deployed_product_id,
 		          subject, description, priority, issue_type, state, created_at, updated_at, closed_at`

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -47,6 +47,10 @@ type CaseRepository interface {
 	// SearchCaseComments returns a paginated slice of comments for the given case
 	// together with the total count of matching rows before pagination.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error)
+	// UpdateCaseState updates the state of the case identified by req.ID.
+	// closed_at is set to NOW() when transitioning to closed, and cleared otherwise.
+	// Returns a NotFoundError if no matching row exists.
+	UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error)
 }
 
 type caseRepo struct {
@@ -208,6 +212,33 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 	}
 
 	return comments, total, nil
+}
+
+// UpdateCaseState implements CaseRepository.
+func (r *caseRepo) UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error) {
+	const query = `
+		UPDATE cases
+		SET state      = $2::case_state_enum,
+		    updated_at = NOW(),
+		    closed_at  = CASE WHEN $2 = 'closed' THEN NOW() ELSE NULL END
+		WHERE id = $1
+		RETURNING id, number, wso2_id, created_by, project_id, deployment_id, deployed_product_id,
+		          subject, description, priority, issue_type, state, created_at, updated_at, closed_at`
+
+	var c domain.Case
+	err := r.db.QueryRow(ctx, query, req.ID, string(req.State)).Scan(
+		&c.ID, &c.Number, &c.Wso2ID, &c.CreatedBy,
+		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
+		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State,
+		&c.CreatedAt, &c.UpdatedAt, &c.ClosedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.Case{}, &apierror.NotFoundError{Msg: "case not found"}
+	}
+	if err != nil {
+		return domain.Case{}, fmt.Errorf("update case state: %w", err)
+	}
+	return c, nil
 }
 
 // SearchCases implements CaseRepository.

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -76,6 +76,7 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
+	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -153,6 +153,17 @@ func (s *caseService) SearchCaseComments(ctx context.Context, req domain.SearchC
 	}, nil
 }
 
+// UpdateCaseState implements CaseService.
+func (s *caseService) UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.Case{}, err
+	}
+	if !validCaseState[req.State] {
+		return domain.Case{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(req.State)}
+	}
+	return s.repo.UpdateCaseState(ctx, req)
+}
+
 // SearchCases implements CaseService.
 func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error) {
 	if err := normalizePagination(&req.Pagination); err != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -107,4 +107,7 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
+	// UpdateCaseState transitions the case to the given state. A ValidationError is
+	// returned for an invalid state value or malformed UUID; a NotFoundError if no case matches.
+	UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error)
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -316,6 +316,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      summary: Update the state of a support case.
+      operationId: patchCase
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCaseStateRequest'
+      responses:
+        "200":
+          description: Case updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Case'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /cases:
     post:
@@ -887,6 +928,15 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    UpdateCaseStateRequest:
+      type: object
+      required: [state]
+      properties:
+        state:
+          type: string
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          description: The new state to transition the case to.
 
     CreateCaseRequest:
       type: object


### PR DESCRIPTION
## Summary

Adds a `PATCH /cases/{id}` endpoint that allows callers to transition a support case to a new state.

### Changes
- **Domain** — `UpdateCaseStateRequest` struct (ID from path, state from body)
- **Repository** — `UpdateCaseState` SQL `UPDATE`; sets `closed_at = NOW()` when transitioning to `closed`, clears it on any other state
- **Service** — validates UUID and state enum before delegating to the repository
- **Handler / Route** — `PatchCase` handler wired to `PATCH /cases/{id}`
- **OpenAPI** — `PATCH /cases/{id}` operation and `UpdateCaseStateRequest` schema

### Accepted state values
`open` · `work_in_progress` · `waiting_on_wso2` · `awaiting_info` . `reopened` · `solution_proposed` · `closed`

### Example
```http
PATCH /cases/550e8400-e29b-41d4-a716-446655440000
Content-Type: application/json

{ "state": "closed" }


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented case state updates. Users can now modify a case's state through a dedicated endpoint, with support for state transitions including open, work in progress, waiting on WSO2, awaiting information, reopened, solution proposed, and closed. State changes automatically manage associated timestamps as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->