### PR TITLE
[Customer Entity] Implement CreateCase and enrich GetCase response for postgres and ServiceNow

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -602,10 +602,27 @@ type UpdateCaseRequest struct {
 	Priority *CasePriority `json:"priority"`
 }
 
+// CreateCaseResponse is the unified response for POST /cases across all data sources.
+type CreateCaseResponse struct {
+	Message string            `json:"message"`
+	Case    CreateCaseDetails `json:"case"`
+}
+
+// CreateCaseDetails carries the key fields of a newly created case.
+type CreateCaseDetails struct {
+	ID         string    `json:"id"`
+	InternalID string    `json:"internalId"`
+	Number     string    `json:"number"`
+	CreatedBy  string    `json:"createdBy"`
+	CreatedOn  time.Time `json:"createdOn"`
+	State      string    `json:"state"`
+}
+
 // CreateCaseRequest is the input for creating a new case.
 // id, number, and internal_id are auto-generated; state defaults to open.
+// CreatedBy is not accepted from the request body and will be wired from auth context later.
 type CreateCaseRequest struct {
-	CreatedBy         string        `json:"createdBy"`
+	CreatedBy         string        `json:"-"`
 	ProjectID         string        `json:"projectId"`
 	DeploymentID      string        `json:"deploymentId"`
 	DeployedProductID string        `json:"deployedProductId"`

--- a/entity-service/internal/repository/user_repo.go
+++ b/entity-service/internal/repository/user_repo.go
@@ -21,10 +21,13 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"golang.org/x/sync/errgroup"
 )
@@ -37,6 +40,9 @@ type UserRepository interface {
 	// connections, so total may differ by at most one write from the page —
 	// this is acceptable for search-style pagination.
 	SearchUsers(ctx context.Context, req domain.SearchUsersRequest) ([]domain.User, int, error)
+	// GetUserByEmail returns the user with the given email address, or a
+	// NotFoundError if no matching user exists.
+	GetUserByEmail(ctx context.Context, email string) (domain.User, error)
 }
 
 type userRepo struct {
@@ -46,6 +52,26 @@ type userRepo struct {
 // NewUserRepository constructs a UserRepository backed by the given connection pool.
 func NewUserRepository(db *pgxpool.Pool) UserRepository {
 	return &userRepo{db: db}
+}
+
+// GetUserByEmail implements UserRepository.
+func (r *userRepo) GetUserByEmail(ctx context.Context, email string) (domain.User, error) {
+	var u domain.User
+	err := r.db.QueryRow(ctx,
+		`SELECT id, user_name, first_name, last_name, email, phone, timezone, user_type, created_at, updated_at
+		 FROM users WHERE email = $1`, email,
+	).Scan(
+		&u.ID, &u.UserName, &u.FirstName, &u.LastName,
+		&u.Email, &u.Phone, &u.Timezone, &u.UserType,
+		&u.CreatedAt, &u.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.User{}, &apierror.NotFoundError{Msg: "no user found with email: " + email}
+	}
+	if err != nil {
+		return domain.User{}, fmt.Errorf("get user by email: %w", err)
+	}
+	return u, nil
 }
 
 // SearchUsers implements UserRepository.

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -88,7 +88,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	deployedProductHandler := handler.NewDeployedProductHandler(activeDeployedProductSvc)
 
 	caseRepo := repository.NewCaseRepository(db)
-	pgCaseSvc := service.NewCaseService(caseRepo)
+	pgCaseSvc := service.NewCaseService(caseRepo, userRepo)
 	var activeCaseSvc service.CaseService
 	if cfg.DataSource == config.DataSourceServiceNow {
 		activeCaseSvc = service.NewServiceNowCaseService(serviceNowIntegrationServiceClient, pgCaseSvc)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -22,16 +22,18 @@ import (
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/repository"
 )
 
 type caseService struct {
-	repo repository.CaseRepository
+	repo     repository.CaseRepository
+	userRepo repository.UserRepository
 }
 
-// NewCaseService constructs a CaseService backed by the given repository.
-func NewCaseService(repo repository.CaseRepository) CaseService {
-	return &caseService{repo: repo}
+// NewCaseService constructs a CaseService backed by the given repositories.
+func NewCaseService(repo repository.CaseRepository, userRepo repository.UserRepository) CaseService {
+	return &caseService{repo: repo, userRepo: userRepo}
 }
 
 var validCaseSortField = map[domain.CaseSortField]bool{
@@ -73,32 +75,58 @@ var validCaseIssueType = map[domain.CaseIssueType]bool{
 }
 
 // CreateCase implements CaseService.
-func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.Case, error) {
-	if err := validateUUIDs("createdBy", []string{req.CreatedBy}); err != nil {
-		return domain.Case{}, err
-	}
+func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.CreateCaseResponse, error) {
 	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
-		return domain.Case{}, err
+		return domain.CreateCaseResponse{}, err
 	}
 	if err := validateUUIDs("deploymentId", []string{req.DeploymentID}); err != nil {
-		return domain.Case{}, err
+		return domain.CreateCaseResponse{}, err
 	}
 	if err := validateUUIDs("deployedProductId", []string{req.DeployedProductID}); err != nil {
-		return domain.Case{}, err
+		return domain.CreateCaseResponse{}, err
 	}
 	if req.Subject == "" {
-		return domain.Case{}, &apierror.ValidationError{Msg: "subject is required"}
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "subject is required"}
 	}
 	if req.Description == "" {
-		return domain.Case{}, &apierror.ValidationError{Msg: "description is required"}
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "description is required"}
 	}
 	if !validCasePriority[req.Priority] {
-		return domain.Case{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(req.Priority)}
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(req.Priority)}
 	}
 	if !validCaseIssueType[req.IssueType] {
-		return domain.Case{}, &apierror.ValidationError{Msg: "issueType contains invalid value: " + string(req.IssueType)}
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "issueType contains invalid value: " + string(req.IssueType)}
 	}
