### PR TITLE
[CSM Portal] UI improvements: case-id search, action gating, comment render & dashboard reconciliation

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
@@ -135,11 +135,17 @@ export function usePostCsmCaseComment(): UseMutationResult<
       >(`/cases/${encodeURIComponent(input.caseId)}/comments`, payload);
       return uiCommentFromBe(created);
     },
-    onSuccess: (newComment, variables) => {
-      queryClient.setQueryData<CsmCaseComment[] | undefined>(
-        [ApiQueryKeys.CSM_CASE_COMMENTS, variables.caseId],
-        (prev) => (prev ? [...prev, newComment] : [newComment]),
-      );
+    onSuccess: (_newComment, variables) => {
+      // The BE create response is a thin ack — it echoes only {id, createdOn,
+      // createdBy(email string)}, not the author's display name, the rendered
+      // content, or the comment type. Appending that partial object renders the
+      // new entry as "Unknown WSO2 —" with no body. Until the BE echoes the full
+      // comment on POST, refetch the list so the new comment is hydrated from
+      // `comments/search`, which returns the full shape. One extra round-trip
+      // per post, but the entry renders correctly.
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CSM_CASE_COMMENTS, variables.caseId],
+      });
     },
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import type {
+  BeCaseSearchPayload,
+  BeCaseSearchResponse,
+} from "@api/backend/types";
+import { getMockCsmCases } from "@features/csm-cases/api/mocks/casesMocks";
+import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
+
+const MOCK_LATENCY_MS = 120;
+
+/** Don't fire a search until the user has typed something searchable. */
+export const QUICK_CASE_MIN_QUERY_LEN = 2;
+
+/** A small result page — the palette only shows the top few hits. */
+const QUICK_CASE_LIMIT = 8;
+
+/**
+ * One hit from the global-search case lookup. Carries only what the palette
+ * needs: the UUID `id` for the `/cases/:id` link and the human-readable
+ * identity/subject for display.
+ */
+export interface QuickCaseHit {
+  id: string;
+  caseNumber?: string;
+  wso2CaseId?: string;
+  subject: string;
+}
+
+/**
+ * Free-text case lookup for the global quick-nav palette. Calls
+ * `POST /cases/search` with the typed text as `searchQuery` (the same search the
+ * cases list uses), so a CS/WSO2 case id — or any subject text — resolves to
+ * matching cases the user can jump straight into.
+ *
+ * The query is disabled until the trimmed text reaches
+ * {@link QUICK_CASE_MIN_QUERY_LEN}, so opening the palette costs no network. In
+ * MOCK mode it filters the seeded set client-side on id/subject.
+ */
+export function useQuickCaseSearch(
+  query: string,
+): UseQueryResult<QuickCaseHit[], Error> {
+  const logger = useLogger();
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<QuickCaseHit[], Error>({
+    queryKey: [ApiQueryKeys.CSM_CASES, "quick-search", q],
+    queryFn: async (): Promise<QuickCaseHit[]> => {
+      if (isMockMode()) {
+        logger.debug(`[useQuickCaseSearch] mock case search for "${q}"`);
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        const needle = q.toLowerCase();
+        return getMockCsmCases("all_customers")
+          .filter((c) => {
+            const id = caseIdLabel(c).toLowerCase();
+            return (
+              id.includes(needle) || c.subject.toLowerCase().includes(needle)
+            );
+          })
+          .slice(0, QUICK_CASE_LIMIT)
+          .map((c) => ({
+            id: c.id,
+            caseNumber: c.caseNumber,
+            wso2CaseId: c.wso2CaseId,
+            subject: c.subject,
+          }));
+      }
+
+      const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+        "/cases/search",
+        {
+          pagination: { offset: 0, limit: QUICK_CASE_LIMIT },
+          searchQuery: q,
+        },
+      );
+      return (res.cases ?? []).map((c) => ({
+        id: c.id,
+        caseNumber: c.number,
+        wso2CaseId: c.internalId,
+        subject: c.subject ?? "(no subject)",
+      }));
+    },
+    enabled: q.length >= QUICK_CASE_MIN_QUERY_LEN,
+    staleTime: 15_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -205,6 +205,8 @@ interface SecondaryItem {
   icon: JSX.Element;
   /** If true, render with a divider below in the menu. */
   divider?: boolean;
+  /** If true, the item is greyed out and not clickable. */
+  disabled?: boolean;
 }
 
 /**
@@ -225,18 +227,21 @@ interface SecondaryItem {
  *   - Open in ServiceNow → this platform replaces ServiceNow; no back-link
  */
 function buildSecondaryItems(): SecondaryItem[] {
+  // Only "Copy case link" is wired up for now. The rest are disabled until
+  // their backend flows land, so the menu advertises the roadmap without
+  // exposing dead actions that would no-op or toast a mock message.
   return [
-    { key: "reassign_engineer", label: "Reassign engineer…", icon: <User size={16} /> },
-    { key: "reassign_group", label: "Reassign to group…", icon: <Users size={16} />, divider: true },
-    { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} /> },
-    { key: "change_severity", label: "Request severity change…", icon: <ShieldAlert size={16} /> },
-    { key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true },
-    { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} /> },
-    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} /> },
-    { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} /> },
-    { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true },
-    { key: "request_call", label: "Request a call…", icon: <Phone size={16} /> },
-    { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },
+    { key: "reassign_engineer", label: "Reassign engineer…", icon: <User size={16} />, disabled: true },
+    { key: "reassign_group", label: "Reassign to group…", icon: <Users size={16} />, divider: true, disabled: true },
+    { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} />, disabled: true },
+    { key: "change_severity", label: "Request severity change…", icon: <ShieldAlert size={16} />, disabled: true },
+    { key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true, disabled: true },
+    { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true },
+    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, disabled: true },
+    { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} />, disabled: true },
+    { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true, disabled: true },
+    { key: "request_call", label: "Request a call…", icon: <Phone size={16} />, disabled: true },
+    { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true, disabled: true },
     { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },
   ];
 }
