### PR TITLE
[CSM Portal] fix: case detail crash on unparseable createdAt (Invalid time value)

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -73,6 +73,7 @@ import {
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
+import { parseBackendTimestamp } from "@utils/dateTime";
 import type {
   CaseLifecycleAction,
   CsmCaseComment,
@@ -228,8 +229,16 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement {
  */
 function buildDescriptionComment(c: CsmCaseDetail): CsmCaseComment | null {
   if (!c.description?.trim()) return null;
-  const createdMs = new Date(c.createdAt).getTime();
-  const at = new Date(createdMs + 1000).toISOString();
+  // Use the shared backend-timestamp parser: `createdAt` arrives in formats a
+  // bare `new Date()` can't parse (e.g. space-separated "YYYY-MM-DD HH:MM:SS"),
+  // and may be missing entirely. A raw `new Date(...).toISOString()` on an
+  // invalid value throws "RangeError: Invalid time value" and crashes the whole
+  // detail page. Offset by 1s only when parseable; otherwise fall back to the
+  // raw value so RelativeTime degrades to "Unknown time" instead of crashing.
+  const created = parseBackendTimestamp(c.createdAt);
+  const at = created
+    ? new Date(created.getTime() + 1000).toISOString()
+    : c.createdAt;
   // The creator may be a WSO2 engineer (case logged in the CSM portal) or a
   // customer (customer portal). Infer from the email domain so the badge isn't
   // always "Customer".


### PR DESCRIPTION
## What

Fixes a crash that takes down the **entire case detail page** (caught by `AppErrorBoundary`):

```
RangeError: Invalid time value
    at Date.toISOString
    at buildDescriptionComment (CsmCaseDetailPage.tsx)
```

## Root cause

`buildDescriptionComment` synthesizes the case's opening comment (the description, dated 1s after `createdAt` so it sorts right after the "Case created" event). It did this with a **raw** `new Date(c.createdAt).toISOString()`.

`createdAt` arrives from the backend in formats a bare `new Date()` cannot reliably parse (e.g. space-separated `"YYYY-MM-DD HH:MM:SS"`), and may be absent for some records. When the parse fails the `Date` is invalid and `toISOString()` throws, crashing the whole page.

The comment bubble never hit this because it formats `createdAt` through the shared `parseBackendTimestamp` util (via `RelativeTime`), which normalizes those formats and returns `null` on invalid input. `buildDescriptionComment` was the one place using a raw `Date`.

## Fix

Use the same `parseBackendTimestamp` util. Offset by 1s only when the timestamp is parseable; otherwise fall back to the raw value so `RelativeTime` degrades to "Unknown time" rather than crashing.

Swept the rest of the codebase for the same pattern — the other production `new Date(...)` usages on backend timestamps are already guarded (`Number.isFinite` / `Number.isNaN`, and `toLocaleDateString` / `getTime()` don't throw). This was the only unguarded `toISOString()` on a backend value.

## Test plan

- `pnpm lint`, `pnpm build`, `pnpm test` (84 pass) all green.
- Opening a case whose `createdAt` is missing/space-separated previously crashed to the error boundary; it now renders, with the description comment showing a relative time (or "Unknown time" when the value is unparseable).