-	return s.repo.CreateCase(ctx, req)
+	if req.CreatedBy == "" {
+		token := middleware.UserIDTokenFromContext(ctx)
+		if token == "" {
+			return domain.CreateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+		}
+		email, err := emailFromJWT(token)
+		if err != nil {
+			return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "x-user-id-token: " + err.Error()}
+		}
+		user, err := s.userRepo.GetUserByEmail(ctx, email)
+		if err != nil {
+			return domain.CreateCaseResponse{}, err
+		}
+		req.CreatedBy = user.ID
+	}
+	c, err := s.repo.CreateCase(ctx, req)
+	if err != nil {
+		return domain.CreateCaseResponse{}, err
+	}
+	return domain.CreateCaseResponse{
+		Message: "Case created successfully.",
+		Case: domain.CreateCaseDetails{
+			ID:         c.ID,
+			InternalID: c.InternalID,
+			Number:     c.Number,
+			CreatedBy:  c.CreatedBy,
+			CreatedOn:  c.CreatedAt,
+			State:      string(c.State),
+		},
+	}, nil
 }
 
 // GetCaseByID implements CaseService.

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -74,8 +74,39 @@ var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeTotalOutage:            true,
 }
 
+// validateCreateCaseRequest validates fields common to all CreateCase data sources.
+// UUID format of ID fields is not checked here — postgres IDs are UUIDs but
+// ServiceNow IDs are opaque hex strings; callers add format checks as needed.
+func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
+	if req.ProjectID == "" {
+		return &apierror.ValidationError{Msg: "projectId is required"}
+	}
+	if req.DeploymentID == "" {
+		return &apierror.ValidationError{Msg: "deploymentId is required"}
+	}
+	if req.DeployedProductID == "" {
+		return &apierror.ValidationError{Msg: "deployedProductId is required"}
+	}
+	if req.Subject == "" {
+		return &apierror.ValidationError{Msg: "subject is required"}
+	}
+	if req.Description == "" {
+		return &apierror.ValidationError{Msg: "description is required"}
+	}
+	if !validCasePriority[req.Priority] {
+		return &apierror.ValidationError{Msg: "priority contains invalid value: " + string(req.Priority)}
+	}
+	if !validCaseIssueType[req.IssueType] {
+		return &apierror.ValidationError{Msg: "issueType contains invalid value: " + string(req.IssueType)}
+	}
+	return nil
+}
+
 // CreateCase implements CaseService.
 func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.CreateCaseResponse, error) {
+	if err := validateCreateCaseRequest(req); err != nil {
+		return domain.CreateCaseResponse{}, err
+	}
 	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
 		return domain.CreateCaseResponse{}, err
 	}
