### PR TITLE
[CSM Portal][BE] fix(handler): improve UUID validation error message and skip for SN IDs

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -314,8 +314,8 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Case ID cannot be empty!")
 		return
 	}
-	if !uuidRe.MatchString(caseID) {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+	if r.Header.Get("x-user-id-token") == "" && !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -390,8 +390,8 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Case ID cannot be empty!")
 		return
 	}
-	if !uuidRe.MatchString(caseID) {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+	if r.Header.Get("x-user-id-token") == "" && !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 )
@@ -314,7 +315,7 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Case ID cannot be empty!")
 		return
 	}
-	if r.Header.Get("x-user-id-token") == "" && !uuidRe.MatchString(caseID) {
+	if strings.TrimSpace(r.Header.Get("x-user-id-token")) == "" && !uuidRe.MatchString(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -390,7 +391,7 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Case ID cannot be empty!")
 		return
 	}
-	if r.Header.Get("x-user-id-token") == "" && !uuidRe.MatchString(caseID) {
+	if strings.TrimSpace(r.Header.Get("x-user-id-token")) == "" && !uuidRe.MatchString(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -588,7 +588,7 @@ func TestPatchCase(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.PatchCase(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
 		assertContentType(t, w, "application/json")
 	})
 
@@ -781,7 +781,7 @@ func TestGetCase(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.GetCase(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
 		assertContentType(t, w, "application/json")
 	})
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -592,6 +592,30 @@ func TestPatchCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("allows non-UUID case ID when x-user-id-token is present", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, caseID string) ([]byte, error) {
+				capturedID = caseID
+				return []byte(`{"id":"sn-123","state":"open"}`), nil
+			},
+			patchCaseFn: func(_ context.Context, caseID string, _ []byte) ([]byte, error) {
+				capturedID = caseID
+				return []byte(`{"id":"sn-123","state":"work_in_progress"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/sn-123", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "sn-123")
+		r.Header.Set("x-user-id-token", "token-value")
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusOK)
+		if capturedID != "sn-123" {
+			t.Errorf("upstream received caseID %q, want %q", capturedID, "sn-123")
+		}
+	})
+
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
 		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
@@ -783,6 +807,26 @@ func TestGetCase(t *testing.T) {
 		assertStatus(t, w, http.StatusBadRequest)
 		assertErrorMessage(t, w, ErrMsgInvalidUUID)
 		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("allows non-UUID case ID when x-user-id-token is present", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, caseID string) ([]byte, error) {
+				capturedID = caseID
+				return []byte(`{"id":"sn-123","state":"open"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/cases/sn-123", nil))
+		r.SetPathValue("id", "sn-123")
+		r.Header.Set("x-user-id-token", "token-value")
+		w := httptest.NewRecorder()
+		h.GetCase(w, r)
+		assertStatus(t, w, http.StatusOK)
+		if capturedID != "sn-123" {
+			t.Errorf("upstream received caseID %q, want %q", capturedID, "sn-123")
+		}
 	})
 
 	type getCaseResp struct {

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -33,6 +33,7 @@ const (
 	ErrMsgTooLarge          = "Request body too large."
 	ErrMsgInternal          = "An internal server error occurred. Please try again later."
 	ErrMsgInvalidTransition = "Invalid state transition."
+	ErrMsgInvalidUUID       = "Invalid UUID format."
 	errMsgReadBody          = "Failed to read request body."
 )
 


### PR DESCRIPTION
## Summary

- Add `ErrMsgInvalidUUID = "Invalid UUID format."` constant so UUID format rejections return a specific, actionable message instead of the generic `"Invalid request payload."`
- Skip UUID format validation on `GetCase` and `PatchCase` when the `x-user-id-token` header is present — ServiceNow IDs do not follow UUID format and would otherwise be incorrectly rejected on the ServiceNow-backed data source
- Update handler tests to assert the new `ErrMsgInvalidUUID` message

## Test plan

- [x] `GET /cases/{id}` with a non-UUID ID and no `x-user-id-token` → 400 `"Invalid UUID format."`
- [x] `PATCH /cases/{id}` with a non-UUID ID and no `x-user-id-token` → 400 `"Invalid UUID format."`
- [x] `GET /cases/{id}` with a non-UUID ID and `x-user-id-token` present → request forwarded to entity service (SN ID accepted)
- [x] `PATCH /cases/{id}` with a non-UUID ID and `x-user-id-token` present → request forwarded to entity service (SN ID accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging: Case API endpoints now return specific "Invalid UUID format" error messages instead of generic bad request responses when case ID validation fails.

* **New Features**
  * Improved case ID handling: Case API validation now supports alternative case ID formats when authentication is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->