### PR TITLE
[CSM Portal][BE] fix: retire reopened case state, map to waiting_on_wso2

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -795,7 +795,6 @@ func TestGetCase(t *testing.T) {
 			{caseStateWorkInProgress, []string{caseStateWaitingOnWSO2, caseStateAwaitingInfo, caseStateSolutionProposed, caseStateClosed}},
 			{caseStateWaitingOnWSO2, []string{caseStateWorkInProgress}},
 			{caseStateAwaitingInfo, []string{caseStateWaitingOnWSO2}},
-			{caseStateReopened, []string{caseStateWaitingOnWSO2}},
 			{caseStateSolutionProposed, []string{caseStateClosed, caseStateWaitingOnWSO2}},
 			{caseStateClosed, []string{}},
 		}

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -23,7 +23,6 @@ const (
 	caseStateWorkInProgress   = "work_in_progress"
 	caseStateWaitingOnWSO2    = "waiting_on_wso2"
 	caseStateAwaitingInfo     = "awaiting_info"
-	caseStateReopened         = "reopened" // deprecated alias for waiting_on_wso2
 	caseStateSolutionProposed = "solution_proposed"
 	caseStateClosed           = "closed"
 )
@@ -40,8 +39,6 @@ func nextStates(state string) []string {
 	case caseStateWaitingOnWSO2:
 		return []string{caseStateWorkInProgress}
 	case caseStateAwaitingInfo:
-		return []string{caseStateWaitingOnWSO2}
-	case caseStateReopened:
 		return []string{caseStateWaitingOnWSO2}
 	case caseStateSolutionProposed:
 		return []string{caseStateClosed, caseStateWaitingOnWSO2}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -431,7 +431,6 @@ const (
 	CaseStateWorkInProgress   CaseState = "work_in_progress"
 	CaseStateWaitingOnWSO2    CaseState = "waiting_on_wso2"
 	CaseStateAwaitingInfo     CaseState = "awaiting_info"
-	CaseStateReopened         CaseState = "reopened"
 	CaseStateSolutionProposed CaseState = "solution_proposed"
 	CaseStateClosed           CaseState = "closed"
 )

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -52,7 +52,6 @@ var validCaseState = map[domain.CaseState]bool{
 	domain.CaseStateWorkInProgress:   true,
 	domain.CaseStateWaitingOnWSO2:    true,
 	domain.CaseStateAwaitingInfo:     true,
-	domain.CaseStateReopened:         true,
 	domain.CaseStateSolutionProposed: true,
 	domain.CaseStateClosed:           true,
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -120,7 +120,6 @@ var snStateIDMap = map[domain.CaseState]int{
 	domain.CaseStateWaitingOnWSO2:    1003,
 	domain.CaseStateSolutionProposed: 6,
 	domain.CaseStateClosed:           3,
-	domain.CaseStateReopened:         1006,
 }
 
 // snSeverityIDMap maps domain CasePriority enums to SN numeric severity IDs.
@@ -631,7 +630,7 @@ var snCaseStateMap = map[string]domain.CaseState{
 	"work in progress":  domain.CaseStateWorkInProgress,
 	"waiting on wso2":   domain.CaseStateWaitingOnWSO2,
 	"awaiting info":     domain.CaseStateAwaitingInfo,
-	"reopened":          domain.CaseStateReopened,
+	"reopened":          domain.CaseStateWaitingOnWSO2,
 	"solution proposed": domain.CaseStateSolutionProposed,
 	"closed":            domain.CaseStateClosed,
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1013,7 +1013,7 @@ components:
       properties:
         state:
           type: string
-          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
           description: The new state to transition the case to.
         priority:
           type: string
@@ -1093,7 +1093,7 @@ components:
           type: array
           items:
             type: string
-            enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+            enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
           description: Filter by case states.
         priorityKeys:
           type: array
@@ -1225,7 +1225,7 @@ components:
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
         state:
           type: string
-          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
         createdAt:
           type: string
           format: date-time
@@ -1259,7 +1259,7 @@ components:
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
         state:
           type: string
-          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
         createdOn:
           type: string
           format: date-time
@@ -1307,7 +1307,7 @@ components:
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
         state:
           type: string
-          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
         createdOn:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

- Maps the ServiceNow `'reopened'` state label to `waiting_on_wso2` in `sn_case_service.go` so the entity service never emits `reopened` to consumers
- Removes `CaseStateReopened` domain constant, its `validCaseState` entry, and its outbound SN numeric state ID (1006) from the entity service
- Removes the deprecated `caseStateReopened` branch from the CSM backend `nextStates()` state machine
- Removes `reopened` from all OpenAPI spec state enums in the entity service

Closes wso2-enterprise/digiops-cs#2090

## Test plan

- [x] All existing handler tests pass (`go test ./...` in `apps/csm-portal/backend`)
- [x] Both services build cleanly (`go build ./...`)
- [x] A SN case with state `reopened` is returned as `waiting_on_wso2` from `GET /cases/{id}` and `POST /cases/search`
- [x] No `nextStates` response includes `reopened`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `reopened` case state. The support case workflow no longer supports this state, and the API will no longer accept it in case updates or searches. Existing cases in this state will be mapped to an alternative state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->