### PR TITLE
[CSM Portal] case detail resilience: unparseable createdAt crash + graceful comments-load failure

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -817,16 +817,24 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   <Skeleton key={i} variant="rectangular" height={56} />
                 ))}
               </Box>
-            ) : isCommentsError ? (
-              <Typography variant="body2" color="error">
-                Could not load comments.
-              </Typography>
             ) : (
-              <CaseActivitiesFeed
-                comments={safeComments}
-                audit={c.audit}
-                attachments={c.attachments}
-              />
+              // A comments-load failure must not blank the whole timeline: the
+              // description, audit trail, and attachments come from the case
+              // itself and loaded fine. Show them, with a non-blocking notice
+              // that the comments portion is missing (per-section degradation).
+              <>
+                {isCommentsError && (
+                  <Typography variant="body2" color="error">
+                    Could not load comments. Showing the rest of the activity —
+                    reload to try again.
+                  </Typography>
+                )}
+                <CaseActivitiesFeed
+                  comments={safeComments}
+                  audit={c.audit}
+                  attachments={c.attachments}
+                />
+              </>
             )}
           </Card>
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -229,12 +229,9 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement {
  */
 function buildDescriptionComment(c: CsmCaseDetail): CsmCaseComment | null {
   if (!c.description?.trim()) return null;
-  // Use the shared backend-timestamp parser: `createdAt` arrives in formats a
-  // bare `new Date()` can't parse (e.g. space-separated "YYYY-MM-DD HH:MM:SS"),
-  // and may be missing entirely. A raw `new Date(...).toISOString()` on an
-  // invalid value throws "RangeError: Invalid time value" and crashes the whole
-  // detail page. Offset by 1s only when parseable; otherwise fall back to the
-  // raw value so RelativeTime degrades to "Unknown time" instead of crashing.
+  // `createdAt` may be missing or in a format a bare `new Date()` can't parse,
+  // which made the old raw `.toISOString()` throw and crash the page. Parse
+  // safely; offset 1s when valid, else fall back to the raw value.
   const created = parseBackendTimestamp(c.createdAt);
   const at = created
     ? new Date(created.getTime() + 1000).toISOString()
@@ -818,10 +815,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 ))}
               </Box>
             ) : (
-              // A comments-load failure must not blank the whole timeline: the
-              // description, audit trail, and attachments come from the case
-              // itself and loaded fine. Show them, with a non-blocking notice
-              // that the comments portion is missing (per-section degradation).
+              // A comments failure shouldn't blank the timeline — the
+              // description, audit, and attachments loaded fine. Show them with
+              // an inline notice.
               <>
                 {isCommentsError && (
                   <Typography variant="body2" color="error">

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -73,6 +73,7 @@ import {
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
+import { parseBackendTimestamp } from "@utils/dateTime";
 import type {
   CaseLifecycleAction,
   CsmCaseComment,
@@ -228,8 +229,16 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement {
  */
 function buildDescriptionComment(c: CsmCaseDetail): CsmCaseComment | null {
   if (!c.description?.trim()) return null;
-  const createdMs = new Date(c.createdAt).getTime();
-  const at = new Date(createdMs + 1000).toISOString();
+  // Use the shared backend-timestamp parser: `createdAt` arrives in formats a
+  // bare `new Date()` can't parse (e.g. space-separated "YYYY-MM-DD HH:MM:SS"),
+  // and may be missing entirely. A raw `new Date(...).toISOString()` on an
+  // invalid value throws "RangeError: Invalid time value" and crashes the whole
+  // detail page. Offset by 1s only when parseable; otherwise fall back to the
+  // raw value so RelativeTime degrades to "Unknown time" instead of crashing.
+  const created = parseBackendTimestamp(c.createdAt);
+  const at = created
+    ? new Date(created.getTime() + 1000).toISOString()
+    : c.createdAt;
   // The creator may be a WSO2 engineer (case logged in the CSM portal) or a
   // customer (customer portal). Infer from the email domain so the badge isn't
   // always "Customer".


### PR DESCRIPTION
## What

Two related fixes that make the **case detail page** resilient to bad/partial data. (Combines the previously separate PRs for the `createdAt` crash and the comments-load degradation into one.)

### 1. Crash on unparseable `createdAt` (Invalid time value)

`buildDescriptionComment` built the case's opening comment with a raw
`new Date(c.createdAt).toISOString()`. When `createdAt` is missing or in a
format `new Date()` can't parse (e.g. space-separated `"YYYY-MM-DD HH:MM:SS"`),
the date is invalid and `toISOString()` throws `RangeError: Invalid time value`,
taking down the **entire** case detail page via the error boundary.

Fixed by using the shared `parseBackendTimestamp` util (the same one the comment
bubble already uses, which is why the bubble rendered fine): offset by 1s only
when parseable, otherwise fall back to the raw value so `RelativeTime` degrades
to "Unknown time" instead of crashing. Swept the codebase — this was the only
unguarded `toISOString()` on a backend timestamp; the rest are already guarded.

### 2. Comments-load failure blanked the whole timeline

When `POST /cases/{id}/comments/search` fails (e.g. an upstream
`400 Invalid request payload`), the activity section replaced the **entire**
timeline with a "Could not load comments." line — also hiding the description,
audit trail, and attachments, which come from the case itself (`GET /cases/{id}`)
and had loaded fine.

Now the activity feed renders whatever loaded (description + audit + attachments)
and the comments failure shows as a **non-blocking inline notice** above it,
matching the per-section error pattern already used on the dashboard.

## Test plan

- `pnpm lint`, `pnpm build`, `pnpm test` (84 pass) all green.
- Open a case whose `createdAt` is missing/space-separated: previously crashed to
  the error boundary; now renders.
- With comments search returning an error: the timeline still shows the
  description, audit, and attachments, with an inline "Could not load comments.
  Showing the rest of the activity — reload to try again." notice.

## Note

The underlying `400` from the comments endpoint is a backend/contract issue (the
csm-portal passes the body through and an upstream rejection surfaces as
`Invalid request payload`); this PR only hardens the frontend and changes no
backend behaviour.