@@ -353,6 +358,7 @@ export default function CaseActionBar({
         {secondary.map((item) => [
           <MenuItem
             key={item.key}
+            disabled={item.disabled}
             onClick={() => {
               setMenuAnchor(null);
               void onAction({ secondary: item.key });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -73,12 +73,7 @@ import {
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
-import { parseBackendTimestamp } from "@utils/dateTime";
-import type {
-  CaseLifecycleAction,
-  CsmCaseComment,
-  CsmCaseDetail,
-} from "@features/csm-cases/types/csmCases";
+import type { CaseLifecycleAction } from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 
 function MetaCell({
@@ -218,41 +213,6 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement {
   return (document.scrollingElement as HTMLElement | null) ?? document.documentElement;
 }
 
-/**
- * Synthesize the case description as a virtual "first comment" so it shows up
- * in the activity stream immediately after the `created` audit event. SN does
- * the same thing — the customer's initial problem statement reads as the
- * opening comment of the case.
- *
- * Dated 1 second after `case.createdAt` so chronological sort places it
- * AFTER the `Case created` audit entry (which is exactly at `createdAt`).
- */
-function buildDescriptionComment(c: CsmCaseDetail): CsmCaseComment | null {
-  if (!c.description?.trim()) return null;
-  // `createdAt` may be missing or in a format a bare `new Date()` can't parse,
-  // which made the old raw `.toISOString()` throw and crash the page. Parse
-  // safely; offset 1s when valid, else fall back to the raw value.
-  const created = parseBackendTimestamp(c.createdAt);
-  const at = created
-    ? new Date(created.getTime() + 1000).toISOString()
-    : c.createdAt;
-  // The creator may be a WSO2 engineer (case logged in the CSM portal) or a
-  // customer (customer portal). Infer from the email domain so the badge isn't
-  // always "Customer".
-  const isWso2 = (c.createdByEmail ?? "").toLowerCase().endsWith("@wso2.com");
-  return {
-    id: `description`,
-    caseId: c.id,
-    authorName:
-      c.createdBy || c.customerContext.primaryContact || c.customer,
-    authorRole: isWso2 ? "wso2_engineer" : "customer",
-    // The description is rich HTML (authored in the case-create editor, same as
-    // comments); the comment bubble sanitizes it with DOMPurify before render.
-    bodyHtml: c.description,
-    createdAt: at,
-  };
-}
-
 const TAB_DEFS: Array<{
   id: CaseTabId;
   label: string;
@@ -261,7 +221,8 @@ const TAB_DEFS: Array<{
 }> = [
   { id: "activities", label: "Activities", icon: <Activity size={16} /> },
   { id: "details", label: "Details", icon: <ListChecks size={16} /> },
-  { id: "sla", label: "SLA", icon: <Clock size={16} /> },
+  // SLA tab is parked until its backend clock data is wired; disabled for now.
+  { id: "sla", label: "SLA", icon: <Clock size={16} />, disabled: true },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
   // Time tracking is parked until its backend flow lands; disabled for now.
   { id: "time", label: "Time tracking", icon: <Layers size={16} />, disabled: true },
@@ -516,15 +477,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const canReopenClosed = (claims?.groups ?? []).some((g) =>
     LEAD_REOPEN_ROLES.has(g),
   );
-  const rawComments = comments ?? [];
-  // The description is the case's opening comment. It is injected into the
-  // stream dated 1s after `created`, so with the default latest-first sort it
-  // sits at the bottom as the oldest entry — read in context after the latest
-  // activity, which is how engineers actually work a case here.
-  const descriptionComment = buildDescriptionComment(c);
-  const safeComments = descriptionComment
-    ? [descriptionComment, ...rawComments]
-    : rawComments;
+  // The case description is already returned by `comments/search` as the
+  // opening comment, so the stream renders it directly — no synthetic entry is
+  // injected (that duplicated the first comment).
+  const safeComments = comments ?? [];
 
   // SLA breach is a live condition, not a dismissible notice: surface it in a
   // persistent banner under the header so it stays visible on every tab, not

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -257,12 +257,14 @@ const TAB_DEFS: Array<{
   id: CaseTabId;
   label: string;
   icon: JSX.Element;
+  disabled?: boolean;
 }> = [
   { id: "activities", label: "Activities", icon: <Activity size={16} /> },
   { id: "details", label: "Details", icon: <ListChecks size={16} /> },
   { id: "sla", label: "SLA", icon: <Clock size={16} /> },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
-  { id: "time", label: "Time tracking", icon: <Layers size={16} /> },
+  // Time tracking is parked until its backend flow lands; disabled for now.
+  { id: "time", label: "Time tracking", icon: <Layers size={16} />, disabled: true },
 ];
 
 export default function CsmCaseDetailPage(): JSX.Element {
@@ -725,6 +727,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               <Tab
                 key={t.id}
                 value={t.id}
+                disabled={t.disabled}
                 icon={t.icon}
                 iconPosition="start"
                 label={count ? `${t.label} (${count})` : t.label}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -23,46 +23,48 @@ import type {
   BeCaseSearchResponse,
 } from "@api/backend/types";
 import { getMockCsmCases } from "@features/csm-cases/api/mocks/casesMocks";
-import { MATRIX_SEVERITIES } from "@features/csm-dashboard/api/useCaseCountsMatrix";
+import {
+  MATRIX_SEVERITIES,
+  MATRIX_STATES,
+} from "@features/csm-dashboard/api/useCaseCountsMatrix";
 import type {
   CaseState,
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
 
 /**
- * Every case state, including `closed` — the composition pies show the whole
- * population, not just the active states the severity/state matrix tracks.
+ * The states the composition pies break down — the SAME active set the
+ * severity×state matrix tracks, so the pie totals reconcile with the table
+ * above them. `closed` is intentionally excluded from both pies and surfaced
+ * separately as {@link CaseComposition.closedTotal}, so a large backlog of
+ * closed cases can't make the active counts disagree with the matrix.
  */
-export const COMPOSITION_STATES: CaseState[] = [
-  "open",
-  "work_in_progress",
-  "waiting_on_wso2",
-  "awaiting_info",
-  "solution_proposed",
-  "reopened",
-  "closed",
-];
+export const COMPOSITION_STATES: CaseState[] = MATRIX_STATES;
 
 export interface CaseComposition {
-  /** Case count per severity, across all states. */
+  /** Active-case count per severity (excludes closed). */
   bySeverity: Record<Severity, number>;
-  /** Case count per state, across all severities. */
+  /** Active-case count per state (excludes closed). */
   byState: Record<CaseState, number>;
   severityTotal: number;
   stateTotal: number;
+  /** Closed cases — excluded from the pies, shown as a separate figure. */
+  closedTotal: number;
 }
 
 /**
  * Case composition for the dashboard pies: a 1-D breakdown by severity and a
- * 1-D breakdown by state, each over *all* cases (closed included).
+ * 1-D breakdown by state, each over the *active* cases only (closed excluded,
+ * matching the severity×state matrix). The closed count is returned separately.
  *
  * The backend has no aggregation endpoint, so — like the severity×state matrix
  * — this fans out count-only searches (`limit: 1`, read `total`): one per
- * severity (filtered by priority, any state) and one per state (filtered by
- * state, any severity). MOCK mode tallies the seeded cases.
+ * severity (filtered by priority AND the active states) and one per active
+ * state (filtered by state), plus one for the closed total. MOCK mode tallies
+ * the seeded cases.
  *
- * Severity and state each partition the same population, so both totals equal
- * the overall case count (give or take cases the backend leaves unprioritised).
+ * Severity and state each partition the same active population, so both totals
+ * are equal and reconcile with the matrix's grand total.
  */
 export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
   const api = useBackendApi();
@@ -74,9 +76,16 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
       const byState = {} as Record<CaseState, number>;
       MATRIX_SEVERITIES.forEach((s) => (bySeverity[s] = 0));
       COMPOSITION_STATES.forEach((s) => (byState[s] = 0));
+      let closedTotal = 0;
 
       if (isMockMode()) {
         for (const c of getMockCsmCases("all_customers")) {
+          // Closed cases are tallied on their own and kept out of the pies so
+          // the active counts reconcile with the matrix above.
+          if (c.state === "closed") {
+            closedTotal += 1;
+            continue;
+          }
           if (bySeverity[c.severity] !== undefined) bySeverity[c.severity] += 1;
           if (byState[c.state] !== undefined) byState[c.state] += 1;
         }
@@ -89,13 +98,19 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             )
             .then((r) => r.total ?? 0);
 
-        // All severity + state counts fire in one parallel wave.
-        const [severityCounts, stateCounts] = await Promise.all([
+        // The active states, expressed once for the severity counts so each is
+        // scoped to active cases (priority AND active-state), not the whole
+        // population.
+        const activeStateKeys = COMPOSITION_STATES.map(beStateFromUi);
+
+        // All severity + state counts (plus the closed total) fire in one wave.
+        const [severityCounts, stateCounts, closedCount] = await Promise.all([
           Promise.all(
             MATRIX_SEVERITIES.map((sev) =>
               countTotal({
                 pagination: { offset: 0, limit: 1 },
                 priorityKeys: [priorityFromSeverity(sev)],
+                stateKeys: activeStateKeys,
               }).then((n) => ({ key: sev, n })),
             ),
           ),
@@ -107,9 +122,14 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
               }).then((n) => ({ key: st, n })),
             ),
           ),
+          countTotal({
+            pagination: { offset: 0, limit: 1 },
+            stateKeys: [beStateFromUi("closed")],
+          }),
         ]);
         severityCounts.forEach(({ key, n }) => (bySeverity[key] = n));
         stateCounts.forEach(({ key, n }) => (byState[key] = n));
+        closedTotal = closedCount;
       }
 
       const severityTotal = MATRIX_SEVERITIES.reduce(
@@ -120,7 +140,7 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
         (a, s) => a + byState[s],
         0,
       );
-      return { bySeverity, byState, severityTotal, stateTotal };
+      return { bySeverity, byState, severityTotal, stateTotal, closedTotal };
     },
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box } from "@wso2/oxygen-ui";
+import { Box, Typography } from "@wso2/oxygen-ui";
 import { useMemo, type JSX } from "react";
 import {
   COMPOSITION_STATES,
@@ -84,30 +84,46 @@ export default function CaseCompositionCharts(): JSX.Element {
     [data],
   );
 
+  const closedTotal = data?.closedTotal ?? 0;
+
   return (
-    <Box
-      sx={{
-        display: "grid",
-        gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
-        gap: 3,
-      }}
-    >
-      <CompositionDonut
-        title="Cases by severity"
-        description="Share of all cases at each severity level (S0–S4), across every state."
-        slices={severitySlices}
-        total={data?.severityTotal ?? 0}
-        isLoading={isLoading}
-        isError={isError}
-      />
-      <CompositionDonut
-        title="Cases by state"
-        description="Share of all cases in each lifecycle state, regardless of severity."
-        slices={stateSlices}
-        total={data?.stateTotal ?? 0}
-        isLoading={isLoading}
-        isError={isError}
-      />
+    <Box>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+          gap: 3,
+        }}
+      >
+        <CompositionDonut
+          title="Cases by severity"
+          description="Share of active cases at each severity level (S0–S4), excluding closed."
+          slices={severitySlices}
+          total={data?.severityTotal ?? 0}
+          isLoading={isLoading}
+          isError={isError}
+        />
+        <CompositionDonut
+          title="Cases by state"
+          description="Share of active cases in each lifecycle state, excluding closed."
+          slices={stateSlices}
+          total={data?.stateTotal ?? 0}
+          isLoading={isLoading}
+          isError={isError}
+        />
+      </Box>
+      {/* Reconciles the pies with the matrix above: both show active cases only,
+          so the closed count is called out here rather than mixed into a slice. */}
+      {!isLoading && !isError && closedTotal > 0 && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: "block", mt: 1.5 }}
+        >
+          These charts and the matrix above show active cases only. Excludes{" "}
+          {closedTotal} closed {closedTotal === 1 ? "case" : "cases"}.
+        </Typography>
+      )}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -63,6 +63,12 @@ export default function QuickNav(): JSX.Element | null {
   // a request; the in-memory pinned/recent/page matching still reacts instantly
   // to `query`.
   const debouncedQuery = useDebouncedValue(query, 180);
+  const trimmedQuery = query.trim();
+  // Case hits lag the input by the debounce window, so `caseSearch.data` can
+  // describe a previous query. Only surface (and allow navigating to) hits once
+  // the query the API actually ran matches what's typed now — otherwise stale
+  // results stay clickable during the debounce window or after the input shrinks.
+  const caseHitsSettled = trimmedQuery === debouncedQuery.trim();
 
   // API-backed case lookup: a CS/WSO2 id (or any subject text) resolves to real
   // cases. Disabled until the query is long enough (see the hook).
@@ -83,23 +89,28 @@ export default function QuickNav(): JSX.Element | null {
   }, [isSignedIn]);
 
   const results: Result[] = useMemo(() => {
-    const q = query.trim().toLowerCase();
+    const q = trimmedQuery.toLowerCase();
     const match = (...parts: (string | undefined)[]) =>
       !q || parts.some((p) => p?.toLowerCase().includes(q));
 
     // Live case hits go first — when someone types a case id, the matching case
-    // is the thing they want, ahead of pinned/recent/pages.
-    const cases: Result[] = (caseSearch.data ?? []).map((c) => {
-      const idLabel = caseIdLabel(c);
-      return {
-        key: `case-${c.id}`,
-        icon: kindIcon("case", 16),
-        label: idLabel || c.subject,
-        sublabel: idLabel ? c.subject : undefined,
-        href: `/cases/${c.id}`,
-        section: "Cases",
-      };
-    });
+    // is the thing they want, ahead of pinned/recent/pages. Only shown once the
+    // debounced query the API ran matches the current input, so stale hits never
+    // stay clickable mid-typing.
+    const cases: Result[] =
+      caseHitsSettled && trimmedQuery.length >= QUICK_CASE_MIN_QUERY_LEN
+        ? (caseSearch.data ?? []).map((c) => {
+            const idLabel = caseIdLabel(c);
+            return {
+              key: `case-${c.id}`,
+              icon: kindIcon("case", 16),
+              label: idLabel || c.subject,
+              sublabel: idLabel ? c.subject : undefined,
+              href: `/cases/${c.id}`,
+              section: "Cases" as const,
+            };
+          })
+        : [];
 
     const pinned: Result[] = recents
       .filter((e) => e.pinned)
@@ -137,7 +148,7 @@ export default function QuickNav(): JSX.Element | null {
     );
 
     return [...cases, ...pinned, ...recent, ...pages];
-  }, [recents, query, caseSearch.data]);
+  }, [recents, trimmedQuery, caseHitsSettled, caseSearch.data]);
 
   // Clamp at render so a stale index from shrinking results never points past
   // the end (avoids a setState-in-effect cascade).
@@ -260,8 +271,8 @@ export default function QuickNav(): JSX.Element | null {
             {results.length === 0 ? (
               <Box sx={{ px: 2, py: 3, textAlign: "center" }}>
                 <Typography variant="body2" color="text.secondary">
-                  {query.trim().length >= QUICK_CASE_MIN_QUERY_LEN &&
-                  caseSearch.isFetching
+                  {trimmedQuery.length >= QUICK_CASE_MIN_QUERY_LEN &&
+                  (caseSearch.isFetching || !caseHitsSettled)
                     ? "Searching cases…"
                     : "No matches."}
                 </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -26,10 +26,16 @@ import { useEffect, useMemo, useState, type JSX } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import { useNavigate } from "react-router";
 import { CSM_NAV_ITEMS } from "@config/csmNavItems";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useRecentViews } from "@features/csm-recent/hooks/useRecentViews";
 import { kindIcon } from "@features/csm-recent/kindMeta";
+import {
+  QUICK_CASE_MIN_QUERY_LEN,
+  useQuickCaseSearch,
+} from "@features/csm-cases/api/useQuickCaseSearch";
+import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 
-type Section = "Pinned" | "Recent" | "Pages";
+type Section = "Cases" | "Pinned" | "Recent" | "Pages";
 
 interface Result {
   key: string;
@@ -53,6 +59,15 @@ export default function QuickNav(): JSX.Element | null {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
 
+  // Debounce the text fed to the case-search API so each keystroke doesn't fire
+  // a request; the in-memory pinned/recent/page matching still reacts instantly
+  // to `query`.
+  const debouncedQuery = useDebouncedValue(query, 180);
+
+  // API-backed case lookup: a CS/WSO2 id (or any subject text) resolves to real
+  // cases. Disabled until the query is long enough (see the hook).
+  const caseSearch = useQuickCaseSearch(open ? debouncedQuery : "");
+
   // ⌘K / Ctrl+K toggles the palette — only while signed in, so we don't hijack
   // the browser shortcut on the sign-in screen (where the palette can't render).
   useEffect(() => {
@@ -71,6 +86,20 @@ export default function QuickNav(): JSX.Element | null {
     const q = query.trim().toLowerCase();
     const match = (...parts: (string | undefined)[]) =>
       !q || parts.some((p) => p?.toLowerCase().includes(q));
+
+    // Live case hits go first — when someone types a case id, the matching case
+    // is the thing they want, ahead of pinned/recent/pages.
+    const cases: Result[] = (caseSearch.data ?? []).map((c) => {
+      const idLabel = caseIdLabel(c);
+      return {
+        key: `case-${c.id}`,
+        icon: kindIcon("case", 16),
+        label: idLabel || c.subject,
+        sublabel: idLabel ? c.subject : undefined,
+        href: `/cases/${c.id}`,
+        section: "Cases",
+      };
+    });
 
     const pinned: Result[] = recents
       .filter((e) => e.pinned)
@@ -107,8 +136,8 @@ export default function QuickNav(): JSX.Element | null {
       }),
     );
 
-    return [...pinned, ...recent, ...pages];
-  }, [recents, query]);
+    return [...cases, ...pinned, ...recent, ...pages];
+  }, [recents, query, caseSearch.data]);
 
   // Clamp at render so a stale index from shrinking results never points past
   // the end (avoids a setState-in-effect cascade).
@@ -217,7 +246,7 @@ export default function QuickNav(): JSX.Element | null {
             <InputBase
               autoFocus
               fullWidth
-              placeholder="Search pinned, recent, and pages…"
+              placeholder="Search cases by id, or jump to pinned, recent, pages…"
               value={query}
               onChange={(e) => {
                 setQuery(e.target.value);
@@ -231,7 +260,10 @@ export default function QuickNav(): JSX.Element | null {
             {results.length === 0 ? (
               <Box sx={{ px: 2, py: 3, textAlign: "center" }}>
                 <Typography variant="body2" color="text.secondary">
-                  No matches.
+                  {query.trim().length >= QUICK_CASE_MIN_QUERY_LEN &&
+                  caseSearch.isFetching
+                    ? "Searching cases…"
+                    : "No matches."}
                 </Typography>
               </Box>
             ) : (


### PR DESCRIPTION
## What

A batch of CSM-portal UI improvements:

1. **Global search by case id.** The Ctrl/Cmd-K quick-nav now resolves a CS/WSO2 case id (or any subject text) to real cases via `POST /cases/search`, and Enter jumps to the case. Previously it matched only in-memory pinned/recent/page entries. Debounced, gated to ≥2 chars, capped at 8 hits, and disabled while the palette is closed.
2. **Gate unimplemented actions.** Every case-detail *More actions* item except **Copy case link** is disabled, and the **Time tracking** tab is disabled, until their backends are wired up — so the menu/tabs still show the roadmap without exposing dead actions.
3. **Fix the just-posted comment rendering.** The comment-create response is a thin ack (no body, type, or author display name), so the appended entry rendered as "Unknown" with an empty body. The list is now refetched on success so the new comment hydrates from `comments/search`.
4. **Reconcile the dashboard pies with the case matrix.** The severity/state matrix tracks active cases (closed excluded), but the two composition pies counted the whole population, so per-severity totals disagreed with the matrix (the gap was the closed cases). Both pies are now scoped to the same active states as the matrix, all three totals reconcile, and the closed count is shown as a caption rather than a slice.

## Why

Items 1–3 remove confusing/dead UI in the case experience. Item 4 fixes a real numeric inconsistency on the dashboard (e.g. the S0 severity-pie total no longer disagrees with the matrix's S0 total).

## Notes

- Frontend only. A few items surfaced backend follow-ups (echo the full comment on create; a `work_note` create rejection; folding the retired `reopened` state into `waiting_on_wso2` at the data source) — these are tracked separately and are out of scope here.
- The dashboard still shows a `Reopened` bucket; it will be retired on the FE once the data source stops emitting that state, to avoid orphaning any case still in it.

## Test

`pnpm build`, `pnpm lint`, and `pnpm test` (84 tests) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick case search functionality to the quick navigation, allowing users to search cases by ID or subject with debounced input and real-time results.

* **Improvements**
  * Dashboard case composition now separately tracks closed cases and displays explanatory messaging that charts and matrix show active cases only.
  * Time tracking tab is now disabled in the case detail view.
  * Menu actions can now be individually disabled while remaining visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->