### PR TITLE
docs(entity-service): add CLAUDE.md

### DIFF
--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -1,0 +1,152 @@
+# Entity Service
+
+Go HTTP server (`net/http`, standard library only) that owns all core CS-platform entities: users, accounts, projects, products, deployments, deployed products, cases, and case comments. It exposes a REST API consumed by portal BFFs and other internal services.
+
+## Architecture
+
+Strict four-layer stack — no shortcuts across layers:
+
+```
+Handler → Service → Repository → PostgreSQL (pgx/v5)
+```
+
+All wiring happens explicitly in `internal/server/routes.go` (no DI framework). The full dependency graph is built there: `NewRepository(db) → NewService(repo) → NewHandler(svc)`, then registered on a `net/http.ServeMux`.
+
+Middleware chain wraps the mux: **Recovery → Logger → Timeout** (10 s per request).
+
+## Running locally
+
+```bash
+cp .env.example .env   # fill in DB_* vars
+go run ./cmd/api/main.go
+```
+
+The server loads `.env` automatically on startup (silently ignored if absent). Port defaults to `8080`; override with `SERVER_PORT`.
+
+## Environment variables
+
+| Variable      | Required | Default | Purpose                   |
+|---------------|----------|---------|---------------------------|
+| `DB_HOST`     | yes      | —       | PostgreSQL hostname        |
+| `DB_PORT`     | yes      | —       | PostgreSQL port            |
+| `DB_USER`     | yes      | —       | Database user              |
+| `DB_PASSWORD` | yes      | —       | Database password          |
+| `DB_NAME`     | yes      | —       | Database name              |
+| `DB_SSLMODE`  | no       | —       | `disable` or `require`    |
+| `SERVER_PORT` | no       | `8080`  | HTTP listen port           |
+
+## Adding a new entity
+
+Follow these steps in order:
+
+1. **Domain types** (`internal/domain/entity.go`) — add request/response structs and any enums; keep all types in this one file
+2. **Repository** (`internal/repository/<entity>_repo.go`) — define the `<Entity>Repository` interface in the same file, then implement it against pgx; use parameterized queries only, never string-interpolate user-supplied values
+3. **Service** (`internal/service/<entity>_service.go`) — implement the business logic (validation, pagination normalization); register the interface in `internal/service/interfaces.go`
+4. **Handler** (`internal/handler/<entity>_handler.go`) — follow the handler pattern below
+5. **Route** (`internal/server/routes.go`) — wire repo → svc → handler, then register routes using Go 1.22 method-prefixed patterns (e.g. `"POST /widgets/{id}/search"`)
+6. **OpenAPI spec** (`openapi.yaml`) — document every new path; declare 400/404/500 responses on every endpoint
+
+## Adding a new endpoint to an existing entity
+
+1. Add the method to the repository interface and implement it
+2. Add the method to the service interface (`interfaces.go`) and implement it in the service
+3. Add the handler func
+4. Register the route in `routes.go`
+5. Document in `openapi.yaml`
+
+## Handler conventions
+
+Every handler follows the same skeleton:
+
+```go
+func (h *WidgetHandler) CreateWidget(w http.ResponseWriter, r *http.Request) {
+    var req domain.CreateWidgetRequest
+    if !decodeRequest(w, r, &req) {   // enforces 1 MiB cap + unknown-field rejection
+        return
+    }
+    result, err := h.svc.CreateWidget(r.Context(), req)
+    if err != nil {
+        writeServiceError(w, r, err)  // maps service errors to HTTP status codes
+        return
+    }
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusCreated)
+    _ = json.NewEncoder(w).Encode(result)
+}
+```
+
+- `decodeRequest` (in `internal/handler/decode.go`) enforces a 1 MiB body cap, rejects unknown fields, and rejects trailing data after the JSON object
+- `writeServiceError` (same file) maps `ValidationError` → 400, `NotFoundError` → 404, `ServiceUnavailableError` → 503, `context.DeadlineExceeded` → 408; everything else → 500
+- Never write custom status mappings inline in a handler
+
+## Service conventions
+
+- Validate all input **before** hitting the repository; return `*apierror.ValidationError` for bad input
+- UUID fields must be validated with `validateUUIDs()` (defined in the service package)
+- Pagination: call `normalizePagination()` — it caps `limit` at 100 and sets defaults
+- Use `validXxx` maps (e.g. `validCaseState`, `validCasePriority`) to validate enum fields; add a map entry whenever you add an enum constant
+- Service methods must not import the `handler` or `repository` packages
+
+## Repository conventions
+
+- Each entity gets one file; the `<Entity>Repository` interface lives at the top of the same file
+- Use `pgx.ErrNoRows` to detect missing rows and return `*apierror.NotFoundError`
+- Wrap unexpected errors with `fmt.Errorf("operation name: %w", err)` for traceability
+- PostgreSQL enum casts are required for enum columns (e.g. `$1::case_state_enum`)
+- For queries that need both a COUNT and a SELECT, run them concurrently with `errgroup` (see `SearchCases` and `SearchCaseComments` in `case_repo.go`)
+
+## Domain types
+
+All shared types live in `internal/domain/entity.go`. Conventions:
+
+- JSON field names use camelCase (`json:"fieldName"`)
+- Request structs include only the fields a caller can supply; ID fields injected from path params use `json:"-"`
+- Optional fields in request structs use pointer types (`*CasePriority`) so absent fields are distinguishable from zero values
+- Response structs return the full entity row
+
+## Error types (`internal/apierror`)
+
+| Type                    | HTTP status | When to use                              |
+|-------------------------|-------------|------------------------------------------|
+| `*ValidationError`      | 400         | Invalid input supplied by the caller     |
+| `*NotFoundError`        | 404         | Requested resource does not exist        |
+| `*ServiceUnavailableError` | 503      | Downstream dependency temporarily down   |
+
+`apierror.WriteJSON(w, status, msg)` writes `{"code": <status>, "message": "<msg>"}`.
+
+## Database migrations
+
+Migrations live in `migrations/` as plain SQL files, numbered `000NNN_<description>.up.sql` / `.down.sql`. Each migration creates its PostgreSQL enums, sequences, and tables in a single transaction. Apply them in ascending order before starting the service.
+
+Key conventions enforced at the DB level:
+- Primary keys are `UUID DEFAULT gen_random_uuid()`
+- Human-readable IDs (e.g. `CASE-001`, `WSO2-001`) are generated from dedicated sequences via column defaults
+- Enum types (e.g. `case_state_enum`, `case_priority_enum`) enforce valid values at the DB level; Go enum validation in the service layer is an additional guard
+- Triggers enforce relational constraints that foreign keys alone cannot express (e.g. deployment must belong to the same project as the case)
+
+## OpenAPI spec
+
+`openapi.yaml` is the source of truth for the API contract.
+
+- Error responses reference `$ref: '#/components/schemas/ErrorResponse'`
+- Path parameters that accept UUIDs must declare `format: uuid`
+- Every writable endpoint (POST, PATCH) needs 400 and 404 responses in addition to the success response
+- Schema names should match the Go domain type names (e.g. `CreateCaseRequest`, `Case`)
+
+## Connection pool settings
+
+Configured in `internal/db/postgres.go`:
+
+| Setting             | Value   |
+|---------------------|---------|
+| Max connections     | 20      |
+| Min connections     | 2       |
+| Max conn lifetime   | 30 min  |
+| Max idle time       | 5 min   |
+
+## Security
+
+- Never commit secrets — use environment variables; `.env` is git-ignored
+- Never log request bodies, passwords, or tokens; log only IDs and sanitised error summaries
+- All SQL uses parameterized queries; never interpolate user input into query strings
+- Validate and reject unexpected input at the handler boundary before it reaches the service or repository

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -6,7 +6,7 @@ Go HTTP server (`net/http`, standard library only) that owns all core CS-platfor
 
 Strict four-layer stack — no shortcuts across layers:
 
-```
+```text
 Handler → Service → Repository → PostgreSQL (pgx/v5)
 ```
 


### PR DESCRIPTION
## Summary

- Adds `entity-service/CLAUDE.md` documenting the service architecture, conventions, and development workflows for Claude Code

## What's covered

- Architecture overview (four-layer stack: Handler → Service → Repository → PostgreSQL, middleware chain)
- Local setup and environment variables
- Step-by-step guides for adding a new entity and adding an endpoint to an existing entity
- Handler, service, and repository conventions (error mapping, enum validation, concurrent COUNT+SELECT pattern)
- Domain type conventions (camelCase JSON, pointer fields for optional PATCH fields)
- Error types and HTTP status mappings (`apierror` package)
- Database migration conventions (UUID PKs, sequence-based human IDs, trigger-enforced constraints)
- OpenAPI spec guidelines
- Security rules (no secrets, no PII in logs, parameterized queries only)

## Test plan

- [ ] Review CLAUDE.md content for accuracy against the current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Entity Service architecture documentation including development conventions, layering patterns, middleware configuration, database migration standards, security guidelines, and API specifications for maintaining consistent standards across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->