### PR TITLE
[CSM Portal] add dev:local Vite local-gateway mode for offline full-stack preview

### DIFF
--- a/apps/csm-portal/webapp/README.md
+++ b/apps/csm-portal/webapp/README.md
@@ -91,6 +91,29 @@ pnpm run test          # Vitest
 pnpm run test:e2e      # Playwright
 ```
 
+## Local Full-Stack Mode (sandboxed dev)
+
+```bash
+pnpm run dev:local     # dev server acting as a local gateway
+```
+
+For environments that cannot reach the hosted identity provider or cloud
+gateway (network-locked devcontainers, headless preview tooling). Sets
+`CSM_PORTAL_LOCAL_BE=1`, which makes the Vite dev server (a) serve
+`/config.js` with overrides — auth base URL pointed at a local mock OIDC
+provider on `:9100`, backend base URL at the same-origin `/local-api`
+path, mocks off — and (b) proxy `/local-api/*` to the local Go backend on
+`:8080`, mapping the incoming `Authorization: Bearer <jwt>` to
+`x-jwt-assertion` exactly as the production gateway does. The app code
+runs unmodified: the real OIDC SDK performs a genuine authorization-code +
+PKCE flow against the mock provider, which signs real RS256 JWTs for any
+username you pick at its login form.
+
+Applies only to the dev `serve` command — `pnpm build` / `pnpm preview`
+can never carry this behaviour. The mock provider, backend, entity service
+and seeded PostgreSQL it talks to must be running separately (the local
+backend stack); this flag only changes the dev server's behaviour.
+
 ## Branching
 
 This webapp lives in the `cs-tools` repo. Work on a feature branch off `v2` (never commit directly to `v2`). Rebase on `origin/v2` before opening a PR.

--- a/apps/csm-portal/webapp/package.json
+++ b/apps/csm-portal/webapp/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:local": "CSM_PORTAL_LOCAL_BE=1 vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -14,8 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { readFileSync } from "node:fs";
 import { fileURLToPath, URL } from "node:url";
-import { defineConfig, mergeConfig } from "vite";
+import { defineConfig, mergeConfig, type Plugin } from "vite";
 import { defineConfig as defineVitestConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
@@ -122,4 +123,91 @@ const vitestConfig = defineVitestConfig({
   },
 });
 
-export default mergeConfig(viteConfig, vitestConfig);
+// ── Local full-stack gateway mode (CSM_PORTAL_LOCAL_BE=1, dev server only) ──
+// Makes the Vite dev server play the role of the production gateway + runtime
+// config for a fully local stack (mock OIDC provider on :9100, csm backend on
+// :8080, entity-service on :8081). The app code runs UNMODIFIED: the real OIDC
+// SDK performs a genuine authorization-code + PKCE flow against the local IdP.
+//
+// Two pieces:
+//   1. /config.js is served with overrides appended: auth base URL → the
+//      local IdP, backend base URL → same-origin /local-api, mocks off.
+//   2. /local-api/* is proxied to the local backend with the incoming
+//      `Authorization: Bearer <jwt>` mapped to `x-jwt-assertion` — exactly
+//      what the production gateway does after validating the token.
+//
+// Injected ONLY for the dev `serve` command under the env flag: `vite build`
+// runs with command === "build", and `vite preview` serves prebuilt dist/, so
+// no production artifact can carry this behaviour.
+
+const LOCAL_IDP = "http://localhost:9100";
+const LOCAL_BACKEND = "http://127.0.0.1:8080";
+
+const CONFIG_OVERRIDES = `
+// --- appended by vite local-gateway mode (CSM_PORTAL_LOCAL_BE=1) ---
+window.config.CSM_PORTAL_AUTH_BASE_URL = "${LOCAL_IDP}";
+window.config.CSM_PORTAL_AUTH_CLIENT_ID = "csm-local-dev";
+window.config.CSM_PORTAL_BACKEND_BASE_URL = "http://localhost:3001/local-api";
+window.config.CSM_PORTAL_USE_MOCKS = false;
+// Pin the runtime mock toggle off so a stale localStorage flag cannot
+// silently re-enable mock data in front of the real local backend.
+try { localStorage.setItem("csm.useMocks", "0"); } catch (e) { /* ignore */ }
+`;
+
+function localGatewayConfigPlugin(): Plugin {
+  return {
+    name: "csm-local-gateway-config",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url?.split("?")[0] !== "/config.js") return next();
+        const original = readFileSync(
+          fileURLToPath(new URL("./public/config.js", import.meta.url)),
+          "utf8",
+        );
+        res.setHeader("Content-Type", "text/javascript");
+        res.setHeader("Cache-Control", "no-store");
+        res.end(original + CONFIG_OVERRIDES);
+      });
+    },
+  };
+}
+
+export default defineConfig(({ command }) => {
+  const merged = mergeConfig(viteConfig, vitestConfig);
+
+  if (command === "serve" && process.env.CSM_PORTAL_LOCAL_BE === "1") {
+    console.log(
+      "[vite] CSM_PORTAL_LOCAL_BE=1 — serving config overrides (local IdP " +
+        `${LOCAL_IDP}, mocks off) and proxying /local-api → ${LOCAL_BACKEND}`,
+    );
+    return mergeConfig(merged, {
+      plugins: [localGatewayConfigPlugin()],
+      server: {
+        proxy: {
+          "/local-api": {
+            target: LOCAL_BACKEND,
+            changeOrigin: true,
+            rewrite: (p: string) => p.replace(/^\/local-api/, ""),
+            configure: (proxy: {
+              on: (ev: string, cb: (...args: unknown[]) => void) => void;
+            }) => {
+              proxy.on("proxyReq", (...args: unknown[]) => {
+                const proxyReq = args[0] as {
+                  setHeader: (k: string, v: string) => void;
+                };
+                const req = args[1] as {
+                  headers: Record<string, string | undefined>;
+                };
+                const auth = req.headers["authorization"];
+                if (auth?.startsWith("Bearer ")) {
+                  proxyReq.setHeader("x-jwt-assertion", auth.slice(7));
+                }
+              });
+            },
+          },
+        },
+      },
+    });
+  }
+  return merged;
+});

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -164,10 +164,21 @@ function localGatewayConfigPlugin(): Plugin {
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         if (req.url?.split("?")[0] !== "/config.js") return next();
-        const original = readFileSync(
-          fileURLToPath(new URL("./public/config.js", import.meta.url)),
-          "utf8",
-        );
+        let original: string;
+        try {
+          original = readFileSync(
+            fileURLToPath(new URL("./public/config.js", import.meta.url)),
+            "utf8",
+          );
+        } catch (err) {
+          server.config.logger.error(
+            `[vite] local-gateway: cannot read public/config.js: ${String(err)}`,
+          );
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end("Missing or unreadable public/config.js");
+          return;
+        }
         res.setHeader("Content-Type", "text/javascript");
         res.setHeader("Cache-Control", "no-store");
         res.end(original + CONFIG_OVERRIDES);

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -147,7 +147,11 @@ const CONFIG_OVERRIDES = `
 // --- appended by vite local-gateway mode (CSM_PORTAL_LOCAL_BE=1) ---
 window.config.CSM_PORTAL_AUTH_BASE_URL = "${LOCAL_IDP}";
 window.config.CSM_PORTAL_AUTH_CLIENT_ID = "csm-local-dev";
