### PR TITLE
[Customer Entity] Extend PATCH /cases/{id} to update case priority

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -487,11 +487,12 @@ type SearchCasesResponse struct {
 	HasMore bool             `json:"hasMore"`
 }
 
-// UpdateCaseStateRequest is the input for PATCH /cases/{id}.
-// Only State may be changed through this endpoint.
-type UpdateCaseStateRequest struct {
-	ID    string    `json:"-"`
-	State CaseState `json:"state"`
+// UpdateCaseRequest is the input for PATCH /cases/{id}.
+// State and Priority may be changed through this endpoint.
+type UpdateCaseRequest struct {
+	ID       string        `json:"-"`
+	State    *CaseState    `json:"state"`
+	Priority *CasePriority `json:"priority"`
 }
 
 // CreateCaseRequest is the input for creating a new case.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -63,14 +63,14 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(c)
 }
 
-// PatchCase handles PATCH /cases/{id} and allows updating the case state.
+// PatchCase handles PATCH /cases/{id} and allows updating the case state and priority.
 func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
-	var req domain.UpdateCaseStateRequest
+	var req domain.UpdateCaseRequest
 	if !decodeRequest(w, r, &req) {
 		return
 	}
 	req.ID = r.PathValue("id")
-	c, err := h.svc.UpdateCaseState(r.Context(), req)
+	c, err := h.svc.UpdateCase(r.Context(), req)
 	if err != nil {
 		writeServiceError(w, r, err)
 		return

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -229,7 +229,7 @@ func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest)
 		SET state      = CASE WHEN $2 <> '' THEN $2::case_state_enum ELSE state END,
 		    priority   = CASE WHEN $3 <> '' THEN $3::case_priority_enum ELSE priority END,
 		    updated_at = NOW(),
-		    closed_at  = CASE WHEN state <> 'closed'::case_state_enum AND $2 = 'closed' THEN NOW() ELSE closed_at END
+		    closed_at  = CASE WHEN $2 = 'closed' THEN NOW() WHEN $2 <> '' AND $2 <> 'closed' THEN NULL ELSE closed_at END
 		WHERE id = $1
 		RETURNING id, number, wso2_id, created_by, project_id, deployment_id, deployed_product_id,
 		          subject, description, priority, issue_type, state, created_at, updated_at, closed_at`

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -47,10 +47,10 @@ type CaseRepository interface {
 	// SearchCaseComments returns a paginated slice of comments for the given case
 	// together with the total count of matching rows before pagination.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error)
-	// UpdateCaseState updates the state of the case identified by req.ID.
-	// closed_at is set to NOW() when transitioning to closed, and cleared otherwise.
+	// UpdateCase updates the state and/or priority of the case identified by req.ID.
+	// closed_at is set to NOW() when transitioning to closed.
 	// Returns a NotFoundError if no matching row exists.
-	UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error)
+	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
 }
 
 type caseRepo struct {
@@ -214,11 +214,20 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 	return comments, total, nil
 }
 
-// UpdateCaseState implements CaseRepository.
-func (r *caseRepo) UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error) {
+// UpdateCase implements CaseRepository.
+func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
+	state := ""
+	if req.State != nil {
+		state = string(*req.State)
+	}
+	priority := ""
+	if req.Priority != nil {
+		priority = string(*req.Priority)
+	}
 	const query = `
 		UPDATE cases
-		SET state      = $2::case_state_enum,
+		SET state      = CASE WHEN $2 <> '' THEN $2::case_state_enum ELSE state END,
+		    priority   = CASE WHEN $3 <> '' THEN $3::case_priority_enum ELSE priority END,
 		    updated_at = NOW(),
 		    closed_at  = CASE WHEN state <> 'closed'::case_state_enum AND $2 = 'closed' THEN NOW() ELSE closed_at END
 		WHERE id = $1
