### PR TITLE
[CSM Portal] case detail: degrade gracefully when comments fail to load

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -808,16 +808,24 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   <Skeleton key={i} variant="rectangular" height={56} />
                 ))}
               </Box>
-            ) : isCommentsError ? (
-              <Typography variant="body2" color="error">
-                Could not load comments.
-              </Typography>
             ) : (
-              <CaseActivitiesFeed
-                comments={safeComments}
-                audit={c.audit}
-                attachments={c.attachments}
-              />
+              // A comments-load failure must not blank the whole timeline: the
+              // description, audit trail, and attachments come from the case
+              // itself and loaded fine. Show them, with a non-blocking notice
+              // that the comments portion is missing (per-section degradation).
+              <>
+                {isCommentsError && (
+                  <Typography variant="body2" color="error">
+                    Could not load comments. Showing the rest of the activity —
+                    reload to try again.
+                  </Typography>
+                )}
+                <CaseActivitiesFeed
+                  comments={safeComments}
+                  audit={c.audit}
+                  attachments={c.attachments}
+                />
+              </>
             )}
           </Card>
         </Box>


### PR DESCRIPTION
## What

Makes the case detail page degrade gracefully when the comments search fails, instead of letting a comments-only failure blank the whole activity timeline.

## Why

When `POST /cases/{id}/comments/search` fails (e.g. an upstream `400 Invalid request payload`), the activity section replaced the **entire** timeline with a single "Could not load comments." line — also hiding the description, audit trail, and attachments, which come from the case itself (`GET /cases/{id}`) and had loaded fine.

A comments-only failure shouldn't take down the parts that loaded.

## Change

Render the activity feed with whatever loaded (description + audit + attachments) and surface the comments failure as a **non-blocking inline notice** above it, matching the per-section error pattern already used on the dashboard. No backend change.

## Test plan

- `pnpm lint`, `pnpm build`, `pnpm test` (84 pass) all green.
- With comments search returning an error: the timeline still renders the description, audit, and attachments, with an inline "Could not load comments. Showing the rest of the activity — reload to try again." notice instead of a blank section.

## Note

The underlying `400` from the comments endpoint is a backend/contract issue (the csm-portal passes the body through and an upstream rejection is surfaced as `Invalid request payload`); this PR only hardens the frontend's handling of it and does not change any backend behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Activity timeline resilience when comment loading fails. The timeline now displays available case information (audit entries, attachments, and description details) alongside a helpful error message prompting reload, instead of showing only an error state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->