-window.config.CSM_PORTAL_BACKEND_BASE_URL = "http://localhost:3001/local-api";
+// Same-origin backend: derive from the actual origin the dev server is reached
+// on, so a forwarded host/IP (devcontainer port-forward, LAN address) still
+// hits the Vite /local-api proxy instead of a hardcoded localhost that would
+// break the same-origin contract.
+window.config.CSM_PORTAL_BACKEND_BASE_URL = window.location.origin + "/local-api";
 window.config.CSM_PORTAL_USE_MOCKS = false;
 // Pin the runtime mock toggle off so a stale localStorage flag cannot
 // silently re-enable mock data in front of the real local backend.


### PR DESCRIPTION
## What

Adds a `pnpm dev:local` script (`CSM_PORTAL_LOCAL_BE=1`, **dev-server only**) that makes the Vite dev server stand in for the production gateway + runtime config, so the CSM webapp can run end-to-end against a fully local backend stack with no access to the hosted identity provider or cloud gateway.

Two pieces, both injected only for the dev `serve` command under the env flag:

1. **`/config.js` overrides** appended at serve time: auth base URL → a local mock OIDC provider on `:9100`, backend base URL → same-origin `/local-api`, mocks off.
2. **`/local-api/*` proxy** to the local backend on `:8080`, mapping the incoming `Authorization: Bearer <jwt>` to `x-jwt-assertion` — matching what the production gateway forwards after validating the token.

## Why

Enables offline / network-locked full-stack preview and headless visual/a11y verification of the webapp against real services (real auth-code + PKCE flow, real RS256 JWTs, real backend responses) without touching app code.

## Safety

- Gated to `command === "serve"` **and** `CSM_PORTAL_LOCAL_BE=1`. `vite build` and `vite preview` can never carry this behaviour into a production artifact.
- App code is unchanged; the real OIDC SDK runs the genuine flow against the mock provider.
- The mock provider, backend, entity service and seeded DB it talks to are run separately; this flag only changes dev-server behaviour.

## Test

- `pnpm build` (tsc + vite build) green — confirms the local-gateway path is excluded from the production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local full-stack development mode for sandboxed, network-restricted setups, enabling the dev server to use local authentication and backend endpoints.
  * Introduced a `dev:local` startup workflow that rewrites runtime configuration on `/config.js`, proxies `/local-api/*` to a local backend, and forwards Bearer JWTs for backend authorization.
  * This mode is dev-server only (not supported for build/preview).

* **Documentation**
  * Updated the README with setup and usage instructions for the new local mode, including required local services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->