### PR TITLE
feat(csm-portal): case create, server-side filters, dashboard matrix, deep-link fix

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -21,6 +21,7 @@ import ErrorLayout from "@layouts/ErrorLayout";
 import CsmComingSoonPage from "@features/csm-coming-soon/pages/CsmComingSoonPage";
 import CsmDashboardPage from "@features/csm-dashboard/pages/CsmDashboardPage";
 import CsmCasesPage from "@features/csm-cases/pages/CsmCasesPage";
+import CsmCaseCreatePage from "@features/csm-cases/pages/CsmCaseCreatePage";
 import CsmCaseDetailPage from "@features/csm-cases/pages/CsmCaseDetailPage";
 import CsmAdminLayout from "@features/csm-admin/pages/CsmAdminLayout";
 import CsmUsersPage from "@features/csm-users/pages/CsmUsersPage";
@@ -112,6 +113,7 @@ export default function App(): JSX.Element {
 
                 <Route path="dashboard" element={<CsmDashboardPage />} />
                 <Route path="cases" element={<CsmCasesPage />} />
+                <Route path="cases/new" element={<CsmCaseCreatePage />} />
                 <Route path="cases/:caseId" element={<CsmCaseDetailPage />} />
 
                 {/* WIP placeholders for top-level features awaiting BFF support */}

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -36,6 +36,17 @@ import { SuccessBannerProvider } from "@context/success-banner/SuccessBannerCont
 import { LoaderProvider } from "@context/linear-loader/LoaderContext";
 import { ErrorPageProvider } from "@context/error-page/ErrorPageContext";
 
+/**
+ * Landing for `/`. Defers to AuthGuard's post-login deep-link restore when a
+ * redirect is pending (rendering nothing so it doesn't race the restore);
+ * otherwise sends the user to the default `/accounts` landing. A pure read of
+ * sessionStorage — AuthGuard owns clearing the key.
+ */
+function RootLanding(): JSX.Element | null {
+  const pending = sessionStorage.getItem("post_login_redirect");
+  return pending ? null : <Navigate to="/accounts" replace />;
+}
+
 export default function App(): JSX.Element {
   return (
     <LoaderProvider>
@@ -69,7 +80,7 @@ export default function App(): JSX.Element {
               />
 
               <Route element={<AuthGuard />}>
-                <Route path="/" element={<Navigate to="/accounts" replace />} />
+                <Route path="/" element={<RootLanding />} />
 
                 {/* BFF-backed pages (entity-service search endpoints) */}
                 <Route path="accounts" element={<CsmAccountsPage />} />

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -39,12 +39,12 @@ import { ErrorPageProvider } from "@context/error-page/ErrorPageContext";
 /**
  * Landing for `/`. Defers to AuthGuard's post-login deep-link restore when a
  * redirect is pending (rendering nothing so it doesn't race the restore);
- * otherwise sends the user to the default `/accounts` landing. A pure read of
+ * otherwise sends the user to the default `/dashboard` landing. A pure read of
  * sessionStorage — AuthGuard owns clearing the key.
  */
 function RootLanding(): JSX.Element | null {
   const pending = sessionStorage.getItem("post_login_redirect");
-  return pending ? null : <Navigate to="/accounts" replace />;
+  return pending ? null : <Navigate to="/dashboard" replace />;
 }
 
 export default function App(): JSX.Element {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDeployedProductSearchPayload,
+  BeDeployedProductSearchResponse,
+  BeProductSearchPayload,
+  BeProductSearchResponse,
+  BeProductVersionSearchPayload,
+  BeProductVersionSearchResponse,
+} from "@api/backend/types";
+
+const PAGE_LIMIT = 200;
+const PRODUCTS_LIMIT = 500;
+
+export interface DeployedProductOption {
+  /** Deployed-product id — the value the case-create payload needs. */
+  id: string;
+  /** Human label: "{product name} {version}". */
+  label: string;
+}
+
+/**
+ * Selectable deployed products for a deployment. The deployed-product records
+ * (`POST /deployments/{id}/products/search`) carry only `productId` /
+ * `productVersionId`, so this resolves readable labels via `POST
+ * /products/search` (id → name) and `POST /products/{id}/versions/search`
+ * (id → version). Disabled until a deployment id is provided.
+ */
+export function useDeployedProductOptions(
+  deploymentId: string | undefined,
+): UseQueryResult<DeployedProductOption[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<DeployedProductOption[], Error>({
+    queryKey: [ApiQueryKeys.DEPLOYMENT_PRODUCTS, deploymentId ?? ""],
+    queryFn: async (): Promise<DeployedProductOption[]> => {
+      const dpRes = await api.post<
+        BeDeployedProductSearchPayload,
+        BeDeployedProductSearchResponse
+      >(`/deployments/${encodeURIComponent(deploymentId as string)}/products/search`, {
+        pagination: { offset: 0, limit: PAGE_LIMIT },
+      });
+      const deployed = dpRes.deployedProducts ?? [];
+      if (deployed.length === 0) return [];
+
+      const productIds = [
+        ...new Set(
+          deployed.map((d) => d.productId).filter((v): v is string => !!v),
+        ),
+      ];
+
+      const [productsRes, versionLists] = await Promise.all([
+        api.post<BeProductSearchPayload, BeProductSearchResponse>(
+          "/products/search",
+          { pagination: { offset: 0, limit: PRODUCTS_LIMIT } },
+        ),
+        Promise.all(
+          productIds.map((pid) =>
+            api
+              .post<
+                BeProductVersionSearchPayload,
+                BeProductVersionSearchResponse
+              >(`/products/${encodeURIComponent(pid)}/versions/search`, {
+                pagination: { offset: 0, limit: PAGE_LIMIT },
+              })
+              .then((r) => r.productVersions ?? [])
+              .catch(() => []),
+          ),
+        ),
+      ]);
+
+      const productName = new Map(
+        (productsRes.products ?? []).map((p) => [p.id, p.name ?? p.id]),
+      );
+      const versionLabel = new Map<string, string>();
+      for (const versions of versionLists) {
+        for (const v of versions) versionLabel.set(v.id, v.version ?? "");
+      }
+
+      return deployed.map((d) => {
+        const name = (d.productId && productName.get(d.productId)) || "Product";
+        const ver =
+          (d.productVersionId && versionLabel.get(d.productVersionId)) || "";
+        return { id: d.id, label: ver ? `${name} ${ver}` : name };
+      });
+    },
+    enabled: !!deploymentId,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -66,11 +66,33 @@ export function useDeployedProductOptions(
         ),
       ];
 
-      const [productsRes, versionLists] = await Promise.all([
-        api.post<BeProductSearchPayload, BeProductSearchResponse>(
-          "/products/search",
-          { pagination: { offset: 0, limit: PRODUCTS_LIMIT } },
-        ),
+      // `/products/search` has no id filter, so page through it collecting
+      // names for the referenced product ids only — stop once every id is
+      // resolved or the catalog is exhausted. Without this, products beyond
+      // the first page collapse to a generic fallback label.
+      const productName = new Map<string, string>();
+      const unresolved = new Set(productIds);
+      const resolveProductNames = async (): Promise<void> => {
+        for (let offset = 0; unresolved.size > 0; offset += PRODUCTS_LIMIT) {
+          const res = await api.post<
+            BeProductSearchPayload,
+            BeProductSearchResponse
+          >("/products/search", {
+            pagination: { offset, limit: PRODUCTS_LIMIT },
+          });
+          const page = res.products ?? [];
+          for (const p of page) {
+            if (unresolved.has(p.id)) {
+              productName.set(p.id, p.name ?? p.id);
+              unresolved.delete(p.id);
+            }
+          }
+          if (page.length < PRODUCTS_LIMIT) break;
+        }
+      };
+
+      const [, versionLists] = await Promise.all([
+        resolveProductNames(),
         Promise.all(
           productIds.map((pid) =>
             api
@@ -86,16 +108,18 @@ export function useDeployedProductOptions(
         ),
       ]);
 
-      const productName = new Map(
-        (productsRes.products ?? []).map((p) => [p.id, p.name ?? p.id]),
-      );
       const versionLabel = new Map<string, string>();
       for (const versions of versionLists) {
         for (const v of versions) versionLabel.set(v.id, v.version ?? "");
       }
 
       return deployed.map((d) => {
-        const name = (d.productId && productName.get(d.productId)) || "Product";
+        // Fall back to the product id (not a generic "Product") so distinct
+        // unresolved products stay distinguishable in the selector.
+        const name =
+          (d.productId && productName.get(d.productId)) ||
+          d.productId ||
+          "Product";
         const ver =
           (d.productVersionId && versionLabel.get(d.productVersionId)) || "";
         return { id: d.id, label: ver ? `${name} ${ver}` : name };

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -26,8 +26,8 @@ import type {
   BeProductVersionSearchResponse,
 } from "@api/backend/types";
 
-const PAGE_LIMIT = 200;
-const PRODUCTS_LIMIT = 500;
+const PAGE_LIMIT = 100;
+const PRODUCTS_LIMIT = 100; // backend caps pagination limit at 100
 
 export interface DeployedProductOption {
   /** Deployed-product id — the value the case-create payload needs. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -68,6 +68,7 @@ function detailFromBeCase(
     description: c.description ?? "",
     assignmentGroup: "grp.cre_team",
     createdBy: reporter,
+    createdByEmail: c.createdBy?.email,
     customerContext: {
       accountName: customer,
       tier: "subscription",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -170,6 +170,9 @@ export function useGetCsmCases(
           assigneeIsMe: false,
           slaClockType: "ack",
           minutesToBreach: 0,
+          // No SLA data from the backend yet — keep the SLA column neutral
+          // rather than painting every open row orange with a bogus "0m left".
+          hasSla: false,
           createdAt: c.createdAt ?? "",
           updatedAt: c.updatedAt ?? c.createdAt ?? "",
         };

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -18,7 +18,12 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
-import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
+import {
+  beStateFromUi,
+  priorityFromSeverity,
+  severityFromPriority,
+  uiStateFromBe,
+} from "@api/backend/mappers";
 import type {
   BeAccountSearchPayload,
   BeAccountSearchResponse,
@@ -28,7 +33,7 @@ import type {
   BeProjectSearchResponse,
 } from "@api/backend/types";
 import { getMockCsmCases } from "@features/csm-cases/api/mocks/casesMocks";
-import type { DashboardScope } from "@features/csm-dashboard/types/abtDashboard";
+import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import type {
   CsmCaseRow,
   CsmCasesListResponse,
@@ -39,7 +44,7 @@ const MOCK_LATENCY_MS = 200;
 /** Page size for the cross-project case list (server-side filtering TBD). */
 const CASES_PAGE_LIMIT = 100;
 /** Page size for the project / account name lookups (customer column). */
-const LOOKUP_PAGE_LIMIT = 200;
+const LOOKUP_PAGE_LIMIT = 100; // backend caps pagination limit at 100
 
 /**
  * Cross-project CSM cases list.
@@ -51,32 +56,52 @@ const LOOKUP_PAGE_LIMIT = 200;
  * (projectId → accountId) + `accounts/search` (accountId → name) rather than
  * the old per-project fan-out.
  *
- * Filtering is still applied client-side in `CsmCasesPage`; pushing filters
- * into the search payload (searchQuery / priorityKeys / stateKeys / projectIds)
- * and true pagination are the follow-up. The BE has no assignee field, so the
- * `scope` parameter remains a no-op in LIVE.
+ * Severity / state filters are pushed into the search payload (priorityKeys /
+ * stateKeys); the remaining filters stay client-side in `CsmCasesPage`
+ * (`applyFilters`), which also drives MOCK mode. The BE has no assignee field,
+ * so `scope` / assignee filters remain inert in LIVE.
  */
 export function useGetCsmCases(
-  scope: DashboardScope,
+  filters: CasesFilters,
 ): UseQueryResult<CsmCasesListResponse, Error> {
   const logger = useLogger();
   const api = useBackendApi();
 
   return useQuery<CsmCasesListResponse, Error>({
-    queryKey: [ApiQueryKeys.CSM_CASES, scope],
+    queryKey: [
+      ApiQueryKeys.CSM_CASES,
+      filters.scope,
+      filters.severities,
+      filters.states,
+      filters.projects,
+    ],
     queryFn: async (): Promise<CsmCasesListResponse> => {
       if (isMockMode()) {
-        logger.debug(`[useGetCsmCases] Returning mock cases for scope=${scope}`);
+        logger.debug(
+          `[useGetCsmCases] Returning mock cases for scope=${filters.scope}`,
+        );
         await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
-        return getMockCsmCases(scope);
+        return getMockCsmCases(filters.scope);
       }
 
       // One cross-project case search, plus project/account lookups for the
       // customer column (cases embed the project, but not its account).
+      // Severity / state filters are applied server-side via the search
+      // payload; the rest stay client-side in CsmCasesPage.
       const [casesResponse, projectsResponse, accountsResponse] =
         await Promise.all([
           api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
             pagination: { offset: 0, limit: CASES_PAGE_LIMIT },
+            ...(filters.severities.length > 0 && {
+              priorityKeys: filters.severities.map(priorityFromSeverity),
+            }),
+            ...(filters.states.length > 0 && {
+              stateKeys: filters.states.map(beStateFromUi),
+            }),
+            // `filters.projects` holds project IDs (the filter is id-based).
+            ...(filters.projects.length > 0 && {
+              projectIds: filters.projects,
+            }),
           }),
           api
             .post<BeProjectSearchPayload, BeProjectSearchResponse>(
@@ -150,7 +175,7 @@ export function useGetCsmCases(
         };
       });
 
-      return { scope, cases };
+      return { scope: filters.scope, cases };
     },
     staleTime: 30_000,
   });

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
@@ -31,11 +31,18 @@ export function useProjectOptions(): UseQueryResult<BeProject[], Error> {
   return useQuery<BeProject[], Error>({
     queryKey: ["csm-case-create-projects"],
     queryFn: async (): Promise<BeProject[]> => {
-      const res = await api.post<
-        BeProjectSearchPayload,
-        BeProjectSearchResponse
-      >("/projects/search", { pagination: { offset: 0, limit: PAGE_LIMIT } });
-      return res.projects ?? [];
+      // Page through so projects beyond the first page are still selectable.
+      const all: BeProject[] = [];
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const res = await api.post<
+          BeProjectSearchPayload,
+          BeProjectSearchResponse
+        >("/projects/search", { pagination: { offset, limit: PAGE_LIMIT } });
+        const page = res.projects ?? [];
+        all.push(...page);
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return all;
     },
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeProject,
+  BeProjectSearchPayload,
+  BeProjectSearchResponse,
+} from "@api/backend/types";
+
+const PAGE_LIMIT = 500;
+
+/** Projects for the case-create project selector, via `POST /projects/search`. */
+export function useProjectOptions(): UseQueryResult<BeProject[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProject[], Error>({
+    queryKey: ["csm-case-create-projects"],
+    queryFn: async (): Promise<BeProject[]> => {
+      const res = await api.post<
+        BeProjectSearchPayload,
+        BeProjectSearchResponse
+      >("/projects/search", { pagination: { offset: 0, limit: PAGE_LIMIT } });
+      return res.projects ?? [];
+    },
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
@@ -22,7 +22,7 @@ import type {
   BeProjectSearchResponse,
 } from "@api/backend/types";
 
-const PAGE_LIMIT = 500;
+const PAGE_LIMIT = 100; // backend caps pagination limit at 100
 
 /** Projects for the case-create project selector, via `POST /projects/search`. */
 export function useProjectOptions(): UseQueryResult<BeProject[], Error> {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDeployment,
+  BeDeploymentSearchPayload,
+  BeDeploymentSearchResponse,
+} from "@api/backend/types";
+
+const PAGE_LIMIT = 200;
+
+/**
+ * Deployments belonging to a project, via `POST /deployments/search`
+ * (`projectIds: [projectId]`). Used by the case-create cascade once a project
+ * is picked. Disabled until a project id is provided.
+ */
+export function useSearchDeployments(
+  projectId: string | undefined,
+): UseQueryResult<BeDeployment[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeDeployment[], Error>({
+    queryKey: [ApiQueryKeys.DEPLOYMENTS, projectId ?? ""],
+    queryFn: async (): Promise<BeDeployment[]> => {
+      const res = await api.post<
+        BeDeploymentSearchPayload,
+        BeDeploymentSearchResponse
+      >("/deployments/search", {
+        projectIds: projectId ? [projectId] : [],
+        pagination: { offset: 0, limit: PAGE_LIMIT },
+      });
+      return res.deployments ?? [];
+    },
+    enabled: !!projectId,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
@@ -38,14 +38,21 @@ export function useSearchDeployments(
   return useQuery<BeDeployment[], Error>({
     queryKey: [ApiQueryKeys.DEPLOYMENTS, projectId ?? ""],
     queryFn: async (): Promise<BeDeployment[]> => {
-      const res = await api.post<
-        BeDeploymentSearchPayload,
-        BeDeploymentSearchResponse
-      >("/deployments/search", {
-        projectIds: projectId ? [projectId] : [],
-        pagination: { offset: 0, limit: PAGE_LIMIT },
-      });
-      return res.deployments ?? [];
+      // Page through so deployments beyond the first page stay selectable.
+      const all: BeDeployment[] = [];
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const res = await api.post<
+          BeDeploymentSearchPayload,
+          BeDeploymentSearchResponse
+        >("/deployments/search", {
+          projectIds: projectId ? [projectId] : [],
+          pagination: { offset, limit: PAGE_LIMIT },
+        });
+        const page = res.deployments ?? [];
+        all.push(...page);
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return all;
     },
     enabled: !!projectId,
     staleTime: 60_000,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
@@ -23,7 +23,7 @@ import type {
   BeDeploymentSearchResponse,
 } from "@api/backend/types";
 
-const PAGE_LIMIT = 200;
+const PAGE_LIMIT = 100; // backend caps pagination limit at 100
 
 /**
  * Deployments belonging to a project, via `POST /deployments/search`

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
+import { getMockCsmCaseDetailById } from "@features/csm-cases/api/mocks/casesMocks";
+import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
+
+/**
+ * Build a case-detail fixture in a given state with an explicit `nextStates`,
+ * reusing the seeded mock so every other required field is realistic.
+ */
+function caseInState(
+  state: CaseState,
+  nextStates: CaseState[] | undefined,
+): CsmCaseDetail {
+  const base = getMockCsmCaseDetailById("case-1001");
+  if (!base) throw new Error("mock case-1001 missing");
+  return { ...base, state, nextStates };
+}
+
+describe("CaseActionBar — nextStates-driven buttons", () => {
+  it("renders one button per backend nextState", () => {
+    // The reported bug: a solution_proposed case returns
+    // nextStates [closed, waiting_on_wso2] but only "Close" showed because the
+    // resume action was hardwired to work_in_progress. Both must now appear.
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("solution_proposed", [
+          "closed",
+          "waiting_on_wso2",
+        ])}
+        onAction={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /resume work/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^close$/i })).toBeInTheDocument();
+  });
+
+  it("shows exactly the transitions the backend permits, nothing more", () => {
+    // work_in_progress could move many ways, but the backend here only allows
+    // two — so only those two buttons render.
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("work_in_progress", [
+          "solution_proposed",
+          "awaiting_info",
+        ])}
+        onAction={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /propose solution/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /request info/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^close$/i })).not.toBeInTheDocument();
+  });
+
+  it("labels the move into Waiting on WSO2 by source: pause vs resume", () => {
+    // From WIP it is a deliberate pause...
+    const { unmount } = render(
+      <CaseActionBar
+        caseDetail={caseInState("work_in_progress", ["waiting_on_wso2"])}
+        onAction={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resume work/i })).not.toBeInTheDocument();
+    unmount();
+
+    // ...but from a paused state (awaiting_info) the same target reads "Resume".
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("awaiting_info", ["waiting_on_wso2"])}
+        onAction={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /resume work/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
+  });
+
+  it("dispatches the action with the backend nextState as the PATCH target", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("solution_proposed", [
+          "closed",
+          "waiting_on_wso2",
+        ])}
+        onAction={onAction}
+      />,
+    );
+    // "Resume work" has no confirm dialog, so it dispatches immediately. The
+    // target must be the real backend nextState (waiting_on_wso2), not a
+    // re-derived guess (work_in_progress).
+    fireEvent.click(screen.getByRole("button", { name: /resume work/i }));
+    expect(onAction).toHaveBeenCalledWith("resume_work", "waiting_on_wso2");
+  });
+
+  it("falls back to the known graph when nextStates is absent", () => {
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("work_in_progress", undefined)}
+        onAction={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /propose solution/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /request info/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^close$/i })).toBeInTheDocument();
+  });
+
+  it("shows no state-change buttons when nextStates is empty (terminal case)", () => {
+    // An empty nextStates is meaningful: a closed/terminal case has no next
+    // step, so it must offer none and not fall back to the graph.
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("closed", [])}
+        onAction={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /resume work/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reopen/i })).not.toBeInTheDocument();
+    // The state-independent "More" overflow is unaffected.
+    expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
+  });
+
+  it("keeps the lead-only Reopen override on a closed case regardless of nextStates", () => {
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("closed", [])}
+        onAction={() => {}}
+        canReopenClosed
+      />,
+    );
+    expect(screen.getByRole("button", { name: /reopen/i })).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -179,7 +179,7 @@ const EDGE_OVERRIDES: Partial<
       label: "Start work",
       color: "primary",
       icon: <Play size={16} />,
-      tooltip: "Assigns this case to you and moves it to Work in progress.",
+      tooltip: "Moves this case to Work in progress.",
     },
   },
   awaiting_info: {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -104,13 +104,13 @@ const PRIMARY_BY_STATE: Record<CaseState, PrimaryAction[]> = {
     {
       action: "request_info",
       label: "Request info",
-      color: "warning",
+      color: "primary",
       icon: <Inbox size={16} />,
     },
     {
       action: "wait_on_wso2",
       label: "Wait on WSO2",
-      color: "warning",
+      color: "primary",
       icon: <Clock size={16} />,
     },
   ],
@@ -147,7 +147,7 @@ const PRIMARY_BY_STATE: Record<CaseState, PrimaryAction[]> = {
     {
       action: "close_no_response",
       label: "Close (no response)",
-      color: "warning",
+      color: "primary",
       icon: <CheckCircle size={16} />,
       confirm: {
         title: "Close without a customer response?",
@@ -187,7 +187,7 @@ const PRIMARY_BY_STATE: Record<CaseState, PrimaryAction[]> = {
 const REOPEN_ACTION: PrimaryAction = {
   action: "reopen",
   label: "Reopen",
-  color: "warning",
+  color: "primary",
   icon: <RotateCcw size={16} />,
   tooltip: "Lead-only: reopen a closed case for an exceptional follow-up.",
   confirm: {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -60,8 +60,16 @@ type ActionConfirm = {
   confirmColor: "primary" | "error" | "warning";
 };
 
-type PrimaryAction = {
+type StateAction = {
   action: CaseLifecycleAction;
+  /**
+   * The state this transition moves the case into. It comes straight from the
+   * backend's `nextStates`, and the same value is what the PATCH writes — so the
+   * button the engineer sees and the transition that is persisted can never
+   * drift apart. (The earlier bug was a hand-maintained action→state map that
+   * disagreed with the backend graph and silently dropped valid buttons.)
+   */
+  targetState: CaseState;
   label: string;
   color: "primary" | "success" | "warning" | "error";
   icon: JSX.Element;
@@ -76,116 +84,189 @@ type PrimaryAction = {
   confirm?: ActionConfirm;
 };
 
-const PRIMARY_BY_STATE: Record<CaseState, PrimaryAction[]> = {
-  // Self-assignment moves the case to WIP (ISSU-002), so "Start work" and a
-  // separate "Assign to me" were the same transition — collapsed to one.
-  open: [
-    {
+const CLOSE_CONFIRM: ActionConfirm = {
+  title: "Close this case?",
+  body: "The customer receives a closure notification and the case moves to “Closed”. Once closed, the case cannot be reopened.",
+  confirmLabel: "Close case",
+  confirmColor: "warning",
+};
+
+/**
+ * Default button for a transition *into* `target`, used whenever the
+ * (source → target) edge needs no source-specific wording. The label describes
+ * the destination; `targetState` is what gets PATCHed.
+ */
+function defaultActionFor(target: CaseState): StateAction | null {
+  switch (target) {
+    case "work_in_progress":
+      // Reached from a paused/parked sub-state — the engineer is un-pausing.
+      return {
+        action: "resume_work",
+        targetState: target,
+        label: "Resume work",
+        color: "primary",
+        icon: <Play size={16} />,
+      };
+    case "waiting_on_wso2":
+      return {
+        action: "wait_on_wso2",
+        targetState: target,
+        label: "Wait on WSO2",
+        color: "primary",
+        icon: <Clock size={16} />,
+      };
+    case "awaiting_info":
+      return {
+        action: "request_info",
+        targetState: target,
+        label: "Request info",
+        color: "primary",
+        icon: <Inbox size={16} />,
+      };
+    case "solution_proposed":
+      return {
+        action: "propose_solution",
+        targetState: target,
+        label: "Propose solution",
+        color: "success",
+        icon: <Send size={16} />,
+        confirm: {
+          title: "Propose solution to the customer?",
+          body: "The customer is notified that a solution has been proposed and the case moves to “Solution proposed”.",
+          confirmLabel: "Propose solution",
+          confirmColor: "primary",
+        },
+      };
+    case "closed":
+      return {
+        action: "close",
+        targetState: target,
+        label: "Close",
+        color: "success",
+        icon: <CheckCircle size={16} />,
+        confirm: CLOSE_CONFIRM,
+      };
+    case "reopen":
+      return {
+        action: "reopen",
+        targetState: target,
+        label: "Reopen",
+        color: "primary",
+        icon: <RotateCcw size={16} />,
+      };
+    // `open` is an initial state, not a transition target the bar offers.
+    case "open":
+    default:
+      return null;
+  }
+}
+
+/**
+ * Source-specific overrides where the label depends on *where the case is
+ * coming from*, not just where it is going. The clearest case is the move into
+ * Waiting on WSO2: from Work in progress it is a deliberate "Wait on WSO2"
+ * pause, but from a paused/parked state (Awaiting info, Solution proposed,
+ * Reopened) the same target means the engineer is *resuming* the case. Anything
+ * not listed here falls back to `defaultActionFor`.
+ */
+const EDGE_OVERRIDES: Partial<
+  Record<CaseState, Partial<Record<CaseState, StateAction>>>
+> = {
+  open: {
+    work_in_progress: {
       action: "start_work",
+      targetState: "work_in_progress",
       label: "Start work",
       color: "primary",
       icon: <Play size={16} />,
       tooltip: "Assigns this case to you and moves it to Work in progress.",
     },
-  ],
-  work_in_progress: [
-    {
-      action: "propose_solution",
-      label: "Propose solution",
-      color: "success",
-      icon: <Send size={16} />,
-      confirm: {
-        title: "Propose solution to the customer?",
-        body: "The customer is notified that a solution has been proposed and the case moves to “Solution proposed”.",
-        confirmLabel: "Propose solution",
-        confirmColor: "primary",
-      },
-    },
-    {
-      action: "request_info",
-      label: "Request info",
-      color: "primary",
-      icon: <Inbox size={16} />,
-    },
-    {
-      action: "wait_on_wso2",
-      label: "Wait on WSO2",
-      color: "primary",
-      icon: <Clock size={16} />,
-    },
-  ],
-  // Resume work first (the safe, recoverable default); "Mark resolved" is the
-  // irreversible, customer-notifying action so it is demoted to outlined AND
-  // gated behind a confirmation.
-  solution_proposed: [
-    {
+  },
+  awaiting_info: {
+    waiting_on_wso2: {
       action: "resume_work",
+      targetState: "waiting_on_wso2",
+      label: "Resume work",
+      color: "primary",
+      icon: <Play size={16} />,
+    },
+  },
+  solution_proposed: {
+    waiting_on_wso2: {
+      action: "resume_work",
+      targetState: "waiting_on_wso2",
       label: "Resume work",
       color: "primary",
       icon: <RotateCcw size={16} />,
     },
-    {
-      action: "close",
-      label: "Close",
-      color: "success",
-      icon: <CheckCircle size={16} />,
-      confirm: {
-        title: "Close this case?",
-        body: "The customer receives a closure notification and the case moves to “Closed”. Once closed, the case cannot be reopened.",
-        confirmLabel: "Close case",
-        confirmColor: "warning",
-      },
-    },
-  ],
-  awaiting_info: [
-    {
+  },
+  reopen: {
+    waiting_on_wso2: {
       action: "resume_work",
+      targetState: "waiting_on_wso2",
       label: "Resume work",
       color: "primary",
       icon: <Play size={16} />,
     },
-    {
-      action: "close_no_response",
-      label: "Close (no response)",
-      color: "primary",
-      icon: <CheckCircle size={16} />,
-      confirm: {
-        title: "Close without a customer response?",
-        body: "The case is closed because the customer did not respond. They still receive a closure notification. Once closed, the case cannot be reopened.",
-        confirmLabel: "Close case",
-        confirmColor: "warning",
-      },
-    },
+  },
+};
+
+function actionFor(from: CaseState, to: CaseState): StateAction | null {
+  return EDGE_OVERRIDES[from]?.[to] ?? defaultActionFor(to);
+}
+
+/**
+ * Fallback target lists, mirroring the backend `nextStates` graph in
+ * `state.go`. Used only when the case carries no `nextStates` (e.g. mock data,
+ * or a backend that hasn't populated the field) so the bar still shows the
+ * expected actions. When the case *does* carry `nextStates`, that drives the
+ * buttons directly and this map is ignored.
+ */
+const FALLBACK_TARGETS: Record<CaseState, CaseState[]> = {
+  open: ["work_in_progress"],
+  work_in_progress: [
+    "solution_proposed",
+    "awaiting_info",
+    "waiting_on_wso2",
+    "closed",
   ],
-  waiting_on_wso2: [
-    {
-      action: "resume_work",
-      label: "Resume work",
-      color: "primary",
-      icon: <Play size={16} />,
-    },
-  ],
-  reopen: [
-    {
-      action: "start_work",
-      label: "Start work",
-      color: "primary",
-      icon: <Play size={16} />,
-    },
-  ],
-  // Closed is terminal for engineers and customers. Reopening is a lead-only
-  // override (see REOPEN_ACTION + the `canReopenClosed` prop) and is appended
-  // separately, so the default closed case offers no reopen path.
+  solution_proposed: ["waiting_on_wso2", "closed"],
+  awaiting_info: ["waiting_on_wso2"],
+  waiting_on_wso2: ["work_in_progress"],
+  reopen: ["waiting_on_wso2"],
   closed: [],
 };
 
 /**
- * Lead-only override to reopen a closed case. Not part of PRIMARY_BY_STATE —
- * it is appended for the `closed` state only when the caller grants the
- * `canReopenClosed` capability, so normal engineers never see it.
+ * Display order for the lifecycle buttons. The forward/safe action sits first
+ * (it gets the contained emphasis); Close is always last so a destructive
+ * action is never the emphasised default. States not listed sort just before
+ * Close.
  */
-const REOPEN_ACTION: PrimaryAction = {
+const DISPLAY_ORDER: CaseState[] = [
+  "solution_proposed",
+  "work_in_progress",
+  "awaiting_info",
+  "waiting_on_wso2",
+  "reopen",
+  "open",
+  "closed",
+];
+const CLOSED_RANK = DISPLAY_ORDER.indexOf("closed");
+function orderRank(s: CaseState): number {
+  const i = DISPLAY_ORDER.indexOf(s);
+  return i === -1 ? CLOSED_RANK - 0.5 : i;
+}
+
+/**
+ * Lead-only override to reopen a closed case. Not part of the normal
+ * `nextStates` flow — the backend reports a closed case as terminal
+ * (`nextStates: []`) — so it is appended for the `closed` state only when the
+ * caller grants the `canReopenClosed` capability.
+ */
+const REOPEN_ACTION: StateAction = {
   action: "reopen",
+  targetState: "reopen",
   label: "Reopen",
   color: "primary",
   icon: <RotateCcw size={16} />,
@@ -244,6 +325,7 @@ interface CaseActionBarProps {
   caseDetail: CsmCaseDetail;
   onAction: (
     action: CaseLifecycleAction | { secondary: string },
+    targetState?: CaseState,
   ) => void | Promise<unknown>;
   /**
    * Grants the lead-only "Reopen" action on a closed case. Defaults to false,
@@ -253,9 +335,11 @@ interface CaseActionBarProps {
 }
 
 /**
- * Lifecycle + overflow action bar for the case detail page. Primary buttons
- * are state-driven (only valid transitions show). Secondary actions live in
- * an overflow menu and are state-independent.
+ * Lifecycle + overflow action bar for the case detail page. Primary buttons are
+ * driven directly by the case's backend-supplied `nextStates`: one button per
+ * reachable state, so the bar always reflects exactly the transitions the
+ * backend permits. Secondary actions live in an overflow menu and are
+ * state-independent.
  */
 export default function CaseActionBar({
   caseDetail,
@@ -263,23 +347,34 @@ export default function CaseActionBar({
   canReopenClosed = false,
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [pendingConfirm, setPendingConfirm] = useState<PrimaryAction | null>(
+  const [pendingConfirm, setPendingConfirm] = useState<StateAction | null>(
     null,
   );
+
+  const from = caseDetail.state;
+  // Render a button for every state the backend says the case can move to. When
+  // the field is absent (undefined — mock data / not yet populated) fall back to
+  // the known graph so the bar isn't empty. An explicit empty list (a terminal
+  // case, e.g. Closed) correctly yields no lifecycle buttons.
+  const targets = caseDetail.nextStates ?? FALLBACK_TARGETS[from] ?? [];
+  const lifecycle = [...new Set(targets)]
+    .sort((a, b) => orderRank(a) - orderRank(b))
+    .map((to) => actionFor(from, to))
+    .filter((a): a is StateAction => a !== null);
   const primary = [
-    ...(PRIMARY_BY_STATE[caseDetail.state] ?? []),
-    ...(caseDetail.state === "closed" && canReopenClosed
-      ? [REOPEN_ACTION]
-      : []),
+    ...lifecycle,
+    // Lead-only reopen is an override outside the normal `nextStates` flow, so
+    // it is gated by capability rather than by the backend transition list.
+    ...(from === "closed" && canReopenClosed ? [REOPEN_ACTION] : []),
   ];
   const secondary = buildSecondaryItems();
 
-  const runPrimary = (p: PrimaryAction): void => {
+  const runPrimary = (p: StateAction): void => {
     if (p.confirm) {
       setPendingConfirm(p);
       return;
     }
-    void onAction(p.action);
+    void onAction(p.action, p.targetState);
   };
 
   return (
@@ -371,7 +466,7 @@ export default function CaseActionBar({
             onClick={() => {
               const p = pendingConfirm;
               setPendingConfirm(null);
-              if (p) void onAction(p.action);
+              if (p) void onAction(p.action, p.targetState);
             }}
           >
             {pendingConfirm?.confirm?.confirmLabel ?? "Confirm"}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -123,21 +123,21 @@ export default function CaseActivitiesFeed({
         <Chip
           size="small"
           variant={showWorkNotes ? "filled" : "outlined"}
-          color={showWorkNotes ? "primary" : "default"}
+          color={showWorkNotes ? "info" : "default"}
           label={`Work notes (${counts.workNotes})`}
           onClick={() => setShowWorkNotes((v) => !v)}
         />
         <Chip
           size="small"
           variant={showLifecycle ? "filled" : "outlined"}
-          color={showLifecycle ? "primary" : "default"}
+          color={showLifecycle ? "info" : "default"}
           label={`State changes (${counts.lifecycle})`}
           onClick={() => setShowLifecycle((v) => !v)}
         />
         <Chip
           size="small"
           variant={showAttachments ? "filled" : "outlined"}
-          color={showAttachments ? "primary" : "default"}
+          color={showAttachments ? "info" : "default"}
           label={`Attachments (${counts.attachments})`}
           onClick={() => setShowAttachments((v) => !v)}
         />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -49,6 +49,7 @@ import type {
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import { isMockMode } from "@api/backend/client";
 
 export type SlaFilter = "any" | "breached" | "at_risk";
 
@@ -94,8 +95,8 @@ interface CasesFilterBarProps {
   onFiltersToggle: () => void;
   /** Full user directory shown in the assignee picker. */
   availableAssigneeUsers: AssigneeUser[];
-  /** Project names seen in the current data. */
-  availableProjects: string[];
+  /** Projects for the (id-based) project filter — value is the id, label the name. */
+  availableProjects: { id: string; name: string }[];
   /** Product names seen in the current data. */
   availableProducts: string[];
 }
@@ -217,6 +218,7 @@ interface SingleSelectFieldProps<T extends string> {
   value: T;
   options: { value: T; label: string }[];
   onChange: (next: T) => void;
+  disabled?: boolean;
 }
 
 function SingleSelectField<T extends string>({
@@ -225,9 +227,10 @@ function SingleSelectField<T extends string>({
   value,
   options,
   onChange,
+  disabled,
 }: SingleSelectFieldProps<T>): JSX.Element {
   return (
-    <FormControl fullWidth size="small">
+    <FormControl fullWidth size="small" disabled={disabled}>
       <InputLabel id={`${id}-label`}>{label}</InputLabel>
       <Select
         labelId={`${id}-label`}
@@ -259,6 +262,7 @@ interface SearchableMultiSelectProps {
   /** Optional filter against synthetic text (e.g. include email in the query). */
   getOptionSearchText?: (value: string) => string;
   onChange: (next: string[]) => void;
+  disabled?: boolean;
 }
 
 /**
@@ -277,6 +281,7 @@ function SearchableMultiSelect({
   getOptionSecondary,
   getOptionSearchText,
   onChange,
+  disabled,
 }: SearchableMultiSelectProps): JSX.Element {
   const format = formatOption ?? ((v: string) => v);
   const searchText = getOptionSearchText ?? format;
@@ -284,6 +289,7 @@ function SearchableMultiSelect({
     <Autocomplete
       multiple
       size="small"
+      disabled={disabled}
       id={id}
       options={options}
       value={values}
@@ -357,6 +363,13 @@ export default function CasesFilterBar({
   const activeCount = countActiveFilters(filters);
   const hasActive = activeCount > 0;
 
+  // Scope (ABT), assignee, and SLA have no backend support yet (no assignee or
+  // SLA fields), so disable them against the live backend — they only do
+  // anything against seeded mock data.
+  const beUnsupported = !isMockMode();
+  const beUnsupportedReason =
+    "Not available against the live backend yet (no assignee / SLA data).";
+
   const severityOptions = useMemo(
     () => ALL_SEVERITIES.map((s) => ({ value: s, label: s })),
     [],
@@ -364,6 +377,16 @@ export default function CasesFilterBar({
   const stateOptions = useMemo(
     () => PRIMARY_STATES.map((s) => ({ value: s, label: STATE_LABEL[s] })),
     [],
+  );
+
+  // Project filter is id-based: options are project ids, displayed by name.
+  const projectIdOptions = useMemo(
+    () => availableProjects.map((p) => p.id),
+    [availableProjects],
+  );
+  const projectNameById = useMemo(
+    () => new Map(availableProjects.map((p) => [p.id, p.name])),
+    [availableProjects],
   );
 
   // Pin "@me" and "Unassigned" to the top of the assignee option list, then
@@ -402,24 +425,30 @@ export default function CasesFilterBar({
       {/* Scope + search + filters toggle. Scope buttons are CSM-specific
           (My ABT vs All customers) and live alongside search at the top. */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
-        <Box sx={{ display: "flex", gap: 0.75 }}>
-          <Button
-            size="small"
-            variant={filters.scope === "my_abt" ? "contained" : "outlined"}
-            color="primary"
-            onClick={() => onChange({ ...filters, scope: "my_abt" })}
-          >
-            My ABT
-          </Button>
-          <Button
-            size="small"
-            variant={filters.scope === "all_customers" ? "contained" : "outlined"}
-            color="primary"
-            onClick={() => onChange({ ...filters, scope: "all_customers" })}
-          >
-            All customers
-          </Button>
-        </Box>
+        <Tooltip title={beUnsupported ? beUnsupportedReason : ""}>
+          <Box sx={{ display: "flex", gap: 0.75 }}>
+            <Button
+              size="small"
+              variant={filters.scope === "my_abt" ? "contained" : "outlined"}
+              color="primary"
+              disabled={beUnsupported}
+              onClick={() => onChange({ ...filters, scope: "my_abt" })}
+            >
+              My ABT
+            </Button>
+            <Button
+              size="small"
+              variant={
+                filters.scope === "all_customers" ? "contained" : "outlined"
+              }
+              color="primary"
+              disabled={beUnsupported}
+              onClick={() => onChange({ ...filters, scope: "all_customers" })}
+            >
+              All customers
+            </Button>
+          </Box>
+        </Tooltip>
 
         <Box sx={{ position: "relative", flex: 1, minWidth: 240 }}>
           <TextField
@@ -491,26 +520,38 @@ export default function CasesFilterBar({
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              <SingleSelectField
-                id="cases-filter-sla"
-                label="SLA"
-                value={filters.sla}
-                options={SLA_OPTIONS}
-                onChange={(next) => onChange({ ...filters, sla: next })}
-              />
+              <Tooltip title={beUnsupported ? beUnsupportedReason : ""}>
+                <Box>
+                  <SingleSelectField
+                    id="cases-filter-sla"
+                    label="SLA"
+                    value={filters.sla}
+                    options={SLA_OPTIONS}
+                    onChange={(next) => onChange({ ...filters, sla: next })}
+                    disabled={beUnsupported}
+                  />
+                </Box>
+              </Tooltip>
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              <SearchableMultiSelect
-                id="cases-filter-assignee"
-                label="Assignee"
-                placeholder="Search users…"
-                values={filters.assignees}
-                options={assigneeOptions}
-                formatOption={assigneeLabel}
-                getOptionSecondary={assigneeSecondary}
-                getOptionSearchText={assigneeSearchText}
-                onChange={(next) => onChange({ ...filters, assignees: next })}
-              />
+              <Tooltip title={beUnsupported ? beUnsupportedReason : ""}>
+                <Box>
+                  <SearchableMultiSelect
+                    id="cases-filter-assignee"
+                    label="Assignee"
+                    placeholder="Search users…"
+                    values={filters.assignees}
+                    options={assigneeOptions}
+                    formatOption={assigneeLabel}
+                    getOptionSecondary={assigneeSecondary}
+                    getOptionSearchText={assigneeSearchText}
+                    onChange={(next) =>
+                      onChange({ ...filters, assignees: next })
+                    }
+                    disabled={beUnsupported}
+                  />
+                </Box>
+              </Tooltip>
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
               <SearchableMultiSelect
@@ -518,7 +559,9 @@ export default function CasesFilterBar({
                 label="Project"
                 placeholder="Type a project…"
                 values={filters.projects}
-                options={availableProjects}
+                options={projectIdOptions}
+                formatOption={(id) => projectNameById.get(id) ?? id}
+                getOptionSearchText={(id) => projectNameById.get(id) ?? id}
                 onChange={(next) => onChange({ ...filters, projects: next })}
               />
             </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -121,6 +121,10 @@ export default function CasesList({
       {!isLoading &&
         cases.map((c) => {
           const breached = c.minutesToBreach < 0;
+          // SLA timing is only meaningful when the backend supplies it; absent
+          // (or explicitly true) → show the clock, false → neutral "—".
+          const hasSla = c.hasSla !== false;
+          const showSla = hasSla && c.state !== "closed";
           const handleClick = () => {
             navigate(`/cases/${c.id}`);
           };
@@ -188,15 +192,25 @@ export default function CasesList({
               <Box sx={{ textAlign: "right" }}>
                 <Typography
                   variant="body2"
-                  color={breached ? "error" : c.minutesToBreach <= 60 ? "warning.main" : "text.primary"}
+                  color={
+                    !showSla
+                      ? "text.primary"
+                      : breached
+                        ? "error"
+                        : c.minutesToBreach <= 60
+                          ? "warning.main"
+                          : "text.primary"
+                  }
                   noWrap
                 >
-                  {c.state === "closed"
-                    ? "—"
-                    : formatTimeToBreach(c.minutesToBreach)}
+                  {!showSla ? "—" : formatTimeToBreach(c.minutesToBreach)}
                 </Typography>
                 <Typography variant="caption" color="text.secondary" noWrap>
-                  {c.state === "closed" ? "Closed" : SLA_CLOCK_LABEL[c.slaClockType]}
+                  {c.state === "closed"
+                    ? "Closed"
+                    : hasSla
+                      ? SLA_CLOCK_LABEL[c.slaClockType]
+                      : "No SLA"}
                 </Typography>
               </Box>
               <Typography

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type JSX } from "react";
+import { useNavigate } from "react-router";
+import { priorityFromSeverity } from "@api/backend/mappers";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useProjectOptions } from "@features/csm-cases/api/useProjectOptions";
+import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
+import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
+import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
+import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type { BeCaseIssueType } from "@api/backend/types";
+
+const SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+
+const ISSUE_TYPES: { value: BeCaseIssueType; label: string }[] = [
+  { value: "total_outage", label: "Total outage" },
+  { value: "partial_outage", label: "Partial outage" },
+  { value: "performance_degradation", label: "Performance degradation" },
+  { value: "error", label: "Error" },
+  { value: "security_or_compliance", label: "Security / compliance" },
+  { value: "question", label: "Question" },
+];
+
+export default function CsmCaseCreatePage(): JSX.Element {
+  const navigate = useNavigate();
+  const { showError } = useErrorBanner();
+
+  const [projectId, setProjectId] = useState("");
+  const [deploymentId, setDeploymentId] = useState("");
+  const [deployedProductId, setDeployedProductId] = useState("");
+  const [severity, setSeverity] = useState<Severity | "">("");
+  const [issueType, setIssueType] = useState<BeCaseIssueType | "">("");
+  const [subject, setSubject] = useState("");
+  const [description, setDescription] = useState("");
+
+  const projects = useProjectOptions();
+  const deployments = useSearchDeployments(projectId || undefined);
+  const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
+  const postCase = usePostCsmCase();
+
+  const canSubmit = useMemo(
+    () =>
+      !!projectId &&
+      !!deploymentId &&
+      !!deployedProductId &&
+      !!severity &&
+      !!issueType &&
+      subject.trim().length > 0 &&
+      description.trim().length > 0 &&
+      !postCase.isPending,
+    [
+      projectId,
+      deploymentId,
+      deployedProductId,
+      severity,
+      issueType,
+      subject,
+      description,
+      postCase.isPending,
+    ],
+  );
+
+  // Cascade resets: a parent change invalidates its children.
+  const onProjectChange = (next: string): void => {
+    setProjectId(next);
+    setDeploymentId("");
+    setDeployedProductId("");
+  };
+  const onDeploymentChange = (next: string): void => {
+    setDeploymentId(next);
+    setDeployedProductId("");
+  };
+
+  const handleSubmit = (): void => {
+    if (!canSubmit || !severity || !issueType) return;
+    postCase.mutate(
+      {
+        projectId,
+        deploymentId,
+        deployedProductId,
+        subject: subject.trim(),
+        description: description.trim(),
+        priority: priorityFromSeverity(severity),
+        issueType,
+      },
+      {
+        onSuccess: (created) => navigate(`/cases/${created.id}`),
+        onError: () => showError("Could not create the case. Please try again."),
+      },
+    );
+  };
+
+  return (
+    <Box sx={{ maxWidth: 760, mx: "auto", px: 2, py: 3 }}>
+      <Button
+        variant="text"
+        startIcon={<ArrowLeft size={16} />}
+        onClick={() => navigate("/cases")}
+        sx={{ mb: 1 }}
+      >
+        Back to cases
+      </Button>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        New case
+      </Typography>
+
+      <Card variant="outlined" sx={{ p: 3, display: "flex", flexDirection: "column", gap: 2.5 }}>
+        <FormControl fullWidth size="small" required>
+          <InputLabel id="case-project-label">Project</InputLabel>
+          <Select
+            labelId="case-project-label"
+            label="Project"
+            value={projectId}
+            onChange={(e) => onProjectChange(String(e.target.value))}
+            disabled={projects.isLoading}
+          >
+            {(projects.data ?? []).map((p) => (
+              <MenuItem key={p.id} value={p.id}>
+                {p.name ?? p.id}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl fullWidth size="small" required>
+          <InputLabel id="case-deployment-label">Deployment</InputLabel>
+          <Select
+            labelId="case-deployment-label"
+            label="Deployment"
+            value={deploymentId}
+            onChange={(e) => onDeploymentChange(String(e.target.value))}
+            disabled={!projectId || deployments.isLoading}
+          >
+            {(deployments.data ?? []).map((d) => (
+              <MenuItem key={d.id} value={d.id}>
+                {d.name ?? d.id}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl fullWidth size="small" required>
+          <InputLabel id="case-product-label">Deployed product</InputLabel>
+          <Select
+            labelId="case-product-label"
+            label="Deployed product"
+            value={deployedProductId}
+            onChange={(e) => setDeployedProductId(String(e.target.value))}
+            disabled={!deploymentId || deployedProducts.isLoading}
+          >
+            {(deployedProducts.data ?? []).map((dp) => (
+              <MenuItem key={dp.id} value={dp.id}>
+                {dp.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <FormControl fullWidth size="small" required>
+            <InputLabel id="case-severity-label">Severity</InputLabel>
+            <Select
+              labelId="case-severity-label"
+              label="Severity"
+              value={severity}
+              onChange={(e) => setSeverity(e.target.value as Severity)}
+            >
+              {SEVERITIES.map((s) => (
+                <MenuItem key={s} value={s}>
+                  {s} · {SEVERITY_LABEL[s]}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth size="small" required>
+            <InputLabel id="case-issue-type-label">Issue type</InputLabel>
+            <Select
+              labelId="case-issue-type-label"
+              label="Issue type"
+              value={issueType}
+              onChange={(e) => setIssueType(e.target.value as BeCaseIssueType)}
+            >
+              {ISSUE_TYPES.map((it) => (
+                <MenuItem key={it.value} value={it.value}>
+                  {it.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+
+        <TextField
+          label="Subject"
+          size="small"
+          fullWidth
+          required
+          value={subject}
+          onChange={(e) => setSubject(e.target.value.slice(0, 200))}
+        />
+        <TextField
+          label="Description"
+          size="small"
+          fullWidth
+          required
+          multiline
+          minRows={4}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5 }}>
+          <Button variant="outlined" onClick={() => navigate("/cases")}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {postCase.isPending ? "Creating…" : "Create case"}
+          </Button>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -73,6 +73,16 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
 
+  // When a selector query fails the form becomes non-completable, so surface it
+  // with an explicit retry rather than leaving an empty dropdown.
+  const hasOptionsError =
+    projects.isError || deployments.isError || deployedProducts.isError;
+  const retryOptions = (): void => {
+    if (projects.isError) void projects.refetch();
+    if (deployments.isError) void deployments.refetch();
+    if (deployedProducts.isError) void deployedProducts.refetch();
+  };
+
   const canSubmit = useMemo(
     () =>
       !!projectId &&
@@ -140,6 +150,24 @@ export default function CsmCaseCreatePage(): JSX.Element {
       </Typography>
 
       <Card variant="outlined" sx={{ p: 3 }}>
+        {hasOptionsError && (
+          <Box
+            sx={{
+              mb: 2,
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              flexWrap: "wrap",
+            }}
+          >
+            <Typography variant="body2" color="error.main">
+              Some dropdown options failed to load.
+            </Typography>
+            <Button size="small" variant="outlined" onClick={retryOptions}>
+              Retry
+            </Button>
+          </Box>
+        )}
         <Grid container spacing={2.5}>
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   Card,
   FormControl,
+  Grid,
   InputLabel,
   MenuItem,
   Select,
@@ -29,6 +30,7 @@ import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import { useNavigate } from "react-router";
 import { priorityFromSeverity } from "@api/backend/mappers";
+import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useProjectOptions } from "@features/csm-cases/api/useProjectOptions";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
@@ -48,6 +50,11 @@ const ISSUE_TYPES: { value: BeCaseIssueType; label: string }[] = [
   { value: "security_or_compliance", label: "Security / compliance" },
   { value: "question", label: "Question" },
 ];
+
+/** The rich-text editor emits `<p></p>` when empty; check the stripped text. */
+function isEmptyHtml(html: string): boolean {
+  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
+}
 
 export default function CsmCaseCreatePage(): JSX.Element {
   const navigate = useNavigate();
@@ -74,7 +81,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       !!severity &&
       !!issueType &&
       subject.trim().length > 0 &&
-      description.trim().length > 0 &&
+      !isEmptyHtml(description) &&
       !postCase.isPending,
     [
       projectId,
@@ -107,7 +114,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
         deploymentId,
         deployedProductId,
         subject: subject.trim(),
-        description: description.trim(),
+        description,
         priority: priorityFromSeverity(severity),
         issueType,
       },
@@ -119,7 +126,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
   };
 
   return (
-    <Box sx={{ maxWidth: 760, mx: "auto", px: 2, py: 3 }}>
+    <Box sx={{ width: "100%", px: 3, py: 3 }}>
       <Button
         variant="text"
         startIcon={<ArrowLeft size={16} />}
@@ -132,112 +139,132 @@ export default function CsmCaseCreatePage(): JSX.Element {
         New case
       </Typography>
 
-      <Card variant="outlined" sx={{ p: 3, display: "flex", flexDirection: "column", gap: 2.5 }}>
-        <FormControl fullWidth size="small" required>
-          <InputLabel id="case-project-label">Project</InputLabel>
-          <Select
-            labelId="case-project-label"
-            label="Project"
-            value={projectId}
-            onChange={(e) => onProjectChange(String(e.target.value))}
-            disabled={projects.isLoading}
-          >
-            {(projects.data ?? []).map((p) => (
-              <MenuItem key={p.id} value={p.id}>
-                {p.name ?? p.id}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+      <Card variant="outlined" sx={{ p: 3 }}>
+        <Grid container spacing={2.5}>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="case-project-label">Project</InputLabel>
+              <Select
+                labelId="case-project-label"
+                label="Project"
+                value={projectId}
+                onChange={(e) => onProjectChange(String(e.target.value))}
+                disabled={projects.isLoading}
+              >
+                {(projects.data ?? []).map((p) => (
+                  <MenuItem key={p.id} value={p.id}>
+                    {p.name ?? p.id}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
 
-        <FormControl fullWidth size="small" required>
-          <InputLabel id="case-deployment-label">Deployment</InputLabel>
-          <Select
-            labelId="case-deployment-label"
-            label="Deployment"
-            value={deploymentId}
-            onChange={(e) => onDeploymentChange(String(e.target.value))}
-            disabled={!projectId || deployments.isLoading}
-          >
-            {(deployments.data ?? []).map((d) => (
-              <MenuItem key={d.id} value={d.id}>
-                {d.name ?? d.id}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="case-deployment-label">Deployment</InputLabel>
+              <Select
+                labelId="case-deployment-label"
+                label="Deployment"
+                value={deploymentId}
+                onChange={(e) => onDeploymentChange(String(e.target.value))}
+                disabled={!projectId || deployments.isLoading}
+              >
+                {(deployments.data ?? []).map((d) => (
+                  <MenuItem key={d.id} value={d.id}>
+                    {d.name ?? d.id}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
 
-        <FormControl fullWidth size="small" required>
-          <InputLabel id="case-product-label">Deployed product</InputLabel>
-          <Select
-            labelId="case-product-label"
-            label="Deployed product"
-            value={deployedProductId}
-            onChange={(e) => setDeployedProductId(String(e.target.value))}
-            disabled={!deploymentId || deployedProducts.isLoading}
-          >
-            {(deployedProducts.data ?? []).map((dp) => (
-              <MenuItem key={dp.id} value={dp.id}>
-                {dp.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="case-product-label">Deployed product</InputLabel>
+              <Select
+                labelId="case-product-label"
+                label="Deployed product"
+                value={deployedProductId}
+                onChange={(e) => setDeployedProductId(String(e.target.value))}
+                disabled={!deploymentId || deployedProducts.isLoading}
+              >
+                {(deployedProducts.data ?? []).map((dp) => (
+                  <MenuItem key={dp.id} value={dp.id}>
+                    {dp.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
 
-        <Box sx={{ display: "flex", gap: 2 }}>
-          <FormControl fullWidth size="small" required>
-            <InputLabel id="case-severity-label">Severity</InputLabel>
-            <Select
-              labelId="case-severity-label"
-              label="Severity"
-              value={severity}
-              onChange={(e) => setSeverity(e.target.value as Severity)}
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="case-severity-label">Severity</InputLabel>
+              <Select
+                labelId="case-severity-label"
+                label="Severity"
+                value={severity}
+                onChange={(e) => setSeverity(e.target.value as Severity)}
+              >
+                {SEVERITIES.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {s} · {SEVERITY_LABEL[s]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="case-issue-type-label">Issue type</InputLabel>
+              <Select
+                labelId="case-issue-type-label"
+                label="Issue type"
+                value={issueType}
+                onChange={(e) => setIssueType(e.target.value as BeCaseIssueType)}
+              >
+                {ISSUE_TYPES.map((it) => (
+                  <MenuItem key={it.value} value={it.value}>
+                    {it.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <TextField
+              label="Subject"
+              size="small"
+              fullWidth
+              required
+              value={subject}
+              onChange={(e) => setSubject(e.target.value.slice(0, 200))}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 0.5 }}
             >
-              {SEVERITIES.map((s) => (
-                <MenuItem key={s} value={s}>
-                  {s} · {SEVERITY_LABEL[s]}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+              Description
+            </Typography>
+            <Editor
+              value={description}
+              onChange={setDescription}
+              placeholder="Describe the issue…"
+              minHeight={180}
+              maxHeight={420}
+              toolbarVariant="full"
+              disabled={postCase.isPending}
+            />
+          </Grid>
+        </Grid>
 
-          <FormControl fullWidth size="small" required>
-            <InputLabel id="case-issue-type-label">Issue type</InputLabel>
-            <Select
-              labelId="case-issue-type-label"
-              label="Issue type"
-              value={issueType}
-              onChange={(e) => setIssueType(e.target.value as BeCaseIssueType)}
-            >
-              {ISSUE_TYPES.map((it) => (
-                <MenuItem key={it.value} value={it.value}>
-                  {it.label}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Box>
-
-        <TextField
-          label="Subject"
-          size="small"
-          fullWidth
-          required
-          value={subject}
-          onChange={(e) => setSubject(e.target.value.slice(0, 200))}
-        />
-        <TextField
-          label="Description"
-          size="small"
-          fullWidth
-          required
-          multiline
-          minRows={4}
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
-
-        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5 }}>
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, mt: 2.5 }}>
           <Button variant="outlined" onClick={() => navigate("/cases")}>
             Cancel
           </Button>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -476,6 +476,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const c = data;
   const isClosed = c.state === "closed";
   const breached = c.minutesToBreach < 0;
+  // The backend carries no SLA timing yet (LIVE detail leaves slaClocks empty
+  // and minutesToBreach at 0). Without this guard the header SLA chip reads
+  // `0 <= 60` and paints every open case orange ("Ack · 0m left"), which is
+  // both wrong and the main source of orange on the screen. Only show SLA
+  // affordances when we actually have clock data (mock, and LIVE once wired).
+  const hasSlaData = c.slaClocks.length > 0;
   const canReopenClosed = (claims?.groups ?? []).some((g) =>
     LEAD_REOPEN_ROLES.has(g),
   );
@@ -580,7 +586,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               label={TIER_LABEL[c.customerContext.tier]}
               color={TIER_COLOR[c.customerContext.tier]}
             />
-            {!isClosed && (
+            {!isClosed && hasSlaData && (
               <Chip
                 size="small"
                 variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -42,6 +42,7 @@ import { useLocation, useNavigate, useParams } from "react-router";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
 import { usePatchCsmCase } from "@features/csm-cases/api/usePatchCsmCase";
 import type { BeCaseState } from "@api/backend/types";
+import { beStateFromUi } from "@api/backend/mappers";
 import {
   useGetCsmCaseComments,
   usePostCsmCaseComment,
@@ -77,6 +78,7 @@ import type {
   CsmCaseComment,
   CsmCaseDetail,
 } from "@features/csm-cases/types/csmCases";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 
 function MetaCell({
   label,
@@ -362,9 +364,18 @@ export default function CsmCaseDetailPage(): JSX.Element {
   }, [data, recordView]);
 
   const onAction = useCallback(
-    (action: CaseLifecycleAction | { secondary: string }) => {
+    (
+      action: CaseLifecycleAction | { secondary: string },
+      // Target state supplied by the action bar, taken straight from the case's
+      // backend `nextStates`. It is authoritative for the PATCH: the action name
+      // (e.g. `resume_work`) maps to different states depending on the source
+      // state, so we never re-derive the target from the action alone.
+      nextState?: CaseState,
+    ) => {
       if (typeof action === "string") {
-        const targetState = LIFECYCLE_TARGET_STATE[action];
+        const targetState = nextState
+          ? beStateFromUi(nextState)
+          : LIFECYCLE_TARGET_STATE[action];
         if (targetState) {
           // Real state transition via PATCH /cases/{id}; the detail + list
           // queries refetch on success so the new state shows.

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -69,6 +69,7 @@ import {
   SEVERITY_COLOR,
   SEVERITY_LABEL,
   SLA_CLOCK_LABEL,
+  STATE_COLOR,
   STATE_LABEL,
   formatTimeToBreach,
 } from "@features/csm-dashboard/utils/abtDashboard";
@@ -589,7 +590,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             <Chip
               size="small"
               label={STATE_LABEL[c.state]}
-              color={isClosed ? "success" : "primary"}
+              color={STATE_COLOR[c.state]}
               sx={{ fontWeight: 600 }}
             />
             <Chip

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -228,21 +228,21 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement {
  */
 function buildDescriptionComment(c: CsmCaseDetail): CsmCaseComment | null {
   if (!c.description?.trim()) return null;
-  const escaped = c.description
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/\n\n+/g, "</p><p>")
-    .replace(/\n/g, "<br>");
   const createdMs = new Date(c.createdAt).getTime();
   const at = new Date(createdMs + 1000).toISOString();
+  // The creator may be a WSO2 engineer (case logged in the CSM portal) or a
+  // customer (customer portal). Infer from the email domain so the badge isn't
+  // always "Customer".
+  const isWso2 = (c.createdByEmail ?? "").toLowerCase().endsWith("@wso2.com");
   return {
     id: `description`,
     caseId: c.id,
     authorName:
       c.createdBy || c.customerContext.primaryContact || c.customer,
-    authorRole: "customer",
-    bodyHtml: `<p>${escaped}</p>`,
+    authorRole: isWso2 ? "wso2_engineer" : "customer",
+    // The description is rich HTML (authored in the case-create editor, same as
+    // comments); the comment bubble sanitizes it with DOMPurify before render.
+    bodyHtml: c.description,
     createdAt: at,
   };
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -25,6 +25,7 @@ import CasesFilterBar, {
 } from "@features/csm-cases/components/CasesFilterBar";
 import CasesList from "@features/csm-cases/components/CasesList";
 import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
+import { useProjectOptions } from "@features/csm-cases/api/useProjectOptions";
 import { useDirectoryUsers } from "@api/useDirectoryUsers";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 import {
@@ -86,6 +87,7 @@ export default function CsmCasesPage(): JSX.Element {
   );
 
   const { data, isLoading, isError } = useGetCsmCases(filters);
+  const { data: projectDirectory } = useProjectOptions();
   const { data: directoryUsers } = useDirectoryUsers();
   const { showError } = useErrorBanner();
   const hasShownErrorRef = useRef(false);
@@ -117,17 +119,27 @@ export default function CsmCasesPage(): JSX.Element {
   }, [directoryUsers]);
 
   // Project filter is id-based (sends projectIds server-side), so options carry
-  // id + name. Derived from the loaded cases (which embed projectId +
-  // projectName) so it works in both LIVE and MOCK without an extra fetch.
+  // id + name. The list is sourced from the full project directory rather than
+  // the loaded cases: once a project is selected the result set is
+  // server-filtered to it, so deriving options from `data.cases` would collapse
+  // the selector to the chosen project and block adding a second one. Loaded
+  // cases backfill the list (covers MOCK mode, where the directory is empty),
+  // and selected ids are always kept visible.
   const availableProjects = useMemo(() => {
     const byId = new Map<string, string>();
+    (projectDirectory ?? []).forEach((p) => byId.set(p.id, p.name || p.id));
     (data?.cases ?? []).forEach((c) => {
-      if (c.projectId) byId.set(c.projectId, c.projectName || c.projectId);
+      if (c.projectId && !byId.has(c.projectId)) {
+        byId.set(c.projectId, c.projectName || c.projectId);
+      }
+    });
+    filters.projects.forEach((id) => {
+      if (!byId.has(id)) byId.set(id, id);
     });
     return Array.from(byId, ([id, name]) => ({ id, name })).sort((a, b) =>
       a.name.localeCompare(b.name),
     );
-  }, [data?.cases]);
+  }, [projectDirectory, data?.cases, filters.projects]);
 
   const availableProducts = useMemo(() => {
     const set = new Set<string>();

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -52,7 +52,7 @@ function applyFilters(cases: CsmCaseRow[], f: CasesFilters): CsmCaseRow[] {
       );
       if (!match) return false;
     }
-    if (f.projects.length && !f.projects.includes(c.projectName)) return false;
+    if (f.projects.length && !f.projects.includes(c.projectId)) return false;
     if (f.products.length && !f.products.includes(c.product)) return false;
     if (q) {
       const hay = `${c.caseNumber} ${c.subject} ${c.customer} ${c.projectName} ${c.assignee} ${c.product}`.toLowerCase();
@@ -85,7 +85,7 @@ export default function CsmCasesPage(): JSX.Element {
     [setSearchParams],
   );
 
-  const { data, isLoading, isError } = useGetCsmCases(filters.scope);
+  const { data, isLoading, isError } = useGetCsmCases(filters);
   const { data: directoryUsers } = useDirectoryUsers();
   const { showError } = useErrorBanner();
   const hasShownErrorRef = useRef(false);
@@ -116,12 +116,17 @@ export default function CsmCasesPage(): JSX.Element {
     return list;
   }, [directoryUsers]);
 
+  // Project filter is id-based (sends projectIds server-side), so options carry
+  // id + name. Derived from the loaded cases (which embed projectId +
+  // projectName) so it works in both LIVE and MOCK without an extra fetch.
   const availableProjects = useMemo(() => {
-    const set = new Set<string>();
+    const byId = new Map<string, string>();
     (data?.cases ?? []).forEach((c) => {
-      if (c.projectName) set.add(c.projectName);
+      if (c.projectId) byId.set(c.projectId, c.projectName || c.projectId);
     });
-    return Array.from(set).sort();
+    return Array.from(byId, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
   }, [data?.cases]);
 
   const availableProducts = useMemo(() => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -49,6 +49,12 @@ export interface CsmCaseRow {
   slaClockType: SlaClockType;
   // Minutes until breach (negative = already breached).
   minutesToBreach: number;
+  /**
+   * Whether SLA timing is actually known for this row. The backend has no SLA
+   * data yet, so LIVE rows set this false and the list renders a neutral "—"
+   * instead of a misleading orange "0m left". Absent/true → render the clock.
+   */
+  hasSla?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -208,8 +208,10 @@ export interface CsmCaseDetail extends CsmCaseRow {
   assignmentGroup: string;
   /** States this case may transition into next, per the backend. */
   nextStates?: CaseState[];
-  /** Customer-side person who opened the case. */
+  /** Display name of the person who opened the case. */
   createdBy?: string;
+  /** Email of the creator — used to tell a WSO2 engineer from a customer. */
+  createdByEmail?: string;
   customerContext: CaseCustomerContext;
   productContext: CaseProductContext;
   slaClocks: CaseSlaClock[];

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
@@ -27,11 +27,16 @@ export const TIER_LABEL: Record<CustomerTier, string> = {
   trial: "Trial",
 };
 
+// Tier is metadata, not an action, so it must not wear the brand accent
+// (`primary`/orange). subscription is the most common tier, so colouring it
+// orange painted nearly every case header orange and also failed WCAG contrast
+// (white-on-#F87643 ~ 2.7:1). It renders neutral; the chromatic tiers stay on
+// contrast-safe semantic roles (their contrastText is dark in this theme).
 export const TIER_COLOR: Record<
   CustomerTier,
-  "primary" | "info" | "success" | "warning"
+  "default" | "info" | "success" | "warning"
 > = {
-  subscription: "primary",
+  subscription: "default",
   managed_cloud: "success",
   saas: "info",
   trial: "warning",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
+import type {
+  BeCaseSearchPayload,
+  BeCaseSearchResponse,
+} from "@api/backend/types";
+import { getMockCsmCases } from "@features/csm-cases/api/mocks/casesMocks";
+import type {
+  CaseState,
+  Severity,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+const PAGE_LIMIT = 100; // backend caps pagination limit at 100
+const MAX_PAGES = 5; // bound the fan-out (≤500 cases sampled for the matrix)
+
+export const MATRIX_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+export const MATRIX_STATES: CaseState[] = [
+  "open",
+  "work_in_progress",
+  "waiting_on_wso2",
+  "awaiting_info",
+  "solution_proposed",
+  "reopen",
+  "closed",
+];
+
+export interface CaseCountsMatrix {
+  /** counts[severity][state] = number of cases. */
+  counts: Record<Severity, Record<CaseState, number>>;
+  severityTotals: Record<Severity, number>;
+  stateTotals: Record<CaseState, number>;
+  total: number;
+  /** True when more cases exist than were sampled (page cap hit). */
+  truncated: boolean;
+}
+
+function emptyMatrix(): CaseCountsMatrix {
+  const counts = {} as Record<Severity, Record<CaseState, number>>;
+  const severityTotals = {} as Record<Severity, number>;
+  const stateTotals = {} as Record<CaseState, number>;
+  for (const s of MATRIX_SEVERITIES) {
+    severityTotals[s] = 0;
+    counts[s] = {} as Record<CaseState, number>;
+    for (const st of MATRIX_STATES) counts[s][st] = 0;
+  }
+  for (const st of MATRIX_STATES) stateTotals[st] = 0;
+  return { counts, severityTotals, stateTotals, total: 0, truncated: false };
+}
+
+/**
+ * Case counts broken down by severity × state, for the dashboard matrix.
+ *
+ * The backend has no aggregation endpoint, so this samples cases via
+ * `POST /cases/search` (up to {@link MAX_PAGES} pages of {@link PAGE_LIMIT}) and
+ * tallies client-side. `truncated` flags when the real total exceeds the
+ * sample. MOCK mode tallies the seeded cases.
+ */
+export function useCaseCountsMatrix(): UseQueryResult<CaseCountsMatrix, Error> {
+  const api = useBackendApi();
+
+  return useQuery<CaseCountsMatrix, Error>({
+    queryKey: [ApiQueryKeys.CSM_CASES, "counts-matrix"],
+    queryFn: async (): Promise<CaseCountsMatrix> => {
+      const matrix = emptyMatrix();
+
+      const tally = (severity: Severity, state: CaseState): void => {
+        if (!matrix.counts[severity] || matrix.counts[severity][state] === undefined) {
+          return;
+        }
+        matrix.counts[severity][state] += 1;
+        matrix.severityTotals[severity] += 1;
+        matrix.stateTotals[state] += 1;
+        matrix.total += 1;
+      };
+
+      if (isMockMode()) {
+        for (const c of getMockCsmCases("all_customers").cases) {
+          tally(c.severity, c.state);
+        }
+        return matrix;
+      }
+
+      let offset = 0;
+      for (let page = 0; page < MAX_PAGES; page += 1) {
+        const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+          "/cases/search",
+          { pagination: { offset, limit: PAGE_LIMIT } },
+        );
+        for (const c of res.cases ?? []) {
+          tally(severityFromPriority(c.priority), uiStateFromBe(c.state));
+        }
+        if (!res.hasMore || (res.cases ?? []).length === 0) break;
+        offset += PAGE_LIMIT;
+        if (page === MAX_PAGES - 1 && res.hasMore) matrix.truncated = true;
+      }
+      return matrix;
+    },
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -21,6 +21,7 @@ import {
   FormControl,
   MenuItem,
   Select,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
@@ -30,6 +31,11 @@ import {
   type DashboardKey,
   type DashboardScope,
 } from "@features/csm-dashboard/types/abtDashboard";
+
+// ABT (Account-Based Team) scoping is not implemented yet, so the My ABT / All
+// customers toggle is disabled and the dashboard is locked to "all customers".
+// Flip this to re-enable the toggle once ABT membership data is available.
+const ABT_SCOPING_ENABLED = false;
 
 interface AbtDashboardHeaderProps {
   engineer?: CsmDashboardEngineer;
@@ -79,24 +85,34 @@ export default function AbtDashboardHeader({
       </Box>
       <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
         {showScopeButtons && (
-          <>
-            <Button
-              size="small"
-              variant={scope === "my_abt" ? "contained" : "outlined"}
-              color="primary"
-              onClick={() => onScopeChange("my_abt")}
-            >
-              My ABT
-            </Button>
-            <Button
-              size="small"
-              variant={scope === "all_customers" ? "contained" : "outlined"}
-              color="primary"
-              onClick={() => onScopeChange("all_customers")}
-            >
-              All customers
-            </Button>
-          </>
+          <Tooltip
+            title={
+              ABT_SCOPING_ENABLED
+                ? ""
+                : "ABT scoping is not available yet — showing all customers."
+            }
+          >
+            <Box sx={{ display: "flex", gap: 1 }}>
+              <Button
+                size="small"
+                variant={scope === "my_abt" ? "contained" : "outlined"}
+                color="primary"
+                disabled={!ABT_SCOPING_ENABLED}
+                onClick={() => onScopeChange("my_abt")}
+              >
+                My ABT
+              </Button>
+              <Button
+                size="small"
+                variant={scope === "all_customers" ? "contained" : "outlined"}
+                color="primary"
+                disabled={!ABT_SCOPING_ENABLED}
+                onClick={() => onScopeChange("all_customers")}
+              >
+                All customers
+              </Button>
+            </Box>
+          </Tooltip>
         )}
         <FormControl size="small" sx={{ minWidth: 200 }}>
           <Select

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Chip,
+  Link,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type JSX } from "react";
+import { Link as RouterLink } from "react-router";
+import {
+  MATRIX_SEVERITIES,
+  MATRIX_STATES,
+  useCaseCountsMatrix,
+} from "@features/csm-dashboard/api/useCaseCountsMatrix";
+import {
+  SEVERITY_COLOR,
+  STATE_LABEL,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import type {
+  CaseState,
+  Severity,
+} from "@features/csm-dashboard/types/abtDashboard";
+import SectionCard from "@features/csm-dashboard/components/SectionCard";
+
+/** Build a `/cases?...` href for the given severity and/or state filter. */
+function casesHref(severity?: Severity, state?: CaseState): string {
+  const params = new URLSearchParams();
+  if (severity) params.set("severities", severity);
+  if (state) params.set("states", state);
+  const qs = params.toString();
+  return qs ? `/cases?${qs}` : "/cases";
+}
+
+/** A count rendered as a link when > 0, muted "0" otherwise. */
+function CountCell({
+  value,
+  href,
+  bold = false,
+}: {
+  value: number;
+  href: string;
+  bold?: boolean;
+}): JSX.Element {
+  return (
+    <TableCell align="center" sx={{ fontWeight: bold ? 700 : 400 }}>
+      {value > 0 ? (
+        <Link
+          component={RouterLink}
+          to={href}
+          underline="hover"
+          color="inherit"
+          sx={{ fontWeight: "inherit" }}
+        >
+          {value}
+        </Link>
+      ) : (
+        <Typography component="span" variant="body2" color="text.disabled">
+          0
+        </Typography>
+      )}
+    </TableCell>
+  );
+}
+
+export default function CaseCountsMatrix(): JSX.Element {
+  const { data, isLoading, isError } = useCaseCountsMatrix();
+
+  return (
+    <SectionCard title="Cases by severity and state">
+      {isLoading ? (
+        <Skeleton variant="rounded" height={220} />
+      ) : isError || !data ? (
+        <Typography variant="body2" color="text.secondary">
+          Could not load case counts.
+        </Typography>
+      ) : (
+        <TableContainer>
+          <Table size="small" aria-label="Case counts by severity and state">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>Severity \ State</TableCell>
+                {MATRIX_STATES.map((st) => (
+                  <TableCell key={st} align="center">
+                    <Link
+                      component={RouterLink}
+                      to={casesHref(undefined, st)}
+                      underline="hover"
+                      color="text.secondary"
+                      sx={{ fontWeight: 600, fontSize: "0.78rem" }}
+                    >
+                      {STATE_LABEL[st]}
+                    </Link>
+                  </TableCell>
+                ))}
+                <TableCell align="center" sx={{ fontWeight: 700 }}>
+                  Total
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {MATRIX_SEVERITIES.map((sev) => (
+                <TableRow key={sev} hover>
+                  <TableCell>
+                    <Link
+                      component={RouterLink}
+                      to={casesHref(sev)}
+                      underline="none"
+                    >
+                      <Chip
+                        size="small"
+                        label={sev}
+                        color={SEVERITY_COLOR[sev]}
+                        sx={{ cursor: "pointer" }}
+                      />
+                    </Link>
+                  </TableCell>
+                  {MATRIX_STATES.map((st) => (
+                    <CountCell
+                      key={st}
+                      value={data.counts[sev][st]}
+                      href={casesHref(sev, st)}
+                    />
+                  ))}
+                  <CountCell
+                    value={data.severityTotals[sev]}
+                    href={casesHref(sev)}
+                    bold
+                  />
+                </TableRow>
+              ))}
+              <TableRow>
+                <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
+                {MATRIX_STATES.map((st) => (
+                  <CountCell
+                    key={st}
+                    value={data.stateTotals[st]}
+                    href={casesHref(undefined, st)}
+                    bold
+                  />
+                ))}
+                <CountCell value={data.total} href="/cases" bold />
+              </TableRow>
+            </TableBody>
+          </Table>
+          {data.truncated && (
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                Sampled the first {data.total} cases; totals may be higher.
+              </Typography>
+            </Box>
+          )}
+        </TableContainer>
+      )}
+    </SectionCard>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -39,7 +39,9 @@ import {
  * are mocks for UX iteration only.
  */
 export default function CsmDashboardPage(): JSX.Element {
-  const [scope, setScope] = useState<DashboardScope>("my_abt");
+  // ABT scoping is not implemented yet, so default to (and stay on)
+  // all-customers; the My ABT / All customers toggle is disabled in the header.
+  const [scope, setScope] = useState<DashboardScope>("all_customers");
   const [dashboardKey, setDashboardKey] = useState<DashboardKey>("engineer");
   const { data, isLoading, isError } = useGetCsmDashboard(scope);
   const { showError } = useErrorBanner();

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -22,6 +22,7 @@ import MyQueueSection from "@features/csm-dashboard/components/MyQueueSection";
 import SlaAtRiskSection from "@features/csm-dashboard/components/SlaAtRiskSection";
 import CustomerSummarySection from "@features/csm-dashboard/components/CustomerSummarySection";
 import RecentActivitySection from "@features/csm-dashboard/components/RecentActivitySection";
+import CaseCountsMatrix from "@features/csm-dashboard/components/CaseCountsMatrix";
 import { useGetCsmDashboard } from "@features/csm-dashboard/api/useGetCsmDashboard";
 import {
   DASHBOARD_OPTIONS,
@@ -70,6 +71,7 @@ export default function CsmDashboardPage(): JSX.Element {
       />
       {dashboardKey === "engineer" ? (
         <>
+          <CaseCountsMatrix />
           <Box
             sx={{
               display: "grid",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
@@ -50,6 +50,30 @@ export const STATE_LABEL: Record<CaseState, string> = {
   closed: "Closed",
 };
 
+// Status chip colour by "whose move is it", so colour carries information when
+// an engineer scans a queue — instead of every open case rendering the same
+// brand orange (the old `isClosed ? "success" : "primary"`, which also failed
+// WCAG contrast). The four buckets:
+//   info (blue)    = active, on us, normal      -> open, work_in_progress
+//   warning (amber)= active, on us, elevated    -> waiting_on_wso2, reopen
+//   default (grey) = waiting on the customer     -> solution_proposed, awaiting_info
+//   success (green)= done                        -> closed
+// All four roles have a dark `contrastText` in this theme, so filled chips pass
+// AA. `primary` (orange) is deliberately not used here: it is reserved for the
+// one real action button, selected nav, and links.
+export const STATE_COLOR: Record<
+  CaseState,
+  "info" | "warning" | "success" | "default"
+> = {
+  open: "info",
+  work_in_progress: "info",
+  waiting_on_wso2: "warning",
+  reopen: "warning",
+  solution_proposed: "default",
+  awaiting_info: "default",
+  closed: "success",
+};
+
 export const SLA_CLOCK_LABEL: Record<SlaClockType, string> = {
   ack: "Ack",
   first_response: "First response",

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -42,15 +42,21 @@ export default function AuthGuard(): JSX.Element {
   const location = useLocation();
   const navigate = useNavigate();
 
+  // After login, restore the saved deep link. The key is cleared ONLY once we
+  // actually arrive at the target — so it survives the Asgardeo SDK reloading
+  // the page to `afterSignInUrl` ("/") after the callback, which would
+  // otherwise drop us on the default `/accounts` landing. The default `/`
+  // landing is deferred to RootLanding in App.tsx while a redirect is pending.
   useEffect(() => {
-    if (isSignedIn) {
-      const redirect = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
-      if (redirect) {
-        sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
-        void navigate(redirect, { replace: true });
-      }
+    if (!isSignedIn) return;
+    const redirect = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
+    if (!redirect) return;
+    if (location.pathname + location.search === redirect) {
+      sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+    } else {
+      void navigate(redirect, { replace: true });
     }
-  }, [isSignedIn, navigate]);
+  }, [isSignedIn, navigate, location.pathname, location.search]);
 
   return (
     <ProtectedRoute

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -28,6 +28,24 @@ if (typeof window !== "undefined") {
 // mounts, so the first render of every data hook reads the correct flag.
 hydrateMockModeFromStorage();
 
+// Capture the entry deep link at module load — before React, routing, or the
+// Asgardeo SDK run — so it can be restored after the IdP round-trip even when
+// the SDK restores the session synchronously (in which case ProtectedRoute's
+// `onSignIn` never fires and the SDK navigates straight to `afterSignInUrl`).
+// AuthGuard reads/clears `post_login_redirect` once signed in. Skip the bare
+// root and the OAuth callback (which carries `?code=&state=`).
+if (typeof window !== "undefined") {
+  try {
+    const entry = window.location.pathname + window.location.search;
+    const isOauthCallback = /[?&](code|state)=/.test(window.location.search);
+    if (entry !== "/" && !isOauthCallback) {
+      window.sessionStorage.setItem("post_login_redirect", entry);
+    }
+  } catch {
+    /* sessionStorage may be unavailable; deep-link restore is best-effort. */
+  }
+}
+
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <AppWithConfig />

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -37,7 +37,11 @@ hydrateMockModeFromStorage();
 if (typeof window !== "undefined") {
   try {
     const entry = window.location.pathname + window.location.search;
-    const isOauthCallback = /[?&](code|state)=/.test(window.location.search);
+    // Only the OAuth callback carries BOTH `code` and `state`; requiring both
+    // avoids misclassifying legitimate deep links that happen to use a business
+    // `state` (or `code`) query param and dropping their post-login restore.
+    const params = new URLSearchParams(window.location.search);
+    const isOauthCallback = params.has("code") && params.has("state");
     if (entry !== "/" && !isOauthCallback) {
       window.sessionStorage.setItem("post_login_redirect", entry);
     }


### PR DESCRIPTION
CSM case-management follow-ups: a create flow, server-side filters, a dashboard breakdown, and auth/UX fixes.

### Case create (`/cases/new`)
- Project → deployment → deployed-product cascade (`projects/search`, `deployments/search`, `deployments/{id}/products/search`, labelled via `products/search` + `products/{id}/versions/search`) → `POST /cases`. Completes FE coverage of the BFF case-management surface.
- Full-width layout; **Description uses the same Lexical rich-text editor as comments** (no internal-note switch).

### Case-list filters → server-side
- `severities` → `priorityKeys`, `states` → `stateKeys`, and an **id-based** `projects` filter → `projectIds`, all pushed into `POST /cases/search`. `search`/`products` stay client-side; `scope`/`assignee`/`SLA` are **disabled in LIVE** (no backend field) with a tooltip.

### Dashboard
- A **severity × state case-count matrix**; every number deep-links to the matching `/cases` filter (cell → `?severities=S0&states=open`, headers → single-filter, plus totals). Counts sampled from `/cases/search` (no BE aggregation), or mocks.

### Detail / correctness fixes
- Description renders as sanitised rich HTML (via the DOMPurify comment bubble) instead of escaped text.
- Description author badge reflects the creator (WSO2 engineer vs customer, by email domain) instead of always "Customer".
- **Pagination cap:** all limits capped at 100 — the entity service rejects `limit > 100` as "Invalid request payload".

### Auth
- **Deep-link restore after IdP auth** (`/cases?severities=S0` was landing on `/accounts`): capture the entry URL at module load, clear the saved redirect only on arrival (survives the SDK's post-callback reload to `afterSignInUrl`), and defer the default `/` → `/accounts` redirect so it can't race the restore. *(Verified working.)*

### Checks
`pnpm build` ✅ · `pnpm lint` ✅ (0 errors) · `pnpm test` ✅ (39)

### Cross-team note
`POST /cases/search` only matches subject/number/wso2Id for `searchQuery`; `scope`/`assignee`/`SLA` filters need an assignee field + SLA data on the entity side before they can work in LIVE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case creation page with cascading project → deployment → deployed-product selectors, subject, rich-text description, and submit flow
  * Dashboard "Cases by severity and state" matrix with navigable counts
  * New lookups for projects, deployments, and deployed-product options

* **Improvements**
  * Post-login deep-link capture and more reliable redirect restoration
  * Filters now use project IDs, disable unsupported backend filters, and surface retry UI for failed option loads
  * Case detail now records creator email and avoids showing SLA timing when SLA data is missing

* **Tests**
  * Added tests covering lifecycle action button behavior in the case action bar
<!-- end of auto-generated comment: release notes by coderabbit.ai -->