### PR TITLE
[CSM Portal] code-split feature routes with React.lazy

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -14,20 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { type JSX } from "react";
+import { type JSX, lazy } from "react";
 import { Navigate, Route, Routes } from "react-router";
 import AuthGuard from "@layouts/AuthGuard";
 import ErrorLayout from "@layouts/ErrorLayout";
 import CsmComingSoonPage from "@features/csm-coming-soon/pages/CsmComingSoonPage";
-import CsmDashboardPage from "@features/csm-dashboard/pages/CsmDashboardPage";
-import CsmCasesPage from "@features/csm-cases/pages/CsmCasesPage";
-import CsmCaseCreatePage from "@features/csm-cases/pages/CsmCaseCreatePage";
-import CsmCaseDetailPage from "@features/csm-cases/pages/CsmCaseDetailPage";
-import CsmAdminLayout from "@features/csm-admin/pages/CsmAdminLayout";
-import CsmUsersPage from "@features/csm-users/pages/CsmUsersPage";
-import CsmAccountsPage from "@features/csm-accounts/pages/CsmAccountsPage";
-import CsmProjectsPage from "@features/csm-projects/pages/CsmProjectsPage";
-import CsmUpdatesPage from "@features/updates/pages/CsmUpdatesPage";
 import Error401Page from "@components/error/Error401Page";
 import Error403Page from "@components/error/Error403Page";
 import Error404Page from "@components/error/Error404Page";
@@ -35,6 +26,41 @@ import { ErrorBannerProvider } from "@context/error-banner/ErrorBannerContext";
 import { SuccessBannerProvider } from "@context/success-banner/SuccessBannerContext";
 import { LoaderProvider } from "@context/linear-loader/LoaderContext";
 import { ErrorPageProvider } from "@context/error-page/ErrorPageContext";
+
+/*
+ * Authenticated feature pages are lazily loaded so each lands in its own chunk
+ * and is fetched only when its route is visited, instead of being bundled into
+ * the initial entry chunk. They all render inside AppLayout's Outlet, which
+ * owns the Suspense boundary that covers the load. Error pages and the shared
+ * CsmComingSoonPage stay eager: they are tiny and act as immediate fallbacks.
+ */
+const CsmDashboardPage = lazy(
+  () => import("@features/csm-dashboard/pages/CsmDashboardPage"),
+);
+const CsmCasesPage = lazy(
+  () => import("@features/csm-cases/pages/CsmCasesPage"),
+);
+const CsmCaseCreatePage = lazy(
+  () => import("@features/csm-cases/pages/CsmCaseCreatePage"),
+);
+const CsmCaseDetailPage = lazy(
+  () => import("@features/csm-cases/pages/CsmCaseDetailPage"),
+);
+const CsmAdminLayout = lazy(
+  () => import("@features/csm-admin/pages/CsmAdminLayout"),
+);
+const CsmUsersPage = lazy(
+  () => import("@features/csm-users/pages/CsmUsersPage"),
+);
+const CsmAccountsPage = lazy(
+  () => import("@features/csm-accounts/pages/CsmAccountsPage"),
+);
+const CsmProjectsPage = lazy(
+  () => import("@features/csm-projects/pages/CsmProjectsPage"),
+);
+const CsmUpdatesPage = lazy(
+  () => import("@features/updates/pages/CsmUpdatesPage"),
+);
 
 /**
  * Landing for `/`. Defers to AuthGuard's post-login deep-link restore when a

--- a/apps/csm-portal/webapp/src/components/route-fallback/RouteSuspenseFallback.tsx
+++ b/apps/csm-portal/webapp/src/components/route-fallback/RouteSuspenseFallback.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, LinearProgress } from "@wso2/oxygen-ui";
+import { type JSX } from "react";
+
+/**
+ * Fallback rendered while a lazily-loaded route chunk is being fetched. Sits
+ * inside the persistent app shell so only the content region shows progress,
+ * mirroring the warning-coloured LinearProgress used elsewhere in the layout.
+ */
+export default function RouteSuspenseFallback(): JSX.Element {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 2,
+      }}
+    >
+      <LinearProgress
+        color="warning"
+        sx={{ width: "80%", maxWidth: 400, height: 4 }}
+      />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { Box, Chip, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
-import { type JSX } from "react";
+import { type JSX, Suspense } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
+import RouteSuspenseFallback from "@components/route-fallback/RouteSuspenseFallback";
 
 interface AdminTab {
   id: string;
@@ -75,7 +76,9 @@ export default function CsmAdminLayout(): JSX.Element {
         ))}
       </Tabs>
 
