### PR TITLE
[CSM Portal][BE] fix(openapi): wrap nullable $ref in allOf for UpdatedCase.assignedTo

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1165,7 +1165,8 @@ components:
             $ref: '#/components/schemas/WatchListUser'
         assignedTo:
           nullable: true
-          $ref: '#/components/schemas/AssignedEngineerRef'
+          allOf:
+            - $ref: '#/components/schemas/AssignedEngineerRef'
 
     WatchListUser:
       type: object


### PR DESCRIPTION
## Summary

In OpenAPI 3.0, `nullable: true` cannot be used as a sibling of `$ref` — the `$ref` keyword replaces all sibling properties, so the `nullable` flag is silently discarded. Parsers like Choreo treat this as an invalid spec and refuse to load it.

The `assignedTo` field in `UpdatedCase` (introduced in PR #890) had this pattern. Fixed by wrapping the ref in `allOf`, which is the correct OpenAPI 3.0 approach for nullable references:

```yaml
assignedTo:
  nullable: true
  allOf:
    - $ref: '#/components/schemas/AssignedEngineerRef'
```

## Test plan

- [ ] Choreo accepts the updated spec without parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API schema structure to use an enhanced reference pattern for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->