### PR TITLE
[Customer Entity] feat(cases): map domain enums to SN numeric IDs for cases/search filters

### DIFF
--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -124,6 +124,8 @@ var snStateIDMap = map[domain.CaseState]int{
 }
 
 // snSeverityIDMap maps domain CasePriority enums to SN numeric severity IDs.
+// CasePriorityCatastrophic is intentionally absent: ServiceNow's severity scale
+// only goes up to Critical (P1=10) and has no catastrophic equivalent.
 var snSeverityIDMap = map[domain.CasePriority]int{
 	domain.CasePriorityCritical: 10,
 	domain.CasePriorityHigh:     11,

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -107,6 +107,68 @@ type snCaseFilters struct {
 	ProjectIDs         []string `json:"projectIds,omitempty"`
 	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
 	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+	StateKeys          []int    `json:"stateKeys,omitempty"`
+	SeverityKeys       []int    `json:"severityKeys,omitempty"`
+	IssueTypeKeys      []int    `json:"issueTypeKeys,omitempty"`
+}
+
+// snStateIDMap maps domain CaseState enums to SN numeric state IDs.
+var snStateIDMap = map[domain.CaseState]int{
+	domain.CaseStateOpen:             1,
+	domain.CaseStateWorkInProgress:   10,
+	domain.CaseStateAwaitingInfo:     18,
+	domain.CaseStateWaitingOnWSO2:    1003,
+	domain.CaseStateSolutionProposed: 6,
+	domain.CaseStateClosed:           3,
+	domain.CaseStateReopened:         1006,
+}
+
+// snSeverityIDMap maps domain CasePriority enums to SN numeric severity IDs.
+var snSeverityIDMap = map[domain.CasePriority]int{
+	domain.CasePriorityCritical: 10,
+	domain.CasePriorityHigh:     11,
+	domain.CasePriorityMedium:   12,
+	domain.CasePriorityLow:      13,
+}
+
+// snIssueTypeIDMap maps domain CaseIssueType enums to SN numeric issue type IDs.
+var snIssueTypeIDMap = map[domain.CaseIssueType]int{
+	domain.CaseIssueTypeTotalOutage:            1,
+	domain.CaseIssueTypePartialOutage:          2,
+	domain.CaseIssueTypePerformanceDegradation: 3,
+	domain.CaseIssueTypeQuestion:               4,
+	domain.CaseIssueTypeSecurityOrCompliance:   5,
+	domain.CaseIssueTypeError:                  6,
+}
+
+func domainStatesToSNIDs(states []domain.CaseState) []int {
+	ids := make([]int, 0, len(states))
+	for _, s := range states {
+		if id, ok := snStateIDMap[s]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func domainPrioritiesToSNIDs(priorities []domain.CasePriority) []int {
+	ids := make([]int, 0, len(priorities))
+	for _, p := range priorities {
+		if id, ok := snSeverityIDMap[p]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func domainIssueTypesToSNIDs(issueTypes []domain.CaseIssueType) []int {
+	ids := make([]int, 0, len(issueTypes))
+	for _, it := range issueTypes {
+		if id, ok := snIssueTypeIDMap[it]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }
 
 type snCaseService struct {
@@ -231,6 +293,9 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			ProjectIDs:         req.ProjectIDs,
 			DeploymentIDs:      req.DeploymentIDs,
 			DeployedProductIDs: req.DeployedProductIDs,
+			StateKeys:          domainStatesToSNIDs(req.StateKeys),
+			SeverityKeys:       domainPrioritiesToSNIDs(req.PriorityKeys),
+			IssueTypeKeys:      domainIssueTypesToSNIDs(req.IssueTypeKeys),
 		},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}


### PR DESCRIPTION
## Summary

- The ServiceNow integration service expects `stateKeys`, `severityKeys`, and `issueTypeKeys` as **integer arrays** in the `POST /cases/search` payload
- Previously these filters were silently dropped — only `projectIds`, `deploymentIds`, and `caseTypes` were forwarded to SN
- Added three lookup maps (`snStateIDMap`, `snSeverityIDMap`, `snIssueTypeIDMap`) keyed on domain enums with IDs sourced from the SN metadata response
- Added three converter helpers (`domainStatesToSNIDs`, `domainPrioritiesToSNIDs`, `domainIssueTypesToSNIDs`) that translate incoming domain enum slices to `[]int`, skipping any unmapped values
- `SearchCases` now populates `stateKeys`, `severityKeys`, and `issueTypeKeys` in the SN payload

## Test plan

- [x] Call `POST /cases/search` with `stateKeys: ["open", "work_in_progress"]` — verify only matching state IDs (1, 10) appear in the SN request
- [x] Call with `priorityKeys: ["critical", "high"]` — verify SN receives `severityKeys: [10, 11]`
- [x] Call with `issueTypeKeys: ["error", "total_outage"]` — verify SN receives `issueTypeKeys: [6, 1]`
- [x] Call with no filter fields — verify `stateKeys`/`severityKeys`/`issueTypeKeys` are omitted from the SN payload (`omitempty`)
- [x] Verify existing filters (`projectIds`, `deploymentIds`, `searchQuery`) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new search filter options to filter cases by state, severity level, and issue type for more targeted case searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->