### PR TITLE
[Customer Entity] Nest case search filters, fix totalRecords mapping, and forward sortBy to ServiceNow

### DIFF
--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -1,3 +1,4 @@
+# Server port
 SERVER_PORT=8080
 
 # Data source: "postgres" (default) or "servicenow"

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -549,11 +549,8 @@ type CaseView struct {
 	AccountDetails         *AccountRef          `json:"account"`
 }
 
-// SearchCasesRequest is the input for a case search operation.
-// SearchQuery is matched case-insensitively against subject, number, and internal_id.
-// All filter slices are optional. SortBy defaults to created_at.
-type SearchCasesRequest struct {
-	Pagination         Pagination      `json:"pagination"`
+// SearchCasesFilters holds all optional filter criteria for a case search.
+type SearchCasesFilters struct {
 	SearchQuery        string          `json:"searchQuery"`
 	ProjectIDs         []string        `json:"projectIds"`
 	DeploymentIDs      []string        `json:"deploymentIds"`
@@ -561,7 +558,14 @@ type SearchCasesRequest struct {
 	StateKeys          []CaseState     `json:"stateKeys"`
 	PriorityKeys       []CasePriority  `json:"priorityKeys"`
 	IssueTypeKeys      []CaseIssueType `json:"issueTypeKeys"`
-	SortBy             CaseSort        `json:"sortBy"`
+}
+
+// SearchCasesRequest is the input for a case search operation.
+// All filter fields are optional and nested under Filters. SortBy defaults to created_at.
+type SearchCasesRequest struct {
+	Filters    SearchCasesFilters `json:"filters"`
+	SortBy     CaseSort           `json:"sortBy"`
+	Pagination Pagination         `json:"pagination"`
 }
 
 // SearchCaseView is the enriched read representation of a case returned in search

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -304,27 +304,27 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 
 	where := "WHERE 1=1"
 
-	if len(req.ProjectIDs) > 0 {
+	if len(req.Filters.ProjectIDs) > 0 {
 		where += fmt.Sprintf(" AND c.project_id = ANY($%d::uuid[])", argIdx)
-		filterArgs = append(filterArgs, req.ProjectIDs)
+		filterArgs = append(filterArgs, req.Filters.ProjectIDs)
 		argIdx++
 	}
 
-	if len(req.DeploymentIDs) > 0 {
+	if len(req.Filters.DeploymentIDs) > 0 {
 		where += fmt.Sprintf(" AND c.deployment_id = ANY($%d::uuid[])", argIdx)
-		filterArgs = append(filterArgs, req.DeploymentIDs)
+		filterArgs = append(filterArgs, req.Filters.DeploymentIDs)
 		argIdx++
 	}
 
-	if len(req.DeployedProductIDs) > 0 {
+	if len(req.Filters.DeployedProductIDs) > 0 {
 		where += fmt.Sprintf(" AND c.deployed_product_id = ANY($%d::uuid[])", argIdx)
-		filterArgs = append(filterArgs, req.DeployedProductIDs)
+		filterArgs = append(filterArgs, req.Filters.DeployedProductIDs)
 		argIdx++
 	}
 
-	if len(req.StateKeys) > 0 {
-		stateStrings := make([]string, len(req.StateKeys))
-		for i, s := range req.StateKeys {
+	if len(req.Filters.StateKeys) > 0 {
+		stateStrings := make([]string, len(req.Filters.StateKeys))
+		for i, s := range req.Filters.StateKeys {
 			stateStrings[i] = string(s)
 		}
 		where += fmt.Sprintf(" AND c.state = ANY($%d::case_state_enum[])", argIdx)
@@ -332,9 +332,9 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
-	if len(req.PriorityKeys) > 0 {
-		priorityStrings := make([]string, len(req.PriorityKeys))
-		for i, p := range req.PriorityKeys {
+	if len(req.Filters.PriorityKeys) > 0 {
+		priorityStrings := make([]string, len(req.Filters.PriorityKeys))
+		for i, p := range req.Filters.PriorityKeys {
 			priorityStrings[i] = string(p)
 		}
 		where += fmt.Sprintf(" AND c.priority = ANY($%d::case_priority_enum[])", argIdx)
@@ -342,9 +342,9 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
-	if len(req.IssueTypeKeys) > 0 {
-		issueTypeStrings := make([]string, len(req.IssueTypeKeys))
-		for i, it := range req.IssueTypeKeys {
+	if len(req.Filters.IssueTypeKeys) > 0 {
+		issueTypeStrings := make([]string, len(req.Filters.IssueTypeKeys))
+		for i, it := range req.Filters.IssueTypeKeys {
 			issueTypeStrings[i] = string(it)
 		}
 		where += fmt.Sprintf(" AND c.issue_type = ANY($%d::case_issue_type_enum[])", argIdx)
@@ -352,8 +352,8 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
-	if req.SearchQuery != "" {
-		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.SearchQuery)
+	if req.Filters.SearchQuery != "" {
+		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.Filters.SearchQuery)
 		pattern := "%" + escaped + "%"
 		where += fmt.Sprintf(` AND (c.subject ILIKE $%d ESCAPE '\' OR c.number ILIKE $%d ESCAPE '\' OR c.internal_id ILIKE $%d ESCAPE '\')`, argIdx, argIdx, argIdx)
 		filterArgs = append(filterArgs, pattern)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -246,30 +246,30 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
-	if err := validateSearchQuery(req.SearchQuery); err != nil {
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
-	if err := validateUUIDs("projectIds", req.ProjectIDs); err != nil {
+	if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
-	if err := validateUUIDs("deploymentIds", req.DeploymentIDs); err != nil {
+	if err := validateUUIDs("deploymentIds", req.Filters.DeploymentIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
-	if err := validateUUIDs("deployedProductIds", req.DeployedProductIDs); err != nil {
+	if err := validateUUIDs("deployedProductIds", req.Filters.DeployedProductIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
 
-	for _, s := range req.StateKeys {
+	for _, s := range req.Filters.StateKeys {
 		if !validCaseState[s] {
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "stateKeys contains invalid value: " + string(s)}
 		}
 	}
-	for _, p := range req.PriorityKeys {
+	for _, p := range req.Filters.PriorityKeys {
 		if !validCasePriority[p] {
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "priorityKeys contains invalid value: " + string(p)}
 		}
 	}
-	for _, it := range req.IssueTypeKeys {
+	for _, it := range req.Filters.IssueTypeKeys {
 		if !validCaseIssueType[it] {
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "issueTypeKeys contains invalid value: " + string(it)}
 		}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -33,7 +33,7 @@ import (
 // snCasesResponse mirrors the Choreo POST /cases/search response.
 type snCasesResponse struct {
 	Cases        []snCase `json:"cases"`
-	TotalRecords int      `json:"totalRecords"`
+	TotalRecords int      `json:"total"`
 	Offset       int      `json:"offset"`
 	Limit        int      `json:"limit"`
 }
@@ -741,7 +741,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
-	if err := validateSearchQuery(req.SearchQuery); err != nil {
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
 
@@ -753,13 +753,13 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	payload := snCaseSearchPayload{
 		Filters: snCaseFilters{
 			CaseTypes:          []string{"default_case"},
-			SearchQuery:        req.SearchQuery,
-			ProjectIDs:         uuidsToSysids(req.ProjectIDs),
-			DeploymentIDs:      uuidsToSysids(req.DeploymentIDs),
-			DeployedProductIDs: uuidsToSysids(req.DeployedProductIDs),
-			StateKeys:          domainStatesToSNIDs(req.StateKeys),
-			SeverityKeys:       domainPrioritiesToSNIDs(req.PriorityKeys),
-			IssueTypeKeys:      domainIssueTypesToSNIDs(req.IssueTypeKeys),
+			SearchQuery:        req.Filters.SearchQuery,
+			ProjectIDs:         uuidsToSysids(req.Filters.ProjectIDs),
+			DeploymentIDs:      uuidsToSysids(req.Filters.DeploymentIDs),
+			DeployedProductIDs: uuidsToSysids(req.Filters.DeployedProductIDs),
+			StateKeys:          domainStatesToSNIDs(req.Filters.StateKeys),
+			SeverityKeys:       domainPrioritiesToSNIDs(req.Filters.PriorityKeys),
+			IssueTypeKeys:      domainIssueTypesToSNIDs(req.Filters.IssueTypeKeys),
 		},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -763,7 +763,11 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	}
 
 	var snSortBy *snCaseSort
-	if snField, ok := snSortFieldMap[req.SortBy.Field]; ok {
+	if req.SortBy.Field != "" {
+		snField, ok := snSortFieldMap[req.SortBy.Field]
+		if !ok {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "sortBy.field " + string(req.SortBy.Field) + " is not supported by ServiceNow"}
+		}
 		order := string(req.SortBy.Order)
 		if order == "" {
 			order = "desc"

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -33,7 +33,7 @@ import (
 // snCasesResponse mirrors the Choreo POST /cases/search response.
 type snCasesResponse struct {
 	Cases        []snCase `json:"cases"`
-	TotalRecords int      `json:"total"`
+	TotalRecords int      `json:"totalRecords"`
 	Offset       int      `json:"offset"`
 	Limit        int      `json:"limit"`
 }
@@ -99,7 +99,19 @@ type snCaseIssueType struct {
 // snCaseSearchPayload is the Choreo POST /cases/search request body.
 type snCaseSearchPayload struct {
 	Filters    snCaseFilters       `json:"filters,omitempty"`
+	SortBy     *snCaseSort         `json:"sortBy,omitempty"`
 	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snCaseSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+// snSortFieldMap maps domain CaseSortField values to SN field names.
+var snSortFieldMap = map[domain.CaseSortField]string{
+	domain.CaseSortFieldCreatedAt: "createdOn",
+	domain.CaseSortFieldUpdatedAt: "updatedOn",
 }
 
 type snCaseFilters struct {
@@ -750,6 +762,15 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
+	var snSortBy *snCaseSort
+	if snField, ok := snSortFieldMap[req.SortBy.Field]; ok {
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snCaseSort{Field: snField, Order: order}
+	}
+
 	payload := snCaseSearchPayload{
 		Filters: snCaseFilters{
 			CaseTypes:          []string{"default_case"},
@@ -761,6 +782,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			SeverityKeys:       domainPrioritiesToSNIDs(req.Filters.PriorityKeys),
 			IssueTypeKeys:      domainIssueTypesToSNIDs(req.Filters.IssueTypeKeys),
 		},
+		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1206,11 +1206,9 @@ components:
             state:
               type: string
 
-    SearchCasesRequest:
+    SearchCasesFilters:
       type: object
       properties:
-        pagination:
-          $ref: '#/components/schemas/Pagination'
         searchQuery:
           type: string
           description: Case-insensitive match against subject, number, and internal_id.
@@ -1247,6 +1245,12 @@ components:
             type: string
             enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
           description: Filter by case issue types.
+
+    SearchCasesRequest:
+      type: object
+      properties:
+        filters:
+          $ref: '#/components/schemas/SearchCasesFilters'
         sortBy:
           type: object
           properties:
@@ -1258,6 +1262,8 @@ components:
               type: string
               enum: [asc, desc]
               description: Sort direction. Defaults to desc.
+        pagination:
+          $ref: '#/components/schemas/Pagination'
 
     UserRef:
       type: object


### PR DESCRIPTION
## Summary
- Restructures SearchCasesRequest to nest all filter fields (searchQuery, projectIds, deploymentIds, deployedProductIds, stateKeys, priorityKeys, issueTypeKeys) under a filters object, with sortBy and pagination at the top level
- Fixes snCasesResponse to map totalRecords from the correct JSON field returned by the SN /cases/search endpoint, so total and hasMore in the response are accurate
- Adds sortBy forwarding to ServiceNow, mapping domain sort fields (created_at → createdOn, updated_at → updatedOn) to SN's expected field names

@coderabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Updated the case search API request format by grouping optional filter criteria (search query, project/deployment/deployed product IDs, and state/priority/issue-type keys) into a dedicated `filters` object.
  * Kept `sortBy` and `pagination` at the top level while aligning behavior across the service and repository.
  * Added support for optional ServiceNow case sorting and refreshed the OpenAPI schema to match the new request shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->