### PR TITLE
[CSM Portal][BE] feat(middleware): add correlation ID propagation

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -2,6 +2,16 @@
 
 Go HTTP server (`net/http`, Go 1.22+) that acts as a backend-for-frontend (BFF) for the CSM portal. It authenticates callers, forwards requests to upstream services, and shapes responses for the frontend.
 
+## Middleware chain
+
+`CorrelationID → Logger → Auth → Mux`
+
+- `CorrelationID` (`internal/middleware/correlation.go`): reads `X-Correlation-ID` from the incoming request or generates a UUID v4; stores the ID in context for the slog handler and for the entity client to forward; echoes the ID in the response header
+- `Logger` (`internal/middleware/logger.go`): logs every completed request (method, path, status, elapsed) via slog; the correlation ID is included automatically in each record
+- `Auth` (`internal/middleware/auth.go`): validates the `x-jwt-assertion` JWT and sets `UserInfo` in context
+
+`middleware.ConfigureLogger()` must be called at startup — it wraps the default slog handler so that every `slog.*Context(r.Context(), …)` call anywhere in the codebase automatically includes `correlationID=<id>` when the context carries one.
+
 ## Upstream service modules
 
 Each upstream service has its own client package under `internal/`:

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -35,6 +35,7 @@ import (
 )
 
 func main() {
+	middleware.ConfigureLogger()
 	cfg := entity.Config{
 		BaseURL:      mustEnv("ENTITY_BASE_URL"),
 		TokenURL:     mustEnv("ENTITY_TOKEN_URL"),
@@ -113,7 +114,11 @@ func main() {
 	slog.Info("CSM Portal Backend started", "addr", addr)
 
 	srv := &http.Server{
-		Handler:           middleware.Auth(authCfg)(mux),
+		Handler: middleware.CorrelationID(
+			middleware.Logger(
+				middleware.Auth(authCfg)(mux),
+			),
+		),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,

--- a/apps/csm-portal/backend/internal/entity/client.go
+++ b/apps/csm-portal/backend/internal/entity/client.go
@@ -37,6 +37,7 @@ var tokenFetchTimeout = 10 * time.Second
 type ctxKey string
 
 const userIDTokenKey ctxKey = "x-user-id-token"
+const correlationIDKey ctxKey = "x-correlation-id"
 
 // WithUserIDToken returns a copy of ctx carrying the x-user-id-token value to
 // be forwarded on every outgoing entity request.
@@ -46,6 +47,17 @@ func WithUserIDToken(ctx context.Context, token string) context.Context {
 
 func userIDTokenFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(userIDTokenKey).(string)
+	return v
+}
+
+// WithCorrelationID returns a copy of ctx carrying the correlation ID to be
+// forwarded as X-Correlation-ID on every outgoing entity request.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationIDKey, id)
+}
+
+func correlationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey).(string)
 	return v
 }
 
@@ -107,6 +119,9 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 	}
 	if token := userIDTokenFromContext(ctx); token != "" {
 		req.Header.Set("x-user-id-token", token)
+	}
+	if id := correlationIDFromContext(ctx); id != "" {
+		req.Header.Set("X-Correlation-ID", id)
 	}
 
 	resp, err := c.http.Do(req)

--- a/apps/csm-portal/backend/internal/middleware/correlation.go
+++ b/apps/csm-portal/backend/internal/middleware/correlation.go
@@ -60,7 +60,9 @@ func CorrelationIDFromContext(ctx context.Context) string {
 
 func newCorrelationID() string {
 	var b [16]byte
-	_, _ = rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("correlationid: failed to read random bytes: " + err.Error())
+	}
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])

