### PR TITLE
[Customer Entity] Add workState to case responses and extend PATCH /cases/{id} for ServiceNow

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -435,6 +435,14 @@ const (
 	CaseStateClosed           CaseState = "closed"
 )
 
+// CaseWorkState represents the work sub-state of a work_in_progress case.
+type CaseWorkState string
+
+const (
+	CaseWorkStateOngoing CaseWorkState = "ongoing"
+	CaseWorkStatePaused  CaseWorkState = "paused"
+)
+
 // CaseSortField enumerates the columns available for sorting case search results.
 type CaseSortField string
 
@@ -535,6 +543,7 @@ type CaseView struct {
 	Priority               CasePriority         `json:"priority"`
 	IssueType              CaseIssueType        `json:"issueType"`
 	State                  CaseState            `json:"state"`
+	WorkState              *CaseWorkState       `json:"workState"`
 	CreatedOn              time.Time            `json:"createdOn"`
 	UpdatedOn              time.Time            `json:"updatedOn"`
 	CreatedByDetails       UserRef              `json:"createdBy"`
@@ -578,6 +587,7 @@ type SearchCaseView struct {
 	Priority               CasePriority       `json:"priority"`
 	IssueType              CaseIssueType      `json:"issueType"`
 	State                  CaseState          `json:"state"`
+	WorkState              *CaseWorkState     `json:"workState"`
 	CreatedOn              time.Time          `json:"createdOn"`
 	UpdatedOn              time.Time          `json:"updatedOn"`
 	ClosedAt               *time.Time         `json:"closedAt"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -608,11 +608,39 @@ type SearchCasesResponse struct {
 }
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
-// State and Priority may be changed through this endpoint.
+// Exactly one of State, Priority, WatchList, or AssigneeEmail must be provided.
+// WatchList and AssigneeEmail are only supported for the ServiceNow data source.
 type UpdateCaseRequest struct {
-	ID       string        `json:"-"`
-	State    *CaseState    `json:"state"`
-	Priority *CasePriority `json:"priority"`
+	ID            string        `json:"-"`
+	State         *CaseState    `json:"state"`
+	Priority      *CasePriority `json:"priority"`
+	WatchList     []string      `json:"watchList"`
+	AssigneeEmail *string       `json:"assigneeEmail"`
+}
+
+// UpdateCaseResponse is the response for PATCH /cases/{id}.
+type UpdateCaseResponse struct {
+	Message string      `json:"message"`
+	Case    UpdatedCase `json:"case"`
+}
+
+// UpdatedCase carries the fields of a case that may change after an update.
+type UpdatedCase struct {
+	ID         string               `json:"id"`
+	UpdatedOn  time.Time            `json:"updatedOn"`
+	UpdatedBy  string               `json:"updatedBy,omitempty"`
+	State      CaseState            `json:"state,omitempty"`
+	Priority   CasePriority         `json:"priority,omitempty"`
+	WatchList  []WatchListUser      `json:"watchList,omitempty"`
+	AssignedTo *AssignedEngineerRef `json:"assignedTo,omitempty"`
+}
+
+// WatchListUser is a compact user reference within the watch list.
+type WatchListUser struct {
+	ID       string `json:"id"`
+	UserName string `json:"userName"`
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
 }
 
 // CreateCaseResponse is the unified response for POST /cases across all data sources.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -63,20 +63,22 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(c)
 }
 
-// PatchCase handles PATCH /cases/{id} and allows updating the case state and priority.
+// PatchCase handles PATCH /cases/{id}.
+// Accepts state, priority (both data sources), or watchList, assigneeEmail (ServiceNow only).
+// Exactly one field must be provided per request.
 func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	var req domain.UpdateCaseRequest
 	if !decodeRequest(w, r, &req) {
 		return
 	}
 	req.ID = r.PathValue("id")
-	c, err := h.svc.UpdateCase(r.Context(), req)
+	resp, err := h.svc.UpdateCase(r.Context(), req)
 	if err != nil {
 		writeServiceError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(c)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // CreateCaseComment handles POST /cases/{id}/comments.

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -109,10 +109,11 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 		pcID, pcNum                         *string
 		rcID, rcNum                         *string
 		accountID, accountName, accountTier string
+		workState                           *string
 	)
 	err := r.db.QueryRow(ctx,
 		`SELECT c.id, c.number, c.internal_id,
-		        c.subject, c.description, c.priority, c.issue_type, c.state,
+		        c.subject, c.description, c.priority, c.issue_type, c.state, c.work_state,
 		        c.created_at, c.updated_at,
 		        u.id, u.first_name || ' ' || u.last_name, u.user_name, u.email,
 		        p.id, p.name,
@@ -137,7 +138,7 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 		 WHERE c.id = $1`, id,
 	).Scan(
 		&cv.ID, &cv.Number, &cv.InternalID,
-		&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State,
+		&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
 		&cv.CreatedOn, &cv.UpdatedOn,
 		&cv.CreatedByDetails.ID, &cv.CreatedByDetails.Name, &cv.CreatedByDetails.UserID, &cv.CreatedByDetails.Email,
 		&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
@@ -156,6 +157,10 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 		return domain.CaseView{}, fmt.Errorf("get case by id: %w", err)
 	}
 	cv.AccountDetails = &domain.AccountRef{ID: accountID, Name: accountName, Type: accountTier}
+	if workState != nil {
+		ws := domain.CaseWorkState(*workState)
+		cv.WorkState = &ws
+	}
 	if aeID != nil {
 		cv.AssignedEngineer = &domain.AssignedEngineerRef{ID: *aeID, Name: *aeName}
 	}
@@ -374,7 +379,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 
 	dataQuery := fmt.Sprintf(
 		`SELECT c.id, c.number, c.internal_id,
-		        c.subject, c.description, c.priority, c.issue_type, c.state,
+		        c.subject, c.description, c.priority, c.issue_type, c.state, c.work_state,
 		        c.created_at, c.updated_at, c.closed_at,
 		        u.id, u.first_name || ' ' || u.last_name, u.user_name, u.email,
 		        p.id, p.name,
@@ -410,9 +415,10 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		for rows.Next() {
 			var cv domain.SearchCaseView
 			var ignoredDisplayName, ignoredUserID string
+			var workState *string
 			if err := rows.Scan(
 				&cv.ID, &cv.Number, &cv.InternalID,
-				&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State,
+				&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
 				&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedAt,
 				&cv.CreatedBy.ID, &ignoredDisplayName, &ignoredUserID, &cv.CreatedBy.Email,
 				&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
@@ -420,6 +426,10 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 				&cv.DeployedProductDetails.ID, &cv.DeployedProductDetails.DisplayName,
 			); err != nil {
 				return fmt.Errorf("scan case: %w", err)
+			}
+			if workState != nil {
+				ws := domain.CaseWorkState(*workState)
+				cv.WorkState = &ws
 			}
 			result = append(result, cv)
 		}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -231,8 +231,18 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if len(req.WatchList) > 0 || req.AssigneeEmail != nil {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList and assigneeEmail are only supported for the ServiceNow data source"}
 	}
-	if req.State == nil && req.Priority == nil {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state or priority must be provided"}
+	fieldCount := 0
+	if req.State != nil {
+		fieldCount++
+	}
+	if req.Priority != nil {
+		fieldCount++
+	}
+	if fieldCount == 0 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of state or priority must be provided"}
+	}
+	if fieldCount > 1 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state or priority may be provided per request"}
 	}
 	if req.State != nil && !validCaseState[*req.State] {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -224,20 +224,35 @@ func (s *caseService) SearchCaseComments(ctx context.Context, req domain.SearchC
 }
 
 // UpdateCase implements CaseService.
-func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
+func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error) {
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
-		return domain.Case{}, err
+		return domain.UpdateCaseResponse{}, err
+	}
+	if len(req.WatchList) > 0 || req.AssigneeEmail != nil {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList and assigneeEmail are only supported for the ServiceNow data source"}
 	}
 	if req.State == nil && req.Priority == nil {
-		return domain.Case{}, &apierror.ValidationError{Msg: "at least one of state or priority must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state or priority must be provided"}
 	}
 	if req.State != nil && !validCaseState[*req.State] {
-		return domain.Case{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
 	}
 	if req.Priority != nil && !validCasePriority[*req.Priority] {
-		return domain.Case{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
 	}
-	return s.repo.UpdateCase(ctx, req)
+	c, err := s.repo.UpdateCase(ctx, req)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+	return domain.UpdateCaseResponse{
+		Message: "Case updated successfully",
+		Case: domain.UpdatedCase{
+			ID:        c.ID,
+			UpdatedOn: c.UpdatedAt,
+			State:     c.State,
+			Priority:  c.Priority,
+		},
+	}, nil
 }
 
 // SearchCases implements CaseService.

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -107,9 +107,10 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
-	// UpdateCase updates the state and/or priority of a case. A ValidationError is
-	// returned for invalid values or malformed UUID; a NotFoundError if no case matches.
-	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
+	// UpdateCase updates the state, priority, watch list, or assignee of a case.
+	// A ValidationError is returned for invalid values or malformed UUID; a NotFoundError if no case matches.
+	// WatchList and AssigneeEmail are only supported for the ServiceNow data source.
+	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error)
 	// CreateCaseAttachment uploads a new attachment for the case identified by req.CaseID.
 	// A ValidationError is returned for invalid input.
 	CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error)

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -52,6 +52,7 @@ type snCase struct {
 	DeployedProduct  snCaseDeployedProduct `json:"deployedProduct"`
 	Product          *snCaseEntityRef      `json:"product"`
 	State            *snCaseState          `json:"state"`
+	WorkState        *snCaseLabel          `json:"workState"`
 	Severity         *snCaseLabel          `json:"severity"`
 	IssueType        *snCaseIssueType      `json:"issueType"`
 	AssignedEngineer *snCaseEntityRef      `json:"assignedEngineer"`
@@ -334,6 +335,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		Priority:    snSeverityToPriority(c.Severity),
 		IssueType:   snIssueTypeToEnum(c.IssueType),
 		State:       state,
+		WorkState:   snWorkStateLabelToEnum(c.WorkState),
 		CreatedOn:   createdOn,
 		UpdatedOn:   updatedOn,
 		CreatedByDetails: domain.UserRef{
@@ -828,6 +830,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			Priority:               snSeverityToPriority(c.Severity),
 			IssueType:              snIssueTypeToEnum(c.IssueType),
 			State:                  state,
+			WorkState:              snWorkStateLabelToEnum(c.WorkState),
 			CreatedOn:              createdOn,
 			UpdatedOn:              updatedOn,
 			CreatedBy:              domain.UserIDEmailRef{Email: c.CreatedBy},
@@ -902,4 +905,17 @@ func snIssueTypeToEnum(issueType *snCaseIssueType) domain.CaseIssueType {
 		return it
 	}
 	return ""
+}
+
+func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
+	if ws == nil {
+		return nil
+	}
+	v := domain.CaseWorkState(strings.ToLower(ws.Label))
+	switch v {
+	case domain.CaseWorkStateOngoing, domain.CaseWorkStatePaused:
+		return &v
+	default:
+		return nil
+	}
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -546,8 +546,145 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 	}, nil
 }
 
