### PR TITLE
[CSM Portal] gate customer replies on case work-state; add engineer assignment

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -188,18 +188,20 @@ export interface BeCaseCreateResponse {
 
 /**
  * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
- * **Exactly one** of `state` / `priority` / `assigneeEmail` / `watchList` must
- * be set per call — the backend rejects zero or more than one. `assigneeEmail`
- * and `watchList` are supported **only** for the ServiceNow data source.
+ * **Exactly one** of `state` / `priority` / `assigneeEmail` / `watchList` is
+ * sent per call — the backend rejects zero or more than one. Encoded as a
+ * discriminated union (each variant `?: never`s the others) so the
+ * exactly-one-field contract is enforced at compile time, not just in docs.
+ * `assigneeEmail` and `watchList` are supported **only** for the ServiceNow
+ * data source.
  */
-export interface BeCaseUpdatePayload {
-  state?: BeCaseState;
-  priority?: BeCasePriority;
+export type BeCaseUpdatePayload =
+  | { state: BeCaseState; priority?: never; assigneeEmail?: never; watchList?: never }
+  | { state?: never; priority: BeCasePriority; assigneeEmail?: never; watchList?: never }
   /** Email of the engineer to assign (ServiceNow only). */
-  assigneeEmail?: string;
+  | { state?: never; priority?: never; assigneeEmail: string; watchList?: never }
   /** Full replacement watch list as emails (ServiceNow only). */
-  watchList?: string[];
-}
+  | { state?: never; priority?: never; assigneeEmail?: never; watchList: string[] };
 
 /** A user in the case watch list, as echoed by `PATCH /cases/{id}`. */
 export interface BeWatchListUser {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -71,6 +71,13 @@ export type BeCaseState =
   | "solution_proposed"
   | "closed";
 
+/**
+ * Work sub-state of a `work_in_progress` case (entity `CaseWorkState`). `null`
+ * when the case is not in progress. The backend rejects comment creation unless
+ * the case is `work_in_progress` AND `ongoing`.
+ */
+export type BeCaseWorkState = "ongoing" | "paused";
+
 export type BeCaseSortField = "created_at" | "updated_at" | "closed_at";
 
 export interface BeCase {
@@ -138,6 +145,8 @@ export interface BeCaseView {
   priority?: BeCasePriority;
   issueType?: BeCaseIssueType;
   state?: BeCaseState;
+  /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
+  workState?: BeCaseWorkState | null;
   nextStates?: BeCaseState[];
   createdBy?: BeUserRef;
   /** The CS engineer the case is assigned to; null when unassigned. */
@@ -178,12 +187,43 @@ export interface BeCaseCreateResponse {
 }
 
 /**
- * Request body for `PATCH /cases/{id}`. At least one of `state` / `priority`
- * must be set (mirrors the entity `UpdateCaseRequest`).
+ * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
+ * **Exactly one** of `state` / `priority` / `assigneeEmail` / `watchList` must
+ * be set per call — the backend rejects zero or more than one. `assigneeEmail`
+ * and `watchList` are supported **only** for the ServiceNow data source.
  */
 export interface BeCaseUpdatePayload {
   state?: BeCaseState;
   priority?: BeCasePriority;
+  /** Email of the engineer to assign (ServiceNow only). */
+  assigneeEmail?: string;
+  /** Full replacement watch list as emails (ServiceNow only). */
+  watchList?: string[];
+}
+
+/** A user in the case watch list, as echoed by `PATCH /cases/{id}`. */
+export interface BeWatchListUser {
+  id: string;
+  userName: string;
+  name?: string;
+  email?: string;
+}
+
+/** The mutated case fields echoed by `PATCH /cases/{id}`. */
+export interface BeUpdatedCase {
+  id: string;
+  updatedOn?: string;
+  updatedBy?: string;
+  state?: BeCaseState;
+  priority?: BeCasePriority;
+  watchList?: BeWatchListUser[];
+  assignedTo?: BeEntityRef | null;
+}
+
+/** `PATCH /cases/{id}` response: a message plus the mutated case fields. */
+export interface BeUpdateCaseResponse {
+  message?: string;
+  case: BeUpdatedCase;
 }
 
 /** Request body for `POST /cases/search` (the flat, cross-project search). */
@@ -226,6 +266,8 @@ export interface BeCaseSearchView {
   priority?: BeCasePriority;
   issueType?: BeCaseIssueType;
   state?: BeCaseState;
+  /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
+  workState?: BeCaseWorkState | null;
   createdOn?: string;
   updatedOn?: string;
   closedAt?: string | null;

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
@@ -412,6 +412,8 @@ const ALL_EXTRA_CASE_SEEDS: CaseSeed[] = [
     projectName: "API Manager",
     severity: "S3",
     state: "work_in_progress",
+    // Paused: exercises the comment-gate disabled state in mock mode.
+    workState: "paused",
     assignee: "Dilan W.",
     assigneeIsMe: false,
     slaClockType: "resolution",
@@ -455,6 +457,11 @@ function deriveWso2CaseId(seed: CaseSeed): string {
 function hydrate(seed: CaseSeed): CsmCaseRow {
   return {
     ...seed,
+    // Default an in-progress case to `ongoing` so the comment composer is
+    // usable in mock mode; a seed may set `paused` explicitly. Non-in-progress
+    // cases have no work sub-state.
+    workState:
+      seed.workState ?? (seed.state === "work_in_progress" ? "ongoing" : null),
     product: deriveProductName(seed.subject, seed.projectName),
     wso2CaseId: deriveWso2CaseId(seed),
   };

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -52,6 +52,7 @@ function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
     product,
     severity: severityFromPriority(c.priority),
     state: uiStateFromBe(c.state),
+    workState: c.workState ?? null,
     nextStates: (c.nextStates ?? []).map(uiStateFromBe),
     assignee,
     // "Is me" needs the signed-in user's entity id, which this mapper doesn't

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -226,6 +226,7 @@ export function useGetCsmCases(
           product: c.deployedProduct?.displayName ?? "—",
           severity: severityFromPriority(c.priority),
           state: uiStateFromBe(c.state),
+          workState: c.workState ?? null,
           // No assignee field on the backend yet; surfaced as "Unassigned".
           assignee: "Unassigned",
           assigneeIsMe: false,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
@@ -52,10 +52,10 @@ export function usePatchCsmCase(
       }
       if (isMockMode()) {
         await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
-        return {
-          message: "Case updated (mock).",
-          case: { id: caseId, state: input.state, priority: input.priority },
-        };
+        // The success handler ignores the body and refetches, so the mock only
+        // needs the id. (Echoing input.state/priority would not type-check
+        // against the single-field union and isn't used anyway.)
+        return { message: "Case updated (mock).", case: { id: caseId } };
       }
       return api.patch<BeCaseUpdatePayload, BeUpdateCaseResponse>(
         `/cases/${encodeURIComponent(caseId)}`,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
@@ -21,38 +21,43 @@ import {
 } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
-import type { BeCase, BeCaseUpdatePayload } from "@api/backend/types";
+import type {
+  BeCaseUpdatePayload,
+  BeUpdateCaseResponse,
+} from "@api/backend/types";
 
 const MOCK_LATENCY_MS = 200;
 
 /**
- * Update a case via `PATCH /cases/{id}` — used for state transitions (and
- * priority changes). On success it invalidates this case's detail query and the
- * cross-project list so both reflect the new state.
+ * Update a case via `PATCH /cases/{id}` — state transitions, priority changes,
+ * assignee (`assigneeEmail`), or watch list (`watchList`). The backend requires
+ * **exactly one** of those fields per call, so callers must not combine them.
+ * The response is `BeUpdateCaseResponse` ({ message, case }), but on success we
+ * ignore the body and invalidate this case's detail query and the cross-project
+ * list so both refetch the authoritative state (incl. fresh `nextStates`).
  *
  * In MOCK mode the mutation resolves without persisting (mock detail data is
  * static), so the caller's optimistic feedback is the only visible effect.
  */
 export function usePatchCsmCase(
   caseId: string | undefined,
-): UseMutationResult<BeCase, Error, BeCaseUpdatePayload> {
+): UseMutationResult<BeUpdateCaseResponse, Error, BeCaseUpdatePayload> {
   const api = useBackendApi();
   const queryClient = useQueryClient();
 
-  return useMutation<BeCase, Error, BeCaseUpdatePayload>({
-    mutationFn: async (input): Promise<BeCase> => {
+  return useMutation<BeUpdateCaseResponse, Error, BeCaseUpdatePayload>({
+    mutationFn: async (input): Promise<BeUpdateCaseResponse> => {
       if (!caseId) {
         throw new Error("Cannot update a case without an id.");
       }
       if (isMockMode()) {
         await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
         return {
-          id: caseId,
-          state: input.state,
-          priority: input.priority,
+          message: "Case updated (mock).",
+          case: { id: caseId, state: input.state, priority: input.priority },
         };
       }
-      return api.patch<BeCaseUpdatePayload, BeCase>(
+      return api.patch<BeCaseUpdatePayload, BeUpdateCaseResponse>(
         `/cases/${encodeURIComponent(caseId)}`,
         input,
       );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Avatar,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  InputAdornment,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Search, UserCheck } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type JSX } from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import type { User } from "@features/csm-users/types/csmUsers";
+
+interface AssignEngineerDialogProps {
+  /** Current assignee display name, or "Unassigned". */
+  currentAssignee?: string;
+  /** Signed-in engineer's email — enables the "Assign to me" shortcut. */
+  currentUserEmail?: string;
+  /** True while a PATCH is in flight; disables the actions. */
+  isAssigning: boolean;
+  onClose: () => void;
+  /** Assign the case to this engineer's email (`PATCH { assigneeEmail }`). */
+  onAssign: (email: string) => void;
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function fullName(u: User): string {
+  return [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.userName;
+}
+
+/**
+ * Pick the engineer to assign a case to. Searches internal users via
+ * `POST /users/search` and assigns by email through `PATCH /cases/{id}`
+ * (`assigneeEmail`). Assignment is a ServiceNow-source capability; on a
+ * Postgres-sourced case the backend rejects it and the caller surfaces the
+ * error. Mount only while open so the user search isn't issued in the
+ * background.
+ */
+export default function AssignEngineerDialog({
+  currentAssignee,
+  currentUserEmail,
+  isAssigning,
+  onClose,
+  onAssign,
+}: AssignEngineerDialogProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const search = useDebouncedValue(input.trim(), 300);
+  const { data, isFetching, isError } = useSearchUsers({
+    ...(search.length > 0 && { searchQuery: search }),
+    pagination: { limit: 8, offset: 0 },
+  });
+
+  // Only internal engineers are assignable, and only ones that carry an email
+  // (the assign call is email-based).
+  const engineers = useMemo(
+    () =>
+      (data?.users ?? []).filter(
+        (u) => u.userType === "internal" && !!u.email,
+      ),
+    [data],
+  );
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Assign engineer</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Currently assigned to{" "}
+            <Box component="span" sx={{ fontWeight: 600, color: "text.primary" }}>
+              {currentAssignee || "Unassigned"}
+            </Box>
+            .
+          </Typography>
+
+          {currentUserEmail && (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<UserCheck size={16} />}
+              disabled={isAssigning}
+              onClick={() => onAssign(currentUserEmail)}
+              sx={{ alignSelf: "flex-start" }}
+            >
+              Assign to me
+            </Button>
+          )}
+
+          <TextField
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Search engineers by name or email…"
+            size="small"
+            fullWidth
+            autoFocus
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={16} />
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <Box sx={{ minHeight: 160 }}>
+            {isFetching ? (
+              <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+                <CircularProgress size={22} />
+              </Box>
+            ) : isError ? (
+              <Typography variant="body2" color="error" sx={{ py: 2 }}>
+                Could not load engineers. Try again.
+              </Typography>
+            ) : engineers.length === 0 ? (
+              <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+                No matching engineers.
+              </Typography>
+            ) : (
+              <Box sx={{ display: "flex", flexDirection: "column" }}>
+                {engineers.map((u) => {
+                  const name = fullName(u);
+                  return (
+                    <Button
+                      key={u.id}
+                      variant="text"
+                      color="inherit"
+                      disabled={isAssigning}
+                      onClick={() => onAssign(u.email)}
+                      sx={{
+                        justifyContent: "flex-start",
+                        textTransform: "none",
+                        px: 1,
+                        py: 0.75,
+                        gap: 1.25,
+                      }}
+                    >
+                      <Avatar sx={{ width: 28, height: 28, fontSize: "0.75rem" }}>
+                        {initialsOf(name)}
+                      </Avatar>
+                      <Box sx={{ minWidth: 0, textAlign: "left" }}>
+                        <Typography variant="body2" sx={{ lineHeight: 1.2 }} noWrap>
+                          {name}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                          sx={{ display: "block" }}
+                        >
+                          {u.email}
+                        </Typography>
+                      </Box>
+                    </Button>
+                  );
+                })}
+              </Box>
+            )}
+          </Box>
+
+          <Typography variant="caption" color="text.secondary">
+            Assignment applies to ServiceNow-managed cases.
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isAssigning}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -203,7 +203,7 @@ function buildSecondaryItems(): SecondaryItem[] {
   // their backend flows land, so the menu advertises the roadmap without
   // exposing dead actions that would no-op or toast a mock message.
   return [
-    { key: "reassign_engineer", label: "Reassign engineer…", icon: <User size={16} />, disabled: true },
+    { key: "reassign_engineer", label: "Assign / reassign engineer…", icon: <User size={16} /> },
     { key: "reassign_group", label: "Reassign to group…", icon: <Users size={16} />, divider: true, disabled: true },
     { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} />, disabled: true },
     { key: "change_severity", label: "Request severity change…", icon: <ShieldAlert size={16} />, disabled: true },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -34,6 +34,7 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -57,6 +58,13 @@ interface CsmCaseCommentInputProps {
     attachments: CommentAttachmentDraft[],
   ) => Promise<unknown> | void;
   disabled?: boolean;
+  /**
+   * When set, a **customer-visible** reply cannot be sent right now (e.g. the
+   * case isn't in-progress/ongoing) and this string explains why. Only the
+   * public-reply path is blocked: internal work notes and attachment-only sends
+   * are always allowed. `null`/absent = public replies allowed.
+   */
+  publicCommentDisabledReason?: string | null;
   /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
   autoFocus?: boolean;
 }
@@ -83,13 +91,18 @@ function isEmpty(html: string): boolean {
 export default function CsmCaseCommentInput({
   onSubmit,
   disabled = false,
+  publicCommentDisabledReason = null,
   autoFocus = false,
 }: CsmCaseCommentInputProps): JSX.Element {
   const [html, setHtml] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [sourceMode, setSourceMode] = useState(false);
-  const [internal, setInternal] = useState(false);
+  // When customer replies are blocked, the only allowed entry is an internal
+  // work note, so start in work-note mode and (below) lock the toggle there.
+  const [internal, setInternal] = useState<boolean>(
+    () => !!publicCommentDisabledReason,
+  );
   const [maximized, setMaximized] = useState(false);
   // Files attached to this comment; uploaded to the case on send.
   const [attachments, setAttachments] = useState<CommentAttachmentDraft[]>([]);
@@ -138,6 +151,13 @@ export default function CsmCaseCommentInput({
       setError("Add a comment or an attachment.");
       return;
     }
+    // A customer-visible reply with text is gated on case state; work notes and
+    // attachment-only sends are not. Block before posting so the BE guard isn't
+    // hit with a doomed request.
+    if (!internal && publicCommentDisabledReason && !isEmpty(html)) {
+      setError(publicCommentDisabledReason);
+      return;
+    }
     if (overSizeLimit) {
       setError(sizeError);
       return;
@@ -175,11 +195,20 @@ export default function CsmCaseCommentInput({
     html,
     attachments,
     internal,
+    publicCommentDisabledReason,
     onSubmit,
     overSizeLimit,
     sizeError,
     submitting,
   ]);
+
+  // Customer replies are blocked for this case state. The composer is locked to
+  // work-note mode (toggle disabled, forced on) so the engineer can only log an
+  // internal note; work notes are allowed in any state.
+  const publicReplyLocked = !!publicCommentDisabledReason;
+  useEffect(() => {
+    if (publicReplyLocked && !internal) setInternal(true);
+  }, [publicReplyLocked, internal]);
 
   const toggleSourceMode = useCallback(
     (nextSource: boolean) => {
@@ -233,7 +262,7 @@ export default function CsmCaseCommentInput({
                 color="warning"
                 checked={internal}
                 onChange={(e) => setInternal(e.target.checked)}
-                disabled={disabled || submitting}
+                disabled={disabled || submitting || publicReplyLocked}
               />
             }
             label={
@@ -350,13 +379,21 @@ export default function CsmCaseCommentInput({
       >
         <Typography
           variant="caption"
-          color={sizeError || error ? "error" : "text.secondary"}
+          color={
+            sizeError || error
+              ? "error"
+              : publicReplyLocked
+                ? "warning.main"
+                : "text.secondary"
+          }
         >
           {sizeError ??
             error ??
-            (sourceMode
-              ? "Output is sent as-is. Use this to fix paste-formatting or insert tables."
-              : "Ctrl/Cmd + Enter to send.")}
+            (publicReplyLocked
+              ? publicCommentDisabledReason
+              : sourceMode
+                ? "Output is sent as-is. Use this to fix paste-formatting or insert tables."
+                : "Ctrl/Cmd + Enter to send.")}
         </Typography>
         <Button
           variant="contained"
@@ -367,7 +404,10 @@ export default function CsmCaseCommentInput({
             disabled ||
             submitting ||
             (isEmpty(html) && attachments.length === 0) ||
-            overSizeLimit
+            overSizeLimit ||
+            // Safety net: a public reply with text while replies are locked.
+            // Normally unreachable — the toggle is forced to work-note mode.
+            (!internal && publicReplyLocked && !isEmpty(html))
           }
           onClick={() => {
             void submit();

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -54,6 +54,7 @@ import {
 } from "@features/csm-cases/api/useCsmCaseAttachments";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
+import AssignEngineerDialog from "@features/csm-cases/components/AssignEngineerDialog";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
 import {
@@ -67,6 +68,10 @@ import {
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
+import {
+  publicCommentGateReason,
+  WORK_STATE_LABEL,
+} from "@features/csm-cases/utils/caseWorkState";
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
@@ -256,6 +261,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [activeTab, setActiveTab] = useState<CaseTabId>("activities");
   const [metaCollapsed, setMetaCollapsed] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
+  const [assignOpen, setAssignOpen] = useState(false);
+  // Email of the signed-in engineer, for the "Assign to me" shortcut.
+  const currentUserEmail = claims?.email ?? undefined;
 
   // Twitter-style permalinks: when the URL has a fragment matching an entry id,
   // jump to the Activities tab, scroll the entry into view vertically, and
@@ -388,6 +396,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Assign / reassign opens the engineer picker; the PATCH happens in
+      // onAssign once an engineer is chosen.
+      if (action.secondary === "reassign_engineer") {
+        setAssignOpen(true);
+        return;
+      }
+
       // Copy-link is async: only confirm success once the clipboard write
       // actually resolves, otherwise a failure shows both a false "copied"
       // toast and an error.
@@ -416,6 +431,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
       });
     },
     [data, showError, patchCase],
+  );
+
+  // Assign the case to the chosen engineer via PATCH { assigneeEmail }. The
+  // detail query is invalidated by the hook, so the assignee display refreshes
+  // on success. (ServiceNow-source only; the BE rejects it for PG cases.)
+  const onAssign = useCallback(
+    (email: string) => {
+      patchCase.mutate(
+        { assigneeEmail: email },
+        {
+          onSuccess: () => {
+            setAssignOpen(false);
+            setFeedback({
+              message: "Case reassigned.",
+              severity: "success",
+              sticky: true,
+            });
+          },
+          onError: (err) => showError("Could not reassign the case.", err),
+        },
+      );
+    },
+    [patchCase, showError],
   );
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
@@ -513,6 +551,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
   const c = data;
   const isClosed = c.state === "closed";
+  // The backend rejects a customer-visible comment unless the case is
+  // work_in_progress + ongoing. Internal work notes are allowed in any state,
+  // so this only disables the public-reply path in the composer — never work
+  // notes. Mirrors the BFF comment guard so the engineer sees a clear reason
+  // instead of a generic error.
+  const publicReplyGateReason = publicCommentGateReason(c.state, c.workState);
   const breached = c.minutesToBreach < 0;
   // The backend carries no SLA timing yet (LIVE detail leaves slaClocks empty
   // and minutesToBreach at 0). Without this guard the header SLA chip reads
@@ -619,6 +663,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
               color={stateColor(c.state)}
               sx={{ fontWeight: 600 }}
             />
+            {c.state === "work_in_progress" && c.workState && (
+              <Chip
+                size="small"
+                variant="outlined"
+                color={c.workState === "paused" ? "warning" : "default"}
+                label={WORK_STATE_LABEL[c.workState]}
+                sx={{ fontWeight: 600 }}
+              />
+            )}
             {!isClosed && hasSlaData && (
               <Chip
                 size="small"
@@ -737,7 +790,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           {/* Comments are latest-in-top (WSO2 convention), so the composer
               belongs at the top. It stays collapsed behind a button to keep
-              the thread the focal point until the engineer chooses to reply. */}
+              the thread the focal point until the engineer chooses to reply.
+              The composer is always available (an internal work note can be
+              added in any state); the public-reply path is gated inside it via
+              `publicReplyGateReason` when the case isn't in-progress/ongoing. */}
           {composerOpen ? (
             <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Box
@@ -759,6 +815,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </Box>
               <CsmCaseCommentInput
                 disabled={!caseId}
+                publicCommentDisabledReason={publicReplyGateReason}
                 autoFocus
                 onSubmit={async (bodyHtml, internal, commentAttachments) => {
                   if (!caseId) return;
@@ -819,7 +876,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 },
               }}
             >
-              Compose a reply to the customer…
+              {publicReplyGateReason
+                ? "Add an internal work note…"
+                : "Compose a reply to the customer…"}
             </Button>
           )}
 
@@ -969,6 +1028,16 @@ export default function CsmCaseDetailPage(): JSX.Element {
             onAdd={() => onAction({ secondary: "log_time" })}
           />
         </Box>
+      )}
+
+      {assignOpen && (
+        <AssignEngineerDialog
+          currentAssignee={c.assignee}
+          currentUserEmail={currentUserEmail}
+          isAssigning={patchCase.isPending}
+          onClose={() => setAssignOpen(false)}
+          onAssign={onAssign}
+        />
       )}
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -16,6 +16,7 @@
 
 import type {
   CaseState,
+  CaseWorkState,
   DashboardScope,
   Severity,
   SlaClockType,
@@ -50,6 +51,12 @@ export interface CsmCaseRow {
   product: string;
   severity: Severity;
   state: CaseState;
+  /**
+   * Work sub-state of an in-progress case (`ongoing` / `paused`); `null` when
+   * the case is not `work_in_progress`. Drives the comment gate and the paused
+   * indicator. See {@link commentGateReason}.
+   */
+  workState?: CaseWorkState | null;
   /** CRE / engineer working the case. "Unassigned" for cases with no one picked up yet. */
   assignee: string;
   assigneeIsMe: boolean;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
@@ -51,14 +51,21 @@ describe("publicCommentGateReason", () => {
     expect(publicCommentGateReason("work_in_progress", "ongoing")).toBeNull();
   });
 
-  it("gives a resume hint (mentioning work notes) for a paused case", () => {
-    const reason = publicCommentGateReason("work_in_progress", "paused");
-    expect(reason).toMatch(/paused/i);
-    expect(reason).toMatch(/work note/i);
+  it("gives a resume hint for a paused case", () => {
+    expect(publicCommentGateReason("work_in_progress", "paused")).toMatch(
+      /paused/i,
+    );
   });
 
   it("gives an in-progress hint for other states", () => {
     expect(publicCommentGateReason("open", null)).toMatch(/in progress/i);
     expect(publicCommentGateReason("closed", null)).toMatch(/in progress/i);
+  });
+
+  it("does not promise a work-note fallback (pending the backend exemption)", () => {
+    expect(publicCommentGateReason("open", null)).not.toMatch(/work note/i);
+    expect(publicCommentGateReason("work_in_progress", "paused")).not.toMatch(
+      /work note/i,
+    );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  caseAcceptsPublicComments,
+  publicCommentGateReason,
+} from "./caseWorkState";
+
+describe("caseAcceptsPublicComments", () => {
+  it("allows public comments only when work_in_progress AND ongoing", () => {
+    expect(caseAcceptsPublicComments("work_in_progress", "ongoing")).toBe(true);
+  });
+
+  it("blocks when work_in_progress but paused", () => {
+    expect(caseAcceptsPublicComments("work_in_progress", "paused")).toBe(false);
+  });
+
+  it("blocks when work_in_progress but workState is absent", () => {
+    expect(caseAcceptsPublicComments("work_in_progress", null)).toBe(false);
+    expect(caseAcceptsPublicComments("work_in_progress", undefined)).toBe(
+      false,
+    );
+  });
+
+  it("blocks in any other state regardless of workState", () => {
+    expect(caseAcceptsPublicComments("open", "ongoing")).toBe(false);
+    expect(caseAcceptsPublicComments("awaiting_info", "ongoing")).toBe(false);
+    expect(caseAcceptsPublicComments("waiting_on_wso2", null)).toBe(false);
+    expect(caseAcceptsPublicComments("solution_proposed", null)).toBe(false);
+    expect(caseAcceptsPublicComments("closed", null)).toBe(false);
+    expect(caseAcceptsPublicComments(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("publicCommentGateReason", () => {
+  it("returns null when public comments are allowed", () => {
+    expect(publicCommentGateReason("work_in_progress", "ongoing")).toBeNull();
+  });
+
+  it("gives a resume hint (mentioning work notes) for a paused case", () => {
+    const reason = publicCommentGateReason("work_in_progress", "paused");
+    expect(reason).toMatch(/paused/i);
+    expect(reason).toMatch(/work note/i);
+  });
+
+  it("gives an in-progress hint for other states", () => {
+    expect(publicCommentGateReason("open", null)).toMatch(/in progress/i);
+    expect(publicCommentGateReason("closed", null)).toMatch(/in progress/i);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -36,8 +36,11 @@ export function caseAcceptsPublicComments(
 /**
  * Human-readable reason a **public comment** cannot be posted right now, or
  * `null` when it can. When set, the composer locks to work-note mode and shows
- * this as the hint, so the engineer understands why their entry is saved as an
- * internal note rather than sent to the customer. Does not apply to work notes.
+ * this as the hint so the engineer understands why a customer reply is
+ * unavailable. Intentionally does not promise that a work note will save — that
+ * depends on the backend exempting work notes from the in-progress guard
+ * (pending follow-up); copy stays non-committal until then. Does not gate work
+ * notes.
  */
 export function publicCommentGateReason(
   state: CaseState | undefined,
@@ -45,9 +48,9 @@ export function publicCommentGateReason(
 ): string | null {
   if (caseAcceptsPublicComments(state, workState)) return null;
   if (state === "work_in_progress" && workState === "paused") {
-    return "This case is paused — customer replies are disabled. This will be saved as an internal work note; resume work to reply.";
+    return "This case is paused — customer replies are disabled. Resume work to reply to the customer.";
   }
-  return "Customer replies are disabled unless the case is actively in progress. This will be saved as an internal work note.";
+  return "Customer replies are disabled unless the case is actively in progress.";
 }
 
 /** Short label for the work sub-state chip on the case header / list. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  CaseState,
+  CaseWorkState,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+/**
+ * Whether a **customer-visible comment** may be posted right now. The backend
+ * gates public comments on `work_in_progress` AND work sub-state `ongoing`.
+ * Internal **work notes are NOT gated** by work-state — they may be added in
+ * any state — so this must only be consulted for public replies, never work
+ * notes. Keep in lockstep with the entity-service / BFF comment guard.
+ */
+export function caseAcceptsPublicComments(
+  state: CaseState | undefined,
+  workState: CaseWorkState | null | undefined,
+): boolean {
+  return state === "work_in_progress" && workState === "ongoing";
+}
+
+/**
+ * Human-readable reason a **public comment** cannot be posted right now, or
+ * `null` when it can. When set, the composer locks to work-note mode and shows
+ * this as the hint, so the engineer understands why their entry is saved as an
+ * internal note rather than sent to the customer. Does not apply to work notes.
+ */
+export function publicCommentGateReason(
+  state: CaseState | undefined,
+  workState: CaseWorkState | null | undefined,
+): string | null {
+  if (caseAcceptsPublicComments(state, workState)) return null;
+  if (state === "work_in_progress" && workState === "paused") {
+    return "This case is paused — customer replies are disabled. This will be saved as an internal work note; resume work to reply.";
+  }
+  return "Customer replies are disabled unless the case is actively in progress. This will be saved as an internal work note.";
+}
+
+/** Short label for the work sub-state chip on the case header / list. */
+export const WORK_STATE_LABEL: Record<CaseWorkState, string> = {
+  ongoing: "Ongoing",
+  paused: "Paused",
+};

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
@@ -24,6 +24,13 @@ export type CaseState =
   | "waiting_on_wso2"
   | "closed";
 
+/**
+ * Work sub-state of a `work_in_progress` case. `null` / absent when the case is
+ * not in progress. Mirrors the entity-service `CaseWorkState` enum; the backend
+ * gates comment posting on `work_in_progress` + `ongoing`.
+ */
+export type CaseWorkState = "ongoing" | "paused";
+
 export type SlaClockType = "ack" | "first_response" | "resolution";
 
 export type DashboardScope = "my_abt" | "all_customers";


### PR DESCRIPTION
## Summary

Adopts the recently-landed case-write contract on the rich `CaseView`: surfaces the case **work sub-state** (`ongoing`/`paused`), gates the **customer-reply** path of the comment composer on it, and adds **engineer assignment** from the case detail.

## What changed

**Work-state + comment gate**
- Thread `workState` (`ongoing` | `paused` | null) through the case read views, the list row type, and both case mappers.
- Show an ongoing/paused chip on the case-detail header.
- New tested util `caseWorkState.ts` (`caseAcceptsPublicComments` / `publicCommentGateReason`).
- The comment composer's **public-reply** path is gated on `work_in_progress` + `ongoing`. **Internal work notes remain allowed in any state** — when a customer reply isn't allowed the composer **locks to work-note mode** (toggle forced on and disabled) and shows the reason, rather than disabling the whole input. Attachment-only sends are unaffected.

**Assign engineer**
- New `AssignEngineerDialog`: searches internal users via `POST /users/search` and offers an "Assign to me" shortcut from the signed-in email claim.
- Opened from the action-bar "Assign / reassign engineer…" item (previously disabled). Assigns via `PATCH /cases/{id}` `{ assigneeEmail }` and refetches the detail so the assignee updates.
- Extended the update payload and corrected the PATCH hook's response type. Each PATCH sends exactly one field (the endpoint requires exactly-one-of state/priority/assigneeEmail/watchList).

## Behaviour notes

- Assignment is a ServiceNow-source capability; on a Postgres-sourced case the backend rejects it and the error surfaces to the user.
- Watchers UI is intentionally **not** included here — it needs a read path for the current watch list, which the case GET does not yet return (raised as a backend follow-up).
- A separate backend follow-up is needed so the comment guard exempts internal work notes (`type=work_note`); until then a work note on a non-in-progress case is rejected upstream even though the UI allows it.

## Testing

- `pnpm build` (tsc -b + vite build) — green
- `pnpm test` (vitest) — 89 passed, incl. new `caseWorkState` tests
- `pnpm lint` (eslint) — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case assignment: Users can assign and reassign engineers using a dedicated dialog.
  * Work state tracking: In-progress cases now show a “Ongoing” or “Paused” sub-state in case details.
  * Comment gating: Customer-visible replies are disabled when a case is paused; internal work notes and attachments remain available.
* **Bug Fixes / UX Improvements**
  * Reassign action in the case action menu is now enabled and relabeled to “Assign / reassign engineer…”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->