### PR TITLE
[CSM Portal][BE] feat(cases): enable workState guard and align with entity-service PR #889

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -194,9 +194,7 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
 		return
 	}
-	// TODO: tighten to include workState once entity service ships the field
-	// if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
-	if currentCase.State != "work_in_progress" {
+	if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
 		writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
 		return
 	}
@@ -404,7 +402,7 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 }
 
 // PatchCase handles PATCH /cases/{id}.
-// Accepts {"state":"<new_state>"} and forwards to the entity service.
+// Accepts state, priority, watchList, or assigneeEmail and forwards to the entity service.
 func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -467,13 +465,6 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity PatchCase failed", "userID", user.UserID, "caseID", caseID, "err", err)
 		mapUpstreamError(w, err, "Failed to update case.")
-		return
-	}
-
-	result, err = injectNextStates(result)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to inject nextStates", "userID", user.UserID, "caseID", caseID, "err", err)
-		writeError(w, http.StatusInternalServerError, "Failed to process case details.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -658,6 +658,14 @@ func TestPatchCase(t *testing.T) {
 			t.Errorf("upstream received invalid JSON body: %s", capturedBody)
 		}
 
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+			t.Fatalf("decode raw response body: %v; raw: %s", err, w.Body.String())
+		}
+		if _, ok := raw["nextStates"]; ok {
+			t.Errorf("response must not include legacy top-level nextStates")
+		}
+
 		type patchCaseResp struct {
 			Message string `json:"message"`
 			Case    struct {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -234,9 +234,35 @@ func TestCreateCaseComment(t *testing.T) {
 		}
 	})
 
