### PR TITLE
[Customer Portal][Webapp] Fix watch list display order after update

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -120,6 +120,7 @@ export default function CaseDetailsDetailsPanel({
     patchCase({ watchList: optimisticList }, {
       onSuccess: () => {
         setIsEditingWatchList(false);
+        setSavedWatchList(null);
         showSuccess("Watch list updated successfully");
       },
       onError: () => {


### PR DESCRIPTION
After a successful watch list update, the display was using the optimistic local state instead of the server response, causing the order to be inconsistent.
Fixed by clearing savedWatchList on success so the UI reflects the exact order returned by the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the watch list state was not properly clearing after successfully saving case details, ensuring the UI correctly reflects changes without retaining stale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->