### PR TITLE
[CSM Portal] FE hardening: token-derived comment author, error boundary, scoped counts invalidation

### DIFF
--- a/apps/csm-portal/webapp/src/AppWithConfig.tsx
+++ b/apps/csm-portal/webapp/src/AppWithConfig.tsx
@@ -19,6 +19,7 @@ import { BrowserRouter } from "react-router";
 import { OxygenUIThemeProvider } from "@wso2/oxygen-ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
+import AppErrorBoundary from "@components/error/AppErrorBoundary";
 import { AsgardeoProvider } from "@asgardeo/react";
 import { themeConfig } from "@config/themeConfig";
 import { loggerConfig } from "@config/loggerConfig";
@@ -89,9 +90,11 @@ export default function AppWithConfig(): JSX.Element {
         <LoggerProvider config={loggerConfig}>
           <OxygenUIThemeProvider theme={themeConfig}>
             <QueryClientProvider client={queryClient}>
-              <MockModeProvider>
-                <App />
-              </MockModeProvider>
+              <AppErrorBoundary>
+                <MockModeProvider>
+                  <App />
+                </MockModeProvider>
+              </AppErrorBoundary>
               {ReactQueryDevtools && (
                 <Suspense fallback={null}>
                   <ReactQueryDevtools initialIsOpen={false} />

--- a/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
+++ b/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
@@ -38,14 +38,17 @@ export default class AppErrorBoundary extends Component<
 > {
   state: AppErrorBoundaryState = { hasError: false };
 
+  /** Flip to the fallback UI when a descendant throws during render. */
   static getDerivedStateFromError(): AppErrorBoundaryState {
     return { hasError: true };
   }
 
+  /** Log the captured error and component stack to the console sink. */
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     console.error("Unhandled render error:", error, errorInfo.componentStack);
   }
 
+  /** Render the children, or the recovery screen once an error is caught. */
   render(): ReactNode {
     if (!this.state.hasError) {
       return this.props.children;

--- a/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
+++ b/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Box, Button, Stack, Typography } from "@wso2/oxygen-ui";
+
+interface AppErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface AppErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Top-level error boundary so an uncaught render error degrades to a
+ * recoverable "something went wrong" screen instead of unmounting the whole
+ * app to a blank page. Class component by necessity: error boundaries have no
+ * hook equivalent, which also means the context-based logger is unavailable
+ * here — console is the only sink that cannot itself fail.
+ */
+export default class AppErrorBoundary extends Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("Unhandled render error:", error, errorInfo.componentStack);
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+    return (
+      <Box
+        sx={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          px: 3,
+        }}
+      >
+        <Stack spacing={2} alignItems="center" sx={{ maxWidth: 480 }}>
+          <Typography variant="h5">Something went wrong</Typography>
+          <Typography variant="body1" color="text.secondary" textAlign="center">
+            An unexpected error occurred while rendering this page. Reloading
+            usually fixes it; your sign-in session is preserved.
+          </Typography>
+          <Button variant="contained" onClick={() => window.location.reload()}>
+            Reload page
+          </Button>
+        </Stack>
+      </Box>
+    );
+  }
+}

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -74,6 +74,7 @@ export const ApiQueryKeys = {
   DEPLOYED_PRODUCT_INSTANCE_METRICS: "deployed-product-instance-metrics",
   CSM_ABT_DASHBOARD: "csm-abt-dashboard",
   CSM_CASES: "csm-cases",
+  CSM_CASE_COUNTS: "csm-case-counts",
   CSM_CASE_DETAIL: "csm-case-detail",
   CSM_CASE_COMMENTS: "csm-case-comments",
   CSM_PROJECTS: "csm-projects",

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -98,10 +98,6 @@ function MetaCell({
   );
 }
 
-// TODO: replace with the engineer name from useGetUserDetails once the
-// `firstName`/`lastName` shape from the CSM backend is wired.
-const CURRENT_ENGINEER_NAME = "Sajith Ekanayaka";
-
 // Reopening a closed case is a lead-only override. We match the lead role from
 // the ID-token group claims.
 // TODO(authz): confirm the exact Asgardeo group(s)/role(s) that designate a
@@ -276,6 +272,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const patchCase = usePatchCsmCase(caseId);
   const recordView = useRecordRecentView();
   const claims = useIdTokenClaims();
+  // Display name for comments authored in this session, resolved from the
+  // signed-in user's ID token. Falls back to the email local part so a token
+  // without name claims still attributes the comment to the right person.
+  const engineerName =
+    claims?.name ||
+    [claims?.given_name, claims?.family_name].filter(Boolean).join(" ") ||
+    claims?.email?.split("@")[0] ||
+    "Unknown engineer";
   const { showError } = useErrorBanner();
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [activeTab, setActiveTab] = useState<CaseTabId>("activities");
@@ -747,7 +751,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   await postComment.mutateAsync({
                     caseId,
                     bodyHtml,
-                    authorName: CURRENT_ENGINEER_NAME,
+                    authorName: engineerName,
                     internal,
                   });
                   // Collapse only on success; on error the input keeps its

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -277,7 +277,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // without name claims still attributes the comment to the right person.
   const engineerName =
     claims?.name ||
-    [claims?.given_name, claims?.family_name].filter(Boolean).join(" ") ||
+    [claims?.given_name, claims?.family_name].filter(Boolean).join(" ").trim() ||
     claims?.email?.split("@")[0] ||
     "Unknown engineer";
   const { showError } = useErrorBanner();

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -72,12 +72,17 @@ function emptyMatrix(): CaseCountsMatrix {
  * `POST /cases/search` (up to {@link MAX_PAGES} pages of {@link PAGE_LIMIT}) and
  * tallies client-side. `truncated` flags when the real total exceeds the
  * sample. MOCK mode tallies the seeded cases.
+ *
+ * Keyed under its own root (not `CSM_CASES`) so case create/patch mutations,
+ * which invalidate the `CSM_CASES` prefix, do not re-trigger this up-to-500-row
+ * fan-out. The matrix is a sampled approximation; `staleTime` plus
+ * refetch-on-mount keeps it fresh enough on the dashboard.
  */
 export function useCaseCountsMatrix(): UseQueryResult<CaseCountsMatrix, Error> {
   const api = useBackendApi();
 
   return useQuery<CaseCountsMatrix, Error>({
-    queryKey: [ApiQueryKeys.CSM_CASES, "counts-matrix"],
+    queryKey: [ApiQueryKeys.CSM_CASE_COUNTS],
     queryFn: async (): Promise<CaseCountsMatrix> => {
       const matrix = emptyMatrix();
 


### PR DESCRIPTION
Three self-contained frontend fixes from the v2 review, no API or behavior contract changes.

## Changes

1. **Comment author from ID token** — `CsmCaseDetailPage` posted every comment with a hardcoded `authorName`. The name is now resolved from the signed-in user's ID token claims (`name` → `given_name family_name` → email local part), using the `useIdTokenClaims()` hook the page already calls.

2. **App-level error boundary** — there was no error boundary above the route tree, so any uncaught render error unmounted the whole app to a blank page. `AppErrorBoundary` (class component, as boundaries require) now wraps `<App />` inside the theme provider and renders a themed "Something went wrong / Reload page" fallback while logging the component stack.

3. **Scoped counts-matrix invalidation** — `useCaseCountsMatrix` was keyed under the `CSM_CASES` prefix, so every case create/patch invalidation re-triggered its up-to-500-row `POST /cases/search` fan-out. It now lives under its own `CSM_CASE_COUNTS` root and refreshes via its `staleTime` (60s) + refetch-on-mount, which is sufficient for a sampled approximation.

## Verification

- `pnpm lint` clean
- `pnpm test` 46/46 passing
- `pnpm build` succeeds (the >500 kB chunk warning is pre-existing and tracked separately in https://github.com/wso2-open-operations/cs-tools/pull/845)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error handling that displays a user-friendly message when issues occur.

* **Bug Fixes**
  * Fixed case comment attribution to display the actual engineer's name instead of placeholder text.

* **Performance**
  * Optimized case counts caching for improved data freshness and reduced refetch overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
