### PR TITLE
[CSM Portal] Replace project-scoped search endpoints with flat POST /cases/search and POST /deployments/search

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -84,7 +84,7 @@ func main() {
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/comments/search", caseHandler.SearchCaseComments)
-	mux.HandleFunc("POST /projects/{id}/cases/search", caseHandler.SearchProjectCases)
+	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)
 	mux.HandleFunc("GET /users/me", usersHandler.GetMe)

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -96,7 +96,7 @@ func main() {
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
-	mux.HandleFunc("POST /projects/{id}/deployments/search", deploymentHandler.SearchDeployments)
+	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("POST /deployments/{id}/products/search", deploymentHandler.SearchDeployedProducts)
 
 	addr := envOrDefault("PORT", ":8080")

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -79,23 +79,6 @@ func injectCreatedBy(body []byte, userID string) ([]byte, error) {
 	return json.Marshal(m)
 }
 
-// injectProjectID merges a project ID into a JSON request body as projectIds: [id].
-func injectProjectID(body []byte, projectID string) ([]byte, error) {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(body, &m); err != nil {
-		return nil, err
-	}
-	if m == nil {
-		m = make(map[string]json.RawMessage)
-	}
-	ids, err := json.Marshal([]string{projectID})
-	if err != nil {
-		return nil, err
-	}
-	m["projectIds"] = ids
-	return json.Marshal(m)
-}
-
 // entityCaseClient abstracts the entity service operations used by CaseHandler,
 // allowing the handler to be tested independently of the real HTTP client.
 type entityCaseClient interface {
@@ -282,18 +265,12 @@ func (h *CaseHandler) SearchCaseComments(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, result)
 }
 
-// SearchProjectCases handles POST /projects/{id}/cases/search.
-// It enforces the project scope by injecting projectIds: [id] into the entity request.
-func (h *CaseHandler) SearchProjectCases(w http.ResponseWriter, r *http.Request) {
+// SearchCases handles POST /cases/search.
+// Project IDs and other filters are accepted directly in the request body.
+func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
-		return
-	}
-
-	projectID := r.PathValue("id")
-	if projectID == "" {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
@@ -313,15 +290,9 @@ func (h *CaseHandler) SearchProjectCases(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	entityBody, err := injectProjectID(body, projectID)
+	result, err := h.entity.SearchCases(r.Context(), body)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
-		return
-	}
-
-	result, err := h.entity.SearchCases(r.Context(), entityBody)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "entity SearchCases failed", "userID", user.UserID, "projectID", projectID, "err", err)
+		slog.ErrorContext(r.Context(), "entity SearchCases failed", "userID", user.UserID, "err", err)
 		mapUpstreamError(w, err, "Failed to search cases.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -504,6 +504,30 @@ func TestSearchCases(t *testing.T) {
 		}
 	})
 
+	t.Run("forwards body without projectIds unchanged", func(t *testing.T) {
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			searchCasesFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"cases":[],"total":0}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search",
+			strings.NewReader(`{"stateKeys":["open"],"pagination":{"limit":10,"offset":0}}`)))
+		w := httptest.NewRecorder()
+		h.SearchCases(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		var sent map[string]json.RawMessage
+		if err := json.Unmarshal(capturedBody, &sent); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		if _, exists := sent["projectIds"]; exists {
+			t.Errorf("upstream body unexpectedly contains projectIds: %s", sent["projectIds"])
+		}
+	})
+
 	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
 		for _, tc := range upstreamErrors("Failed to search cases.") {
 			t.Run(tc.name, func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -439,36 +439,24 @@ func TestSearchCaseComments(t *testing.T) {
 	})
 }
 
-// ----- SearchProjectCases -----
+// ----- SearchCases -----
 
