### PR TITLE
[CSM Portal] FE: correlation ID, deep-link fix, 50-cap pagination, dashboard trim

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -17,6 +17,10 @@
 import { type JSX, lazy } from "react";
 import { Navigate, Route, Routes } from "react-router";
 import AuthGuard from "@layouts/AuthGuard";
+import {
+  POST_LOGIN_REDIRECT_KEY,
+  PostLoginRedirectConsumer,
+} from "@layouts/postLoginRedirect";
 import ErrorLayout from "@layouts/ErrorLayout";
 import CsmComingSoonPage from "@features/csm-coming-soon/pages/CsmComingSoonPage";
 import Error401Page from "@components/error/Error401Page";
@@ -69,7 +73,7 @@ const CsmUpdatesPage = lazy(
  * sessionStorage — AuthGuard owns clearing the key.
  */
 function RootLanding(): JSX.Element | null {
-  const pending = sessionStorage.getItem("post_login_redirect");
+  const pending = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
   return pending ? null : <Navigate to="/dashboard" replace />;
 }
 
@@ -79,6 +83,7 @@ export default function App(): JSX.Element {
       <ErrorBannerProvider>
         <SuccessBannerProvider>
           <ErrorPageProvider>
+            <PostLoginRedirectConsumer />
             <Routes>
               <Route
                 path="/401"

--- a/apps/csm-portal/webapp/src/api/backend/client.ts
+++ b/apps/csm-portal/webapp/src/api/backend/client.ts
@@ -17,6 +17,7 @@
 import { useCallback, useMemo } from "react";
 import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import type { BeErrorPayload } from "@api/backend/types";
+import { CORRELATION_ID_HEADER } from "@utils/correlationId";
 
 /**
  * `true` when the mock toggle is on. Hooks should branch on this and call
@@ -37,11 +38,26 @@ export function backendBaseUrl(): string {
 export class BackendApiError extends Error {
   status: number;
   payload?: BeErrorPayload;
-  constructor(status: number, message: string, payload?: BeErrorPayload) {
+  /**
+   * Correlation ID for this failed request, read back from the response's
+   * `X-Correlation-ID` header (the backend echoes the ID it logged against).
+   * Surface it to users as a support "Reference ID". `undefined` when the
+   * gateway does not expose the header on cross-origin responses (it must be
+   * listed in `Access-Control-Expose-Headers`); the FE access log still records
+   * the ID regardless.
+   */
+  correlationId?: string;
+  constructor(
+    status: number,
+    message: string,
+    payload?: BeErrorPayload,
+    correlationId?: string,
+  ) {
     super(message);
     this.name = "BackendApiError";
     this.status = status;
     this.payload = payload;
+    this.correlationId = correlationId;
   }
 }
 
@@ -56,7 +72,9 @@ async function readError(response: Response): Promise<BackendApiError> {
     payload?.message ??
     response.statusText ??
     `Request failed with status ${response.status}`;
-  return new BackendApiError(response.status, msg, payload);
+  const correlationId =
+    response.headers.get(CORRELATION_ID_HEADER) ?? undefined;
+  return new BackendApiError(response.status, msg, payload, correlationId);
 }
 
 /**

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -14,6 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/**
+ * Maximum pagination `limit` the backend currently accepts on search endpoints.
+ * TEMPORARY: the backend hard-caps the limit at 50 — requests with a larger
+ * value are rejected, so every search payload must stay at or below this. Was
+ * 100. Raise this back once the backend lifts the cap; it is the single point
+ * of revert for that change.
+ */
+export const BE_MAX_PAGE_LIMIT = 50;
+
 // Constants for API-related query keys.
 export const ApiQueryKeys = {
   PROJECTS: "projects",

--- a/apps/csm-portal/webapp/src/context/error-banner/ErrorBannerContext.tsx
+++ b/apps/csm-portal/webapp/src/context/error-banner/ErrorBannerContext.tsx
@@ -29,10 +29,15 @@ import {
 } from "react";
 
 import { ERROR_BANNER_TIMEOUT_MS } from "@constants/common";
+import { getErrorReferenceId } from "@utils/correlationId";
 
 interface ErrorBannerContextType {
-  /** Show the error banner with the given user-facing message. */
-  showError: (message: string) => void;
+  /**
+   * Show the error banner with the given user-facing message. Pass the original
+   * error as the second argument to append a support "Reference ID" (the
+   * request's correlation ID) when one is available.
+   */
+  showError: (message: string, error?: unknown) => void;
 }
 
 const ErrorBannerContext = createContext<ErrorBannerContextType | undefined>(
@@ -56,8 +61,9 @@ export function ErrorBannerProvider({
   const [message, setMessage] = useState<string | null>(null);
   const [key, setKey] = useState(0);
 
-  const showError = useCallback((msg: string) => {
-    setMessage(msg);
+  const showError = useCallback((msg: string, error?: unknown) => {
+    const referenceId = getErrorReferenceId(error);
+    setMessage(referenceId ? `${msg} (Reference ID: ${referenceId})` : msg);
     setKey((prev) => prev + 1);
   }, []);
 

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -36,7 +36,8 @@ import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts"
 import type { SearchAccountsRequest } from "@features/csm-accounts/types/csmAccounts";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
-const ROWS_PER_PAGE_OPTIONS = [10, 20, 50, 100];
+// 100 dropped: the backend rejects pagination limits above 50 (BE_MAX_PAGE_LIMIT).
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -34,10 +34,11 @@ import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts";
 import type { SearchAccountsRequest } from "@features/csm-accounts/types/csmAccounts";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
-// 100 dropped: the backend rejects pagination limits above 50 (BE_MAX_PAGE_LIMIT).
-const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+// Top option is the backend's max page limit; larger requests are rejected.
+const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
@@ -22,7 +22,7 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
-import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
 import type {
   BeCaseComment,
@@ -42,14 +42,14 @@ import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
 
 const MOCK_LATENCY_MS = 150;
 
-/** Page size used by the comments list. Capped at 100 by the BE. */
-const COMMENTS_PAGE_LIMIT = 100;
+/** Page size used by the comments list. Capped by the BE; see BE_MAX_PAGE_LIMIT. */
+const COMMENTS_PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
 
 /**
  * Load all comments on a case. In LIVE mode calls
- * `POST /cases/{id}/comments/search` with a wide page (limit=100). If a case
- * exceeds that, switch consumers to an explicit pagination wrapper rather
- * than chasing pages here.
+ * `POST /cases/{id}/comments/search` with a single wide page (limit capped at
+ * BE_MAX_PAGE_LIMIT). If a case exceeds that, switch consumers to an explicit
+ * pagination wrapper rather than chasing pages here.
  */
 export function useGetCsmCaseComments(
   caseId: string | undefined,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
   BeDeployedProductSearchPayload,
@@ -26,8 +26,8 @@ import type {
   BeProductVersionSearchResponse,
 } from "@api/backend/types";
 
-const PAGE_LIMIT = 100;
-const PRODUCTS_LIMIT = 100; // backend caps pagination limit at 100
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+const PRODUCTS_LIMIT = BE_MAX_PAGE_LIMIT;
 // Bound the catalog scan: if referenced product ids can't be resolved (deleted
 // or bad data), don't page through an unbounded catalog. ~2000 products covered.
 const MAX_CATALOG_PAGES = 20;

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -30,7 +30,9 @@ const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
 const PRODUCTS_LIMIT = BE_MAX_PAGE_LIMIT;
 // Bound the catalog scan: if referenced product ids can't be resolved (deleted
 // or bad data), don't page through an unbounded catalog. ~2000 products covered.
-const MAX_CATALOG_PAGES = 20;
+// Doubled from 20 when the page limit halved to BE_MAX_PAGE_LIMIT, so the total
+// scan ceiling (pages * limit) is unchanged.
+const MAX_CATALOG_PAGES = 40;
 
 export interface DeployedProductOption {
   /** Deployed-product id — the value the case-create payload needs. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -20,7 +20,7 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
-import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { isMockMode, useBackendApi, type BackendApi } from "@api/backend/client";
 import {
   beStateFromUi,
@@ -46,11 +46,13 @@ import type {
 const MOCK_LATENCY_MS = 200;
 
 /** Page size for the cross-project case list (server-side filtering TBD). */
-const CASES_PAGE_LIMIT = 100;
+const CASES_PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
 /** Page size for the account name lookup (customer column). */
-const LOOKUP_PAGE_LIMIT = 100; // backend caps pagination limit at 100
+const LOOKUP_PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
 // Cap the account scan the same way useProjectOptions caps the project scan.
-const LOOKUP_MAX_PAGES = 20;
+// Doubled from 20 when the page limit halved to BE_MAX_PAGE_LIMIT, so the total
+// scan ceiling (pages * limit) is unchanged.
+const LOOKUP_MAX_PAGES = 40;
 
 /**
  * Query options for the account-name lookup (`POST /accounts/search`). Kept as

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectOptions.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useBackendApi, type BackendApi } from "@api/backend/client";
 import type {
   BeProject,
@@ -23,10 +23,11 @@ import type {
   BeProjectSearchResponse,
 } from "@api/backend/types";
 
-const PAGE_LIMIT = 100; // backend caps pagination limit at 100
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
 // Cap the scan so a large project catalog can't fire unbounded sequential
-// requests (~2000 projects covered).
-const MAX_PAGES = 20;
+// requests (~2000 projects covered). Doubled from 20 when the page limit halved
+// to BE_MAX_PAGE_LIMIT, so the scan ceiling (pages * limit) is unchanged.
+const MAX_PAGES = 40;
 
 /**
  * Query options for the full project directory, via `POST /projects/search`.

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchDeployments.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
   BeDeployment,
@@ -23,7 +23,7 @@ import type {
   BeDeploymentSearchResponse,
 } from "@api/backend/types";
 
-const PAGE_LIMIT = 100; // backend caps pagination limit at 100
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
 
 /**
  * Deployments belonging to a project, via `POST /deployments/search`

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -131,7 +131,8 @@ export default function CsmCaseCreatePage(): JSX.Element {
       },
       {
         onSuccess: (created) => navigate(`/cases/${created.id}`),
-        onError: () => showError("Could not create the case. Please try again."),
+        onError: (err) =>
+          showError("Could not create the case. Please try again.", err),
       },
     );
   };

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -396,9 +396,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   severity: LIFECYCLE_SEVERITY[action],
                   sticky: true,
                 }),
-              onError: () =>
+              onError: (err) =>
                 showError(
                   "Could not update the case. Please try again.",
+                  err,
                 ),
             },
           );

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -86,7 +86,7 @@ export default function CsmCasesPage(): JSX.Element {
     [setSearchParams],
   );
 
-  const { data, isLoading, isError } = useGetCsmCases(filters);
+  const { data, isLoading, isError, error } = useGetCsmCases(filters);
   const { data: projectDirectory } = useProjectOptions();
   const { data: directoryUsers } = useDirectoryUsers();
   const { showError } = useErrorBanner();
@@ -96,10 +96,10 @@ export default function CsmCasesPage(): JSX.Element {
   useEffect(() => {
     if (isError && !hasShownErrorRef.current) {
       hasShownErrorRef.current = true;
-      showError("Could not load cases.");
+      showError("Could not load cases.", error);
     }
     if (!isError) hasShownErrorRef.current = false;
-  }, [isError, showError]);
+  }, [isError, error, showError]);
 
   const filtered = useMemo(() => {
     const list = data?.cases ?? [];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
 import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
 import type {
@@ -28,8 +28,8 @@ import type {
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
 
-const PAGE_LIMIT = 100; // backend caps pagination limit at 100
-const MAX_PAGES = 5; // bound the fan-out (≤500 cases sampled for the matrix)
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+const MAX_PAGES = 10; // bound the fan-out (≤500 cases sampled for the matrix); doubled from 5 when the page limit halved to BE_MAX_PAGE_LIMIT
 
 export const MATRIX_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
 export const MATRIX_STATES: CaseState[] = [

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -37,6 +37,11 @@ import {
 // Flip this to re-enable the toggle once ABT membership data is available.
 const ABT_SCOPING_ENABLED = false;
 
+// Only the Engineer dashboard is live; the others are mock placeholders, so the
+// switcher is disabled and locked to Engineer. Flip this to re-enable the
+// dropdown once the other dashboards are real.
+const DASHBOARD_SWITCHER_ENABLED = false;
+
 interface AbtDashboardHeaderProps {
   engineer?: CsmDashboardEngineer;
   scope: DashboardScope;
@@ -120,19 +125,30 @@ export default function AbtDashboardHeader({
             </Box>
           </Tooltip>
         )}
-        <FormControl size="small" sx={{ minWidth: 200 }}>
-          <Select
-            value={dashboardKey}
-            onChange={(e) => onDashboardChange(e.target.value as DashboardKey)}
-            displayEmpty
-          >
-            {DASHBOARD_OPTIONS.map((o) => (
-              <MenuItem key={o.key} value={o.key}>
-                {o.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <Tooltip
+          title={
+            DASHBOARD_SWITCHER_ENABLED
+              ? ""
+              : "Other dashboards are not available yet — showing the Engineer dashboard."
+          }
+        >
+          <FormControl size="small" sx={{ minWidth: 200 }}>
+            <Select
+              value={dashboardKey}
+              onChange={(e) =>
+                onDashboardChange(e.target.value as DashboardKey)
+              }
+              disabled={!DASHBOARD_SWITCHER_ENABLED}
+              displayEmpty
+            >
+              {DASHBOARD_OPTIONS.map((o) => (
+                <MenuItem key={o.key} value={o.key}>
+                  {o.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Tooltip>
       </Box>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -17,10 +17,6 @@
 import { Box, Card, Chip, Typography } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
 import AbtDashboardHeader from "@features/csm-dashboard/components/AbtDashboardHeader";
-import MyQueueSection from "@features/csm-dashboard/components/MyQueueSection";
-import SlaAtRiskSection from "@features/csm-dashboard/components/SlaAtRiskSection";
-import CustomerSummarySection from "@features/csm-dashboard/components/CustomerSummarySection";
-import RecentActivitySection from "@features/csm-dashboard/components/RecentActivitySection";
 import CaseCountsMatrix from "@features/csm-dashboard/components/CaseCountsMatrix";
 import { useGetCsmDashboard } from "@features/csm-dashboard/api/useGetCsmDashboard";
 import {
@@ -30,31 +26,26 @@ import {
 } from "@features/csm-dashboard/types/abtDashboard";
 
 /**
- * Top-level CSM dashboard. Hosts the engineer-overview dashboard (queue +
- * SLA + customers + activity) plus four placeholder dashboards selectable
- * from the top-right dropdown (Operations, IAM CS, Security, Team
- * performance). Per DashboardsAndReportsProposal.md the real tab+widget
- * model lives behind the entity-service reports DSL; these placeholders
- * are mocks for UX iteration only.
+ * Top-level CSM dashboard. Currently locked to the Engineer dashboard and
+ * showing only the "Cases by severity and state" matrix: the queue / SLA /
+ * customers / activity widgets are hidden, and the dashboard switcher dropdown
+ * (Operations, IAM CS, Security, Team performance) is disabled in the header
+ * because those are mock placeholders. Re-enable via DASHBOARD_SWITCHER_ENABLED
+ * in AbtDashboardHeader and restore the hidden sections here once the real
+ * tab+widget model (DashboardsAndReportsProposal.md, entity-service reports
+ * DSL) lands. The placeholder dashboards below are kept for that restore.
  */
 export default function CsmDashboardPage(): JSX.Element {
   // ABT scoping is not implemented yet, so default to (and stay on)
   // all-customers; the My ABT / All customers toggle is disabled in the header.
   const [scope, setScope] = useState<DashboardScope>("all_customers");
+  // Locked to the Engineer dashboard: the switcher is disabled in the header
+  // (the other dashboards are mock placeholders), so this never changes today.
   const [dashboardKey, setDashboardKey] = useState<DashboardKey>("engineer");
-  const { data, isLoading, isError } = useGetCsmDashboard(scope);
-  // No page-level "Could not load dashboard" toast: this aggregate query backs
-  // four independent sections (queue, SLA, customers, recent activity), while
-  // the severity matrix loads from a separate source. A global toast wrongly
-  // implies the whole page is dead. Pass isError to each section so the engineer
-  // sees exactly what's missing and what's still trustworthy (§2.2).
-
-  const scopeLabel =
-    scope === "my_abt"
-      ? data?.engineer?.abtName
-        ? `In ${data.engineer.abtName}`
-        : "ABT scope"
-      : "All customers";
+  // Only the engineer-overview header consumes this now; the queue/SLA/customer/
+  // activity widgets are hidden, leaving the standalone severity-by-state matrix
+  // (CaseCountsMatrix, which loads from its own source) as the only widget.
+  const { data, isError } = useGetCsmDashboard(scope);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -67,52 +58,7 @@ export default function CsmDashboardPage(): JSX.Element {
         isError={isError}
       />
       {dashboardKey === "engineer" ? (
-        <>
-          <CaseCountsMatrix />
-          <Box
-            sx={{
-              display: "grid",
-              gap: 2,
-              gridTemplateColumns: {
-                xs: "1fr",
-                md: "repeat(2, minmax(0, 1fr))",
-              },
-            }}
-          >
-            <MyQueueSection
-              queue={data?.queue}
-              isLoading={isLoading}
-              isError={isError}
-            />
-            <SlaAtRiskSection
-              cases={data?.slaAtRisk}
-              isLoading={isLoading}
-              isError={isError}
-            />
-          </Box>
-          <Box
-            sx={{
-              display: "grid",
-              gap: 2,
-              gridTemplateColumns: {
-                xs: "1fr",
-                md: "minmax(0, 7fr) minmax(0, 5fr)",
-              },
-            }}
-          >
-            <CustomerSummarySection
-              customers={data?.customers}
-              isLoading={isLoading}
-              scopeLabel={scopeLabel}
-              isError={isError}
-            />
-            <RecentActivitySection
-              activity={data?.recentActivity}
-              isLoading={isLoading}
-              isError={isError}
-            />
-          </Box>
-        </>
+        <CaseCountsMatrix />
       ) : (
         <DashboardPlaceholder dashboardKey={dashboardKey} />
       )}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -36,7 +36,8 @@ import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects"
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
-const ROWS_PER_PAGE_OPTIONS = [10, 20, 50, 100];
+// 100 dropped: the backend rejects pagination limits above 50 (BE_MAX_PAGE_LIMIT).
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -34,10 +34,11 @@ import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects";
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
-// 100 dropped: the backend rejects pagination limits above 50 (BE_MAX_PAGE_LIMIT).
-const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+// Top option is the backend's max page limit; larger requests are rejected.
+const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -36,7 +36,8 @@ import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
-const ROWS_PER_PAGE_OPTIONS = [10, 20, 50, 100];
+// 100 dropped: the backend rejects pagination limits above 50 (BE_MAX_PAGE_LIMIT).
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
 
 export default function CsmUsersPage(): JSX.Element {
   const [searchInput, setSearchInput] = useState("");

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -34,10 +34,11 @@ import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
-// 100 dropped: the backend rejects pagination limits above 50 (BE_MAX_PAGE_LIMIT).
-const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+// Top option is the backend's max page limit; larger requests are rejected.
+const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
 export default function CsmUsersPage(): JSX.Element {
   const [searchInput, setSearchInput] = useState("");

--- a/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -18,6 +18,8 @@ import { useCallback } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import { apiConfig } from "@config/apiConfig";
 import { AUTH_NOT_READY_ERROR_MESSAGE } from "@constants/apiConstants";
+import { useLogger } from "@hooks/useLogger";
+import { CORRELATION_ID_HEADER, newCorrelationId } from "@utils/correlationId";
 
 /**
  * True when `getAccessToken()` failed because the Asgardeo SDK had not finished
@@ -58,6 +60,7 @@ function buildRequestHeaders(
   options: RequestInit | undefined,
   token: string,
   idToken: string,
+  correlationId: string,
 ): Headers {
   // When `input` is a Request, `init.headers` on the outer fetch call REPLACES
   // the request's headers wholesale — it does not merge. Seed the headers from
@@ -75,6 +78,13 @@ function buildRequestHeaders(
   // customer portal): the gateway validates the bearer, while the backend
   // reads the user's identity claims from `x-user-id-token`.
   headers.set("x-user-id-token", idToken);
+  // Correlation ID for end-to-end tracing. The backend honours an inbound value
+  // and only generates its own when absent, so a caller-supplied header (rare:
+  // a retry that wants to reuse an ID) is preserved; otherwise we stamp a fresh
+  // per-request UUID.
+  if (!headers.has(CORRELATION_ID_HEADER)) {
+    headers.set(CORRELATION_ID_HEADER, correlationId);
+  }
   if (!headers.has("Accept")) {
     headers.set("Accept", "application/json");
   }
@@ -113,6 +123,7 @@ function buildRequestHeaders(
 // leaked to third-party hosts.
 export function useAuthApiClient() {
   const { getAccessToken, getIdToken } = useAsgardeo();
+  const logger = useLogger();
 
   return useCallback(
     async (input: RequestInfo | URL, options?: RequestInit): Promise<Response> => {
@@ -146,11 +157,42 @@ export function useAuthApiClient() {
         throw new Error("Unable to retrieve ID token");
       }
 
-      return fetch(input, {
-        ...options,
-        headers: buildRequestHeaders(input, options, token, idToken),
-      });
+      // One correlation ID per physical request (React Query retries each get a
+      // distinct one, matching the backend's per-request unit). A caller that
+      // pre-set the header keeps its value; we log whichever ID actually ships.
+      const headers = buildRequestHeaders(
+        input,
+        options,
+        token,
+        idToken,
+        newCorrelationId(),
+      );
+      const correlationId = headers.get(CORRELATION_ID_HEADER) ?? "";
+      const method = (
+        options?.method ??
+        (input instanceof Request ? input.method : "GET")
+      ).toUpperCase();
+
+      // Centralised FE access log, mirroring the backend's request-logging
+      // middleware: every backend call is logged once here with the same
+      // correlation ID that backend + entity-service stamp on their log lines.
+      try {
+        const response = await fetch(input, { ...options, headers });
+        const line = `[api] ${method} ${url.pathname} -> ${response.status} correlationID=${correlationId}`;
+        if (response.ok) {
+          logger.debug(line);
+        } else {
+          logger.error(line);
+        }
+        return response;
+      } catch (error) {
+        logger.error(
+          `[api] ${method} ${url.pathname} -> network error correlationID=${correlationId}`,
+          error,
+        );
+        throw error;
+      }
     },
-    [getAccessToken, getIdToken],
+    [getAccessToken, getIdToken, logger],
   );
 }

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -19,8 +19,7 @@ import { useAsgardeo } from "@asgardeo/react";
 import { ProtectedRoute } from "@asgardeo/react-router";
 import { useLocation, useNavigate } from "react-router";
 import AppLayout from "@layouts/AppLayout";
-
-const POST_LOGIN_REDIRECT_KEY = "post_login_redirect";
+import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
 
 /**
  * AuthGuard renders AppLayout (header/footer) so loading state is visible
@@ -42,11 +41,14 @@ export default function AuthGuard(): JSX.Element {
   const location = useLocation();
   const navigate = useNavigate();
 
-  // After login, restore the saved deep link. The key is cleared ONLY once we
-  // actually arrive at the target — so it survives the Asgardeo SDK reloading
-  // the page to `afterSignInUrl` ("/") after the callback, which would
-  // otherwise drop us on the default `/accounts` landing. The default `/`
-  // landing is deferred to RootLanding in App.tsx while a redirect is pending.
+  // After login, restore the saved deep link so it survives the Asgardeo SDK
+  // reloading the page to `afterSignInUrl` ("/") after the callback (which would
+  // otherwise drop us on the default landing). The key is consumed by
+  // PostLoginRedirectConsumer once we arrive at the target — that consumer runs
+  // above <Routes> so it also clears the key for routes AuthGuard never mounts
+  // (e.g. the 404 page); clearing here would strand the key on a dead deep link
+  // and bounce the next `/` visit back to it. The default `/` landing is
+  // deferred to RootLanding in App.tsx while a redirect is pending.
   useEffect(() => {
     if (!isSignedIn) return;
     const redirect = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
@@ -54,9 +56,7 @@ export default function AuthGuard(): JSX.Element {
     // Compare (and restore) the full location including the hash, so anchor
     // permalinks like `/cases/:id#description` are honoured, not stripped.
     const here = location.pathname + location.search + location.hash;
-    if (here === redirect) {
-      sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
-    } else {
+    if (here !== redirect) {
       void navigate(redirect, { replace: true });
     }
   }, [isSignedIn, navigate, location.pathname, location.search, location.hash]);

--- a/apps/csm-portal/webapp/src/layouts/postLoginRedirect.tsx
+++ b/apps/csm-portal/webapp/src/layouts/postLoginRedirect.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { useLocation } from "react-router";
+
+/**
+ * sessionStorage key holding the deep link to restore after the IdP sign-in
+ * round-trip. Written at module load (main.tsx) and on `onSignIn` (AuthGuard);
+ * consumed by {@link PostLoginRedirectConsumer} once we arrive at the target.
+ */
+export const POST_LOGIN_REDIRECT_KEY = "post_login_redirect";
+
+/**
+ * Clears {@link POST_LOGIN_REDIRECT_KEY} as soon as we have arrived at the
+ * stored target, for ANY route — including ones outside the AuthGuard route
+ * group (the 401/403/404 pages and the `*` catch-all).
+ *
+ * This must live above `<Routes>` rather than inside AuthGuard: AuthGuard only
+ * mounts for app routes, so a deep link to a non-existent path used to land on
+ * the `*` 404 page with AuthGuard never mounting, stranding the key. The stale
+ * key then hijacked the next visit to `/`, bouncing the user back to the dead
+ * URL on a loop until they typed a valid one.
+ *
+ * Clearing is gated on `isSignedIn`: when a logged-out user deep-links to a
+ * valid page, `here === redirect` is already true on first paint, but the key
+ * must survive until the login round-trip completes — so we only consume it
+ * once authenticated.
+ */
+export function PostLoginRedirectConsumer(): null {
+  const { isSignedIn } = useAsgardeo();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    const redirect = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
+    if (!redirect) return;
+    const here = location.pathname + location.search + location.hash;
+    if (here === redirect) {
+      sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+    }
+  }, [isSignedIn, location.pathname, location.search, location.hash]);
+
+  return null;
+}

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import AppWithConfig from "./AppWithConfig";
 import { hydrateMockModeFromStorage } from "@context/mock-mode/MockModeContext";
+import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
 
 if (typeof window !== "undefined") {
   (window as unknown as { Prism: typeof Prism }).Prism = Prism;
@@ -46,7 +47,7 @@ if (typeof window !== "undefined") {
     const params = new URLSearchParams(window.location.search);
     const isOauthCallback = params.has("code") && params.has("state");
     if (entry !== "/" && !isOauthCallback) {
-      window.sessionStorage.setItem("post_login_redirect", entry);
+      window.sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, entry);
     }
   } catch {
     /* sessionStorage may be unavailable; deep-link restore is best-effort. */

--- a/apps/csm-portal/webapp/src/utils/correlationId.test.ts
+++ b/apps/csm-portal/webapp/src/utils/correlationId.test.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CORRELATION_ID_HEADER,
   getErrorReferenceId,
@@ -32,6 +32,33 @@ describe("newCorrelationId", () => {
   it("returns a distinct value each call", () => {
     const ids = new Set(Array.from({ length: 100 }, () => newCorrelationId()));
     expect(ids.size).toBe(100);
+  });
+});
+
+describe("newCorrelationId fallbacks", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses getRandomValues when randomUUID is unavailable", () => {
+    let calls = 0;
+    vi.stubGlobal("crypto", {
+      getRandomValues: (arr: Uint8Array) => {
+        // Deterministic, varied fill; the generator sets the version/variant
+        // bits itself, so any byte values still yield a well-formed UUID v4.
+        for (let i = 0; i < arr.length; i += 1) arr[i] = (i * 37 + calls) & 0xff;
+        calls += 1;
+        return arr;
+      },
+    });
+    expect(newCorrelationId()).toMatch(UUID_V4);
+    // Distinct seeds across calls produce distinct IDs.
+    expect(newCorrelationId()).not.toBe(newCorrelationId());
+  });
+
+  it("falls back to a non-crypto UUID when Web Crypto is unavailable", () => {
+    vi.stubGlobal("crypto", undefined);
+    expect(newCorrelationId()).toMatch(UUID_V4);
   });
 });
 

--- a/apps/csm-portal/webapp/src/utils/correlationId.test.ts
+++ b/apps/csm-portal/webapp/src/utils/correlationId.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  CORRELATION_ID_HEADER,
+  getErrorReferenceId,
+  newCorrelationId,
+} from "./correlationId";
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("newCorrelationId", () => {
+  it("returns a UUID v4", () => {
+    expect(newCorrelationId()).toMatch(UUID_V4);
+  });
+
+  it("returns a distinct value each call", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => newCorrelationId()));
+    expect(ids.size).toBe(100);
+  });
+});
+
+describe("CORRELATION_ID_HEADER", () => {
+  it("matches the backend header name", () => {
+    expect(CORRELATION_ID_HEADER).toBe("X-Correlation-ID");
+  });
+});
+
+describe("getErrorReferenceId", () => {
+  it("extracts a correlationId from an error-like object", () => {
+    expect(getErrorReferenceId({ correlationId: "abc-123" })).toBe("abc-123");
+  });
+
+  it("returns undefined for an empty correlationId", () => {
+    expect(getErrorReferenceId({ correlationId: "" })).toBeUndefined();
+  });
+
+  it("returns undefined when the field is missing or wrong type", () => {
+    expect(getErrorReferenceId(new Error("boom"))).toBeUndefined();
+    expect(getErrorReferenceId({ correlationId: 42 })).toBeUndefined();
+    expect(getErrorReferenceId(null)).toBeUndefined();
+    expect(getErrorReferenceId(undefined)).toBeUndefined();
+    expect(getErrorReferenceId("string")).toBeUndefined();
+  });
+});

--- a/apps/csm-portal/webapp/src/utils/correlationId.ts
+++ b/apps/csm-portal/webapp/src/utils/correlationId.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * HTTP header used to carry a request's correlation ID end-to-end. The FE
+ * originates the value on every backend call; csm-portal-backend and the
+ * entity-service honour the inbound header (only generating their own when it
+ * is absent) and stamp it onto every log line, so a single ID ties the FE
+ * action to its backend + entity-service log trail.
+ *
+ * Must match `correlationIDHeader` in
+ * `apps/csm-portal/backend/internal/middleware/correlation.go`.
+ */
+export const CORRELATION_ID_HEADER = "X-Correlation-ID";
+
+/**
+ * Returns a fresh UUID v4 to use as a request correlation ID.
+ *
+ * Prefers the platform `crypto.randomUUID()` (available in every secure context
+ * we ship to: HTTPS in production and `http://localhost` in dev, both of which
+ * the spec treats as secure). Falls back to a `crypto.getRandomValues`-seeded
+ * UUID v4, and finally to a non-cryptographic generator, so a correlation ID is
+ * always produced rather than letting a missing API break a request.
+ */
+export function newCorrelationId(): string {
+  const c = globalThis.crypto;
+  if (c?.randomUUID) {
+    return c.randomUUID();
+  }
+  if (c?.getRandomValues) {
+    const b = c.getRandomValues(new Uint8Array(16));
+    b[6] = (b[6] & 0x0f) | 0x40; // version 4
+    b[8] = (b[8] & 0x3f) | 0x80; // variant
+    const hex = Array.from(b, (n) => n.toString(16).padStart(2, "0"));
+    return (
+      hex.slice(0, 4).join("") +
+      "-" +
+      hex.slice(4, 6).join("") +
+      "-" +
+      hex.slice(6, 8).join("") +
+      "-" +
+      hex.slice(8, 10).join("") +
+      "-" +
+      hex.slice(10, 16).join("")
+    );
+  }
+  // Last-resort fallback (non-cryptographic); only reached when the Web Crypto
+  // API is entirely unavailable, which should not happen in supported runtimes.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (ch) => {
+    const r = (Math.random() * 16) | 0;
+    const v = ch === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Returns the correlation ID carried by an error (e.g. `BackendApiError`), or
+ * `undefined`. Duck-typed on a `correlationId: string` field to avoid coupling
+ * this util to the backend-client module. Use to show users a support
+ * "Reference ID" alongside an error message.
+ */
+export function getErrorReferenceId(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "correlationId" in error) {
+    const id = (error as { correlationId?: unknown }).correlationId;
+    if (typeof id === "string" && id.length > 0) return id;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What

A batch of CSM-portal frontend changes. Five commits, independent but shipped together; theme/contract unchanged, light + dark both supported.

### 1. Originate `X-Correlation-ID` from the frontend (feat)

The backend and entity-service already honour an inbound `X-Correlation-ID`
header (generating their own only as a fallback) and stamp it on every log
line. The frontend never sent one, so a trace started at the backend and the FE
had no shared ID. This makes the FE the origin:

- New `utils/correlationId.ts`: `newCorrelationId()` (`crypto.randomUUID` with
  cryptographic + non-secure fallbacks), the shared `X-Correlation-ID` header
  constant, and a `getErrorReferenceId()` extractor.
- `useAuthApiClient` is the single choke point for every backend call. It stamps
  a fresh per-request UUID on the header (preserving any caller-supplied value)
  and emits **one centralised FE access log per call** carrying the ID,
  mirroring the backend's request-logging middleware.
- `BackendApiError` carries the correlation ID (read from the echoed response
  header); the error banner surfaces it to users as a support **"Reference ID"**.

### 2. Stop a dead deep link from hijacking the root route (fix)

Opening a non-existent path renders the 404 page, which lives **outside** the
`AuthGuard` route group. The post-login deep-link key (written on every load to
survive the IdP reload to `/`) was only ever cleared inside `AuthGuard`, so it
was never cleared for the 404 page and got stranded in `sessionStorage`. The
next visit to `/` then read the stale key and bounced the user back to the dead
URL on a loop until they manually typed a valid path.

Fix: move the "consume on arrival" logic into a `PostLoginRedirectConsumer`
mounted above `<Routes>`, so it runs for **every** route including the 404 page.
Clearing is gated on `isSignedIn` so a logged-out deep link still survives the
login round-trip. `AuthGuard` now only performs the post-login navigate, and the
shared key constant is centralised to prevent drift.

### 3. Cap pagination limit at 50 to match the backend (fix)

The backend rejects pagination limits above 50 (was 100), so cross-project
case / account / project / deployment / product searches and the dashboard
severity matrix were failing. Introduces a single `BE_MAX_PAGE_LIMIT = 50`
constant that every search page size points at (one-line revert when the
backend lifts the cap), and drops the `100` option from the
accounts/users/projects table page-size selectors. Where a bounded scan
paginated with a fixed `MAX_PAGES`, the page cap is doubled so the total scan
ceiling (`pages * limit`) is unchanged despite the smaller page.

### 4. Correlation-ID fallback tests (test)

Adds tests stubbing `globalThis.crypto` to exercise the `getRandomValues` path
(randomUUID absent) and the final non-crypto path (Web Crypto unavailable),
asserting both still yield a well-formed UUID v4.

### 5. Dashboard: show only "Cases by severity and state" (dashboard)

Hides the queue / SLA / customers / recent-activity widgets and renders only the
standalone severity-by-state matrix. Disables the dashboard switcher dropdown
(the other dashboards are mock placeholders) via a `DASHBOARD_SWITCHER_ENABLED`
flag, mirroring the existing `ABT_SCOPING_ENABLED` pattern, so it stays locked to
the Engineer dashboard selected by default. The hidden sections and placeholder
dashboards are kept in code for an easy restore.

## Test plan

- `pnpm lint`, `pnpm build`, `pnpm test` (84 pass, incl. correlation-ID unit +
  fallback tests) all green.
- Redirect fix: open a non-existent path (404), then open `/` — previously
  looped back to the dead URL; now lands on the dashboard.
- Pagination: search payloads now send `limit: 50`; previously-failing
  cases/accounts/projects/deployments searches and the dashboard matrix load.


