### PR TITLE
[Customer Entity] Add dual-datasource support with ServiceNow via Choreo API

### DIFF
--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -1,7 +1,17 @@
 SERVER_PORT=8080
+
+# Data source: "postgres" (default) or "servicenow"
+DATA_SOURCE=postgres
+
+# PostgreSQL — required when DATA_SOURCE=postgres
+# Also required when DATA_SOURCE=servicenow (used as fallback for GET /projects/{id})
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=<YOUR_DB_USER>
 DB_PASSWORD=<YOUR_DB_PASSWORD>
 DB_NAME=<YOUR_DB_NAME>
 DB_SSLMODE=disable
+
+# ServiceNow via Choreo — required when DATA_SOURCE=servicenow
+# Requests must include the x-user-id-token header for authentication
+SN_BASE_URL=<CHOREO_BALLERINA_SERVICE_BASE_URL>

--- a/entity-service/cmd/api/main.go
+++ b/entity-service/cmd/api/main.go
@@ -38,6 +38,9 @@ func main() {
 	}
 
 	cfg := config.Load()
+	if err := cfg.Validate(); err != nil {
+		log.Fatalf("invalid configuration: %v", err)
+	}
 
 	pool, err := db.NewPoolIfNeeded(cfg)
 	if err != nil {

--- a/entity-service/cmd/api/main.go
+++ b/entity-service/cmd/api/main.go
@@ -39,17 +39,16 @@ func main() {
 
 	cfg := config.Load()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	pool, err := db.NewPool(ctx, cfg.DSN())
+	pool, err := db.NewPoolIfNeeded(cfg)
 	if err != nil {
 		log.Fatalf("connect to database: %v", err)
 	}
-	defer pool.Close()
+	if pool != nil {
+		defer pool.Close()
+	}
 
 	addr := ":" + cfg.ServerPort
-	srv := server.New(addr, pool)
+	srv := server.New(addr, pool, cfg)
 
 	go func() {
 		log.Printf("Customer Entity REST Service started in PORT : %s", cfg.ServerPort)

--- a/entity-service/internal/apierror/errors.go
+++ b/entity-service/internal/apierror/errors.go
@@ -58,6 +58,24 @@ type ServiceUnavailableError struct {
 // Error implements the error interface.
 func (e *ServiceUnavailableError) Error() string { return e.Msg }
 
+// UnauthorizedError signals that the caller is not authenticated and should be
+// reported as HTTP 401.
+type UnauthorizedError struct {
+	Msg string
+}
+
+// Error implements the error interface.
+func (e *UnauthorizedError) Error() string { return e.Msg }
+
+// ForbiddenError signals that the caller is authenticated but not permitted to
+// access the resource and should be reported as HTTP 403.
+type ForbiddenError struct {
+	Msg string
+}
+
+// Error implements the error interface.
+func (e *ForbiddenError) Error() string { return e.Msg }
+
 // WriteJSON writes an ErrorResponse JSON body with the given HTTP status code.
 func WriteJSON(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")

--- a/entity-service/internal/config/config.go
+++ b/entity-service/internal/config/config.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 )
@@ -70,6 +71,22 @@ func getEnvOrDefault(key, defaultVal string) string {
 		return v
 	}
 	return defaultVal
+}
+
+// Validate checks that the configuration is self-consistent. It returns an
+// error if DATA_SOURCE is an unrecognised value, or if SN_BASE_URL is missing
+// when DATA_SOURCE=servicenow.
+func (c *Config) Validate() error {
+	switch c.DataSource {
+	case DataSourcePostgres, DataSourceServiceNow:
+		// valid
+	default:
+		return fmt.Errorf("invalid DATA_SOURCE %q: must be %q or %q", c.DataSource, DataSourcePostgres, DataSourceServiceNow)
+	}
+	if c.DataSource == DataSourceServiceNow && c.SNBaseURL == "" {
+		return fmt.Errorf("SN_BASE_URL is required when DATA_SOURCE=servicenow")
+	}
+	return nil
 }
 
 // DSN constructs a PostgreSQL connection string from the config fields.

--- a/entity-service/internal/config/config.go
+++ b/entity-service/internal/config/config.go
@@ -22,6 +22,16 @@ import (
 	"os"
 )
 
+// DataSource identifies which backend the service reads from.
+type DataSource string
+
+const (
+	// DataSourcePostgres uses the local PostgreSQL database.
+	DataSourcePostgres DataSource = "postgres"
+	// DataSourceServiceNow uses the Choreo ServiceNow API.
+	DataSourceServiceNow DataSource = "servicenow"
+)
+
 // Config holds all environment-driven settings for the service.
 type Config struct {
 	DBHost     string
@@ -31,6 +41,11 @@ type Config struct {
 	DBName     string
 	DBSSLMode  string
 	ServerPort string
+	// DataSource controls which backend is used. Defaults to "postgres".
+	DataSource DataSource
+	// SNBaseURL is the base URL for the Choreo ServiceNow API
+	// Required when DataSource is "servicenow".
+	SNBaseURL string
 }
 
 // Load reads configuration from environment variables and returns a populated
@@ -45,6 +60,8 @@ func Load() *Config {
 		DBName:     os.Getenv("DB_NAME"),
 		DBSSLMode:  os.Getenv("DB_SSLMODE"),
 		ServerPort: getEnvOrDefault("SERVER_PORT", "8080"),
+		DataSource: DataSource(getEnvOrDefault("DATA_SOURCE", string(DataSourcePostgres))),
+		SNBaseURL:  os.Getenv("SN_BASE_URL"),
 	}
 }
 

--- a/entity-service/internal/db/postgres.go
+++ b/entity-service/internal/db/postgres.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/config"
 )
 
 const (
@@ -57,4 +58,16 @@ func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	}
 
 	return pool, nil
+}
+
+// NewPoolIfNeeded creates a connection pool only when cfg.DataSource requires
+// Postgres. Returns nil, nil when the datasource is ServiceNow so the server
+// can start without a local database.
+func NewPoolIfNeeded(cfg *config.Config) (*pgxpool.Pool, error) {
+	if cfg.DataSource == config.DataSourceServiceNow {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return NewPool(ctx, cfg.DSN())
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -131,18 +131,31 @@ const (
 	SubscriptionTypeProfessionalServices     SubscriptionType = "professional_services"
 )
 
+// ClosureStatus represents the closure/access state of a project.
+type ClosureStatus string
+
+const (
+	ClosureStatusNotify     ClosureStatus = "notify"
+	ClosureStatusClosed     ClosureStatus = "closed"
+	ClosureStatusOpen       ClosureStatus = "open"
+	ClosureStatusReadOnly   ClosureStatus = "read_only"
+	ClosureStatusRestricted ClosureStatus = "restricted"
+	ClosureStatusSuspended  ClosureStatus = "suspended"
+)
+
 // Project represents a customer project linked to an account.
 type Project struct {
-	ID               string           `json:"id"`
-	AccountID        string           `json:"accountId"`
-	SfID             string           `json:"sfId"`
-	Name             string           `json:"name"`
-	ProjectKey       string           `json:"projectKey"`
+	ID               string         `json:"id"`
+	AccountID        string         `json:"accountId"`
+	SfID             string         `json:"sfId"`
+	Name             string         `json:"name"`
+	Key              string         `json:"key"`
 	SubscriptionType SubscriptionType `json:"subscriptionType"`
-	StartDate        time.Time        `json:"startDate"`
-	EndDate          time.Time        `json:"endDate"`
-	CreatedAt        time.Time        `json:"createdAt"`
-	UpdatedAt        time.Time        `json:"updatedAt"`
+	ClosureStatus    *ClosureStatus `json:"closureStatus,omitempty"`
+	StartDate        time.Time      `json:"startDate"`
+	EndDate          time.Time      `json:"endDate"`
+	CreatedAt        time.Time      `json:"createdAt"`
+	UpdatedAt        time.Time      `json:"updatedAt"`
 }
 
 // SearchProjectsRequest is the input for a project search operation.
@@ -152,13 +165,24 @@ type SearchProjectsRequest struct {
 	SearchQuery string     `json:"searchQuery"`
 }
 
+// ProjectView is the unified search result shape returned for all data sources.
+// Both Postgres and ServiceNow responses are mapped to this type so callers
+// receive the same fields regardless of which backend is active.
+type ProjectView struct {
+	ID               string           `json:"id"`
+	Name             string           `json:"name"`
+	Key              string           `json:"key"`
+	SubscriptionType SubscriptionType `json:"subscriptionType"`
+	CreatedOn        time.Time        `json:"createdOn"`
+}
+
 // SearchProjectsResponse is the paginated result of a project search.
 type SearchProjectsResponse struct {
-	Projects []Project `json:"projects"`
-	Total    int       `json:"total"`
-	Limit    int       `json:"limit"`
-	Offset   int       `json:"offset"`
-	HasMore  bool      `json:"hasMore"`
+	Projects []ProjectView `json:"projects"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+	HasMore  bool          `json:"hasMore"`
 }
 
 // ProductClass classifies a product as either a standalone software or a managed service.

--- a/entity-service/internal/handler/decode.go
+++ b/entity-service/internal/handler/decode.go
@@ -53,12 +53,24 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 		ve  *apierror.ValidationError
 		nfe *apierror.NotFoundError
 		sue *apierror.ServiceUnavailableError
+		ue  *apierror.UnauthorizedError
+		fe  *apierror.ForbiddenError
 	)
 	switch {
 	case errors.As(err, &ve):
 		// 400 – caller-supplied input is invalid; the message is safe to return.
 		log.Printf("Bad request: %s %s: %s", r.Method, r.URL.Path, ve.Msg)
 		apierror.WriteJSON(w, http.StatusBadRequest, ve.Msg)
+
+	case errors.As(err, &ue):
+		// 401 – caller is not authenticated.
+		log.Printf("Unauthorized: %s %s: %s", r.Method, r.URL.Path, ue.Msg)
+		apierror.WriteJSON(w, http.StatusUnauthorized, ue.Msg)
+
+	case errors.As(err, &fe):
+		// 403 – caller is authenticated but not permitted.
+		log.Printf("Forbidden: %s %s: %s", r.Method, r.URL.Path, fe.Msg)
+		apierror.WriteJSON(w, http.StatusForbidden, fe.Msg)
 
 	case errors.As(err, &nfe):
 		// 404 – resource not found; message is safe to return.

--- a/entity-service/internal/middleware/usertoken.go
+++ b/entity-service/internal/middleware/usertoken.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+)
+
+// userIDTokenKey is the context key for the x-user-id-token header value.
+type userIDTokenKey struct{}
+
+// UserIDToken extracts the x-user-id-token request header and stores it in the
+// request context so downstream service implementations can forward it to
+// external APIs without coupling the handler to any specific data source.
+func UserIDToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("x-user-id-token")
+		if token != "" {
+			r = r.WithContext(context.WithValue(r.Context(), userIDTokenKey{}, token))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// UserIDTokenFromContext retrieves the x-user-id-token value stored by the
+// UserIDToken middleware. Returns an empty string if not present.
+func UserIDTokenFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(userIDTokenKey{}).(string)
+	return v
+}

--- a/entity-service/internal/repository/project_repo.go
+++ b/entity-service/internal/repository/project_repo.go
@@ -62,7 +62,7 @@ func (r *projectRepo) SearchProjects(ctx context.Context, req domain.SearchProje
 		// All three ILIKE branches reference the same positional parameter — PostgreSQL
 		// allows a single $N to appear multiple times in one query.
 		where += fmt.Sprintf(
-			" AND (name ILIKE $%d ESCAPE '\\' OR project_key ILIKE $%d ESCAPE '\\' OR subscription_type::TEXT ILIKE $%d ESCAPE '\\')",
+			" AND (name ILIKE $%d ESCAPE '\\' OR key ILIKE $%d ESCAPE '\\' OR subscription_type::TEXT ILIKE $%d ESCAPE '\\')",
 			argIdx, argIdx, argIdx,
 		)
 		filterArgs = append(filterArgs, pattern)
@@ -72,7 +72,7 @@ func (r *projectRepo) SearchProjects(ctx context.Context, req domain.SearchProje
 	countQuery := "SELECT COUNT(*) FROM projects " + where
 
 	dataQuery := fmt.Sprintf(
-		`SELECT id, account_id, sf_id, name, project_key, subscription_type,
+		`SELECT id, account_id, sf_id, name, key, subscription_type, closure_status,
 		        start_date, end_date, created_at, updated_at
 		 FROM projects %s
 		 ORDER BY created_at DESC, id
@@ -104,7 +104,7 @@ func (r *projectRepo) SearchProjects(ctx context.Context, req domain.SearchProje
 		for rows.Next() {
 			var p domain.Project
 			if err := rows.Scan(
-				&p.ID, &p.AccountID, &p.SfID, &p.Name, &p.ProjectKey, &p.SubscriptionType,
+				&p.ID, &p.AccountID, &p.SfID, &p.Name, &p.Key, &p.SubscriptionType, &p.ClosureStatus,
 				&p.StartDate, &p.EndDate, &p.CreatedAt, &p.UpdatedAt,
 			); err != nil {
 				return fmt.Errorf("scan project: %w", err)
@@ -129,11 +129,11 @@ func (r *projectRepo) SearchProjects(ctx context.Context, req domain.SearchProje
 func (r *projectRepo) GetProjectByID(ctx context.Context, id string) (domain.Project, error) {
 	var p domain.Project
 	err := r.db.QueryRow(ctx,
-		`SELECT id, account_id, sf_id, name, project_key, subscription_type,
+		`SELECT id, account_id, sf_id, name, key, subscription_type, closure_status,
 		        start_date, end_date, created_at, updated_at
 		 FROM projects WHERE id = $1`, id,
 	).Scan(
-		&p.ID, &p.AccountID, &p.SfID, &p.Name, &p.ProjectKey, &p.SubscriptionType,
+		&p.ID, &p.AccountID, &p.SfID, &p.Name, &p.Key, &p.SubscriptionType, &p.ClosureStatus,
 		&p.StartDate, &p.EndDate, &p.CreatedAt, &p.UpdatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -21,16 +21,18 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/config"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/handler"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/repository"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/snclient"
 )
 
 // NewRouter builds the dependency graph (repository → service → handler),
 // registers all routes, and wraps the mux with the middleware chain:
 // Recovery → Logger → Timeout.
-func NewRouter(db *pgxpool.Pool) http.Handler {
+func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	userRepo := repository.NewUserRepository(db)
 	userSvc := service.NewUserService(userRepo)
 	userHandler := handler.NewUserHandler(userSvc)
@@ -40,8 +42,14 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 	accountHandler := handler.NewAccountHandler(accountSvc)
 
 	projectRepo := repository.NewProjectRepository(db)
-	projectSvc := service.NewProjectService(projectRepo)
-	projectHandler := handler.NewProjectHandler(projectSvc)
+	pgProjectSvc := service.NewProjectService(projectRepo)
+	var activeProjectSvc service.ProjectService
+	if cfg.DataSource == config.DataSourceServiceNow {
+		activeProjectSvc = service.NewSNProjectService(snclient.New(cfg.SNBaseURL), pgProjectSvc)
+	} else {
+		activeProjectSvc = pgProjectSvc
+	}
+	projectHandler := handler.NewProjectHandler(activeProjectSvc)
 
 	productRepo := repository.NewProductRepository(db)
 	productSvc := service.NewProductService(productRepo)
@@ -84,7 +92,9 @@ func NewRouter(db *pgxpool.Pool) http.Handler {
 
 	return middleware.Recovery(
 		middleware.Logger(
-			middleware.Timeout(10 * time.Second)(mux),
+			middleware.UserIDToken(
+				middleware.Timeout(10 * time.Second)(mux),
+			),
 		),
 	)
 }

--- a/entity-service/internal/server/server.go
+++ b/entity-service/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/config"
 )
 
 const (
@@ -32,10 +33,10 @@ const (
 
 // New creates an http.Server listening on addr with production-safe timeouts
 // and the full middleware/router chain wired up via NewRouter.
-func New(addr string, db *pgxpool.Pool) *http.Server {
+func New(addr string, db *pgxpool.Pool, cfg *config.Config) *http.Server {
 	return &http.Server{
 		Addr:         addr,
-		Handler:      NewRouter(db),
+		Handler:      NewRouter(db, cfg),
 		ReadTimeout:  serverReadTimeout,
 		WriteTimeout: serverWriteTimeout,
 		IdleTimeout:  serverIdleTimeout,

--- a/entity-service/internal/service/project_service.go
+++ b/entity-service/internal/service/project_service.go
@@ -47,8 +47,19 @@ func (s *projectService) SearchProjects(ctx context.Context, req domain.SearchPr
 		return domain.SearchProjectsResponse{}, err
 	}
 
+	views := make([]domain.ProjectView, len(projects))
+	for i, p := range projects {
+		views[i] = domain.ProjectView{
+			ID:               p.ID,
+			Name:             p.Name,
+			Key:              p.Key,
+			SubscriptionType: p.SubscriptionType,
+			CreatedOn:        p.CreatedAt,
+		}
+	}
+
 	return domain.SearchProjectsResponse{
-		Projects: projects,
+		Projects: views,
 		Total:    total,
 		Limit:    req.Pagination.Limit,
 		Offset:   req.Pagination.Offset,

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -92,7 +92,7 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
-		return domain.SearchProjectsResponse{}, &apierror.ValidationError{Msg: "x-user-id-token header is required"}
+		return domain.SearchProjectsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
 	payload := snSearchProjectsPayload{

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package service is declared in interfaces.go.
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/snclient"
+)
+
+// snProjectsResponse mirrors the Choreo POST /projects/search response.
+type snProjectsResponse struct {
+	Projects     []snProject `json:"projects"`
+	TotalRecords int         `json:"totalRecords"`
+	Offset       int         `json:"offset"`
+	Limit        int         `json:"limit"`
+}
+
+type snProject struct {
+	ID        string        `json:"id"`
+	Name      string        `json:"name"`
+	Key       string        `json:"key"`
+	Type      snProjectType `json:"type"`
+	CreatedOn string        `json:"createdOn"`
+}
+
+type snProjectType struct {
+	Name string `json:"name"`
+}
+
+// snSearchProjectsPayload is the Choreo POST /projects/search request body.
+type snSearchProjectsPayload struct {
+	Filters    snProjectFilters    `json:"filters"`
+	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snProjectFilters struct {
+	SearchQuery string `json:"searchQuery,omitempty"`
+}
+
+type snProjectPagination struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+// snCreatedOnLayout is the time format used by the Choreo API.
+const snCreatedOnLayout = "2006-01-02 15:04:05"
+
+type snProjectService struct {
+	client     *snclient.Client
+	pgFallback ProjectService
+}
+
+// NewSNProjectService constructs a ProjectService backed by the Choreo API.
+// pgFallback is used for GetProjectByID (no SN single-project endpoint).
+func NewSNProjectService(client *snclient.Client, pgFallback ProjectService) ProjectService {
+	return &snProjectService{client: client, pgFallback: pgFallback}
+}
+
+// SearchProjects implements ProjectService. It calls the Choreo API, parses the
+// response, and maps each item to domain.ProjectView so the shape is identical
+// to the Postgres path.
+func (s *snProjectService) SearchProjects(ctx context.Context, req domain.SearchProjectsRequest) (domain.SearchProjectsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchProjectsResponse{}, err
+	}
+	if err := validateSearchQuery(req.SearchQuery); err != nil {
+		return domain.SearchProjectsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchProjectsResponse{}, &apierror.ValidationError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snSearchProjectsPayload{
+		Filters:    snProjectFilters{SearchQuery: req.SearchQuery},
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+	raw, err := s.client.Post(ctx, "/projects/search", token, payload)
+	if err != nil {
+		return domain.SearchProjectsResponse{}, err
+	}
+
+	var snResp snProjectsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: parse response: %w", err)
+	}
+
+	views := make([]domain.ProjectView, 0, len(snResp.Projects))
+	for _, p := range snResp.Projects {
+		createdOn, err := time.Parse(snCreatedOnLayout, p.CreatedOn)
+		if err != nil {
+			return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: parse createdOn %q: %w", p.CreatedOn, err)
+		}
+		views = append(views, domain.ProjectView{
+			ID:               p.ID,
+			Name:             p.Name,
+			Key:              p.Key,
+			SubscriptionType: snTypeNameToSubscriptionType(p.Type.Name),
+			CreatedOn:        createdOn,
+		})
+	}
+
+	total := snResp.TotalRecords
+	return domain.SearchProjectsResponse{
+		Projects: views,
+		Total:    total,
+		Limit:    req.Pagination.Limit,
+		Offset:   req.Pagination.Offset,
+		HasMore:  req.Pagination.Offset+len(views) < total,
+	}, nil
+}
+
+// GetProjectByID implements ProjectService by delegating to the postgres service.
+func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domain.Project, error) {
+	return s.pgFallback.GetProjectByID(ctx, id)
+}
+
+// snTypeNameToSubscriptionType converts a SN project type name (e.g. "Cloud Support")
+// to the domain SubscriptionType enum (e.g. "cloud_support").
+func snTypeNameToSubscriptionType(name string) domain.SubscriptionType {
+	return domain.SubscriptionType(strings.ToLower(strings.ReplaceAll(name, " ", "_")))
+}

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -115,11 +115,15 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 		if err != nil {
 			return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: parse createdOn %q: %w", p.CreatedOn, err)
 		}
+		subType, err := snTypeNameToSubscriptionType(p.Type.Name)
+		if err != nil {
+			return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: project %q: %w", p.ID, err)
+		}
 		views = append(views, domain.ProjectView{
 			ID:               p.ID,
 			Name:             p.Name,
 			Key:              p.Key,
-			SubscriptionType: snTypeNameToSubscriptionType(p.Type.Name),
+			SubscriptionType: subType,
 			CreatedOn:        createdOn,
 		})
 	}
@@ -139,8 +143,26 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 	return s.pgFallback.GetProjectByID(ctx, id)
 }
 
+// validSubscriptionTypes is the set of known SubscriptionType enum values.
+var validSubscriptionTypes = map[domain.SubscriptionType]struct{}{
+	domain.SubscriptionTypeDevelopmentSupport:       {},
+	domain.SubscriptionTypeManagedCloudSubscription: {},
+	domain.SubscriptionTypeEvaluationSubscription:   {},
+	domain.SubscriptionTypeSubscription:             {},
+	domain.SubscriptionTypeCloudEvaluationSupport:   {},
+	domain.SubscriptionTypeInternal:                 {},
+	domain.SubscriptionTypePlatformerSubscription:   {},
+	domain.SubscriptionTypeCloudSupport:             {},
+	domain.SubscriptionTypeProfessionalServices:     {},
+}
+
 // snTypeNameToSubscriptionType converts a SN project type name (e.g. "Cloud Support")
-// to the domain SubscriptionType enum (e.g. "cloud_support").
-func snTypeNameToSubscriptionType(name string) domain.SubscriptionType {
-	return domain.SubscriptionType(strings.ToLower(strings.ReplaceAll(name, " ", "_")))
+// to the domain SubscriptionType enum (e.g. "cloud_support"). Returns an error
+// if the converted value is not a known enum value.
+func snTypeNameToSubscriptionType(name string) (domain.SubscriptionType, error) {
+	st := domain.SubscriptionType(strings.ToLower(strings.ReplaceAll(name, " ", "_")))
+	if _, ok := validSubscriptionTypes[st]; !ok {
+		return "", fmt.Errorf("unknown subscription type %q from ServiceNow", name)
+	}
+	return st, nil
 }

--- a/entity-service/internal/snclient/client.go
+++ b/entity-service/internal/snclient/client.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package snclient provides an HTTP client for the Choreo ServiceNow API.
+package snclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+)
+
+// Client is a thin HTTP wrapper around the Choreo ServiceNow API base URL.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// New constructs a Client with a default 15-second timeout.
+func New(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// Post sends a POST request to the given path, attaching the caller-supplied
+// userIDToken as the x-user-id-token header. It returns the raw response body
+// on 2xx; non-2xx responses are mapped to typed apierror values.
+func (c *Client) Post(ctx context.Context, path string, userIDToken string, payload any) (json.RawMessage, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("snclient: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("snclient: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-user-id-token", userIDToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, &apierror.ServiceUnavailableError{Msg: fmt.Sprintf("snclient: %s: %v", path, err)}
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("snclient: read response body: %w", err)
+	}
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return json.RawMessage(raw), nil
+	case resp.StatusCode == http.StatusBadRequest:
+		return nil, &apierror.ValidationError{Msg: "downstream service rejected the request"}
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, &apierror.UnauthorizedError{Msg: "invalid or missing x-user-id-token"}
+	case resp.StatusCode == http.StatusForbidden:
+		return nil, &apierror.ForbiddenError{Msg: "not authorized to access this resource"}
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, &apierror.NotFoundError{Msg: "resource not found in downstream service"}
+	case resp.StatusCode == http.StatusServiceUnavailable:
+		return nil, &apierror.ServiceUnavailableError{Msg: "downstream service unavailable"}
+	default:
+		return nil, fmt.Errorf("snclient: %s: unexpected status %d: %s", path, resp.StatusCode, raw)
+	}
+}

--- a/entity-service/internal/snclient/client.go
+++ b/entity-service/internal/snclient/client.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,6 +64,9 @@ func (c *Client) Post(ctx context.Context, path string, userIDToken string, payl
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		return nil, &apierror.ServiceUnavailableError{Msg: fmt.Sprintf("snclient: %s: %v", path, err)}
 	}
 	defer resp.Body.Close()

--- a/entity-service/migrations/000003_create_projects.up.sql
+++ b/entity-service/migrations/000003_create_projects.up.sql
@@ -10,13 +10,23 @@ CREATE TYPE subscription_type_enum AS ENUM (
     'professional_services'
 );
 
+CREATE TYPE closure_status_enum AS ENUM (
+    'notify',
+    'closed',
+    'open',
+    'read_only',
+    'restricted',
+    'suspended'
+);
+
 CREATE TABLE IF NOT EXISTS projects (
     id                TEXT                   PRIMARY KEY,
     account_id        TEXT                   NOT NULL,
     sf_id             TEXT                   NOT NULL UNIQUE,
     name              TEXT                   NOT NULL,
-    project_key       TEXT                   NOT NULL UNIQUE,
+    key               TEXT                   NOT NULL UNIQUE,
     subscription_type subscription_type_enum NOT NULL,
+    closure_status    closure_status_enum    NULL,
     start_date        DATE                   NOT NULL,
     end_date          DATE                   NOT NULL,
     created_at        TIMESTAMPTZ            NOT NULL DEFAULT NOW(),

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -658,7 +658,7 @@ components:
           $ref: '#/components/schemas/Pagination'
         searchQuery:
           type: string
-          description: Case-insensitive match against name, project_key, and subscription_type.
+          description: Case-insensitive match against name, key, and subscription_type.
 
     Project:
       type: object
@@ -671,7 +671,7 @@ components:
           type: string
         name:
           type: string
-        projectKey:
+        key:
           type: string
         subscriptionType:
           type: string
@@ -685,6 +685,16 @@ components:
             - platformer_subscription
             - cloud_support
             - professional_services
+        closureStatus:
+          type: string
+          nullable: true
+          enum:
+            - notify
+            - closed
+            - open
+            - read_only
+            - restricted
+            - suspended
         startDate:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

- Introduces a `DATA_SOURCE` config switch (`postgres` | `servicenow`) so the service can serve project data from either the local PostgreSQL database or the Choreo-hosted Ballerina entity service that proxies ServiceNow — with no
  changes to the HTTP API surface.
- Adds a generic Choreo HTTP client (`snclient`) that forwards the caller's `x-user-id-token` header and maps non-2xx responses to typed errors.
- Both datasources return the same `ProjectView` shape (`id`, `name`, `key`, `subscriptionType`, `createdOn`), with SN type names mapped to the existing `SubscriptionType` enum values.
- When `DATA_SOURCE=servicenow` the server skips the Postgres connection on startup, so a local database is not required.

The active implementation is wired at startup in `routes.go` based on `DATA_SOURCE`. Handlers and service interfaces have zero datasource awareness.
The caller's `x-user-id-token` is extracted once by `UserIDToken` middleware and passed through context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple data sources: PostgreSQL and ServiceNow for project data.
  * Introduced project closure status tracking with multiple states.
  * Improved authorization handling with proper error responses for unauthorized and forbidden requests.

* **Changes**
  * Renamed project identifier field from `projectKey` to `key`.
  * Updated project search results to use a simplified format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->