### PR TITLE
[Customer Entity] Add case attachment APIs (create, search, download) via ServiceNow

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -703,3 +703,59 @@ type SearchCaseCommentsResponse struct {
 	Offset   int           `json:"offset"`
 	HasMore  bool          `json:"hasMore"`
 }
+
+// Attachment represents a file attachment linked to a case.
+type Attachment struct {
+	ID          string    `json:"id"`
+	CaseID      string    `json:"caseId"`
+	Name        string    `json:"name"`
+	Type        string    `json:"type"`
+	SizeBytes   int       `json:"sizeBytes"`
+	Description *string   `json:"description"`
+	CreatedBy   string    `json:"createdBy"`
+	CreatedOn   time.Time `json:"createdOn"`
+	DownloadURL *string   `json:"downloadUrl"`
+	PreviewURL  *string   `json:"previewUrl"`
+}
+
+// CreateAttachmentRequest is the input for POST /cases/{id}/attachments.
+// CaseID is populated from the URL path parameter and is not part of the JSON body.
+type CreateAttachmentRequest struct {
+	CaseID      string  `json:"-"`
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	File        string  `json:"file"`
+	Description *string `json:"description"`
+}
+
+// AttachmentDetail holds the core fields returned after creating an attachment.
+type AttachmentDetail struct {
+	ID          string    `json:"id"`
+	SizeBytes   int       `json:"sizeBytes"`
+	CreatedOn   time.Time `json:"createdOn"`
+	CreatedBy   string    `json:"createdBy"`
+	DownloadURL string    `json:"downloadUrl"`
+}
+
+// CreateAttachmentResponse is the response for POST /cases/{id}/attachments.
+type CreateAttachmentResponse struct {
+	Message    string           `json:"message"`
+	Attachment AttachmentDetail `json:"attachment"`
+}
+
+// SearchAttachmentsRequest is the input for POST /cases/{id}/attachments/search.
+// CaseID is populated from the URL path parameter and is not part of the JSON body.
+type SearchAttachmentsRequest struct {
+	CaseID     string     `json:"-"`
+	Pagination Pagination `json:"pagination"`
+}
+
+// SearchAttachmentsResponse is the paginated result of an attachment search.
+// HasMore is true when additional pages are available beyond the current offset.
+type SearchAttachmentsResponse struct {
+	Attachments []Attachment `json:"attachments"`
+	Total       int          `json:"total"`
+	Limit       int          `json:"limit"`
+	Offset      int          `json:"offset"`
+	HasMore     bool         `json:"hasMore"`
+}

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -126,3 +126,49 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// CreateCaseAttachment handles POST /cases/{id}/attachments.
+func (h *CaseHandler) CreateCaseAttachment(w http.ResponseWriter, r *http.Request) {
+	var req domain.CreateAttachmentRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.CaseID = r.PathValue("id")
+	resp, err := h.svc.CreateCaseAttachment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// SearchCaseAttachments handles POST /cases/{id}/attachments/search.
+func (h *CaseHandler) SearchCaseAttachments(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchAttachmentsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.CaseID = r.PathValue("id")
+	resp, err := h.svc.SearchCaseAttachments(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetCaseAttachmentContent handles GET /cases/{case_id}/attachments/{attachment_id}/content.
+func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Request) {
+	caseID := r.PathValue("case_id")
+	attachmentID := r.PathValue("attachment_id")
+	content, contentType, err := h.svc.GetCaseAttachmentContent(r.Context(), caseID, attachmentID)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	_, _ = w.Write(content)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -115,6 +115,9 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/comments/search", caseHandler.SearchCaseComments)
+	mux.HandleFunc("POST /cases/{id}/attachments", caseHandler.CreateCaseAttachment)
+	mux.HandleFunc("POST /cases/{id}/attachments/search", caseHandler.SearchCaseAttachments)
+	mux.HandleFunc("GET /cases/{case_id}/attachments/{attachment_id}/content", caseHandler.GetCaseAttachmentContent)
 
 	return middleware.CorrelationID(
 		middleware.Recovery(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -299,3 +299,15 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 		HasMore: req.Pagination.Offset+len(cases) < total,
 	}, nil
 }
+
+func (s *caseService) CreateCaseAttachment(_ context.Context, _ domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
+	return domain.CreateAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) SearchCaseAttachments(_ context.Context, _ domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error) {
+	return domain.SearchAttachmentsResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) GetCaseAttachmentContent(_ context.Context, _, _ string) ([]byte, string, error) {
+	return nil, "", &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -110,4 +110,14 @@ type CaseService interface {
 	// UpdateCase updates the state and/or priority of a case. A ValidationError is
 	// returned for invalid values or malformed UUID; a NotFoundError if no case matches.
 	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
+	// CreateCaseAttachment uploads a new attachment for the case identified by req.CaseID.
+	// A ValidationError is returned for invalid input.
+	CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error)
+	// SearchCaseAttachments returns a paginated list of attachments for the case identified
+	// by req.CaseID. A ValidationError is returned for invalid input.
+	SearchCaseAttachments(ctx context.Context, req domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error)
+	// GetCaseAttachmentContent returns the raw binary content and its Content-Type
+	// for the attachment identified by attachmentID on the given case.
+	// A NotFoundError is returned if absent.
+	GetCaseAttachmentContent(ctx context.Context, caseID, attachmentID string) (content []byte, contentType string, err error)
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -585,6 +585,11 @@ func (s *snCaseService) CreateCaseAttachment(ctx context.Context, req domain.Cre
 	}
 	rawBase64 := req.File[markerIdx+len(base64Marker):]
 
+	// Early size guard: decoded size ≈ 3/4 of base64 length. Reject before allocating.
+	if len(rawBase64)*3/4 > maxAttachmentBytes {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "file exceeds maximum allowed size of 10 MB"}
+	}
+
 	decoded, err := base64.StdEncoding.DecodeString(rawBase64)
 	if err != nil {
 		// try URL-safe variant

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -537,6 +538,200 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 
 func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
 	return s.pgFallback.UpdateCase(ctx, req)
+}
+
+type snCreateAttachmentPayload struct {
+	ReferenceID   string  `json:"referenceId"`
+	ReferenceType string  `json:"referenceType"`
+	Name          string  `json:"name"`
+	Type          string  `json:"type"`
+	File          string  `json:"file"`
+	Description   *string `json:"description,omitempty"`
+}
+
+type snCreateAttachmentResponse struct {
+	Message    string `json:"message"`
+	Attachment struct {
+		ID          string `json:"id"`
+		SizeBytes   int    `json:"sizeBytes"`
+		CreatedOn   string `json:"createdOn"`
+		CreatedBy   string `json:"createdBy"`
+		DownloadURL string `json:"downloadUrl"`
+	} `json:"attachment"`
+}
+
+const maxAttachmentBytes = 10 * 1024 * 1024 // 10 MB decoded
+
+func (s *snCaseService) CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
+	if req.Name == "" {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "name is required"}
+	}
+	if req.Type == "" {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "type is required"}
+	}
+	if req.File == "" {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "file is required"}
+	}
+
+	// file must be a data URI: data:<mime>;base64,<encoded>
+	const dataURIPrefix = "data:"
+	const base64Marker = ";base64,"
+	if !strings.HasPrefix(req.File, dataURIPrefix) {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "file must be a base64 data URI (e.g. data:image/png;base64,...)"}
+	}
+	markerIdx := strings.Index(req.File, base64Marker)
+	if markerIdx == -1 {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "file must be a base64 data URI (e.g. data:image/png;base64,...)"}
+	}
+	rawBase64 := req.File[markerIdx+len(base64Marker):]
+
+	decoded, err := base64.StdEncoding.DecodeString(rawBase64)
+	if err != nil {
+		// try URL-safe variant
+		decoded, err = base64.URLEncoding.DecodeString(rawBase64)
+		if err != nil {
+			return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "file contains invalid base64 data"}
+		}
+	}
+	if len(decoded) > maxAttachmentBytes {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "file exceeds maximum allowed size of 10 MB"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.CreateAttachmentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snCreateAttachmentPayload{
+		ReferenceID:   uuidToSysid(req.CaseID),
+		ReferenceType: "case",
+		Name:          req.Name,
+		Type:          req.Type,
+		File:          rawBase64,
+		Description:   req.Description,
+	}
+
+	raw, err := s.client.Post(ctx, "/attachments", token, payload)
+	if err != nil {
+		return domain.CreateAttachmentResponse{}, err
+	}
+
+	var snResp snCreateAttachmentResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CreateAttachmentResponse{}, fmt.Errorf("sn create attachment: parse response: %w", err)
+	}
+
+	createdOn, err := time.Parse(snCreatedOnLayout, snResp.Attachment.CreatedOn)
+	if err != nil {
+		return domain.CreateAttachmentResponse{}, fmt.Errorf("sn create attachment: parse createdOn %q: %w", snResp.Attachment.CreatedOn, err)
+	}
+
+	return domain.CreateAttachmentResponse{
+		Message: snResp.Message,
+		Attachment: domain.AttachmentDetail{
+			ID:          sysidToUUID(snResp.Attachment.ID),
+			SizeBytes:   snResp.Attachment.SizeBytes,
+			CreatedOn:   createdOn,
+			CreatedBy:   snResp.Attachment.CreatedBy,
+			DownloadURL: snResp.Attachment.DownloadURL,
+		},
+	}, nil
+}
+
+type snSearchAttachmentsPayload struct {
+	ReferenceID   string             `json:"referenceId"`
+	ReferenceType string             `json:"referenceType"`
+	Pagination    snProjectPagination `json:"pagination"`
+}
+
+type snAttachment struct {
+	ID          string  `json:"id"`
+	ReferenceID string  `json:"referenceId"`
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	SizeBytes   int     `json:"sizeBytes"`
+	Description *string `json:"description"`
+	CreatedBy   string  `json:"createdBy"`
+	CreatedOn   string  `json:"createdOn"`
+	DownloadURL *string `json:"downloadUrl"`
+	PreviewURL  *string `json:"previewUrl"`
+}
+
+type snSearchAttachmentsResponse struct {
+	Attachments  []snAttachment `json:"attachments"`
+	TotalRecords int            `json:"totalRecords"`
+	Offset       int            `json:"offset"`
+	Limit        int            `json:"limit"`
+}
+
+func (s *snCaseService) SearchCaseAttachments(ctx context.Context, req domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchAttachmentsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchAttachmentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snSearchAttachmentsPayload{
+		ReferenceID:   uuidToSysid(req.CaseID),
+		ReferenceType: "case",
+		Pagination:    snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/attachments/search", token, payload)
+	if err != nil {
+		return domain.SearchAttachmentsResponse{}, err
+	}
+
+	var snResp snSearchAttachmentsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchAttachmentsResponse{}, fmt.Errorf("sn search attachments: parse response: %w", err)
+	}
+
+	attachments := make([]domain.Attachment, 0, len(snResp.Attachments))
+	for _, a := range snResp.Attachments {
+		createdOn, err := time.Parse(snCreatedOnLayout, a.CreatedOn)
+		if err != nil {
+			return domain.SearchAttachmentsResponse{}, fmt.Errorf("sn search attachments: parse createdOn %q: %w", a.CreatedOn, err)
+		}
+		attachments = append(attachments, domain.Attachment{
+			ID:          sysidToUUID(a.ID),
+			CaseID:      sysidToUUID(a.ReferenceID),
+			Name:        a.Name,
+			Type:        a.Type,
+			SizeBytes:   a.SizeBytes,
+			Description: a.Description,
+			CreatedBy:   a.CreatedBy,
+			CreatedOn:   createdOn,
+			DownloadURL: a.DownloadURL,
+			PreviewURL:  a.PreviewURL,
+		})
+	}
+
+	total := snResp.TotalRecords
+	return domain.SearchAttachmentsResponse{
+		Attachments: attachments,
+		Total:       total,
+		Limit:       req.Pagination.Limit,
+		Offset:      req.Pagination.Offset,
+		HasMore:     req.Pagination.Offset+len(attachments) < total,
+	}, nil
+}
+
+func (s *snCaseService) GetCaseAttachmentContent(ctx context.Context, _, attachmentID string) ([]byte, string, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return nil, "", &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	resp, err := s.client.GetBinary(ctx, "/attachments/"+uuidToSysid(attachmentID)+"/content", token)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return resp.Body, resp.ContentType, nil
 }
 
 // SearchCases implements CaseService by calling the Choreo POST /cases/search endpoint.

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -156,6 +156,62 @@ func (c *Client) Get(ctx context.Context, path string, userIDToken string) (json
 	return c.do(req, path)
 }
 