-func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
-	return s.pgFallback.UpdateCase(ctx, req)
+type snUpdateCasePayload struct {
+	StateKey      *int     `json:"stateKey,omitempty"`
+	SeverityKey   *int     `json:"severityKey,omitempty"`
+	WatchList     []string `json:"watchList,omitempty"`
+	AssigneeEmail *string  `json:"assigneeEmail,omitempty"`
+}
+
+type snUpdateCaseResponse struct {
+	Message string `json:"message"`
+	Case    struct {
+		ID        string        `json:"id"`
+		UpdatedOn string        `json:"updatedOn"`
+		UpdatedBy string        `json:"updatedBy"`
+		State     *snCaseState  `json:"state"`
+		Severity  *snCaseLabel  `json:"severity"`
+		WatchList []struct {
+			ID       string `json:"id"`
+			UserName string `json:"userName"`
+			Name     string `json:"name"`
+			Email    string `json:"email"`
+		} `json:"watchList"`
+		AssignedTo *struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"assignedTo"`
+	} `json:"case"`
+}
+
+func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+
+	fieldCount := 0
+	if req.State != nil {
+		fieldCount++
+	}
+	if req.Priority != nil {
+		fieldCount++
+	}
+	if len(req.WatchList) > 0 {
+		fieldCount++
+	}
+	if req.AssigneeEmail != nil {
+		fieldCount++
+	}
+	if fieldCount == 0 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state, priority, watchList, or assigneeEmail must be provided"}
+	}
+	if fieldCount > 1 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, priority, watchList, or assigneeEmail may be provided per request"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.UpdateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snUpdateCasePayload{}
+	if req.State != nil {
+		if !validCaseState[*req.State] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
+		}
+		id, ok := snStateIDMap[*req.State]
+		if !ok {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state " + string(*req.State) + " is not supported by ServiceNow"}
+		}
+		payload.StateKey = &id
+	}
+	if req.Priority != nil {
+		if !validCasePriority[*req.Priority] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
+		}
+		id, ok := snSeverityIDMap[*req.Priority]
+		if !ok {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority " + string(*req.Priority) + " is not supported by ServiceNow"}
+		}
+		payload.SeverityKey = &id
+	}
+	if len(req.WatchList) > 0 {
+		payload.WatchList = req.WatchList
+	}
+	if req.AssigneeEmail != nil {
+		payload.AssigneeEmail = req.AssigneeEmail
+	}
+
+	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+
+	var snResp snUpdateCaseResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse response: %w", err)
+	}
+
+	updatedOn, err := time.Parse(snCreatedOnLayout, snResp.Case.UpdatedOn)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse updatedOn %q: %w", snResp.Case.UpdatedOn, err)
+	}
+
+	resp := domain.UpdateCaseResponse{
+		Message: snResp.Message,
+		Case: domain.UpdatedCase{
+			ID:        sysidToUUID(snResp.Case.ID),
+			UpdatedOn: updatedOn,
+			UpdatedBy: snResp.Case.UpdatedBy,
+		},
+	}
+
+	if snResp.Case.State != nil {
+		state, err := snCaseStateLabelToEnum(snResp.Case.State)
+		if err == nil {
+			resp.Case.State = state
+		}
+	}
+	if snResp.Case.Severity != nil {
+		resp.Case.Priority = snSeverityToPriority(snResp.Case.Severity)
+	}
+	if snResp.Case.AssignedTo != nil {
+		resp.Case.AssignedTo = &domain.AssignedEngineerRef{
+			ID:   sysidToUUID(snResp.Case.AssignedTo.ID),
+			Name: snResp.Case.AssignedTo.Name,
+		}
+	}
+	if len(snResp.Case.WatchList) > 0 {
+		wl := make([]domain.WatchListUser, 0, len(snResp.Case.WatchList))
+		for _, u := range snResp.Case.WatchList {
+			wl = append(wl, domain.WatchListUser{
+				ID:       sysidToUUID(u.ID),
+				UserName: u.UserName,
+				Name:     u.Name,
+				Email:    u.Email,
+			})
+		}
+		resp.Case.WatchList = wl
+	}
+
+	return resp, nil
 }
 
 type snCreateAttachmentPayload struct {

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -216,6 +216,31 @@ func (c *Client) GetBinary(ctx context.Context, path string, userIDToken string)
 	}
 }
 
+// Patch sends a PATCH request to the given path. The OAuth2 bearer token is
+// added as Authorization header; userIDToken is forwarded as x-user-id-token.
+// Returns the raw response body on 2xx.
+func (c *Client) Patch(ctx context.Context, path string, userIDToken string, payload any) (json.RawMessage, error) {
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("snclient: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("snclient: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("x-user-id-token", userIDToken)
+
+	return c.do(req, path)
+}
+
 // Post sends a POST request to the given path. The OAuth2 bearer token is
 // added as Authorization header; userIDToken is forwarded as x-user-id-token.
 // Returns the raw response body on 2xx.

--- a/entity-service/migrations/000008_create_cases.up.sql
+++ b/entity-service/migrations/000008_create_cases.up.sql
@@ -1,3 +1,8 @@
+CREATE TYPE case_work_state_enum AS ENUM (
+  'ongoing',
+  'paused'
+);
+
 CREATE TYPE case_priority_enum AS ENUM (
   'catastrophic',
   'critical',
@@ -45,6 +50,7 @@ CREATE TABLE cases (
   updated_at          TIMESTAMP DEFAULT NOW(),
   closed_at           TIMESTAMP,
   assigned_engineer   UUID NULL REFERENCES users(id),
+  work_state          case_work_state_enum NULL,
   parent_case_id      UUID NULL REFERENCES cases(id),
   related_case_id     UUID NULL REFERENCES cases(id),
 
@@ -52,7 +58,14 @@ CREATE TABLE cases (
     CHECK (state != 'closed' OR closed_at IS NOT NULL),
 
   CONSTRAINT chk_closed_at_not_on_open
-    CHECK (closed_at IS NULL OR state = 'closed')
+    CHECK (closed_at IS NULL OR state = 'closed'),
+
+  CONSTRAINT chk_work_state_only_on_wip
+    CHECK (
+      (state = 'work_in_progress' AND work_state IS NOT NULL)
+      OR
+      (state != 'work_in_progress' AND work_state IS NULL)
+    )
 );
 
 CREATE OR REPLACE FUNCTION check_case_deployment_belongs_to_project()
@@ -112,6 +125,20 @@ CREATE TRIGGER trg_case_catastrophic_priority
   BEFORE INSERT OR UPDATE ON cases
   FOR EACH ROW EXECUTE FUNCTION check_case_catastrophic_priority();
 
+CREATE OR REPLACE FUNCTION sync_work_state_on_state_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.state != 'work_in_progress' THEN
+    NEW.work_state := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_work_state_on_state_change
+  BEFORE INSERT OR UPDATE ON cases
+  FOR EACH ROW EXECUTE FUNCTION sync_work_state_on_state_change();
+
 -- Enable trigram extension for ILIKE '%...%' support
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
@@ -133,6 +160,19 @@ CREATE INDEX idx_cases_closed_at           ON cases(closed_at);
 CREATE INDEX idx_cases_project_state         ON cases(project_id, state);
 CREATE INDEX idx_cases_priority_state        ON cases(priority, state);
 CREATE INDEX idx_cases_priority_issue_type   ON cases(priority, issue_type);
+
+-- work_state indexes
+CREATE UNIQUE INDEX uidx_cases_one_ongoing_per_engineer
+  ON cases (assigned_engineer)
+  WHERE work_state = 'ongoing';
+
+CREATE INDEX idx_cases_work_state
+  ON cases(work_state)
+  WHERE work_state IS NOT NULL;
+
+CREATE INDEX idx_cases_engineer_work_state
+  ON cases(assigned_engineer, work_state)
+  WHERE work_state IS NOT NULL;
 
 -- Trigram indexes for ILIKE search on subject, number, internal_id
 CREATE INDEX idx_cases_subject_trgm  ON cases USING GIN (subject  gin_trgm_ops);

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -316,7 +316,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     patch:
-      summary: Update the state and/or priority of a support case.
+      summary: Update a support case.
+      description: |
+        Updates exactly one field of the case. Provide exactly one of: `state`, `priority`,
+        `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        only when the ServiceNow data source is active.
       operationId: patchCase
       parameters:
         - name: id
@@ -337,7 +341,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Case'
+                $ref: '#/components/schemas/UpdateCaseResponse'
         "400":
           description: Bad request.
           content:
@@ -1146,10 +1150,14 @@ components:
 
     UpdateCaseRequest:
       type: object
-      description: At least one of state or priority must be provided.
-      anyOf:
+      description: |
+        Exactly one of `state`, `priority`, `watchList`, or `assigneeEmail` must be provided.
+        `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
+      oneOf:
         - required: [state]
         - required: [priority]
+        - required: [watchList]
+        - required: [assigneeEmail]
       properties:
         state:
           type: string
@@ -1159,6 +1167,67 @@ components:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new priority (severity) of the case.
+        watchList:
+          type: array
+          items:
+            type: string
+            format: email
+          description: List of email addresses to set as the case watch list (ServiceNow only).
+        assigneeEmail:
+          type: string
+          format: email
+          description: Email of the engineer to assign to this case (ServiceNow only).
+
+    UpdateCaseResponse:
+      type: object
+      required: [message, case]
+      properties:
+        message:
+          type: string
+        case:
+          $ref: '#/components/schemas/UpdatedCase'
+
+    UpdatedCase:
+      type: object
+      required: [id, updatedOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
+          description: Email or display name of the user who performed the update.
+        state:
+          type: string
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        priority:
+          type: string
+          enum: [catastrophic, critical, high, medium, low]
+        watchList:
+          type: array
+          items:
+            $ref: '#/components/schemas/WatchListUser'
+        assignedTo:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+
+    WatchListUser:
+      type: object
+      required: [id, userName]
+      properties:
+        id:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
 
     CreateCaseRequest:
       type: object
@@ -1406,6 +1475,11 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          nullable: true
+          description: Work sub-state, present only when state is work_in_progress.
         createdOn:
           type: string
           format: date-time
@@ -1454,6 +1528,11 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          nullable: true
+          description: Work sub-state, present only when state is work_in_progress.
         createdOn:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

- Adds `workState` field (`ongoing` | `paused`) to `GET /cases/{id}` and `POST /cases/search` responses for both Postgres and ServiceNow data sources. The field is `null` when the case is not in `work_in_progress` state.
- Extends `PATCH /cases/{id}` to support `watchList` and `assigneeEmail` updates via ServiceNow, in addition to the existing `state` and `priority` fields. Enforces exactly-one-field semantics per request.
- Adds the `work_state` column, constraint, trigger, and indexes to the `000008_create_cases` migration script.
- Updates `openapi.yaml` with `workState` on `CaseView`/`CaseSearchView`, new `UpdateCaseRequest` oneOf constraint, and `UpdateCaseResponse`/`UpdatedCase`/`WatchListUser` schemas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cases now include a work state indicator (ongoing/paused) for work-in-progress cases
  * Case update endpoint now supports watch list and assignee email modifications (ServiceNow data source only)
  * Enhanced update response includes detailed case information

* **Documentation**
  * API specifications updated to reflect new case update functionality and constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->