### PR TITLE
[Customer Entity] Skip UUID validation for ServiceNow deployment IDs

### DIFF
--- a/entity-service/internal/service/sn_deployed_product_service.go
+++ b/entity-service/internal/service/sn_deployed_product_service.go
@@ -84,9 +84,6 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchDeployedProductsResponse{}, err
 	}
-	if err := validateUUIDs("deploymentIds", req.DeploymentIDs); err != nil {
-		return domain.SearchDeployedProductsResponse{}, err
-	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {


### PR DESCRIPTION
## Summary
- ServiceNow deployment IDs are opaque hex strings, not UUIDs; the UUID format check was rejecting valid SN IDs on POST /deployed-products/search
- Removed `validateUUIDs("deploymentIds", ...)` from the SN deployed-product service only — the Postgres path retains its validation unchanged



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified deployment ID validation in product search requests to streamline the request processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->