### PR TITLE
[CSM Portal] align case-detail creator & assignee with the CaseView payload

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -95,7 +95,7 @@ export interface BeCase {
 /** A referenced user, as embedded in case views (not just an id string). */
 export interface BeUserRef {
   id: string;
-  displayName?: string;
+  name?: string;
   userId?: string;
   email?: string;
 }
@@ -141,6 +141,8 @@ export interface BeCaseView {
   state?: BeCaseState;
   nextStates?: BeCaseState[];
   createdBy?: BeUserRef;
+  /** The CS engineer the case is assigned to; null when unassigned. */
+  assignedEngineer?: BeEntityRef | null;
   account?: BeCaseAccountRef;
   project?: BeEntityRef;
   deployment?: BeEntityRef;

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -36,7 +36,9 @@ const MOCK_LATENCY_MS = 150;
 function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
   const account = c.account;
   const customer = account?.name ?? "—";
-  const reporter = c.createdBy?.displayName ?? c.createdBy?.email;
+  // createdBy.name can be empty for unhydrated users, so fall back to the email.
+  const reporter = c.createdBy?.name?.trim() || c.createdBy?.email;
+  const assignee = c.assignedEngineer?.name?.trim() || "Unassigned";
   const product = c.deployedProduct?.displayName ?? "—";
   return {
     id: c.id,
@@ -51,9 +53,9 @@ function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
     severity: severityFromPriority(c.priority),
     state: uiStateFromBe(c.state),
     nextStates: (c.nextStates ?? []).map(uiStateFromBe),
-    // The backend has no assignee field yet; `createdBy` is the reporter, not
-    // the assigned engineer, so don't surface it here as the assignee.
-    assignee: "Unassigned",
+    assignee,
+    // "Is me" needs the signed-in user's entity id, which this mapper doesn't
+    // have; left false until the assignee can be compared to the current user.
     assigneeIsMe: false,
     slaClockType: "ack",
     minutesToBreach: 0,


### PR DESCRIPTION
## Problem

On the case-detail page:
- **Creator** was read from `createdBy.displayName`, but the CaseView embeds the reporter as `{ id, name, userId, email }`. With no `displayName`, the reporter silently fell back to the raw email.
- **Assignee** was hardcoded to "Unassigned" — the CaseView now carries `assignedEngineer`.

CaseView payload (relevant fields):

```json
"assignedEngineer": { "id": "94a1b01b-…", "name": "John Doe ⓦ" },
"createdBy": { "id": "", "name": "", "userId": "", "email": "john@abc.com" }
```

## Changes (frontend only)

- `BeUserRef.displayName` renamed to **`name`** to match the payload (only the case-detail mapper read it).
- Added **`assignedEngineer`** (`BeEntityRef | null`) to `BeCaseView`.
- **Reporter** now uses `createdBy.name`, falling back to the email when `name` is empty (unhydrated users return `name: ""`).
- **Assignee** now uses `assignedEngineer.name`, falling back to "Unassigned" when null.

Verified with `pnpm lint`, `pnpm exec tsc -b`, and `pnpm test` (84 passing).

## Note

`assigneeIsMe` stays `false` for now — the "is me" highlight needs the signed-in user's entity id to compare against `assignedEngineer.id`, which this mapper doesn't have. Left as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Case detail views now accurately display assigned CS engineers instead of showing all cases as unassigned, improving visibility into case ownership and team allocation
  * Standardized how user information is referenced throughout the case management interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->