### PR TITLE
[CSM Portal] BE resilience: token-fetch timeouts, graceful shutdown, outbound deadlines, 409/422 passthrough

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -17,10 +17,14 @@
 package main
 
 import (
+	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/entity"
@@ -100,20 +104,42 @@ func main() {
 	mux.HandleFunc("POST /deployments/{id}/products/search", deploymentHandler.SearchDeployedProducts)
 
 	addr := envOrDefault("PORT", ":8080")
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Error("failed to bind", "addr", addr, "err", err)
+		os.Exit(1)
+	}
 	slog.Info("CSM Portal Backend started", "addr", addr)
 
 	srv := &http.Server{
-		Addr:              addr,
 		Handler:           middleware.Auth(authCfg)(mux),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
 	}
-	if err := srv.ListenAndServe(); err != nil {
-		slog.Error("server exited", "err", err)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			slog.Error("server exited", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	stop()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("graceful shutdown failed", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("CSM Portal Backend stopped")
 }
 
 func mustEnv(key string) string {

--- a/apps/csm-portal/backend/internal/entity/client.go
+++ b/apps/csm-portal/backend/internal/entity/client.go
@@ -26,8 +26,13 @@ import (
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var tokenFetchTimeout = 10 * time.Second
 
 type ctxKey string
 
@@ -74,8 +79,10 @@ func NewClient(cfg Config) *Client {
 	// TODO: wrap the base transport with a retry transport that retries on
 	// HTTP 502, 503, and 504 (up to 3 attempts with a 2 s interval) to match
 	// the retryConfig defined in the Ballerina entity client.
-	httpClient := cc.Client(context.Background())
-	httpClient.Timeout = 300 * time.Second
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout})
+	httpClient := cc.Client(tokenCtx)
+	httpClient.Timeout = 25 * time.Second
 
 	return &Client{
 		http:    httpClient,

--- a/apps/csm-portal/backend/internal/entity/client_test.go
+++ b/apps/csm-portal/backend/internal/entity/client_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestTokenFetchTimeout verifies that a stalled token endpoint fails requests
+// within the configured timeout rather than blocking indefinitely.
+func TestTokenFetchTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Token server that stalls longer than tokenFetchTimeout but returns eventually
+	// so httptest.Server.Close() can drain cleanly.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer tokenSrv.Close()
+
+	// Use a short timeout so the test runs quickly.
+	tokenFetchTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { tokenFetchTimeout = 10 * time.Second })
+
+	client := NewClient(Config{
+		BaseURL:      tokenSrv.URL,
+		TokenURL:     tokenSrv.URL + "/token",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	start := time.Now()
+	_, err := client.GetCase(context.Background(), "11111111-1111-1111-1111-111111111111")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from hung token server, got nil")
+	}
+	// Should fail well within 1 s (configured at 100 ms); allow 2 s for CI jitter.
+	if elapsed > 2*time.Second {
+		t.Errorf("token fetch took %v; expected <2s with 100ms timeout", elapsed)
+	}
+}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -43,6 +43,11 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 		{"apierror 403", &apierror.Error{StatusCode: http.StatusForbidden}, http.StatusForbidden, ErrMsgForbidden},
 		{"apierror 404", &apierror.Error{StatusCode: http.StatusNotFound}, http.StatusNotFound, ErrMsgNotFound},
 		{"apierror 400", &apierror.Error{StatusCode: http.StatusBadRequest}, http.StatusBadRequest, ErrMsgBadRequest},
+		{"apierror 409", &apierror.Error{StatusCode: http.StatusConflict, Body: "conflict upstream message"}, http.StatusConflict, "conflict upstream message"},
+		{"apierror 422", &apierror.Error{StatusCode: http.StatusUnprocessableEntity, Body: "invalid state transition"}, http.StatusUnprocessableEntity, "invalid state transition"},
+		{"apierror 502", &apierror.Error{StatusCode: http.StatusBadGateway}, http.StatusServiceUnavailable, fallback},
+		{"apierror 503", &apierror.Error{StatusCode: http.StatusServiceUnavailable}, http.StatusServiceUnavailable, fallback},
+		{"apierror 504", &apierror.Error{StatusCode: http.StatusGatewayTimeout}, http.StatusServiceUnavailable, fallback},
 		{"apierror unmapped (418)", &apierror.Error{StatusCode: http.StatusTeapot}, http.StatusInternalServerError, fallback},
 		{"non-apierror error", errors.New("upstream connection refused"), http.StatusInternalServerError, fallback},
 	}

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -79,6 +79,10 @@ func mapUpstreamError(w http.ResponseWriter, err error, fallbackMsg string) {
 			writeError(w, http.StatusNotFound, ErrMsgNotFound)
 		case http.StatusBadRequest:
 			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		case http.StatusConflict, http.StatusUnprocessableEntity:
+			writeError(w, apiErr.StatusCode, apiErr.Body)
+		case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			writeError(w, http.StatusServiceUnavailable, fallbackMsg)
 		default:
 			writeError(w, http.StatusInternalServerError, fallbackMsg)
 		}

--- a/apps/csm-portal/backend/internal/scim/client.go
+++ b/apps/csm-portal/backend/internal/scim/client.go
@@ -26,8 +26,13 @@ import (
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var tokenFetchTimeout = 10 * time.Second
 
 // Config holds the configuration for the SCIM operations client.
 type Config struct {
@@ -55,8 +60,10 @@ func NewClient(cfg Config) *Client {
 		Scopes:       cfg.Scopes,
 	}
 
-	httpClient := cc.Client(context.Background())
-	httpClient.Timeout = 300 * time.Second
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout})
+	httpClient := cc.Client(tokenCtx)
+	httpClient.Timeout = 25 * time.Second
 
 	return &Client{
 		http:    httpClient,

--- a/apps/csm-portal/backend/internal/updates/client.go
+++ b/apps/csm-portal/backend/internal/updates/client.go
@@ -26,8 +26,13 @@ import (
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var tokenFetchTimeout = 10 * time.Second
 
 // Config holds the configuration for the updates service client.
 type Config struct {
@@ -58,8 +63,10 @@ func NewClient(cfg Config) *Client {
 	// TODO: wrap the base transport with a retry transport that retries on
 	// HTTP 408, 502, 503, and 504 (up to 3 attempts with a 2 s interval) to
 	// match the retryConfig defined in the Ballerina updates client.
-	httpClient := cc.Client(context.Background())
-	httpClient.Timeout = 300 * time.Second
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout})
+	httpClient := cc.Client(tokenCtx)
+	httpClient.Timeout = 25 * time.Second
 
 	return &Client{
 		http:    httpClient,

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -173,14 +173,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "409":
+          description: Conflict (e.g. concurrent update).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "422":
+          description: Unprocessable entity (e.g. invalid state transition).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "503":
+          description: Upstream service unavailable.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

Fixes four resilience gaps in the CSM portal backend identified in wso2-enterprise/digiops-cs#1946. No API shape changes — lifecycle/timeout/error-mapping fixes only.

- **Token-fetch timeout**: inject a bounded `http.Client{Timeout: 10s}` via `oauth2.HTTPClient` into the token-endpoint context for all three upstream clients (`entity`, `scim`, `updates`). Previously a hung token server would block all concurrent requests indefinitely via the `ReuseTokenSource` mutex.
- **Outbound timeout**: reduce from 300 s → 25 s across all three clients, keeping it below the server `WriteTimeout` (30 s) so a slow upstream cannot leak goroutines.
- **Graceful shutdown**: bind with `net.Listen` first (so "started" is only logged when the port is actually held), then handle SIGTERM/SIGINT with a 15 s `srv.Shutdown` drain window.
- **Error mapping**: `mapUpstreamError` now passes through upstream 409/422 with the original message (user-correctable errors) and maps 502/503/504 → 503 so the FE retry policy can act on it. `openapi.yaml` documents the new codes on `PATCH /cases/{id}`.

## Test plan

- [x] All existing handler tests pass (extended `upstreamErrors` table covers new `mapUpstreamError` branches)
- [x] `TestTokenFetchTimeout` in `internal/entity` verifies a stalled token server fails within the configured deadline (runs in ~600 ms with the 100 ms test override)
- [x] `go build ./...` succeeds
- [x] Pre-push hook runs full test suite — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)