### PR TITLE
[CSM Portal] WCAG-AA pass, top-nav working set + Quick-nav, saved filter views, resilient dashboard

### DIFF
--- a/apps/csm-portal/webapp/src/components/SemanticChip.tsx
+++ b/apps/csm-portal/webapp/src/components/SemanticChip.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Chip, useTheme } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { pickAccessibleText } from "@utils/contrastText";
+
+/** The semantic palette roles a chip may carry. */
+export type SemanticRole = "error" | "warning" | "info" | "success" | "default";
+
+interface SemanticChipProps {
+  role: SemanticRole;
+  label: string;
+  size?: "small" | "medium";
+  /** Bold label — use for priority signals (severity), not quiet metadata. */
+  bold?: boolean;
+  /** Pointer cursor when wrapped in a link / clickable row. */
+  clickable?: boolean;
+}
+
+/**
+ * A chip whose filled label always clears WCAG AA.
+ *
+ * A plain `<Chip color="error">` uses MUI's `contrastText`, computed against a
+ * 3:1 floor, so white-on-saturated chip labels (~13px) sit around 3:1 and fail
+ * AA (4.5:1) — in every theme, because it is the contrast-target that is wrong,
+ * not the palette. This keeps the vivid `*.main` fill but picks the label colour
+ * (near-black vs white) by the fill's measured luminance, which clears 4.5:1 for
+ * the saturated semantic colours in all shipped themes and both colour modes.
+ * The `default`/grey role has no accessible solid fill, so it renders outlined.
+ */
+export default function SemanticChip({
+  role,
+  label,
+  size = "small",
+  bold = false,
+  clickable = false,
+}: SemanticChipProps): JSX.Element {
+  const theme = useTheme();
+
+  if (role === "default") {
+    return (
+      <Chip
+        size={size}
+        variant="outlined"
+        label={label}
+        sx={clickable ? { cursor: "pointer" } : undefined}
+      />
+    );
+  }
+
+  const bg = theme.palette[role].main;
+  const fg = pickAccessibleText(bg);
+
+  return (
+    <Chip
+      size={size}
+      label={label}
+      sx={{
+        bgcolor: bg,
+        color: fg,
+        ...(bold ? { fontWeight: 600 } : {}),
+        "& .MuiChip-label": { color: fg },
+        ...(clickable ? { cursor: "pointer" } : {}),
+      }}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/components/SeverityChip.tsx
+++ b/apps/csm-portal/webapp/src/components/SeverityChip.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+import {
+  SEVERITY_COLOR,
+  SEVERITY_LABEL,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import SemanticChip from "@components/SemanticChip";
+
+interface SeverityChipProps {
+  severity: Severity;
+  /** Append the descriptive label, e.g. "S1 — Critical" (used on the case header). */
+  withLabel?: boolean;
+  size?: "small" | "medium";
+  /** Render a pointer cursor when the chip is wrapped in a link/clickable row. */
+  clickable?: boolean;
+}
+
+/**
+ * The single source of truth for rendering a case severity badge. Severity is
+ * the highest-priority scan signal in the portal, so it renders as a bold,
+ * solid {@link SemanticChip} (which guarantees WCAG AA) — visually out-ranking
+ * the quieter outlined state chip.
+ */
+export default function SeverityChip({
+  severity,
+  withLabel = false,
+  size = "small",
+  clickable = false,
+}: SeverityChipProps): JSX.Element {
+  return (
+    <SemanticChip
+      role={SEVERITY_COLOR[severity]}
+      label={
+        withLabel ? `${severity} — ${SEVERITY_LABEL[severity]}` : severity
+      }
+      size={size}
+      bold
+      clickable={clickable}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/components/header/Actions.tsx
+++ b/apps/csm-portal/webapp/src/components/header/Actions.tsx
@@ -26,6 +26,7 @@ import UserProfile from "@components/header/UserProfile";
 import MockModeToggle from "@components/header/MockModeToggle";
 import ThemeSelect from "@components/header/ThemeSelect";
 import RecentViewsButton from "@features/csm-recent/components/RecentViewsButton";
+import PinThisPageButton from "@features/csm-recent/components/PinThisPageButton";
 
 export default function Actions(): JSX.Element {
   const { isSignedIn } = useAsgardeo();
@@ -35,6 +36,7 @@ export default function Actions(): JSX.Element {
       <MockModeToggle />
       <ThemeSelect />
       <ColorSchemeToggle />
+      {isSignedIn && <PinThisPageButton />}
       {isSignedIn && <RecentViewsButton />}
       <Divider
         orientation="vertical"

--- a/apps/csm-portal/webapp/src/components/header/Actions.tsx
+++ b/apps/csm-portal/webapp/src/components/header/Actions.tsx
@@ -25,6 +25,7 @@ import { useAsgardeo } from "@asgardeo/react";
 import UserProfile from "@components/header/UserProfile";
 import MockModeToggle from "@components/header/MockModeToggle";
 import ThemeSelect from "@components/header/ThemeSelect";
+import RecentViewsButton from "@features/csm-recent/components/RecentViewsButton";
 
 export default function Actions(): JSX.Element {
   const { isSignedIn } = useAsgardeo();
@@ -34,6 +35,7 @@ export default function Actions(): JSX.Element {
       <MockModeToggle />
       <ThemeSelect />
       <ColorSchemeToggle />
+      {isSignedIn && <RecentViewsButton />}
       <Divider
         orientation="vertical"
         flexItem

--- a/apps/csm-portal/webapp/src/components/header/Header.tsx
+++ b/apps/csm-portal/webapp/src/components/header/Header.tsx
@@ -18,6 +18,8 @@ import { type JSX } from "react";
 import { Header as HeaderUI } from "@wso2/oxygen-ui";
 import Brand from "@components/header/Brand";
 import Actions from "@components/header/Actions";
+import PinnedTabs from "@features/csm-recent/components/PinnedTabs";
+import QuickNav from "@features/csm-recent/components/QuickNav";
 
 interface HeaderProps {
   onToggleSidebar: () => void;
@@ -36,7 +38,8 @@ export default function Header({
         <HeaderUI.Toggle collapsed={collapsed} onToggle={onToggleSidebar} />
       )}
       <Brand />
-      <HeaderUI.Spacer />
+      <QuickNav />
+      <PinnedTabs />
       <Actions />
     </HeaderUI>
   );

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -15,20 +15,9 @@
 // under the License.
 
 import { Box, Chip, Link, Sidebar } from "@wso2/oxygen-ui";
-import {
-  Briefcase,
-  Building,
-  ChartColumn,
-  Clock,
-  Cog,
-  FolderOpen,
-  Headset,
-  RefreshCw,
-  Settings,
-  Shield,
-} from "@wso2/oxygen-ui-icons-react";
-import { type ComponentType, type JSX } from "react";
+import { type JSX } from "react";
 import { Link as NavigateLink, useLocation } from "react-router";
+import { CSM_NAV_ITEMS, navItemForPath } from "@config/csmNavItems";
 
 interface CsmSideBarProps {
   collapsed: boolean;
@@ -37,35 +26,9 @@ interface CsmSideBarProps {
   onToggleExpand?: (id: string) => void;
 }
 
-interface CsmNavItem {
-  id: string;
-  label: string;
-  path: string;
-  icon: ComponentType<{ size?: number | string }>;
-  wip?: boolean;
-}
-
-const CSM_NAV_ITEMS: CsmNavItem[] = [
-  { id: "dashboard", label: "Dashboard", path: "/dashboard", icon: ChartColumn },
-  { id: "cases", label: "Cases", path: "/cases", icon: Headset },
-  { id: "operations", label: "Operations", path: "/operations", icon: Cog },
-  { id: "engagements", label: "Engagements", path: "/engagements", icon: Briefcase },
-  { id: "updates", label: "Updates", path: "/updates", icon: RefreshCw },
-  { id: "security-center", label: "Security center", path: "/security-center", icon: Shield },
-  { id: "time-cards", label: "Time cards", path: "/time-cards", icon: Clock },
-  { id: "accounts", label: "Accounts", path: "/accounts", icon: Building },
-  { id: "projects", label: "Projects", path: "/projects", icon: FolderOpen },
-  { id: "admin", label: "Administration", path: "/admin", icon: Settings },
-];
-
 function pickActiveId(pathname: string): string {
   if (pathname === "/" || pathname === "") return "accounts";
-  for (const item of CSM_NAV_ITEMS) {
-    if (pathname === item.path || pathname.startsWith(`${item.path}/`)) {
-      return item.id;
-    }
-  }
-  return "accounts";
+  return navItemForPath(pathname)?.id ?? "accounts";
 }
 
 export default function CsmSideBar({

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Link, Sidebar } from "@wso2/oxygen-ui";
+import { Link, Sidebar } from "@wso2/oxygen-ui";
 import { type JSX } from "react";
 import { Link as NavigateLink, useLocation } from "react-router";
 import { CSM_NAV_ITEMS, navItemForPath } from "@config/csmNavItems";
@@ -62,29 +62,10 @@ export default function CsmSideBar({
                 <Sidebar.ItemIcon>
                   <item.icon size={20} />
                 </Sidebar.ItemIcon>
-                <Sidebar.ItemLabel>
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 1,
-                      width: "100%",
-                    }}
-                  >
-                    <Box component="span" sx={{ flex: 1 }}>
-                      {item.label}
-                    </Box>
-                    {item.wip && !collapsed && (
-                      <Chip
-                        size="small"
-                        label="WIP"
-                        color="warning"
-                        variant="outlined"
-                        sx={{ height: 18, fontSize: 10 }}
-                      />
-                    )}
-                  </Box>
-                </Sidebar.ItemLabel>
+                {/* Plain string: Oxygen derives the collapsed-rail tooltip via
+                    String(ItemLabel.children), so a wrapper element would render
+                    as "[object Object]". */}
+                <Sidebar.ItemLabel>{item.label}</Sidebar.ItemLabel>
               </Sidebar.Item>
             </Link>
           ))}

--- a/apps/csm-portal/webapp/src/config/a11yThemeOverrides.ts
+++ b/apps/csm-portal/webapp/src/config/a11yThemeOverrides.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { OxygenTheme } from "@wso2/oxygen-ui/styles/Themes/OxygenThemeBase";
+import { pickAccessibleText } from "@utils/contrastText";
+
+/**
+ * Accessibility overlay applied on top of whichever Oxygen theme is active.
+ *
+ * The brand accent (`primary.main`, a light salmon orange ~`#F87643`) is fine
+ * as white-on-orange (contained buttons) and as orange-on-dark, but as *text or
+ * border on a light surface* it sits around 2.5:1 and fails WCAG AA. That makes
+ * every text/outlined `color="primary"` button unreadable in light mode. Rather
+ * than darken the brand fill (which would dull the contained CTA the brand
+ * wants kept vivid) or patch each call site, we shift only the text/border
+ * colour of text & outlined primary buttons to the darker `primary.dark` shade,
+ * and only in the light colour scheme (`applyStyles("light", …)`); dark mode,
+ * where orange-on-dark already passes, is untouched. Kept theme-agnostic — it
+ * reads `primary.dark` from whatever theme is active, so it survives a theme
+ * swap and is not a different named theme.
+ *
+ * Returns a shallow clone of `base` with the extra `MuiButton` style slots
+ * merged in, preserving the theme's CSS-variable colour schemes.
+ */
+export function withA11yOverrides(base: OxygenTheme): OxygenTheme {
+  // CSS-vars themes expose `applyStyles(scheme, styles)`, which scopes the
+  // given styles to one colour scheme. Typed loosely because the public
+  // OxygenTheme type does not surface the CssVars helpers.
+  const lightColor = ({
+    theme,
+  }: {
+    theme: {
+      applyStyles: (scheme: string, styles: Record<string, unknown>) => unknown;
+      palette: { primary: { dark: string } };
+    };
+  }): Record<string, unknown> => ({
+    ...(theme.applyStyles("light", {
+      color: theme.palette.primary.dark,
+    }) as Record<string, unknown>),
+  });
+
+  const lightColorAndBorder = ({
+    theme,
+  }: {
+    theme: {
+      applyStyles: (scheme: string, styles: Record<string, unknown>) => unknown;
+      palette: { primary: { dark: string } };
+    };
+  }): Record<string, unknown> => ({
+    ...(theme.applyStyles("light", {
+      color: theme.palette.primary.dark,
+      borderColor: theme.palette.primary.dark,
+    }) as Record<string, unknown>),
+  });
+
+  // Oxygen's `UserMenu` paints the user-initial avatar (trigger + dropdown
+  // header) as white-on-`primary.main`, which is ~2.7:1 and fails AA in BOTH
+  // modes (the fill is orange in light and dark alike). The avatar is rendered
+  // inside the library component, so there is no call site to patch: override
+  // the `MuiUserMenu` `avatar`/`headerAvatar` slots and let the initial pick a
+  // contrast-safe colour from the resolved fill. Unlike the button fix this is
+  // not mode-scoped: the fill is the same orange in both schemes, so the same
+  // dark-on-orange label is correct everywhere. Mirrors the inline avatar fix
+  // in `CsmCaseCommentBubble`.
+  const avatarText = ({
+    theme,
+  }: {
+    theme: { palette: { primary: { main: string } } };
+  }): Record<string, unknown> => ({
+    color: pickAccessibleText(theme.palette.primary.main),
+  });
+
+  const baseComponents = (base as { components?: Record<string, unknown> })
+    .components;
+  const baseButton =
+    (baseComponents?.MuiButton as
+      | { styleOverrides?: Record<string, unknown> }
+      | undefined) ?? {};
+  const baseUserMenu =
+    (baseComponents?.MuiUserMenu as
+      | { styleOverrides?: Record<string, unknown> }
+      | undefined) ?? {};
+  const baseChip =
+    (baseComponents?.MuiChip as
+      | { styleOverrides?: Record<string, unknown> }
+      | undefined) ?? {};
+
+  return {
+    ...base,
+    components: {
+      ...baseComponents,
+      MuiButton: {
+        ...baseButton,
+        styleOverrides: {
+          ...baseButton.styleOverrides,
+          textPrimary: lightColor,
+          outlinedPrimary: lightColorAndBorder,
+        },
+      },
+      MuiUserMenu: {
+        ...baseUserMenu,
+        styleOverrides: {
+          ...baseUserMenu.styleOverrides,
+          avatar: avatarText,
+          headerAvatar: avatarText,
+        },
+      },
+      // Outlined `color="primary"` chips (e.g. the "WSO2" author-org badge on
+      // comments) paint their label and border with `primary.main`, which is
+      // ~2.5:1 on a light surface — the same orange-on-light failure as the
+      // text/outlined buttons above, and fixed the same way: shift to
+      // `primary.dark` in light mode only. Dark mode (orange-on-dark) passes
+      // and is left untouched.
+      MuiChip: {
+        ...baseChip,
+        styleOverrides: {
+          ...baseChip.styleOverrides,
+          outlinedPrimary: lightColorAndBorder,
+        },
+      },
+    },
+  } as OxygenTheme;
+}

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Briefcase,
+  Building,
+  ChartColumn,
+  Clock,
+  Cog,
+  FolderOpen,
+  Headset,
+  RefreshCw,
+  Settings,
+  Shield,
+} from "@wso2/oxygen-ui-icons-react";
+import type { ComponentType } from "react";
+
+export interface CsmNavItem {
+  id: string;
+  label: string;
+  path: string;
+  icon: ComponentType<{ size?: number | string }>;
+  wip?: boolean;
+}
+
+/**
+ * The CSM portal's top-level pages. Single source of truth for the sidebar nav,
+ * the Quick-nav palette's "Pages" section, and "Pin this page" title/kind
+ * derivation — so a new page only has to be added here once.
+ */
+export const CSM_NAV_ITEMS: CsmNavItem[] = [
+  { id: "dashboard", label: "Dashboard", path: "/dashboard", icon: ChartColumn },
+  { id: "cases", label: "Cases", path: "/cases", icon: Headset },
+  { id: "operations", label: "Operations", path: "/operations", icon: Cog },
+  { id: "engagements", label: "Engagements", path: "/engagements", icon: Briefcase },
+  { id: "updates", label: "Updates", path: "/updates", icon: RefreshCw },
+  { id: "security-center", label: "Security center", path: "/security-center", icon: Shield },
+  { id: "time-cards", label: "Time cards", path: "/time-cards", icon: Clock },
+  { id: "accounts", label: "Accounts", path: "/accounts", icon: Building },
+  { id: "projects", label: "Projects", path: "/projects", icon: FolderOpen },
+  { id: "admin", label: "Administration", path: "/admin", icon: Settings },
+];
+
+/** The nav item whose path is (a prefix of) `pathname`, if any. */
+export function navItemForPath(pathname: string): CsmNavItem | undefined {
+  return CSM_NAV_ITEMS.find(
+    (item) => pathname === item.path || pathname.startsWith(`${item.path}/`),
+  );
+}

--- a/apps/csm-portal/webapp/src/context/theme/ThemePreferenceContext.tsx
+++ b/apps/csm-portal/webapp/src/context/theme/ThemePreferenceContext.tsx
@@ -33,6 +33,7 @@ import {
   THEME_OPTIONS,
   type ThemeKey,
 } from "@config/themeConfig";
+import { withA11yOverrides } from "@config/a11yThemeOverrides";
 
 const STORAGE_KEY = "csm.theme";
 
@@ -76,6 +77,12 @@ export function ThemePreferenceProvider({
 }): JSX.Element {
   const [themeKey, setThemeKeyState] = useState<ThemeKey>(() => readInitial());
 
+  // Layer the WCAG-AA accent overlay on the resolved theme (see
+  // withA11yOverrides). Memoised so the theme object is stable per key.
+  const theme = useMemo(() => withA11yOverrides(resolveTheme(themeKey)), [
+    themeKey,
+  ]);
+
   const setThemeKey = useCallback((next: ThemeKey): void => {
     setThemeKeyState(next);
     try {
@@ -92,7 +99,7 @@ export function ThemePreferenceProvider({
 
   return (
     <ThemePreferenceContext.Provider value={value}>
-      <OxygenUIThemeProvider theme={resolveTheme(themeKey)}>
+      <OxygenUIThemeProvider theme={theme}>
         {children}
       </OxygenUIThemeProvider>
     </ThemePreferenceContext.Provider>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -14,13 +14,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
-import { pickAccessibleText } from "@utils/contrastText";
+import {
+  Box,
+  Checkbox,
+  Chip,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Paper,
+  Typography,
+} from "@wso2/oxygen-ui";
 import {
   Activity,
+  ArrowDown,
+  ArrowUp,
   ArrowUpRight,
   CheckCircle,
   Link as LinkIcon,
+  ListFilter,
   Paperclip,
   Plus,
   TriangleAlert,
@@ -70,6 +81,7 @@ export default function CaseActivitiesFeed({
   const [showLifecycle, setShowLifecycle] = useState(true);
   const [showAttachments, setShowAttachments] = useState(true);
   const [newestFirst, setNewestFirst] = useState(true);
+  const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
 
   const entries: FeedEntry[] = useMemo(() => {
     const out: FeedEntry[] = [];
@@ -108,16 +120,35 @@ export default function CaseActivitiesFeed({
     attachments: attachments.length,
   };
 
-  // A filled `color="info"` chip uses MUI's contrastText (3:1 floor), so the
-  // selected filter toggles render white-on-blue at ~3.9:1 and fail WCAG AA for
-  // their small labels. Override the label colour with a luminance-matched
-  // choice so the active toggle stays legible.
-  const theme = useTheme();
-  const activeFilterFg = pickAccessibleText(theme.palette.info.main);
-  const activeFilterSx = {
-    color: activeFilterFg,
-    "& .MuiChip-label": { color: activeFilterFg },
-  };
+  // Filters live in a dropdown so the timeline reads as content, not a row of
+  // loud toggles. Surface how many of the three categories are showing when not
+  // all are, so the (collapsed) filter state stays discoverable.
+  const filterOptions: {
+    label: string;
+    checked: boolean;
+    toggle: () => void;
+  }[] = [
+    {
+      label: `Work notes (${counts.workNotes})`,
+      checked: showWorkNotes,
+      toggle: () => setShowWorkNotes((v) => !v),
+    },
+    {
+      label: `State changes (${counts.lifecycle})`,
+      checked: showLifecycle,
+      toggle: () => setShowLifecycle((v) => !v),
+    },
+    {
+      label: `Attachments (${counts.attachments})`,
+      checked: showAttachments,
+      toggle: () => setShowAttachments((v) => !v),
+    },
+  ];
+  const activeFilters = filterOptions.filter((o) => o.checked).length;
+  const filterLabel =
+    activeFilters < filterOptions.length
+      ? `Filter (${activeFilters}/${filterOptions.length})`
+      : "Filter";
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
@@ -125,49 +156,53 @@ export default function CaseActivitiesFeed({
         sx={{
           display: "flex",
           alignItems: "center",
-          gap: 1.5,
+          gap: 1,
           flexWrap: "wrap",
         }}
       >
-        <Typography variant="caption" color="text.secondary">
-          Filter:
-        </Typography>
-        <Chip
-          size="small"
-          variant={showWorkNotes ? "filled" : "outlined"}
-          color={showWorkNotes ? "info" : "default"}
-          label={`Work notes (${counts.workNotes})`}
-          onClick={() => setShowWorkNotes((v) => !v)}
-          sx={showWorkNotes ? activeFilterSx : undefined}
-        />
-        <Chip
-          size="small"
-          variant={showLifecycle ? "filled" : "outlined"}
-          color={showLifecycle ? "info" : "default"}
-          label={`State changes (${counts.lifecycle})`}
-          onClick={() => setShowLifecycle((v) => !v)}
-          sx={showLifecycle ? activeFilterSx : undefined}
-        />
-        <Chip
-          size="small"
-          variant={showAttachments ? "filled" : "outlined"}
-          color={showAttachments ? "info" : "default"}
-          label={`Attachments (${counts.attachments})`}
-          onClick={() => setShowAttachments((v) => !v)}
-          sx={showAttachments ? activeFilterSx : undefined}
-        />
         <Box sx={{ flex: 1 }} />
         <Chip
           size="small"
           variant="outlined"
+          icon={<ListFilter size={14} />}
+          label={filterLabel}
+          onClick={(e) => setFilterAnchor(e.currentTarget)}
+          aria-haspopup="true"
+          aria-expanded={Boolean(filterAnchor)}
+        />
+        <Menu
+          anchorEl={filterAnchor}
+          open={Boolean(filterAnchor)}
+          onClose={() => setFilterAnchor(null)}
+          anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+          transformOrigin={{ vertical: "top", horizontal: "right" }}
+        >
+          {filterOptions.map((o) => (
+            <MenuItem key={o.label} dense onClick={o.toggle}>
+              <Checkbox
+                size="small"
+                edge="start"
+                checked={o.checked}
+                tabIndex={-1}
+                disableRipple
+              />
+              <ListItemText primary={o.label} />
+            </MenuItem>
+          ))}
+        </Menu>
+        <Chip
+          size="small"
+          variant="outlined"
+          icon={newestFirst ? <ArrowDown size={14} /> : <ArrowUp size={14} />}
           label={newestFirst ? "Newest first" : "Oldest first"}
           onClick={() => setNewestFirst((v) => !v)}
+          aria-label={`Sort: ${newestFirst ? "newest first" : "oldest first"} (click to reverse)`}
         />
       </Box>
 
       {entries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
-          Nothing to show — try widening the filters above.
+          Nothing to show — enable more categories in the Filter menu.
         </Typography>
       ) : (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -14,7 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Paper, Typography } from "@wso2/oxygen-ui";
+import { Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
+import { pickAccessibleText } from "@utils/contrastText";
 import {
   Activity,
   ArrowUpRight,
@@ -107,6 +108,17 @@ export default function CaseActivitiesFeed({
     attachments: attachments.length,
   };
 
+  // A filled `color="info"` chip uses MUI's contrastText (3:1 floor), so the
+  // selected filter toggles render white-on-blue at ~3.9:1 and fail WCAG AA for
+  // their small labels. Override the label colour with a luminance-matched
+  // choice so the active toggle stays legible.
+  const theme = useTheme();
+  const activeFilterFg = pickAccessibleText(theme.palette.info.main);
+  const activeFilterSx = {
+    color: activeFilterFg,
+    "& .MuiChip-label": { color: activeFilterFg },
+  };
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
       <Box
@@ -126,6 +138,7 @@ export default function CaseActivitiesFeed({
           color={showWorkNotes ? "info" : "default"}
           label={`Work notes (${counts.workNotes})`}
           onClick={() => setShowWorkNotes((v) => !v)}
+          sx={showWorkNotes ? activeFilterSx : undefined}
         />
         <Chip
           size="small"
@@ -133,6 +146,7 @@ export default function CaseActivitiesFeed({
           color={showLifecycle ? "info" : "default"}
           label={`State changes (${counts.lifecycle})`}
           onClick={() => setShowLifecycle((v) => !v)}
+          sx={showLifecycle ? activeFilterSx : undefined}
         />
         <Chip
           size="small"
@@ -140,6 +154,7 @@ export default function CaseActivitiesFeed({
           color={showAttachments ? "info" : "default"}
           label={`Attachments (${counts.attachments})`}
           onClick={() => setShowAttachments((v) => !v)}
+          sx={showAttachments ? activeFilterSx : undefined}
         />
         <Box sx={{ flex: 1 }} />
         <Chip

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -14,16 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, Chip, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { Box, Card, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ReactNode } from "react";
-import type { NavigateFunction } from "react-router";
+import { Link as RouterLink } from "react-router";
 import { TIER_COLOR, TIER_LABEL } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+import SemanticChip from "@components/SemanticChip";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
-  navigate: NavigateFunction;
   collapsed: boolean;
   onToggleCollapsed: () => void;
 }
@@ -57,31 +57,35 @@ function Cell({
 }
 
 function LinkText({
-  onClick,
+  to,
   children,
 }: {
-  onClick: () => void;
+  to: string;
   children: ReactNode;
 }): JSX.Element {
   return (
+    // Real anchor (RouterLink) so account/project links are cmd/middle-clickable
+    // and copyable, with plain left-click staying in-app.
     <Typography
-      component="span"
-      role="link"
-      tabIndex={0}
+      component={RouterLink}
+      to={to}
       variant="body2"
       noWrap
-      onClick={onClick}
-      onKeyDown={(e) => {
-        // Keyboard activation: Enter/Space mirror the click so the link is
-        // reachable without a pointer.
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onClick();
-        }
-      }}
-      sx={{
+      sx={(t) => ({
         cursor: "pointer",
-        color: "primary.main",
+        textDecoration: "none",
+        // Brand orange (`primary.main`) on a light surface fails WCAG AA
+        // (~2.5:1), and the darker `primary.dark` shade fails on the dark
+        // surface (~4.0:1). Pick per colour scheme. `palette.mode` is unreliable
+        // here: the app drives theming through MUI CssVars (`useColorScheme`),
+        // where `palette.mode` stays pinned to the default scheme, so a
+        // `mode === "dark"` check always resolved to the light branch. Scope the
+        // dark colour with `applyStyles("dark", …)` instead — the same mechanism
+        // the a11y button overrides use.
+        color: t.palette.primary.dark,
+        ...t.applyStyles("dark", {
+          color: t.palette.primary.main,
+        }),
         "&:hover": { textDecoration: "underline" },
         "&:focus-visible": {
           outline: "2px solid",
@@ -89,7 +93,7 @@ function LinkText({
           outlineOffset: 2,
           borderRadius: 0.5,
         },
-      }}
+      })}
     >
       {children}
     </Typography>
@@ -104,7 +108,6 @@ function LinkText({
  */
 export default function CaseMetaBand({
   detail: c,
-  navigate,
   collapsed,
   onToggleCollapsed,
 }: CaseMetaBandProps): JSX.Element {
@@ -183,11 +186,7 @@ export default function CaseMetaBand({
         >
           <Cell label="Tier">
             <Box sx={{ minWidth: 0 }}>
-              <Chip
-                size="small"
-                label={TIER_LABEL[tier]}
-                color={TIER_COLOR[tier]}
-              />
+              <SemanticChip role={TIER_COLOR[tier]} label={TIER_LABEL[tier]} />
             </Box>
           </Cell>
           <Cell label="Assignee">
@@ -206,7 +205,7 @@ export default function CaseMetaBand({
           </Cell>
           <Cell label="Account">
             {c.accountId ? (
-              <LinkText onClick={() => navigate(`/accounts/${c.accountId}`)}>
+              <LinkText to={`/accounts/${c.accountId}`}>
                 {c.customer}
               </LinkText>
             ) : (
@@ -217,7 +216,7 @@ export default function CaseMetaBand({
           </Cell>
           <Cell label="Project">
             {c.projectId ? (
-              <LinkText onClick={() => navigate(`/projects/${c.projectId}`)}>
+              <LinkText to={`/projects/${c.projectId}`}>
                 {c.projectName}
               </LinkText>
             ) : (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -20,13 +20,20 @@ import {
   Button,
   Checkbox,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
   FormControl,
   Grid,
   IconButton,
   InputAdornment,
   InputLabel,
+  ListItemIcon,
   ListItemText,
+  ListSubheader,
+  Menu,
   MenuItem,
   Paper,
   Select,
@@ -36,19 +43,33 @@ import {
 } from "@wso2/oxygen-ui";
 import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import {
+  Bookmark,
+  BookmarkPlus,
+  Check,
   ChevronDown,
   ChevronUp,
   ListFilter,
   Search,
+  Trash2,
   X,
 } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, type JSX } from "react";
+import { useMemo, useState, type JSX } from "react";
 import type {
   CaseState,
   DashboardScope,
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import {
+  readCasesFiltersFromUrl,
+  writeCasesFiltersToUrl,
+} from "@features/csm-cases/utils/casesFiltersUrl";
+import {
+  deleteFilterView,
+  saveFilterView,
+  SUGGESTED_FILTER_VIEWS,
+  useSavedFilterViews,
+} from "@features/csm-cases/utils/savedFilterViews";
 import { isMockMode } from "@api/backend/client";
 
 export type SlaFilter = "any" | "breached" | "at_risk";
@@ -363,6 +384,39 @@ export default function CasesFilterBar({
   const activeCount = countActiveFilters(filters);
   const hasActive = activeCount > 0;
 
+  // ── Saved views ──────────────────────────────────────────────────────────
+  // A saved view is just a name pointing at a serialized filter query string;
+  // applying one feeds the parsed filters back through onChange (which the page
+  // writes to the URL), so the URL stays the source of truth.
+  const savedViews = useSavedFilterViews();
+  const currentQs = writeCasesFiltersToUrl(filters).toString();
+  // Canonicalize a query string (normalize comma encoding, param order, and
+  // drop unknown params) so the "active view" check matches regardless of how a
+  // view's qs was authored — suggested presets use literal commas, while
+  // writeCasesFiltersToUrl emits %2C.
+  const canonicalQs = (qs: string): string =>
+    writeCasesFiltersToUrl(
+      readCasesFiltersFromUrl(new URLSearchParams(qs)),
+    ).toString();
+  const currentCanonical = canonicalQs(currentQs);
+  const isActiveView = (qs: string): boolean => canonicalQs(qs) === currentCanonical;
+  const [savedAnchor, setSavedAnchor] = useState<HTMLElement | null>(null);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [newViewName, setNewViewName] = useState("");
+
+  const applyView = (qs: string): void => {
+    setSavedAnchor(null);
+    onChange(readCasesFiltersFromUrl(new URLSearchParams(qs)));
+  };
+
+  const handleSaveView = (): void => {
+    if (!newViewName.trim()) return;
+    saveFilterView(newViewName, currentQs);
+    setNewViewName("");
+    setSaveDialogOpen(false);
+    setSavedAnchor(null);
+  };
+
   // Scope (ABT), assignee, and SLA have no backend support yet (no assignee or
   // SLA fields), so disable them against the live backend — they only do
   // anything against seeded mock data.
@@ -484,6 +538,86 @@ export default function CasesFilterBar({
         <Button
           variant="outlined"
           size="small"
+          color="inherit"
+          onClick={(e) => setSavedAnchor(e.currentTarget)}
+          startIcon={<Bookmark size={16} />}
+          endIcon={<ChevronDown size={16} />}
+          aria-haspopup="true"
+          aria-expanded={Boolean(savedAnchor)}
+        >
+          Saved views
+        </Button>
+        <Menu
+          anchorEl={savedAnchor}
+          open={Boolean(savedAnchor)}
+          onClose={() => setSavedAnchor(null)}
+          anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        >
+          <MenuItem
+            onClick={() => {
+              setSavedAnchor(null);
+              setSaveDialogOpen(true);
+            }}
+          >
+            <ListItemIcon>
+              <BookmarkPlus size={16} />
+            </ListItemIcon>
+            <ListItemText primary="Save current view…" />
+          </MenuItem>
+          <Divider />
+          <ListSubheader sx={{ lineHeight: "32px" }}>Suggested</ListSubheader>
+          {SUGGESTED_FILTER_VIEWS.map((v) => (
+            <MenuItem
+              key={`suggested-${v.name}`}
+              selected={isActiveView(v.qs)}
+              onClick={() => applyView(v.qs)}
+            >
+              <ListItemIcon>
+                {isActiveView(v.qs) ? <Check size={16} /> : null}
+              </ListItemIcon>
+              <ListItemText primary={v.name} />
+            </MenuItem>
+          ))}
+          <Divider />
+          <ListSubheader sx={{ lineHeight: "32px" }}>Saved</ListSubheader>
+          {savedViews.length === 0 ? (
+            <MenuItem disabled>
+              <ListItemText
+                primary="No saved views yet"
+                slotProps={{ primary: { variant: "body2" } }}
+              />
+            </MenuItem>
+          ) : (
+            savedViews.map((v) => (
+              <MenuItem
+                key={`saved-${v.name}`}
+                selected={isActiveView(v.qs)}
+                onClick={() => applyView(v.qs)}
+              >
+                <ListItemIcon>
+                  {isActiveView(v.qs) ? <Check size={16} /> : null}
+                </ListItemIcon>
+                <ListItemText primary={v.name} />
+                <IconButton
+                  size="small"
+                  edge="end"
+                  aria-label={`Delete saved view ${v.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    deleteFilterView(v.name);
+                  }}
+                  sx={{ ml: 1 }}
+                >
+                  <Trash2 size={15} />
+                </IconButton>
+              </MenuItem>
+            ))
+          )}
+        </Menu>
+
+        <Button
+          variant="outlined"
+          size="small"
           onClick={hasActive ? onReset : onFiltersToggle}
           startIcon={hasActive ? <X size={16} /> : <ListFilter size={16} />}
           endIcon={
@@ -494,6 +628,50 @@ export default function CasesFilterBar({
           {hasActive ? `Clear filters (${activeCount})` : "Filters"}
         </Button>
       </Box>
+
+      <Dialog
+        open={saveDialogOpen}
+        onClose={() => setSaveDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Save current view</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            margin="dense"
+            label="View name"
+            placeholder="e.g. My open S1/S2"
+            value={newViewName}
+            onChange={(e) => setNewViewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSaveView();
+              }
+            }}
+            helperText={
+              activeCount === 0
+                ? "Tip: no filters are active — this view will show all cases."
+                : `Captures the ${activeCount} active filter${activeCount === 1 ? "" : "s"}.`
+            }
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button color="inherit" onClick={() => setSaveDialogOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSaveView}
+            disabled={!newViewName.trim()}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Collapsible filter grid. Severity / state stay as fixed multi-selects;
           assignee / project / product are type-to-search Autocompletes. */}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -16,15 +16,15 @@
 
 import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
-import { useNavigate } from "react-router";
+import { Link as RouterLink } from "react-router";
 import {
-  SEVERITY_COLOR,
   SLA_CLOCK_LABEL,
   formatTimeToBreach,
   stateColor,
   stateLabel,
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
+import SeverityChip from "@components/SeverityChip";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 
 interface CasesListProps {
@@ -49,7 +49,6 @@ export default function CasesList({
   cases,
   isLoading,
 }: CasesListProps): JSX.Element {
-  const navigate = useNavigate();
   const theme = useTheme();
 
   return (
@@ -126,21 +125,15 @@ export default function CasesList({
           // (or explicitly true) → show the clock, false → neutral "—".
           const hasSla = c.hasSla !== false;
           const showSla = hasSla && c.state !== "closed";
-          const handleClick = () => {
-            navigate(`/cases/${c.id}`);
-          };
           return (
+            // A real anchor (not a click-handler div) so the row supports
+            // cmd/middle-click "open in new tab" — essential when an engineer
+            // pulls up other cases for reference — and exposes a copyable URL
+            // (ISSU-031). RouterLink keeps plain left-click as in-app SPA nav.
             <Box
               key={c.id}
-              role="button"
-              tabIndex={0}
-              onClick={handleClick}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  handleClick();
-                }
-              }}
+              component={RouterLink}
+              to={`/cases/${c.id}`}
               sx={{
                 gridColumn: "1 / -1",
                 display: "grid",
@@ -152,6 +145,8 @@ export default function CasesList({
                 borderBottom: 1,
                 borderColor: "divider",
                 cursor: "pointer",
+                color: "inherit",
+                textDecoration: "none",
                 "&:hover": {
                   bgcolor: "action.hover",
                 },
@@ -173,11 +168,7 @@ export default function CasesList({
               <Typography variant="body2" noWrap>
                 {c.customer}
               </Typography>
-              <Chip
-                size="small"
-                label={c.severity}
-                color={SEVERITY_COLOR[c.severity]}
-              />
+              <SeverityChip severity={c.severity} />
               <Chip
                 size="small"
                 variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -14,10 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Avatar, Box, Chip, Paper, Typography } from "@wso2/oxygen-ui";
+import { Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
 import type { JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
+import SemanticChip from "@components/SemanticChip";
+import { pickAccessibleText } from "@utils/contrastText";
 import { initialsOf } from "@utils/userClaims";
 import type {
   CsmCaseComment,
@@ -72,6 +74,7 @@ const PURIFY_CONFIG = {
 export default function CsmCaseCommentBubble({
   comment,
 }: CsmCaseCommentBubbleProps): JSX.Element {
+  const theme = useTheme();
   const safeHtml = DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG);
   const isSystem = comment.authorRole === "system";
 
@@ -89,7 +92,7 @@ export default function CsmCaseCommentBubble({
           scrollMarginTop: 96,
         }}
       >
-        <Chip size="small" color="warning" label="System" />
+        <SemanticChip role="warning" label="System" />
         <Box
           sx={{
             flex: 1,
@@ -108,6 +111,16 @@ export default function CsmCaseCommentBubble({
 
   const isInternal = !!comment.internal;
 
+  // The author avatar carries the brand orange for WSO2 engineers; its initials
+  // must stay legible on that fill (white-on-orange ~2.4:1 fails AA). Pick the
+  // text colour by the fill's luminance, and use a dark-enough grey for
+  // customers (grey.500 also fails with either text colour).
+  const avatarBg =
+    comment.authorRole === "wso2_engineer"
+      ? theme.palette.primary.main
+      : theme.palette.grey[700];
+  const avatarFg = pickAccessibleText(avatarBg);
+
   return (
     <Box
       id={comment.id}
@@ -115,10 +128,8 @@ export default function CsmCaseCommentBubble({
     >
       <Avatar
         sx={{
-          bgcolor:
-            comment.authorRole === "wso2_engineer"
-              ? "primary.main"
-              : "grey.500",
+          bgcolor: avatarBg,
+          color: avatarFg,
           width: 32,
           height: 32,
           fontSize: "0.85rem",
@@ -149,12 +160,7 @@ export default function CsmCaseCommentBubble({
             variant="outlined"
           />
           {isInternal && (
-            <Chip
-              size="small"
-              label="Internal work note"
-              color="warning"
-              variant="filled"
-            />
+            <SemanticChip role="warning" label="Internal work note" />
           )}
           <Typography variant="caption" color="text.secondary">
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -363,7 +363,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
     recordView({
       kind: "case",
       id: data.id,
-      title: `${data.caseNumber} · ${data.subject}`,
+      // Show the WSO2 case id (not the CS case number) as the recent/pinned
+      // label — it is the id engineers and customers reference.
+      title: `${data.wso2CaseId} · ${data.subject}`,
       subtitle: `${data.customer} · ${data.projectName}`,
       href: `/cases/${data.id}`,
     });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -66,14 +66,13 @@ import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import {
-  SEVERITY_COLOR,
-  SEVERITY_LABEL,
   SLA_CLOCK_LABEL,
   formatTimeToBreach,
   stateColor,
   stateLabel,
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
+import SeverityChip from "@components/SeverityChip";
 import type {
   CaseLifecycleAction,
   CsmCaseComment,
@@ -588,13 +587,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
               distinct from the free-form tags by a divider, so the current
               state doesn't get lost among the tag chips. */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            <SeverityChip severity={c.severity} withLabel />
             <Chip
               size="small"
-              label={`${c.severity} — ${SEVERITY_LABEL[c.severity]}`}
-              color={SEVERITY_COLOR[c.severity]}
-            />
-            <Chip
-              size="small"
+              variant="outlined"
               label={stateLabel(c.state)}
               color={stateColor(c.state)}
               sx={{ fontWeight: 600 }}
@@ -638,7 +634,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
       <CaseMetaBand
         detail={c}
-        navigate={navigate}
         collapsed={metaCollapsed}
         onToggleCollapsed={() => setMetaCollapsed((v) => !v)}
       />

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  deleteFilterView,
+  saveFilterView,
+  useSavedFilterViews,
+} from "./savedFilterViews";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("savedFilterViews", () => {
+  it("starts empty", () => {
+    const { result } = renderHook(() => useSavedFilterViews());
+    expect(result.current).toEqual([]);
+  });
+
+  it("saves a view and exposes it to readers in the same tab", () => {
+    const reader = renderHook(() => useSavedFilterViews());
+    act(() => {
+      saveFilterView("My S1/S2", "severities=S1,S2");
+    });
+    expect(reader.result.current).toHaveLength(1);
+    expect(reader.result.current[0]).toEqual({
+      name: "My S1/S2",
+      qs: "severities=S1,S2",
+    });
+  });
+
+  it("trims the name and ignores an empty one", () => {
+    const reader = renderHook(() => useSavedFilterViews());
+    act(() => {
+      expect(saveFilterView("  Spaced  ", "states=open")).toBe("Spaced");
+      expect(saveFilterView("   ", "states=open")).toBe("");
+    });
+    expect(reader.result.current.map((v) => v.name)).toEqual(["Spaced"]);
+  });
+
+  it("overwrites a view with the same name (case-insensitive), newest first", () => {
+    const reader = renderHook(() => useSavedFilterViews());
+    act(() => saveFilterView("Triage", "states=open"));
+    act(() => saveFilterView("Other", "sla=breached"));
+    act(() => saveFilterView("triage", "states=work_in_progress"));
+
+    // "triage" replaces "Triage" and moves to the front; no duplicate.
+    expect(reader.result.current).toEqual([
+      { name: "triage", qs: "states=work_in_progress" },
+      { name: "Other", qs: "sla=breached" },
+    ]);
+  });
+
+  it("persists across a fresh hook mount (reload)", () => {
+    act(() => saveFilterView("Persisted", "states=reopened"));
+    const remount = renderHook(() => useSavedFilterViews());
+    expect(remount.result.current).toEqual([
+      { name: "Persisted", qs: "states=reopened" },
+    ]);
+  });
+
+  it("deletes a view by name (case-insensitive)", () => {
+    const reader = renderHook(() => useSavedFilterViews());
+    act(() => saveFilterView("Keep", "states=open"));
+    act(() => saveFilterView("Drop", "states=closed"));
+    act(() => deleteFilterView("DROP"));
+    expect(reader.result.current.map((v) => v.name)).toEqual(["Keep"]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+
+/**
+ * Named, reusable cases-list filter sets for high-volume triage ("my open
+ * S1/S2"). Stored as the serialized query string produced by
+ * {@link casesFiltersUrl} — the URL stays the single source of truth, so a saved
+ * view is just a label pointing at a `/cases?<qs>` shape. No second filter
+ * format is invented.
+ */
+export interface SavedFilterView {
+  name: string;
+  /** Serialized filters: the `/cases?<qs>` query string (no leading `?`). */
+  qs: string;
+}
+
+const STORAGE_KEY = "csm.savedFilters.v1";
+const STORAGE_EVENT = "csm:saved-filters-changed";
+const MAX_VIEWS = 50;
+
+/**
+ * Built-in suggested views. Kept as constants (not seeded into storage) so they
+ * always appear and can't be "deleted then reappear on reload". Only severity /
+ * state based, which work against the live backend (assignee/SLA filters do
+ * not yet).
+ */
+export const SUGGESTED_FILTER_VIEWS: readonly SavedFilterView[] = [
+  { name: "S0/S1 active", qs: "severities=S0,S1&states=open,work_in_progress,reopened" },
+  { name: "Awaiting info", qs: "states=awaiting_info" },
+  { name: "Open (unstarted)", qs: "states=open" },
+];
+
+function readStorage(): SavedFilterView[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (v): v is SavedFilterView =>
+        typeof v === "object" &&
+        v !== null &&
+        typeof (v as SavedFilterView).name === "string" &&
+        typeof (v as SavedFilterView).qs === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(views: SavedFilterView[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(views.slice(0, MAX_VIEWS)));
+    // In-tab listeners (the storage event only fires cross-tab).
+    window.dispatchEvent(new CustomEvent(STORAGE_EVENT));
+  } catch {
+    // ignore quota / serialization errors
+  }
+}
+
+/** Reactive list of the user's saved views (updates across components + tabs). */
+export function useSavedFilterViews(): SavedFilterView[] {
+  const [views, setViews] = useState<SavedFilterView[]>(() => readStorage());
+  useEffect(() => {
+    const sync = () => setViews(readStorage());
+    window.addEventListener(STORAGE_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(STORAGE_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+  return views;
+}
+
+/**
+ * Save (or overwrite by name) a view. Most-recently-saved first. No-op for an
+ * empty name. Returns the trimmed name actually stored.
+ */
+export function saveFilterView(name: string, qs: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  const current = readStorage().filter(
+    (v) => v.name.toLowerCase() !== trimmed.toLowerCase(),
+  );
+  writeStorage([{ name: trimmed, qs }, ...current]);
+  return trimmed;
+}
+
+/** Delete a saved view by name (case-insensitive). */
+export function deleteFilterView(name: string): void {
+  writeStorage(
+    readStorage().filter(
+      (v) => v.name.toLowerCase() !== name.trim().toLowerCase(),
+    ),
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -43,6 +43,7 @@ interface AbtDashboardHeaderProps {
   onScopeChange: (scope: DashboardScope) => void;
   dashboardKey: DashboardKey;
   onDashboardChange: (key: DashboardKey) => void;
+  isError?: boolean;
 }
 
 export default function AbtDashboardHeader({
@@ -51,6 +52,7 @@ export default function AbtDashboardHeader({
   onScopeChange,
   dashboardKey,
   onDashboardChange,
+  isError,
 }: AbtDashboardHeaderProps): JSX.Element {
   const currentOption = DASHBOARD_OPTIONS.find((o) => o.key === dashboardKey);
   const showScopeButtons = currentOption?.scopeBased ?? false;
@@ -71,7 +73,11 @@ export default function AbtDashboardHeader({
           sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}
         >
           <Typography variant="body2" color="text.secondary">
-            {engineer ? engineer.name : "Loading engineer…"}
+            {engineer
+              ? engineer.name
+              : isError
+                ? "Engineer overview"
+                : "Loading engineer…"}
           </Typography>
           {engineer?.abtName && (
             <Chip

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -16,7 +16,6 @@
 
 import {
   Box,
-  Chip,
   Link,
   Skeleton,
   Table,
@@ -34,10 +33,8 @@ import {
   MATRIX_STATES,
   useCaseCountsMatrix,
 } from "@features/csm-dashboard/api/useCaseCountsMatrix";
-import {
-  SEVERITY_COLOR,
-  STATE_LABEL,
-} from "@features/csm-dashboard/utils/abtDashboard";
+import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import SeverityChip from "@components/SeverityChip";
 import type {
   CaseState,
   Severity,
@@ -76,7 +73,7 @@ function CountCell({
           {value}
         </Link>
       ) : (
-        <Typography component="span" variant="body2" color="text.disabled">
+        <Typography component="span" variant="body2" color="text.secondary">
           0
         </Typography>
       )}
@@ -128,12 +125,7 @@ export default function CaseCountsMatrix(): JSX.Element {
                       to={casesHref(sev)}
                       underline="none"
                     >
-                      <Chip
-                        size="small"
-                        label={sev}
-                        color={SEVERITY_COLOR[sev]}
-                        sx={{ cursor: "pointer" }}
-                      />
+                      <SeverityChip severity={sev} clickable />
                     </Link>
                   </TableCell>
                   {MATRIX_STATES.map((st) => (

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CustomerSummarySection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CustomerSummarySection.tsx
@@ -24,6 +24,7 @@ interface CustomerSummarySectionProps {
   customers?: CsmCustomerSummary[];
   isLoading: boolean;
   scopeLabel: string;
+  isError?: boolean;
 }
 
 function TierChip({ tier }: { tier: string }): JSX.Element {
@@ -42,7 +43,18 @@ export default function CustomerSummarySection({
   customers,
   isLoading,
   scopeLabel,
+  isError,
 }: CustomerSummarySectionProps): JSX.Element {
+  if (isError) {
+    return (
+      <SectionCard title="Customers" subtitle={scopeLabel}>
+        <Typography variant="body2" color="text.secondary">
+          Couldn’t load customer summaries right now.
+        </Typography>
+      </SectionCard>
+    );
+  }
+
   return (
     <SectionCard
       title="Customers"

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
@@ -14,16 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import { Box, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
 import type { JSX, KeyboardEvent } from "react";
 import { useNavigate } from "react-router";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
 import {
-  SEVERITY_COLOR,
   SLA_CLOCK_LABEL,
   formatTimeToBreach,
   stateLabel,
 } from "@features/csm-dashboard/utils/abtDashboard";
+import SeverityChip from "@components/SeverityChip";
 import { casesHref } from "@features/csm-cases/utils/casesFiltersUrl";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/components/CasesFilterBar";
 import type { CsmQueueSummary } from "@features/csm-dashboard/types/abtDashboard";
@@ -175,11 +175,7 @@ export default function MyQueueSection({
                 },
               }}
             >
-              <Chip
-                size="small"
-                label={c.severity}
-                color={SEVERITY_COLOR[c.severity]}
-              />
+              <SeverityChip severity={c.severity} />
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography variant="body2" noWrap>
                   <strong>{c.caseNumber}</strong> · {c.subject}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
@@ -31,6 +31,7 @@ import type { CsmQueueSummary } from "@features/csm-dashboard/types/abtDashboard
 interface MyQueueSectionProps {
   queue?: CsmQueueSummary;
   isLoading: boolean;
+  isError?: boolean;
 }
 
 function StatPill({
@@ -90,10 +91,21 @@ function StatPill({
 export default function MyQueueSection({
   queue,
   isLoading,
+  isError,
 }: MyQueueSectionProps): JSX.Element {
   const navigate = useNavigate();
   const theme = useTheme();
   const go = (href: string) => navigate(href);
+
+  if (isError) {
+    return (
+      <SectionCard title="My queue" subtitle="Cases assigned to you">
+        <Typography variant="body2" color="text.secondary">
+          Couldn’t load your queue right now.
+        </Typography>
+      </SectionCard>
+    );
+  }
 
   return (
     <SectionCard

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/RecentActivitySection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/RecentActivitySection.tsx
@@ -26,6 +26,7 @@ import type {
 interface RecentActivitySectionProps {
   activity?: CsmRecentActivity[];
   isLoading: boolean;
+  isError?: boolean;
 }
 
 const TYPE_LABEL: Record<CsmRecentActivityType, string> = {
@@ -50,7 +51,18 @@ const TYPE_COLOR: Record<
 export default function RecentActivitySection({
   activity,
   isLoading,
+  isError,
 }: RecentActivitySectionProps): JSX.Element {
+  if (isError) {
+    return (
+      <SectionCard title="Recent activity" subtitle="Across ABT cases">
+        <Typography variant="body2" color="text.secondary">
+          Couldn’t load recent activity right now.
+        </Typography>
+      </SectionCard>
+    );
+  }
+
   return (
     <SectionCard title="Recent activity" subtitle="Across ABT cases">
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/SlaAtRiskSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/SlaAtRiskSection.tsx
@@ -19,11 +19,11 @@ import type { JSX } from "react";
 import { useNavigate } from "react-router";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
 import {
-  SEVERITY_COLOR,
   SLA_CLOCK_LABEL,
   formatTimeToBreach,
   stateLabel,
 } from "@features/csm-dashboard/utils/abtDashboard";
+import SeverityChip from "@components/SeverityChip";
 import { casesHref } from "@features/csm-cases/utils/casesFiltersUrl";
 import type { CsmSlaAtRiskCase } from "@features/csm-dashboard/types/abtDashboard";
 
@@ -114,11 +114,7 @@ export default function SlaAtRiskSection({
                 },
               }}
             >
-              <Chip
-                size="small"
-                label={c.severity}
-                color={SEVERITY_COLOR[c.severity]}
-              />
+              <SeverityChip severity={c.severity} />
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography variant="body2" noWrap>
                   <strong>{c.caseNumber}</strong> · {c.subject}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/SlaAtRiskSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/SlaAtRiskSection.tsx
@@ -30,16 +30,31 @@ import type { CsmSlaAtRiskCase } from "@features/csm-dashboard/types/abtDashboar
 interface SlaAtRiskSectionProps {
   cases?: CsmSlaAtRiskCase[];
   isLoading: boolean;
+  isError?: boolean;
 }
 
 export default function SlaAtRiskSection({
   cases,
   isLoading,
+  isError,
 }: SlaAtRiskSectionProps): JSX.Element {
   const navigate = useNavigate();
   const theme = useTheme();
   const go = (href: string) => navigate(href);
   const breachedCount = (cases ?? []).filter((c) => c.minutesToBreach < 0).length;
+
+  if (isError) {
+    return (
+      <SectionCard
+        title="SLA at risk"
+        subtitle="Cases breaching or about to breach"
+      >
+        <Typography variant="body2" color="text.secondary">
+          Couldn’t load SLA data right now.
+        </Typography>
+      </SectionCard>
+    );
+  }
 
   return (
     <SectionCard

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -15,8 +15,7 @@
 // under the License.
 
 import { Box, Card, Chip, Typography } from "@wso2/oxygen-ui";
-import { useEffect, useRef, useState, type JSX } from "react";
-import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useState, type JSX } from "react";
 import AbtDashboardHeader from "@features/csm-dashboard/components/AbtDashboardHeader";
 import MyQueueSection from "@features/csm-dashboard/components/MyQueueSection";
 import SlaAtRiskSection from "@features/csm-dashboard/components/SlaAtRiskSection";
@@ -44,16 +43,11 @@ export default function CsmDashboardPage(): JSX.Element {
   const [scope, setScope] = useState<DashboardScope>("all_customers");
   const [dashboardKey, setDashboardKey] = useState<DashboardKey>("engineer");
   const { data, isLoading, isError } = useGetCsmDashboard(scope);
-  const { showError } = useErrorBanner();
-  const hasShownErrorRef = useRef(false);
-
-  useEffect(() => {
-    if (isError && !hasShownErrorRef.current) {
-      hasShownErrorRef.current = true;
-      showError("Could not load dashboard.");
-    }
-    if (!isError) hasShownErrorRef.current = false;
-  }, [isError, showError]);
+  // No page-level "Could not load dashboard" toast: this aggregate query backs
+  // four independent sections (queue, SLA, customers, recent activity), while
+  // the severity matrix loads from a separate source. A global toast wrongly
+  // implies the whole page is dead. Pass isError to each section so the engineer
+  // sees exactly what's missing and what's still trustworthy (§2.2).
 
   const scopeLabel =
     scope === "my_abt"
@@ -70,6 +64,7 @@ export default function CsmDashboardPage(): JSX.Element {
         onScopeChange={setScope}
         dashboardKey={dashboardKey}
         onDashboardChange={setDashboardKey}
+        isError={isError}
       />
       {dashboardKey === "engineer" ? (
         <>
@@ -84,8 +79,16 @@ export default function CsmDashboardPage(): JSX.Element {
               },
             }}
           >
-            <MyQueueSection queue={data?.queue} isLoading={isLoading} />
-            <SlaAtRiskSection cases={data?.slaAtRisk} isLoading={isLoading} />
+            <MyQueueSection
+              queue={data?.queue}
+              isLoading={isLoading}
+              isError={isError}
+            />
+            <SlaAtRiskSection
+              cases={data?.slaAtRisk}
+              isLoading={isLoading}
+              isError={isError}
+            />
           </Box>
           <Box
             sx={{
@@ -101,10 +104,12 @@ export default function CsmDashboardPage(): JSX.Element {
               customers={data?.customers}
               isLoading={isLoading}
               scopeLabel={scopeLabel}
+              isError={isError}
             />
             <RecentActivitySection
               activity={data?.recentActivity}
               isLoading={isLoading}
+              isError={isError}
             />
           </Box>
         </>

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/PinThisPageButton.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/PinThisPageButton.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { IconButton, Tooltip } from "@wso2/oxygen-ui";
+import { Pin, PinOff } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { useLocation } from "react-router";
+import {
+  toggleRecentViewPin,
+  useRecentViews,
+  useRecordRecentView,
+} from "@features/csm-recent/hooks/useRecentViews";
+import { currentPageEntry } from "@features/csm-recent/currentPageEntry";
+
+/**
+ * Pins the CURRENT route into the top-nav working set — for any page, not just
+ * case/project/account detail (dashboards, filtered searches, list pages).
+ *
+ * If the route is already tracked as a recent (e.g. a detail page recorded it
+ * on visit), we pin that existing entry so we never create a duplicate; the
+ * richer auto-recorded title wins. Otherwise we derive a page/search entry from
+ * the route, record it, and pin it.
+ */
+export default function PinThisPageButton(): JSX.Element | null {
+  const { isSignedIn } = useAsgardeo();
+  const location = useLocation();
+  const recents = useRecentViews();
+  const record = useRecordRecentView();
+
+  if (!isSignedIn) return null;
+
+  const href = location.pathname + location.search;
+  const existing = recents.find((e) => e.href === href);
+  const isPinned = !!existing?.pinned;
+
+  const onToggle = () => {
+    if (existing) {
+      toggleRecentViewPin(existing.kind, existing.id);
+      return;
+    }
+    const entry = currentPageEntry(location.pathname, location.search);
+    record(entry); // adds to recents (unpinned, most recent)
+    toggleRecentViewPin(entry.kind, entry.id); // then promote into the bar
+  };
+
+  return (
+    <Tooltip
+      title={
+        isPinned
+          ? "Unpin this page from the top nav bar"
+          : "Pin this page to the top nav bar"
+      }
+    >
+      <IconButton
+        size="small"
+        aria-label={isPinned ? "Unpin this page" : "Pin this page to top nav bar"}
+        aria-pressed={isPinned}
+        onClick={onToggle}
+        // Pinned state carries the brand accent, kept AA-legible per scheme
+        // (primary.dark on light, primary.main on dark) — palette.mode is
+        // unreliable under CssVars.
+        sx={(t) => ({
+          ...(isPinned
+            ? {
+                color: t.palette.primary.dark,
+                ...t.applyStyles("dark", { color: t.palette.primary.main }),
+              }
+            : {}),
+        })}
+      >
+        {isPinned ? <PinOff size={18} /> : <Pin size={18} />}
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Tooltip } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { useLocation, useNavigate } from "react-router";
+import {
+  toggleRecentViewPin,
+  useRecentViews,
+  type RecentView,
+} from "@features/csm-recent/hooks/useRecentViews";
+import { kindIcon } from "@features/csm-recent/kindMeta";
+
+/** Compact chip label: the case id / entity name (the part before " · "). */
+function shortLabel(entry: RecentView): string {
+  return entry.title.split(" · ")[0] || entry.title;
+}
+
+/**
+ * The pinned working set rendered as persistent tabs in the top nav bar, so an
+ * engineer can hold several cases (or projects/accounts) one click away without
+ * leaving the current screen. Pins are added from the Recent Views panel and
+ * removed via each tab's delete affordance.
+ *
+ * Sits in the header's flexible middle region: when nothing is pinned it
+ * collapses to a plain spacer so the brand stays left and the actions stay
+ * right, exactly like the `Header.Spacer` it replaces.
+ */
+export default function PinnedTabs(): JSX.Element {
+  const { isSignedIn } = useAsgardeo();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const pinned = useRecentViews().filter((e) => e.pinned);
+
+  // Always occupy the flexible middle slot so the layout is identical whether or
+  // not anything is pinned (and when signed out, where pins are not actionable).
+  if (!isSignedIn || pinned.length === 0) {
+    return <Box sx={{ flexGrow: 1 }} />;
+  }
+
+  return (
+    <Box
+      sx={{
+        flexGrow: 1,
+        minWidth: 0,
+        display: "flex",
+        alignItems: "center",
+        gap: 0.75,
+        overflowX: "auto",
+        // Quiet scrollbar — the strip should read as content, not a control.
+        "&::-webkit-scrollbar": { height: 6 },
+        "&::-webkit-scrollbar-thumb": {
+          bgcolor: "action.disabled",
+          borderRadius: 3,
+        },
+      }}
+    >
+      {pinned.map((entry) => {
+        const active = location.pathname === entry.href.split("?")[0];
+        return (
+          <Tooltip key={`${entry.kind}-${entry.id}`} title={entry.title}>
+            <Chip
+              size="small"
+              icon={kindIcon(entry.kind, 14)}
+              label={shortLabel(entry)}
+              variant={active ? "filled" : "outlined"}
+              onClick={() => navigate(entry.href)}
+              onDelete={() => toggleRecentViewPin(entry.kind, entry.id)}
+              aria-label={`${shortLabel(entry)} — pinned tab`}
+              sx={{
+                flexShrink: 0,
+                maxWidth: 200,
+                cursor: "pointer",
+                // Active = where you are now: a calm selected fill, not the
+                // brand orange (white-on-orange small text fails AA).
+                ...(active
+                  ? { bgcolor: "action.selected", fontWeight: 600 }
+                  : {}),
+              }}
+            />
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
@@ -70,7 +70,14 @@ export default function PinnedTabs(): JSX.Element {
       }}
     >
       {pinned.map((entry) => {
-        const active = location.pathname === entry.href.split("?")[0];
+        // A search pin is path + query, so match the full href; for everything
+        // else match the path alone (the case/project/account a tab points at,
+        // independent of any query). Path-only matching would light up every
+        // pinned search on the same route at once.
+        const active =
+          entry.kind === "search"
+            ? location.pathname + location.search === entry.href
+            : location.pathname === entry.href.split("?")[0];
         return (
           <Tooltip key={`${entry.kind}-${entry.id}`} title={entry.title}>
             <Chip

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  ButtonBase,
+  Dialog,
+  InputBase,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Search } from "@wso2/oxygen-ui-icons-react";
+import { useEffect, useMemo, useState, type JSX } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { useNavigate } from "react-router";
+import { CSM_NAV_ITEMS } from "@config/csmNavItems";
+import { useRecentViews } from "@features/csm-recent/hooks/useRecentViews";
+import { kindIcon } from "@features/csm-recent/kindMeta";
+
+type Section = "Pinned" | "Recent" | "Pages";
+
+interface Result {
+  key: string;
+  icon: JSX.Element;
+  label: string;
+  sublabel?: string;
+  href: string;
+  section: Section;
+}
+
+const RECENT_LIMIT = 8;
+
+const isMac =
+  typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
+
+export default function QuickNav(): JSX.Element | null {
+  const { isSignedIn } = useAsgardeo();
+  const navigate = useNavigate();
+  const recents = useRecentViews();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+
+  // ⌘K / Ctrl+K toggles the palette from anywhere.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const results: Result[] = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const match = (...parts: (string | undefined)[]) =>
+      !q || parts.some((p) => p?.toLowerCase().includes(q));
+
+    const pinned: Result[] = recents
+      .filter((e) => e.pinned)
+      .filter((e) => match(e.title, e.subtitle))
+      .map((e) => ({
+        key: `pin-${e.kind}-${e.id}`,
+        icon: kindIcon(e.kind, 16),
+        label: e.title,
+        sublabel: e.subtitle,
+        href: e.href,
+        section: "Pinned",
+      }));
+
+    const recent: Result[] = recents
+      .filter((e) => !e.pinned)
+      .filter((e) => match(e.title, e.subtitle))
+      .slice(0, RECENT_LIMIT)
+      .map((e) => ({
+        key: `rec-${e.kind}-${e.id}`,
+        icon: kindIcon(e.kind, 16),
+        label: e.title,
+        sublabel: e.subtitle,
+        href: e.href,
+        section: "Recent",
+      }));
+
+    const pages: Result[] = CSM_NAV_ITEMS.filter((i) => match(i.label)).map(
+      (i) => ({
+        key: `page-${i.id}`,
+        icon: <i.icon size={16} />,
+        label: i.label,
+        href: i.path,
+        section: "Pages",
+      }),
+    );
+
+    return [...pinned, ...recent, ...pages];
+  }, [recents, query]);
+
+  // Clamp at render so a stale index from shrinking results never points past
+  // the end (avoids a setState-in-effect cascade).
+  const safeActive = results.length ? Math.min(active, results.length - 1) : 0;
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+    setActive(0);
+  };
+
+  const choose = (r: Result | undefined) => {
+    if (!r) return;
+    close();
+    navigate(r.href);
+  };
+
+  const onListKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive(results.length ? (safeActive + 1) % results.length : 0);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive(
+        results.length ? (safeActive - 1 + results.length) % results.length : 0,
+      );
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      choose(results[safeActive]);
+    }
+  };
+
+  if (!isSignedIn) return null;
+
+  const shortcut = isMac ? "⌘K" : "Ctrl K";
+
+  return (
+    <>
+      <ButtonBase
+        onClick={() => setOpen(true)}
+        aria-label="Search or jump to (open quick nav)"
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          height: 36,
+          width: { xs: 40, sm: 200, md: 260 },
+          px: { xs: 0, sm: 1.25 },
+          justifyContent: { xs: "center", sm: "flex-start" },
+          borderRadius: 1,
+          border: 1,
+          borderColor: "divider",
+          color: "text.secondary",
+          flexShrink: 0,
+          "&:hover": { bgcolor: "action.hover" },
+        }}
+      >
+        <Search size={16} />
+        <Typography
+          variant="body2"
+          noWrap
+          sx={{ flex: 1, textAlign: "left", display: { xs: "none", sm: "block" } }}
+        >
+          Search or jump to…
+        </Typography>
+        <Box
+          component="span"
+          sx={{
+            display: { xs: "none", sm: "block" },
+            fontSize: 11,
+            px: 0.5,
+            borderRadius: 0.5,
+            border: 1,
+            borderColor: "divider",
+            color: "text.secondary",
+          }}
+        >
+          {shortcut}
+        </Box>
+      </ButtonBase>
+
+      <Dialog
+        open={open}
+        onClose={close}
+        fullWidth
+        maxWidth="sm"
+        sx={{ "& .MuiDialog-container": { alignItems: "flex-start" } }}
+        slotProps={{ paper: { sx: { mt: "12vh", overflow: "hidden" } } }}
+      >
+        <Box
+          onKeyDown={onListKeyDown}
+          sx={{ display: "flex", flexDirection: "column", maxHeight: "60vh" }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              px: 2,
+              py: 1.5,
+              borderBottom: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Search size={18} />
+            <InputBase
+              autoFocus
+              fullWidth
+              placeholder="Search pinned, recent, and pages…"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActive(0);
+              }}
+              inputProps={{ "aria-label": "Quick nav search" }}
+            />
+          </Box>
+
+          <Box sx={{ overflowY: "auto" }}>
+            {results.length === 0 ? (
+              <Box sx={{ px: 2, py: 3, textAlign: "center" }}>
+                <Typography variant="body2" color="text.secondary">
+                  No matches.
+                </Typography>
+              </Box>
+            ) : (
+              results.map((r, i) => {
+                const newSection = i === 0 || results[i - 1].section !== r.section;
+                return (
+                  <Box key={r.key}>
+                    {newSection && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{
+                          display: "block",
+                          px: 2,
+                          pt: 1,
+                          pb: 0.5,
+                          fontWeight: 600,
+                        }}
+                      >
+                        {r.section}
+                      </Typography>
+                    )}
+                    <Box
+                      role="button"
+                      tabIndex={-1}
+                      onMouseEnter={() => setActive(i)}
+                      onClick={() => choose(r)}
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1.5,
+                        px: 2,
+                        py: 1,
+                        cursor: "pointer",
+                        bgcolor: i === safeActive ? "action.selected" : undefined,
+                      }}
+                    >
+                      {r.icon}
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography variant="body2" noWrap>
+                          {r.label}
+                        </Typography>
+                        {r.sublabel && (
+                          <Typography variant="caption" color="text.secondary" noWrap>
+                            {r.sublabel}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  </Box>
+                );
+              })
+            )}
+          </Box>
+        </Box>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -53,8 +53,10 @@ export default function QuickNav(): JSX.Element | null {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
 
-  // ⌘K / Ctrl+K toggles the palette from anywhere.
+  // ⌘K / Ctrl+K toggles the palette — only while signed in, so we don't hijack
+  // the browser shortcut on the sign-in screen (where the palette can't render).
   useEffect(() => {
+    if (!isSignedIn) return;
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
@@ -63,7 +65,7 @@ export default function QuickNav(): JSX.Element | null {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [isSignedIn]);
 
   const results: Result[] = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
@@ -23,14 +23,7 @@ import {
   Typography,
   useTheme,
 } from "@wso2/oxygen-ui";
-import {
-  Building,
-  FolderOpen,
-  Headset,
-  History,
-  Pin,
-  PinOff,
-} from "@wso2/oxygen-ui-icons-react";
+import { History, Pin, PinOff } from "@wso2/oxygen-ui-icons-react";
 import {
   useCallback,
   useEffect,
@@ -49,34 +42,20 @@ import {
   type RecentView,
   type RecentViewKind,
 } from "@features/csm-recent/hooks/useRecentViews";
+import { KIND_LABEL, KIND_ORDER, kindIcon } from "@features/csm-recent/kindMeta";
 import RelativeTime from "@components/RelativeTime";
 
 const PANEL_WIDTH = 360;
 
-const KIND_LABEL: Record<RecentViewKind, string> = {
-  case: "Cases",
-  project: "Projects",
-  account: "Accounts",
-};
-
-const KIND_ORDER: RecentViewKind[] = ["case", "project", "account"];
-
-function kindIcon(kind: RecentViewKind): JSX.Element {
-  switch (kind) {
-    case "case":
-      return <Headset size={16} />;
-    case "project":
-      return <FolderOpen size={16} />;
-    case "account":
-      return <Building size={16} />;
-  }
-}
-
-function groupByKind(entries: RecentView[]): Record<RecentViewKind, RecentView[]> {
+function groupByKind(
+  entries: RecentView[],
+): Record<RecentViewKind, RecentView[]> {
   const out: Record<RecentViewKind, RecentView[]> = {
     case: [],
     project: [],
     account: [],
+    search: [],
+    page: [],
   };
   for (const e of entries) out[e.kind].push(e);
   return out;
@@ -128,11 +107,11 @@ export default function RecentViewsButton(): JSX.Element {
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [open]);
 
-  const pinned = useMemo(() => recents.filter((e) => e.pinned), [recents]);
-  const grouped = useMemo(
-    () => groupByKind(recents.filter((e) => !e.pinned)),
-    [recents],
-  );
+  // Pinned entries surface as tabs in the top nav bar (PinnedTabs) AND stay in
+  // the history list here — pinning promotes an item into the working set
+  // without removing it from "recently viewed". The per-row toggle reflects the
+  // pinned state (Unpin vs Pin to top nav bar).
+  const grouped = useMemo(() => groupByKind(recents), [recents]);
 
   const handleSelect = (entry: RecentView) => {
     setOpen(false);
@@ -172,13 +151,15 @@ export default function RecentViewsButton(): JSX.Element {
           </Typography>
         )}
       </Box>
-      <Tooltip title={entry.pinned ? "Unpin" : "Pin to working set"}>
+      <Tooltip
+        title={entry.pinned ? "Unpin from top nav bar" : "Pin to top nav bar"}
+      >
         <IconButton
           size="small"
           aria-label={
             entry.pinned
-              ? `Unpin ${entry.title}`
-              : `Pin ${entry.title} to working set`
+              ? `Unpin ${entry.title} from top nav bar`
+              : `Pin ${entry.title} to top nav bar`
           }
           // Stop the row's navigate; pinning must not leave the panel.
           onClick={(e) => {
@@ -260,35 +241,8 @@ export default function RecentViewsButton(): JSX.Element {
         {recents.length === 0 && (
           <Box sx={{ px: 1.5, py: 2.5, textAlign: "center" }}>
             <Typography variant="body2" color="text.secondary">
-              No recent items. Open a case, project, or account to start tracking history. Pin the ones you are actively working to keep them here.
+              No recent items. Open a case, project, or account to start tracking history, then pin the ones you are actively working to keep them in the top nav bar.
             </Typography>
-          </Box>
-        )}
-
-        {pinned.length > 0 && (
-          <Box>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 0.5,
-                px: 1.5,
-                py: 0.5,
-                bgcolor: "background.default",
-                borderBottom: 1,
-                borderColor: "divider",
-              }}
-            >
-              <Pin size={12} />
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ fontWeight: 600 }}
-              >
-                Pinned · working set
-              </Typography>
-            </Box>
-            {pinned.map(renderRow)}
           </Box>
         )}
 

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
@@ -125,6 +125,9 @@ export default function RecentViewsButton(): JSX.Element {
       tabIndex={0}
       onClick={() => handleSelect(entry)}
       onKeyDown={(e) => {
+        // Only act on keys aimed at the row itself; Enter/Space on the nested
+        // pin button must toggle the pin, not navigate the row.
+        if (e.target !== e.currentTarget) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           handleSelect(entry);
@@ -221,10 +224,7 @@ export default function RecentViewsButton(): JSX.Element {
         }}
       >
         <Typography variant="subtitle2">Recently viewed</Typography>
-        {grouped.case.length +
-          grouped.project.length +
-          grouped.account.length >
-          0 && (
+        {recents.some((e) => !e.pinned) && (
           <Tooltip title="Clear history (pinned items are kept)">
             <Button
               size="small"

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
@@ -28,6 +28,8 @@ import {
   FolderOpen,
   Headset,
   History,
+  Pin,
+  PinOff,
 } from "@wso2/oxygen-ui-icons-react";
 import {
   useCallback,
@@ -42,6 +44,7 @@ import { createPortal } from "react-dom";
 import { useNavigate } from "react-router";
 import {
   clearRecentViews,
+  toggleRecentViewPin,
   useRecentViews,
   type RecentView,
   type RecentViewKind,
@@ -125,12 +128,85 @@ export default function RecentViewsButton(): JSX.Element {
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [open]);
 
-  const grouped = useMemo(() => groupByKind(recents), [recents]);
+  const pinned = useMemo(() => recents.filter((e) => e.pinned), [recents]);
+  const grouped = useMemo(
+    () => groupByKind(recents.filter((e) => !e.pinned)),
+    [recents],
+  );
 
   const handleSelect = (entry: RecentView) => {
     setOpen(false);
     navigate(entry.href);
   };
+
+  const renderRow = (entry: RecentView): JSX.Element => (
+    <Box
+      key={`${entry.kind}-${entry.id}`}
+      role="button"
+      tabIndex={0}
+      onClick={() => handleSelect(entry)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleSelect(entry);
+        }
+      }}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        px: 1.5,
+        py: 1,
+        cursor: "pointer",
+        "&:hover": { bgcolor: "action.hover" },
+      }}
+    >
+      {kindIcon(entry.kind)}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography variant="body2" noWrap>
+          {entry.title}
+        </Typography>
+        {entry.subtitle && (
+          <Typography variant="caption" color="text.secondary" noWrap>
+            {entry.subtitle}
+          </Typography>
+        )}
+      </Box>
+      <Tooltip title={entry.pinned ? "Unpin" : "Pin to working set"}>
+        <IconButton
+          size="small"
+          aria-label={
+            entry.pinned
+              ? `Unpin ${entry.title}`
+              : `Pin ${entry.title} to working set`
+          }
+          // Stop the row's navigate; pinning must not leave the panel.
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleRecentViewPin(entry.kind, entry.id);
+          }}
+          // Pinned icon carries the brand accent, but orange-on-light is ~2.5:1
+          // (below the 3:1 icon floor), so shift to primary.dark in light mode
+          // and keep the brighter accent in dark — `palette.mode` is unreliable
+          // under CssVars, so scope with applyStyles.
+          sx={(t) => ({
+            flexShrink: 0,
+            ...(entry.pinned
+              ? {
+                  color: t.palette.primary.dark,
+                  ...t.applyStyles("dark", { color: t.palette.primary.main }),
+                }
+              : {}),
+          })}
+        >
+          {entry.pinned ? <PinOff size={15} /> : <Pin size={15} />}
+        </IconButton>
+      </Tooltip>
+      <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+        <RelativeTime iso={entry.visitedAt} href={entry.href} />
+      </Typography>
+    </Box>
+  );
 
   const panel = open && anchorRect && (
     <Paper
@@ -164,14 +240,19 @@ export default function RecentViewsButton(): JSX.Element {
         }}
       >
         <Typography variant="subtitle2">Recently viewed</Typography>
-        {recents.length > 0 && (
-          <Button
-            size="small"
-            variant="text"
-            onClick={() => clearRecentViews()}
-          >
-            Clear
-          </Button>
+        {grouped.case.length +
+          grouped.project.length +
+          grouped.account.length >
+          0 && (
+          <Tooltip title="Clear history (pinned items are kept)">
+            <Button
+              size="small"
+              variant="text"
+              onClick={() => clearRecentViews()}
+            >
+              Clear history
+            </Button>
+          </Tooltip>
         )}
       </Box>
 
@@ -179,8 +260,35 @@ export default function RecentViewsButton(): JSX.Element {
         {recents.length === 0 && (
           <Box sx={{ px: 1.5, py: 2.5, textAlign: "center" }}>
             <Typography variant="body2" color="text.secondary">
-              No recent items. Open a case, project, or account to start tracking history.
+              No recent items. Open a case, project, or account to start tracking history. Pin the ones you are actively working to keep them here.
             </Typography>
+          </Box>
+        )}
+
+        {pinned.length > 0 && (
+          <Box>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                px: 1.5,
+                py: 0.5,
+                bgcolor: "background.default",
+                borderBottom: 1,
+                borderColor: "divider",
+              }}
+            >
+              <Pin size={12} />
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 600 }}
+              >
+                Pinned · working set
+              </Typography>
+            </Box>
+            {pinned.map(renderRow)}
           </Box>
         )}
 
@@ -202,44 +310,7 @@ export default function RecentViewsButton(): JSX.Element {
                   {KIND_LABEL[kind]}
                 </Typography>
               </Box>
-              {group.map((entry) => (
-                <Box
-                  key={`${entry.kind}-${entry.id}`}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => handleSelect(entry)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      handleSelect(entry);
-                    }
-                  }}
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 1.5,
-                    px: 1.5,
-                    py: 1,
-                    cursor: "pointer",
-                    "&:hover": { bgcolor: "action.hover" },
-                  }}
-                >
-                  {kindIcon(entry.kind)}
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography variant="body2" noWrap>
-                      {entry.title}
-                    </Typography>
-                    {entry.subtitle && (
-                      <Typography variant="caption" color="text.secondary" noWrap>
-                        {entry.subtitle}
-                      </Typography>
-                    )}
-                  </Box>
-                  <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
-                    <RelativeTime iso={entry.visitedAt} href={entry.href} />
-                  </Typography>
-                </Box>
-              ))}
+              {group.map(renderRow)}
             </Box>
           );
         })}

--- a/apps/csm-portal/webapp/src/features/csm-recent/currentPageEntry.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/currentPageEntry.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { CSM_NAV_ITEMS, navItemForPath } from "@config/csmNavItems";
+import type { RecentView } from "@features/csm-recent/hooks/useRecentViews";
+
+type PageEntry = Omit<RecentView, "visitedAt" | "pinned">;
+
+/** Title-case a path segment: "security-center" -> "Security center". */
+function humanizeSegment(segment: string): string {
+  const words = segment.replace(/[-_]+/g, " ").trim();
+  if (!words) return "Page";
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/** Short, human summary of a filter query string for a "search" label. */
+function summarizeQuery(search: string): string {
+  const params = new URLSearchParams(search);
+  const q = params.get("q") || params.get("query") || params.get("search");
+  if (q) return `“${q}”`;
+  const keys = [...params.keys()].filter((k) => params.get(k));
+  if (keys.length === 0) return "filtered";
+  return `${keys.length} filter${keys.length > 1 ? "s" : ""}`;
+}
+
+/**
+ * Build a pinnable Recent View for an arbitrary current route, so "Pin this
+ * page" works anywhere — not just on case/project/account detail pages (those
+ * already record richer entries on visit).
+ *
+ * - A known nav page with a filter query -> a "search" (e.g. a saved Cases view)
+ * - A known nav page with no query        -> a "page"
+ * - Anything else                          -> a best-effort "page"
+ *
+ * Detail routes are deliberately handled by their own recorders; callers should
+ * prefer an existing recorded entry whose `href` matches before falling back to
+ * this. `id` is the full href so distinct filtered views pin separately.
+ */
+export function currentPageEntry(pathname: string, search: string): PageEntry {
+  const href = pathname + search;
+  const nav = navItemForPath(pathname);
+  const onNavRoot = nav && pathname === nav.path;
+
+  if (search && search !== "?") {
+    const base = onNavRoot ? nav.label : humanizeSegment(pathname.split("/")[1] ?? "");
+    return {
+      kind: "search",
+      id: href,
+      title: `${base}: ${summarizeQuery(search)}`,
+      href,
+    };
+  }
+
+  if (onNavRoot) {
+    return { kind: "page", id: nav.path, title: nav.label, href: nav.path };
+  }
+
+  // Unknown route (or a sub-route we don't have a recorder for): label from the
+  // first path segment so the pin is still recognisable.
+  const seg = pathname.split("/").filter(Boolean)[0] ?? "";
+  return {
+    kind: "page",
+    id: pathname,
+    title: humanizeSegment(seg) || "Page",
+    href: pathname,
+  };
+}
+
+/** True when the current route maps onto one of the known nav pages. */
+export function isKnownPage(pathname: string): boolean {
+  return CSM_NAV_ITEMS.some((i) => pathname === i.path);
+}

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
@@ -18,12 +18,13 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearRecentViews,
+  toggleRecentViewPin,
   useRecentViews,
   useRecordRecentView,
   type RecentView,
 } from "./useRecentViews";
 
-const entry = (id: string): Omit<RecentView, "visitedAt"> => ({
+const entry = (id: string): Omit<RecentView, "visitedAt" | "pinned"> => ({
   kind: "case",
   id,
   title: `Case ${id}`,
@@ -94,5 +95,57 @@ describe("useRecentViews + useRecordRecentView", () => {
 
     act(() => clearRecentViews());
     expect(reader.result.current).toEqual([]);
+  });
+
+  describe("pinning", () => {
+    it("toggles pinned state by kind+id", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("1")));
+      expect(reader.result.current[0].pinned).toBeFalsy();
+
+      act(() => toggleRecentViewPin("case", "1"));
+      expect(reader.result.current[0].pinned).toBe(true);
+
+      act(() => toggleRecentViewPin("case", "1"));
+      expect(reader.result.current[0].pinned).toBe(false);
+    });
+
+    it("never evicts pinned entries when the recency cap is exceeded", () => {
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("keep")));
+      act(() => toggleRecentViewPin("case", "keep"));
+      // Push well past the 12-entry unpinned cap.
+      for (let i = 0; i < 15; i++) {
+        act(() => recorder.result.current(entry(String(i))));
+      }
+      const reader = renderHook(() => useRecentViews());
+      const ids = reader.result.current.map((v) => v.id);
+      // The pinned entry survives; unpinned are still capped at 12.
+      expect(ids).toContain("keep");
+      expect(ids.filter((id) => id !== "keep")).toHaveLength(12);
+    });
+
+    it("preserves the pinned flag when an entry is re-visited", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("1")));
+      act(() => toggleRecentViewPin("case", "1"));
+      expect(reader.result.current[0].pinned).toBe(true);
+
+      act(() => recorder.result.current(entry("1")));
+      expect(reader.result.current[0].pinned).toBe(true);
+    });
+
+    it("clearRecentViews keeps pinned entries", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("history")));
+      act(() => recorder.result.current(entry("pinned")));
+      act(() => toggleRecentViewPin("case", "pinned"));
+
+      act(() => clearRecentViews());
+      expect(reader.result.current.map((v) => v.id)).toEqual(["pinned"]);
+    });
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
@@ -16,12 +16,19 @@
 
 import { useCallback, useEffect, useState } from "react";
 
-export type RecentViewKind = "case" | "project" | "account";
+export type RecentViewKind =
+  | "case"
+  | "project"
+  | "account"
+  | "search"
+  | "page";
 
 const RECENT_VIEW_KINDS: readonly RecentViewKind[] = [
   "case",
   "project",
   "account",
+  "search",
+  "page",
 ];
 
 function isRecentViewKind(v: unknown): v is RecentViewKind {

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
@@ -39,11 +39,37 @@ export interface RecentView {
   href: string;
   /** ISO timestamp of the last visit. */
   visitedAt: string;
+  /**
+   * Pinned entries form the engineer's working set: they are never evicted by
+   * the recency cap and surface in a dedicated "Pinned" group. Absent/false for
+   * ordinary history entries.
+   */
+  pinned?: boolean;
 }
 
 const STORAGE_KEY = "csm.recentViews.v1";
+/** Recency cap for UNPINNED entries only — pinned entries are always kept. */
 const MAX_ENTRIES = 12;
 const STORAGE_EVENT = "csm:recent-views-changed";
+
+/**
+ * Enforce the recency cap on unpinned entries while keeping every pinned entry,
+ * preserving overall (recency) order. Pinned entries are the working set the
+ * engineer manages explicitly, so they must survive any number of new visits.
+ */
+function capUnpinned(entries: RecentView[]): RecentView[] {
+  const kept: RecentView[] = [];
+  let unpinned = 0;
+  for (const e of entries) {
+    if (e.pinned) {
+      kept.push(e);
+    } else if (unpinned < MAX_ENTRIES) {
+      kept.push(e);
+      unpinned += 1;
+    }
+  }
+  return kept;
+}
 
 function readStorage(): RecentView[] {
   try {
@@ -102,22 +128,42 @@ export function useRecentViews(): RecentView[] {
  * bumps the existing entry to the top, caps the list at {@link MAX_ENTRIES}.
  */
 export function useRecordRecentView(): (
-  entry: Omit<RecentView, "visitedAt">,
+  entry: Omit<RecentView, "visitedAt" | "pinned">,
 ) => void {
-  return useCallback((entry: Omit<RecentView, "visitedAt">) => {
+  return useCallback((entry: Omit<RecentView, "visitedAt" | "pinned">) => {
     const now = new Date().toISOString();
     const current = readStorage();
+    const existing = current.find(
+      (e) => e.kind === entry.kind && e.id === entry.id,
+    );
     const filtered = current.filter(
       (e) => !(e.kind === entry.kind && e.id === entry.id),
     );
-    const next: RecentView[] = [
-      { ...entry, visitedAt: now },
+    // Re-visiting an entry must preserve its pinned state — a pin is not lost
+    // just because the case was opened again.
+    const next: RecentView[] = capUnpinned([
+      { ...entry, visitedAt: now, pinned: existing?.pinned },
       ...filtered,
-    ].slice(0, MAX_ENTRIES);
+    ]);
     writeStorage(next);
   }, []);
 }
 
+/**
+ * Pin or unpin an entry by `kind`+`id`. Pinning keeps it in the working set
+ * indefinitely; unpinning returns it to ordinary history (subject to the cap).
+ * No-op if the entry is not currently tracked.
+ */
+export function toggleRecentViewPin(kind: RecentViewKind, id: string): void {
+  const current = readStorage();
+  const next = current.map((e) =>
+    e.kind === kind && e.id === id ? { ...e, pinned: !e.pinned } : e,
+  );
+  writeStorage(capUnpinned(next));
+}
+
 export function clearRecentViews(): void {
-  writeStorage([]);
+  // Keep pinned entries — "Clear" wipes browsing history, not the working set
+  // the engineer deliberately assembled.
+  writeStorage(readStorage().filter((e) => e.pinned));
 }

--- a/apps/csm-portal/webapp/src/features/csm-recent/kindMeta.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/kindMeta.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Building,
+  File,
+  FolderOpen,
+  Headset,
+  Search,
+} from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import type { RecentViewKind } from "@features/csm-recent/hooks/useRecentViews";
+
+/** Plural section label per kind, used as group headers in the Recent panel. */
+export const KIND_LABEL: Record<RecentViewKind, string> = {
+  case: "Cases",
+  project: "Projects",
+  account: "Accounts",
+  search: "Searches",
+  page: "Pages",
+};
+
+/** Stable display order for kind groups. */
+export const KIND_ORDER: RecentViewKind[] = [
+  "case",
+  "search",
+  "project",
+  "account",
+  "page",
+];
+
+export function kindIcon(kind: RecentViewKind, size = 16): JSX.Element {
+  switch (kind) {
+    case "case":
+      return <Headset size={size} />;
+    case "project":
+      return <FolderOpen size={size} />;
+    case "account":
+      return <Building size={size} />;
+    case "search":
+      return <Search size={size} />;
+    case "page":
+      return <File size={size} />;
+  }
+}

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -51,18 +51,22 @@ export default function AuthGuard(): JSX.Element {
     if (!isSignedIn) return;
     const redirect = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
     if (!redirect) return;
-    if (location.pathname + location.search === redirect) {
+    // Compare (and restore) the full location including the hash, so anchor
+    // permalinks like `/cases/:id#description` are honoured, not stripped.
+    const here = location.pathname + location.search + location.hash;
+    if (here === redirect) {
       sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
     } else {
       void navigate(redirect, { replace: true });
     }
-  }, [isSignedIn, navigate, location.pathname, location.search]);
+  }, [isSignedIn, navigate, location.pathname, location.search, location.hash]);
 
   return (
     <ProtectedRoute
       loader={<AppLayout />}
       onSignIn={(defaultSignIn, signInOptions) => {
-        const intended = location.pathname + location.search;
+        const intended =
+          location.pathname + location.search + location.hash;
         if (intended !== "/") {
           sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, intended);
         }

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -36,7 +36,10 @@ hydrateMockModeFromStorage();
 // root and the OAuth callback (which carries `?code=&state=`).
 if (typeof window !== "undefined") {
   try {
-    const entry = window.location.pathname + window.location.search;
+    // Include the hash so permalinks like `/cases/:id#description` (per-comment /
+    // per-section anchors) survive the IdP round-trip, not just pathname+search.
+    const entry =
+      window.location.pathname + window.location.search + window.location.hash;
     // Only the OAuth callback carries BOTH `code` and `state`; requiring both
     // avoids misclassifying legitimate deep links that happen to use a business
     // `state` (or `code`) query param and dropping their post-login restore.

--- a/apps/csm-portal/webapp/src/utils/contrastText.test.ts
+++ b/apps/csm-portal/webapp/src/utils/contrastText.test.ts
@@ -16,8 +16,10 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  compositeOver,
   contrastRatio,
   NEAR_BLACK,
+  NEAR_BLACK_ALPHA,
   parseColor,
   pickAccessibleText,
   WHITE,
@@ -73,9 +75,15 @@ describe("pickAccessibleText", () => {
 
   for (const [name, main] of Object.entries(SEMANTIC_MAINS)) {
     it(`picks a text colour that passes AA on ${name} (${main})`, () => {
+      const bg = parseColor(main)!;
       const text = pickAccessibleText(main);
-      const textRgb = parseColor(text === NEAR_BLACK ? "#000000" : "#ffffff")!;
-      const ratio = contrastRatio(parseColor(main)!, textRgb);
+      // Evaluate the colour as actually rendered: NEAR_BLACK is translucent, so
+      // composite it over the fill rather than treating it as opaque black.
+      const textRgb =
+        text === NEAR_BLACK
+          ? compositeOver({ r: 0, g: 0, b: 0 }, NEAR_BLACK_ALPHA, bg)
+          : { r: 255, g: 255, b: 255 };
+      const ratio = contrastRatio(bg, textRgb);
       expect(ratio).toBeGreaterThanOrEqual(4.5);
     });
   }

--- a/apps/csm-portal/webapp/src/utils/contrastText.test.ts
+++ b/apps/csm-portal/webapp/src/utils/contrastText.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  contrastRatio,
+  NEAR_BLACK,
+  parseColor,
+  pickAccessibleText,
+  WHITE,
+} from "./contrastText";
+
+describe("parseColor", () => {
+  it("parses 6-digit and 3-digit hex", () => {
+    expect(parseColor("#ff0000")).toEqual({ r: 255, g: 0, b: 0 });
+    expect(parseColor("#0f0")).toEqual({ r: 0, g: 255, b: 0 });
+  });
+  it("parses rgb()/rgba()", () => {
+    expect(parseColor("rgb(2, 136, 209)")).toEqual({ r: 2, g: 136, b: 209 });
+    expect(parseColor("rgba(0,0,0,0.5)")).toEqual({ r: 0, g: 0, b: 0 });
+  });
+  it("returns null for garbage", () => {
+    expect(parseColor("not-a-colour")).toBeNull();
+    expect(parseColor("")).toBeNull();
+  });
+});
+
+describe("contrastRatio", () => {
+  it("is 21 for black vs white", () => {
+    expect(
+      contrastRatio({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 }),
+    ).toBeCloseTo(21, 0);
+  });
+});
+
+describe("pickAccessibleText", () => {
+  it("falls back to white for an unparseable background", () => {
+    expect(pickAccessibleText("garbage")).toBe(WHITE);
+  });
+
+  // The contract that protects every SeverityChip: whatever text colour we pick
+  // for a saturated semantic surface must itself clear WCAG AA (4.5:1) for small
+  // text. These are the real `*.main` values shipped by the Oxygen themes (both
+  // colour modes) plus the MUI defaults seen on staging — if any future theme
+  // tweak drops one below 4.5:1 with both black and white, this test fails.
+  const SEMANTIC_MAINS: Record<string, string> = {
+    "acrylic-dark error": "#ef4444",
+    "acrylic-dark warning": "#f59e0b",
+    "acrylic-dark info": "#5567d5",
+    "acrylic-dark success": "#22c55e",
+    "acrylic-light error": "#f87171",
+    "acrylic-light warning": "#fbbf24",
+    "acrylic-light info": "#6b7de0",
+    "acrylic-light success": "#4ade80",
+    "mui-default error": "#f44336",
+    "mui-default warning": "#ed6c02",
+    "mui-default info": "#0288d1",
+    "mui-default success": "#2e7d32",
+  };
+
+  for (const [name, main] of Object.entries(SEMANTIC_MAINS)) {
+    it(`picks a text colour that passes AA on ${name} (${main})`, () => {
+      const text = pickAccessibleText(main);
+      const textRgb = parseColor(text === NEAR_BLACK ? "#000000" : "#ffffff")!;
+      const ratio = contrastRatio(parseColor(main)!, textRgb);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+});

--- a/apps/csm-portal/webapp/src/utils/contrastText.ts
+++ b/apps/csm-portal/webapp/src/utils/contrastText.ts
@@ -27,8 +27,10 @@
  * every shipped theme this clears 4.5:1.
  */
 
-/** MUI's conventional near-black body-text colour. */
-export const NEAR_BLACK = "rgba(0, 0, 0, 0.87)";
+/** Opacity of MUI's conventional near-black body-text colour. */
+export const NEAR_BLACK_ALPHA = 0.87;
+/** MUI's conventional near-black body-text colour (translucent). */
+export const NEAR_BLACK = `rgba(0, 0, 0, ${NEAR_BLACK_ALPHA})`;
 export const WHITE = "#ffffff";
 
 interface Rgb {
@@ -89,17 +91,29 @@ export function contrastRatio(a: Rgb, b: Rgb): number {
   return (hi + 0.05) / (lo + 0.05);
 }
 
+/** Composite a translucent foreground over an opaque background. */
+export function compositeOver(fg: Rgb, alpha: number, bg: Rgb): Rgb {
+  return {
+    r: fg.r * alpha + bg.r * (1 - alpha),
+    g: fg.g * alpha + bg.g * (1 - alpha),
+    b: fg.b * alpha + bg.b * (1 - alpha),
+  };
+}
+
 /**
  * Pick the label colour (near-black or white) with the higher contrast against
- * `background`. Falls back to white for an unparseable background so a coloured
- * chip never renders invisible text.
+ * `background`. The near-black candidate is the translucent {@link NEAR_BLACK},
+ * so we evaluate the colour it actually composites to over the (opaque) surface
+ * — not opaque black — otherwise the picked colour could sit below 4.5:1 even
+ * though the opaque-black comparison said it passed. Falls back to white for an
+ * unparseable background so a coloured chip never renders invisible text.
  */
 export function pickAccessibleText(background: string): string {
   const bg = parseColor(background);
   if (!bg) return WHITE;
-  const black = { r: 0, g: 0, b: 0 };
   const white = { r: 255, g: 255, b: 255 };
-  return contrastRatio(bg, black) >= contrastRatio(bg, white)
+  const nearBlack = compositeOver({ r: 0, g: 0, b: 0 }, NEAR_BLACK_ALPHA, bg);
+  return contrastRatio(bg, nearBlack) >= contrastRatio(bg, white)
     ? NEAR_BLACK
     : WHITE;
 }

--- a/apps/csm-portal/webapp/src/utils/contrastText.ts
+++ b/apps/csm-portal/webapp/src/utils/contrastText.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * WCAG-aware text-colour selection for coloured surfaces (chips, badges).
+ *
+ * MUI's built-in `getContrastText` targets a 3:1 ratio (the floor for *large*
+ * text). Chip and badge labels are small (~13px), which need 4.5:1, so a filled
+ * `color="error"`/`"warning"`/`"info"` chip can render white-on-saturated text
+ * at ~3:1 and silently fail WCAG AA. Rather than hardcode per-theme hexes (which
+ * break when the Oxygen theme or mode changes), pick the label colour from the
+ * resolved background's measured luminance: whichever of near-black / white
+ * gives the higher contrast. For the saturated semantic `*.main` colours in
+ * every shipped theme this clears 4.5:1.
+ */
+
+/** MUI's conventional near-black body-text colour. */
+export const NEAR_BLACK = "rgba(0, 0, 0, 0.87)";
+export const WHITE = "#ffffff";
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Parse `#rgb`, `#rrggbb`, or `rgb()/rgba()` into 0-255 channels; null if not. */
+export function parseColor(input: string): Rgb | null {
+  if (!input) return null;
+  const s = input.trim();
+  const hex = s.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    let h = hex[1];
+    if (h.length === 3) {
+      h = h
+        .split("")
+        .map((c) => c + c)
+        .join("");
+    }
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16),
+    };
+  }
+  const rgb = s.match(/rgba?\(([^)]+)\)/i);
+  if (rgb) {
+    const parts = rgb[1].split(",").map((p) => parseFloat(p));
+    if (parts.length >= 3 && parts.slice(0, 3).every((n) => !Number.isNaN(n))) {
+      return { r: parts[0], g: parts[1], b: parts[2] };
+    }
+  }
+  return null;
+}
+
+function channelLuminance(value: number): number {
+  const v = value / 255;
+  return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG relative luminance of an RGB colour. */
+export function relativeLuminance({ r, g, b }: Rgb): number {
+  return (
+    0.2126 * channelLuminance(r) +
+    0.7152 * channelLuminance(g) +
+    0.0722 * channelLuminance(b)
+  );
+}
+
+/** WCAG contrast ratio between two parsed colours (1..21). */
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Pick the label colour (near-black or white) with the higher contrast against
+ * `background`. Falls back to white for an unparseable background so a coloured
+ * chip never renders invisible text.
+ */
+export function pickAccessibleText(background: string): string {
+  const bg = parseColor(background);
+  if (!bg) return WHITE;
+  const black = { r: 0, g: 0, b: 0 };
+  const white = { r: 255, g: 255, b: 255 };
+  return contrastRatio(bg, black) >= contrastRatio(bg, white)
+    ? NEAR_BLACK
+    : WHITE;
+}


### PR DESCRIPTION
## What

A batch of CSM-portal UX / accessibility / triage-efficiency improvements for the internal CS-engineer portal. Theme unchanged; light + dark both supported.

### Accessibility (WCAG AA, both themes)
- Severity / state / tier chips, comment author-org and kind chips, activity filter toggles, and avatars all meet AA contrast. Added a luminance-based label-colour util + accessible `SemanticChip`/`SeverityChip`.
- Orange-on-light failures fixed at the theme layer: text/outlined `primary` buttons and outlined `primary` chips shift to the darker primary shade in light mode only, via `applyStyles` (the app is a CSS-vars theme where `palette.mode` is unreliable — documented inline).
- Header user avatar and de-emphasised dashboard zero-counts made legible.
- Case rows and account/project meta are now real anchor links (cmd/middle-click + copyable URLs).

### Top nav bar: working set + Quick-nav
- Pinned items render as tabs in the header (active-route highlight, unpin, overflow scroll). Pin **any** page — cases, projects, accounts, dashboards, filtered searches — via a "Pin this page" toggle; pins persist (localStorage) and also stay in the Recently-viewed list.
- **Quick-nav (⌘K / Ctrl-K)**: a header search box opens a command palette over pinned + recent + known pages, with keyboard nav and click-to-jump. FE-only (no backend search dependency).
- Cases show the WSO2 case id in recents/pins.
- Fixed collapsed-sidebar tooltips that rendered as "[object Object]".

### Cases: saved filter views
- Save the current cases filters under a name and re-apply later; delete; active-view checkmark; a few suggested presets. Stored as the existing serialized filter query string, applied back through the URL (URL stays the source of truth). Unit-tested.

### Resilient dashboard (per-section errors)
- Replaced the page-level "could not load" toast with per-section inline errors, so a single failing upstream no longer blanks the whole page; the severity matrix (separate source) keeps rendering real data.

### Deep-link permalink fix
- Preserve the URL hash (e.g. `…/cases/:id#description`) across the post-login redirect so anchor permalinks survive authentication.

## Activity feed tidy-up
- The always-visible activity filter toggles collapsed into a quiet "Filter" dropdown (checkboxes); the sort control gained a direction arrow.

## Test plan
- `pnpm build`, `pnpm lint`, `pnpm test` (76 passing) all green.
- Objective colour/contrast audit on cases list, dashboard, and case detail: **0 WCAG-AA failures in both light and dark**.
- Cold deep-link (wiped session → auth → `/cases/:id#description`) verified to land with the hash intact.

## Notes
- Depends on the local-preview tooling PR for running the full stack locally (separate PR).
- Two backend/contract follow-ups surfaced during triage (a missing dashboard aggregate endpoint returning 404, and the absence of a case `assignee` field) are tracked separately for the backend owner; this PR is FE-only and degrades gracefully around both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick navigation panel (Cmd+K/Ctrl+K) to search and jump to pinned pages and recent items
  * Pinned tabs in the header for frequently accessed content
  * Saved views for case filters (save, name, and reapply custom combinations)
  * Pin/unpin support for recent pages and searches

* **Improvements**
  * Accessibility: improved text and border contrast for chips and buttons (including semantic severity styling)
  * Case filter UI now uses a single dropdown chip (with counts) instead of multiple chips
  * Dashboard sections show independent error messages; recent “Clear history” keeps pinned items
  * Auth redirects now preserve URL hash fragments after login
<!-- end of auto-generated comment: release notes by coderabbit.ai -->