@@ -226,7 +235,7 @@ func (r *caseRepo) UpdateCaseState(ctx context.Context, req domain.UpdateCaseSta
 		          subject, description, priority, issue_type, state, created_at, updated_at, closed_at`
 
 	var c domain.Case
-	err := r.db.QueryRow(ctx, query, req.ID, string(req.State)).Scan(
+	err := r.db.QueryRow(ctx, query, req.ID, state, priority).Scan(
 		&c.ID, &c.Number, &c.Wso2ID, &c.CreatedBy,
 		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
 		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State,
@@ -236,7 +245,7 @@ func (r *caseRepo) UpdateCaseState(ctx context.Context, req domain.UpdateCaseSta
 		return domain.Case{}, &apierror.NotFoundError{Msg: "case not found"}
 	}
 	if err != nil {
-		return domain.Case{}, fmt.Errorf("update case state: %w", err)
+		return domain.Case{}, fmt.Errorf("update case: %w", err)
 	}
 	return c, nil
 }

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -153,15 +153,21 @@ func (s *caseService) SearchCaseComments(ctx context.Context, req domain.SearchC
 	}, nil
 }
 
-// UpdateCaseState implements CaseService.
-func (s *caseService) UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error) {
+// UpdateCase implements CaseService.
+func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.Case{}, err
 	}
-	if !validCaseState[req.State] {
-		return domain.Case{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(req.State)}
+	if req.State == nil && req.Priority == nil {
+		return domain.Case{}, &apierror.ValidationError{Msg: "at least one of state or priority must be provided"}
 	}
-	return s.repo.UpdateCaseState(ctx, req)
+	if req.State != nil && !validCaseState[*req.State] {
+		return domain.Case{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
+	}
+	if req.Priority != nil && !validCasePriority[*req.Priority] {
+		return domain.Case{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
+	}
+	return s.repo.UpdateCase(ctx, req)
 }
 
 // SearchCases implements CaseService.

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -107,7 +107,7 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
-	// UpdateCaseState transitions the case to the given state. A ValidationError is
-	// returned for an invalid state value or malformed UUID; a NotFoundError if no case matches.
-	UpdateCaseState(ctx context.Context, req domain.UpdateCaseStateRequest) (domain.Case, error)
+	// UpdateCase updates the state and/or priority of a case. A ValidationError is
+	// returned for invalid values or malformed UUID; a NotFoundError if no case matches.
+	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -932,6 +932,9 @@ components:
     UpdateCaseRequest:
       type: object
       description: At least one of state or priority must be provided.
+      anyOf:
+        - required: [state]
+        - required: [priority]
       properties:
         state:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -317,7 +317,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     patch:
-      summary: Update the state of a support case.
+      summary: Update the state and/or priority of a support case.
       operationId: patchCase
       parameters:
         - name: id
@@ -331,7 +331,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateCaseStateRequest'
+              $ref: '#/components/schemas/UpdateCaseRequest'
       responses:
         "200":
           description: Case updated successfully.
@@ -929,14 +929,18 @@ components:
         hasMore:
           type: boolean
 
-    UpdateCaseStateRequest:
+    UpdateCaseRequest:
       type: object
-      required: [state]
+      description: At least one of state or priority must be provided.
       properties:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
           description: The new state to transition the case to.
+        priority:
+          type: string
+          enum: [catastrophic, critical, high, medium, low]
+          description: The new priority (severity) of the case.
 
     CreateCaseRequest:
       type: object


### PR DESCRIPTION
## Summary

- Extends `PATCH /cases/{id}` to accept an optional `priority` field alongside the existing `state` field
- Renames `UpdateCaseStateRequest` → `UpdateCaseRequest` across domain, service, repository, and handler layers
- Both fields are optional pointers; at least one must be provided (validated in service layer)
- SQL uses `CASE WHEN` to update only the fields present in the request
- Updates OpenAPI spec: renames schema to `UpdateCaseRequest`, removes `required: [state]`, adds `priority` enum field


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced the PATCH /cases/{id} endpoint to support updating both state and priority fields in a single request. Both fields are optional, enabling flexible partial updates: change state alone, priority alone, or modify both fields together. This improves efficiency and reduces the number of API calls needed for case management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->