### PR TITLE
[Customer Portal][Webapp] Add start/end datetime cross-field validation for service requests

### DIFF
--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
@@ -34,12 +34,10 @@ import {
   isFileCopyPathField,
   isDescriptionField,
   isDateTimeField,
-  isPastOnlyDateTimeField,
+  isStartDateTimeField,
+  isEndDateTimeField,
 } from "@features/operations/utils/serviceRequestValidation";
-import {
-  computeMinScheduleDatetimeLocalForTimeZone,
-  computeMaxDatetimeLocalForTimeZone,
-} from "@features/support/utils/support";
+import { computeMinScheduleDatetimeLocalForTimeZone } from "@features/support/utils/support";
 import { resolveDisplayTimeZone } from "@utils/dateTime";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
@@ -221,7 +219,6 @@ export default function VariableFormFields({
   const { showError } = useErrorBanner();
   const effectiveTimeZone = userTimeZone ?? resolveDisplayTimeZone();
   const minDatetime = computeMinScheduleDatetimeLocalForTimeZone(0, effectiveTimeZone);
-  const maxDatetime = computeMaxDatetimeLocalForTimeZone(effectiveTimeZone);
   const sortedVariables = useMemo(
     () => (variables ? [...variables].sort((a, b) => a.order - b.order) : []),
     [variables],
@@ -509,7 +506,27 @@ export default function VariableFormFields({
     }
 
     if (isDateTimeField(variable)) {
-      const isPastOnly = isPastOnlyDateTimeField(variable);
+      const isStart = isStartDateTimeField(variable);
+      const isEnd = isEndDateTimeField(variable);
+
+      let dateError = false;
+      let dateHelperText: string = `Timezone: ${effectiveTimeZone}`;
+
+      if (isStart || isEnd) {
+        const startField = sortedVariables.find(isStartDateTimeField);
+        const endField = sortedVariables.find(isEndDateTimeField);
+        const startVal = startField ? (values[startField.id] ?? "") : "";
+        const endVal = endField ? (values[endField.id] ?? "") : "";
+        if (startVal && endVal && startVal >= endVal) {
+          dateError = true;
+          dateHelperText = isStart
+            ? "Start time must be before end time."
+            : "End time must be after start time.";
+        }
+      }
+
+      const inputConstraints = !isStart && !isEnd ? { min: minDatetime } : {};
+
       return (
         <Grid key={variable.id} size={{ xs: 12, sm: 6 }}>
           <Box sx={{ mb: 1 }}>
@@ -523,8 +540,9 @@ export default function VariableFormFields({
             onChange={(e) => onChange(variable.id, e.target.value)}
             disabled={isContext}
             slotProps={{ inputLabel: { shrink: true } }}
-            inputProps={isPastOnly ? { max: maxDatetime } : { min: minDatetime }}
-            helperText={`Timezone: ${effectiveTimeZone}`}
+            inputProps={inputConstraints}
+            error={dateError}
+            helperText={dateHelperText}
           />
         </Grid>
       );

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
@@ -34,8 +34,12 @@ import {
   isFileCopyPathField,
   isDescriptionField,
   isDateTimeField,
+  isPastOnlyDateTimeField,
 } from "@features/operations/utils/serviceRequestValidation";
-import { computeMinScheduleDatetimeLocalForTimeZone } from "@features/support/utils/support";
+import {
+  computeMinScheduleDatetimeLocalForTimeZone,
+  computeMaxDatetimeLocalForTimeZone,
+} from "@features/support/utils/support";
 import { resolveDisplayTimeZone } from "@utils/dateTime";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
@@ -217,6 +221,7 @@ export default function VariableFormFields({
   const { showError } = useErrorBanner();
   const effectiveTimeZone = userTimeZone ?? resolveDisplayTimeZone();
   const minDatetime = computeMinScheduleDatetimeLocalForTimeZone(0, effectiveTimeZone);
+  const maxDatetime = computeMaxDatetimeLocalForTimeZone(effectiveTimeZone);
   const sortedVariables = useMemo(
     () => (variables ? [...variables].sort((a, b) => a.order - b.order) : []),
     [variables],
@@ -504,6 +509,7 @@ export default function VariableFormFields({
     }
 
     if (isDateTimeField(variable)) {
+      const isPastOnly = isPastOnlyDateTimeField(variable);
       return (
         <Grid key={variable.id} size={{ xs: 12, sm: 6 }}>
           <Box sx={{ mb: 1 }}>
@@ -517,7 +523,7 @@ export default function VariableFormFields({
             onChange={(e) => onChange(variable.id, e.target.value)}
             disabled={isContext}
             slotProps={{ inputLabel: { shrink: true } }}
-            inputProps={{ min: minDatetime }}
+            inputProps={isPastOnly ? { max: maxDatetime } : { min: minDatetime }}
             helperText={`Timezone: ${effectiveTimeZone}`}
           />
         </Grid>

--- a/apps/customer-portal/webapp/src/features/operations/utils/serviceRequestValidation.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/serviceRequestValidation.ts
@@ -131,13 +131,16 @@ export function isDateTimeField(variable: CatalogItemVariable): boolean {
   return DATE_TIME_FIELD_PATTERNS.some((p) => p.test(q));
 }
 
-/**
- * True if the datetime field is for historical/log retrieval (Start Time / End Time)
- * rather than scheduling a future action. These fields should use max=now instead of min=future.
- */
-export function isPastOnlyDateTimeField(variable: CatalogItemVariable): boolean {
-  const q = (variable.questionText ?? "").trim();
-  return /^(start|end)\s*(date|time)$/i.test(q);
+function normalizeQuestionText(questionText: string): string {
+  return (questionText ?? "").trim().replace(/^[\s*•]+\s*(?:required\s*:?\s*)?/i, "").trim();
+}
+
+export function isStartDateTimeField(variable: CatalogItemVariable): boolean {
+  return /^start\s*(date|time)$/i.test(normalizeQuestionText(variable.questionText ?? ""));
+}
+
+export function isEndDateTimeField(variable: CatalogItemVariable): boolean {
+  return /^end\s*(date|time)$/i.test(normalizeQuestionText(variable.questionText ?? ""));
 }
 
 /**

--- a/apps/customer-portal/webapp/src/features/operations/utils/serviceRequestValidation.ts
+++ b/apps/customer-portal/webapp/src/features/operations/utils/serviceRequestValidation.ts
@@ -132,6 +132,15 @@ export function isDateTimeField(variable: CatalogItemVariable): boolean {
 }
 
 /**
+ * True if the datetime field is for historical/log retrieval (Start Time / End Time)
+ * rather than scheduling a future action. These fields should use max=now instead of min=future.
+ */
+export function isPastOnlyDateTimeField(variable: CatalogItemVariable): boolean {
+  const q = (variable.questionText ?? "").trim();
+  return /^(start|end)\s*(date|time)$/i.test(q);
+}
+
+/**
  * Returns user-editable variables (excludes context and hidden).
  * Hot fix: all typable fields are mandatory.
  */

--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -1864,14 +1864,6 @@ export function computeMinScheduleDatetimeLocalForTimeZone(
   return severityStr > floorStr ? severityStr : floorStr;
 }
 
-/** Returns the current datetime as a datetime-local string in the given timezone (used as max for past-date fields). */
-export function computeMaxDatetimeLocalForTimeZone(
-  profileTimeZone?: string | null,
-): string {
-  const tz = resolveCallSchedulingTimeZone(profileTimeZone);
-  return instantToDatetimeLocalStringInZone(Date.now(), tz);
-}
-
 export {
   countListSearchAndFilters,
   hasListSearchOrFilters,

--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -1864,6 +1864,14 @@ export function computeMinScheduleDatetimeLocalForTimeZone(
   return severityStr > floorStr ? severityStr : floorStr;
 }
 
+/** Returns the current datetime as a datetime-local string in the given timezone (used as max for past-date fields). */
+export function computeMaxDatetimeLocalForTimeZone(
+  profileTimeZone?: string | null,
+): string {
+  const tz = resolveCallSchedulingTimeZone(profileTimeZone);
+  return instantToDatetimeLocalStringInZone(Date.now(), tz);
+}
+
 export {
   countListSearchAndFilters,
   hasListSearchOrFilters,


### PR DESCRIPTION
## Problem
The Start Time and End Time fields in service requests like "Request Product Logs" were incorrectly restricted to future dates only. Since these fields represent a historical log range, users must be able to select any past or future date freely.

## Solution
- Removed all `min`/`max` browser constraints from Start Time and End Time fields.
- Added cross-field validation: when both fields have values and start ≥ end, an inline error is shown on the offending field ("Start time must be before end time." / "End time must be after start time.").
- All other datetime fields (e.g. scheduled, planned, implementation) retain the existing `min: future` constraint.

## Changes
- `serviceRequestValidation.ts` — added `isStartDateTimeField` and `isEndDateTimeField` helpers; removed `isPastOnlyDateTimeField`
- `support.ts` — removed `computeMaxDatetimeLocalForTimeZone` (no longer needed)
- `VariableFormFields.tsx` — updated datetime field renderer with cross-field
  start/end validation logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date/time field validation to ensure start dates occur before end dates in service requests.
  * Improved error messages to guide users when date ranges are invalid.
  * Refined constraint application for datetime inputs to enhance form usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->