### PR TITLE
[CSM Portal] align case-detail with the backend: comments, creator & assignee

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -93,50 +93,55 @@ describe("uiCommentFromBe", () => {
   const base: BeCaseComment = {
     id: "c1",
     caseId: "case1",
-    commentType: "comment",
-    body: "hello",
-    createdBy: "user-123",
-    createdAt: "2026-06-01T10:00:00Z",
+    type: "comment",
+    content: "<p>hello</p>",
+    createdBy: {
+      id: "user@wso2.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      fullName: "Ada Lovelace ⓦ",
+    },
+    createdOn: "2026-06-01T10:00:00Z",
   };
 
   it("wraps a public comment as a wso2_engineer, non-internal bubble", () => {
     const ui = uiCommentFromBe(base);
     expect(ui.authorRole).toBe("wso2_engineer");
     expect(ui.internal).toBe(false);
-    expect(ui.authorName).toBe("user-123");
+    expect(ui.authorName).toBe("Ada Lovelace ⓦ");
     expect(ui.bodyHtml).toBe("<p>hello</p>");
+    expect(ui.createdAt).toBe("2026-06-01T10:00:00Z");
   });
 
   it("marks a work_note as internal", () => {
-    const ui = uiCommentFromBe({ ...base, commentType: "work_note" });
+    const ui = uiCommentFromBe({ ...base, type: "work_note" });
     expect(ui.authorRole).toBe("wso2_engineer");
     expect(ui.internal).toBe(true);
   });
 
   it("renders an activity entry as a system author", () => {
-    const ui = uiCommentFromBe({ ...base, commentType: "activity" });
+    const ui = uiCommentFromBe({ ...base, type: "activity" });
     expect(ui.authorRole).toBe("system");
     expect(ui.internal).toBe(false);
   });
 
-  it("escapes HTML-special characters and converts newlines (htmlFromPlain)", () => {
+  it("passes through the HTML content untouched (sanitised at render)", () => {
     const ui = uiCommentFromBe({
       ...base,
-      body: 'a & b < c > d\nsecond <script>',
+      content: '<p>a &amp; b</p><img src=x onerror="alert(1)">',
     });
-    expect(ui.bodyHtml).toBe(
-      "<p>a &amp; b &lt; c &gt; d<br/>second &lt;script&gt;</p>",
-    );
-    // No raw angle brackets survive the escape.
-    expect(ui.bodyHtml).not.toContain("<script>");
+    expect(ui.bodyHtml).toBe('<p>a &amp; b</p><img src=x onerror="alert(1)">');
   });
 
-  it("normalises CRLF/CR line endings to a single break (no \\r artifacts)", () => {
-    const ui = uiCommentFromBe({
-      ...base,
-      body: "line1\r\nline2\rline3\nline4",
-    });
-    expect(ui.bodyHtml).toBe("<p>line1<br/>line2<br/>line3<br/>line4</p>");
-    expect(ui.bodyHtml).not.toContain("\r");
+  it("falls back from fullName to first+last, then id", () => {
+    expect(
+      uiCommentFromBe({
+        ...base,
+        createdBy: { id: "x@wso2.com", firstName: "Grace", lastName: "Hopper" },
+      }).authorName,
+    ).toBe("Grace Hopper");
+    expect(
+      uiCommentFromBe({ ...base, createdBy: { id: "x@wso2.com" } }).authorName,
+    ).toBe("x@wso2.com");
   });
 });

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -102,39 +102,35 @@ export function beStateFromUi(state: CaseState): BeCaseState {
 // Comments
 // ---------------------------------------------------------------------------
 
-function htmlFromPlain(body: string): string {
-  const escaped = body
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    // Normalise CRLF/CR to a single break so Windows line endings don't leave
-    // stray \r artifacts in the rendered HTML.
-    .replace(/\r\n?|\n/g, "<br/>");
-  return `<p>${escaped}</p>`;
-}
-
 export function commentTypeFromInternal(
   internal: boolean,
 ): BeCreatableCommentType {
   return internal ? "work_note" : "comment";
 }
 
+/** Best display name from the comment author block, falling back to the id. */
+function authorDisplayName(author: BeCaseComment["createdBy"]): string {
+  if (!author) return "Unknown";
+  const full = author.fullName?.trim();
+  if (full) return full;
+  const composed = [author.firstName, author.lastName]
+    .filter((p) => p && p.trim())
+    .join(" ")
+    .trim();
+  return composed || author.id || "Unknown";
+}
+
 export function uiCommentFromBe(comment: BeCaseComment): CsmCaseComment {
   const role: CsmCommentAuthorRole =
-    comment.commentType === "work_note"
-      ? "wso2_engineer"
-      : comment.commentType === "activity"
-        ? "system"
-        : "wso2_engineer";
+    comment.type === "activity" ? "system" : "wso2_engineer";
   return {
     id: comment.id,
     caseId: comment.caseId,
-    // BE returns a user id; the UI shows whatever it gets. A future user
-    // lookup can hydrate this to a display name without changing the shape.
-    authorName: comment.createdBy,
+    authorName: authorDisplayName(comment.createdBy),
     authorRole: role,
-    bodyHtml: htmlFromPlain(comment.body),
-    createdAt: comment.createdAt,
-    internal: comment.commentType === "work_note",
+    // `content` is already rich-text HTML; the bubble sanitises it on render.
+    bodyHtml: comment.content ?? "",
+    createdAt: comment.createdOn,
+    internal: comment.type === "work_note",
   };
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -237,21 +237,31 @@ export interface BeCaseSearchResponse extends BeSearchResponseBase {
 
 export type BeCaseCommentType = "work_note" | "comment" | "activity";
 
+/** Author block embedded in a comment; the BE hydrates it from the user store. */
+export interface BeCaseCommentAuthor {
+  id: string;
+  firstName?: string;
+  lastName?: string;
+  fullName?: string;
+}
+
 export interface BeCaseComment {
   id: string;
   caseId: string;
-  commentType: BeCaseCommentType;
-  body: string;
-  createdBy: string;
-  createdAt: string;
+  type: BeCaseCommentType;
+  /** Rich-text HTML body (sanitised at render time). */
+  content: string;
+  createdBy: BeCaseCommentAuthor;
+  createdOn: string;
 }
 
 /** Comment types a client may create. `activity` is system-generated only. */
 export type BeCreatableCommentType = Exclude<BeCaseCommentType, "activity">;
 
 export interface BeCaseCommentCreatePayload {
-  commentType: BeCreatableCommentType;
-  body: string;
+  type: BeCreatableCommentType;
+  /** Rich-text HTML body. */
+  content: string;
 }
 
 export interface BeCaseCommentSearchPayload {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -95,7 +95,7 @@ export interface BeCase {
 /** A referenced user, as embedded in case views (not just an id string). */
 export interface BeUserRef {
   id: string;
-  displayName?: string;
+  name?: string;
   userId?: string;
   email?: string;
 }
@@ -141,6 +141,8 @@ export interface BeCaseView {
   state?: BeCaseState;
   nextStates?: BeCaseState[];
   createdBy?: BeUserRef;
+  /** The CS engineer the case is assigned to; null when unassigned. */
+  assignedEngineer?: BeEntityRef | null;
   account?: BeCaseAccountRef;
   project?: BeEntityRef;
   deployment?: BeEntityRef;

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
@@ -125,9 +125,9 @@ export function usePostCsmCaseComment(): UseMutationResult<
       }
 
       const payload: BeCaseCommentCreatePayload = {
-        commentType: commentTypeFromInternal(input.internal ?? false),
-        // BE stores plain text. Strip simple HTML so we don't double-escape on read.
-        body: input.bodyHtml.replace(/<\/?[^>]+>/g, "").trim(),
+        type: commentTypeFromInternal(input.internal ?? false),
+        // BE stores rich-text HTML; send the editor output as-is.
+        content: input.bodyHtml,
       };
       const created = await api.post<
         BeCaseCommentCreatePayload,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -36,7 +36,9 @@ const MOCK_LATENCY_MS = 150;
 function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
   const account = c.account;
   const customer = account?.name ?? "—";
-  const reporter = c.createdBy?.displayName ?? c.createdBy?.email;
+  // createdBy.name can be empty for unhydrated users, so fall back to the email.
+  const reporter = c.createdBy?.name?.trim() || c.createdBy?.email;
+  const assignee = c.assignedEngineer?.name?.trim() || "Unassigned";
   const product = c.deployedProduct?.displayName ?? "—";
   return {
     id: c.id,
@@ -51,9 +53,9 @@ function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
     severity: severityFromPriority(c.priority),
     state: uiStateFromBe(c.state),
     nextStates: (c.nextStates ?? []).map(uiStateFromBe),
-    // The backend has no assignee field yet; `createdBy` is the reporter, not
-    // the assigned engineer, so don't surface it here as the assignee.
-    assignee: "Unassigned",
+    assignee,
+    // "Is me" needs the signed-in user's entity id, which this mapper doesn't
+    // have; left false until the assignee can be compared to the current user.
     assigneeIsMe: false,
     slaClockType: "ack",
     minutesToBreach: 0,


### PR DESCRIPTION
Aligns the case-detail page with the real backend `CaseView` / comments payloads. Frontend only. (Folds in what was previously #877.)

## 1. Comments load failure

The case-detail page showed **"Could not load comments…"** despite a valid backend response. The FE typed each comment as `{ commentType, body, createdBy: string, createdAt }` and ran `htmlFromPlain(comment.body)`; the real shape is `{ type, content, createdBy: {…}, createdOn }`, so `body` was undefined, the mapper threw, and the whole query rejected.

- `BeCaseComment` retyped: `type`, `content` (rich-text HTML), `createdOn`, and a `createdBy` author object (`id`/`firstName`/`lastName`/`fullName`).
- `uiCommentFromBe` reads the new fields, derives the author name (`fullName` → `firstName+lastName` → `id`), and passes `content` through as HTML (the bubble already DOMPurify-sanitises it). Removed the obsolete plain-text wrapping.
- Create payload aligned to `{ type, content }`, sending the editor HTML as-is.
- Mapper unit tests updated.

## 2. Creator & assignee

- `createdBy` was read from `createdBy.displayName`; the payload uses `name`, so the reporter silently fell back to the raw email. `BeUserRef.displayName` renamed to `name`; reporter now uses `createdBy.name` with an email fallback when empty (unhydrated users return `name: ""`).
- Assignee was hardcoded to "Unassigned". Added `assignedEngineer` (`BeEntityRef | null`) to `BeCaseView`; assignee now reads `assignedEngineer.name`, falling back to "Unassigned" when null.

Verified with `pnpm lint`, `pnpm exec tsc -b`, and `pnpm test` (84 passing).

## Notes for reviewers
- The **comment read** path is confirmed against the live response. The **comment create** path is aligned to the same model for consistency (the old request stripped HTML and used `commentType`/`body`, which can't match the new read shape) — worth a real post-a-comment test against the deployed backend to confirm the create request contract.
- `assigneeIsMe` stays `false`: the "is me" highlight needs the signed-in user's entity id to compare against `assignedEngineer.id`, which this mapper doesn't have. Follow-up.