--- a/apps/csm-portal/backend/internal/middleware/correlation.go
+++ b/apps/csm-portal/backend/internal/middleware/correlation.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/entity"
+)
+
+const correlationIDHeader = "X-Correlation-ID"
+
+type correlationIDKey struct{}
+
+// CorrelationID is an HTTP middleware that reads the X-Correlation-ID request
+// header or generates a UUID v4 if absent. The ID is:
+//   - stored in the context for automatic inclusion in slog records
+//   - stored in the entity client context so it is forwarded on every outgoing
+//     entity-service request
+//   - echoed in the response header so callers can reference it in support
+//     requests
+func CorrelationID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get(correlationIDHeader)
+		if id == "" {
+			id = newCorrelationID()
+		}
+		w.Header().Set(correlationIDHeader, id)
+		ctx := context.WithValue(r.Context(), correlationIDKey{}, id)
+		ctx = entity.WithCorrelationID(ctx, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// CorrelationIDFromContext returns the correlation ID stored in ctx, or ""
+// if the CorrelationID middleware was not applied.
+func CorrelationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey{}).(string)
+	return v
+}
+
+func newCorrelationID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+// ctxHandler wraps a slog.Handler to automatically inject the correlation ID
+// from the request context into every log record produced via *Context methods.
+type ctxHandler struct {
+	inner slog.Handler
+}
+
+func (h ctxHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h ctxHandler) Handle(ctx context.Context, r slog.Record) error {
+	if id := CorrelationIDFromContext(ctx); id != "" {
+		r.AddAttrs(slog.String("correlationID", id))
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h ctxHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return ctxHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h ctxHandler) WithGroup(name string) slog.Handler {
+	return ctxHandler{inner: h.inner.WithGroup(name)}
+}
+
+// ConfigureLogger sets up the default slog logger with a handler that
+// automatically adds the correlation ID from the request context to every log
+// record. It writes directly to os.Stderr to avoid a deadlock: slog.SetDefault
+// also redirects log.std's output through the new handler, and if the inner
+// handler were the old defaultHandler (which itself writes to log.std) a cycle
+// would form. Call once at startup before any log statements.
+func ConfigureLogger() {
+	inner := slog.NewTextHandler(os.Stderr, nil)
+	slog.SetDefault(slog.New(ctxHandler{inner: inner}))
+}

--- a/apps/csm-portal/backend/internal/middleware/logger.go
+++ b/apps/csm-portal/backend/internal/middleware/logger.go
@@ -14,11 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package middleware provides composable HTTP middleware for the entity service.
 package middleware
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 )
@@ -35,13 +34,19 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-// Logger is an HTTP middleware that logs each request's method, path, response
-// status code, and elapsed time.
+// Logger is an HTTP middleware that logs each completed request via slog. The
+// correlation ID is included automatically in every record when ConfigureLogger
+// has been called (it is attached by the ctxHandler from the context).
 func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rw, r)
-		log.Printf("%s %s correlationID=%s status=%d elapsed=%s", r.Method, r.URL.Path, CorrelationIDFromContext(r.Context()), rw.status, time.Since(start))
+		slog.InfoContext(r.Context(), "request completed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rw.status,
+			"elapsed", time.Since(start).String(),
+		)
 	})
 }

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -12,7 +12,9 @@ Handler → Service → Repository → PostgreSQL (pgx/v5)
 
 All wiring happens explicitly in `internal/server/routes.go` (no DI framework). The full dependency graph is built there: `NewRepository(db) → NewService(repo) → NewHandler(svc)`, then registered on a `net/http.ServeMux`.
 
-Middleware chain wraps the mux: **Recovery → Logger → Timeout** (10 s per request).
+Middleware chain wraps the mux: **CorrelationID → Recovery → Logger → UserIDToken → Timeout** (10 s per request).
+
+`CorrelationID` reads the `X-Correlation-ID` request header forwarded by the portal BFF, or generates a UUID v4 if absent. The ID is stored in the request context and echoed in the response header. All access log lines and panic logs include the correlation ID for end-to-end request tracing.
 
 ## Running locally
 

--- a/entity-service/internal/middleware/correlationid.go
+++ b/entity-service/internal/middleware/correlationid.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+)
+
+// correlationIDHeader is the HTTP header used to propagate the correlation ID
+// across service boundaries.
+const correlationIDHeader = "X-Correlation-ID"
+
+type correlationIDKey struct{}
+
+// CorrelationID is an HTTP middleware that reads the X-Correlation-ID request
+// header (forwarded by the portal BFF) or generates a UUID v4 if absent.
+// The ID is stored in the request context for logging and echoed in the
+// response header so callers can reference it in support requests.
+func CorrelationID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get(correlationIDHeader)
+		if id == "" {
+			id = newCorrelationID()
+		}
+		w.Header().Set(correlationIDHeader, id)
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), correlationIDKey{}, id)))
+	})
+}
+
+// CorrelationIDFromContext returns the correlation ID stored in ctx by the
+// CorrelationID middleware, or an empty string if absent.
+func CorrelationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey{}).(string)
+	return v
+}
+
+// newCorrelationID generates a random UUID v4.
+func newCorrelationID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}

--- a/entity-service/internal/middleware/correlationid.go
+++ b/entity-service/internal/middleware/correlationid.go
@@ -54,7 +54,9 @@ func CorrelationIDFromContext(ctx context.Context) string {
 // newCorrelationID generates a random UUID v4.
 func newCorrelationID() string {
 	var b [16]byte
-	_, _ = rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("correlationid: failed to read random bytes: " + err.Error())
+	}
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])

