### PR TITLE
feat(csm-portal): runtime theme selector in the header

### DIFF
--- a/apps/csm-portal/webapp/public/config.js.example
+++ b/apps/csm-portal/webapp/public/config.js.example
@@ -13,6 +13,9 @@ window.config = {
   // CSM_PORTAL_BACKEND_BASE_URL: "https://<choreo-org-id>-az-stg.prod.wdt.choreoapis.dev/<key>/csm-portal-backend/v1.0",
   CSM_PORTAL_BACKEND_BASE_URL: "<your-backend-base-url>",
 
+  // Default Oxygen UI theme. One of: "acrylicOrange", "acrylicPurple",
+  // "choreo", "classic", "highContrast". Users can override this at runtime via
+  // the header theme dropdown (the choice is persisted per browser).
   CSM_PORTAL_THEME: "acrylicOrange",
   CSM_PORTAL_LOG_LEVEL: "ERROR",
 

--- a/apps/csm-portal/webapp/src/AppWithConfig.tsx
+++ b/apps/csm-portal/webapp/src/AppWithConfig.tsx
@@ -16,14 +16,13 @@
 
 import { type JSX, lazy, Suspense } from "react";
 import { BrowserRouter } from "react-router";
-import { OxygenUIThemeProvider } from "@wso2/oxygen-ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { AsgardeoProvider } from "@asgardeo/react";
-import { themeConfig } from "@config/themeConfig";
 import { loggerConfig } from "@config/loggerConfig";
 import LoggerProvider from "@context/logger/LoggerProvider";
 import { MockModeProvider } from "@context/mock-mode/MockModeContext";
+import { ThemePreferenceProvider } from "@context/theme/ThemePreferenceContext";
 import { authConfig } from "@config/authConfig";
 
 // React-Query devtools ship from a devDependency and must not enter the
@@ -87,7 +86,7 @@ export default function AppWithConfig(): JSX.Element {
     >
       <BrowserRouter>
         <LoggerProvider config={loggerConfig}>
-          <OxygenUIThemeProvider theme={themeConfig}>
+          <ThemePreferenceProvider>
             <QueryClientProvider client={queryClient}>
               <MockModeProvider>
                 <App />
@@ -98,7 +97,7 @@ export default function AppWithConfig(): JSX.Element {
                 </Suspense>
               )}
             </QueryClientProvider>
-          </OxygenUIThemeProvider>
+          </ThemePreferenceProvider>
         </LoggerProvider>
       </BrowserRouter>
     </AsgardeoProvider>

--- a/apps/csm-portal/webapp/src/components/header/Actions.tsx
+++ b/apps/csm-portal/webapp/src/components/header/Actions.tsx
@@ -24,6 +24,7 @@ import type { JSX } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import UserProfile from "@components/header/UserProfile";
 import MockModeToggle from "@components/header/MockModeToggle";
+import ThemeSelect from "@components/header/ThemeSelect";
 
 export default function Actions(): JSX.Element {
   const { isSignedIn } = useAsgardeo();
@@ -31,6 +32,7 @@ export default function Actions(): JSX.Element {
   return (
     <HeaderUI.Actions>
       <MockModeToggle />
+      <ThemeSelect />
       <ColorSchemeToggle />
       <Divider
         orientation="vertical"

--- a/apps/csm-portal/webapp/src/components/header/ThemeSelect.tsx
+++ b/apps/csm-portal/webapp/src/components/header/ThemeSelect.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  MenuItem,
+  Select,
+  Tooltip,
+  type SelectChangeEvent,
+} from "@wso2/oxygen-ui";
+import { Palette } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { useThemePreference } from "@context/theme/ThemePreferenceContext";
+import { isThemeKey } from "@config/themeConfig";
+
+/**
+ * Header dropdown that switches the active Oxygen UI theme at runtime. The
+ * choice is persisted per user (localStorage) by the ThemePreferenceProvider,
+ * so it survives reloads. Orthogonal to the light/dark ColorSchemeToggle that
+ * sits next to it — this picks the palette, that picks the colour scheme.
+ */
+export default function ThemeSelect(): JSX.Element {
+  const { themeKey, setThemeKey, options } = useThemePreference();
+
+  const handleChange = (e: SelectChangeEvent<string>): void => {
+    const next = e.target.value;
+    if (isThemeKey(next)) setThemeKey(next);
+  };
+
+  return (
+    <Tooltip title="Theme">
+      <Box sx={{ display: "flex", alignItems: "center" }}>
+        <Select
+          value={themeKey}
+          onChange={handleChange}
+          size="small"
+          variant="standard"
+          disableUnderline
+          aria-label="Select theme"
+          startAdornment={
+            <Palette
+              size={16}
+              style={{ marginRight: 6, opacity: 0.7, flexShrink: 0 }}
+            />
+          }
+          sx={{
+            minWidth: 132,
+            fontSize: "0.8125rem",
+            color: "text.secondary",
+            "& .MuiSelect-select": {
+              display: "flex",
+              alignItems: "center",
+              py: 0.5,
+            },
+          }}
+        >
+          {options.map((o) => (
+            <MenuItem key={o.key} value={o.key} sx={{ fontSize: "0.8125rem" }}>
+              {o.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </Box>
+    </Tooltip>
+  );
+}

--- a/apps/csm-portal/webapp/src/config/themeConfig.ts
+++ b/apps/csm-portal/webapp/src/config/themeConfig.ts
@@ -17,19 +17,55 @@
 import {
   AcrylicOrangeTheme,
   AcrylicPurpleTheme,
-  HighContrastTheme,
+  ChoreoTheme,
   ClassicTheme,
+  HighContrastTheme,
 } from "@wso2/oxygen-ui";
 import type { OxygenTheme } from "@wso2/oxygen-ui/styles/Themes/OxygenThemeBase";
 
-// Themes configuration.
-const themes: Record<string, OxygenTheme> = {
+/**
+ * Every Oxygen UI theme the CSM portal exposes, keyed by the value used in
+ * `window.config.CSM_PORTAL_THEME` and persisted as the user's runtime choice.
+ * Single source of truth for both the build-time default and the runtime theme
+ * dropdown — add a theme here and it appears in the picker.
+ */
+export const THEMES = {
   acrylicOrange: AcrylicOrangeTheme,
   acrylicPurple: AcrylicPurpleTheme,
-  highContrast: HighContrastTheme,
+  choreo: ChoreoTheme,
   classic: ClassicTheme,
-};
+  highContrast: HighContrastTheme,
+} satisfies Record<string, OxygenTheme>;
 
-export const themeConfig =
-  themes[window.config?.CSM_PORTAL_THEME || "acrylicOrange"] ||
-  AcrylicOrangeTheme;
+export type ThemeKey = keyof typeof THEMES;
+
+export const DEFAULT_THEME_KEY: ThemeKey = "acrylicOrange";
+
+/** Human labels for the theme dropdown, in display order. */
+export const THEME_OPTIONS: { key: ThemeKey; label: string }[] = [
+  { key: "acrylicOrange", label: "Acrylic Orange" },
+  { key: "acrylicPurple", label: "Acrylic Purple" },
+  { key: "choreo", label: "Choreo" },
+  { key: "classic", label: "Classic" },
+  { key: "highContrast", label: "High Contrast" },
+];
+
+/** True when `value` is a known theme key. */
+export function isThemeKey(value: unknown): value is ThemeKey {
+  return typeof value === "string" && value in THEMES;
+}
+
+/** Resolve a (possibly invalid) key to a concrete Oxygen theme. */
+export function resolveTheme(key: string | undefined): OxygenTheme {
+  return isThemeKey(key) ? THEMES[key] : THEMES[DEFAULT_THEME_KEY];
+}
+
+/**
+ * Build-time default theme key from `window.config`, falling back to
+ * {@link DEFAULT_THEME_KEY}. The runtime picker layers a persisted user choice
+ * on top of this (see `ThemePreferenceProvider`).
+ */
+export function configThemeKey(): ThemeKey {
+  const fromConfig = window.config?.CSM_PORTAL_THEME;
+  return isThemeKey(fromConfig) ? fromConfig : DEFAULT_THEME_KEY;
+}

--- a/apps/csm-portal/webapp/src/context/theme/ThemePreferenceContext.tsx
+++ b/apps/csm-portal/webapp/src/context/theme/ThemePreferenceContext.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/* eslint-disable react-refresh/only-export-components -- Provider component and its useXxx hook are colocated per the repo's context idiom (fast-refresh DX only) */
+
+import { OxygenUIThemeProvider } from "@wso2/oxygen-ui";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type JSX,
+  type ReactNode,
+} from "react";
+import {
+  configThemeKey,
+  isThemeKey,
+  resolveTheme,
+  THEME_OPTIONS,
+  type ThemeKey,
+} from "@config/themeConfig";
+
+const STORAGE_KEY = "csm.theme";
+
+interface ThemePreferenceContextValue {
+  /** The currently applied Oxygen theme key. */
+  themeKey: ThemeKey;
+  /** Set (and persist) the theme key. */
+  setThemeKey: (next: ThemeKey) => void;
+  /** Theme keys + labels for rendering the picker. */
+  options: typeof THEME_OPTIONS;
+}
+
+const ThemePreferenceContext =
+  createContext<ThemePreferenceContextValue | null>(null);
+
+/**
+ * Initial theme key: a saved user choice wins, otherwise the build-time
+ * `window.config.CSM_PORTAL_THEME` default.
+ */
+function readInitial(): ThemeKey {
+  try {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (isThemeKey(saved)) return saved;
+  } catch {
+    /* localStorage may be unavailable — fall back to the config default */
+  }
+  return configThemeKey();
+}
+
+/**
+ * Owns the runtime theme selection. Holds the chosen key in React state so the
+ * picker can switch themes live, persists the choice to localStorage, and wraps
+ * children in {@link OxygenUIThemeProvider} with the resolved theme. Sits above
+ * the rest of the provider tree so every component (including the header
+ * dropdown) renders under the selected theme.
+ */
+export function ThemePreferenceProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  const [themeKey, setThemeKeyState] = useState<ThemeKey>(() => readInitial());
+
+  const setThemeKey = useCallback((next: ThemeKey): void => {
+    setThemeKeyState(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* ignore — the in-memory choice still applies for this session */
+    }
+  }, []);
+
+  const value = useMemo<ThemePreferenceContextValue>(
+    () => ({ themeKey, setThemeKey, options: THEME_OPTIONS }),
+    [themeKey, setThemeKey],
+  );
+
+  return (
+    <ThemePreferenceContext.Provider value={value}>
+      <OxygenUIThemeProvider theme={resolveTheme(themeKey)}>
+        {children}
+      </OxygenUIThemeProvider>
+    </ThemePreferenceContext.Provider>
+  );
+}
+
+export function useThemePreference(): ThemePreferenceContextValue {
+  const ctx = useContext(ThemePreferenceContext);
+  if (!ctx) {
+    throw new Error(
+      "useThemePreference must be used within a ThemePreferenceProvider",
+    );
+  }
+  return ctx;
+}


### PR DESCRIPTION
## What

Adds a runtime **theme selector** to the top-right header bar so users can switch the active Oxygen UI theme without a rebuild.

- Dropdown sits next to the existing light/dark `ColorSchemeToggle` — an orthogonal axis: this picks the **palette**, that picks the **colour scheme**.
- Covers all five Oxygen UI themes: **Acrylic Orange** (default), **Acrylic Purple**, **Choreo**, **Classic**, **High Contrast**. (`Choreo` was previously unwired.)
- The choice is **persisted per browser** (localStorage), layered over the build-time `CSM_PORTAL_THEME` default.

## How

- `themeConfig.ts` — now a theme **registry**: `THEMES`, `THEME_OPTIONS`, `resolveTheme()`, `isThemeKey()`, `configThemeKey()`. Add a theme here and it appears in the picker automatically.
- `ThemePreferenceProvider` (new) — owns the selected key in React state, persists it, and wraps the app in `OxygenUIThemeProvider` so switching re-themes live. Mirrors the existing `MockModeProvider` idiom.
- `ThemeSelect` (new) — the compact header dropdown.
- `Actions.tsx` / `AppWithConfig.tsx` — mount the dropdown; replace the static theme provider.
- `config.js.example` — document the valid theme keys.

## Notes

- Branch is cut from `v2` (independent of the open case-management PR), so this diff is theming-only.
- No backend/contract/schema change; no new dependency (all five themes already ship with `@wso2/oxygen-ui`).

## Verification

`tsc -b`, `eslint`, `pnpm build`, and `vitest` (39 tests) all pass.