+// BinaryResponse holds the raw body and the upstream Content-Type for binary downloads.
+type BinaryResponse struct {
+	Body        []byte
+	ContentType string
+}
+
+// GetBinary sends a GET request and returns the raw response body together with
+// the upstream Content-Type header. Use this instead of Get for endpoints that
+// return non-JSON binary content (e.g. file downloads).
+func (c *Client) GetBinary(ctx context.Context, path string, userIDToken string) (BinaryResponse, error) {
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return BinaryResponse{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return BinaryResponse{}, fmt.Errorf("snclient: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("x-user-id-token", userIDToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return BinaryResponse{}, err
+		}
+		return BinaryResponse{}, &apierror.ServiceUnavailableError{Msg: fmt.Sprintf("snclient: %s: %v", path, err)}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return BinaryResponse{}, fmt.Errorf("snclient: read response body: %w", err)
+	}
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		ct := resp.Header.Get("Content-Type")
+		if ct == "" {
+			ct = http.DetectContentType(body)
+		}
+		return BinaryResponse{Body: body, ContentType: ct}, nil
+	case resp.StatusCode == http.StatusUnauthorized:
+		return BinaryResponse{}, &apierror.UnauthorizedError{Msg: "invalid or missing x-user-id-token"}
+	case resp.StatusCode == http.StatusForbidden:
+		return BinaryResponse{}, &apierror.ForbiddenError{Msg: "not authorized to access this resource"}
+	case resp.StatusCode == http.StatusNotFound:
+		return BinaryResponse{}, &apierror.NotFoundError{Msg: "resource not found in downstream service"}
+	case resp.StatusCode == http.StatusServiceUnavailable:
+		return BinaryResponse{}, &apierror.ServiceUnavailableError{Msg: "downstream service unavailable"}
+	default:
+		return BinaryResponse{}, fmt.Errorf("snclient: %s: unexpected status %d: %s", path, resp.StatusCode, body)
+	}
+}
+
 // Post sends a POST request to the given path. The OAuth2 bearer token is
 // added as Authorization header; userIDToken is forwarded as x-user-id-token.
 // Returns the raw response body on 2xx.

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -187,9 +187,13 @@ func (c *Client) GetBinary(ctx context.Context, path string, userIDToken string)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	const maxBinaryBytes = 10*1024*1024 + 1 // 10 MB + 1 to detect over-limit responses
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBinaryBytes))
 	if err != nil {
 		return BinaryResponse{}, fmt.Errorf("snclient: read response body: %w", err)
+	}
+	if len(body) >= maxBinaryBytes {
+		return BinaryResponse{}, &apierror.ValidationError{Msg: "attachment content exceeds maximum allowed size of 10 MB"}
 	}
 
 	switch {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -491,6 +491,146 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/{id}/attachments:
+    post:
+      summary: Upload a file attachment to a support case.
+      operationId: createCaseAttachment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAttachmentRequest'
+      responses:
+        "201":
+          description: Attachment uploaded successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateAttachmentResponse'
+        "400":
+          description: Bad request (missing fields, invalid data URI, or file exceeds 10 MB).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /cases/{id}/attachments/search:
+    post:
+      summary: Search attachments linked to a support case.
+      operationId: searchCaseAttachments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchAttachmentsRequest'
+      responses:
+        "200":
+          description: Paginated list of attachments for the case.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchAttachmentsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /cases/{case_id}/attachments/{attachment_id}/content:
+    get:
+      summary: Download the binary content of a case attachment.
+      operationId: getCaseAttachmentContent
+      parameters:
+        - name: case_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Case UUID.
+        - name: attachment_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Attachment UUID.
+      responses:
+        "200":
+          description: Raw file content. Content-Type reflects the actual file type (e.g. image/png, application/pdf).
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Attachment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /deployed-products/search:
     post:
       summary: Search deployed products by deployment IDs.
@@ -1381,6 +1521,99 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CaseComment'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    CreateAttachmentRequest:
+      type: object
+      required: [name, type, file]
+      properties:
+        name:
+          type: string
+          description: File name including extension.
+        type:
+          type: string
+          description: MIME type of the file (e.g. image/png, application/pdf).
+        file:
+          type: string
+          description: Base64 data URI of the file content (e.g. data:image/png;base64,...). Maximum decoded size is 10 MB.
+        description:
+          type: string
+          nullable: true
+
+    AttachmentDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sizeBytes:
+          type: integer
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        downloadUrl:
+          type: string
+
+    CreateAttachmentResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        attachment:
+          $ref: '#/components/schemas/AttachmentDetail'
+
+    Attachment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        caseId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        type:
+          type: string
+        sizeBytes:
+          type: integer
+        description:
+          type: string
+          nullable: true
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        downloadUrl:
+          type: string
+          nullable: true
+        previewUrl:
+          type: string
+          nullable: true
+
+    SearchAttachmentsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    SearchAttachmentsResponse:
+      type: object
+      properties:
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attachment'
         total:
           type: integer
         limit:


### PR DESCRIPTION
## Summary

- Adds `POST /cases/{id}/attachments` to upload a file attachment to a ServiceNow case. The request accepts a base64 data URI (`data:<mime>;base64,...`) with a 10 MB decoded size limit; the data URI prefix is stripped before forwarding to ServiceNow.
- Adds `POST /cases/{id}/attachments/search` to return a paginated list of attachments linked to a case, following the existing pagination conventions (`total`, `limit`, `offset`, `hasMore`).
- Adds `GET /cases/{case_id}/attachments/{attachment_id}/content` to stream raw file content back to the caller. A new `GetBinary` client method preserves the upstream `Content-Type` header (falling back to Go's built-in content sniffing) so browsers and API clients can render files correctly — unlike the existing `Get` method which discards response headers.
- All three endpoints are ServiceNow-only; the PostgreSQL `CaseService` stubs return `503 Service Unavailable`.
- All IDs follow the existing sysid ↔ UUID conversion rules: UUIDs are converted to sysids on outbound SN requests, and all response IDs are converted back to UUIDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file attachment capability for cases, enabling improved documentation and case management workflows
  * Added search and filtering functionality across case attachments for quick access to relevant files
  * Added ability to download and retrieve attachment content directly from the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->