### PR TITLE
[CSM Portal][BE] fix(openapi): inline UpdatedCase.assignedTo to fix dangling $ref

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1165,8 +1165,13 @@ components:
             $ref: '#/components/schemas/WatchListUser'
         assignedTo:
           nullable: true
-          allOf:
-            - $ref: '#/components/schemas/AssignedEngineerRef'
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
 
     WatchListUser:
       type: object


### PR DESCRIPTION
## Summary

The `UpdatedCase.assignedTo` field introduced in PR #890 referenced `#/components/schemas/AssignedEngineerRef`, but that schema is only defined in the entity-service spec — it does not exist in the CSM portal spec. This caused swagger-cli (and Choreo) to reject the file with:

```
Token "AssignedEngineerRef" does not exist.
```

Fixed by inlining the two-field object schema (`id` + `name`) directly on `assignedTo`, removing the dangling `$ref`.

## Test plan

- [ ] `swagger-cli validate openapi.yaml` passes ✅ (validated locally)
- [ ] Choreo accepts the spec without parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)