-	// TODO: re-enable once entity service ships workState
-	// t.Run("rejects comment when work_state is not ongoing", ...)
-	// t.Run("rejects comment when workState is absent", ...)
+	t.Run("rejects comment when work_state is not ongoing", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress","workState":"paused"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+	})
+
+	t.Run("rejects comment when workState is absent", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+	})
 
 	t.Run("forwards body to entity and returns response", func(t *testing.T) {
 		var capturedCaseID string
@@ -602,9 +628,10 @@ func TestPatchCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("forwards case ID and body, returns 200 with nextStates injected", func(t *testing.T) {
+	t.Run("forwards case ID and body, returns 200 with upstream response", func(t *testing.T) {
 		var capturedID string
 		var capturedBody []byte
+		const upstreamResp = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-06-18T10:00:00Z","state":"work_in_progress"}}`
 		client := &mockEntityCaseClient{
 			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
 				return []byte(`{"id":"` + testCaseID + `","state":"open"}`), nil
@@ -612,7 +639,7 @@ func TestPatchCase(t *testing.T) {
 			patchCaseFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
 				capturedID = caseID
 				capturedBody = body
-				return []byte(`{"id":"` + testCaseID + `","state":"work_in_progress"}`), nil
+				return []byte(upstreamResp), nil
 			},
 		}
 		h := NewCaseHandler(client)
@@ -632,25 +659,21 @@ func TestPatchCase(t *testing.T) {
 		}
 
 		type patchCaseResp struct {
-			ID         string   `json:"id"`
-			State      string   `json:"state"`
-			NextStates []string `json:"nextStates"`
+			Message string `json:"message"`
+			Case    struct {
+				ID    string `json:"id"`
+				State string `json:"state"`
+			} `json:"case"`
 		}
 		resp := decodeJSON[patchCaseResp](t, w)
-		if resp.ID != testCaseID {
-			t.Errorf("response id = %q, want %q", resp.ID, testCaseID)
+		if resp.Message != "Case updated successfully" {
+			t.Errorf("response message = %q, want %q", resp.Message, "Case updated successfully")
 		}
-		if resp.State != caseStateWorkInProgress {
-			t.Errorf("response state = %q, want %q", resp.State, caseStateWorkInProgress)
+		if resp.Case.ID != testCaseID {
+			t.Errorf("response case.id = %q, want %q", resp.Case.ID, testCaseID)
 		}
-		wantNext := []string{caseStateWaitingOnWSO2, caseStateAwaitingInfo, caseStateSolutionProposed, caseStateClosed}
-		if len(resp.NextStates) != len(wantNext) {
-			t.Fatalf("nextStates = %v, want %v", resp.NextStates, wantNext)
-		}
-		for i, got := range resp.NextStates {
-			if got != wantNext[i] {
-				t.Errorf("nextStates[%d] = %q, want %q", i, got, wantNext[i])
-			}
+		if resp.Case.State != caseStateWorkInProgress {
+			t.Errorf("response case.state = %q, want %q", resp.Case.State, caseStateWorkInProgress)
 		}
 	})
 

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1155,7 +1155,7 @@ components:
           description: Email or display name of the user who performed the update.
         state:
           type: string
-          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
         priority:
           type: string
           enum: [catastrophic, critical, high, medium, low]

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -126,7 +126,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
     patch:
-      summary: Update the state and/or priority of a support case.
+      summary: Update a support case.
+      description: |
+        Updates exactly one field of the case. Provide exactly one of: `state`, `priority`,
+        `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        only when the ServiceNow data source is active.
       operationId: patchCasesId
       parameters:
         - name: id
@@ -148,7 +152,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CaseView'
+                $ref: '#/components/schemas/UpdateCaseResponse'
         "400":
           description: Bad request (e.g. malformed UUID, invalid state value, or invalid state transition).
           content:
@@ -1099,10 +1103,14 @@ components:
 
     UpdateCaseRequest:
       type: object
-      description: At least one of state or priority must be provided.
-      anyOf:
+      description: |
+        Exactly one of `state`, `priority`, `watchList`, or `assigneeEmail` must be provided.
+        `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
+      oneOf:
         - required: [state]
         - required: [priority]
+        - required: [watchList]
+        - required: [assigneeEmail]
       properties:
         state:
           type: string
@@ -1112,6 +1120,67 @@ components:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new priority (severity) of the case.
+        watchList:
+          type: array
+          items:
+            type: string
+            format: email
+          description: List of email addresses to set as the case watch list (ServiceNow only).
+        assigneeEmail:
+          type: string
+          format: email
+          description: Email of the engineer to assign to this case (ServiceNow only).
+
+    UpdateCaseResponse:
+      type: object
+      required: [message, case]
+      properties:
+        message:
+          type: string
+        case:
+          $ref: '#/components/schemas/UpdatedCase'
+
+    UpdatedCase:
+      type: object
+      required: [id, updatedOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
+          description: Email or display name of the user who performed the update.
+        state:
+          type: string
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        priority:
+          type: string
+          enum: [catastrophic, critical, high, medium, low]
+        watchList:
+          type: array
+          items:
+            $ref: '#/components/schemas/WatchListUser'
+        assignedTo:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+
+    WatchListUser:
+      type: object
+      required: [id, userName]
+      properties:
+        id:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
 
     CaseCreatePayload:
       type: object
@@ -1307,7 +1376,7 @@ components:
           nullable: true
           enum:
             - ongoing
-            - on_hold
+            - paused
           description: Sub-state of work_in_progress. Null when state is not work_in_progress.
         closedAt:
           type: string


### PR DESCRIPTION
## Summary

- **Enable full workState comment guard**: `CreateCaseComment` now rejects with 409 unless `state == work_in_progress` AND `workState == ongoing`. Previously the `workState` check was commented out pending entity-service delivery.
- **Fix `workState` enum**: corrected `on_hold` → `paused` in `openapi.yaml`; the entity service uses `ongoing`/`paused`, not `on_hold`.
- **Remove `injectNextStates` from `PatchCase`**: entity-service PR #889 changed the PATCH response from a full `CaseView` to `UpdateCaseResponse` (`{message, case: {id, updatedOn, state?, ...}}`). The previous code was silently injecting `nextStates: []` on every PATCH response because there is no top-level `state` key in the new shape. `nextStates` remains injected by `GetCase`.
- **Sync `UpdateCaseRequest` schema**: `anyOf` → `oneOf`; add `watchList` and `assigneeEmail` fields added by entity-service PR #889.
- **Add `UpdateCaseResponse` / `UpdatedCase` / `WatchListUser` schemas** to openapi.yaml, mirroring the entity-service spec.

## Test plan

- [ ] `make test` passes (pre-push hook confirmed)
- [ ] `CreateCaseComment` returns 409 when case `state != work_in_progress`
- [ ] `CreateCaseComment` returns 409 when `workState == paused`
- [ ] `CreateCaseComment` returns 409 when `workState` is absent
- [ ] `CreateCaseComment` proceeds when `state == work_in_progress` and `workState == ongoing`
- [ ] `PatchCase` returns the entity-service `UpdateCaseResponse` without a spurious `nextStates` field
- [ ] `GetCase` still injects `nextStates` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Case updates now support watchList and assigneeEmail modifications in addition to state and priority.
  * Added assignedTo field to case responses.

* **Bug Fixes**
  * Updated case update endpoint response format to properly include message and nested case details.

* **Changes**
  * Updated workState enum value from "on_hold" to "paused."
  * watchList now returns user information objects instead of plain email strings.
  * Case updates now require exactly one field per request among state, priority, watchList, or assigneeEmail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->