### PR TITLE
[CSM Portal][BE] fix(cases): exempt work_note from comment state guard

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -179,24 +179,32 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	current, err := h.entity.GetCase(r.Context(), caseID)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "entity GetCase failed during comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
-		mapUpstreamError(w, err, "Failed to create case comment.")
-		return
+	// Work notes are internal-only and exempt from the state gate.
+	var reqMeta struct {
+		Type string `json:"type"`
 	}
-	var currentCase struct {
-		State     string  `json:"state"`
-		WorkState *string `json:"workState"`
-	}
-	if err := json.Unmarshal(current, &currentCase); err != nil {
-		slog.ErrorContext(r.Context(), "failed to parse case state for comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
-		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
-		return
-	}
-	if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
-		writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
-		return
+	_ = json.Unmarshal(body, &reqMeta) // body is already validated JSON
+
+	if reqMeta.Type != "work_note" {
+		current, err := h.entity.GetCase(r.Context(), caseID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "entity GetCase failed during comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
+			mapUpstreamError(w, err, "Failed to create case comment.")
+			return
+		}
+		var currentCase struct {
+			State     string  `json:"state"`
+			WorkState *string `json:"workState"`
+		}
+		if err := json.Unmarshal(current, &currentCase); err != nil {
+			slog.ErrorContext(r.Context(), "failed to parse case state for comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
+			writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+			return
+		}
+		if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
+			writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
+			return
+		}
 	}
 
 	result, err := h.entity.CreateCaseComment(r.Context(), caseID, body)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -264,6 +264,34 @@ func TestCreateCaseComment(t *testing.T) {
 		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
 	})
 
+	t.Run("allows work_note in any case state without calling GetCase", func(t *testing.T) {
+		for _, state := range []string{"open", "work_in_progress", "waiting_on_wso2", "awaiting_info", "solution_proposed", "closed"} {
+			state := state
+			t.Run(state, func(t *testing.T) {
+				t.Parallel()
+				getCalled := false
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						getCalled = true
+						return []byte(`{"state":"` + state + `"}`), nil
+					},
+					createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return []byte(`{"id":"wn-1"}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(`{"type":"work_note","content":"internal note"}`)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.CreateCaseComment(w, r)
+				assertStatus(t, w, http.StatusCreated)
+				if getCalled {
+					t.Errorf("GetCase should not be called for work_note")
+				}
+			})
+		}
+	})
+
 	t.Run("forwards body to entity and returns response", func(t *testing.T) {
 		var capturedCaseID string
 		var capturedBody []byte

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -253,7 +253,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
         "409":
-          description: Conflict — customer-visible comments (type=comment) can only be posted when the case is work_in_progress with workState=ongoing. Work notes (type=work_note) are exempt and allowed in any state.
+          description: Conflict — comments and activities (type=comment or type=activity) require the case to be work_in_progress with workState=ongoing. Work notes (type=work_note) are exempt and allowed in any state.
           content:
             application/json:
               schema:
@@ -2038,10 +2038,10 @@ components:
     CaseCommentCreatePayload:
       type: object
       required:
-        - commentType
+        - type
         - body
       properties:
-        commentType:
+        type:
           type: string
           enum: [work_note, comment, activity]
           description: work_note is restricted to internal users; activity to internal and system users
@@ -2056,7 +2056,7 @@ components:
           type: string
         caseId:
           type: string
-        commentType:
+        type:
           type: string
           enum: [work_note, comment, activity]
         body:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -253,7 +253,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
         "409":
-          description: Conflict — comment posting is not allowed in the current case state (case must be work_in_progress with work_state ongoing).
+          description: Conflict — customer-visible comments (type=comment) can only be posted when the case is work_in_progress with workState=ongoing. Work notes (type=work_note) are exempt and allowed in any state.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

- `CreateCaseComment` now parses `type` from the request body before the state gate.
- `type=work_note` skips the guard entirely — `GetCase` is never called and the comment is forwarded in any case state.
- `type=comment` (and any other/missing type) still requires `state==work_in_progress && workState==ongoing`.
- Updated the `409` response description in `openapi.yaml` to document the exemption.

Fixes digiops-cs#2112.

## Test plan

- [x] `make test` passes
- [x] `POST /cases/{id}/comments` with `type=work_note` returns 201 on a closed / paused / awaiting-info case
- [x] `POST` with `type=comment` on a non-ongoing case still returns 409
- [x] `POST` with `type=comment` on `work_in_progress + ongoing` still returns 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work notes can now be added to cases in any state. Customer-visible comments continue to require cases in `work_in_progress` state with `ongoing` work state.

* **Documentation**
  * Updated API documentation to clarify comment type restrictions and allowed case states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->