### PR TITLE
[CSM Portal][BE] feat(cases): update case search payload to nest filters under filters object

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -68,6 +68,9 @@ func NewCaseHandler(entity entityCaseClient) *CaseHandler {
 // maxRequestBodyBytes caps incoming request bodies at 1 MiB to prevent memory DoS.
 const maxRequestBodyBytes = 1 << 20
 
+// maxCaseBodyBytes caps case-create bodies at 10 MiB to accommodate rich descriptions.
+const maxCaseBodyBytes = 10 << 20
+
 // maxCommentBodyBytes caps comment-create bodies at 10 MiB. Comments can carry
 // inline images as base64 data URIs, which inflate raw image size by ~33%, so
 // a 1 MiB global cap rejects images well under ServiceNow's own limit.
@@ -106,7 +109,7 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, maxCaseBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		if _, ok := err.(*http.MaxBytesError); ok {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -179,6 +179,26 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	current, err := h.entity.GetCase(r.Context(), caseID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetCase failed during comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamError(w, err, "Failed to create case comment.")
+		return
+	}
+	var currentCase struct {
+		State     string  `json:"state"`
+		WorkState *string `json:"workState"`
+	}
+	if err := json.Unmarshal(current, &currentCase); err != nil {
+		slog.ErrorContext(r.Context(), "failed to parse case state for comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+	if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
+		writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
+		return
+	}
+
 	result, err := h.entity.CreateCaseComment(r.Context(), caseID, body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateCaseComment failed", "userID", user.UserID, "caseID", caseID, "err", err)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -212,10 +212,65 @@ func TestCreateCaseComment(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	const ongoingCase = `{"state":"work_in_progress","workState":"ongoing"}`
+
+	t.Run("rejects comment when state is not work_in_progress", func(t *testing.T) {
+		for _, state := range []string{"open", "waiting_on_wso2", "closed"} {
+			state := state
+			t.Run(state, func(t *testing.T) {
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(`{"state":"` + state + `","workState":null}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.CreateCaseComment(w, r)
+				assertStatus(t, w, http.StatusConflict)
+				assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+			})
+		}
+	})
+
+	t.Run("rejects comment when work_state is not ongoing", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress","workState":"on_hold"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+	})
+
+	t.Run("rejects comment when workState is absent", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+	})
+
 	t.Run("forwards body to entity and returns response", func(t *testing.T) {
 		var capturedCaseID string
 		var capturedBody []byte
 		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(ongoingCase), nil
+			},
 			createCaseCommentFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
 				capturedCaseID = caseID
 				capturedBody = body
@@ -250,6 +305,9 @@ func TestCreateCaseComment(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(ongoingCase), nil
+					},
 					createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
 						return nil, tc.err
 					},

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -68,9 +68,9 @@ func TestCreateCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+	t.Run("rejects body exceeding 10 MiB case limit", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases", strings.NewReader(strings.Repeat("x", maxCaseBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.CreateCase(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -411,7 +411,7 @@ func TestSearchCases(t *testing.T) {
 		}
 		h := NewCaseHandler(client)
 		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search",
-			strings.NewReader(`{"projectIds":["proj-1"],"stateKeys":["open"],"pagination":{"limit":10,"offset":0}}`)))
+			strings.NewReader(`{"filters":{"projectIds":["proj-1"],"stateKeys":["open"]},"pagination":{"limit":10,"offset":0}}`)))
 		w := httptest.NewRecorder()
 		h.SearchCases(w, r)
 
@@ -422,9 +422,13 @@ func TestSearchCases(t *testing.T) {
 		if err := json.Unmarshal(capturedBody, &sent); err != nil {
 			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
+		var filters map[string]json.RawMessage
+		if err := json.Unmarshal(sent["filters"], &filters); err != nil {
+			t.Fatalf("upstream filters field invalid JSON: %v", err)
+		}
 		var ids []string
-		if err := json.Unmarshal(sent["projectIds"], &ids); err != nil || len(ids) != 1 || ids[0] != "proj-1" {
-			t.Errorf("upstream projectIds = %v, want [\"proj-1\"]", ids)
+		if err := json.Unmarshal(filters["projectIds"], &ids); err != nil || len(ids) != 1 || ids[0] != "proj-1" {
+			t.Errorf("upstream filters.projectIds = %v, want [\"proj-1\"]", ids)
 		}
 
 		resp := decodeJSON[map[string]any](t, w)
@@ -443,7 +447,7 @@ func TestSearchCases(t *testing.T) {
 		}
 		h := NewCaseHandler(client)
 		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search",
-			strings.NewReader(`{"stateKeys":["open"],"pagination":{"limit":10,"offset":0}}`)))
+			strings.NewReader(`{"filters":{"stateKeys":["open"]},"pagination":{"limit":10,"offset":0}}`)))
 		w := httptest.NewRecorder()
 		h.SearchCases(w, r)
 
@@ -452,8 +456,12 @@ func TestSearchCases(t *testing.T) {
 		if err := json.Unmarshal(capturedBody, &sent); err != nil {
 			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
-		if _, exists := sent["projectIds"]; exists {
-			t.Errorf("upstream body unexpectedly contains projectIds: %s", sent["projectIds"])
+		var filters map[string]json.RawMessage
+		if err := json.Unmarshal(sent["filters"], &filters); err != nil {
+			t.Fatalf("upstream filters field invalid JSON: %v", err)
+		}
+		if _, exists := filters["projectIds"]; exists {
+			t.Errorf("upstream filters unexpectedly contains projectIds: %s", filters["projectIds"])
 		}
 	})
 

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -32,7 +32,8 @@ const (
 	ErrMsgBadRequest   = "Invalid request payload."
 	ErrMsgTooLarge          = "Request body too large."
 	ErrMsgInternal          = "An internal server error occurred. Please try again later."
-	ErrMsgInvalidTransition = "Invalid state transition."
+	ErrMsgInvalidTransition  = "Invalid state transition."
+	ErrMsgCommentNotAllowed  = "Comments can only be added when the case is in progress and the work state is ongoing."
 	ErrMsgInvalidUUID       = "Invalid UUID format."
 	errMsgReadBody          = "Failed to read request body."
 )

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -248,6 +248,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "409":
+          description: Conflict — comment posting is not allowed in the current case state (case must be work_in_progress with work_state ongoing).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
           content:
@@ -1296,6 +1302,13 @@ components:
         updatedAt:
           type: string
           format: date-time
+        workState:
+          type: string
+          nullable: true
+          enum:
+            - ongoing
+            - on_hold
+          description: Sub-state of work_in_progress. Null when state is not work_in_progress.
         closedAt:
           type: string
           format: date-time

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1142,25 +1142,17 @@ components:
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
           description: Nature of the issue
 
-    CaseSearchPayload:
+    CaseSearchFilters:
       type: object
-      nullable: true
       properties:
+        searchQuery:
+          type: string
+          description: Searches across subject, number, and wso2Id (case-insensitive)
         projectIds:
           type: array
           items:
             type: string
           description: Filter by project IDs (optional)
-        pagination:
-          allOf:
-            - $ref: '#/components/schemas/Pagination'
-            - properties:
-                limit:
-                  default: 20
-                  maximum: 100
-        searchQuery:
-          type: string
-          description: Searches across subject, number, and wso2Id (case-insensitive)
         deploymentIds:
           type: array
           items:
@@ -1207,6 +1199,13 @@ components:
               - security_or_compliance
               - total_outage
           description: Filter by issue type (optional)
+
+    CaseSearchPayload:
+      type: object
+      nullable: true
+      properties:
+        filters:
+          $ref: '#/components/schemas/CaseSearchFilters'
         sortBy:
           type: object
           properties:
@@ -1218,6 +1217,13 @@ components:
               type: string
               enum: [asc, desc]
               default: desc
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
 
     CaseSearchResponse:
       type: object


### PR DESCRIPTION
## Summary
- Restructures `CaseSearchPayload` in `openapi.yaml` to nest all filter fields under a `filters` object, with `sortBy` and `pagination` at the top level — aligns the CSM Portal BFF contract with the entity-service restructure from PR #884
- Raises `CreateCase` body cap from 1 MiB (`maxRequestBodyBytes`) to 10 MiB (`maxCaseBodyBytes`) to match the comment endpoint
- Gates comment creation on case state: `CreateCaseComment` fetches the case and rejects with 409 if `state != work_in_progress` or `workState != ongoing` (refs digiops-cs#2093)
- Adds `workState` field to the `Case` schema and documents the 409 response on `POST /cases/{id}/comments`

## Test plan
- [x] `TestSearchCases` — updated to use nested `filters` payload shape
- [x] `TestCreateCase` — updated to assert 10 MiB cap
- [x] `TestCreateCaseComment` — three new guard tests (wrong state, `on_hold` work state, absent work state); existing tests updated with `getCaseFn`
- [x] Pre-push hook ran full backend test suite — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)