### PR TITLE
[CSM Portal][BE] fix(cases): remove user lookup from CreateCaseComment

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -19,7 +19,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -31,38 +30,6 @@ import (
 
 var uuidRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
-var errUserNotFound = errors.New("authenticated user not found in entity service")
-
-// resolveUserID looks up the entity-service UUID for the given email via users/search.
-// TODO: remove once DB-level auth propagates the entity UUID directly through the token.
-func resolveUserID(ctx context.Context, entity entityCaseClient, email string) (string, error) {
-	body, err := json.Marshal(map[string]any{
-		"searchQuery": email,
-		"pagination":  map[string]any{"limit": 1, "offset": 0},
-	})
-	if err != nil {
-		return "", err
-	}
-	resp, err := entity.SearchUsers(ctx, body)
-	if err != nil {
-		return "", err
-	}
-	var result struct {
-		Users []struct {
-			ID    string `json:"id"`
-			Email string `json:"email"`
-		} `json:"users"`
-	}
-	if err := json.Unmarshal(resp, &result); err != nil {
-		return "", err
-	}
-	// Verify exact email match — SearchUsers may perform fuzzy/prefix search.
-	if len(result.Users) == 0 || result.Users[0].Email != email {
-		return "", errUserNotFound
-	}
-	return result.Users[0].ID, nil
-}
-
 // stripField removes the named key from a JSON object body, if present.
 func stripField(body []byte, field string) ([]byte, error) {
 	var m map[string]json.RawMessage
@@ -70,23 +37,6 @@ func stripField(body []byte, field string) ([]byte, error) {
 		return nil, err
 	}
 	delete(m, field)
-	return json.Marshal(m)
-}
-
-// injectCreatedBy merges createdBy into a JSON request body.
-func injectCreatedBy(body []byte, userID string) ([]byte, error) {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(body, &m); err != nil {
-		return nil, err
-	}
-	if m == nil {
-		m = make(map[string]json.RawMessage)
-	}
-	id, err := json.Marshal(userID)
-	if err != nil {
-		return nil, err
-	}
-	m["createdBy"] = id
 	return json.Marshal(m)
 }
 
@@ -99,7 +49,6 @@ type entityCaseClient interface {
 	SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
-	SearchUsers(ctx context.Context, body []byte) ([]byte, error)
 }
 
 // CaseHandler handles HTTP requests for case operations, delegating to the
@@ -164,7 +113,7 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 }
 
 // CreateCaseComment handles POST /cases/{id}/comments.
-// createdBy is resolved server-side from the authenticated user's email.
+// createdBy is resolved by the entity service from the forwarded x-user-id-token.
 func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -194,26 +143,9 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	userID, err := resolveUserID(r.Context(), h.entity, user.Email)
