### PR TITLE
[CSM Portal] case detail: project/account views, attachments, content-size guards & activity UX

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -59,8 +59,14 @@ const CsmUsersPage = lazy(
 const CsmAccountsPage = lazy(
   () => import("@features/csm-accounts/pages/CsmAccountsPage"),
 );
+const CsmAccountDetailPage = lazy(
+  () => import("@features/csm-accounts/pages/CsmAccountDetailPage"),
+);
 const CsmProjectsPage = lazy(
   () => import("@features/csm-projects/pages/CsmProjectsPage"),
+);
+const CsmProjectDetailPage = lazy(
+  () => import("@features/csm-projects/pages/CsmProjectDetailPage"),
 );
 const CsmUpdatesPage = lazy(
   () => import("@features/updates/pages/CsmUpdatesPage"),
@@ -113,9 +119,11 @@ export default function App(): JSX.Element {
               <Route element={<AuthGuard />}>
                 <Route path="/" element={<RootLanding />} />
 
-                {/* BFF-backed pages (entity-service search endpoints) */}
+                {/* BFF-backed pages (entity-service search + by-id endpoints) */}
                 <Route path="accounts" element={<CsmAccountsPage />} />
+                <Route path="accounts/:id" element={<CsmAccountDetailPage />} />
                 <Route path="projects" element={<CsmProjectsPage />} />
+                <Route path="projects/:id" element={<CsmProjectDetailPage />} />
 
                 {/* Administration — Users tab is real, others are WIP */}
                 <Route path="admin" element={<CsmAdminLayout />}>

--- a/apps/csm-portal/webapp/src/api/backend/client.ts
+++ b/apps/csm-portal/webapp/src/api/backend/client.ts
@@ -88,6 +88,12 @@ export interface BackendApi {
   post<TRequest, TResponse>(path: string, body: TRequest): Promise<TResponse>;
   patch<TRequest, TResponse>(path: string, body: TRequest): Promise<TResponse>;
   postEmpty<TResponse>(path: string): Promise<TResponse>;
+  /**
+   * Authenticated binary GET. Used for endpoints that stream raw file content
+   * (e.g. attachment download) rather than JSON. Unlike {@link BackendApi.get},
+   * a 404 throws like any other error — there is no "null" body for a binary.
+   */
+  getBlob(path: string): Promise<Blob>;
 }
 
 /**
@@ -146,6 +152,11 @@ export function useBackendApi(): BackendApi {
         });
         if (!response.ok) throw await readError(response);
         return (await response.json()) as TResponse;
+      },
+      async getBlob(path: string): Promise<Blob> {
+        const response = await authFetch(buildUrl(path), { method: "GET" });
+        if (!response.ok) throw await readError(response);
+        return await response.blob();
       },
     }),
     [authFetch, buildUrl],

--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -50,18 +50,12 @@ describe("priorityFromSeverity", () => {
 });
 
 describe("uiStateFromBe / beStateFromUi", () => {
-  it("passes reopened through unchanged (UI and backend now share the spelling)", () => {
-    expect(uiStateFromBe("reopened")).toBe("reopened");
-    expect(beStateFromUi("reopened")).toBe("reopened");
-  });
-
   it("passes through shared states unchanged", () => {
     for (const s of [
       "open",
       "work_in_progress",
       "waiting_on_wso2",
       "awaiting_info",
-      "reopened",
       "solution_proposed",
       "closed",
     ] as const) {

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -21,12 +21,14 @@
  */
 
 import type {
+  BeAttachment,
   BeCaseComment,
   BeCreatableCommentType,
   BeCasePriority,
   BeCaseState,
 } from "@api/backend/types";
 import type {
+  CaseAttachment,
   CsmCaseComment,
   CsmCommentAuthorRole,
 } from "@features/csm-cases/types/csmCases";
@@ -132,5 +134,21 @@ export function uiCommentFromBe(comment: BeCaseComment): CsmCaseComment {
     bodyHtml: comment.content ?? "",
     createdAt: comment.createdOn,
     internal: comment.type === "work_note",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+/** Map a backend attachment onto the UI's `CaseAttachment` shape. */
+export function uiAttachmentFromBe(att: BeAttachment): CaseAttachment {
+  return {
+    id: att.id,
+    filename: att.name,
+    size: att.sizeBytes,
+    contentType: att.type,
+    uploadedBy: att.createdBy || "Unknown",
+    uploadedAt: att.createdOn,
   };
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -188,8 +188,9 @@ export interface BeCaseUpdatePayload {
 }
 
 /** Request body for `POST /cases/search` (the flat, cross-project search). */
-export interface BeCaseSearchPayload {
-  pagination?: BePagination;
+/** Filter block for `POST /cases/search`; all fields are optional. */
+export interface BeCaseSearchFilters {
+  /** Searches across subject, number, and wso2Id (case-insensitive). */
   searchQuery?: string;
   /** Optional project filter; omit for a cross-project search. */
   projectIds?: string[];
@@ -198,6 +199,12 @@ export interface BeCaseSearchPayload {
   stateKeys?: BeCaseState[];
   priorityKeys?: BeCasePriority[];
   issueTypeKeys?: BeCaseIssueType[];
+}
+
+export interface BeCaseSearchPayload {
+  /** All filter fields are nested here; `sortBy`/`pagination` stay top-level. */
+  filters?: BeCaseSearchFilters;
+  pagination?: BePagination;
   sortBy?: {
     field?: BeCaseSortField;
     order?: "asc" | "desc";

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -275,6 +275,58 @@ export interface BeCaseCommentSearchResponse extends BeSearchResponseBase {
 }
 
 // ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+/** A case attachment as returned by `POST /cases/{id}/attachments/search`. */
+export interface BeAttachment {
+  id: string;
+  caseId: string;
+  name: string;
+  /** MIME type (e.g. image/png, application/pdf). */
+  type: string;
+  sizeBytes: number;
+  description?: string | null;
+  createdBy: string;
+  createdOn: string;
+  downloadUrl?: string | null;
+  previewUrl?: string | null;
+}
+
+export interface BeAttachmentSearchPayload {
+  pagination?: BePagination;
+}
+
+export interface BeAttachmentSearchResponse extends BeSearchResponseBase {
+  attachments: BeAttachment[];
+}
+
+/**
+ * Upload payload for `POST /cases/{id}/attachments`. `file` is a base64 data
+ * URI (e.g. `data:image/png;base64,...`); the BE caps the decoded size at 10 MB.
+ */
+export interface BeAttachmentCreatePayload {
+  name: string;
+  type: string;
+  file: string;
+  description?: string | null;
+}
+
+/** Thin ack returned by `POST /cases/{id}/attachments`. */
+export interface BeAttachmentDetail {
+  id: string;
+  sizeBytes: number;
+  createdOn: string;
+  createdBy: string;
+  downloadUrl: string;
+}
+
+export interface BeAttachmentCreateResponse {
+  message?: string;
+  attachment?: BeAttachmentDetail;
+}
+
+// ---------------------------------------------------------------------------
 // Users
 // ---------------------------------------------------------------------------
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -68,7 +68,6 @@ export type BeCaseState =
   | "work_in_progress"
   | "waiting_on_wso2"
   | "awaiting_info"
-  | "reopened"
   | "solution_proposed"
   | "closed";
 

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -43,6 +43,7 @@ import Toolbar, {
 } from "@components/rich-text-editor/ToolBar";
 import type { JSX } from "react";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import { ImageNode } from "@components/rich-text-editor/ImageNode";
 import ImagesPlugin from "@components/rich-text-editor/ImagesPlugin";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
@@ -312,6 +313,7 @@ const Editor = ({
   id,
   showKeyboardHint = false,
   maxHeight = "300px",
+  autoFocus = false,
   onFocus,
   onBlur,
   overlayElement,
@@ -333,6 +335,8 @@ const Editor = ({
   id?: string;
   showKeyboardHint?: boolean;
   maxHeight?: string | number;
+  /** Focus the editor on mount (e.g. when a reply composer opens). */
+  autoFocus?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
   /** Optional element rendered as an absolute overlay at the bottom-right inside the editor. */
@@ -510,6 +514,7 @@ const Editor = ({
             }
             ErrorBoundary={LexicalErrorBoundary}
           />
+          {autoFocus && <AutoFocusPlugin />}
           <HistoryPlugin />
           <ListPlugin />
           <ImagesPlugin />

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -87,6 +87,7 @@ export const ApiQueryKeys = {
   CSM_CASE_DETAIL: "csm-case-detail",
   CSM_CASE_COMMENTS: "csm-case-comments",
   CSM_PROJECTS: "csm-projects",
+  CSM_PROJECT_DETAIL: "csm-project-detail",
   CSM_ACCOUNTS: "csm-accounts",
   CSM_ACCOUNT_DETAIL: "csm-account-detail",
   CSM_ACCOUNT_PROJECTS: "csm-account-projects",

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -86,6 +86,7 @@ export const ApiQueryKeys = {
   CSM_CASE_COUNTS: "csm-case-counts",
   CSM_CASE_DETAIL: "csm-case-detail",
   CSM_CASE_COMMENTS: "csm-case-comments",
+  CSM_CASE_ATTACHMENTS: "csm-case-attachments",
   CSM_PROJECTS: "csm-projects",
   CSM_PROJECT_DETAIL: "csm-project-detail",
   CSM_ACCOUNTS: "csm-accounts",

--- a/apps/csm-portal/webapp/src/features/csm-accounts/api/useGetAccount.ts
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/api/useGetAccount.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAuthApiClient } from "@hooks/useAuthApiClient";
+import { apiConfig } from "@config/apiConfig";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
+import type { Account } from "@features/csm-accounts/types/csmAccounts";
+
+/**
+ * Look up a single account by id via `GET /accounts/{id}` (BFF passthrough to
+ * the entity service). Returns `null` (not an error) on 404 so the page can
+ * render a not-found state instead of an error banner. The query stays disabled
+ * until an id is present so a bare `/accounts/` never fires a request.
+ */
+export function useGetAccount(
+  id: string | undefined,
+): UseQueryResult<Account | null, Error> {
+  const authFetch = useAuthApiClient();
+
+  return useQuery<Account | null, Error>({
+    queryKey: [ApiQueryKeys.CSM_ACCOUNT_DETAIL, id ?? ""],
+    queryFn: async (): Promise<Account | null> => {
+      if (!id) return null;
+
+      const res = await authFetch(
+        `${apiConfig.backendUrl}/accounts/${encodeURIComponent(id)}`,
+      );
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ApiError(
+          res.status,
+          res.statusText,
+          parseApiResponseMessage(body, res.status, res.statusText),
+        );
+      }
+      return (await res.json()) as Account;
+    },
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode } from "react";
+import { useNavigate, useParams } from "react-router";
+import { useGetAccount } from "@features/csm-accounts/api/useGetAccount";
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString();
+}
+
+function MetaCell({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function Mono({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <Typography variant="body2" sx={{ fontFamily: "monospace", wordBreak: "break-all" }}>
+      {children}
+    </Typography>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={onClick}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back to accounts
+    </Button>
+  );
+}
+
+export default function CsmAccountDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useGetAccount(id);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rectangular" height={32} width={240} />
+        <Skeleton variant="rectangular" height={220} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/accounts")} />
+        <Typography variant="body1" color="error">
+          Could not load account {id}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/accounts")} />
+        <Typography variant="h5">Account not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No account with id <code>{id}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const a = data;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <BackButton onClick={() => navigate("/accounts")} />
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="h5">{a.name}</Typography>
+          <Chip
+            size="small"
+            label={a.tier}
+            color={a.tier === "enterprise" ? "primary" : "default"}
+            variant="outlined"
+          />
+          {a.deactivationDate && (
+            <Chip size="small" label="Deactivated" color="default" variant="outlined" />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+          {a.sfId}
+        </Typography>
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Tier">
+            <Typography variant="body2" sx={{ textTransform: "capitalize" }}>
+              {a.tier}
+            </Typography>
+          </MetaCell>
+          <MetaCell label="Region">
+            <Typography variant="body2">{a.region ?? "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Salesforce ID">
+            <Mono>{a.sfId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Activated">
+            <Typography variant="body2">{formatDate(a.activationDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="Deactivated">
+            <Typography variant="body2">{formatDate(a.deactivationDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="AI agent">
+            <Chip
+              size="small"
+              variant="outlined"
+              color={a.agentEnabled ? "success" : "default"}
+              label={a.agentEnabled ? "Enabled" : "Disabled"}
+            />
+          </MetaCell>
+          <MetaCell label="KB references">
+            <Chip
+              size="small"
+              variant="outlined"
+              color={a.kbReferencesEnabled ? "success" : "default"}
+              label={a.kbReferencesEnabled ? "Enabled" : "Disabled"}
+            />
+          </MetaCell>
+          <MetaCell label="Owner ID">
+            <Mono>{a.ownerId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Technical owner ID">
+            <Mono>{a.technicalOwnerId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Created">
+            <Typography variant="body2">{formatDate(a.createdAt)}</Typography>
+          </MetaCell>
+          <MetaCell label="Last updated">
+            <Typography variant="body2">{formatDate(a.updatedAt)}</Typography>
+          </MetaCell>
+          <MetaCell label="Account ID">
+            <Mono>{a.id}</Mono>
+          </MetaCell>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -31,6 +31,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts";
 import type { SearchAccountsRequest } from "@features/csm-accounts/types/csmAccounts";
@@ -132,7 +133,21 @@ export default function CsmAccountsPage(): JSX.Element {
               ) : (
                 accounts.map((a) => (
                   <TableRow key={a.id} hover>
-                    <TableCell>{a.name}</TableCell>
+                    <TableCell>
+                      <Typography
+                        component={RouterLink}
+                        to={`/accounts/${a.id}`}
+                        variant="body2"
+                        sx={(t) => ({
+                          textDecoration: "none",
+                          color: t.palette.primary.dark,
+                          ...t.applyStyles("dark", { color: t.palette.primary.main }),
+                          "&:hover": { textDecoration: "underline" },
+                        })}
+                      >
+                        {a.name}
+                      </Typography>
+                    </TableCell>
                     <TableCell>{a.sfId}</TableCell>
                     <TableCell>
                       <Chip

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
@@ -357,7 +357,7 @@ const ABT_CASE_SEEDS: CaseSeed[] = [
     projectId: "prj-acme-iam-prod",
     projectName: "IAM Production",
     severity: "S2",
-    state: "reopened",
+    state: "waiting_on_wso2",
     assignee: "Sajith Ekanayaka",
     assigneeIsMe: true,
     slaClockType: "ack",
@@ -809,8 +809,6 @@ function deriveTags(c: CsmCaseRow): CaseTag[] {
     tags.push({ id: "t-priority", label: "high-priority", color: "error" });
   if (c.minutesToBreach < 0)
     tags.push({ id: "t-breach", label: "sla-breached", color: "warning" });
-  if (c.state === "reopened")
-    tags.push({ id: "t-reopen", label: "reopened", color: "warning" });
   const subjLower = c.subject.toLowerCase();
   if (subjLower.includes("ldap")) tags.push({ id: "t-ldap", label: "ldap", color: "info" });
   if (subjLower.includes("saml") || subjLower.includes("oidc"))
@@ -915,15 +913,6 @@ function deriveAudit(c: CsmCaseRow): CaseAuditEntry[] {
       kind: "state_change",
       actor: assignee,
       description: "Case closed",
-      createdAt: c.updatedAt,
-    });
-  }
-  if (c.state === "reopened") {
-    events.push({
-      id: `a-${c.id}-3`,
-      kind: "state_change",
-      actor: "Customer",
-      description: "Customer reopened the case",
       createdAt: c.updatedAt,
     });
   }
@@ -1198,7 +1187,6 @@ const MOCK_NEXT_STATES: Record<CaseState, CaseState[]> = {
   ],
   waiting_on_wso2: ["work_in_progress"],
   awaiting_info: ["waiting_on_wso2"],
-  reopened: ["waiting_on_wso2"],
   solution_proposed: ["closed", "waiting_on_wso2"],
   closed: [],
 };

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
@@ -1147,6 +1147,41 @@ function deriveAttachments(c: CsmCaseRow): CaseAttachment[] {
   return sets[seedIdx % 4] ?? [];
 }
 
+// Attachments uploaded during a mock session, keyed by case id, so a mock
+// upload is visible on the next list refetch (the seeded set is deterministic).
+const mockUploadedAttachments = new Map<string, CaseAttachment[]>();
+
+/** Mock attachment list: seeded set plus anything uploaded this session. */
+export function getMockCsmCaseAttachments(caseId: string): CaseAttachment[] {
+  const row = getMockCsmCaseById(caseId);
+  const seeded = row ? deriveAttachments(row) : [];
+  const uploaded = mockUploadedAttachments.get(caseId) ?? [];
+  // Newest first matches how the widget sorts; concat is enough since the
+  // widget re-sorts by uploadedAt.
+  return [...uploaded, ...seeded];
+}
+
+/** Mock attachment upload: records and echoes back a fresh `CaseAttachment`. */
+export function postMockCsmCaseAttachment(input: {
+  caseId: string;
+  filename: string;
+  size: number;
+  contentType: string;
+  uploadedBy: string;
+}): CaseAttachment {
+  const created: CaseAttachment = {
+    id: `att-${input.caseId}-${Date.now()}`,
+    filename: input.filename,
+    size: input.size,
+    contentType: input.contentType,
+    uploadedBy: input.uploadedBy,
+    uploadedAt: new Date().toISOString(),
+  };
+  const existing = mockUploadedAttachments.get(input.caseId) ?? [];
+  mockUploadedAttachments.set(input.caseId, [created, ...existing]);
+  return created;
+}
+
 /**
  * Mirror of the backend transition graph in
  * `apps/csm-portal/backend/internal/handler/state.go` (`nextStates`). The mock

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -123,6 +123,8 @@ export function useGetCsmCaseAttachments(
 export interface PostCsmCaseAttachmentInput {
   caseId: string;
   file: File;
+  /** Display name for the attachment; defaults to the file's own name. */
+  name?: string;
   /** Optional free-text note stored with the attachment. */
   description?: string;
   /** Display name of the uploader (used by the mock; the BE sets its own). */
@@ -160,7 +162,7 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
         await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
         return postMockCsmCaseAttachment({
           caseId: input.caseId,
-          filename: input.file.name,
+          filename: input.name?.trim() || input.file.name,
           size: input.file.size,
           contentType: input.file.type || "application/octet-stream",
           uploadedBy: input.uploadedBy,
@@ -169,7 +171,7 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
 
       const dataUri = await readFileAsDataUrl(input.file);
       const payload: BeAttachmentCreatePayload = {
-        name: input.file.name,
+        name: input.name?.trim() || input.file.name,
         type: input.file.type || "application/octet-stream",
         file: dataUri,
         description: input.description?.trim() || null,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import type {
+  BeAttachmentCreatePayload,
+  BeAttachmentCreateResponse,
+  BeAttachmentSearchPayload,
+  BeAttachmentSearchResponse,
+} from "@api/backend/types";
+import { uiAttachmentFromBe } from "@api/backend/mappers";
+import {
+  getMockCsmCaseAttachments,
+  postMockCsmCaseAttachment,
+} from "@features/csm-cases/api/mocks/casesMocks";
+import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
+
+const MOCK_LATENCY_MS = 150;
+
+/**
+ * Page size used by the attachments list. A single wide page is enough for the
+ * case-detail view. If a case ever exceeds this, switch to an explicit
+ * pagination wrapper rather than chasing pages.
+ */
+const ATTACHMENTS_PAGE_LIMIT = 50;
+
+/**
+ * Max upload size in bytes. The BE caps the decoded file at 10 MB (the
+ * request body itself is capped higher to allow base64 inflation). Validate
+ * here so the user gets a clear message instead of a 413.
+ */
+export const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Read a File as a base64 data URI (`data:<mime>;base64,...`). */
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") resolve(reader.result);
+      else reject(new Error("Failed to read the file."));
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read the file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+/** Trigger a browser "save as" for a fetched blob. */
+function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Load all attachments on a case. In LIVE mode calls
+ * `POST /cases/{id}/attachments/search` with a single wide page.
+ */
+export function useGetCsmCaseAttachments(
+  caseId: string | undefined,
+): UseQueryResult<CaseAttachment[], Error> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useQuery<CaseAttachment[], Error>({
+    queryKey: [ApiQueryKeys.CSM_CASE_ATTACHMENTS, caseId ?? ""],
+    queryFn: async (): Promise<CaseAttachment[]> => {
+      if (!caseId) return [];
+
+      if (isMockMode()) {
+        logger.debug(
+          `[useGetCsmCaseAttachments] Returning mock attachments for ${caseId}`,
+        );
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return getMockCsmCaseAttachments(caseId);
+      }
+
+      const payload: BeAttachmentSearchPayload = {
+        pagination: { offset: 0, limit: ATTACHMENTS_PAGE_LIMIT },
+      };
+      const response = await api.post<
+        BeAttachmentSearchPayload,
+        BeAttachmentSearchResponse
+      >(
+        `/cases/${encodeURIComponent(caseId)}/attachments/search`,
+        payload,
+      );
+      return response.attachments.map(uiAttachmentFromBe);
+    },
+    enabled: !!caseId,
+    staleTime: 10_000,
+  });
+}
+
+export interface PostCsmCaseAttachmentInput {
+  caseId: string;
+  file: File;
+  /** Optional free-text note stored with the attachment. */
+  description?: string;
+  /** Display name of the uploader (used by the mock; the BE sets its own). */
+  uploadedBy: string;
+}
+
+/**
+ * Upload a file attachment to a case via `POST /cases/{id}/attachments`. The
+ * file is sent as a base64 data URI. The create response is a thin ack, so the
+ * list is refetched on success to hydrate the new entry from search.
+ */
+export function usePostCsmCaseAttachment(): UseMutationResult<
+  CaseAttachment | null,
+  Error,
+  PostCsmCaseAttachmentInput
+> {
+  const logger = useLogger();
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<CaseAttachment | null, Error, PostCsmCaseAttachmentInput>({
+    mutationFn: async (input): Promise<CaseAttachment | null> => {
+      if (input.file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+        throw new Error(
+          `"${input.file.name}" is too large. The maximum attachment size is ${
+            MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)
+          } MB.`,
+        );
+      }
+
+      if (isMockMode()) {
+        logger.debug(
+          `[usePostCsmCaseAttachment] Posting mock attachment for ${input.caseId}`,
+        );
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return postMockCsmCaseAttachment({
+          caseId: input.caseId,
+          filename: input.file.name,
+          size: input.file.size,
+          contentType: input.file.type || "application/octet-stream",
+          uploadedBy: input.uploadedBy,
+        });
+      }
+
+      const dataUri = await readFileAsDataUrl(input.file);
+      const payload: BeAttachmentCreatePayload = {
+        name: input.file.name,
+        type: input.file.type || "application/octet-stream",
+        file: dataUri,
+        description: input.description?.trim() || null,
+      };
+      await api.post<BeAttachmentCreatePayload, BeAttachmentCreateResponse>(
+        `/cases/${encodeURIComponent(input.caseId)}/attachments`,
+        payload,
+      );
+      // The create response is a thin ack; refetch hydrates the full entry.
+      return null;
+    },
+    onSuccess: (_created, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CSM_CASE_ATTACHMENTS, variables.caseId],
+      });
+    },
+  });
+}
+
+/**
+ * Returns a function that downloads an attachment's content and saves it. The
+ * content endpoint streams raw bytes behind auth, so it is fetched as a blob
+ * (a plain `<a href>` would miss the auth headers) and handed to the browser.
+ */
+export function useDownloadCsmCaseAttachment(): (
+  caseId: string,
+  attachment: CaseAttachment,
+) => Promise<void> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useCallback(
+    async (caseId: string, attachment: CaseAttachment): Promise<void> => {
+      if (isMockMode()) {
+        logger.debug(
+          `[useDownloadCsmCaseAttachment] Mock download of ${attachment.filename}`,
+        );
+        const placeholder = new Blob(
+          [`Mock content for ${attachment.filename}`],
+          { type: "text/plain" },
+        );
+        saveBlob(placeholder, attachment.filename);
+        return;
+      }
+
+      const blob = await api.getBlob(
+        `/cases/${encodeURIComponent(caseId)}/attachments/${encodeURIComponent(
+          attachment.id,
+        )}/content`,
+      );
+      saveBlob(blob, attachment.filename);
+    },
+    [api, logger],
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -171,17 +171,20 @@ export function useGetCsmCases(
         api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
           pagination: { offset, limit: pageSize },
           sortBy: { field: "updated_at", order: "desc" },
-          ...(search.length > 0 && { searchQuery: search }),
-          ...(filters.severities.length > 0 && {
-            priorityKeys: filters.severities.map(priorityFromSeverity),
-          }),
-          ...(filters.states.length > 0 && {
-            stateKeys: filters.states.map(beStateFromUi),
-          }),
-          // `filters.projects` holds project IDs (the filter is id-based).
-          ...(filters.projects.length > 0 && {
-            projectIds: filters.projects,
-          }),
+          // Filter fields are nested under `filters` (BE payload restructure).
+          filters: {
+            ...(search.length > 0 && { searchQuery: search }),
+            ...(filters.severities.length > 0 && {
+              priorityKeys: filters.severities.map(priorityFromSeverity),
+            }),
+            ...(filters.states.length > 0 && {
+              stateKeys: filters.states.map(beStateFromUi),
+            }),
+            // `filters.projects` holds project IDs (the filter is id-based).
+            ...(filters.projects.length > 0 && {
+              projectIds: filters.projects,
+            }),
+          },
         }),
         queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {
           logger.warn(

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -89,7 +89,7 @@ export function useQuickCaseSearch(
         "/cases/search",
         {
           pagination: { offset: 0, limit: QUICK_CASE_LIMIT },
-          searchQuery: q,
+          filters: { searchQuery: q },
         },
       );
       return (res.cases ?? []).map((c) => ({

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -174,17 +174,4 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
     // The state-independent "More" overflow is unaffected.
     expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
   });
-
-  it("keeps the lead-only Reopen override on a closed case regardless of nextStates", () => {
-    render(
-      <CaseActionBar
-        caseDetail={caseInState("closed", [])}
-        onAction={() => {}}
-        canReopenClosed
-      />,
-    );
-    // The button carries a tooltip, so its accessible name is the tooltip text;
-    // assert the visible "Reopened" label (the BE state name) instead.
-    expect(screen.getByText("Reopened")).toBeInTheDocument();
-  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -40,7 +40,6 @@ import {
   PauseCircle,
   Phone,
   Play,
-  RotateCcw,
   Send,
   ShieldAlert,
   TriangleAlert,
@@ -85,8 +84,6 @@ type PrimaryButton = TargetConfig & {
 
 const CLOSE_CONFIRM: ActionConfirm = {
   title: "Close this case?",
-  // No "cannot be reopened" claim — reopen is a lead-only override, so that
-  // assertion would be false for leads.
   body: "The customer receives a closure notification and the case moves to “Closed”.",
   confirmLabel: "Close case",
   confirmColor: "warning",
@@ -97,8 +94,7 @@ const CLOSE_CONFIRM: ActionConfirm = {
  * Customer-notifying / hard-to-undo transitions carry a confirm gate so a stray
  * click in a busy queue can't silently close a case or email the customer.
  */
-const TARGET_CONFIG: Record<CaseState, TargetConfig> = {
-  open: { action: "reopen", color: "primary", icon: <RotateCcw size={16} /> },
+const TARGET_CONFIG: Partial<Record<CaseState, TargetConfig>> = {
   work_in_progress: {
     action: "resume_work",
     color: "primary",
@@ -125,7 +121,6 @@ const TARGET_CONFIG: Record<CaseState, TargetConfig> = {
       confirmColor: "primary",
     },
   },
-  reopened: { action: "reopen", color: "primary", icon: <RotateCcw size={16} /> },
   closed: {
     action: "close",
     color: "warning",
@@ -167,7 +162,6 @@ const DISPLAY_ORDER: CaseState[] = [
   "work_in_progress",
   "awaiting_info",
   "waiting_on_wso2",
-  "reopened",
   "open",
   "closed",
 ];
@@ -176,28 +170,6 @@ function orderRank(s: CaseState): number {
   const i = DISPLAY_ORDER.indexOf(s);
   return i === -1 ? CLOSED_RANK - 0.5 : i;
 }
-
-/**
- * Lead-only override to reopen a closed case. Not part of the normal
- * `nextStates` flow — the backend reports a closed case as terminal
- * (`nextStates: []`) — so it is appended for the `closed` state only when the
- * caller grants the `canReopenClosed` capability. Labelled by the BE state it
- * lands in (`reopened` → "Reopened") like every other button.
- */
-const REOPEN_BUTTON: PrimaryButton = {
-  targetState: "reopened",
-  label: stateLabel("reopened"),
-  action: "reopen",
-  color: "warning",
-  icon: <RotateCcw size={16} />,
-  tooltip: "Lead-only: reopen a closed case for an exceptional follow-up.",
-  confirm: {
-    title: "Reopen this closed case?",
-    body: "The case returns to an active state and the customer is notified.",
-    confirmLabel: "Reopen case",
-    confirmColor: "warning",
-  },
-};
 
 interface SecondaryItem {
   key: string;
@@ -252,11 +224,6 @@ interface CaseActionBarProps {
     action: CaseLifecycleAction | { secondary: string },
     targetState?: CaseState,
   ) => void | Promise<unknown>;
-  /**
-   * Grants the lead-only "Reopen" action on a closed case. Defaults to false,
-   * so a closed case is terminal unless the caller is a lead.
-   */
-  canReopenClosed?: boolean;
 }
 
 /**
@@ -269,14 +236,12 @@ interface CaseActionBarProps {
 export default function CaseActionBar({
   caseDetail,
   onAction,
-  canReopenClosed = false,
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [pendingConfirm, setPendingConfirm] = useState<PrimaryButton | null>(
     null,
   );
 
-  const from = caseDetail.state;
   // Render a button for every state the backend says the case can move to. The
   // backend `nextStates` is the single source of truth: an empty/terminal list
   // (e.g. Closed) yields no lifecycle buttons, and a missing field also yields
@@ -285,12 +250,7 @@ export default function CaseActionBar({
   const lifecycle = [...new Set(targets)]
     .sort((a, b) => orderRank(a) - orderRank(b))
     .map(buttonFor);
-  const primary = [
-    ...lifecycle,
-    // Lead-only reopen is an override outside the normal `nextStates` flow, so
-    // it is gated by capability rather than by the backend transition list.
-    ...(from === "closed" && canReopenClosed ? [REOPEN_BUTTON] : []),
-  ];
+  const primary = lifecycle;
   const secondary = buildSecondaryItems();
 
   const runPrimary = (p: PrimaryButton): void => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -240,7 +240,7 @@ export default function CaseActivitiesFeed({
                   >
                     {AUDIT_ICON[e.entry.kind]}
                   </Box>
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Box sx={{ flex: 1, minWidth: 0, overflowWrap: "anywhere" }}>
                     <Typography variant="body2">
                       {e.entry.description}
                     </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -15,7 +15,9 @@
 // under the License.
 
 import {
+  Avatar,
   Box,
+  Button,
   Checkbox,
   Chip,
   ListItemText,
@@ -30,6 +32,7 @@ import {
   ArrowUp,
   ArrowUpRight,
   CheckCircle,
+  Download,
   Link as LinkIcon,
   ListFilter,
   Paperclip,
@@ -57,6 +60,8 @@ interface CaseActivitiesFeedProps {
   comments: CsmCaseComment[];
   audit: CaseAuditEntry[];
   attachments: CaseAttachment[];
+  /** Download a file surfaced in the timeline. */
+  onDownloadAttachment?: (attachment: CaseAttachment) => void;
 }
 
 const AUDIT_ICON: Record<CaseAuditEntry["kind"], JSX.Element> = {
@@ -76,6 +81,7 @@ export default function CaseActivitiesFeed({
   comments,
   audit,
   attachments,
+  onDownloadAttachment,
 }: CaseActivitiesFeedProps): JSX.Element {
   const [showWorkNotes, setShowWorkNotes] = useState(true);
   const [showLifecycle, setShowLifecycle] = useState(true);
@@ -261,43 +267,95 @@ export default function CaseActivitiesFeed({
                 </Paper>
               );
             }
-            // attachment
+            // attachment — rendered like a comment: avatar + card carrying the
+            // file description and a download action.
             return (
-              <Paper
+              <Box
                 id={e.attachment.id}
                 key={`f-${e.attachment.id}`}
-                variant="outlined"
                 sx={{
-                  p: 1,
                   display: "flex",
-                  alignItems: "center",
-                  gap: 1.25,
-                  backgroundColor: "background.default",
+                  gap: 1.5,
+                  alignItems: "flex-start",
                   scrollMarginTop: 96,
                 }}
               >
-                <Paperclip size={14} />
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography variant="body2">
-                    <strong>{e.attachment.filename}</strong>{" "}
-                    <Typography
-                      component="span"
-                      variant="caption"
-                      color="text.secondary"
-                    >
-                      ({formatBytes(e.attachment.size)} · {e.attachment.contentType})
+                <Avatar
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "action.selected",
+                    color: "text.secondary",
+                  }}
+                >
+                  <Paperclip size={16} />
+                </Avatar>
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    p: 1.5,
+                    flex: 1,
+                    minWidth: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 0.75,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <Typography variant="subtitle2">
+                      {e.attachment.uploadedBy}
                     </Typography>
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    Uploaded by {e.attachment.uploadedBy} ·{" "}
-                    <RelativeTime
-                      iso={e.attachment.uploadedAt}
-                      href={`#${e.attachment.id}`}
-                    />
-                  </Typography>
-                </Box>
-                <Chip size="small" variant="outlined" label="Attachment" />
-              </Paper>
+                    <Chip size="small" variant="outlined" label="Attachment" />
+                    <Typography variant="caption" color="text.secondary">
+                      <RelativeTime
+                        iso={e.attachment.uploadedAt}
+                        href={`#${e.attachment.id}`}
+                      />
+                    </Typography>
+                  </Box>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      gap: 1,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{ fontWeight: 600, overflowWrap: "anywhere" }}
+                      >
+                        {e.attachment.filename}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {formatBytes(e.attachment.size)} ·{" "}
+                        {e.attachment.contentType}
+                      </Typography>
+                    </Box>
+                    {onDownloadAttachment && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<Download size={14} />}
+                        onClick={() => onDownloadAttachment(e.attachment)}
+                        aria-label={`Download ${e.attachment.filename}`}
+                        sx={{ flexShrink: 0 }}
+                      >
+                        Download
+                      </Button>
+                    )}
+                  </Box>
+                </Paper>
+              </Box>
             );
           })}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -20,9 +20,7 @@ import {
   Button,
   Card,
   Chip,
-  IconButton,
   LinearProgress,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import {
@@ -792,15 +790,16 @@ export function AttachmentsWidget({
                   {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />
                 </Typography>
               </Box>
-              <Tooltip title="Download">
-                <IconButton
-                  size="small"
-                  aria-label={`Download ${a.filename}`}
-                  onClick={() => onDownload?.(a)}
-                >
-                  <Download size={16} />
-                </IconButton>
-              </Tooltip>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<Download size={14} />}
+                onClick={() => onDownload?.(a)}
+                aria-label={`Download ${a.filename}`}
+                sx={{ flexShrink: 0 }}
+              >
+                Download
+              </Button>
             </Box>
           ))}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -42,10 +42,11 @@ import {
   Server,
   Shield,
   TriangleAlert,
+  Upload,
   User,
   Users,
 } from "@wso2/oxygen-ui-icons-react";
-import type { JSX } from "react";
+import { useRef, type ChangeEvent, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
 import { initialsOf } from "@utils/userClaims";
 import { formatBytes } from "@utils/formatBytes";
@@ -666,34 +667,103 @@ export function TimeLogsWidget({
  */
 export function AttachmentsWidget({
   attachments,
+  loading = false,
+  error = false,
+  onRetry,
+  uploading = false,
+  uploadError,
+  onUpload,
   onDownloadAll,
   onDownload,
 }: {
   attachments: CaseAttachment[];
+  /** List query is loading. */
+  loading?: boolean;
+  /** List query failed. */
+  error?: boolean;
+  onRetry?: () => void;
+  /** An upload is in flight. */
+  uploading?: boolean;
+  /** Message shown when the last upload failed (size, network, 413, …). */
+  uploadError?: string | null;
+  onUpload?: (file: File) => void;
   onDownloadAll?: () => void;
   onDownload?: (attachment: CaseAttachment) => void;
 }): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const sorted = [...attachments].sort(
     (a, b) =>
       new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime(),
   );
+
+  const pickFile = (): void => fileInputRef.current?.click();
+  const onFileChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const file = e.target.files?.[0];
+    if (file) onUpload?.(file);
+    // Reset so re-selecting the same file still fires onChange.
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
   return (
     <WidgetCard
       title={`Attachments (${sorted.length})`}
       icon={<Paperclip size={16} />}
       action={
-        <Button
-          size="small"
-          variant="text"
-          startIcon={<Download size={14} />}
-          onClick={onDownloadAll}
-          disabled={sorted.length === 0}
-        >
-          Download all
-        </Button>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          {onUpload && (
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Upload size={14} />}
+              onClick={pickFile}
+              disabled={uploading}
+            >
+              {uploading ? "Uploading…" : "Upload"}
+            </Button>
+          )}
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<Download size={14} />}
+            onClick={onDownloadAll}
+            disabled={sorted.length === 0}
+          >
+            Download all
+          </Button>
+        </Box>
       }
     >
-      {sorted.length === 0 ? (
+      {onUpload && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          hidden
+          onChange={onFileChange}
+          aria-hidden
+        />
+      )}
+      {uploading && <LinearProgress sx={{ mb: 1 }} />}
+      {uploadError && (
+        <Typography variant="body2" color="error" sx={{ mb: 1 }}>
+          {uploadError}
+        </Typography>
+      )}
+      {loading ? (
+        <Typography variant="body2" color="text.secondary">
+          Loading attachments…
+        </Typography>
+      ) : error ? (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="body2" color="error">
+            Could not load attachments.
+          </Typography>
+          {onRetry && (
+            <Button size="small" variant="outlined" onClick={onRetry}>
+              Retry
+            </Button>
+          )}
+        </Box>
+      ) : sorted.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No attachments on this case.
         </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -778,13 +778,42 @@ export function AttachmentsWidget({
                 borderRadius: 1,
                 border: 1,
                 borderColor: "divider",
+                transition: "background-color 120ms, border-color 120ms",
+                "&:hover": {
+                  borderColor: "primary.main",
+                  backgroundColor: "action.hover",
+                },
               }}
             >
               <Paperclip size={16} />
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
-                  {a.filename}
-                </Typography>
+                {onDownload ? (
+                  <Typography
+                    component="button"
+                    variant="body2"
+                    noWrap
+                    onClick={() => onDownload(a)}
+                    title={`Download ${a.filename}`}
+                    sx={{
+                      display: "block",
+                      width: "100%",
+                      textAlign: "left",
+                      p: 0,
+                      border: 0,
+                      bgcolor: "transparent",
+                      cursor: "pointer",
+                      fontWeight: 600,
+                      color: "primary.main",
+                      "&:hover": { textDecoration: "underline" },
+                    }}
+                  >
+                    {a.filename}
+                  </Typography>
+                ) : (
+                  <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                    {a.filename}
+                  </Typography>
+                )}
                 <Typography variant="caption" color="text.secondary" noWrap>
                   {formatBytes(a.size)} · {a.contentType} · uploaded by{" "}
                   {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -131,7 +131,6 @@ const PRIMARY_STATES: CaseState[] = [
   "awaiting_info",
   "solution_proposed",
   "waiting_on_wso2",
-  "reopened",
   "closed",
 ];
 const SLA_OPTIONS: { value: SlaFilter; label: string }[] = [

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -71,11 +71,25 @@ const PURIFY_CONFIG = {
   ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
 };
 
+/**
+ * Comment bodies are usually rich-text HTML authored in the editor, but some
+ * (ServiceNow-sourced or API-created notes) are plain text. Detect a real tag so
+ * plain text isn't fed through `innerHTML`, where its line breaks would collapse;
+ * plain text is rendered as text with `white-space: pre-wrap` instead.
+ */
+const HTML_TAG_RE = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
+function isHtmlContent(s: string): boolean {
+  return HTML_TAG_RE.test(s);
+}
+
 export default function CsmCaseCommentBubble({
   comment,
 }: CsmCaseCommentBubbleProps): JSX.Element {
   const theme = useTheme();
-  const safeHtml = DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG);
+  const isHtml = isHtmlContent(comment.bodyHtml);
+  const safeHtml = isHtml
+    ? DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG)
+    : "";
   const isSystem = comment.authorRole === "system";
 
   if (isSystem) {
@@ -93,18 +107,33 @@ export default function CsmCaseCommentBubble({
         }}
       >
         <SemanticChip role="warning" label="System" />
-        <Box
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            overflowWrap: "anywhere",
-            wordBreak: "break-word",
-            "& p": { m: 0 },
-            "& a": { color: "primary.main" },
-            ...{ "& *": { fontSize: "0.875rem" } },
-          }}
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+        {isHtml ? (
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflowWrap: "anywhere",
+              wordBreak: "break-word",
+              "& p": { m: 0 },
+              "& a": { color: "primary.main" },
+              ...{ "& *": { fontSize: "0.875rem" } },
+            }}
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        ) : (
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflowWrap: "anywhere",
+              wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
+              fontSize: "0.875rem",
+            }}
+          >
+            {comment.bodyHtml}
+          </Box>
+        )}
         <Typography variant="caption" color="text.secondary">
           <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
         </Typography>
@@ -168,45 +197,60 @@ export default function CsmCaseCommentBubble({
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
           </Typography>
         </Box>
-        <Box
-          sx={{
-            minWidth: 0,
-            overflowWrap: "anywhere",
-            wordBreak: "break-word",
-            "& p": { m: 0 },
-            "& p + p": { mt: 0.75 },
-            "& ul, & ol": { ml: 3, my: 0.5 },
-            "& code": {
-              bgcolor: "background.default",
-              px: 0.5,
-              borderRadius: 0.5,
-              fontFamily: "monospace",
-              fontSize: "0.85em",
+        {isHtml ? (
+          <Box
+            sx={{
+              minWidth: 0,
               overflowWrap: "anywhere",
-            },
-            "& pre": {
-              bgcolor: "background.default",
-              p: 1,
-              borderRadius: 1,
-              overflowX: "auto",
-              fontFamily: "monospace",
-              fontSize: "0.85em",
-            },
-            "& a": { color: "primary.main" },
-            "& img": { maxWidth: "100%" },
-            "& blockquote": {
-              borderLeft: 3,
-              borderColor: "divider",
-              pl: 1.5,
-              ml: 0,
-              my: 0.75,
-              color: "text.secondary",
-              fontStyle: "italic",
-            },
-            "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
-          }}
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+              wordBreak: "break-word",
+              "& p": { m: 0 },
+              "& p + p": { mt: 0.75 },
+              "& ul, & ol": { ml: 3, my: 0.5 },
+              "& code": {
+                bgcolor: "background.default",
+                px: 0.5,
+                borderRadius: 0.5,
+                fontFamily: "monospace",
+                fontSize: "0.85em",
+                overflowWrap: "anywhere",
+              },
+              "& pre": {
+                bgcolor: "background.default",
+                p: 1,
+                borderRadius: 1,
+                overflowX: "auto",
+                fontFamily: "monospace",
+                fontSize: "0.85em",
+              },
+              "& a": { color: "primary.main" },
+              "& img": { maxWidth: "100%" },
+              "& blockquote": {
+                borderLeft: 3,
+                borderColor: "divider",
+                pl: 1.5,
+                ml: 0,
+                my: 0.75,
+                color: "text.secondary",
+                fontStyle: "italic",
+              },
+              "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
+            }}
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        ) : (
+          // Plain-text body: render as text and honour newlines/whitespace.
+          <Typography
+            variant="body2"
+            sx={{
+              minWidth: 0,
+              overflowWrap: "anywhere",
+              wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {comment.bodyHtml}
+          </Typography>
+        )}
       </Paper>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -96,6 +96,9 @@ export default function CsmCaseCommentBubble({
         <Box
           sx={{
             flex: 1,
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
             "& p": { m: 0 },
             "& a": { color: "primary.main" },
             ...{ "& *": { fontSize: "0.875rem" } },
@@ -148,7 +151,6 @@ export default function CsmCaseCommentBubble({
           gap: 0.75,
           backgroundColor: isInternal ? "warning.50" : undefined,
           borderColor: isInternal ? "warning.main" : undefined,
-          borderLeft: isInternal ? 3 : undefined,
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
@@ -159,15 +161,18 @@ export default function CsmCaseCommentBubble({
             color={ROLE_COLOR[comment.authorRole]}
             variant="outlined"
           />
-          {isInternal && (
-            <SemanticChip role="warning" label="Internal work note" />
-          )}
+          {/* A filled chip "bubble" marks the work note; paired with the tinted
+              background it reads as internal without a heavy banner. */}
+          {isInternal && <SemanticChip role="warning" label="Internal note" />}
           <Typography variant="caption" color="text.secondary">
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
           </Typography>
         </Box>
         <Box
           sx={{
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
             "& p": { m: 0 },
             "& p + p": { mt: 0.75 },
             "& ul, & ol": { ml: 3, my: 0.5 },
@@ -177,6 +182,7 @@ export default function CsmCaseCommentBubble({
               borderRadius: 0.5,
               fontFamily: "monospace",
               fontSize: "0.85em",
+              overflowWrap: "anywhere",
             },
             "& pre": {
               bgcolor: "background.default",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
+import { alpha, Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
 import type { JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
@@ -149,7 +149,9 @@ export default function CsmCaseCommentBubble({
           display: "flex",
           flexDirection: "column",
           gap: 0.75,
-          backgroundColor: isInternal ? "warning.50" : undefined,
+          backgroundColor: isInternal
+            ? alpha(theme.palette.warning.main, 0.15)
+            : undefined,
           borderColor: isInternal ? "warning.main" : undefined,
         }}
       >

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -71,25 +71,11 @@ const PURIFY_CONFIG = {
   ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
 };
 
-/**
- * Comment bodies are usually rich-text HTML authored in the editor, but some
- * (ServiceNow-sourced or API-created notes) are plain text. Detect a real tag so
- * plain text isn't fed through `innerHTML`, where its line breaks would collapse;
- * plain text is rendered as text with `white-space: pre-wrap` instead.
- */
-const HTML_TAG_RE = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
-function isHtmlContent(s: string): boolean {
-  return HTML_TAG_RE.test(s);
-}
-
 export default function CsmCaseCommentBubble({
   comment,
 }: CsmCaseCommentBubbleProps): JSX.Element {
   const theme = useTheme();
-  const isHtml = isHtmlContent(comment.bodyHtml);
-  const safeHtml = isHtml
-    ? DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG)
-    : "";
+  const safeHtml = DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG);
   const isSystem = comment.authorRole === "system";
 
   if (isSystem) {
@@ -107,33 +93,18 @@ export default function CsmCaseCommentBubble({
         }}
       >
         <SemanticChip role="warning" label="System" />
-        {isHtml ? (
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              "& p": { m: 0 },
-              "& a": { color: "primary.main" },
-              ...{ "& *": { fontSize: "0.875rem" } },
-            }}
-            dangerouslySetInnerHTML={{ __html: safeHtml }}
-          />
-        ) : (
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              whiteSpace: "pre-wrap",
-              fontSize: "0.875rem",
-            }}
-          >
-            {comment.bodyHtml}
-          </Box>
-        )}
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
+            "& p": { m: 0 },
+            "& a": { color: "primary.main" },
+            ...{ "& *": { fontSize: "0.875rem" } },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
         <Typography variant="caption" color="text.secondary">
           <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
         </Typography>
@@ -197,60 +168,45 @@ export default function CsmCaseCommentBubble({
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
           </Typography>
         </Box>
-        {isHtml ? (
-          <Box
-            sx={{
-              minWidth: 0,
+        <Box
+          sx={{
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
+            "& p": { m: 0 },
+            "& p + p": { mt: 0.75 },
+            "& ul, & ol": { ml: 3, my: 0.5 },
+            "& code": {
+              bgcolor: "background.default",
+              px: 0.5,
+              borderRadius: 0.5,
+              fontFamily: "monospace",
+              fontSize: "0.85em",
               overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              "& p": { m: 0 },
-              "& p + p": { mt: 0.75 },
-              "& ul, & ol": { ml: 3, my: 0.5 },
-              "& code": {
-                bgcolor: "background.default",
-                px: 0.5,
-                borderRadius: 0.5,
-                fontFamily: "monospace",
-                fontSize: "0.85em",
-                overflowWrap: "anywhere",
-              },
-              "& pre": {
-                bgcolor: "background.default",
-                p: 1,
-                borderRadius: 1,
-                overflowX: "auto",
-                fontFamily: "monospace",
-                fontSize: "0.85em",
-              },
-              "& a": { color: "primary.main" },
-              "& img": { maxWidth: "100%" },
-              "& blockquote": {
-                borderLeft: 3,
-                borderColor: "divider",
-                pl: 1.5,
-                ml: 0,
-                my: 0.75,
-                color: "text.secondary",
-                fontStyle: "italic",
-              },
-              "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
-            }}
-            dangerouslySetInnerHTML={{ __html: safeHtml }}
-          />
-        ) : (
-          // Plain-text body: render as text and honour newlines/whitespace.
-          <Typography
-            variant="body2"
-            sx={{
-              minWidth: 0,
-              overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            {comment.bodyHtml}
-          </Typography>
-        )}
+            },
+            "& pre": {
+              bgcolor: "background.default",
+              p: 1,
+              borderRadius: 1,
+              overflowX: "auto",
+              fontFamily: "monospace",
+              fontSize: "0.85em",
+            },
+            "& a": { color: "primary.main" },
+            "& img": { maxWidth: "100%" },
+            "& blockquote": {
+              borderLeft: 3,
+              borderColor: "divider",
+              pl: 1.5,
+              ml: 0,
+              my: 0.75,
+              color: "text.secondary",
+              fontStyle: "italic",
+            },
+            "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
       </Paper>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -42,6 +42,7 @@ import {
 } from "react";
 import Editor from "@components/rich-text-editor/Editor";
 import { formatBytes } from "@utils/formatBytes";
+import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/csm-cases/api/useCsmCaseAttachments";
 
 interface CsmCaseCommentInputProps {
   onSubmit: (
@@ -138,6 +139,18 @@ export default function CsmCaseCommentInput({
     }
     if (overSizeLimit) {
       setError(sizeError);
+      return;
+    }
+    // Pre-validate file sizes before posting anything: the send is multi-step
+    // (comment then uploads), so catching an oversized file here avoids posting
+    // the comment and then failing on the upload (which would double-post on retry).
+    const tooLarge = attachments.find((f) => f.size > MAX_ATTACHMENT_SIZE_BYTES);
+    if (tooLarge) {
+      setError(
+        `"${tooLarge.name}" is too large. The maximum attachment size is ${formatBytes(
+          MAX_ATTACHMENT_SIZE_BYTES,
+        )}.`,
+      );
       return;
     }
     setError(null);

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -32,15 +32,31 @@ import {
   Minimize2,
   Send,
 } from "@wso2/oxygen-ui-icons-react";
-import { useCallback, useMemo, useRef, useState, type JSX } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type JSX,
+} from "react";
 import Editor from "@components/rich-text-editor/Editor";
 import { formatBytes } from "@utils/formatBytes";
 
 interface CsmCaseCommentInputProps {
-  onSubmit: (html: string, internal: boolean) => Promise<unknown> | void;
+  onSubmit: (
+    html: string,
+    internal: boolean,
+    files: File[],
+  ) => Promise<unknown> | void;
   disabled?: boolean;
   /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
   autoFocus?: boolean;
+}
+
+/** Stable identity for an attached File, used to dedupe re-picked files. */
+function fileSignature(f: File): string {
+  return `${f.name}-${f.size}-${f.lastModified}`;
 }
 
 // Mirrors the BE request-body cap for POST /cases/{id}/comments
@@ -68,6 +84,28 @@ export default function CsmCaseCommentInput({
   const [sourceMode, setSourceMode] = useState(false);
   const [internal, setInternal] = useState(false);
   const [maximized, setMaximized] = useState(false);
+  // Files attached to this comment; uploaded to the case on send.
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const onAttachmentClick = useCallback(() => fileInputRef.current?.click(), []);
+  const onFilesPicked = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const picked = Array.from(e.target.files ?? []);
+      if (picked.length) {
+        setAttachments((prev) => {
+          const seen = new Set(prev.map(fileSignature));
+          return [...prev, ...picked.filter((f) => !seen.has(fileSignature(f)))];
+        });
+      }
+      // Reset so re-selecting the same file still fires onChange.
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    },
+    [],
+  );
+  const onAttachmentRemove = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  }, []);
 
   // Incrementing this trigger clears the editor (see Editor's ResetPlugin).
   const resetTriggerRef = useRef(0);
@@ -93,8 +131,9 @@ export default function CsmCaseCommentInput({
 
   const submit = useCallback(async () => {
     if (submitting || disabled) return;
-    if (isEmpty(html)) {
-      setError("Comment is empty.");
+    // Allow an attachment-only post (no text) — the case still gets the files.
+    if (isEmpty(html) && attachments.length === 0) {
+      setError("Add a comment or an attachment.");
       return;
     }
     if (overSizeLimit) {
@@ -104,8 +143,9 @@ export default function CsmCaseCommentInput({
     setError(null);
     setSubmitting(true);
     try {
-      await onSubmit(html, internal);
+      await onSubmit(html, internal, attachments);
       setHtml("");
+      setAttachments([]);
       resetTriggerRef.current += 1;
       setResetTrigger(resetTriggerRef.current);
       setEditorMountKey((k) => k + 1);
@@ -114,7 +154,16 @@ export default function CsmCaseCommentInput({
     } finally {
       setSubmitting(false);
     }
-  }, [disabled, html, internal, onSubmit, overSizeLimit, sizeError, submitting]);
+  }, [
+    disabled,
+    html,
+    attachments,
+    internal,
+    onSubmit,
+    overSizeLimit,
+    sizeError,
+    submitting,
+  ]);
 
   const toggleSourceMode = useCallback(
     (nextSource: boolean) => {
@@ -259,11 +308,24 @@ export default function CsmCaseCommentInput({
           showKeyboardHint
           autoFocus={autoFocus}
           enterToSubmit={false}
+          onAttachmentClick={onAttachmentClick}
+          attachments={attachments}
+          onAttachmentRemove={onAttachmentRemove}
           onSubmitKeyDown={() => {
             void submit();
           }}
         />
       )}
+
+      {/* Hidden picker driven by the editor toolbar's attach button. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        hidden
+        onChange={onFilesPicked}
+        aria-hidden
+      />
 
       <Box
         sx={{
@@ -288,7 +350,12 @@ export default function CsmCaseCommentInput({
           color={internal ? "warning" : "primary"}
           size="small"
           startIcon={internal ? <Lock size={16} /> : <Send size={16} />}
-          disabled={disabled || submitting || isEmpty(html) || overSizeLimit}
+          disabled={
+            disabled ||
+            submitting ||
+            (isEmpty(html) && attachments.length === 0) ||
+            overSizeLimit
+          }
           onClick={() => {
             void submit();
           }}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -31,13 +31,22 @@ import {
   Minimize2,
   Send,
 } from "@wso2/oxygen-ui-icons-react";
-import { useCallback, useRef, useState, type JSX } from "react";
+import { useCallback, useMemo, useRef, useState, type JSX } from "react";
 import Editor from "@components/rich-text-editor/Editor";
+import { formatBytes } from "@utils/formatBytes";
 
 interface CsmCaseCommentInputProps {
   onSubmit: (html: string, internal: boolean) => Promise<unknown> | void;
   disabled?: boolean;
 }
+
+// Mirrors the BE request-body cap for POST /cases/{id}/comments
+// (handler `maxCommentBodyBytes = 10 << 20`). Comments carry inline images as
+// base64 data URIs, so the body can get large; the BE returns 413 past this.
+const MAX_COMMENT_BODY_BYTES = 10 * 1024 * 1024;
+// Reserve headroom for the JSON envelope ({ type, content }) + string escaping
+// so the FE blocks before the BE rejects with 413.
+const MAX_COMMENT_CONTENT_BYTES = MAX_COMMENT_BODY_BYTES - 1024;
 
 /** Strip tags + collapse whitespace to decide if the editor is effectively empty. */
 function isEmpty(html: string): boolean {
@@ -65,10 +74,27 @@ export default function CsmCaseCommentInput({
   // per mount).
   const [editorMountKey, setEditorMountKey] = useState(0);
 
+  // UTF-8 byte size of the comment body. The BE caps the whole request body, so
+  // mirror it here to fail fast with a clear message instead of a 413.
+  const bodyBytes = useMemo(
+    () => new TextEncoder().encode(html).length,
+    [html],
+  );
+  const overSizeLimit = bodyBytes > MAX_COMMENT_CONTENT_BYTES;
+  const sizeError = overSizeLimit
+    ? `Comment is too large (${formatBytes(bodyBytes)}). Maximum is ${formatBytes(
+        MAX_COMMENT_BODY_BYTES,
+      )} — remove or shrink inline images.`
+    : null;
+
   const submit = useCallback(async () => {
     if (submitting || disabled) return;
     if (isEmpty(html)) {
       setError("Comment is empty.");
+      return;
+    }
+    if (overSizeLimit) {
+      setError(sizeError);
       return;
     }
     setError(null);
@@ -84,7 +110,7 @@ export default function CsmCaseCommentInput({
     } finally {
       setSubmitting(false);
     }
-  }, [disabled, html, internal, onSubmit, submitting]);
+  }, [disabled, html, internal, onSubmit, overSizeLimit, sizeError, submitting]);
 
   const toggleSourceMode = useCallback(
     (nextSource: boolean) => {
@@ -242,9 +268,10 @@ export default function CsmCaseCommentInput({
       >
         <Typography
           variant="caption"
-          color={error ? "error" : "text.secondary"}
+          color={sizeError || error ? "error" : "text.secondary"}
         >
-          {error ??
+          {sizeError ??
+            error ??
             (sourceMode
               ? "Output is sent as-is. Use this to fix paste-formatting or insert tables."
               : "Ctrl/Cmd + Enter to send.")}
@@ -254,7 +281,7 @@ export default function CsmCaseCommentInput({
           color={internal ? "warning" : "primary"}
           size="small"
           startIcon={internal ? <Lock size={16} /> : <Send size={16} />}
-          disabled={disabled || submitting || isEmpty(html)}
+          disabled={disabled || submitting || isEmpty(html) || overSizeLimit}
           onClick={() => {
             void submit();
           }}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -37,18 +37,24 @@ import {
   useMemo,
   useRef,
   useState,
-  type ChangeEvent,
   type JSX,
 } from "react";
 import Editor from "@components/rich-text-editor/Editor";
 import { formatBytes } from "@utils/formatBytes";
 import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/csm-cases/api/useCsmCaseAttachments";
+import CsmUploadAttachmentModal from "@features/csm-cases/components/CsmUploadAttachmentModal";
+
+/** A file staged for upload, with the display name chosen in the modal. */
+export interface CommentAttachmentDraft {
+  file: File;
+  name: string;
+}
 
 interface CsmCaseCommentInputProps {
   onSubmit: (
     html: string,
     internal: boolean,
-    files: File[],
+    attachments: CommentAttachmentDraft[],
   ) => Promise<unknown> | void;
   disabled?: boolean;
   /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
@@ -86,24 +92,19 @@ export default function CsmCaseCommentInput({
   const [internal, setInternal] = useState(false);
   const [maximized, setMaximized] = useState(false);
   // Files attached to this comment; uploaded to the case on send.
-  const [attachments, setAttachments] = useState<File[]>([]);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [attachments, setAttachments] = useState<CommentAttachmentDraft[]>([]);
+  const [attachModalOpen, setAttachModalOpen] = useState(false);
 
-  const onAttachmentClick = useCallback(() => fileInputRef.current?.click(), []);
-  const onFilesPicked = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const picked = Array.from(e.target.files ?? []);
-      if (picked.length) {
-        setAttachments((prev) => {
-          const seen = new Set(prev.map(fileSignature));
-          return [...prev, ...picked.filter((f) => !seen.has(fileSignature(f)))];
-        });
+  const onAttachmentClick = useCallback(() => setAttachModalOpen(true), []);
+  const onSelectAttachment = useCallback((file: File, name: string) => {
+    setAttachments((prev) => {
+      // Dedupe re-picked files by identity (the chosen name may still differ).
+      if (prev.some((a) => fileSignature(a.file) === fileSignature(file))) {
+        return prev;
       }
-      // Reset so re-selecting the same file still fires onChange.
-      if (fileInputRef.current) fileInputRef.current.value = "";
-    },
-    [],
-  );
+      return [...prev, { file, name }];
+    });
+  }, []);
   const onAttachmentRemove = useCallback((index: number) => {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
   }, []);
@@ -144,7 +145,9 @@ export default function CsmCaseCommentInput({
     // Pre-validate file sizes before posting anything: the send is multi-step
     // (comment then uploads), so catching an oversized file here avoids posting
     // the comment and then failing on the upload (which would double-post on retry).
-    const tooLarge = attachments.find((f) => f.size > MAX_ATTACHMENT_SIZE_BYTES);
+    const tooLarge = attachments.find(
+      (a) => a.file.size > MAX_ATTACHMENT_SIZE_BYTES,
+    );
     if (tooLarge) {
       setError(
         `"${tooLarge.name}" is too large. The maximum attachment size is ${formatBytes(
@@ -322,7 +325,7 @@ export default function CsmCaseCommentInput({
           autoFocus={autoFocus}
           enterToSubmit={false}
           onAttachmentClick={onAttachmentClick}
-          attachments={attachments}
+          attachments={attachments.map((a) => a.file)}
           onAttachmentRemove={onAttachmentRemove}
           onSubmitKeyDown={() => {
             void submit();
@@ -330,14 +333,11 @@ export default function CsmCaseCommentInput({
         />
       )}
 
-      {/* Hidden picker driven by the editor toolbar's attach button. */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        multiple
-        hidden
-        onChange={onFilesPicked}
-        aria-hidden
+      {/* Naming picker driven by the editor toolbar's attach button. */}
+      <CsmUploadAttachmentModal
+        open={attachModalOpen}
+        onClose={() => setAttachModalOpen(false)}
+        onSelect={onSelectAttachment}
       />
 
       <Box

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -15,6 +15,7 @@
 // under the License.
 
 import {
+  alpha,
   Box,
   Button,
   FormControlLabel,
@@ -133,7 +134,9 @@ export default function CsmCaseCommentInput({
         gap: 1,
         p: internal ? 1.25 : 0,
         borderRadius: internal ? 1 : 0,
-        backgroundColor: internal ? "warning.50" : undefined,
+        backgroundColor: internal
+          ? (theme) => alpha(theme.palette.warning.main, 0.15)
+          : undefined,
         border: internal ? 1 : 0,
         borderColor: internal ? "warning.main" : undefined,
       }}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -38,6 +38,8 @@ import { formatBytes } from "@utils/formatBytes";
 interface CsmCaseCommentInputProps {
   onSubmit: (html: string, internal: boolean) => Promise<unknown> | void;
   disabled?: boolean;
+  /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
+  autoFocus?: boolean;
 }
 
 // Mirrors the BE request-body cap for POST /cases/{id}/comments
@@ -57,6 +59,7 @@ function isEmpty(html: string): boolean {
 export default function CsmCaseCommentInput({
   onSubmit,
   disabled = false,
+  autoFocus = false,
 }: CsmCaseCommentInputProps): JSX.Element {
   const [html, setHtml] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
@@ -251,6 +254,7 @@ export default function CsmCaseCommentInput({
           maxHeight={maximized ? 720 : 260}
           toolbarVariant="full"
           showKeyboardHint
+          autoFocus={autoFocus}
           enterToSubmit={false}
           onSubmitKeyDown={() => {
             void submit();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
@@ -160,7 +160,16 @@ export default function CsmUploadAttachmentModal({
         />
         {!file ? (
           <Box
+            role="button"
+            tabIndex={0}
+            aria-label="Choose a file to attach"
             onClick={() => fileInputRef.current?.click()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                fileInputRef.current?.click();
+              }
+            }}
             onDrop={onDrop}
             onDragOver={(e) => {
               e.preventDefault();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Paperclip, Upload, X } from "@wso2/oxygen-ui-icons-react";
+import {
+  useCallback,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type JSX,
+} from "react";
+import { formatBytes } from "@utils/formatBytes";
+import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/csm-cases/api/useCsmCaseAttachments";
+
+interface CsmUploadAttachmentModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Hand the chosen file + display name back to the composer. */
+  onSelect: (file: File, name: string) => void;
+}
+
+function fileExtension(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  return dot < 0 || dot === fileName.length - 1 ? "" : fileName.slice(dot);
+}
+
+function baseFileName(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  return dot < 0 || dot === fileName.length - 1 ? fileName : fileName.slice(0, dot);
+}
+
+/** Keep the original extension on a renamed file so the type stays obvious. */
+function withExtension(name: string, ext: string): string {
+  if (!ext) return name;
+  return name.toLowerCase().endsWith(ext.toLowerCase()) ? name : `${name}${ext}`;
+}
+
+/**
+ * Pick (or drop) a single file and give it a display name before attaching it
+ * to a comment. Mirrors the customer portal's UploadAttachmentModal `onSelect`
+ * flow — the file isn't uploaded here; the composer uploads it on send.
+ */
+export default function CsmUploadAttachmentModal({
+  open,
+  onClose,
+  onSelect,
+}: CsmUploadAttachmentModalProps): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState("");
+  const [dragOver, setDragOver] = useState(false);
+
+  const tooLarge = !!file && file.size > MAX_ATTACHMENT_SIZE_BYTES;
+  const displayName = name.trim() || (file ? baseFileName(file.name) : "");
+  const canAdd = !!file && !tooLarge && !!displayName;
+
+  const reset = useCallback(() => {
+    setFile(null);
+    setName("");
+    setDragOver(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [onClose, reset]);
+
+  const pickFile = useCallback((selected: File | null) => {
+    setFile(selected);
+    if (selected) setName(baseFileName(selected.name));
+  }, []);
+
+  const onInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      pickFile(e.target.files?.[0] ?? null);
+      e.target.value = "";
+    },
+    [pickFile],
+  );
+
+  const onDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const dropped = e.dataTransfer.files?.[0];
+      if (dropped) pickFile(dropped);
+    },
+    [pickFile],
+  );
+
+  const handleAdd = useCallback(() => {
+    if (!file || tooLarge) return;
+    const finalName = withExtension(
+      name.trim() || baseFileName(file.name),
+      fileExtension(file.name),
+    );
+    if (!finalName) return;
+    onSelect(file, finalName);
+    handleClose();
+  }, [file, name, tooLarge, onSelect, handleClose]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="csm-upload-attachment-title"
+    >
+      <DialogTitle id="csm-upload-attachment-title" sx={{ pr: 6 }}>
+        Attach a file
+        <IconButton
+          aria-label="Close"
+          onClick={handleClose}
+          size="small"
+          sx={{ position: "absolute", right: 12, top: 12 }}
+        >
+          <X size={20} aria-hidden />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        {tooLarge && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {file?.name} is {formatBytes(file.size)}. The maximum attachment size
+            is {formatBytes(MAX_ATTACHMENT_SIZE_BYTES)}.
+          </Alert>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          hidden
+          onChange={onInputChange}
+          aria-hidden
+        />
+        {!file ? (
+          <Box
+            onClick={() => fileInputRef.current?.click()}
+            onDrop={onDrop}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragOver(true);
+            }}
+            onDragLeave={() => setDragOver(false)}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1,
+              py: 4,
+              px: 2,
+              borderRadius: 1,
+              border: "1px dashed",
+              borderColor: dragOver ? "primary.main" : "divider",
+              backgroundColor: dragOver ? "action.hover" : "transparent",
+              cursor: "pointer",
+              textAlign: "center",
+            }}
+          >
+            <Upload size={24} />
+            <Typography variant="body2">
+              Drag a file here, or click to choose
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Up to {formatBytes(MAX_ATTACHMENT_SIZE_BYTES)}
+            </Typography>
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              p: 1,
+              borderRadius: 1,
+              border: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Paperclip size={16} />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography variant="body2" noWrap>
+                {file.name}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {formatBytes(file.size)} · {file.type || "unknown type"}
+              </Typography>
+            </Box>
+            <Button size="small" variant="text" onClick={() => pickFile(null)}>
+              Change
+            </Button>
+          </Box>
+        )}
+
+        <TextField
+          fullWidth
+          label="Attachment name"
+          placeholder="Leave empty to use the file name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={!file}
+          sx={{ mt: 2 }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2, pt: 1 }}>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleAdd}
+          disabled={!canAdd}
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -27,13 +27,14 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import { priorityFromSeverity } from "@api/backend/mappers";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
+import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
@@ -61,7 +62,16 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const navigate = useNavigate();
   const { showError } = useErrorBanner();
 
-  const [projectId, setProjectId] = useState("");
+  // When the form is opened from a project's page (`/cases/new?projectId=…`),
+  // the project is fixed and shown read-only: the engineer can't accidentally
+  // file the case against the wrong project. The id seeds the form's project
+  // state once and the picker is replaced by a locked field. Opened without the
+  // param (the cases-list "New case" entry), the searchable picker is shown.
+  const [searchParams] = useSearchParams();
+  const lockedProjectId = searchParams.get("projectId") ?? "";
+  const isProjectLocked = !!lockedProjectId;
+
+  const [projectId, setProjectId] = useState(lockedProjectId);
   const [deploymentId, setDeploymentId] = useState("");
   const [deployedProductId, setDeployedProductId] = useState("");
   const [severity, setSeverity] = useState<Severity | "">("");
@@ -72,6 +82,15 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
+
+  // Resolve the locked project's display name so the read-only field shows the
+  // name (not the raw id). Only fetched when the form is project-scoped.
+  const lockedProject = useGetProject(isProjectLocked ? lockedProjectId : undefined);
+  const lockedProjectLabel = lockedProject.data?.name
+    ? lockedProject.data.name
+    : lockedProject.isLoading
+      ? "Loading project…"
+      : lockedProjectId;
 
   // When a selector query fails the form becomes non-completable, so surface it
   // with an explicit retry rather than leaving an empty dropdown. (Projects are
@@ -170,11 +189,31 @@ export default function CsmCaseCreatePage(): JSX.Element {
         )}
         <Grid container spacing={2.5}>
           <Grid size={{ xs: 12, md: 4 }}>
-            <AsyncProjectSelect
-              value={projectId}
-              onChange={onProjectChange}
-              required
-            />
+            {isProjectLocked ? (
+              <TextField
+                fullWidth
+                size="small"
+                label="Project"
+                required
+                value={lockedProjectLabel}
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    endAdornment: (
+                      <Lock size={16} aria-hidden style={{ opacity: 0.6 }} />
+                    ),
+                  },
+                  htmlInput: { "aria-readonly": true },
+                }}
+                helperText="Locked to the project you opened this from. To file against another project, open that project first."
+              />
+            ) : (
+              <AsyncProjectSelect
+                value={projectId}
+                onChange={onProjectChange}
+                required
+              />
+            )}
           </Grid>
 
           <Grid size={{ xs: 12, md: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -31,6 +31,7 @@ import { ArrowLeft, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { priorityFromSeverity } from "@api/backend/mappers";
+import { formatBytes } from "@utils/formatBytes";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
@@ -57,6 +58,16 @@ const ISSUE_TYPES: { value: BeCaseIssueType; label: string }[] = [
 function isEmptyHtml(html: string): boolean {
   return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
 }
+
+// Cap the case-create body, which carries the description HTML (with base64
+// inline images). FOLLOW-UP: the CSM backend currently caps POST /cases at
+// 1 MiB (maxRequestBodyBytes); this 10 MiB FE cap assumes the endpoint is
+// raised to match the comment endpoint (maxCommentBodyBytes = 10 MiB). Until
+// the BE matches, it still returns 413 past 1 MiB.
+const MAX_DESCRIPTION_BODY_BYTES = 10 * 1024 * 1024;
+// Reserve headroom for the other create fields (ids, subject) + JSON envelope
+// so the FE blocks before the BE rejects.
+const MAX_DESCRIPTION_CONTENT_BYTES = MAX_DESCRIPTION_BODY_BYTES - 4 * 1024;
 
 export default function CsmCaseCreatePage(): JSX.Element {
   const navigate = useNavigate();
@@ -101,6 +112,21 @@ export default function CsmCaseCreatePage(): JSX.Element {
     if (deployedProducts.isError) void deployedProducts.refetch();
   };
 
+  // UTF-8 byte size of the description; the BE caps the whole create body, so
+  // mirror it here to fail fast with a clear message instead of a 413.
+  const descriptionBytes = useMemo(
+    () => new TextEncoder().encode(description).length,
+    [description],
+  );
+  const descriptionOverLimit = descriptionBytes > MAX_DESCRIPTION_CONTENT_BYTES;
+  const descriptionError = descriptionOverLimit
+    ? `The case description is too large (${formatBytes(
+        descriptionBytes,
+      )}). Maximum is ${formatBytes(
+        MAX_DESCRIPTION_BODY_BYTES,
+      )} — reduce the size or the number of inline images and try again.`
+    : null;
+
   const canSubmit = useMemo(
     () =>
       !!projectId &&
@@ -110,6 +136,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       !!issueType &&
       subject.trim().length > 0 &&
       !isEmptyHtml(description) &&
+      !descriptionOverLimit &&
       !postCase.isPending,
     [
       projectId,
@@ -119,6 +146,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       issueType,
       subject,
       description,
+      descriptionOverLimit,
       postCase.isPending,
     ],
   );
@@ -135,7 +163,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
   };
 
   const handleSubmit = (): void => {
-    if (!canSubmit || !severity || !issueType) return;
+    if (!canSubmit || !severity || !issueType || descriptionOverLimit) return;
     postCase.mutate(
       {
         projectId,
@@ -336,6 +364,15 @@ export default function CsmCaseCreatePage(): JSX.Element {
                 disabled={postCase.isPending}
               />
             </Box>
+            {descriptionError && (
+              <Typography
+                variant="caption"
+                color="error"
+                sx={{ display: "block", mt: 0.5 }}
+              >
+                {descriptionError}
+              </Typography>
+            )}
           </Grid>
         </Grid>
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -464,12 +464,16 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
   const onDownloadAllAttachments = useCallback(() => {
     if (!caseId) return;
-    // No bulk endpoint; fetch each sequentially and save.
-    attachmentList.forEach((a) => {
-      void downloadAttachment(caseId, a).catch((err) =>
-        showError(`Could not download ${a.filename}.`, err),
-      );
-    });
+    // No bulk endpoint; fetch each sequentially (not a parallel burst) and save.
+    void (async () => {
+      for (const a of attachmentList) {
+        try {
+          await downloadAttachment(caseId, a);
+        } catch (err) {
+          showError(`Could not download ${a.filename}.`, err);
+        }
+      }
+    })();
   }, [caseId, attachmentList, downloadAttachment, showError]);
 
   if (isLoading) {

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -780,16 +780,34 @@ export default function CsmCaseDetailPage(): JSX.Element {
               <CsmCaseCommentInput
                 disabled={!caseId}
                 autoFocus
-                onSubmit={async (bodyHtml, internal) => {
+                onSubmit={async (bodyHtml, internal, files) => {
                   if (!caseId) return;
-                  await postComment.mutateAsync({
-                    caseId,
-                    bodyHtml,
-                    authorName: engineerName,
-                    internal,
-                  });
+                  // Post the comment only when there's text; an attachment-only
+                  // send skips the comment endpoint and just uploads the files.
+                  const hasText =
+                    bodyHtml
+                      .replace(/<[^>]*>/g, "")
+                      .replace(/&nbsp;/g, " ")
+                      .trim().length > 0;
+                  if (hasText) {
+                    await postComment.mutateAsync({
+                      caseId,
+                      bodyHtml,
+                      authorName: engineerName,
+                      internal,
+                    });
+                  }
+                  // Attachments are case-level (no comment linkage on the BE);
+                  // upload each sequentially so a failure surfaces clearly.
+                  for (const file of files) {
+                    await postAttachment.mutateAsync({
+                      caseId,
+                      file,
+                      uploadedBy: engineerName,
+                    });
+                  }
                   // Collapse only on success; on error the input keeps its
-                  // draft and surfaces the failure.
+                  // draft + files and surfaces the failure.
                   setComposerOpen(false);
                 }}
               />

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -760,7 +760,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               <CsmCaseCommentInput
                 disabled={!caseId}
                 autoFocus
-                onSubmit={async (bodyHtml, internal, files) => {
+                onSubmit={async (bodyHtml, internal, commentAttachments) => {
                   if (!caseId) return;
                   // Post the comment only when there's text; an attachment-only
                   // send skips the comment endpoint and just uploads the files.
@@ -779,10 +779,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   }
                   // Attachments are case-level (no comment linkage on the BE);
                   // upload each sequentially so a failure surfaces clearly.
-                  for (const file of files) {
+                  for (const { file, name } of commentAttachments) {
                     await postAttachment.mutateAsync({
                       caseId,
                       file,
+                      name,
                       uploadedBy: engineerName,
                     });
                   }

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -37,7 +37,7 @@ import {
   TriangleAlert,
   X,
 } from "@wso2/oxygen-ui-icons-react";
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
 import { usePatchCsmCase } from "@features/csm-cases/api/usePatchCsmCase";
@@ -47,6 +47,11 @@ import {
   useGetCsmCaseComments,
   usePostCsmCaseComment,
 } from "@features/csm-cases/api/useCsmCaseComments";
+import {
+  useGetCsmCaseAttachments,
+  usePostCsmCaseAttachment,
+  useDownloadCsmCaseAttachment,
+} from "@features/csm-cases/api/useCsmCaseAttachments";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
@@ -73,7 +78,10 @@ import {
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
-import type { CaseLifecycleAction } from "@features/csm-cases/types/csmCases";
+import type {
+  CaseAttachment,
+  CaseLifecycleAction,
+} from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 
 function MetaCell({
@@ -182,8 +190,6 @@ const SECONDARY_TOAST: Record<string, string> = {
   request_call: "Request a call dialog (mock).",
   log_time: "Log time dialog (mock).",
   copy_link: "Case link copied to clipboard.",
-  download_all_attachments: "Preparing all attachments for download (mock).",
-  download_attachment: "Downloading attachment (mock).",
 };
 
 type CaseTabId =
@@ -239,6 +245,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
     isError: isCommentsError,
   } = useGetCsmCaseComments(caseId);
   const postComment = usePostCsmCaseComment();
+  const {
+    data: attachments,
+    isLoading: isAttachmentsLoading,
+    isError: isAttachmentsError,
+    refetch: refetchAttachments,
+  } = useGetCsmCaseAttachments(caseId);
+  const postAttachment = usePostCsmCaseAttachment();
+  const downloadAttachment = useDownloadCsmCaseAttachment();
   const patchCase = usePatchCsmCase(caseId);
   const recordView = useRecordRecentView();
   const claims = useIdTokenClaims();
@@ -416,6 +430,47 @@ export default function CsmCaseDetailPage(): JSX.Element {
     },
     [data, showError, patchCase],
   );
+
+  const attachmentList = useMemo(() => attachments ?? [], [attachments]);
+
+  const onUploadAttachment = useCallback(
+    (file: File) => {
+      if (!caseId) return;
+      postAttachment.mutate(
+        { caseId, file, uploadedBy: engineerName },
+        {
+          onSuccess: () =>
+            setFeedback({
+              message: `Uploaded ${file.name}.`,
+              severity: "success",
+              sticky: false,
+            }),
+          // Failures surface inline on the widget via postAttachment.error.
+        },
+      );
+    },
+    [caseId, engineerName, postAttachment],
+  );
+
+  const onDownloadAttachment = useCallback(
+    (attachment: CaseAttachment) => {
+      if (!caseId) return;
+      void downloadAttachment(caseId, attachment).catch((err) =>
+        showError(`Could not download ${attachment.filename}.`, err),
+      );
+    },
+    [caseId, downloadAttachment, showError],
+  );
+
+  const onDownloadAllAttachments = useCallback(() => {
+    if (!caseId) return;
+    // No bulk endpoint; fetch each sequentially and save.
+    attachmentList.forEach((a) => {
+      void downloadAttachment(caseId, a).catch((err) =>
+        showError(`Could not download ${a.filename}.`, err),
+      );
+    });
+  }, [caseId, attachmentList, downloadAttachment, showError]);
 
   if (isLoading) {
     return (
@@ -675,7 +730,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             // Counts shown only where the tab IS the list (unambiguous).
             const count =
               t.id === "attachments"
-                ? c.attachments.length
+                ? attachmentList.length
                 : t.id === "time"
                   ? c.timeLogs.length
                   : undefined;
@@ -771,7 +826,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 <Chip
                   size="small"
                   variant="outlined"
-                  label={`${safeComments.length + c.audit.length + c.attachments.length} entries`}
+                  label={`${safeComments.length + c.audit.length + attachmentList.length} entries`}
                 />
               )}
             </Box>
@@ -796,7 +851,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 <CaseActivitiesFeed
                   comments={safeComments}
                   audit={c.audit}
-                  attachments={c.attachments}
+                  attachments={attachmentList}
                 />
               </>
             )}
@@ -884,9 +939,20 @@ export default function CsmCaseDetailPage(): JSX.Element {
       {activeTab === "attachments" && (
         <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
           <AttachmentsWidget
-            attachments={c.attachments}
-            onDownloadAll={() => onAction({ secondary: "download_all_attachments" })}
-            onDownload={() => onAction({ secondary: "download_attachment" })}
+            attachments={attachmentList}
+            loading={isAttachmentsLoading}
+            error={isAttachmentsError}
+            onRetry={() => void refetchAttachments()}
+            uploading={postAttachment.isPending}
+            uploadError={
+              postAttachment.isError
+                ? (postAttachment.error?.message ??
+                  "Could not upload the attachment.")
+                : null
+            }
+            onUpload={onUploadAttachment}
+            onDownloadAll={onDownloadAllAttachments}
+            onDownload={onDownloadAttachment}
           />
         </Box>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -779,6 +779,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </Box>
               <CsmCaseCommentInput
                 disabled={!caseId}
+                autoFocus
                 onSubmit={async (bodyHtml, internal) => {
                   if (!caseId) return;
                   await postComment.mutateAsync({

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -101,16 +101,6 @@ function MetaCell({
   );
 }
 
-// Reopening a closed case is a lead-only override. We match the lead role from
-// the ID-token group claims.
-// TODO(authz): confirm the exact Asgardeo group(s)/role(s) that designate a
-// "lead" with the gateway/permission model — these identifiers are provisional.
-const LEAD_REOPEN_ROLES = new Set([
-  "cre_lead",
-  "CRE_LEADS_GROUP",
-  "leadership",
-]);
-
 const LIFECYCLE_TOAST: Record<CaseLifecycleAction, string> = {
   start_work: "Started work on this case.",
   assign_to_me: "Assigned to you.",
@@ -120,7 +110,6 @@ const LIFECYCLE_TOAST: Record<CaseLifecycleAction, string> = {
   resume_work: "Resumed work on this case.",
   close: "Case closed.",
   close_no_response: "Closed (no response received).",
-  reopen: "Case reopened.",
   transition: "Case updated.",
 };
 
@@ -145,7 +134,6 @@ const LIFECYCLE_SEVERITY: Record<CaseLifecycleAction, FeedbackSeverity> = {
   resume_work: "info",
   close: "success",
   close_no_response: "success",
-  reopen: "info",
   transition: "info",
 };
 
@@ -162,7 +150,6 @@ const LIFECYCLE_TARGET_STATE: Partial<
   wait_on_wso2: "waiting_on_wso2",
   close: "closed",
   close_no_response: "closed",
-  reopen: "reopened",
 };
 
 const FEEDBACK_PALETTE: Record<
@@ -533,9 +520,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // both wrong and the main source of orange on the screen. Only show SLA
   // affordances when we actually have clock data (mock, and LIVE once wired).
   const hasSlaData = c.slaClocks.length > 0;
-  const canReopenClosed = (claims?.groups ?? []).some((g) =>
-    LEAD_REOPEN_ROLES.has(g),
-  );
   // The case description is already returned by `comments/search` as the
   // opening comment, so the stream renders it directly — no synthetic entry is
   // injected (that duplicated the first comment).
@@ -659,11 +643,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           <Typography variant="h5">{c.subject}</Typography>
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
-          <CaseActionBar
-            caseDetail={c}
-            onAction={onAction}
-            canReopenClosed={canReopenClosed}
-          />
+          <CaseActionBar caseDetail={c} onAction={onAction} />
         </Box>
       </Box>
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -857,6 +857,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   comments={safeComments}
                   audit={c.audit}
                   attachments={attachmentList}
+                  onDownloadAttachment={onDownloadAttachment}
                 />
               </>
             )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -221,7 +221,6 @@ export type CaseLifecycleAction =
   | "resume_work"
   | "close"
   | "close_no_response"
-  | "reopen"
   // Generic transition into a state the frontend has no curated action for
   // (e.g. a state added on the backend). Drives the post-transition toast only;
   // the PATCH target always comes from the backend `nextStates` value.

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -43,7 +43,6 @@ const VALID_STATES: CaseState[] = [
   "solution_proposed",
   "awaiting_info",
   "waiting_on_wso2",
-  "reopened",
   "closed",
 ];
 const VALID_SLA: SlaFilter[] = ["any", "at_risk", "breached"];

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.test.ts
@@ -67,10 +67,10 @@ describe("savedFilterViews", () => {
   });
 
   it("persists across a fresh hook mount (reload)", () => {
-    act(() => saveFilterView("Persisted", "states=reopened"));
+    act(() => saveFilterView("Persisted", "states=waiting_on_wso2"));
     const remount = renderHook(() => useSavedFilterViews());
     expect(remount.result.current).toEqual([
-      { name: "Persisted", qs: "states=reopened" },
+      { name: "Persisted", qs: "states=waiting_on_wso2" },
     ]);
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.ts
@@ -40,7 +40,7 @@ const MAX_VIEWS = 50;
  * not yet).
  */
 export const SUGGESTED_FILTER_VIEWS: readonly SavedFilterView[] = [
-  { name: "S0/S1 active", qs: "severities=S0,S1&states=open,work_in_progress,reopened" },
+  { name: "S0/S1 active", qs: "severities=S0,S1&states=open,work_in_progress" },
   { name: "Awaiting info", qs: "states=awaiting_info" },
   { name: "Open (unstarted)", qs: "states=open" },
 ];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
@@ -293,7 +293,7 @@ const sumQueue = (cases: CsmQueueCase[]) => {
   let inProgress = 0;
   let awaitingInfo = 0;
   for (const c of cases) {
-    if (c.state === "open" || c.state === "reopened") actionRequired += 1;
+    if (c.state === "open") actionRequired += 1;
     else if (c.state === "work_in_progress") inProgress += 1;
     else if (c.state === "awaiting_info") awaitingInfo += 1;
   }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -102,6 +102,13 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
         // scoped to active cases (priority AND active-state), not the whole
         // population.
         const activeStateKeys = COMPOSITION_STATES.map(beStateFromUi);
+        // The state/closed counts don't filter by severity. The backend,
+        // however, counts only catastrophic cases when `priorityKeys` is absent
+        // (an empty priority filter is not treated as "all"), which made the
+        // state pie show the S0 row only and disagree with the matrix totals.
+        // Pass every priority explicitly so these counts span all severities.
+        // BE follow-up: treat an absent/empty priorityKeys as "all priorities".
+        const allPriorityKeys = MATRIX_SEVERITIES.map(priorityFromSeverity);
 
         // All severity + state counts (plus the closed total) fire in one wave.
         const [severityCounts, stateCounts, closedCount] = await Promise.all([
@@ -120,13 +127,19 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             COMPOSITION_STATES.map((st) =>
               countTotal({
                 pagination: { offset: 0, limit: 1 },
-                filters: { stateKeys: [beStateFromUi(st)] },
+                filters: {
+                  stateKeys: [beStateFromUi(st)],
+                  priorityKeys: allPriorityKeys,
+                },
               }).then((n) => ({ key: st, n })),
             ),
           ),
           countTotal({
             pagination: { offset: 0, limit: 1 },
-            filters: { stateKeys: [beStateFromUi("closed")] },
+            filters: {
+              stateKeys: [beStateFromUi("closed")],
+              priorityKeys: allPriorityKeys,
+            },
           }),
         ]);
         severityCounts.forEach(({ key, n }) => (bySeverity[key] = n));

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -109,8 +109,10 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             MATRIX_SEVERITIES.map((sev) =>
               countTotal({
                 pagination: { offset: 0, limit: 1 },
-                priorityKeys: [priorityFromSeverity(sev)],
-                stateKeys: activeStateKeys,
+                filters: {
+                  priorityKeys: [priorityFromSeverity(sev)],
+                  stateKeys: activeStateKeys,
+                },
               }).then((n) => ({ key: sev, n })),
             ),
           ),
@@ -118,13 +120,13 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             COMPOSITION_STATES.map((st) =>
               countTotal({
                 pagination: { offset: 0, limit: 1 },
-                stateKeys: [beStateFromUi(st)],
+                filters: { stateKeys: [beStateFromUi(st)] },
               }).then((n) => ({ key: st, n })),
             ),
           ),
           countTotal({
             pagination: { offset: 0, limit: 1 },
-            stateKeys: [beStateFromUi("closed")],
+            filters: { stateKeys: [beStateFromUi("closed")] },
           }),
         ]);
         severityCounts.forEach(({ key, n }) => (bySeverity[key] = n));

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -37,7 +37,6 @@ export const MATRIX_STATES: CaseState[] = [
   "waiting_on_wso2",
   "awaiting_info",
   "solution_proposed",
-  "reopened",
 ];
 
 export interface CaseCountsMatrix {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -106,8 +106,10 @@ export function useCaseCountsMatrix(): UseQueryResult<CaseCountsMatrix, Error> {
           api
             .post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
               pagination: { offset: 0, limit: 1 },
-              priorityKeys: [priorityFromSeverity(severity)],
-              stateKeys: [beStateFromUi(state)],
+              filters: {
+                priorityKeys: [priorityFromSeverity(severity)],
+                stateKeys: [beStateFromUi(state)],
+              },
             })
             .then((res) => ({ severity, state, count: res.total ?? 0 })),
         ),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
@@ -50,7 +50,6 @@ const STATE_SLICE_COLOR: Record<CaseState, string> = {
   waiting_on_wso2: paletteColor("amber", 700, "#b45309"),
   awaiting_info: paletteColor("cyan", 500, "#06b6d4"),
   solution_proposed: paletteColor("teal", 500, "#14b8a6"),
-  reopened: paletteColor("deepOrange", 400, "#ff7043"),
   closed: paletteColor("grey", 500, "#6b7280"),
 };
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -67,9 +67,9 @@ function CountCell({
         underline="hover"
         color="inherit"
         sx={{
-          // Larger, heavier numbers so the counts read at a glance from across
-          // the dashboard, not just on close inspection.
-          fontSize: bold ? "1.35rem" : "1.2rem",
+          // Keep the counts readable but compact — totals a touch larger/heavier
+          // so the row/column sums still stand out from the per-cell values.
+          fontSize: bold ? "1rem" : "0.9rem",
           fontWeight: bold ? 700 : 600,
           lineHeight: 1,
         }}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
@@ -116,7 +116,7 @@ export default function MyQueueSection({
         <StatPill
           label="Action required"
           value={isLoading ? "—" : (queue?.actionRequiredCount ?? 0)}
-          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN], states: ["open", "reopened"] })}
+          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN], states: ["open"] })}
           onNavigate={go}
         />
         <StatPill

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
@@ -22,7 +22,6 @@ export type CaseState =
   | "solution_proposed"
   | "awaiting_info"
   | "waiting_on_wso2"
-  | "reopened"
   | "closed";
 
 export type SlaClockType = "ack" | "first_response" | "resolution";

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
@@ -46,7 +46,6 @@ export const STATE_LABEL: Record<CaseState, string> = {
   solution_proposed: "Solution proposed",
   awaiting_info: "Awaiting info",
   waiting_on_wso2: "Waiting on WSO2",
-  reopened: "Reopened",
   closed: "Closed",
 };
 
@@ -55,7 +54,7 @@ export const STATE_LABEL: Record<CaseState, string> = {
 // brand orange (the old `isClosed ? "success" : "primary"`, which also failed
 // WCAG contrast). The four buckets:
 //   info (blue)    = active, on us, normal      -> open, work_in_progress
-//   warning (amber)= active, on us, elevated    -> waiting_on_wso2, reopened
+//   warning (amber)= active, on us, elevated    -> waiting_on_wso2
 //   default (grey) = waiting on the customer     -> solution_proposed, awaiting_info
 //   success (green)= done                        -> closed
 // All four roles have a dark `contrastText` in this theme, so filled chips pass
@@ -68,7 +67,6 @@ export const STATE_COLOR: Record<
   open: "info",
   work_in_progress: "info",
   waiting_on_wso2: "warning",
-  reopened: "warning",
   solution_proposed: "default",
   awaiting_info: "default",
   closed: "success",

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useGetProject.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useGetProject.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAuthApiClient } from "@hooks/useAuthApiClient";
+import { apiConfig } from "@config/apiConfig";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
+import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
+
+/**
+ * Look up a single project by id via `GET /projects/{id}` (BFF passthrough to
+ * the entity service). The response is the enriched {@link ProjectDetails} shape
+ * with the parent `account` embedded. Returns `null` (not an error) on 404 so
+ * the page can render a not-found state instead of an error banner. The query
+ * stays disabled until an id is present so a bare `/projects/` never fires.
+ */
+export function useGetProject(
+  id: string | undefined,
+): UseQueryResult<ProjectDetails | null, Error> {
+  const authFetch = useAuthApiClient();
+
+  return useQuery<ProjectDetails | null, Error>({
+    queryKey: [ApiQueryKeys.CSM_PROJECT_DETAIL, id ?? ""],
+    queryFn: async (): Promise<ProjectDetails | null> => {
+      if (!id) return null;
+
+      const res = await authFetch(
+        `${apiConfig.backendUrl}/projects/${encodeURIComponent(id)}`,
+      );
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ApiError(
+          res.status,
+          res.statusText,
+          parseApiResponseMessage(body, res.status, res.statusText),
+        );
+      }
+      return (await res.json()) as ProjectDetails;
+    },
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode } from "react";
+import { Link as RouterLink, useNavigate, useParams } from "react-router";
+import { useGetProject } from "@features/csm-projects/api/useGetProject";
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString();
+}
+
+function formatSubscriptionType(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function MetaCell({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+// Real anchor (RouterLink) so the account link is cmd/middle-clickable and
+// copyable, with plain left-click staying in-app. Colour is picked per colour
+// scheme: brand orange (`primary.main`) fails WCAG AA on a light surface, while
+// `primary.dark` fails on the dark surface, so we apply the dark shade only in
+// the light scheme and vice versa (matching the case meta band's links).
+function LinkText({ to, children }: { to: string; children: ReactNode }): JSX.Element {
+  return (
+    <Typography
+      component={RouterLink}
+      to={to}
+      variant="body2"
+      sx={(t) => ({
+        cursor: "pointer",
+        textDecoration: "none",
+        color: t.palette.primary.dark,
+        ...t.applyStyles("dark", { color: t.palette.primary.main }),
+        "&:hover": { textDecoration: "underline" },
+        "&:focus-visible": {
+          outline: "2px solid",
+          outlineColor: "primary.main",
+          outlineOffset: 2,
+          borderRadius: 0.5,
+        },
+      })}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+function Mono({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <Typography variant="body2" sx={{ fontFamily: "monospace", wordBreak: "break-all" }}>
+      {children}
+    </Typography>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={onClick}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back to projects
+    </Button>
+  );
+}
+
+export default function CsmProjectDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useGetProject(id);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rectangular" height={32} width={240} />
+        <Skeleton variant="rectangular" height={220} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/projects")} />
+        <Typography variant="body1" color="error">
+          Could not load project {id}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/projects")} />
+        <Typography variant="h5">Project not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No project with id <code>{id}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const p = data;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <BackButton onClick={() => navigate("/projects")} />
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+            <Typography variant="h5">{p.name}</Typography>
+            <Chip
+              size="small"
+              label={formatSubscriptionType(p.subscriptionType)}
+              variant="outlined"
+            />
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+            {p.key}
+          </Typography>
+        </Box>
+        {/* File a case already scoped to this project — the create form locks the
+            project field, so it can't be filed against the wrong one. */}
+        <Button
+          variant="contained"
+          startIcon={<Plus size={16} />}
+          onClick={() => navigate(`/cases/new?projectId=${encodeURIComponent(p.id)}`)}
+          sx={{ flexShrink: 0 }}
+        >
+          Create case
+        </Button>
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Project key">
+            <Mono>{p.key}</Mono>
+          </MetaCell>
+          <MetaCell label="Subscription">
+            <Typography variant="body2">{formatSubscriptionType(p.subscriptionType)}</Typography>
+          </MetaCell>
+          <MetaCell label="Account">
+            {p.account?.id ? (
+              <LinkText to={`/accounts/${p.account.id}`}>
+                {p.account.name || p.account.id}
+              </LinkText>
+            ) : (
+              <Typography variant="body2">—</Typography>
+            )}
+          </MetaCell>
+          <MetaCell label="Account tier">
+            <Typography variant="body2">{p.account?.tier || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Start date">
+            <Typography variant="body2">{formatDate(p.startDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="End date">
+            <Typography variant="body2">{formatDate(p.endDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="Salesforce ID">
+            <Mono>{p.sfId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Created">
+            <Typography variant="body2">{formatDate(p.createdOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Last updated">
+            <Typography variant="body2">{formatDate(p.updatedOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Project ID">
+            <Mono>{p.id}</Mono>
+          </MetaCell>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -31,6 +31,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects";
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
@@ -135,8 +136,22 @@ export default function CsmProjectsPage(): JSX.Element {
               ) : (
                 projects.map((p) => (
                   <TableRow key={p.id} hover>
-                    <TableCell>{p.name}</TableCell>
-                    <TableCell>{p.projectKey}</TableCell>
+                    <TableCell>
+                      <Typography
+                        component={RouterLink}
+                        to={`/projects/${p.id}`}
+                        variant="body2"
+                        sx={(t) => ({
+                          textDecoration: "none",
+                          color: t.palette.primary.dark,
+                          ...t.applyStyles("dark", { color: t.palette.primary.main }),
+                          "&:hover": { textDecoration: "underline" },
+                        })}
+                      >
+                        {p.name}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{p.key}</TableCell>
                     <TableCell>
                       <Chip
                         size="small"

--- a/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
@@ -30,12 +30,48 @@ export interface Project {
   accountId: string;
   sfId: string;
   name: string;
-  projectKey: string;
+  // The search endpoint returns this as `key` (not `projectKey`).
+  key: string;
   subscriptionType: SubscriptionType;
   startDate: string;
   endDate: string;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Parent-account reference embedded in the project detail response
+ * (`GET /projects/{id}`). The backend JOINs the account, so the project view
+ * gets the account name (and a few account facts) with no extra call. `tier` is
+ * free-form here (e.g. "Enterprise"), not the lowercase {@link AccountTier} enum.
+ */
+export interface ProjectAccountRef {
+  id: string;
+  name: string;
+  activationDate: string | null;
+  tier: string;
+  region?: string | null;
+  agentEnabled: boolean;
+  kbReferencesEnabled: boolean;
+}
+
+/**
+ * Enriched single-project shape returned by `GET /projects/{id}`. Distinct from
+ * {@link Project} (the search-result row): it embeds the parent `account`, and
+ * uses `createdOn` / `updatedOn` rather than the search row's
+ * `createdAt` / `updatedAt`.
+ */
+export interface ProjectDetails {
+  id: string;
+  account: ProjectAccountRef;
+  sfId: string;
+  name: string;
+  key: string;
+  subscriptionType: SubscriptionType;
+  startDate: string;
+  endDate: string;
+  createdOn: string;
+  updatedOn: string;
 }
 
 export interface SearchProjectsRequest {

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -98,7 +98,7 @@ const viteConfig = defineConfig({
   },
   envPrefix: ["CSM_PORTAL_"],
   server: {
-    port: 3001,
+    port: 3000,
     strictPort: true,
   },
 });
@@ -152,6 +152,13 @@ window.config.CSM_PORTAL_AUTH_CLIENT_ID = "csm-local-dev";
 // hits the Vite /local-api proxy instead of a hardcoded localhost that would
 // break the same-origin contract.
 window.config.CSM_PORTAL_BACKEND_BASE_URL = window.location.origin + "/local-api";
+// Sign-in/out redirects back to the dev server's OWN origin. The base config
+// pins these to a fixed host:port (e.g. http://localhost:3000); left unchanged,
+// the mock-IdP PKCE callback redirects to that port instead of the port the dev
+// server actually runs on, so the SPA never completes the code exchange and
+// loops on sign-in. Same same-origin rationale as the backend URL above.
+window.config.CSM_PORTAL_AUTH_SIGN_IN_REDIRECT_URL = window.location.origin;
+window.config.CSM_PORTAL_AUTH_SIGN_OUT_REDIRECT_URL = window.location.origin;
 window.config.CSM_PORTAL_USE_MOCKS = false;
 // Pin the runtime mock toggle off so a stale localStorage flag cannot
 // silently re-enable mock data in front of the real local backend.


### PR DESCRIPTION
## What

Builds out the CSM case-detail experience and related views. Frontend only.

### Project & account detail views
- New routes `/projects/:id` and `/accounts/:id`, backed by `GET /projects/{id}` and `GET /accounts/{id}`, resolving the account/project links the case meta band already renders (these previously 404'd because no route existed).
- Project detail consumes the enriched project response (parent account embedded): links to the account by name and shows the tier with no extra request. Typed as a dedicated `ProjectDetails` shape, distinct from the search-result row.
- Account detail shows tier, region, activation/deactivation, AI-agent and KB-reference flags, and ownership.
- List pages: project/account name cells now link into the detail pages.
- Fix: the projects list rendered a blank key column — the search endpoint returns `key`, but the FE type used `projectKey`. Renamed to match.
- Project-scoped case creation: a **Create case** action on the project view opens the new-case form with the project pre-selected and read-only, so a case can't be filed against the wrong project. The unscoped create flow (searchable picker) is unchanged.

### Case attachments
- Consume the case-attachment endpoints: list (`POST /cases/{id}/attachments/search`), upload (`POST /cases/{id}/attachments` — file sent as a base64 data URI, 10 MB client-side cap, list refetched on success), and download (authenticated binary GET of `.../content`, saved as a blob — a plain anchor would miss the auth headers).
- The Attachments tab now lists real files (replacing the hard-coded empty array in LIVE mode) and feeds the tab badge and the activity timeline.
- Download affordances: each row has a labelled **Download** button, the filename is a download link, and the row highlights on hover. The activity stream renders attachments like comments (avatar + card carrying the file description + a Download button).

### Content-size guards
- The comment editor and the case-description editor validate the body's UTF-8 byte size client-side and block submit with a clear message before the backend would reject it, matching the backend caps (10 MiB for comment-create and case-create).

### Search-filter alignment
- The case-search payload nests all filter fields under a `filters` object (matching the backend restructure); `sortBy`/`pagination` stay top-level. Updated every `/cases/search` caller: cases list, quick (Ctrl/Cmd-K) search, dashboard counts matrix, and the composition pies.

### Activity stream & misc UX
- Long unbroken comment/audit content wraps instead of pushing the layout past the viewport.
- Work notes are marked with a visible tinted background plus an "Internal note" chip (no heavy banner).
- The reply composer auto-focuses the editor when it opens.
- "Download all" fetches each file sequentially rather than firing every request at once.
- `dev:local` gateway: override the sign-in/out redirect URLs to the dev server's own origin so the local full-stack preview's auth works on non-default ports (mirrors the existing same-origin backend-URL override). Dev-server only; never emitted in a build.

## Testing

- `pnpm lint`, `pnpm build`, and `pnpm test` (84 tests) are green.

## Notes / follow-ups

- Listing the projects of a given account is not yet supported by the project-search endpoint (no account filter); tracked separately.
- Plain-text comment rendering (honouring line breaks for non-HTML bodies) was intentionally reverted from this PR, to be addressed consistently with the customer portal later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account and project detail pages with clickable names.
  * Added full case attachment support (list, upload, download) and attachment submission in case comments.
  * Added a single-file attachment upload modal and better attachment download actions in the activity feed.

* **Changes**
  * Removed the “reopen” lifecycle capability and the related “reopened” case state across the portal.
  * Updated case creation/detail to enforce UTF-8 byte limits (description and comment bodies) and improved validation.
  * Restructured case search filters and refined attachments/comment wrapping for cleaner readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->