### PR TITLE
[Customer Entity] Add SN case search and unify search response shape

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -554,8 +554,8 @@ type SearchCaseView struct {
 	Priority               CasePriority       `json:"priority"`
 	IssueType              CaseIssueType      `json:"issueType"`
 	State                  CaseState          `json:"state"`
-	CreatedAt              time.Time          `json:"createdAt"`
-	UpdatedAt              time.Time          `json:"updatedAt"`
+	CreatedOn              time.Time          `json:"createdOn"`
+	UpdatedOn              time.Time          `json:"updatedOn"`
 	ClosedAt               *time.Time         `json:"closedAt"`
 	CreatedBy              UserIDEmailRef     `json:"createdBy"`
 	ProjectDetails         EntityRef          `json:"project"`

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -366,7 +366,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 			if err := rows.Scan(
 				&cv.ID, &cv.Number, &cv.InternalID,
 				&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State,
-				&cv.CreatedAt, &cv.UpdatedAt, &cv.ClosedAt,
+				&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedAt,
 				&cv.CreatedBy.ID, &ignoredDisplayName, &ignoredUserID, &cv.CreatedBy.Email,
 				&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
 				&cv.DeploymentDetails.ID, &cv.DeploymentDetails.Name,

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -73,8 +73,14 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	deployedProductHandler := handler.NewDeployedProductHandler(deployedProductSvc)
 
 	caseRepo := repository.NewCaseRepository(db)
-	caseSvc := service.NewCaseService(caseRepo)
-	caseHandler := handler.NewCaseHandler(caseSvc)
+	pgCaseSvc := service.NewCaseService(caseRepo)
+	var activeCaseSvc service.CaseService
+	if cfg.DataSource == config.DataSourceServiceNow {
+		activeCaseSvc = service.NewSNCaseService(snclient.New(cfg.SNBaseURL), pgCaseSvc)
+	} else {
+		activeCaseSvc = pgCaseSvc
+	}
+	caseHandler := handler.NewCaseHandler(activeCaseSvc)
 
 	mux := http.NewServeMux()
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/snclient"
+)
+
+// snCasesResponse mirrors the Choreo POST /cases/search response.
+type snCasesResponse struct {
+	Cases        []snCase `json:"cases"`
+	TotalRecords int      `json:"totalRecords"`
+	Offset       int      `json:"offset"`
+	Limit        int      `json:"limit"`
+}
+
+type snCase struct {
+	ID              string           `json:"id"`
+	InternalID      string           `json:"internalId"`
+	Number          string           `json:"number"`
+	Title           string           `json:"title"`
+	Description     string           `json:"description"`
+	CreatedOn       string           `json:"createdOn"`
+	UpdatedOn       *string          `json:"updatedOn"`
+	CreatedBy       string           `json:"createdBy"`
+	Project         snCaseEntityRef  `json:"project"`
+	Deployment      snCaseEntityRef  `json:"deployment"`
+	DeployedProduct snCaseEntityRef  `json:"deployedProduct"`
+	State           *snCaseState     `json:"state"`
+	Severity        *snCaseLabel     `json:"severity"`
+	IssueType       *snCaseIssueType `json:"issueType"`
+}
+
+type snCaseEntityRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type snCaseState struct {
+	ID    int    `json:"id"`
+	Label string `json:"label"`
+}
+
+type snCaseLabel struct {
+	Label string `json:"label"`
+}
+
+type snCaseIssueType struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// snCaseSearchPayload is the Choreo POST /cases/search request body.
+type snCaseSearchPayload struct {
+	Filters    snCaseFilters       `json:"filters,omitempty"`
+	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snCaseFilters struct {
+	CaseTypes          []string `json:"caseTypes"`
+	SearchQuery        string   `json:"searchQuery,omitempty"`
+	ProjectIDs         []string `json:"projectIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+}
+
+type snCaseService struct {
+	client     *snclient.Client
+	pgFallback CaseService
+}
+
+// NewSNCaseService constructs a CaseService that delegates SearchCases to the
+// Choreo API and all write/read-by-id operations to pgFallback.
+func NewSNCaseService(client *snclient.Client, pgFallback CaseService) CaseService {
+	return &snCaseService{client: client, pgFallback: pgFallback}
+}
+
+func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.Case, error) {
+	return s.pgFallback.CreateCase(ctx, req)
+}
+
+func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.CaseView, error) {
+	return s.pgFallback.GetCaseByID(ctx, id)
+}
+
+func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+	return s.pgFallback.CreateCaseComment(ctx, req)
+}
+
+func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error) {
+	return s.pgFallback.SearchCaseComments(ctx, req)
+}
+
+func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
+	return s.pgFallback.UpdateCase(ctx, req)
+}
+
+// SearchCases implements CaseService by calling the Choreo POST /cases/search endpoint.
+func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+	if err := validateSearchQuery(req.SearchQuery); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snCaseSearchPayload{
+		Filters: snCaseFilters{
+			CaseTypes:          []string{"default_case"},
+			SearchQuery:        req.SearchQuery,
+			ProjectIDs:         req.ProjectIDs,
+			DeploymentIDs:      req.DeploymentIDs,
+			DeployedProductIDs: req.DeployedProductIDs,
+		},
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/search", token, payload)
+	if err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+
+	var snResp snCasesResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchCasesResponse{}, fmt.Errorf("sn cases: parse response: %w", err)
+	}
+
+	views := make([]domain.SearchCaseView, 0, len(snResp.Cases))
+	for _, c := range snResp.Cases {
+		createdOn, err := time.Parse(snCreatedOnLayout, c.CreatedOn)
+		if err != nil {
+			return domain.SearchCasesResponse{}, fmt.Errorf("sn cases: parse createdOn %q: %w", c.CreatedOn, err)
+		}
+
+		updatedOn := createdOn
+		if c.UpdatedOn != nil && *c.UpdatedOn != "" {
+			updatedOn, err = time.Parse(snCreatedOnLayout, *c.UpdatedOn)
+			if err != nil {
+				return domain.SearchCasesResponse{}, fmt.Errorf("sn cases: parse updatedOn %q: %w", *c.UpdatedOn, err)
+			}
+		}
+
+		state, err := snCaseStateLabelToEnum(c.State)
+		if err != nil {
+			return domain.SearchCasesResponse{}, fmt.Errorf("sn cases: case %q: %w", c.ID, err)
+		}
+
+		views = append(views, domain.SearchCaseView{
+			ID:          c.ID,
+			Number:      c.Number,
+			InternalID:  c.InternalID,
+			Subject:     c.Title,
+			Description: c.Description,
+			Priority:    snSeverityToPriority(c.Severity),
+			IssueType:   snIssueTypeToEnum(c.IssueType),
+			State:       state,
+			CreatedOn:   createdOn,
+			UpdatedOn:   updatedOn,
+			CreatedBy:   domain.UserIDEmailRef{Email: c.CreatedBy},
+			ProjectDetails:         domain.EntityRef{ID: c.Project.ID, Name: c.Project.Name},
+			DeploymentDetails:      domain.EntityRef{ID: c.Deployment.ID, Name: c.Deployment.Name},
+			DeployedProductDetails: domain.DeployedProductRef{ID: c.DeployedProduct.ID, DisplayName: c.DeployedProduct.Name},
+		})
+	}
+
+	total := snResp.TotalRecords
+	return domain.SearchCasesResponse{
+		Cases:   views,
+		Total:   total,
+		Limit:   req.Pagination.Limit,
+		Offset:  req.Pagination.Offset,
+		HasMore: req.Pagination.Offset+len(views) < total,
+	}, nil
+}
+
+// snCaseStateMap maps SN state labels (lowercased) to domain CaseState enums.
+var snCaseStateMap = map[string]domain.CaseState{
+	"open":              domain.CaseStateOpen,
+	"work in progress":  domain.CaseStateWorkInProgress,
+	"waiting on wso2":   domain.CaseStateWaitingOnWSO2,
+	"awaiting info":     domain.CaseStateAwaitingInfo,
+	"reopened":          domain.CaseStateReopened,
+	"solution proposed": domain.CaseStateSolutionProposed,
+	"closed":            domain.CaseStateClosed,
+}
+
+func snCaseStateLabelToEnum(state *snCaseState) (domain.CaseState, error) {
+	if state == nil {
+		return domain.CaseStateOpen, nil
+	}
+	if v, ok := snCaseStateMap[strings.ToLower(state.Label)]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("unknown case state %q from ServiceNow", state.Label)
+}
+
+func snSeverityToPriority(severity *snCaseLabel) domain.CasePriority {
+	if severity == nil {
+		return ""
+	}
+	p := domain.CasePriority(strings.ToLower(severity.Label))
+	if validCasePriority[p] {
+		return p
+	}
+	return ""
+}
+
+func snIssueTypeToEnum(issueType *snCaseIssueType) domain.CaseIssueType {
+	if issueType == nil {
+		return ""
+	}
+	it := domain.CaseIssueType(strings.ToLower(strings.ReplaceAll(issueType.ID, " ", "_")))
+	if validCaseIssueType[it] {
+		return it
+	}
+	return ""
+}

--- a/entity-service/migrations/000008_create_cases.up.sql
+++ b/entity-service/migrations/000008_create_cases.up.sql
@@ -44,6 +44,9 @@ CREATE TABLE cases (
   created_at          TIMESTAMP DEFAULT NOW(),
   updated_at          TIMESTAMP DEFAULT NOW(),
   closed_at           TIMESTAMP,
+  assigned_engineer   UUID NULL REFERENCES users(id),
+  parent_case_id      UUID NULL REFERENCES cases(id),
+  related_case_id     UUID NULL REFERENCES cases(id),
 
   CONSTRAINT chk_closed_at_on_closed
     CHECK (state != 'closed' OR closed_at IS NOT NULL),


### PR DESCRIPTION
## Summary

- Add `sn_case_service.go` — implements `CaseService.SearchCases` via the Choreo `POST /cases/search` API with `caseTypes: ["default_case"]` in the filters; all write and read-by-id operations delegate to the postgres fallback
- Rename `SearchCaseView.CreatedAt/UpdatedAt` → `CreatedOn/UpdatedOn` (JSON: `createdOn`/`updatedOn`) to align the search response shape with the unified contract shared by both datasources
- Wire `NewSNCaseService` in `routes.go` when `DATA_SOURCE=servicenow`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated ServiceNow as an optional case management backend with automatic fallback to database-backed storage.
  * Added three new case fields: assigned engineer, parent case, and related case references to support case relationships and hierarchies.

* **Bug Fixes**
  * Corrected timestamp field naming in case search responses from `createdAt`/`updatedAt` to `createdOn`/`updatedOn`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->