@@ -84,18 +115,6 @@ func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseReque
 	}
 	if err := validateUUIDs("deployedProductId", []string{req.DeployedProductID}); err != nil {
 		return domain.CreateCaseResponse{}, err
-	}
-	if req.Subject == "" {
-		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "subject is required"}
-	}
-	if req.Description == "" {
-		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "description is required"}
-	}
-	if !validCasePriority[req.Priority] {
-		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(req.Priority)}
-	}
-	if !validCaseIssueType[req.IssueType] {
-		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "issueType contains invalid value: " + string(req.IssueType)}
 	}
 	if req.CreatedBy == "" {
 		token := middleware.UserIDTokenFromContext(ctx)

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -92,7 +92,7 @@ type DeployedProductService interface {
 type CaseService interface {
 	// CreateCase creates a new case with auto-generated id, number, and internal_id.
 	// State defaults to open. A ValidationError is returned for invalid input.
-	CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.Case, error)
+	CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.CreateCaseResponse, error)
 	// GetCaseByID returns the enriched case view for the given UUID. A
 	// ValidationError is returned for a malformed UUID; a NotFoundError if no case matches.
 	GetCaseByID(ctx context.Context, id string) (domain.CaseView, error)

--- a/entity-service/internal/service/jwt.go
+++ b/entity-service/internal/service/jwt.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// emailFromJWT decodes the payload of a JWT (without verifying the signature)
+// and returns the value of the "email" claim.
+func emailFromJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("malformed JWT: expected 3 parts, got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("malformed JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("malformed JWT claims: %w", err)
+	}
+	if claims.Email == "" {
+		return "", fmt.Errorf("email claim not present in token")
+	}
+	return claims.Email, nil
+}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -120,8 +120,96 @@ func NewServiceNowCaseService(client *integrationservice.Client, pgFallback Case
 	return &snCaseService{client: client, pgFallback: pgFallback}
 }
 
