### PR TITLE
fix(csm-portal): case-management UI-review fixes; cache directory lookups across filter changes; send x-user-id-token

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -28,6 +28,9 @@ import type {
 
 const PAGE_LIMIT = 100;
 const PRODUCTS_LIMIT = 100; // backend caps pagination limit at 100
+// Bound the catalog scan: if referenced product ids can't be resolved (deleted
+// or bad data), don't page through an unbounded catalog. ~2000 products covered.
+const MAX_CATALOG_PAGES = 20;
 
 export interface DeployedProductOption {
   /** Deployed-product id — the value the case-create payload needs. */
@@ -73,22 +76,25 @@ export function useDeployedProductOptions(
       const productName = new Map<string, string>();
       const unresolved = new Set(productIds);
       const resolveProductNames = async (): Promise<void> => {
-        for (let offset = 0; unresolved.size > 0; offset += PRODUCTS_LIMIT) {
+        let offset = 0;
+        for (let page = 0; unresolved.size > 0 && page < MAX_CATALOG_PAGES; page += 1) {
           const res = await api.post<
             BeProductSearchPayload,
             BeProductSearchResponse
           >("/products/search", {
             pagination: { offset, limit: PRODUCTS_LIMIT },
           });
-          const page = res.products ?? [];
-          for (const p of page) {
+          const products = res.products ?? [];
+          for (const p of products) {
             if (unresolved.has(p.id)) {
               productName.set(p.id, p.name ?? p.id);
               unresolved.delete(p.id);
             }
           }
-          if (page.length < PRODUCTS_LIMIT) break;
+          if (products.length < PRODUCTS_LIMIT) break;
+          offset += PRODUCTS_LIMIT;
         }
+        // Any still-unresolved ids fall back to the id as their label below.
       };
 
       const [, versionLists] = await Promise.all([

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -68,12 +68,14 @@ export function useGetCsmCases(
   const api = useBackendApi();
 
   return useQuery<CsmCasesListResponse, Error>({
+    // Sort the array filters so selection order doesn't fragment the cache
+    // (["S1","S2"] and ["S2","S1"] are the same query).
     queryKey: [
       ApiQueryKeys.CSM_CASES,
       filters.scope,
-      filters.severities,
-      filters.states,
-      filters.projects,
+      [...filters.severities].sort(),
+      [...filters.states].sort(),
+      [...filters.projects].sort(),
     ],
     queryFn: async (): Promise<CsmCasesListResponse> => {
       if (isMockMode()) {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -14,23 +14,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
 import { ApiQueryKeys } from "@constants/apiConstants";
-import { isMockMode, useBackendApi } from "@api/backend/client";
+import { isMockMode, useBackendApi, type BackendApi } from "@api/backend/client";
 import {
   beStateFromUi,
   priorityFromSeverity,
   severityFromPriority,
   uiStateFromBe,
 } from "@api/backend/mappers";
+import { projectOptionsQueryOptions } from "@features/csm-cases/api/useProjectOptions";
 import type {
+  BeAccount,
   BeAccountSearchPayload,
   BeAccountSearchResponse,
   BeCaseSearchPayload,
   BeCaseSearchResponse,
-  BeProjectSearchPayload,
-  BeProjectSearchResponse,
 } from "@api/backend/types";
 import { getMockCsmCases } from "@features/csm-cases/api/mocks/casesMocks";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
@@ -43,8 +47,40 @@ const MOCK_LATENCY_MS = 200;
 
 /** Page size for the cross-project case list (server-side filtering TBD). */
 const CASES_PAGE_LIMIT = 100;
-/** Page size for the project / account name lookups (customer column). */
+/** Page size for the account name lookup (customer column). */
 const LOOKUP_PAGE_LIMIT = 100; // backend caps pagination limit at 100
+// Cap the account scan the same way useProjectOptions caps the project scan.
+const LOOKUP_MAX_PAGES = 20;
+
+/**
+ * Query options for the account-name lookup (`POST /accounts/search`). Kept as
+ * its own stably-keyed query (resolved via `queryClient.fetchQuery`) so filter
+ * changes on the cases list — which change the cases query key — reuse the
+ * cached directory instead of re-fetching every account each time.
+ */
+function accountOptionsQueryOptions(api: BackendApi) {
+  return {
+    queryKey: [ApiQueryKeys.CSM_ACCOUNTS, "options"],
+    queryFn: async (): Promise<BeAccount[]> => {
+      const all: BeAccount[] = [];
+      let offset = 0;
+      for (let page = 0; page < LOOKUP_MAX_PAGES; page += 1) {
+        const res = await api.post<
+          BeAccountSearchPayload,
+          BeAccountSearchResponse
+        >("/accounts/search", {
+          pagination: { offset, limit: LOOKUP_PAGE_LIMIT },
+        });
+        const accounts = res.accounts ?? [];
+        all.push(...accounts);
+        if (accounts.length < LOOKUP_PAGE_LIMIT) break;
+        offset += LOOKUP_PAGE_LIMIT;
+      }
+      return all;
+    },
+    staleTime: 60_000,
+  } as const;
+}
 
 /**
  * Cross-project CSM cases list.
@@ -52,9 +88,13 @@ const LOOKUP_PAGE_LIMIT = 100; // backend caps pagination limit at 100
  * LIVE mode does a single `POST /cases/search` (the flat, cross-project search)
  * and maps each rich `CaseSearchView` — which embeds project / deployment /
  * deployed-product — to the UI `CsmCaseRow`. The account (customer) name is the
- * only field not embedded, so it's resolved once via `projects/search`
- * (projectId → accountId) + `accounts/search` (accountId → name) rather than
- * the old per-project fan-out.
+ * only field not embedded, so it's resolved via `projects/search`
+ * (projectId → accountId) + `accounts/search` (accountId → name). Both lookups
+ * live under their own stable query keys (resolved with
+ * `queryClient.fetchQuery`), so changing list filters only re-runs
+ * `/cases/search`; the project/account directories come from cache until they
+ * go stale. The project lookup shares `useProjectOptions`' key, which the
+ * cases page already mounts for its filter options.
  *
  * Severity / state filters are pushed into the search payload (priorityKeys /
  * stateKeys); the remaining filters stay client-side in `CsmCasesPage`
@@ -66,6 +106,7 @@ export function useGetCsmCases(
 ): UseQueryResult<CsmCasesListResponse, Error> {
   const logger = useLogger();
   const api = useBackendApi();
+  const queryClient = useQueryClient();
 
   return useQuery<CsmCasesListResponse, Error>({
     // Sort the array filters so selection order doesn't fragment the cache
@@ -87,67 +128,45 @@ export function useGetCsmCases(
       }
 
       // One cross-project case search, plus project/account lookups for the
-      // customer column (cases embed the project, but not its account).
-      // Severity / state filters are applied server-side via the search
-      // payload; the rest stay client-side in CsmCasesPage.
-      const [casesResponse, projectsResponse, accountsResponse] =
-        await Promise.all([
-          api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
-            pagination: { offset: 0, limit: CASES_PAGE_LIMIT },
-            ...(filters.severities.length > 0 && {
-              priorityKeys: filters.severities.map(priorityFromSeverity),
-            }),
-            ...(filters.states.length > 0 && {
-              stateKeys: filters.states.map(beStateFromUi),
-            }),
-            // `filters.projects` holds project IDs (the filter is id-based).
-            ...(filters.projects.length > 0 && {
-              projectIds: filters.projects,
-            }),
+      // customer column (cases embed the project, but not its account). The
+      // lookups go through `fetchQuery` with their own stable keys, so they
+      // hit the network only when their cache is stale — not on every filter
+      // change. Lookup failures degrade to "—" names, not a failed list.
+      const [casesResponse, projects, accounts] = await Promise.all([
+        api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
+          pagination: { offset: 0, limit: CASES_PAGE_LIMIT },
+          ...(filters.severities.length > 0 && {
+            priorityKeys: filters.severities.map(priorityFromSeverity),
           }),
-          api
-            .post<BeProjectSearchPayload, BeProjectSearchResponse>(
-              "/projects/search",
-              { pagination: { offset: 0, limit: LOOKUP_PAGE_LIMIT } },
-            )
-            .catch((err) => {
-              logger.warn(
-                `[useGetCsmCases] /projects/search failed: ${(err as Error).message}`,
-              );
-              return {
-                projects: [],
-                total: 0,
-                limit: 0,
-                offset: 0,
-                hasMore: false,
-              } satisfies BeProjectSearchResponse;
-            }),
-          api
-            .post<BeAccountSearchPayload, BeAccountSearchResponse>(
-              "/accounts/search",
-              { pagination: { offset: 0, limit: LOOKUP_PAGE_LIMIT } },
-            )
-            .catch((err) => {
-              logger.warn(
-                `[useGetCsmCases] /accounts/search failed: ${(err as Error).message}`,
-              );
-              return {
-                accounts: [],
-                total: 0,
-                limit: 0,
-                offset: 0,
-                hasMore: false,
-              } satisfies BeAccountSearchResponse;
-            }),
-        ]);
+          ...(filters.states.length > 0 && {
+            stateKeys: filters.states.map(beStateFromUi),
+          }),
+          // `filters.projects` holds project IDs (the filter is id-based).
+          ...(filters.projects.length > 0 && {
+            projectIds: filters.projects,
+          }),
+        }),
+        queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {
+          logger.warn(
+            `[useGetCsmCases] project lookup failed: ${(err as Error).message}`,
+          );
+          return [];
+        }),
+        queryClient.fetchQuery(accountOptionsQueryOptions(api)).catch((err) => {
+          logger.warn(
+            `[useGetCsmCases] account lookup failed: ${(err as Error).message}`,
+          );
+          return [];
+        }),
+      ]);
 
       const projectAccount = new Map<string, string>(
-        (projectsResponse.projects ?? [])
+        projects
           .filter((p) => p.accountId)
           .map((p) => [p.id, p.accountId as string]),
       );
       const accountName = new Map<string, string>(
-        (accountsResponse.accounts ?? [])
+        accounts
           .filter((a) => a.name)
           .map((a) => [a.id, a.name as string]),
       );

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
@@ -16,7 +16,7 @@
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
-import { useBackendApi } from "@api/backend/client";
+import { useBackendApi, type BackendApi } from "@api/backend/client";
 import type {
   BeProject,
   BeProjectSearchPayload,
@@ -28,12 +28,15 @@ const PAGE_LIMIT = 100; // backend caps pagination limit at 100
 // requests (~2000 projects covered).
 const MAX_PAGES = 20;
 
-/** Projects for the case-create project selector, via `POST /projects/search`. */
-export function useProjectOptions(): UseQueryResult<BeProject[], Error> {
-  const api = useBackendApi();
-
-  return useQuery<BeProject[], Error>({
-    queryKey: [ApiQueryKeys.CSM_PROJECTS, "case-create-options"],
+/**
+ * Query options for the full project directory, via `POST /projects/search`.
+ * Exported (rather than only the hook) so non-component code — e.g. the
+ * `useGetCsmCases` queryFn — can resolve the same cached data through
+ * `queryClient.fetchQuery` instead of re-fetching on every cases query.
+ */
+export function projectOptionsQueryOptions(api: BackendApi) {
+  return {
+    queryKey: [ApiQueryKeys.CSM_PROJECTS, "options"],
     queryFn: async (): Promise<BeProject[]> => {
       // Page through so projects beyond the first page are still selectable.
       const all: BeProject[] = [];
@@ -51,5 +54,12 @@ export function useProjectOptions(): UseQueryResult<BeProject[], Error> {
       return all;
     },
     staleTime: 60_000,
-  });
+  } as const;
+}
+
+/** Projects for the case-create / case-filter project selectors. */
+export function useProjectOptions(): UseQueryResult<BeProject[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProject[], Error>(projectOptionsQueryOptions(api));
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
@@ -15,6 +15,7 @@
 // under the License.
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
   BeProject,
@@ -23,24 +24,29 @@ import type {
 } from "@api/backend/types";
 
 const PAGE_LIMIT = 100; // backend caps pagination limit at 100
+// Cap the scan so a large project catalog can't fire unbounded sequential
+// requests (~2000 projects covered).
+const MAX_PAGES = 20;
 
 /** Projects for the case-create project selector, via `POST /projects/search`. */
 export function useProjectOptions(): UseQueryResult<BeProject[], Error> {
   const api = useBackendApi();
 
   return useQuery<BeProject[], Error>({
-    queryKey: ["csm-case-create-projects"],
+    queryKey: [ApiQueryKeys.CSM_PROJECTS, "case-create-options"],
     queryFn: async (): Promise<BeProject[]> => {
       // Page through so projects beyond the first page are still selectable.
       const all: BeProject[] = [];
-      for (let offset = 0; ; offset += PAGE_LIMIT) {
+      let offset = 0;
+      for (let page = 0; page < MAX_PAGES; page += 1) {
         const res = await api.post<
           BeProjectSearchPayload,
           BeProjectSearchResponse
         >("/projects/search", { pagination: { offset, limit: PAGE_LIMIT } });
-        const page = res.projects ?? [];
-        all.push(...page);
-        if (page.length < PAGE_LIMIT) break;
+        const projects = res.projects ?? [];
+        all.push(...projects);
+        if (projects.length < PAGE_LIMIT) break;
+        offset += PAGE_LIMIT;
       }
       return all;
     },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -36,10 +36,10 @@ function caseInState(
 }
 
 describe("CaseActionBar — nextStates-driven buttons", () => {
-  it("renders one button per backend nextState", () => {
+  it("renders one button per backend nextState, labelled by the target state", () => {
     // The reported bug: a solution_proposed case returns
-    // nextStates [closed, waiting_on_wso2] but only "Close" showed because the
-    // resume action was hardwired to work_in_progress. Both must now appear.
+    // nextStates [closed, waiting_on_wso2] but only one button showed. Both
+    // must appear, each named after the backend state it moves into.
     render(
       <CaseActionBar
         caseDetail={caseInState("solution_proposed", [
@@ -49,13 +49,11 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /resume work/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^close$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /waiting on wso2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^closed$/i })).toBeInTheDocument();
   });
 
   it("shows exactly the transitions the backend permits, nothing more", () => {
-    // work_in_progress could move many ways, but the backend here only allows
-    // two — so only those two buttons render.
     render(
       <CaseActionBar
         caseDetail={caseInState("work_in_progress", [
@@ -65,51 +63,65 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /propose solution/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /request info/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /^close$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /solution proposed/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /awaiting info/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /waiting on wso2/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^closed$/i })).not.toBeInTheDocument();
   });
 
-  it("labels the move into Waiting on WSO2 by source: pause vs resume", () => {
-    // From WIP it is a deliberate pause...
+  it("labels a target the same regardless of source state (no UI-invented verbs)", () => {
+    // From WIP, moving to waiting_on_wso2...
     const { unmount } = render(
       <CaseActionBar
         caseDetail={caseInState("work_in_progress", ["waiting_on_wso2"])}
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /resume work/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /waiting on wso2/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
     unmount();
 
-    // ...but from a paused state (awaiting_info) the same target reads "Resume".
+    // ...and from a paused state, the SAME target reads the same — "Waiting on
+    // WSO2", not a fabricated "Resume work".
     render(
       <CaseActionBar
         caseDetail={caseInState("awaiting_info", ["waiting_on_wso2"])}
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /resume work/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /waiting on wso2/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
   });
 
   it("dispatches the action with the backend nextState as the PATCH target", () => {
     const onAction = vi.fn();
     render(
       <CaseActionBar
-        caseDetail={caseInState("solution_proposed", [
-          "closed",
-          "waiting_on_wso2",
-        ])}
+        caseDetail={caseInState("awaiting_info", ["waiting_on_wso2"])}
         onAction={onAction}
       />,
     );
-    // "Resume work" has no confirm dialog, so it dispatches immediately. The
-    // target must be the real backend nextState (waiting_on_wso2), not a
-    // re-derived guess (work_in_progress).
-    fireEvent.click(screen.getByRole("button", { name: /resume work/i }));
-    expect(onAction).toHaveBeenCalledWith("resume_work", "waiting_on_wso2");
+    // "Waiting on WSO2" has no confirm dialog, so it dispatches immediately, and
+    // the target must be the real backend nextState.
+    fireEvent.click(screen.getByRole("button", { name: /waiting on wso2/i }));
+    expect(onAction).toHaveBeenCalledWith("wait_on_wso2", "waiting_on_wso2");
+  });
+
+  it("gates a customer-notifying transition behind a confirm dialog before dispatch", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("work_in_progress", ["closed"])}
+        onAction={onAction}
+      />,
+    );
+    // Clicking "Closed" must NOT dispatch yet — it opens a confirm dialog.
+    fireEvent.click(screen.getByRole("button", { name: /^closed$/i }));
+    expect(onAction).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // Confirming dispatches with the close action + closed target.
+    fireEvent.click(screen.getByRole("button", { name: /close case/i }));
+    expect(onAction).toHaveBeenCalledWith("close", "closed");
   });
 
   it("falls back to the known graph when nextStates is absent", () => {
@@ -119,23 +131,21 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /propose solution/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /request info/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^close$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /solution proposed/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /awaiting info/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /waiting on wso2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^closed$/i })).toBeInTheDocument();
   });
 
   it("shows no state-change buttons when nextStates is empty (terminal case)", () => {
-    // An empty nextStates is meaningful: a closed/terminal case has no next
-    // step, so it must offer none and not fall back to the graph.
     render(
       <CaseActionBar
         caseDetail={caseInState("closed", [])}
         onAction={() => {}}
       />,
     );
-    expect(screen.queryByRole("button", { name: /resume work/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /reopen/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /waiting on wso2/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reopened/i })).not.toBeInTheDocument();
     // The state-independent "More" overflow is unaffected.
     expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
   });
@@ -148,6 +158,8 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         canReopenClosed
       />,
     );
-    expect(screen.getByRole("button", { name: /reopen/i })).toBeInTheDocument();
+    // The button carries a tooltip, so its accessible name is the tooltip text;
+    // assert the visible "Reopened" label (the BE state name) instead.
+    expect(screen.getByText("Reopened")).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -52,6 +52,7 @@ import type {
   CsmCaseDetail,
 } from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
+import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 
 type ActionConfirm = {
   title: string;
@@ -60,159 +61,81 @@ type ActionConfirm = {
   confirmColor: "primary" | "error" | "warning";
 };
 
-type StateAction = {
+/**
+ * Presentation for a transition *into* a given state. The button LABEL is never
+ * stored here — it always comes from `STATE_LABEL[targetState]`, so the bar
+ * honours the backend transition graph verbatim and never invents UI-specific
+ * verbs. This only carries the icon/colour, the lifecycle action used for the
+ * post-transition toast, and an optional confirm gate.
+ */
+type TargetConfig = {
   action: CaseLifecycleAction;
-  /**
-   * The state this transition moves the case into. It comes straight from the
-   * backend's `nextStates`, and the same value is what the PATCH writes — so the
-   * button the engineer sees and the transition that is persisted can never
-   * drift apart. (The earlier bug was a hand-maintained action→state map that
-   * disagreed with the backend graph and silently dropped valid buttons.)
-   */
-  targetState: CaseState;
-  label: string;
   color: "primary" | "success" | "warning" | "error";
   icon: JSX.Element;
-  /** Hover hint clarifying the consequence of the transition. */
-  tooltip?: string;
-  /**
-   * When set, the action is gated behind a confirmation dialog. Used for
-   * transitions that notify the customer or are otherwise hard to undo, so a
-   * stray click in a busy queue can't silently close a case or email the
-   * customer.
-   */
   confirm?: ActionConfirm;
+};
+
+/** A concrete button: a target state plus its presentation. */
+type PrimaryButton = TargetConfig & {
+  targetState: CaseState;
+  label: string;
+  tooltip?: string;
 };
 
 const CLOSE_CONFIRM: ActionConfirm = {
   title: "Close this case?",
-  body: "The customer receives a closure notification and the case moves to “Closed”. Once closed, the case cannot be reopened.",
+  // No "cannot be reopened" claim — reopen is a lead-only override, so that
+  // assertion would be false for leads.
+  body: "The customer receives a closure notification and the case moves to “Closed”.",
   confirmLabel: "Close case",
   confirmColor: "warning",
 };
 
 /**
- * Default button for a transition *into* `target`, used whenever the
- * (source → target) edge needs no source-specific wording. The label describes
- * the destination; `targetState` is what gets PATCHed.
+ * Per-target-state presentation. One entry per state a case can move INTO.
+ * Customer-notifying / hard-to-undo transitions carry a confirm gate so a stray
+ * click in a busy queue can't silently close a case or email the customer.
  */
-function defaultActionFor(target: CaseState): StateAction | null {
-  switch (target) {
-    case "work_in_progress":
-      // Reached from a paused/parked sub-state — the engineer is un-pausing.
-      return {
-        action: "resume_work",
-        targetState: target,
-        label: "Resume work",
-        color: "primary",
-        icon: <Play size={16} />,
-      };
-    case "waiting_on_wso2":
-      return {
-        action: "wait_on_wso2",
-        targetState: target,
-        label: "Wait on WSO2",
-        color: "primary",
-        icon: <Clock size={16} />,
-      };
-    case "awaiting_info":
-      return {
-        action: "request_info",
-        targetState: target,
-        label: "Request info",
-        color: "primary",
-        icon: <Inbox size={16} />,
-      };
-    case "solution_proposed":
-      return {
-        action: "propose_solution",
-        targetState: target,
-        label: "Propose solution",
-        color: "success",
-        icon: <Send size={16} />,
-        confirm: {
-          title: "Propose solution to the customer?",
-          body: "The customer is notified that a solution has been proposed and the case moves to “Solution proposed”.",
-          confirmLabel: "Propose solution",
-          confirmColor: "primary",
-        },
-      };
-    case "closed":
-      return {
-        action: "close",
-        targetState: target,
-        label: "Close",
-        color: "success",
-        icon: <CheckCircle size={16} />,
-        confirm: CLOSE_CONFIRM,
-      };
-    case "reopen":
-      return {
-        action: "reopen",
-        targetState: target,
-        label: "Reopen",
-        color: "primary",
-        icon: <RotateCcw size={16} />,
-      };
-    // `open` is an initial state, not a transition target the bar offers.
-    case "open":
-    default:
-      return null;
-  }
-}
-
-/**
- * Source-specific overrides where the label depends on *where the case is
- * coming from*, not just where it is going. The clearest case is the move into
- * Waiting on WSO2: from Work in progress it is a deliberate "Wait on WSO2"
- * pause, but from a paused/parked state (Awaiting info, Solution proposed,
- * Reopened) the same target means the engineer is *resuming* the case. Anything
- * not listed here falls back to `defaultActionFor`.
- */
-const EDGE_OVERRIDES: Partial<
-  Record<CaseState, Partial<Record<CaseState, StateAction>>>
-> = {
-  open: {
-    work_in_progress: {
-      action: "start_work",
-      targetState: "work_in_progress",
-      label: "Start work",
-      color: "primary",
-      icon: <Play size={16} />,
-      tooltip: "Moves this case to Work in progress.",
-    },
+const TARGET_CONFIG: Record<CaseState, TargetConfig> = {
+  open: { action: "reopen", color: "primary", icon: <RotateCcw size={16} /> },
+  work_in_progress: {
+    action: "resume_work",
+    color: "primary",
+    icon: <Play size={16} />,
+  },
+  waiting_on_wso2: {
+    action: "wait_on_wso2",
+    color: "primary",
+    icon: <Clock size={16} />,
   },
   awaiting_info: {
-    waiting_on_wso2: {
-      action: "resume_work",
-      targetState: "waiting_on_wso2",
-      label: "Resume work",
-      color: "primary",
-      icon: <Play size={16} />,
-    },
+    action: "request_info",
+    color: "primary",
+    icon: <Inbox size={16} />,
   },
   solution_proposed: {
-    waiting_on_wso2: {
-      action: "resume_work",
-      targetState: "waiting_on_wso2",
-      label: "Resume work",
-      color: "primary",
-      icon: <RotateCcw size={16} />,
+    action: "propose_solution",
+    color: "success",
+    icon: <Send size={16} />,
+    confirm: {
+      title: "Propose solution to the customer?",
+      body: "The customer is notified that a solution has been proposed and the case moves to “Solution proposed”.",
+      confirmLabel: "Propose solution",
+      confirmColor: "primary",
     },
   },
-  reopen: {
-    waiting_on_wso2: {
-      action: "resume_work",
-      targetState: "waiting_on_wso2",
-      label: "Resume work",
-      color: "primary",
-      icon: <Play size={16} />,
-    },
+  reopen: { action: "reopen", color: "primary", icon: <RotateCcw size={16} /> },
+  closed: {
+    action: "close",
+    color: "warning",
+    icon: <CheckCircle size={16} />,
+    confirm: CLOSE_CONFIRM,
   },
 };
 
-function actionFor(from: CaseState, to: CaseState): StateAction | null {
-  return EDGE_OVERRIDES[from]?.[to] ?? defaultActionFor(to);
+/** Build the button for a transition into `target`, labelled by the BE state. */
+function buttonFor(target: CaseState): PrimaryButton {
+  return { targetState: target, label: STATE_LABEL[target], ...TARGET_CONFIG[target] };
 }
 
 /**
@@ -262,13 +185,14 @@ function orderRank(s: CaseState): number {
  * Lead-only override to reopen a closed case. Not part of the normal
  * `nextStates` flow — the backend reports a closed case as terminal
  * (`nextStates: []`) — so it is appended for the `closed` state only when the
- * caller grants the `canReopenClosed` capability.
+ * caller grants the `canReopenClosed` capability. Labelled by the BE state it
+ * lands in (`reopen` → "Reopened") like every other button.
  */
-const REOPEN_ACTION: StateAction = {
-  action: "reopen",
+const REOPEN_BUTTON: PrimaryButton = {
   targetState: "reopen",
-  label: "Reopen",
-  color: "primary",
+  label: STATE_LABEL.reopen,
+  action: "reopen",
+  color: "warning",
   icon: <RotateCcw size={16} />,
   tooltip: "Lead-only: reopen a closed case for an exceptional follow-up.",
   confirm: {
@@ -337,9 +261,9 @@ interface CaseActionBarProps {
 /**
  * Lifecycle + overflow action bar for the case detail page. Primary buttons are
  * driven directly by the case's backend-supplied `nextStates`: one button per
- * reachable state, so the bar always reflects exactly the transitions the
- * backend permits. Secondary actions live in an overflow menu and are
- * state-independent.
+ * reachable state, labelled with that state's name, so the bar always reflects
+ * exactly the transitions the backend permits. Secondary actions live in an
+ * overflow menu and are state-independent.
  */
 export default function CaseActionBar({
   caseDetail,
@@ -347,7 +271,7 @@ export default function CaseActionBar({
   canReopenClosed = false,
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [pendingConfirm, setPendingConfirm] = useState<StateAction | null>(
+  const [pendingConfirm, setPendingConfirm] = useState<PrimaryButton | null>(
     null,
   );
 
@@ -359,17 +283,16 @@ export default function CaseActionBar({
   const targets = caseDetail.nextStates ?? FALLBACK_TARGETS[from] ?? [];
   const lifecycle = [...new Set(targets)]
     .sort((a, b) => orderRank(a) - orderRank(b))
-    .map((to) => actionFor(from, to))
-    .filter((a): a is StateAction => a !== null);
+    .map(buttonFor);
   const primary = [
     ...lifecycle,
     // Lead-only reopen is an override outside the normal `nextStates` flow, so
     // it is gated by capability rather than by the backend transition list.
-    ...(from === "closed" && canReopenClosed ? [REOPEN_ACTION] : []),
+    ...(from === "closed" && canReopenClosed ? [REOPEN_BUTTON] : []),
   ];
   const secondary = buildSecondaryItems();
 
-  const runPrimary = (p: StateAction): void => {
+  const runPrimary = (p: PrimaryButton): void => {
     if (p.confirm) {
       setPendingConfirm(p);
       return;
@@ -399,12 +322,19 @@ export default function CaseActionBar({
             {p.label}
           </Button>
         );
+        // `targetState` is unique per button (each moves to a distinct state),
+        // so it is the correct React key — the lifecycle action is not (e.g.
+        // `resume_work` can map from more than one source state).
         return p.tooltip ? (
-          <Tooltip key={p.action} title={p.tooltip}>
+          <Tooltip key={p.targetState} title={p.tooltip}>
             {button}
           </Tooltip>
         ) : (
-          <Box key={p.action} component="span" sx={{ display: "inline-flex" }}>
+          <Box
+            key={p.targetState}
+            component="span"
+            sx={{ display: "inline-flex" }}
+          >
             {button}
           </Box>
         );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -20,6 +20,7 @@ import { useNavigate } from "react-router";
 import {
   SEVERITY_COLOR,
   SLA_CLOCK_LABEL,
+  STATE_COLOR,
   STATE_LABEL,
   formatTimeToBreach,
 } from "@features/csm-dashboard/utils/abtDashboard";
@@ -177,9 +178,12 @@ export default function CasesList({
                 label={c.severity}
                 color={SEVERITY_COLOR[c.severity]}
               />
-              <Typography variant="body2" noWrap>
-                {STATE_LABEL[c.state]}
-              </Typography>
+              <Chip
+                size="small"
+                variant="outlined"
+                label={STATE_LABEL[c.state]}
+                color={STATE_COLOR[c.state]}
+              />
               <Typography variant="body2" noWrap>
                 {c.assigneeIsMe ? (
                   <strong>{c.assignee}</strong>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   Card,
   FormControl,
+  FormHelperText,
   Grid,
   InputLabel,
   MenuItem,
@@ -204,6 +205,11 @@ export default function CsmCaseCreatePage(): JSX.Element {
                   </MenuItem>
                 ))}
               </Select>
+              {!projectId ? (
+                <FormHelperText>Select a project first</FormHelperText>
+              ) : deployments.isLoading ? (
+                <FormHelperText>Loading deployments…</FormHelperText>
+              ) : null}
             </FormControl>
           </Grid>
 
@@ -223,6 +229,11 @@ export default function CsmCaseCreatePage(): JSX.Element {
                   </MenuItem>
                 ))}
               </Select>
+              {!deploymentId ? (
+                <FormHelperText>Select a deployment first</FormHelperText>
+              ) : deployedProducts.isLoading ? (
+                <FormHelperText>Loading products…</FormHelperText>
+              ) : null}
             </FormControl>
           </Grid>
 
@@ -270,25 +281,34 @@ export default function CsmCaseCreatePage(): JSX.Element {
               required
               value={subject}
               onChange={(e) => setSubject(e.target.value.slice(0, 200))}
+              helperText={
+                subject.length >= 160 ? `${subject.length}/200` : undefined
+              }
             />
           </Grid>
           <Grid size={{ xs: 12 }}>
             <Typography
+              id="case-description-label"
+              component="label"
               variant="caption"
               color="text.secondary"
               sx={{ display: "block", mb: 0.5 }}
             >
               Description
             </Typography>
-            <Editor
-              value={description}
-              onChange={setDescription}
-              placeholder="Describe the issue…"
-              minHeight={180}
-              maxHeight={420}
-              toolbarVariant="full"
-              disabled={postCase.isPending}
-            />
+            {/* Editor doesn't accept an `id`, so associate the label by wrapping
+                the editor in a labelled group for assistive tech. */}
+            <Box role="group" aria-labelledby="case-description-label">
+              <Editor
+                value={description}
+                onChange={setDescription}
+                placeholder="Describe the issue…"
+                minHeight={180}
+                maxHeight={420}
+                toolbarVariant="full"
+                disabled={postCase.isPending}
+              />
+            </Box>
           </Grid>
         </Grid>
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -100,7 +100,7 @@ export default function CaseCountsMatrix(): JSX.Element {
           <Table size="small" aria-label="Case counts by severity and state">
             <TableHead>
               <TableRow>
-                <TableCell sx={{ fontWeight: 600 }}>Severity \ State</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Severity / State</TableCell>
                 {MATRIX_STATES.map((st) => (
                   <TableCell key={st} align="center">
                     <Link
@@ -122,7 +122,7 @@ export default function CaseCountsMatrix(): JSX.Element {
             <TableBody>
               {MATRIX_SEVERITIES.map((sev) => (
                 <TableRow key={sev} hover>
-                  <TableCell>
+                  <TableCell component="th" scope="row">
                     <Link
                       component={RouterLink}
                       to={casesHref(sev)}
@@ -151,7 +151,9 @@ export default function CaseCountsMatrix(): JSX.Element {
                 </TableRow>
               ))}
               <TableRow>
-                <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
+                <TableCell component="th" scope="row" sx={{ fontWeight: 700 }}>
+                  Total
+                </TableCell>
                 {MATRIX_STATES.map((st) => (
                   <CountCell
                     key={st}

--- a/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -57,6 +57,7 @@ function buildRequestHeaders(
   input: RequestInfo | URL,
   options: RequestInit | undefined,
   token: string,
+  idToken: string,
 ): Headers {
   // When `input` is a Request, `init.headers` on the outer fetch call REPLACES
   // the request's headers wholesale — it does not merge. Seed the headers from
@@ -70,6 +71,10 @@ function buildRequestHeaders(
   }
 
   headers.set("Authorization", `Bearer ${token}`);
+  // The ID token travels alongside the access token (same convention as the
+  // customer portal): the gateway validates the bearer, while the backend
+  // reads the user's identity claims from `x-user-id-token`.
+  headers.set("x-user-id-token", idToken);
   if (!headers.has("Accept")) {
     headers.set("Accept", "application/json");
   }
@@ -98,14 +103,16 @@ function buildRequestHeaders(
   return headers;
 }
 
-// Fetch wrapper that attaches a fresh IdP access token as the bearer. The
+// Fetch wrapper that attaches a fresh IdP access token as the bearer and the
+// ID token as `x-user-id-token` (the customer portal's convention). The
 // Choreo gateway validates the access token and forwards it upstream as
-// `x-jwt-assertion`, which csm-portal-backend reads in its auth middleware.
-// The token is only attached when the request origin matches the configured
-// backend; calls to any other origin go through bare fetch so credentials
-// can't be leaked to third-party hosts.
+// `x-jwt-assertion`, which csm-portal-backend reads in its auth middleware;
+// `x-user-id-token` passes through to the backend untouched.
+// The tokens are only attached when the request origin matches the configured
+// backend; calls to any other origin are refused so credentials can't be
+// leaked to third-party hosts.
 export function useAuthApiClient() {
-  const { getAccessToken } = useAsgardeo();
+  const { getAccessToken, getIdToken } = useAsgardeo();
 
   return useCallback(
     async (input: RequestInfo | URL, options?: RequestInit): Promise<Response> => {
@@ -117,8 +124,12 @@ export function useAuthApiClient() {
       }
 
       let token: string | undefined;
+      let idToken: string | undefined;
       try {
-        token = await getAccessToken();
+        [token, idToken] = await Promise.all([
+          getAccessToken(),
+          getIdToken(),
+        ]);
       } catch (error) {
         // Normalise the SDK-not-initialized race into the shared "auth not
         // ready" signal so callers warn-and-retry instead of surfacing a raw
@@ -131,12 +142,15 @@ export function useAuthApiClient() {
       if (!token) {
         throw new Error("Unable to retrieve access token");
       }
+      if (!idToken) {
+        throw new Error("Unable to retrieve ID token");
+      }
 
       return fetch(input, {
         ...options,
-        headers: buildRequestHeaders(input, options, token),
+        headers: buildRequestHeaders(input, options, token, idToken),
       });
     },
-    [getAccessToken],
+    [getAccessToken, getIdToken],
   );
 }


### PR DESCRIPTION
Follow-ups after a UX + React review of the case-management work merged in #836, plus two fixes batched in: cases-list directory lookups no longer re-fetch on every filter change, and the webapp now sends `x-user-id-token` to the backend.

## Auth

**Send `x-user-id-token` to the backend.** `useAuthApiClient` now sends the Asgardeo ID token in an `x-user-id-token` header alongside the access-token bearer, mirroring the customer portal's convention, so the backend can read the user's identity claims.
- The csm backend doesn't consume this header yet (its middleware reads `x-jwt-assertion` only) — the header is inert until that lands.
- Gateway/CORS config must allow the header if it doesn't already.

## Cases list

**Stop re-fetching all projects/accounts on every filter change.** `useGetCsmCases` fetched `/projects/search` and `/accounts/search` inside the cases query function, so every filter change (a new query key) re-ran both directory scans. The two lookups now resolve through `queryClient.fetchQuery` under their own stable keys with a 60s `staleTime` — filter changes only re-run `/cases/search`.
- The project lookup shares the `useProjectOptions` directory query the page already mounts for its filter options, and now covers the full paged catalog instead of only the first 100 projects.
- The account lookup gets the same paged scan with the same page cap.

**State column rendered as a `STATE_COLOR` chip**, matching the detail page so the "whose move is it" state colour-coding shows in the queue.

## Case action bar

- **Label each lifecycle button by the backend target state** (`STATE_LABEL`), driven directly by `nextStates`. Drops the source-aware `Resume work` / `Wait on WSO2` relabelling, which mislabelled transitions (moving into `waiting_on_wso2` from a paused state showed "Resume work"). The bar now honours the BE transition graph verbatim.
- **React key is `targetState`, not the lifecycle action** — `action` is not unique across source states (e.g. `resume_work`), `targetState` always is.
- Close button + its confirm dialog are both `warning`-coloured; dropped the false "cannot be reopened" line (leads can reopen).

## Case create (`/cases/new`)

- Dependent selects now show **why** they're disabled (`Select a project first` / `Loading deployments…`) so the left-to-right project → deployment → deployed-product cascade is legible (the disabling itself was already correct).
- Description label associated with the editor via a labelled group (the editor takes no `id`); Subject shows a counter near the 200-char cap.

## Data hooks

- `useGetCsmCases` query key **sorts the array filters** so selection order doesn't fragment the cache (`[S1,S2]` == `[S2,S1]`).
- `useDeployedProductOptions` and `useProjectOptions` **cap their catalog paging** so bad/large data can't fire unbounded sequential requests.
- `useProjectOptions` uses a namespaced `ApiQueryKeys` key instead of a raw string.

## Dashboard matrix

- Forward slash in the corner header; severity + Total cells are **row headers** (`th scope="row"`) for screen readers.

## Checks

`pnpm lint` ✅ · `pnpm test` ✅ (47) · `pnpm build` ✅ (re-run on the latest commit)

## Deferred (not in this PR — flagging for discussion)

- Backend `state.go` transition graph has odd edges (`awaiting_info → [waiting_on_wso2]` only — no close-no-response path; `solution_proposed` can't return to `work_in_progress`). The FE now mirrors the BE faithfully; if the graph is wrong, fix `state.go`.
- The deployed-product selector still resolves product/version labels by paging the product catalog (`/products/search` has no id filter). Planned BE fix: embed `productName` / `productVersionName` in the `/deployments/{id}/products/search` response; the FE scan gets deleted once that ships.
- The filter "Filters/Clear" button is dual-mode (can't open the panel while filters are active) — a UX redesign, left out of this fix-batch.
- WCAG contrast of the new chip colours in both themes is asserted from code comments, not measured (no browser available in the review env).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helper text guidance in case creation form for deployment and product selectors
  * Added character counter for case subject field (200-character limit)
  * Enhanced case state display with color-coded status chips in the cases list

* **Improvements**
  * Improved form accessibility with explicit label associations and editor labeling
  * Enhanced table header semantics for better accessibility
  * Optimized data fetching performance and cache consistency for case information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