-func TestSearchProjectCases(t *testing.T) {
+func TestSearchCases(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := httptest.NewRequest(http.MethodPost, "/projects/proj-1/cases/search", strings.NewReader(`{}`))
-		r.SetPathValue("id", "proj-1")
+		r := httptest.NewRequest(http.MethodPost, "/cases/search", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
-		h.SearchProjectCases(w, r)
+		h.SearchCases(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
 		assertErrorMessage(t, w, ErrMsgUnauthorized)
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("rejects missing project id", func(t *testing.T) {
-		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects//cases/search", strings.NewReader(`{}`)))
-		w := httptest.NewRecorder()
-		h.SearchProjectCases(w, r)
-		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgBadRequest)
-		assertContentType(t, w, "application/json")
-	})
-
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/cases/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
-		r.SetPathValue("id", "proj-1")
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
-		h.SearchProjectCases(w, r)
+		h.SearchCases(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
 		assertErrorMessage(t, w, ErrMsgTooLarge)
 		assertContentType(t, w, "application/json")
@@ -476,40 +464,27 @@ func TestSearchProjectCases(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/cases/search", strings.NewReader(`not-json`)))
-		r.SetPathValue("id", "proj-1")
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
-		h.SearchProjectCases(w, r)
+		h.SearchCases(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
 		assertErrorMessage(t, w, ErrMsgBadRequest)
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("handles JSON null body as empty object without panic", func(t *testing.T) {
-		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/cases/search", strings.NewReader(`null`)))
-		r.SetPathValue("id", "proj-1")
-		w := httptest.NewRecorder()
-		h.SearchProjectCases(w, r)
-		assertStatus(t, w, http.StatusOK)
-		assertContentType(t, w, "application/json")
-	})
-
-	t.Run("injects projectId from path and forwards to upstream", func(t *testing.T) {
-		const projectID = "proj-42"
+	t.Run("forwards body to upstream and returns 200", func(t *testing.T) {
 		var capturedBody []byte
 		client := &mockEntityCaseClient{
 			searchCasesFn: func(_ context.Context, body []byte) ([]byte, error) {
 				capturedBody = body
-				return []byte(`{"cases":[{"id":"case-1","projectId":"proj-42"}],"total":1}`), nil
+				return []byte(`{"cases":[{"id":"case-1"}],"total":1}`), nil
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-42/cases/search",
-			strings.NewReader(`{"pagination":{"limit":10,"offset":0},"stateKeys":["open"]}`)))
-		r.SetPathValue("id", projectID)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search",
+			strings.NewReader(`{"projectIds":["proj-1"],"stateKeys":["open"],"pagination":{"limit":10,"offset":0}}`)))
 		w := httptest.NewRecorder()
-		h.SearchProjectCases(w, r)
+		h.SearchCases(w, r)
 
 		assertStatus(t, w, http.StatusOK)
 		assertContentType(t, w, "application/json")
@@ -519,41 +494,13 @@ func TestSearchProjectCases(t *testing.T) {
 			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
 		var ids []string
-		if err := json.Unmarshal(sent["projectIds"], &ids); err != nil || len(ids) != 1 || ids[0] != projectID {
-			t.Errorf("upstream projectIds = %v, want [%q]", ids, projectID)
+		if err := json.Unmarshal(sent["projectIds"], &ids); err != nil || len(ids) != 1 || ids[0] != "proj-1" {
+			t.Errorf("upstream projectIds = %v, want [\"proj-1\"]", ids)
 		}
 
 		resp := decodeJSON[map[string]any](t, w)
 		if resp["total"] != float64(1) {
 			t.Errorf("total = %v, want 1", resp["total"])
-		}
-	})
-
-	t.Run("path project id overrides any projectIds in request body", func(t *testing.T) {
-		const projectID = "proj-authoritative"
-		var capturedBody []byte
-		client := &mockEntityCaseClient{
-			searchCasesFn: func(_ context.Context, body []byte) ([]byte, error) {
-				capturedBody = body
-				return []byte(`{"cases":[],"total":0}`), nil
-			},
-		}
-		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-authoritative/cases/search",
-			strings.NewReader(`{"projectIds":["proj-attacker","proj-other"]}`)))
-		r.SetPathValue("id", projectID)
-		w := httptest.NewRecorder()
-		h.SearchProjectCases(w, r)
-
-		assertStatus(t, w, http.StatusOK)
-
-		var sent map[string]json.RawMessage
-		if err := json.Unmarshal(capturedBody, &sent); err != nil {
-			t.Fatalf("upstream received invalid JSON: %v", err)
-		}
-		var ids []string
-		if err := json.Unmarshal(sent["projectIds"], &ids); err != nil || len(ids) != 1 || ids[0] != projectID {
-			t.Errorf("upstream projectIds = %v, want [%q] (path ID must win)", ids, projectID)
 		}
 	})
 
@@ -567,10 +514,9 @@ func TestSearchProjectCases(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/cases/search", strings.NewReader(`{}`)))
-				r.SetPathValue("id", "proj-1")
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
-				h.SearchProjectCases(w, r)
+				h.SearchCases(w, r)
 				assertStatus(t, w, tc.wantCode)
 				assertErrorMessage(t, w, tc.wantMsg)
 				assertContentType(t, w, "application/json")

--- a/apps/csm-portal/backend/internal/handler/deployments.go
+++ b/apps/csm-portal/backend/internal/handler/deployments.go
@@ -61,17 +61,12 @@ func NewDeploymentHandler(entity entityDeploymentClient) *DeploymentHandler {
 	return &DeploymentHandler{entity: entity}
 }
 
-// SearchDeployments handles POST /projects/{id}/deployments/search.
+// SearchDeployments handles POST /deployments/search.
+// Project IDs and other filters are accepted directly in the request body.
 func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
-		return
-	}
-
-	projectID := r.PathValue("id")
-	if projectID == "" {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
@@ -92,8 +87,6 @@ func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// TODO: Decode into a typed SearchDeploymentsRequest and validate fields before forwarding.
-
 	result, err := h.entity.SearchDeployments(r.Context(), body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchDeployments failed", "userID", user.UserID, "err", err)
@@ -101,7 +94,6 @@ func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// TODO: Unmarshal result and filter to only the fields required by the frontend.
 	writeJSON(w, http.StatusOK, result)
 }
 

--- a/apps/csm-portal/backend/internal/handler/deployments_test.go
+++ b/apps/csm-portal/backend/internal/handler/deployments_test.go
@@ -28,8 +28,7 @@ import (
 func TestSearchDeployments(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
-		r := httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(`{}`))
-		r.SetPathValue("id", "proj-1")
+		r := httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -37,20 +36,9 @@ func TestSearchDeployments(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("rejects missing project id", func(t *testing.T) {
-		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects//deployments/search", strings.NewReader(`{}`)))
-		w := httptest.NewRecorder()
-		h.SearchDeployments(w, r)
-		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgBadRequest)
-		assertContentType(t, w, "application/json")
-	})
-
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
-		r.SetPathValue("id", "proj-1")
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -60,8 +48,7 @@ func TestSearchDeployments(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(`not-json`)))
-		r.SetPathValue("id", "proj-1")
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -69,8 +56,8 @@ func TestSearchDeployments(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
-		const reqPayload = `{"searchQuery":"prod","deploymentTypeKeys":["primary_production"]}`
+	t.Run("forwards body to upstream and returns 200", func(t *testing.T) {
+		const reqPayload = `{"projectIds":["proj-1"],"searchQuery":"prod","deploymentTypeKeys":["primary_production"]}`
 		var capturedBody []byte
 		client := &mockEntityDeploymentClient{
 			searchDeploymentsFn: func(_ context.Context, body []byte) ([]byte, error) {
@@ -79,8 +66,7 @@ func TestSearchDeployments(t *testing.T) {
 			},
 		}
 		h := NewDeploymentHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(reqPayload)))
-		r.SetPathValue("id", "proj-1")
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(reqPayload)))
 		w := httptest.NewRecorder()
 		h.SearchDeployments(w, r)
 
@@ -105,8 +91,7 @@ func TestSearchDeployments(t *testing.T) {
 					},
 				}
 				h := NewDeploymentHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/projects/proj-1/deployments/search", strings.NewReader(`{}`)))
-				r.SetPathValue("id", "proj-1")
+				r := withUser(httptest.NewRequest(http.MethodPost, "/deployments/search", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
 				h.SearchDeployments(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -653,17 +653,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /projects/{id}/deployments/search:
+  /deployments/search:
     post:
-      summary: Search deployments of a project.
-      operationId: postProjectsIdDeploymentsSearch
-      parameters:
-        - name: id
-          in: path
-          description: ID of the project
-          required: true
-          schema:
-            type: string
+      summary: Search deployments.
+      operationId: postDeploymentsSearch
       requestBody:
         description: Deployment search payload
         content:
@@ -686,6 +679,18 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
           content:
             application/json:
               schema:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -598,23 +598,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /projects/{id}/cases/search:
+  /cases/search:
     post:
-      summary: Search cases for a specific project.
-      operationId: postProjectsIdCasesSearch
-      parameters:
-        - name: id
-          in: path
-          description: ID of the project
-          required: true
-          schema:
-            type: string
+      summary: Search cases.
+      operationId: postCasesSearch
       requestBody:
-        description: Project case search payload
+        description: Case search payload
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProjectCaseSearchPayload'
+              $ref: '#/components/schemas/CaseSearchPayload'
         required: true
       responses:
         "200":
@@ -637,12 +630,6 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "403":
           description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-        "404":
-          description: NotFound
           content:
             application/json:
               schema:
@@ -948,11 +935,15 @@ components:
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
           description: Nature of the issue
 
-    ProjectCaseSearchPayload:
+    CaseSearchPayload:
       type: object
       nullable: true
-      description: Case search payload for a project-scoped search. The project ID is taken from the URL path; any projectIds in the body are ignored.
       properties:
+        projectIds:
+          type: array
+          items:
+            type: string
+          description: Filter by project IDs (optional)
         pagination:
           allOf:
             - $ref: '#/components/schemas/Pagination'

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -634,6 +634,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
           content:


### PR DESCRIPTION
## Summary

Flattens two project-scoped search endpoints so callers supply filter IDs directly in the request body instead of the URL path.

### POST /cases/search (replaces POST /projects/{id}/cases/search)
- Removes `injectProjectID` helper — body forwarded as-is (raw passthrough)
- Renames `ProjectCaseSearchPayload` → `CaseSearchPayload`; adds optional `projectIds` filter field
- Adds `404` response (missing from old spec; `mapUpstreamError` can return it)

### POST /deployments/search (replaces POST /projects/{id}/deployments/search)
- Removes the unused path param extraction — `DeploymentSearchPayload` already had `projectIds`
- Adds `403` and `404` responses (both missing from old spec)

## Test plan
- [x] `make test` passes
- [x] `POST /cases/search` with `{"projectIds":["<uuid>"]}` returns matching cases
- [x] `POST /cases/search` with no `projectIds` returns all accessible cases
- [x] `POST /deployments/search` with `{"projectIds":["<uuid>"]}` returns matching deployments
- [x] Old project-scoped paths return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)