-func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.Case, error) {
-	return s.pgFallback.CreateCase(ctx, req)
+// snPriorityID maps domain CasePriority to the ServiceNow severity choice-list value.
+var snPriorityID = map[domain.CasePriority]int{
+	domain.CasePriorityCatastrophic: 14,
+	domain.CasePriorityCritical:     10,
+	domain.CasePriorityHigh:         11,
+	domain.CasePriorityMedium:       12,
+	domain.CasePriorityLow:          13,
+}
+
+// snIssueTypeID maps domain CaseIssueType to the ServiceNow issue-type choice-list value.
+var snIssueTypeID = map[domain.CaseIssueType]int{
+	domain.CaseIssueTypeTotalOutage:            1,
+	domain.CaseIssueTypePartialOutage:          2,
+	domain.CaseIssueTypePerformanceDegradation: 3,
+	domain.CaseIssueTypeQuestion:               4,
+	domain.CaseIssueTypeSecurityOrCompliance:   5,
+	domain.CaseIssueTypeError:                  6,
+}
+
+type snCreateCasePayload struct {
+	Type              string `json:"type"`
+	ProjectID         string `json:"projectId"`
+	DeploymentID      string `json:"deploymentId"`
+	DeployedProductID string `json:"deployedProductId"`
+	Title             string `json:"title"`
+	Description       string `json:"description"`
+	SeverityKey       int    `json:"severityKey"`
+	IssueTypeKey      int    `json:"issueTypeKey"`
+}
+
+type snCreateCaseResponse struct {
+	Message string `json:"message"`
+	Case    struct {
+		ID         string       `json:"id"`
+		InternalID string       `json:"internalId"`
+		Number     string       `json:"number"`
+		CreatedBy  string       `json:"createdBy"`
+		CreatedOn  string       `json:"createdOn"`
+		State      *snCaseState `json:"state"`
+	} `json:"case"`
+}
+
+func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.CreateCaseResponse, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.CreateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snCreateCasePayload{
+		Type:              "default_case",
+		ProjectID:         req.ProjectID,
+		DeploymentID:      req.DeploymentID,
+		DeployedProductID: req.DeployedProductID,
+		Title:             req.Subject,
+		Description:       req.Description,
+		SeverityKey:  snPriorityID[req.Priority],
+		IssueTypeKey: snIssueTypeID[req.IssueType],
+	}
+
+	raw, err := s.client.Post(ctx, "/cases", token, payload)
+	if err != nil {
+		return domain.CreateCaseResponse{}, err
+	}
+
+	var snResp snCreateCaseResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CreateCaseResponse{}, fmt.Errorf("sn create case: parse response: %w", err)
+	}
+
+	createdOn, err := time.Parse(snCreatedOnLayout, snResp.Case.CreatedOn)
+	if err != nil {
+		return domain.CreateCaseResponse{}, fmt.Errorf("sn create case: parse createdOn %q: %w", snResp.Case.CreatedOn, err)
+	}
+
+	stateLabel := ""
+	if snResp.Case.State != nil {
+		stateLabel = snResp.Case.State.Label
+	}
+
+	return domain.CreateCaseResponse{
+		Message: snResp.Message,
+		Case: domain.CreateCaseDetails{
+			ID:         snResp.Case.ID,
+			InternalID: snResp.Case.InternalID,
+			Number:     snResp.Case.Number,
+			CreatedBy:  snResp.Case.CreatedBy,
+			CreatedOn:  createdOn,
+			State:      stateLabel,
+		},
+	}, nil
 }
 
 func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.CaseView, error) {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -163,6 +163,10 @@ type snCreateCaseResponse struct {
 }
 
 func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.CreateCaseResponse, error) {
+	if err := validateCreateCaseRequest(req); err != nil {
+		return domain.CreateCaseResponse{}, err
+	}
+
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
 		return domain.CreateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -373,7 +373,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Case'
+                $ref: '#/components/schemas/CreateCaseResponse'
         "400":
           description: Bad request.
           content:
@@ -1022,17 +1022,17 @@ components:
 
     CreateCaseRequest:
       type: object
-      required: [createdBy, projectId, deploymentId, deployedProductId, subject, description, priority, issueType]
+      required: [projectId, deploymentId, deployedProductId, subject, description, priority, issueType]
       properties:
-        createdBy:
-          type: string
-          description: UUID of the user creating the case.
         projectId:
           type: string
+          format: uuid
         deploymentId:
           type: string
+          format: uuid
         deployedProductId:
           type: string
+          format: uuid
         subject:
           type: string
         description:
@@ -1043,6 +1043,28 @@ components:
         issueType:
           type: string
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
+
+    CreateCaseResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        case:
+          type: object
+          properties:
+            id:
+              type: string
+            internalId:
+              type: string
+            number:
+              type: string
+            createdBy:
+              type: string
+            createdOn:
+              type: string
+              format: date-time
+            state:
+              type: string
 
     SearchCasesRequest:
       type: object
@@ -1103,15 +1125,47 @@ components:
         id:
           type: string
           format: uuid
-        displayName:
+          nullable: true
+        name:
           type: string
-          description: firstName + lastName
+          description: firstName + lastName (null for ServiceNow data source)
+          nullable: true
         userId:
           type: string
-          description: Username / login identifier.
+          description: Username / login identifier (null for ServiceNow data source)
+          nullable: true
         email:
           type: string
           format: email
+
+    AssignedEngineerRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+
+    CaseNumberRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+
+    AccountRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
 
     UserIDEmailRef:
       type: object
@@ -1206,16 +1260,12 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
-        closedAt:
-          type: string
-          format: date-time
-          nullable: true
         createdBy:
           $ref: '#/components/schemas/UserRef'
         project:
@@ -1224,6 +1274,16 @@ components:
           $ref: '#/components/schemas/EntityRef'
         deployedProduct:
           $ref: '#/components/schemas/DeployedProductRef'
+        product:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          $ref: '#/components/schemas/AssignedEngineerRef'
+        parentCase:
+          $ref: '#/components/schemas/CaseNumberRef'
+        relatedCase:
+          $ref: '#/components/schemas/CaseNumberRef'
+        account:
+          $ref: '#/components/schemas/AccountRef'
 
     CaseSearchView:
       type: object
@@ -1248,16 +1308,12 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
-        closedAt:
-          type: string
-          format: date-time
-          nullable: true
         createdBy:
           $ref: '#/components/schemas/UserIDEmailRef'
         project:


### PR DESCRIPTION
## Summary
- Remove `createdBy` from `CreateCaseRequest` body; resolve it automatically from the `x-user-id-token` JWT email claim via a `users` table lookup for the postgres data source
- Add unified `CreateCaseResponse` shape (`message` + `case` details) returned by both postgres and ServiceNow
- Implement `snCaseService.CreateCase` — calls `POST /cases` on the integration service with `type: "default_case"` and maps domain `priority`/`issueType` enums to SN `severityKey`/`issueTypeKey` numeric values
- Enrich `CaseView` (GET /cases/{id}) with `product`, `account`, `assignedEngineer`, `parentCase`, and `relatedCase` fields; implement `snCaseService.GetCaseByID` via `GET /cases/{id}` on the integration service
- Rename `UserRef.displayName` → `name`; replace `createdAt`/`updatedAt` with `createdOn`/`updatedOn` across `CaseView` and `CaseSearchView`
- Update `openapi.yaml` to reflect all contract changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case creation now automatically detects the user creating a case from authentication token when creator is not explicitly provided
  * Case creation endpoint returns enhanced structured response containing success message along with case identifiers and metadata
  * Added validation for project, deployment, and product identifiers to ensure UUID format compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->