+	result, err := h.entity.CreateCaseComment(r.Context(), caseID, body)
 	if err != nil {
-		if errors.Is(err, errUserNotFound) {
-			writeError(w, http.StatusForbidden, ErrMsgForbidden)
-			return
-		}
-		slog.ErrorContext(r.Context(), "resolveUserID failed", "email", user.Email, "err", err)
-		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
-		return
-	}
-
-	entityBody, err := injectCreatedBy(body, userID)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
-		return
-	}
-
-	result, err := h.entity.CreateCaseComment(r.Context(), caseID, entityBody)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "entity CreateCaseComment failed", "userID", userID, "caseID", caseID, "err", err)
+		slog.ErrorContext(r.Context(), "entity CreateCaseComment failed", "userID", user.UserID, "caseID", caseID, "err", err)
 		mapUpstreamError(w, err, "Failed to create case comment.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -167,12 +167,7 @@ func TestCreateCase(t *testing.T) {
 // ----- CreateCaseComment -----
 
 func TestCreateCaseComment(t *testing.T) {
-	const validPayload = `{"commentType":"comment","body":"Looking into this now."}`
-	const resolvedUserID = "entity-user-uuid-42"
-
-	userSearchOK := func(_ context.Context, _ []byte) ([]byte, error) {
-		return []byte(`{"users":[{"id":"` + resolvedUserID + `","email":"agent@example.com"}],"total":1}`), nil
-	}
+	const validPayload = `{"type":"comment","content":"Looking into this now."}`
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
@@ -217,15 +212,14 @@ func TestCreateCaseComment(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("resolves createdBy server-side and forwards to upstream", func(t *testing.T) {
+	t.Run("forwards body to entity and returns response", func(t *testing.T) {
 		var capturedCaseID string
 		var capturedBody []byte
 		client := &mockEntityCaseClient{
-			searchUsersFn: userSearchOK,
 			createCaseCommentFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
 				capturedCaseID = caseID
 				capturedBody = body
-				return []byte(`{"id":"comment-1","caseId":"case-1","commentType":"comment","body":"Looking into this now.","createdBy":"` + resolvedUserID + `","createdAt":"2026-06-03T00:00:00Z"}`), nil
+				return []byte(`{"message":"Comment created successfully","comment":{"id":"comment-1","createdOn":"2026-06-03T00:00:00Z","createdBy":"agent@example.com"}}`), nil
 			},
 		}
 		h := NewCaseHandler(client)
@@ -240,52 +234,15 @@ func TestCreateCaseComment(t *testing.T) {
 		if capturedCaseID != "case-1" {
 			t.Errorf("upstream received caseID %q, want %q", capturedCaseID, "case-1")
 		}
-
-		var sent map[string]json.RawMessage
-		if err := json.Unmarshal(capturedBody, &sent); err != nil {
-			t.Fatalf("upstream received invalid JSON: %v", err)
-		}
-		var gotID string
-		if err := json.Unmarshal(sent["createdBy"], &gotID); err != nil || gotID != resolvedUserID {
-			t.Errorf("upstream createdBy = %q, want %q", gotID, resolvedUserID)
+		if string(capturedBody) != validPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, validPayload)
 		}
 
 		resp := decodeJSON[map[string]any](t, w)
-		if resp["id"] != "comment-1" {
-			t.Errorf("response id = %v, want comment-1", resp["id"])
+		comment, _ := resp["comment"].(map[string]any)
+		if comment["id"] != "comment-1" {
+			t.Errorf("response comment.id = %v, want comment-1", comment["id"])
 		}
-	})
-
-	t.Run("returns 403 when user not found in entity service", func(t *testing.T) {
-		client := &mockEntityCaseClient{
-			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
-				return []byte(`{"users":[],"total":0}`), nil
-			},
-		}
-		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
-		r.SetPathValue("id", "case-1")
-		w := httptest.NewRecorder()
-		h.CreateCaseComment(w, r)
-		assertStatus(t, w, http.StatusForbidden)
-		assertErrorMessage(t, w, ErrMsgForbidden)
-		assertContentType(t, w, "application/json")
-	})
-
-	t.Run("returns 500 when user lookup fails", func(t *testing.T) {
-		client := &mockEntityCaseClient{
-			searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
-				return nil, errors.New("entity service unavailable")
-			},
-		}
-		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
-		r.SetPathValue("id", "case-1")
-		w := httptest.NewRecorder()
-		h.CreateCaseComment(w, r)
-		assertStatus(t, w, http.StatusInternalServerError)
-		assertErrorMessage(t, w, ErrMsgInternal)
-		assertContentType(t, w, "application/json")
 	})
 
 	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
@@ -293,7 +250,6 @@ func TestCreateCaseComment(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				client := &mockEntityCaseClient{
-					searchUsersFn: userSearchOK,
 					createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
 						return nil, tc.err
 					},

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -91,7 +91,6 @@ type mockEntityCaseClient struct {
 	searchCaseCommentsFn  func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCasesFn         func(ctx context.Context, body []byte) ([]byte, error)
 	getCaseFn             func(ctx context.Context, caseID string) ([]byte, error)
-	searchUsersFn         func(ctx context.Context, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
@@ -136,12 +135,6 @@ func (m *mockEntityCaseClient) GetCase(ctx context.Context, caseID string) ([]by
 	return []byte(`{}`), nil
 }
 
-func (m *mockEntityCaseClient) SearchUsers(ctx context.Context, body []byte) ([]byte, error) {
-	if m.searchUsersFn != nil {
-		return m.searchUsersFn(ctx, body)
-	}
-	return []byte(`{"users":[{"id":"user-123"}],"total":1}`), nil
-}
 
 // ----- mock updates client -----
 

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -146,6 +146,17 @@ Configured in `internal/db/postgres.go`:
 | Max conn lifetime   | 30 min  |
 | Max idle time       | 5 min   |
 
+## ServiceNow data source (`sn_*` services)
+
+ServiceNow uses 32-character hex sysids (e.g. `abc123...`) while the rest of the platform uses standard UUIDs (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). Conversion helpers live in `internal/service/sn_id.go`.
+
+**Rules — apply without exception:**
+
+- **Outbound (request to SN):** convert every UUID to a sysid with `uuidToSysid()` / `uuidsToSysids()` before including it in the SN payload.
+- **Inbound (response from SN):** convert every ID field back to a UUID with `sysidToUUID()` before populating the domain response struct. This includes every ID in every response type — cases, comments, projects, deployments, deployed products, etc.
+
+Missing a `sysidToUUID()` call on a response ID means callers receive a bare sysid they cannot use to call back into the entity service.
+
 ## Security
 
 - Never commit secrets — use environment variables; `.env` is git-ignored

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -416,7 +416,7 @@ func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.Create
 	return domain.CreateCaseCommentResponse{
 		Message: snResp.Message,
 		Comment: domain.CaseCommentDetail{
-			ID:        snResp.Comment.ID,
+			ID:        sysidToUUID(snResp.Comment.ID),
 			CreatedOn: createdOn,
 			CreatedBy: snResp.Comment.CreatedBy,
 		},


### PR DESCRIPTION
## Summary

- Removes the `resolveUserID` + `injectCreatedBy` chain from `CreateCaseComment` in the BFF
- The BFF was injecting `createdBy` into the request body, but `CreateCaseCommentRequest.CreatedBy` is tagged `json:"-"` in the entity service — causing `DisallowUnknownFields` to reject it with a 400
- The entity service already resolves `createdBy` from the forwarded `x-user-id-token`, so the BFF only needs to pass the body through
- Removes `SearchUsers` from `entityCaseClient` interface (was only used for the user lookup)
- Updates tests to reflect the simplified flow and corrects the test payload field names (`type`/`content` instead of `commentType`/`body`)

## Test plan

- [x] `POST /cases/{id}/comments` with `{"type":"comment","content":"..."}` returns 201
- [x] Confirm no extra `users/search` call is made on comment creation
- [x] All handler tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated case comment creation to modify request payload structure and backend user identity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->