### PR TITLE
[CSM Portal] Add PATCH /cases/{id} endpoint for case state transitions

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -81,6 +81,7 @@ func main() {
 	})
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
+	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/comments/search", caseHandler.SearchCaseComments)
 	mux.HandleFunc("POST /projects/{id}/cases/search", caseHandler.SearchProjectCases)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -41,6 +41,12 @@ func (c *Client) GetCase(ctx context.Context, caseID string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/cases/%s", url.PathEscape(caseID)), nil)
 }
 
+// PatchCase calls PATCH /cases/{id} on the entity service to update case state.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) PatchCase(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/cases/%s", url.PathEscape(caseID)), body)
+}
+
 // CreateCaseComment calls POST /cases/{id}/comments on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -100,6 +100,7 @@ func injectProjectID(body []byte, projectID string) ([]byte, error) {
 // allowing the handler to be tested independently of the real HTTP client.
 type entityCaseClient interface {
 	CreateCase(ctx context.Context, body []byte) ([]byte, error)
+	PatchCase(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
@@ -322,6 +323,58 @@ func (h *CaseHandler) SearchProjectCases(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchCases failed", "userID", user.UserID, "projectID", projectID, "err", err)
 		mapUpstreamError(w, err, "Failed to search cases.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// PatchCase handles PATCH /cases/{id}.
+// Accepts {"state":"<new_state>"} and forwards to the entity service.
+func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("id")
+	if caseID == "" {
+		writeError(w, http.StatusBadRequest, "Case ID cannot be empty!")
+		return
+	}
+	if !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.PatchCase(r.Context(), caseID, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity PatchCase failed", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamError(w, err, "Failed to update case.")
+		return
+	}
+
+	result, err = injectNextStates(result)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to inject nextStates", "userID", user.UserID, "caseID", caseID, "err", err)
+		writeError(w, http.StatusInternalServerError, "Failed to process case details.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -579,6 +579,137 @@ func TestSearchProjectCases(t *testing.T) {
 	})
 }
 
+// ----- PatchCase -----
+
+func TestPatchCase(t *testing.T) {
+	const testCaseID = "11111111-1111-1111-1111-111111111111"
+	const validPayload = `{"state":"work_in_progress"}`
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(validPayload))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty case ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/", strings.NewReader(validPayload)))
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, "Case ID cannot be empty!")
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/not-a-uuid", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`not-json`)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards case ID and body, returns 200 with nextStates injected", func(t *testing.T) {
+		var capturedID string
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			patchCaseFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
+				capturedID = caseID
+				capturedBody = body
+				return []byte(`{"id":"` + testCaseID + `","state":"work_in_progress"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(validPayload)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedID != testCaseID {
+			t.Errorf("upstream received caseID %q, want %q", capturedID, testCaseID)
+		}
+		if !json.Valid(capturedBody) {
+			t.Errorf("upstream received invalid JSON body: %s", capturedBody)
+		}
+
+		type patchCaseResp struct {
+			ID         string   `json:"id"`
+			State      string   `json:"state"`
+			NextStates []string `json:"nextStates"`
+		}
+		resp := decodeJSON[patchCaseResp](t, w)
+		if resp.ID != testCaseID {
+			t.Errorf("response id = %q, want %q", resp.ID, testCaseID)
+		}
+		if resp.State != caseStateWorkInProgress {
+			t.Errorf("response state = %q, want %q", resp.State, caseStateWorkInProgress)
+		}
+		wantNext := []string{caseStateWaitingOnWSO2, caseStateAwaitingInfo, caseStateSolutionProposed, caseStateClosed}
+		if len(resp.NextStates) != len(wantNext) {
+			t.Fatalf("nextStates = %v, want %v", resp.NextStates, wantNext)
+		}
+		for i, got := range resp.NextStates {
+			if got != wantNext[i] {
+				t.Errorf("nextStates[%d] = %q, want %q", i, got, wantNext[i])
+			}
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to update case.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					patchCaseFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(validPayload)))
+				r.SetPathValue("id", testCaseID)
+				w := httptest.NewRecorder()
+				h.PatchCase(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 // ----- GetCase -----
 
 func TestGetCase(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -86,6 +86,7 @@ func decodeJSON[T any](t *testing.T, w *httptest.ResponseRecorder) T {
 
 type mockEntityCaseClient struct {
 	createCaseFn          func(ctx context.Context, body []byte) ([]byte, error)
+	patchCaseFn           func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	createCaseCommentFn   func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCaseCommentsFn  func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCasesFn         func(ctx context.Context, body []byte) ([]byte, error)
@@ -96,6 +97,13 @@ type mockEntityCaseClient struct {
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
 	if m.createCaseFn != nil {
 		return m.createCaseFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) PatchCase(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	if m.patchCaseFn != nil {
+		return m.patchCaseFn(ctx, caseID, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -125,6 +125,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+    patch:
+      summary: Update the state of a support case.
+      operationId: patchCasesId
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the case.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCaseStateRequest'
+      responses:
+        "200":
+          description: Case updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseView'
+        "400":
+          description: Bad request (e.g. malformed UUID or invalid state value).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
 
   /cases/{id}/comments:
     post:
@@ -836,6 +896,15 @@ components:
       properties:
         message:
           type: string
+
+    UpdateCaseStateRequest:
+      type: object
+      required: [state]
+      properties:
+        state:
+          type: string
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          description: The new state to transition the case to.
 
     CaseCreatePayload:
       type: object


### PR DESCRIPTION
## Summary

- **Entity client** (`internal/entity/entity.go`) — adds `PatchCase(ctx, caseID, body)` calling `PATCH /cases/{id}` on the entity service
- **Handler** (`internal/handler/cases.go`) — adds `PatchCase` to `entityCaseClient` interface and implements the handler: auth check → UUID validation → body size cap → JSON validation → forward to entity client → inject `nextStates` → 200
- **Route** (`cmd/server/main.go`) — wires `PATCH /cases/{id}` to `caseHandler.PatchCase`
- **OpenAPI spec** (`openapi.yaml`) — adds `PATCH /cases/{id}` operation (200/400/401/403/404/413/500) and `UpdateCaseStateRequest` schema with the state enum
- **Tests** — adds `TestPatchCase` covering auth guard, empty/malformed UUID, body size, invalid JSON, happy path with `nextStates` injection, and upstream error mapping; extends mock with `patchCaseFn`

Implements the entity-service endpoint introduced in wso2-open-operations/cs-tools#829.

## Test plan
- [x] `make test` passes (pre-push hook already verified this)
- [x] `PATCH /cases/{id}` with a valid UUID and `{"state":"closed"}` returns 200 with `nextStates: []`
- [x] `PATCH /cases/not-a-uuid` returns 400
- [x] `PATCH /cases/{id}` without a JWT returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for partial case updates via a new PATCH endpoint, enabling case state modifications with authentication enforcement and input validation.
  * Includes comprehensive error handling for invalid requests, malformed data, and oversized payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->