### PR TITLE
[CSM Portal] Forward x-user-id-token header to entity service

### DIFF
--- a/apps/csm-portal/backend/internal/entity/client.go
+++ b/apps/csm-portal/backend/internal/entity/client.go
@@ -29,6 +29,21 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+type ctxKey string
+
+const userIDTokenKey ctxKey = "x-user-id-token"
+
+// WithUserIDToken returns a copy of ctx carrying the x-user-id-token value to
+// be forwarded on every outgoing entity request.
+func WithUserIDToken(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, userIDTokenKey, token)
+}
+
+func userIDTokenFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(userIDTokenKey).(string)
+	return v
+}
+
 // Config holds the configuration for the entity service client.
 type Config struct {
 	BaseURL      string
@@ -82,6 +97,9 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 	}
 	if len(body) > 0 {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := userIDTokenFromContext(ctx); token != "" {
+		req.Header.Set("x-user-id-token", token)
 	}
 
 	resp, err := c.http.Do(req)

--- a/apps/csm-portal/backend/internal/middleware/auth.go
+++ b/apps/csm-portal/backend/internal/middleware/auth.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/entity"
 )
 
 // authErrorBody is the JSON error payload for auth failures.
@@ -109,6 +110,7 @@ func Auth(cfg Config) func(http.Handler) http.Handler {
 			}
 
 			ctx := context.WithValue(r.Context(), userInfoKey, info)
+			ctx = entity.WithUserIDToken(ctx, r.Header.Get("x-user-id-token"))
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}


### PR DESCRIPTION
## Summary

- Accepts the `x-user-id-token` header from incoming BFF requests
- The auth middleware stores the token in the request context after JWT validation
- The entity client reads it from context in `do()` and sets it on every outgoing entity service request

## Test plan

- [x] Confirm existing tests still pass (`make test`)
- [x] Send a request with `x-user-id-token: <token>` and verify the entity service receives the header
- [x] Send a request without `x-user-id-token` and verify the entity service call succeeds without the header (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced authentication token propagation through request contexts across internal service layers for improved request handling and user identification consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->