### PR TITLE
[Customer Entity] Align schema, resolve createdBy from JWT, and add ServiceNow support for Case Comments

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -654,10 +654,23 @@ type CaseComment struct {
 // CreateCaseCommentRequest is the input for creating a new case comment.
 // CaseID is populated from the URL path parameter and is not part of the JSON body.
 type CreateCaseCommentRequest struct {
-	CaseID string      `json:"-"`
-	Type   CommentType `json:"type"`
+	CaseID    string      `json:"-"`
+	CreatedBy string      `json:"-"`
+	Type      CommentType `json:"type"`
 	Content   string      `json:"content"`
-	CreatedBy string      `json:"createdBy"`
+}
+
+// CreateCaseCommentResponse is the response for creating a new case comment.
+type CreateCaseCommentResponse struct {
+	Message string            `json:"message"`
+	Comment CaseCommentDetail `json:"comment"`
+}
+
+// CaseCommentDetail holds the core fields returned after creating a comment.
+type CaseCommentDetail struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
 }
 
 // SearchCaseCommentsRequest is the input for listing comments on a case.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -645,17 +645,17 @@ const (
 type CaseComment struct {
 	ID          string      `json:"id"`
 	CaseID      string      `json:"caseId"`
-	CommentType CommentType `json:"commentType"`
-	Body        string      `json:"body"`
-	CreatedBy   string      `json:"createdBy"`
-	CreatedAt   time.Time   `json:"createdAt"`
+	Type      CommentType `json:"type"`
+	Body      string      `json:"body"`
+	CreatedBy string      `json:"createdBy"`
+	CreatedAt time.Time   `json:"createdAt"`
 }
 
 // CreateCaseCommentRequest is the input for creating a new case comment.
 // CaseID is populated from the URL path parameter and is not part of the JSON body.
 type CreateCaseCommentRequest struct {
-	CaseID      string      `json:"-"`
-	CommentType CommentType `json:"commentType"`
+	CaseID string      `json:"-"`
+	Type   CommentType `json:"type"`
 	Body        string      `json:"body"`
 	CreatedBy   string      `json:"createdBy"`
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -646,7 +646,7 @@ type CaseComment struct {
 	ID          string      `json:"id"`
 	CaseID      string      `json:"caseId"`
 	Type      CommentType `json:"type"`
-	Body      string      `json:"body"`
+	Content   string      `json:"content"`
 	CreatedBy string      `json:"createdBy"`
 	CreatedAt time.Time   `json:"createdAt"`
 }
@@ -656,8 +656,8 @@ type CaseComment struct {
 type CreateCaseCommentRequest struct {
 	CaseID string      `json:"-"`
 	Type   CommentType `json:"type"`
-	Body        string      `json:"body"`
-	CreatedBy   string      `json:"createdBy"`
+	Content   string      `json:"content"`
+	CreatedBy string      `json:"createdBy"`
 }
 
 // SearchCaseCommentsRequest is the input for listing comments on a case.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -86,14 +86,14 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	req.CaseID = r.PathValue("id")
-	comment, err := h.svc.CreateCaseComment(r.Context(), req)
+	resp, err := h.svc.CreateCaseComment(r.Context(), req)
 	if err != nil {
 		writeServiceError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(comment)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // SearchCaseComments handles POST /cases/{id}/comments/search.

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -171,14 +171,14 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 // CreateCaseComment implements CaseRepository.
 func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
 	const query = `
-		INSERT INTO case_comments (case_id, comment_type, body, created_by)
+		INSERT INTO case_comments (case_id, type, body, created_by)
 		VALUES ($1, $2::comment_type_enum, $3, $4)
-		RETURNING id, case_id, comment_type, body, created_by, created_at`
+		RETURNING id, case_id, type, body, created_by, created_at`
 
 	var c domain.CaseComment
 	err := r.db.QueryRow(ctx, query,
-		req.CaseID, string(req.CommentType), req.Body, req.CreatedBy,
-	).Scan(&c.ID, &c.CaseID, &c.CommentType, &c.Body, &c.CreatedBy, &c.CreatedAt)
+		req.CaseID, string(req.Type), req.Body, req.CreatedBy,
+	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Body, &c.CreatedBy, &c.CreatedAt)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 			switch pgErr.Code {
@@ -197,7 +197,7 @@ func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseC
 func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error) {
 	const countQuery = `SELECT COUNT(*) FROM case_comments WHERE case_id = $1`
 	const dataQuery = `
-		SELECT id, case_id, comment_type, body, created_by, created_at
+		SELECT id, case_id, type, body, created_by, created_at
 		FROM case_comments
 		WHERE case_id = $1
 		ORDER BY created_at DESC, id
@@ -225,7 +225,7 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 		result := make([]domain.CaseComment, 0, req.Pagination.Limit)
 		for rows.Next() {
 			var c domain.CaseComment
-			if err := rows.Scan(&c.ID, &c.CaseID, &c.CommentType, &c.Body, &c.CreatedBy, &c.CreatedAt); err != nil {
+			if err := rows.Scan(&c.ID, &c.CaseID, &c.Type, &c.Body, &c.CreatedBy, &c.CreatedAt); err != nil {
 				return fmt.Errorf("scan case comment: %w", err)
 			}
 			result = append(result, c)

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -171,14 +171,14 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 // CreateCaseComment implements CaseRepository.
 func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
 	const query = `
-		INSERT INTO case_comments (case_id, type, body, created_by)
+		INSERT INTO case_comments (case_id, type, content, created_by)
 		VALUES ($1, $2::comment_type_enum, $3, $4)
-		RETURNING id, case_id, type, body, created_by, created_at`
+		RETURNING id, case_id, type, content, created_by, created_at`
 
 	var c domain.CaseComment
 	err := r.db.QueryRow(ctx, query,
-		req.CaseID, string(req.Type), req.Body, req.CreatedBy,
-	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Body, &c.CreatedBy, &c.CreatedAt)
+		req.CaseID, string(req.Type), req.Content, req.CreatedBy,
+	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedAt)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 			switch pgErr.Code {
@@ -197,7 +197,7 @@ func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseC
 func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error) {
 	const countQuery = `SELECT COUNT(*) FROM case_comments WHERE case_id = $1`
 	const dataQuery = `
-		SELECT id, case_id, type, body, created_by, created_at
+		SELECT id, case_id, type, content, created_by, created_at
 		FROM case_comments
 		WHERE case_id = $1
 		ORDER BY created_at DESC, id
@@ -225,7 +225,7 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 		result := make([]domain.CaseComment, 0, req.Pagination.Limit)
 		for rows.Next() {
 			var c domain.CaseComment
-			if err := rows.Scan(&c.ID, &c.CaseID, &c.Type, &c.Body, &c.CreatedBy, &c.CreatedAt); err != nil {
+			if err := rows.Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedAt); err != nil {
 				return fmt.Errorf("scan case comment: %w", err)
 			}
 			result = append(result, c)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -163,20 +163,41 @@ var validCommentType = map[domain.CommentType]bool{
 }
 
 // CreateCaseComment implements CaseService.
-func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
+func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CreateCaseCommentResponse, error) {
 	if err := validateUUIDs("caseId", []string{req.CaseID}); err != nil {
-		return domain.CaseComment{}, err
-	}
-	if err := validateUUIDs("createdBy", []string{req.CreatedBy}); err != nil {
-		return domain.CaseComment{}, err
+		return domain.CreateCaseCommentResponse{}, err
 	}
 	if !validCommentType[req.Type] {
-		return domain.CaseComment{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}
 	}
 	if req.Content == "" {
-		return domain.CaseComment{}, &apierror.ValidationError{Msg: "content is required"}
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "content is required"}
 	}
-	return s.repo.CreateCaseComment(ctx, req)
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.CreateCaseCommentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+	email, err := emailFromJWT(token)
+	if err != nil {
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "x-user-id-token: " + err.Error()}
+	}
+	user, err := s.userRepo.GetUserByEmail(ctx, email)
+	if err != nil {
+		return domain.CreateCaseCommentResponse{}, err
+	}
+	req.CreatedBy = user.ID
+	c, err := s.repo.CreateCaseComment(ctx, req)
+	if err != nil {
+		return domain.CreateCaseCommentResponse{}, err
+	}
+	return domain.CreateCaseCommentResponse{
+		Message: "Comment created successfully",
+		Comment: domain.CaseCommentDetail{
+			ID:        c.ID,
+			CreatedOn: c.CreatedAt,
+			CreatedBy: user.Email,
+		},
+	}, nil
 }
 
 // SearchCaseComments implements CaseService.

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -170,8 +170,8 @@ func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCa
 	if err := validateUUIDs("createdBy", []string{req.CreatedBy}); err != nil {
 		return domain.CaseComment{}, err
 	}
-	if !validCommentType[req.CommentType] {
-		return domain.CaseComment{}, &apierror.ValidationError{Msg: "commentType contains invalid value: " + string(req.CommentType)}
+	if !validCommentType[req.Type] {
+		return domain.CaseComment{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}
 	}
 	if req.Body == "" {
 		return domain.CaseComment{}, &apierror.ValidationError{Msg: "body is required"}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -173,8 +173,8 @@ func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCa
 	if !validCommentType[req.Type] {
 		return domain.CaseComment{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}
 	}
-	if req.Body == "" {
-		return domain.CaseComment{}, &apierror.ValidationError{Msg: "body is required"}
+	if req.Content == "" {
+		return domain.CaseComment{}, &apierror.ValidationError{Msg: "content is required"}
 	}
 	return s.repo.CreateCaseComment(ctx, req)
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -103,7 +103,7 @@ type CaseService interface {
 	SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error)
 	// CreateCaseComment creates a new comment on the case identified by req.CaseID.
 	// A ValidationError is returned for invalid input or constraint violations.
-	CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error)
+	CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CreateCaseCommentResponse, error)
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -354,8 +354,73 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	return cv, nil
 }
 
-func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CaseComment, error) {
-	return s.pgFallback.CreateCaseComment(ctx, req)
+type snCreateCommentPayload struct {
+	ReferenceID   string `json:"referenceId"`
+	ReferenceType string `json:"referenceType"`
+	Type          string `json:"type"`
+	Content       string `json:"content"`
+}
+
+type snCreateCommentResponse struct {
+	Message string `json:"message"`
+	Comment struct {
+		ID        string `json:"id"`
+		CreatedOn string `json:"createdOn"`
+		CreatedBy string `json:"createdBy"`
+	} `json:"comment"`
+}
+
+func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CreateCaseCommentResponse, error) {
+	if !validCommentType[req.Type] {
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}
+	}
+	if req.Content == "" {
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "content is required"}
+	}
+	if req.Type == domain.CommentTypeActivity {
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "type 'activity' is not supported for ServiceNow"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.CreateCaseCommentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	snType := string(req.Type)
+	if req.Type == domain.CommentTypeComment {
+		snType = "comments"
+	}
+
+	payload := snCreateCommentPayload{
+		ReferenceID:   uuidToSysid(req.CaseID),
+		ReferenceType: "case",
+		Type:          snType,
+		Content:       req.Content,
+	}
+
+	raw, err := s.client.Post(ctx, "/comments", token, payload)
+	if err != nil {
+		return domain.CreateCaseCommentResponse{}, err
+	}
+
+	var snResp snCreateCommentResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CreateCaseCommentResponse{}, fmt.Errorf("sn create comment: parse response: %w", err)
+	}
+
+	createdOn, err := time.Parse(snCreatedOnLayout, snResp.Comment.CreatedOn)
+	if err != nil {
+		return domain.CreateCaseCommentResponse{}, fmt.Errorf("sn create comment: parse createdOn %q: %w", snResp.Comment.CreatedOn, err)
+	}
+
+	return domain.CreateCaseCommentResponse{
+		Message: snResp.Message,
+		Comment: domain.CaseCommentDetail{
+			ID:        snResp.Comment.ID,
+			CreatedOn: createdOn,
+			CreatedBy: snResp.Comment.CreatedBy,
+		},
+	}, nil
 }
 
 func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error) {

--- a/entity-service/migrations/000009_create_case_comments.up.sql
+++ b/entity-service/migrations/000009_create_case_comments.up.sql
@@ -5,12 +5,12 @@ CREATE TYPE comment_type_enum AS ENUM (
 );
 
 CREATE TABLE case_comments (
-  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  case_id      UUID NOT NULL REFERENCES cases(id),
-  comment_type comment_type_enum NOT NULL,
-  body         TEXT NOT NULL,
-  created_by   TEXT NOT NULL REFERENCES users(id),
-  created_at   TIMESTAMP DEFAULT NOW()
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id    UUID NOT NULL REFERENCES cases(id),
+  type       comment_type_enum NOT NULL,
+  body       TEXT NOT NULL,
+  created_by TEXT NOT NULL REFERENCES users(id),
+  created_at TIMESTAMP DEFAULT NOW()
 );
 
 -- This function checks if a user has one of the allowed user types. It can be used in triggers or other functions to enforce access control based on user type.
@@ -42,7 +42,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION check_work_note_creator()
 RETURNS TRIGGER AS $$
 BEGIN
-  IF NEW.comment_type = 'work_note' THEN
+  IF NEW.type = 'work_note' THEN
     PERFORM assert_user_type_enum(
       NEW.created_by,
       ARRAY['internal']::user_type_enum[],
@@ -56,7 +56,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION check_activity_creator()
 RETURNS TRIGGER AS $$
 BEGIN
-  IF NEW.comment_type = 'activity' THEN
+  IF NEW.type = 'activity' THEN
     PERFORM assert_user_type_enum(
       NEW.created_by,
       ARRAY['internal', 'system']::user_type_enum[],
@@ -81,6 +81,6 @@ CREATE TRIGGER trg_check_activity_creator
 
 CREATE INDEX idx_case_comments_case_id    ON case_comments(case_id);
 CREATE INDEX idx_case_comments_created_by ON case_comments(created_by);
-CREATE INDEX idx_case_comments_type       ON case_comments(comment_type);
+CREATE INDEX idx_case_comments_type       ON case_comments(type);
 CREATE INDEX idx_case_comments_case_time  ON case_comments(case_id, created_at DESC);
-CREATE INDEX idx_case_comments_case_type  ON case_comments(case_id, comment_type);
+CREATE INDEX idx_case_comments_case_type  ON case_comments(case_id, type);

--- a/entity-service/migrations/000009_create_case_comments.up.sql
+++ b/entity-service/migrations/000009_create_case_comments.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE case_comments (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   case_id    UUID NOT NULL REFERENCES cases(id),
   type       comment_type_enum NOT NULL,
-  body       TEXT NOT NULL,
+  content    TEXT NOT NULL,
   created_by TEXT NOT NULL REFERENCES users(id),
   created_at TIMESTAMP DEFAULT NOW()
 );

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1341,7 +1341,7 @@ components:
 
     CreateCaseCommentRequest:
       type: object
-      required: [type, content, createdBy]
+      required: [type, content]
       properties:
         type:
           type: string
@@ -1349,9 +1349,6 @@ components:
           description: work_note is restricted to internal users; activity to internal and system users.
         content:
           type: string
-        createdBy:
-          type: string
-          description: UUID of the user creating the comment.
 
     CaseComment:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1341,9 +1341,9 @@ components:
 
     CreateCaseCommentRequest:
       type: object
-      required: [commentType, body, createdBy]
+      required: [type, body, createdBy]
       properties:
-        commentType:
+        type:
           type: string
           enum: [work_note, comment, activity]
           description: work_note is restricted to internal users; activity to internal and system users.
@@ -1360,7 +1360,7 @@ components:
           type: string
         caseId:
           type: string
-        commentType:
+        type:
           type: string
           enum: [work_note, comment, activity]
         body:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1341,13 +1341,13 @@ components:
 
     CreateCaseCommentRequest:
       type: object
-      required: [type, body, createdBy]
+      required: [type, content, createdBy]
       properties:
         type:
           type: string
           enum: [work_note, comment, activity]
           description: work_note is restricted to internal users; activity to internal and system users.
-        body:
+        content:
           type: string
         createdBy:
           type: string
@@ -1363,7 +1363,7 @@ components:
         type:
           type: string
           enum: [work_note, comment, activity]
-        body:
+        content:
           type: string
         createdBy:
           type: string


### PR DESCRIPTION
## Summary
- Renamed `comment_type` → `type` and `body` → `content` columns across migration, domain structs, repository queries, service validation, and OpenAPI spec
- Removed `createdBy` from the request body; resolved from JWT token (same pattern as case create) for both Postgres and ServiceNow datasources
- Implemented `CreateCaseComment` via the ServiceNow integration service with type mapping (`comment` → `comments`, `work_note` → `work_note`; `activity` rejected for SN)
- Introduced `CreateCaseCommentResponse` as the unified response shape for both datasources


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Case comment creation API request fields renamed: `commentType` and `body` now `type` and `content`
  * Request no longer accepts `createdBy` parameter (automatically derived from user authentication)
  * Response now includes message confirmation and detailed comment metadata with ID and created timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->