### PR TITLE
[CSM Portal][BE] feat(auth): fall back to x-jwt-assertion when x-user-id-token is absent

### DIFF
--- a/apps/csm-portal/backend/internal/middleware/auth.go
+++ b/apps/csm-portal/backend/internal/middleware/auth.go
@@ -110,7 +110,11 @@ func Auth(cfg Config) func(http.Handler) http.Handler {
 			}
 
 			ctx := context.WithValue(r.Context(), userInfoKey, info)
-			ctx = entity.WithUserIDToken(ctx, r.Header.Get("x-user-id-token"))
+			userIDToken := r.Header.Get("x-user-id-token")
+			if userIDToken == "" {
+				userIDToken = tokenStr
+			}
+			ctx = entity.WithUserIDToken(ctx, userIDToken)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}


### PR DESCRIPTION
## Summary

- When an incoming request carries `x-user-id-token`, that value is forwarded to the entity service unchanged (existing behaviour)
- When `x-user-id-token` is absent, the already-validated `x-jwt-assertion` token is used as a fallback, so the entity service always receives a user identity token

## Changes

- `apps/csm-portal/backend/internal/middleware/auth.go` — read `x-user-id-token`; if empty, fall back to `tokenStr` (the `x-jwt-assertion` value already validated earlier in the same middleware)

## Test plan

- [x] Send a request with both `x-user-id-token` and `x-jwt-assertion` — confirm entity service receives the `x-user-id-token` value
- [x] Send a request with only `x-jwt-assertion` — confirm entity service receives the JWT value forwarded as `x-user-id-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)