### PR TITLE
[Customer Entity] Implement SearchCaseComments with ServiceNow support

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -641,14 +641,22 @@ const (
 	CommentTypeActivity CommentType = "activity"
 )
 
+// CommentUserRef holds user details embedded in a case comment response.
+type CommentUserRef struct {
+	ID        string `json:"id"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	FullName  string `json:"fullName"`
+}
+
 // CaseComment represents a comment on a support case.
 type CaseComment struct {
-	ID          string      `json:"id"`
-	CaseID      string      `json:"caseId"`
-	Type      CommentType `json:"type"`
-	Content   string      `json:"content"`
-	CreatedBy string      `json:"createdBy"`
-	CreatedAt time.Time   `json:"createdAt"`
+	ID        string         `json:"id"`
+	CaseID    string         `json:"caseId"`
+	Type      CommentType    `json:"type"`
+	Content   string         `json:"content"`
+	CreatedBy CommentUserRef `json:"createdBy"`
+	CreatedAt time.Time      `json:"createdOn"`
 }
 
 // CreateCaseCommentRequest is the input for creating a new case comment.
@@ -676,8 +684,14 @@ type CaseCommentDetail struct {
 // SearchCaseCommentsRequest is the input for listing comments on a case.
 // CaseID is populated from the URL path parameter and is not part of the JSON body.
 type SearchCaseCommentsRequest struct {
-	CaseID     string     `json:"-"`
-	Pagination Pagination `json:"pagination"`
+	CaseID     string      `json:"-"`
+	Filters    *CommentFilters `json:"filters"`
+	Pagination Pagination  `json:"pagination"`
+}
+
+// CommentFilters holds optional filter criteria for searching case comments.
+type CommentFilters struct {
+	Type *CommentType `json:"type"`
 }
 
 // SearchCaseCommentsResponse is the paginated result of a case comment search.

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -195,13 +195,26 @@ func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseC
 
 // SearchCaseComments implements CaseRepository.
 func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error) {
-	const countQuery = `SELECT COUNT(*) FROM case_comments WHERE case_id = $1`
-	const dataQuery = `
-		SELECT id, case_id, type, content, created_by, created_at
-		FROM case_comments
-		WHERE case_id = $1
-		ORDER BY created_at DESC, id
-		LIMIT $2 OFFSET $3`
+	args := []any{req.CaseID}
+	typeFilter := ""
+	if req.Filters != nil && req.Filters.Type != nil {
+		args = append(args, string(*req.Filters.Type))
+		typeFilter = fmt.Sprintf(" AND cc.type = $%d::comment_type_enum", len(args))
+	}
+
+	countQuery := `SELECT COUNT(*) FROM case_comments cc WHERE cc.case_id = $1` + typeFilter
+	dataQuery := fmt.Sprintf(`
+		SELECT cc.id, cc.case_id, cc.type, cc.content,
+		       u.id, u.first_name, u.last_name,
+		       TRIM(u.first_name || ' ' || u.last_name) AS full_name,
+		       cc.created_at
+		FROM case_comments cc
+		JOIN users u ON u.id = cc.created_by
+		WHERE cc.case_id = $1%s
+		ORDER BY cc.created_at DESC, cc.id
+		LIMIT $%d OFFSET $%d`, typeFilter, len(args)+1, len(args)+2)
+
+	dataArgs := append(args, req.Pagination.Limit, req.Pagination.Offset)
 
 	var total int
 	var comments []domain.CaseComment
@@ -209,14 +222,14 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		if err := r.db.QueryRow(egCtx, countQuery, req.CaseID).Scan(&total); err != nil {
+		if err := r.db.QueryRow(egCtx, countQuery, args...).Scan(&total); err != nil {
 			return fmt.Errorf("count case comments: %w", err)
 		}
 		return nil
 	})
 
 	eg.Go(func() error {
-		rows, err := r.db.Query(egCtx, dataQuery, req.CaseID, req.Pagination.Limit, req.Pagination.Offset)
+		rows, err := r.db.Query(egCtx, dataQuery, dataArgs...)
 		if err != nil {
 			return fmt.Errorf("query case comments: %w", err)
 		}
@@ -225,7 +238,11 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 		result := make([]domain.CaseComment, 0, req.Pagination.Limit)
 		for rows.Next() {
 			var c domain.CaseComment
-			if err := rows.Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedAt); err != nil {
+			if err := rows.Scan(
+				&c.ID, &c.CaseID, &c.Type, &c.Content,
+				&c.CreatedBy.ID, &c.CreatedBy.FirstName, &c.CreatedBy.LastName,
+				&c.CreatedBy.FullName, &c.CreatedAt,
+			); err != nil {
 				return fmt.Errorf("scan case comment: %w", err)
 			}
 			result = append(result, c)

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -120,7 +120,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		middleware.Recovery(
 			middleware.Logger(
 				middleware.UserIDToken(
-					middleware.Timeout(10 * time.Second)(mux),
+					middleware.Timeout(30 * time.Second)(mux),
 				),
 			),
 		),

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -208,6 +208,9 @@ func (s *caseService) SearchCaseComments(ctx context.Context, req domain.SearchC
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchCaseCommentsResponse{}, err
 	}
+	if req.Filters != nil && req.Filters.Type != nil && !validCommentType[*req.Filters.Type] {
+		return domain.SearchCaseCommentsResponse{}, &apierror.ValidationError{Msg: "filters.type contains invalid value: " + string(*req.Filters.Type)}
+	}
 	comments, total, err := s.repo.SearchCaseComments(ctx, req)
 	if err != nil {
 		return domain.SearchCaseCommentsResponse{}, err

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -423,8 +423,105 @@ func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.Create
 	}, nil
 }
 
+type snCommentFilters struct {
+	Type string `json:"type,omitempty"`
+}
+
+type snSearchCommentsPayload struct {
+	ReferenceID   string             `json:"referenceId"`
+	ReferenceType string             `json:"referenceType"`
+	Filters       *snCommentFilters  `json:"filters,omitempty"`
+	Pagination    snProjectPagination `json:"pagination"`
+}
+
+type snComment struct {
+	ID                  string `json:"id"`
+	ReferenceID         string `json:"referenceId"`
+	Content             string `json:"content"`
+	Type                string `json:"type"`
+	CreatedOn           string `json:"createdOn"`
+	CreatedBy           string `json:"createdBy"`
+	CreatedByFirstName  string `json:"createdByFirstName"`
+	CreatedByLastName   string `json:"createdByLastName"`
+	CreatedByFullName   string `json:"createdByFullName"`
+}
+
+type snSearchCommentsResponse struct {
+	Comments     []snComment `json:"comments"`
+	Offset       int         `json:"offset"`
+	Limit        int         `json:"limit"`
+	TotalRecords int         `json:"totalRecords"`
+}
+
+var snCommentTypeMap = map[domain.CommentType]string{
+	domain.CommentTypeComment:  "comments",
+	domain.CommentTypeWorkNote: "work_note",
+}
+
 func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error) {
-	return s.pgFallback.SearchCaseComments(ctx, req)
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchCaseCommentsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchCaseCommentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snSearchCommentsPayload{
+		ReferenceID:   uuidToSysid(req.CaseID),
+		ReferenceType: "case",
+		Pagination:    snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+	if req.Filters != nil && req.Filters.Type != nil {
+		if snType, ok := snCommentTypeMap[*req.Filters.Type]; ok {
+			payload.Filters = &snCommentFilters{Type: snType}
+		}
+	}
+
+	raw, err := s.client.Post(ctx, "/comments/search", token, payload)
+	if err != nil {
+		return domain.SearchCaseCommentsResponse{}, err
+	}
+
+	var snResp snSearchCommentsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchCaseCommentsResponse{}, fmt.Errorf("sn search comments: parse response: %w", err)
+	}
+
+	comments := make([]domain.CaseComment, 0, len(snResp.Comments))
+	for _, c := range snResp.Comments {
+		createdAt, err := time.Parse(snCreatedOnLayout, c.CreatedOn)
+		if err != nil {
+			return domain.SearchCaseCommentsResponse{}, fmt.Errorf("sn search comments: parse createdOn %q: %w", c.CreatedOn, err)
+		}
+		commentType := domain.CommentTypeComment
+		if c.Type == "work_note" {
+			commentType = domain.CommentTypeWorkNote
+		}
+		comments = append(comments, domain.CaseComment{
+			ID:      sysidToUUID(c.ID),
+			CaseID:  sysidToUUID(c.ReferenceID),
+			Type:    commentType,
+			Content: c.Content,
+			CreatedBy: domain.CommentUserRef{
+				ID:        c.CreatedBy,
+				FirstName: c.CreatedByFirstName,
+				LastName:  c.CreatedByLastName,
+				FullName:  c.CreatedByFullName,
+			},
+			CreatedAt: createdAt,
+		})
+	}
+
+	total := snResp.TotalRecords
+	return domain.SearchCaseCommentsResponse{
+		Comments: comments,
+		Total:    total,
+		Limit:    req.Pagination.Limit,
+		Offset:   req.Pagination.Offset,
+		HasMore:  req.Pagination.Offset+len(comments) < total,
+	}, nil
 }
 
 func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -474,9 +474,13 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 		Pagination:    snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 	if req.Filters != nil && req.Filters.Type != nil {
-		if snType, ok := snCommentTypeMap[*req.Filters.Type]; ok {
-			payload.Filters = &snCommentFilters{Type: snType}
+		snType, ok := snCommentTypeMap[*req.Filters.Type]
+		if !ok {
+			return domain.SearchCaseCommentsResponse{}, &apierror.ValidationError{
+				Msg: "filters.type is not supported for ServiceNow: " + string(*req.Filters.Type),
+			}
 		}
+		payload.Filters = &snCommentFilters{Type: snType}
 	}
 
 	raw, err := s.client.Post(ctx, "/comments/search", token, payload)
@@ -495,9 +499,16 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 		if err != nil {
 			return domain.SearchCaseCommentsResponse{}, fmt.Errorf("sn search comments: parse createdOn %q: %w", c.CreatedOn, err)
 		}
-		commentType := domain.CommentTypeComment
-		if c.Type == "work_note" {
+		var commentType domain.CommentType
+		switch c.Type {
+		case "comments", "comment":
+			commentType = domain.CommentTypeComment
+		case "work_note":
 			commentType = domain.CommentTypeWorkNote
+		case "activity":
+			commentType = domain.CommentTypeActivity
+		default:
+			commentType = domain.CommentTypeComment
 		}
 		comments = append(comments, domain.CaseComment{
 			ID:      sysidToUUID(c.ID),


### PR DESCRIPTION
## Summary
- Implemented `SearchCaseComments` via the ServiceNow integration service with `POST /comments/search`, passing `referenceId`, `referenceType`, and optional `type` filter with SN type mapping (`comment`→`comments`, `work_note`→`work_note`)
- Added optional `filters.type` to `SearchCaseCommentsRequest`; validated in the Postgres service path
- Updated Postgres repository query to JOIN with `users` table and return `createdBy` as an object (`id`, `firstName`, `lastName`, `fullName`) for both datasources
- Renamed `createdAt` → `createdOn` in `CaseComment` response and fixed `caseId` to return UUID format by converting `referenceId` from SN sysid
- Increased global request timeout to 30s to accommodate slow ServiceNow responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering capability to case comments by type
  * Enhanced case comment display with richer user information (names and IDs)

* **Improvements**
  * Increased HTTP request timeout from 10 to 30 seconds for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->