### PR TITLE
[CSM Portal][BE] fix(cases): raise body cap for comment-create to 10 MiB

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -65,6 +65,11 @@ func NewCaseHandler(entity entityCaseClient) *CaseHandler {
 // maxRequestBodyBytes caps incoming request bodies at 1 MiB to prevent memory DoS.
 const maxRequestBodyBytes = 1 << 20
 
+// maxCommentBodyBytes caps comment-create bodies at 10 MiB. Comments can carry
+// inline images as base64 data URIs, which inflate raw image size by ~33%, so
+// a 1 MiB global cap rejects images well under ServiceNow's own limit.
+const maxCommentBodyBytes = 10 << 20
+
 // CreateCase handles POST /cases.
 func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
@@ -127,7 +132,7 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, maxCommentBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		if _, ok := err.(*http.MaxBytesError); ok {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -190,9 +190,9 @@ func TestCreateCaseComment(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+	t.Run("rejects body exceeding 10 MiB comment limit", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(strings.Repeat("x", maxCommentBodyBytes+1))))
 		r.SetPathValue("id", "case-1")
 		w := httptest.NewRecorder()
 		h.CreateCaseComment(w, r)


### PR DESCRIPTION
## Summary

- Adds a dedicated `maxCommentBodyBytes = 10 MiB` constant for `POST /cases/{id}/comments`
- All other endpoints keep the existing `maxRequestBodyBytes = 1 MiB` DoS guard unchanged

**Why 10 MiB:** comments can carry inline images as base64 data URIs, which inflate raw image size by ~33%. A 1 MiB cap rejects any image over ~750 KB raw. 10 MiB aligns with ServiceNow's own attachment limit and gives comfortable headroom for multi-image comments.

Closes wso2-enterprise/digiops-cs#2091

## Test plan

- [ ] `POST /cases/{id}/comments` with a body between 1 MiB and 10 MiB returns 201 (no longer 413)
- [ ] `POST /cases/{id}/comments` with a body > 10 MiB still returns 413
- [ ] All other endpoints (`POST /cases`, `POST /cases/search`, `PATCH /cases/{id}`, etc.) still return 413 for bodies > 1 MiB
- [ ] Handler tests pass: `go test ./internal/handler/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum allowed size for case comments from 1 MiB to 10 MiB, enabling users to submit larger comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->