### PR TITLE
[CSM Portal] case-create project search, deployed-product labels, dashboard count cells

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -113,10 +113,21 @@ export interface BeDeployedProductRef {
 }
 
 /**
+ * Account summary embedded in the CaseView. `type` is the account/support tier
+ * (e.g. "Enterprise"); it is a free-form string, not the PG `basic|enterprise`
+ * enum, because ServiceNow-sourced cases pass their support tier through as-is.
+ */
+export interface BeCaseAccountRef {
+  id: string;
+  name?: string;
+  type?: string;
+}
+
+/**
  * `GET /cases/{id}` response — the rich CaseView. Unlike {@link BeCase} (the
  * flat create/legacy shape), it embeds the related entities as objects, so the
- * UI gets project / deployment / deployed-product / reporter names without any
- * extra lookups.
+ * UI gets account / project / deployment / deployed-product / reporter names
+ * without any extra lookups.
  */
 export interface BeCaseView {
   id: string;
@@ -130,6 +141,7 @@ export interface BeCaseView {
   state?: BeCaseState;
   nextStates?: BeCaseState[];
   createdBy?: BeUserRef;
+  account?: BeCaseAccountRef;
   project?: BeEntityRef;
   deployment?: BeEntityRef;
   deployedProduct?: BeDeployedProductRef;
@@ -335,35 +347,6 @@ export interface BeProject {
   endDate?: string;
   createdAt?: string;
   updatedAt?: string;
-}
-
-/** Account summary embedded in the project-detail response. */
-export interface BeProjectAccountRef {
-  id: string;
-  name?: string;
-  tier?: BeAccountTier;
-  region?: string;
-  activationDate?: string | null;
-  agentEnabled?: boolean;
-  kbReferencesEnabled?: boolean;
-}
-
-/**
- * `GET /projects/{id}` response. Unlike the search shape ({@link BeProject}),
- * it embeds the linked `account` (id + name + tier + region), so the case
- * detail can resolve the customer and tier without a separate account lookup.
- */
-export interface BeProjectDetail {
-  id: string;
-  account?: BeProjectAccountRef;
-  sfId?: string;
-  name?: string;
-  key?: string;
-  subscriptionType?: BeSubscriptionType;
-  startDate?: string;
-  endDate?: string;
-  createdOn?: string;
-  updatedOn?: string;
 }
 
 export interface BeProjectSearchPayload {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -148,6 +148,22 @@ export interface BeCaseCreatePayload {
   issueType: BeCaseIssueType;
 }
 
+/** The case summary embedded in the `POST /cases` success envelope. */
+export interface BeCreatedCase {
+  id: string;
+  internalId?: string;
+  number?: string;
+  createdBy?: string;
+  createdOn?: string;
+  state?: string;
+}
+
+/** `POST /cases` response: a message plus the created case. */
+export interface BeCaseCreateResponse {
+  message?: string;
+  case: BeCreatedCase;
+}
+
 /**
  * Request body for `PATCH /cases/{id}`. At least one of `state` / `priority`
  * must be set (mirrors the entity `UpdateCaseRequest`).

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -417,13 +417,24 @@ export interface BeProductVersionSearchResponse extends BeSearchResponseBase {
 // Deployed products (deployment ↔ product link)
 // ---------------------------------------------------------------------------
 
+/** Product version as embedded in a deployed-product record. */
+export interface BeDeployedProductVersion {
+  id: string;
+  name: string;
+  releasedDate?: string | null;
+  supportEoLDate?: string | null;
+}
+
 export interface BeDeployedProduct {
   id: string;
-  deploymentId?: string;
-  productId?: string;
-  productVersionId?: string;
-  createdAt?: string;
-  updatedAt?: string;
+  deployment?: BeEntityRef;
+  product?: BeEntityRef;
+  version?: BeDeployedProductVersion | null;
+  cores?: number | null;
+  tps?: number | null;
+  category?: string | null;
+  createdOn?: string;
+  updatedOn?: string;
 }
 
 export interface BeDeployedProductSearchPayload {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -321,6 +321,35 @@ export interface BeProject {
   updatedAt?: string;
 }
 
+/** Account summary embedded in the project-detail response. */
+export interface BeProjectAccountRef {
+  id: string;
+  name?: string;
+  tier?: BeAccountTier;
+  region?: string;
+  activationDate?: string | null;
+  agentEnabled?: boolean;
+  kbReferencesEnabled?: boolean;
+}
+
+/**
+ * `GET /projects/{id}` response. Unlike the search shape ({@link BeProject}),
+ * it embeds the linked `account` (id + name + tier + region), so the case
+ * detail can resolve the customer and tier without a separate account lookup.
+ */
+export interface BeProjectDetail {
+  id: string;
+  account?: BeProjectAccountRef;
+  sfId?: string;
+  name?: string;
+  key?: string;
+  subscriptionType?: BeSubscriptionType;
+  startDate?: string;
+  endDate?: string;
+  createdOn?: string;
+  updatedOn?: string;
+}
+
 export interface BeProjectSearchPayload {
   pagination?: BePagination;
   searchQuery?: string;

--- a/apps/csm-portal/webapp/src/components/SemanticChip.tsx
+++ b/apps/csm-portal/webapp/src/components/SemanticChip.tsx
@@ -51,7 +51,15 @@ export default function SemanticChip({
 }: SemanticChipProps): JSX.Element {
   const theme = useTheme();
 
-  if (role === "default") {
+  // Resolve the palette fill defensively: an unexpected role (e.g. a free-form
+  // value that slipped past the type) must degrade to the outlined default
+  // chip, never read `.main` off an undefined palette entry and crash the page.
+  const paletteEntry =
+    role === "default"
+      ? undefined
+      : (theme.palette[role] as { main?: string } | undefined);
+
+  if (!paletteEntry?.main) {
     return (
       <Chip
         size={size}
@@ -62,7 +70,7 @@ export default function SemanticChip({
     );
   }
 
-  const bg = theme.palette[role].main;
+  const bg = paletteEntry.main;
   const fg = pickAccessibleText(bg);
 
   return (

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
@@ -495,7 +495,7 @@ export function getMockCsmCaseById(
 const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   "acc-001": {
     accountName: "Acme Financial",
-    tier: "managed_cloud",
+    tier: "enterprise",
     region: "us-east-1",
     primaryContact: "Renee Park",
     primaryContactEmail: "renee.park@acmefinancial.com",
@@ -505,7 +505,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   },
   "acc-002": {
     accountName: "Globex Corp",
-    tier: "subscription",
+    tier: "basic",
     region: "eu-west-1",
     primaryContact: "Helena Voss",
     primaryContactEmail: "h.voss@globex.com",
@@ -514,7 +514,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   },
   "acc-003": {
     accountName: "Initech Systems",
-    tier: "managed_cloud",
+    tier: "enterprise",
     region: "ap-southeast-1",
     primaryContact: "Peter Gibbons",
     primaryContactEmail: "peter@initech.io",
@@ -524,7 +524,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   },
   "acc-004": {
     accountName: "Soylent Industries",
-    tier: "subscription",
+    tier: "basic",
     region: "us-west-2",
     primaryContact: "Marie Sandwitch",
     primaryContactEmail: "marie@soylent.com",
@@ -533,7 +533,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   },
   "acc-005": {
     accountName: "Umbrella Health",
-    tier: "saas",
+    tier: "enterprise",
     region: "us-east-1",
     primaryContact: "Albert Wesker",
     primaryContactEmail: "a.wesker@umbrella.health",
@@ -542,7 +542,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   },
   "acc-101": {
     accountName: "Wayne Enterprises",
-    tier: "subscription",
+    tier: "basic",
     region: "us-east-1",
     primaryContact: "Lucius Fox",
     primaryContactEmail: "lfox@wayne.com",
@@ -551,7 +551,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   },
   "acc-102": {
     accountName: "Stark Industries",
-    tier: "managed_cloud",
+    tier: "enterprise",
     region: "us-west-1",
     primaryContact: "Pepper Potts",
     primaryContactEmail: "pepper@stark.com",
@@ -561,7 +561,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
   },
   "acc-103": {
     accountName: "Tyrell Corp",
-    tier: "subscription",
+    tier: "basic",
     region: "eu-central-1",
     primaryContact: "Eldon Tyrell",
     primaryContactEmail: "eldon@tyrell.corp",
@@ -572,7 +572,7 @@ const CUSTOMER_CONTEXTS: Record<string, CaseCustomerContext> = {
 
 const FALLBACK_CUSTOMER: CaseCustomerContext = {
   accountName: "Unknown Account",
-  tier: "subscription",
+  tier: "basic",
   region: "unknown",
   primaryContact: "(no primary contact)",
   primaryContactEmail: "—",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useDeployedProductOptions.ts
@@ -20,19 +20,9 @@ import { useBackendApi } from "@api/backend/client";
 import type {
   BeDeployedProductSearchPayload,
   BeDeployedProductSearchResponse,
-  BeProductSearchPayload,
-  BeProductSearchResponse,
-  BeProductVersionSearchPayload,
-  BeProductVersionSearchResponse,
 } from "@api/backend/types";
 
 const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
-const PRODUCTS_LIMIT = BE_MAX_PAGE_LIMIT;
-// Bound the catalog scan: if referenced product ids can't be resolved (deleted
-// or bad data), don't page through an unbounded catalog. ~2000 products covered.
-// Doubled from 20 when the page limit halved to BE_MAX_PAGE_LIMIT, so the total
-// scan ceiling (pages * limit) is unchanged.
-const MAX_CATALOG_PAGES = 40;
 
 export interface DeployedProductOption {
   /** Deployed-product id — the value the case-create payload needs. */
@@ -43,10 +33,10 @@ export interface DeployedProductOption {
 
 /**
  * Selectable deployed products for a deployment. The deployed-product records
- * (`POST /deployments/{id}/products/search`) carry only `productId` /
- * `productVersionId`, so this resolves readable labels via `POST
- * /products/search` (id → name) and `POST /products/{id}/versions/search`
- * (id → version). Disabled until a deployment id is provided.
+ * (`POST /deployments/{id}/products/search`) embed the resolved `product` and
+ * `version` objects, so the readable label is built straight from those — no
+ * secondary product/version lookups needed. Disabled until a deployment id is
+ * provided.
  */
 export function useDeployedProductOptions(
   deploymentId: string | undefined,
@@ -63,73 +53,12 @@ export function useDeployedProductOptions(
         pagination: { offset: 0, limit: PAGE_LIMIT },
       });
       const deployed = dpRes.deployedProducts ?? [];
-      if (deployed.length === 0) return [];
-
-      const productIds = [
-        ...new Set(
-          deployed.map((d) => d.productId).filter((v): v is string => !!v),
-        ),
-      ];
-
-      // `/products/search` has no id filter, so page through it collecting
-      // names for the referenced product ids only — stop once every id is
-      // resolved or the catalog is exhausted. Without this, products beyond
-      // the first page collapse to a generic fallback label.
-      const productName = new Map<string, string>();
-      const unresolved = new Set(productIds);
-      const resolveProductNames = async (): Promise<void> => {
-        let offset = 0;
-        for (let page = 0; unresolved.size > 0 && page < MAX_CATALOG_PAGES; page += 1) {
-          const res = await api.post<
-            BeProductSearchPayload,
-            BeProductSearchResponse
-          >("/products/search", {
-            pagination: { offset, limit: PRODUCTS_LIMIT },
-          });
-          const products = res.products ?? [];
-          for (const p of products) {
-            if (unresolved.has(p.id)) {
-              productName.set(p.id, p.name ?? p.id);
-              unresolved.delete(p.id);
-            }
-          }
-          if (products.length < PRODUCTS_LIMIT) break;
-          offset += PRODUCTS_LIMIT;
-        }
-        // Any still-unresolved ids fall back to the id as their label below.
-      };
-
-      const [, versionLists] = await Promise.all([
-        resolveProductNames(),
-        Promise.all(
-          productIds.map((pid) =>
-            api
-              .post<
-                BeProductVersionSearchPayload,
-                BeProductVersionSearchResponse
-              >(`/products/${encodeURIComponent(pid)}/versions/search`, {
-                pagination: { offset: 0, limit: PAGE_LIMIT },
-              })
-              .then((r) => r.productVersions ?? [])
-              .catch(() => []),
-          ),
-        ),
-      ]);
-
-      const versionLabel = new Map<string, string>();
-      for (const versions of versionLists) {
-        for (const v of versions) versionLabel.set(v.id, v.version ?? "");
-      }
 
       return deployed.map((d) => {
         // Fall back to the product id (not a generic "Product") so distinct
-        // unresolved products stay distinguishable in the selector.
-        const name =
-          (d.productId && productName.get(d.productId)) ||
-          d.productId ||
-          "Product";
-        const ver =
-          (d.productVersionId && versionLabel.get(d.productVersionId)) || "";
+        // products with missing names stay distinguishable in the selector.
+        const name = d.product?.name || d.product?.id || "Product";
+        const ver = d.version?.name ?? "";
         return { id: d.id, label: ver ? `${name} ${ver}` : name };
       });
     },

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -19,11 +19,7 @@ import { useLogger } from "@hooks/useLogger";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
 import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
-import type {
-  BeCaseView,
-  BeProjectAccountRef,
-  BeProjectDetail,
-} from "@api/backend/types";
+import type { BeCaseView } from "@api/backend/types";
 import { getMockCsmCaseDetailById } from "@features/csm-cases/api/mocks/casesMocks";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 
@@ -31,16 +27,14 @@ const MOCK_LATENCY_MS = 150;
 
 /**
  * Build a CsmCaseDetail from the rich `BeCaseView`. The view embeds the
- * project / deployment / deployed-product / reporter as objects, so their
- * display names come straight off the response. Only the account (customer)
- * name is not embedded and is passed in after a best-effort lookup. Side
- * widgets the backend doesn't return yet (SLA clocks, watchers, tags, time
- * logs, attachments, linked items) default to empty / placeholder values.
+ * account / project / deployment / deployed-product / reporter as objects, so
+ * their names (and the account tier) come straight off the response with no
+ * extra lookups. Side widgets the backend doesn't return yet (SLA clocks,
+ * watchers, tags, time logs, attachments, linked items) default to empty /
+ * placeholder values.
  */
-function detailFromBeCase(
-  c: BeCaseView,
-  account?: BeProjectAccountRef,
-): CsmCaseDetail {
+function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
+  const account = c.account;
   const customer = account?.name ?? "—";
   const reporter = c.createdBy?.displayName ?? c.createdBy?.email;
   const product = c.deployedProduct?.displayName ?? "—";
@@ -71,15 +65,15 @@ function detailFromBeCase(
     createdByEmail: c.createdBy?.email,
     customerContext: {
       accountName: customer,
-      // Real account tier (basic/enterprise) from the embedded project account;
-      // default to basic when the account didn't resolve.
-      tier: account?.tier ?? "basic",
-      region: account?.region ?? "—",
+      // Account tier from the embedded account's `type` (e.g. "Enterprise");
+      // free-form, so tolerated downstream by tierLabel/tierColor.
+      tier: account?.type ?? "",
+      // The CaseView account ref carries only id/name/type, so region and the
+      // account manager aren't available here.
+      region: "—",
       // The reporter (createdBy) is the customer-side person who opened it.
       primaryContact: reporter ?? "—",
       primaryContactEmail: c.createdBy?.email ?? "—",
-      // The embedded project account ref doesn't carry the owner; leave the
-      // account manager unresolved until a dedicated field is available.
       accountManager: "—",
       openCases: 0,
     },
@@ -129,28 +123,10 @@ export function useGetCsmCaseDetail(
       );
       if (!beCase) return null;
 
-      // The CaseView already embeds project / deployment / deployed-product /
-      // reporter names, so no lookups are needed for those. The account
-      // (customer name + tier + region) isn't on the CaseView, but the
-      // project-detail response embeds it, so one project fetch resolves it —
-      // no separate account call. Failures degrade gracefully: the case still
-      // renders with a "—" customer.
-      let account: BeProjectAccountRef | undefined;
-      if (beCase.project?.id) {
-        try {
-          const fullProject = await api.get<BeProjectDetail>(
-            `/projects/${encodeURIComponent(beCase.project.id)}`,
-          );
-          account = fullProject?.account;
-        } catch (err) {
-          logger.warn(
-            `[useGetCsmCaseDetail] account hydrate failed: ${
-              (err as Error).message
-            }`,
-          );
-        }
-      }
-      return detailFromBeCase(beCase, account);
+      // The CaseView embeds account / project / deployment / deployed-product /
+      // reporter, so the whole detail builds from this one response — no
+      // follow-up lookups.
+      return detailFromBeCase(beCase);
     },
     enabled: !!caseId,
     staleTime: 30_000,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -20,9 +20,9 @@ import { ApiQueryKeys } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
 import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
 import type {
-  BeAccount,
   BeCaseView,
-  BeProject,
+  BeProjectAccountRef,
+  BeProjectDetail,
 } from "@api/backend/types";
 import { getMockCsmCaseDetailById } from "@features/csm-cases/api/mocks/casesMocks";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
@@ -39,7 +39,7 @@ const MOCK_LATENCY_MS = 150;
  */
 function detailFromBeCase(
   c: BeCaseView,
-  account?: BeAccount,
+  account?: BeProjectAccountRef,
 ): CsmCaseDetail {
   const customer = account?.name ?? "—";
   const reporter = c.createdBy?.displayName ?? c.createdBy?.email;
@@ -71,12 +71,16 @@ function detailFromBeCase(
     createdByEmail: c.createdBy?.email,
     customerContext: {
       accountName: customer,
-      tier: "subscription",
+      // Real account tier (basic/enterprise) from the embedded project account;
+      // default to basic when the account didn't resolve.
+      tier: account?.tier ?? "basic",
       region: account?.region ?? "—",
       // The reporter (createdBy) is the customer-side person who opened it.
       primaryContact: reporter ?? "—",
       primaryContactEmail: c.createdBy?.email ?? "—",
-      accountManager: account?.ownerId ?? "—",
+      // The embedded project account ref doesn't carry the owner; leave the
+      // account manager unresolved until a dedicated field is available.
+      accountManager: "—",
       openCases: 0,
     },
     productContext: {
@@ -126,23 +130,18 @@ export function useGetCsmCaseDetail(
       if (!beCase) return null;
 
       // The CaseView already embeds project / deployment / deployed-product /
-      // reporter names, so no lookups are needed for those. Only the account
-      // (customer) name is not embedded — resolve it best-effort via the
-      // project's account (the embedded project ref carries id + name only, so
-      // fetch the full project for its accountId, then the account). Failures
-      // degrade gracefully: the case still renders with a "—" customer.
-      let account: BeAccount | undefined;
+      // reporter names, so no lookups are needed for those. The account
+      // (customer name + tier + region) isn't on the CaseView, but the
+      // project-detail response embeds it, so one project fetch resolves it —
+      // no separate account call. Failures degrade gracefully: the case still
+      // renders with a "—" customer.
+      let account: BeProjectAccountRef | undefined;
       if (beCase.project?.id) {
         try {
-          const fullProject = await api.get<BeProject>(
+          const fullProject = await api.get<BeProjectDetail>(
             `/projects/${encodeURIComponent(beCase.project.id)}`,
           );
-          if (fullProject?.accountId) {
-            account =
-              (await api.get<BeAccount>(
-                `/accounts/${encodeURIComponent(fullProject.accountId)}`,
-              )) ?? undefined;
-          }
+          account = fullProject?.account;
         } catch (err) {
           logger.warn(
             `[useGetCsmCaseDetail] account hydrate failed: ${

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/usePostCsmCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/usePostCsmCase.ts
@@ -21,57 +21,59 @@ import {
 } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
-import type { BeCase, BeCaseCreatePayload } from "@api/backend/types";
+import type {
+  BeCaseCreatePayload,
+  BeCaseCreateResponse,
+  BeCreatedCase,
+} from "@api/backend/types";
 
 const MOCK_LATENCY_MS = 200;
 
 /**
- * Create a case via `POST /cases`. Returns the created case. The mutation
- * also invalidates project-scoped case searches so list views refresh.
+ * Create a case via `POST /cases`. The backend wraps the result in a
+ * `{ message, case }` envelope, so this unwraps and returns the created case
+ * (its `id` drives the post-create redirect). The mutation also invalidates
+ * project-scoped case searches so list views refresh.
  *
  * In MOCK mode the mutation resolves with a fabricated case using the input
  * payload; nothing is persisted server-side.
  */
 export function usePostCsmCase(): UseMutationResult<
-  BeCase,
+  BeCreatedCase,
   Error,
   BeCaseCreatePayload
 > {
   const api = useBackendApi();
   const queryClient = useQueryClient();
 
-  return useMutation<BeCase, Error, BeCaseCreatePayload>({
-    mutationFn: async (input): Promise<BeCase> => {
+  return useMutation<BeCreatedCase, Error, BeCaseCreatePayload>({
+    mutationFn: async (input): Promise<BeCreatedCase> => {
       if (isMockMode()) {
         await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
         const now = new Date().toISOString();
         return {
           id: `mock-${Math.random().toString(36).slice(2, 10)}`,
           number: `CS-MOCK-${Math.floor(Math.random() * 9000) + 1000}`,
-          projectId: input.projectId,
-          deploymentId: input.deploymentId,
-          deployedProductId: input.deployedProductId,
-          subject: input.subject,
-          description: input.description,
-          priority: input.priority,
-          issueType: input.issueType,
-          state: "open",
-          createdAt: now,
-          updatedAt: now,
+          createdBy: "mock@wso2.com",
+          createdOn: now,
+          state: "Open",
         };
       }
-      return api.post<BeCaseCreatePayload, BeCase>("/cases", input);
+      const res = await api.post<BeCaseCreatePayload, BeCaseCreateResponse>(
+        "/cases",
+        input,
+      );
+      return res.case;
     },
-    onSuccess: (created) => {
-      // Invalidate any project-scoped search for the case's project.
-      if (created.projectId) {
-        queryClient.invalidateQueries({
-          queryKey: [
-            ApiQueryKeys.BACKEND_PROJECT_CASES_SEARCH,
-            created.projectId,
-          ],
-        });
-      }
+    // The create response carries no projectId, so invalidate the project-scoped
+    // search using the submitted payload's project instead.
+    onSuccess: (_created, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          ApiQueryKeys.BACKEND_PROJECT_CASES_SEARCH,
+          variables.projectId,
+        ],
+      });
       // And the cross-project CSM cases list (fan-out aggregation).
       queryClient.invalidateQueries({ queryKey: [ApiQueryKeys.CSM_CASES] });
     },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
@@ -54,7 +54,10 @@ export default function AsyncProjectSelect({
   const debounced = useDebouncedValue(searchTerm, 300);
   const query = debounced.trim();
 
-  const { data, isFetching } = useProjectSearch(query, query.length > 0);
+  const { data, isFetching, isError } = useProjectSearch(
+    query,
+    query.length > 0,
+  );
 
   // Captured at selection time so the field stays labelled once the search
   // results change to a different term.
@@ -102,18 +105,27 @@ export default function AsyncProjectSelect({
       noOptionsText={
         query.length === 0
           ? "Type to search projects…"
-          : isFetching
-            ? "Searching…"
-            : "No projects found"
+          : isError
+            ? "Could not load projects"
+            : isFetching
+              ? "Searching…"
+              : "No projects found"
       }
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          label={label}
-          required={required}
-          placeholder={value ? undefined : "Type a project…"}
-        />
-      )}
+      renderInput={(params) => {
+        const failed = query.length > 0 && isError;
+        return (
+          <TextField
+            {...params}
+            label={label}
+            required={required}
+            placeholder={value ? undefined : "Type a project…"}
+            error={failed}
+            helperText={
+              failed ? "Project search failed. Type to retry." : undefined
+            }
+          />
+        );
+      }}
     />
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Autocomplete, TextField } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useProjectSearch } from "@features/csm-cases/api/useProjectSearch";
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+interface AsyncProjectSelectProps {
+  id?: string;
+  label?: string;
+  /** Selected project id ("" when none). */
+  value: string;
+  onChange: (next: string) => void;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+/**
+ * Single-project picker that searches the backend as the user types instead of
+ * loading the whole project catalogue up front (see {@link useProjectSearch}).
+ * The name of the picked project is remembered so the field keeps its label
+ * even after the search term — and its results — move on.
+ */
+export default function AsyncProjectSelect({
+  id = "case-project",
+  label = "Project",
+  value,
+  onChange,
+  required,
+  disabled,
+}: AsyncProjectSelectProps): JSX.Element {
+  // Tracked separately from the displayed input value (which MUI manages and
+  // shows the selected project's name) so the type-ahead query keeps working.
+  const [searchTerm, setSearchTerm] = useState("");
+  const debounced = useDebouncedValue(searchTerm, 300);
+  const query = debounced.trim();
+
+  const { data, isFetching } = useProjectSearch(query, query.length > 0);
+
+  // Captured at selection time so the field stays labelled once the search
+  // results change to a different term.
+  const [picked, setPicked] = useState<ProjectOption | null>(null);
+
+  const selectedOption = useMemo<ProjectOption | null>(() => {
+    if (!value) return null;
+    if (picked && picked.id === value) return picked;
+    const match = (data ?? []).find((p) => p.id === value);
+    if (match) return { id: match.id, name: match.name || match.id };
+    return { id: value, name: value };
+  }, [value, picked, data]);
+
+  // Pool = the current selection (so it can render) + the search results,
+  // de-duplicated by id.
+  const options = useMemo<ProjectOption[]>(() => {
+    const results = (data ?? []).map((p) => ({ id: p.id, name: p.name || p.id }));
+    if (selectedOption && !results.some((o) => o.id === selectedOption.id)) {
+      return [selectedOption, ...results];
+    }
+    return results;
+  }, [data, selectedOption]);
+
+  return (
+    <Autocomplete<ProjectOption>
+      fullWidth
+      size="small"
+      id={id}
+      options={options}
+      value={selectedOption}
+      disabled={disabled}
+      loading={isFetching}
+      // The backend already filtered by the typed term; don't re-filter locally.
+      filterOptions={(opts) => opts}
+      getOptionLabel={(opt) => opt.name}
+      isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      onChange={(_event, next) => {
+        setPicked(next);
+        onChange(next ? next.id : "");
+      }}
+      onInputChange={(_event, val, reason) => {
+        if (reason === "input") setSearchTerm(val);
+        else if (reason === "clear") setSearchTerm("");
+      }}
+      noOptionsText={
+        query.length === 0
+          ? "Type to search projects…"
+          : isFetching
+            ? "Searching…"
+            : "No projects found"
+      }
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          required={required}
+          placeholder={value ? undefined : "Type a project…"}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -61,7 +61,7 @@ import type {
   CaseWatcher,
   DeploymentCategory,
 } from "@features/csm-cases/types/csmCases";
-import { TIER_COLOR, TIER_LABEL } from "@features/csm-cases/utils/caseTier";
+import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import {
   SLA_CLOCK_LABEL,
   formatTimeToBreach,
@@ -148,8 +148,8 @@ export function CustomerContextWidget({
       action={
         <Chip
           size="small"
-          label={TIER_LABEL[ctx.tier]}
-          color={TIER_COLOR[ctx.tier]}
+          label={tierLabel(ctx.tier)}
+          color={tierColor(ctx.tier)}
         />
       }
     >

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -18,7 +18,7 @@ import { Box, Card, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
-import { TIER_COLOR, TIER_LABEL } from "@features/csm-cases/utils/caseTier";
+import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import SemanticChip from "@components/SemanticChip";
 
@@ -123,7 +123,7 @@ export default function CaseMetaBand({
   const projectType = c.projectName?.split(" - ")[1]?.trim() || "—";
   // One-line digest shown when the band is collapsed, so collapsing doesn't
   // hide every triage fact — account, tier, and who owns the case stay visible.
-  const collapsedSummary = [c.customer, TIER_LABEL[tier], c.assignee]
+  const collapsedSummary = [c.customer, tierLabel(tier), c.assignee]
     .filter(Boolean)
     .join(" · ");
 
@@ -190,7 +190,7 @@ export default function CaseMetaBand({
         >
           <Cell label="Tier">
             <Box sx={{ minWidth: 0 }}>
-              <SemanticChip role={TIER_COLOR[tier]} label={TIER_LABEL[tier]} />
+              <SemanticChip role={tierColor(tier)} label={tierLabel(tier)} />
             </Box>
           </Cell>
           <Cell label="Assignee">

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -106,9 +106,9 @@ function LinkText({
 
 /**
  * Always-visible facts band shown directly under the case header. Engineers
- * see assignee, deployment/product/version, who created the case, and which
- * account/project it belongs to without diving into a tab. The chevron in the
- * top-right collapses the band body into a slim header strip.
+ * see assignee, project type, deployment/product, who created the case, and
+ * which account/project it belongs to without diving into a tab. The chevron in
+ * the top-right collapses the band body into a slim header strip.
  */
 export default function CaseMetaBand({
   detail: c,
@@ -117,10 +117,10 @@ export default function CaseMetaBand({
 }: CaseMetaBandProps): JSX.Element {
   const product = c.productContext;
   const tier = c.customerContext.tier;
-  const versionLabel =
-    product.updateLevel && product.updateLevel.trim().length > 0
-      ? product.updateLevel
-      : product.version || "—";
+  // Project type is encoded as the second " - "-delimited segment of the
+  // project name (e.g. "Acme - Managed Cloud" → "Managed Cloud"). Temporary
+  // until the backend exposes it as a first-class field.
+  const projectType = c.projectName?.split(" - ")[1]?.trim() || "—";
   // One-line digest shown when the band is collapsed, so collapsing doesn't
   // hide every triage fact — account, tier, and who owns the case stay visible.
   const collapsedSummary = [c.customer, TIER_LABEL[tier], c.assignee]
@@ -229,6 +229,11 @@ export default function CaseMetaBand({
               </Typography>
             )}
           </Cell>
+          <Cell label="Project type">
+            <Typography variant="body2" noWrap>
+              {projectType}
+            </Typography>
+          </Cell>
           <Cell label="Deployment">
             <Typography variant="body2" noWrap>
               {product.deployment ?? "—"}
@@ -237,11 +242,6 @@ export default function CaseMetaBand({
           <Cell label="Product">
             <Typography variant="body2" noWrap>
               {product.product ?? "—"}
-            </Typography>
-          </Cell>
-          <Cell label="Version">
-            <Typography variant="body2" noWrap>
-              {versionLabel}
             </Typography>
           </Cell>
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -33,7 +33,7 @@ import { useNavigate } from "react-router";
 import { priorityFromSeverity } from "@api/backend/mappers";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
-import { useProjectOptions } from "@features/csm-cases/api/useProjectOptions";
+import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
@@ -69,17 +69,15 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const [subject, setSubject] = useState("");
   const [description, setDescription] = useState("");
 
-  const projects = useProjectOptions();
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
 
   // When a selector query fails the form becomes non-completable, so surface it
-  // with an explicit retry rather than leaving an empty dropdown.
-  const hasOptionsError =
-    projects.isError || deployments.isError || deployedProducts.isError;
+  // with an explicit retry rather than leaving an empty dropdown. (Projects are
+  // searched on demand by AsyncProjectSelect, which reports its own state.)
+  const hasOptionsError = deployments.isError || deployedProducts.isError;
   const retryOptions = (): void => {
-    if (projects.isError) void projects.refetch();
     if (deployments.isError) void deployments.refetch();
     if (deployedProducts.isError) void deployedProducts.refetch();
   };
@@ -172,22 +170,11 @@ export default function CsmCaseCreatePage(): JSX.Element {
         )}
         <Grid container spacing={2.5}>
           <Grid size={{ xs: 12, md: 4 }}>
-            <FormControl fullWidth size="small" required>
-              <InputLabel id="case-project-label">Project</InputLabel>
-              <Select
-                labelId="case-project-label"
-                label="Project"
-                value={projectId}
-                onChange={(e) => onProjectChange(String(e.target.value))}
-                disabled={projects.isLoading}
-              >
-                {(projects.data ?? []).map((p) => (
-                  <MenuItem key={p.id} value={p.id}>
-                    {p.name ?? p.id}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <AsyncProjectSelect
+              value={projectId}
+              onChange={onProjectChange}
+              required
+            />
           </Grid>
 
           <Grid size={{ xs: 12, md: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -61,7 +61,7 @@ import {
   TimeLogsWidget,
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
-import { TIER_COLOR, TIER_LABEL } from "@features/csm-cases/utils/caseTier";
+import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
@@ -621,8 +621,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
             />
             <Chip
               size="small"
-              label={TIER_LABEL[c.customerContext.tier]}
-              color={TIER_COLOR[c.customerContext.tier]}
+              label={tierLabel(c.customerContext.tier)}
+              color={tierColor(c.customerContext.tier)}
             />
             {!isClosed && hasSlaData && (
               <Chip

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -61,7 +61,6 @@ import {
   TimeLogsWidget,
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
-import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
@@ -618,11 +617,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
               label={stateLabel(c.state)}
               color={stateColor(c.state)}
               sx={{ fontWeight: 600 }}
-            />
-            <Chip
-              size="small"
-              label={tierLabel(c.customerContext.tier)}
-              color={tierColor(c.customerContext.tier)}
             />
             {!isClosed && hasSlaData && (
               <Chip

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -96,7 +96,7 @@ export default function CsmCasesPage(): JSX.Element {
   const { data: directoryUsers } = useDirectoryUsers();
   const { showError } = useErrorBanner();
   const hasShownErrorRef = useRef(false);
-  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(true);
 
   useEffect(() => {
     if (isError && !hasShownErrorRef.current) {

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -106,8 +106,12 @@ export interface CaseAttachment {
   uploadedAt: string;
 }
 
-/** Account tier, mirroring the entity-service account `tier` enum. */
-export type CustomerTier = "basic" | "enterprise";
+/**
+ * Account tier as shown on a case. Free-form: the CaseView's `account.type` is
+ * the PG `basic|enterprise` enum for native cases but a raw ServiceNow support
+ * tier (e.g. "Enterprise") for SN-sourced ones, so render it defensively.
+ */
+export type CustomerTier = string;
 
 export type SlaClockState = "running" | "paused" | "met" | "breached";
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -106,8 +106,8 @@ export interface CaseAttachment {
   uploadedAt: string;
 }
 
-/** Plan/tier the customer holds for the affected product. */
-export type CustomerTier = "subscription" | "managed_cloud" | "saas" | "trial";
+/** Account tier, mirroring the entity-service account `tier` enum. */
+export type CustomerTier = "basic" | "enterprise";
 
 export type SlaClockState = "running" | "paused" | "met" | "breached";
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
@@ -15,24 +15,36 @@
 // under the License.
 
 import type { CustomerTier } from "@features/csm-cases/types/csmCases";
+import type { SemanticRole } from "@components/SemanticChip";
 
 // Single source of truth for how a customer tier is labelled and coloured.
 // Lives in its own module (not a component file) so the header chip-row, the
 // meta band, and the Customer widget can all share it without tripping the
 // react-refresh "components-only export" rule.
-export const TIER_LABEL: Record<CustomerTier, string> = {
-  basic: "Basic",
-  enterprise: "Enterprise",
-};
+//
+// Tier is free-form (PG `basic|enterprise` for native cases, raw ServiceNow
+// support tiers like "Enterprise" for SN-sourced ones), so these tolerate any
+// string and fall back instead of assuming a closed set.
+
+/** Title-case a raw tier token, e.g. "managed_cloud" → "Managed Cloud". */
+function titleCase(s: string): string {
+  return s
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+/** Human label for a tier; "—" when unset, otherwise the title-cased value. */
+export function tierLabel(tier: CustomerTier | undefined): string {
+  const t = (tier ?? "").trim();
+  return t ? titleCase(t) : "—";
+}
 
 // Tier is metadata, not an action, so it must not wear the brand accent
 // (`primary`/orange) — that fails WCAG contrast (white-on-#F87643 ~ 2.7:1) and
-// would paint case headers orange. basic renders neutral; enterprise takes a
-// contrast-safe semantic role (its contrastText is dark in this theme).
-export const TIER_COLOR: Record<
-  CustomerTier,
-  "default" | "info" | "success" | "warning"
-> = {
-  basic: "default",
-  enterprise: "info",
-};
+// would paint case headers orange. Enterprise takes a contrast-safe semantic
+// role; everything else (incl. unknown tiers) renders neutral.
+export function tierColor(tier: CustomerTier | undefined): SemanticRole {
+  return (tier ?? "").trim().toLowerCase() === "enterprise" ? "info" : "default";
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseTier.ts
@@ -21,23 +21,18 @@ import type { CustomerTier } from "@features/csm-cases/types/csmCases";
 // meta band, and the Customer widget can all share it without tripping the
 // react-refresh "components-only export" rule.
 export const TIER_LABEL: Record<CustomerTier, string> = {
-  subscription: "Subscription",
-  managed_cloud: "Managed Cloud",
-  saas: "SaaS",
-  trial: "Trial",
+  basic: "Basic",
+  enterprise: "Enterprise",
 };
 
 // Tier is metadata, not an action, so it must not wear the brand accent
-// (`primary`/orange). subscription is the most common tier, so colouring it
-// orange painted nearly every case header orange and also failed WCAG contrast
-// (white-on-#F87643 ~ 2.7:1). It renders neutral; the chromatic tiers stay on
-// contrast-safe semantic roles (their contrastText is dark in this theme).
+// (`primary`/orange) — that fails WCAG contrast (white-on-#F87643 ~ 2.7:1) and
+// would paint case headers orange. basic renders neutral; enterprise takes a
+// contrast-safe semantic role (its contrastText is dark in this theme).
 export const TIER_COLOR: Record<
   CustomerTier,
   "default" | "info" | "success" | "warning"
 > = {
-  subscription: "default",
-  managed_cloud: "success",
-  saas: "info",
-  trial: "warning",
+  basic: "default",
+  enterprise: "info",
 };

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -49,7 +49,7 @@ function casesHref(severity?: Severity, state?: CaseState): string {
   return qs ? `/cases?${qs}` : "/cases";
 }
 
-/** A count rendered as a link when > 0, muted "0" otherwise. */
+/** A count rendered as a link, styled the same whether the value is 0 or more. */
 function CountCell({
   value,
   href,
@@ -61,28 +61,21 @@ function CountCell({
 }): JSX.Element {
   return (
     <TableCell align="center">
-      {value > 0 ? (
-        <Link
-          component={RouterLink}
-          to={href}
-          underline="hover"
-          color="inherit"
-          sx={{
-            // Larger, heavier numbers so the counts read at a glance from across
-            // the dashboard, not just on close inspection.
-            fontSize: bold ? "1.35rem" : "1.2rem",
-            fontWeight: bold ? 700 : 600,
-            lineHeight: 1,
-          }}
-        >
-          {value}
-        </Link>
-      ) : (
-        // Zeros stay small and muted so the eye lands on the cells that matter.
-        <Typography component="span" variant="body2" color="text.disabled">
-          0
-        </Typography>
-      )}
+      <Link
+        component={RouterLink}
+        to={href}
+        underline="hover"
+        color="inherit"
+        sx={{
+          // Larger, heavier numbers so the counts read at a glance from across
+          // the dashboard, not just on close inspection.
+          fontSize: bold ? "1.35rem" : "1.2rem",
+          fontWeight: bold ? 700 : 600,
+          lineHeight: 1,
+        }}
+      >
+        {value}
+      </Link>
     </TableCell>
   );
 }


### PR DESCRIPTION
## What

Frontend-only changes to the CSM portal.

### Case create page
- **Project field is now a type-ahead search.** Previously the page paged through the entire project catalogue (hundreds of records) on mount before the form was usable. It now uses a new `AsyncProjectSelect` that queries the backend as the user types (debounced, first page of matches only), mirroring the existing async project filter on the case list.
- **Deployed-product labels fixed.** The deployed-product records returned by the backend already embed resolved `product` and `version` objects, but the option builder was reading flat fields that don't exist in that shape, so every option collapsed to a generic `Product` label. It now reads the embedded objects and renders `"{product name} {version}"` directly. This also removes the obsolete secondary lookups (paging `/products/search` and a per-product versions search), so the dropdown populates from the single deployed-products call.

### Case list page
- The filter panel now starts **expanded** by default instead of collapsed.

### Dashboard
- In the **Cases by severity and state** matrix, `0` cells now use the same size, weight, and link treatment as non-zero counts, so the grid reads consistently instead of muting the zeros.

## Notes
- The FE `BeDeployedProduct` type was corrected to match the nested shape the backend actually returns.
- Verified with `pnpm lint` and `pnpm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an async Project selector with debounced, backend-backed search and stable selection during results updates.
  * Improved deployed product selection using embedded product/version data for smoother loading.

* **UI/UX Improvements**
  * Case filters panel now opens by default on the CSM Cases page.
  * Case count values are always shown as clickable links.
  * Case metadata band now highlights “Project type” and updates the shown fact set.

* **Data & Display Updates**
  * Customer tier values and related labels/colors now support only **basic** and **enterprise**.
  * Case detail customer context is updated to use embedded project account information with safe fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->