--- a/entity-service/internal/middleware/recovery.go
+++ b/entity-service/internal/middleware/recovery.go
@@ -48,7 +48,7 @@ func Recovery(next http.Handler) http.Handler {
 		rw := &recoveryWriter{ResponseWriter: w}
 		defer func() {
 			if rec := recover(); rec != nil {
-				log.Printf("Panic recovered (type: %T)", rec)
+				log.Printf("panic recovered correlationID=%s (type: %T)", CorrelationIDFromContext(r.Context()), rec)
 				if !rw.headerWritten {
 					rw.ResponseWriter.Header().Set("Content-Type", "application/json")
 					rw.ResponseWriter.WriteHeader(http.StatusInternalServerError)

--- a/entity-service/internal/middleware/recovery.go
+++ b/entity-service/internal/middleware/recovery.go
@@ -48,7 +48,7 @@ func Recovery(next http.Handler) http.Handler {
 		rw := &recoveryWriter{ResponseWriter: w}
 		defer func() {
 			if rec := recover(); rec != nil {
-				log.Printf("panic recovered correlationID=%s (type: %T)", CorrelationIDFromContext(r.Context()), rec)
+				log.Printf("panic recovered correlationID=%s value=%v (type: %T)", CorrelationIDFromContext(r.Context()), rec, rec)
 				if !rw.headerWritten {
 					rw.ResponseWriter.Header().Set("Content-Type", "application/json")
 					rw.ResponseWriter.WriteHeader(http.StatusInternalServerError)

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -31,7 +31,7 @@ import (
 
 // NewRouter builds the dependency graph (repository → service → handler),
 // registers all routes, and wraps the mux with the middleware chain:
-// Recovery → Logger → Timeout.
+// CorrelationID → Recovery → Logger → UserIDToken → Timeout.
 func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	userRepo := repository.NewUserRepository(db)
 	userSvc := service.NewUserService(userRepo)
@@ -90,10 +90,12 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/comments/search", caseHandler.SearchCaseComments)
 
-	return middleware.Recovery(
-		middleware.Logger(
-			middleware.UserIDToken(
-				middleware.Timeout(10 * time.Second)(mux),
+	return middleware.CorrelationID(
+		middleware.Recovery(
+			middleware.Logger(
+				middleware.UserIDToken(
+					middleware.Timeout(10 * time.Second)(mux),
+				),
 			),
 		),
 	)


### PR DESCRIPTION
## Summary

- Adds `X-Correlation-ID` tracking end-to-end across **entity-service** and **csm-portal/backend**
- csm-portal generates or accepts the header on every incoming request, stores it in the request context, and forwards it on every outgoing call to entity-service
- Both services include the correlation ID in **all** access log lines (success and error) — following the standard distributed tracing practice of logging the ID on every request so the full trace is available even when failures are discovered after the fact
- A custom `slog` context handler in csm-portal automatically injects `correlationID=<id>` into every `slog.*Context(r.Context(), …)` call without requiring changes to individual handlers

## Changes

### entity-service
- `internal/middleware/correlationid.go` — new `CorrelationID` middleware: reads `X-Correlation-ID` from the request header or generates a UUID v4; stores in context; echoes in response header
- `internal/middleware/logger.go` — access log now includes `correlationID=`
- `internal/middleware/recovery.go` — panic log now includes `correlationID=`
- `internal/server/routes.go` — chain updated to `CorrelationID → Recovery → Logger → UserIDToken → Timeout`

### csm-portal/backend
- `internal/middleware/correlation.go` — new `CorrelationID` middleware + `ctxHandler` slog wrapper + `ConfigureLogger()`
- `internal/middleware/logger.go` — new access logger (all requests) via slog
- `internal/entity/client.go` — `WithCorrelationID` / `correlationIDFromContext`; `do()` now sets `X-Correlation-ID` on every outgoing request
- `cmd/server/main.go` — calls `ConfigureLogger()` at startup; handler chain updated to `CorrelationID → Logger → Auth → Mux`

## Test plan

- [x] Start csm-portal and entity-service locally; make a request and confirm `X-Correlation-ID` appears in the response header
- [x] Check entity-service logs — confirm every access log line includes the same `correlationID=` as the response header
- [x] Check csm-portal logs — confirm `correlationID` appears in both access log (`request completed`) and any error logs for the same request
- [x] Make a request without an `X-Correlation-ID` header — confirm a UUID v4 is generated and appears consistently across both services
- [x] Pass a custom `X-Correlation-ID` value — confirm the same ID propagates through to entity-service logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented end-to-end request correlation IDs across services for improved tracing and debugging. Correlation IDs are automatically generated when missing and propagated through logs and outgoing requests.
  * Enhanced logging to include correlation IDs in all log entries and HTTP response headers for improved observability.

* **Documentation**
  * Updated middleware chain documentation to reflect correlation ID handling in request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->