-      <Outlet />
+      <Suspense fallback={<RouteSuspenseFallback />}>
+        <Outlet />
+      </Suspense>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -22,7 +22,14 @@ import {
   LinearProgress,
   Typography,
 } from "@wso2/oxygen-ui";
-import { type JSX, type ReactNode, useRef, useEffect, useState } from "react";
+import {
+  type JSX,
+  type ReactNode,
+  Suspense,
+  useRef,
+  useEffect,
+  useState,
+} from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import { useLoader } from "@context/linear-loader/LoaderContext";
 import { useErrorPageContext } from "@context/error-page/ErrorPageContext";
@@ -34,6 +41,7 @@ import TopBanner from "@components/top-banner/TopBanner";
 import Footer from "@components/footer/Footer";
 import Header from "@components/header/Header";
 import CsmSideBar from "@components/side-nav-bar/CsmSideBar";
+import RouteSuspenseFallback from "@components/route-fallback/RouteSuspenseFallback";
 
 const SIDEBAR_COLLAPSED_KEY = "csm.sidebar.collapsed";
 
@@ -204,7 +212,9 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
                     </Typography>
                   </Box>
                 ) : (
-                  children || <Outlet />
+                  <Suspense fallback={<RouteSuspenseFallback />}>
+                    {children || <Outlet />}
+                  </Suspense>
                 )}
               </Box>
             </Box>


### PR DESCRIPTION
## What

The CSM webapp shipped its entire UI in a single entry chunk because every page component was statically imported in `App.tsx`. This splits the nine authenticated feature pages into on-demand chunks via `React.lazy`.

## Why

Every user downloaded **2,148 kB raw / 768 kB gzip** of JS on first paint, including the case-detail view, the rich-text editor, the updates/PDF code, and admin pages they may never open. The production build emitted the 500 kB chunk-size warning.

## How

- `App.tsx`: nine feature pages converted to `React.lazy`. Error pages and the tiny shared `CsmComingSoonPage` stay eager as immediate fallbacks.
- `AppLayout.tsx`: a `Suspense` boundary at the content `Outlet`, so the nav shell stays mounted while a route chunk loads (reuses the layout's warning-coloured `LinearProgress` idiom).
- `CsmAdminLayout.tsx`: a nested `Suspense` so switching admin sub-tabs doesn't flash the tabs shell.
- New `RouteSuspenseFallback` shared fallback component.

## Result

| | Before | After |
|---|---|---|
| Entry chunk (raw) | 2,148 kB | 1,617 kB |
| Entry chunk (gzip) | 768 kB | **603 kB** |

~165 kB less gzipped JS on first load. Heaviest views now split out: CaseDetail 106 kB, dashboard 31 kB, updates 22 kB, and the rich-text Editor to its own 257 kB chunk.

The shared vendor bundle (oxygen-ui/MUI + react + asgardeo) still exceeds 500 kB and the build warning persists; a `manualChunks` vendor split is a reasonable follow-up but is a caching win, not a first-load win, so it's left out of this PR.

## Verification

- `pnpm build`, `pnpm lint`, `pnpm test` (47 tests) all pass.
- Driven locally through a headless browser against a mock-OIDC + backend stack: `/dashboard`, `/cases`, `/accounts`, `/projects`, and `/admin/users` all render through the lazy boundaries with no stuck fallback and no runtime error. (Data "could not load" banners in that environment are expected backend 401s, unrelated to this change.)