### PR TITLE
[Customer Entity] Extend case endpoints with workState update, full response field parity, and *On timestamp convention

### DIFF
--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -105,6 +105,7 @@ All shared types live in `internal/domain/entity.go`. Conventions:
 - Request structs include only the fields a caller can supply; ID fields injected from path params use `json:"-"`
 - Optional fields in request structs use pointer types (`*CasePriority`) so absent fields are distinguishable from zero values
 - Response structs return the full entity row
+- **Date/time field naming:** all timestamp fields in response structs must use the `On` suffix: `createdOn`, `updatedOn`, `closedOn`. Never use `At` (`createdAt`, `updatedAt`, `closedAt`). Domain-specific date fields that carry a business meaning (e.g. `startDate`, `endDate`, `activationDate`) keep the `Date` suffix. This applies to both Go struct field names and JSON tags.
 
 ## Error types (`internal/apierror`)
 

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -467,7 +467,7 @@ type CaseSort struct {
 }
 
 // Case represents a customer support case as stored in the database.
-// ClosedAt and WorkState are the only nullable fields; all others are required.
+// ClosedOn and WorkState are the only nullable fields; all others are required.
 // Used as the response for write operations (create/update).
 type Case struct {
 	ID                string         `json:"id"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -43,8 +43,8 @@ type User struct {
 	Phone     *string   `json:"phone"`
 	Timezone  *string   `json:"timezone"`
 	UserType  UserType  `json:"userType"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	CreatedOn time.Time `json:"createdOn"`
+	UpdatedOn time.Time `json:"updatedOn"`
 }
 
 // Pagination controls which page of results is returned.
@@ -95,8 +95,8 @@ type Account struct {
 	TechnicalOwnerID    *string     `json:"technicalOwnerId"`
 	AgentEnabled        bool        `json:"agentEnabled"`
 	KbReferencesEnabled bool        `json:"kbReferencesEnabled"`
-	CreatedAt           time.Time   `json:"createdAt"`
-	UpdatedAt           time.Time   `json:"updatedAt"`
+	CreatedOn           time.Time   `json:"createdOn"`
+	UpdatedOn           time.Time   `json:"updatedOn"`
 }
 
 // SearchAccountsRequest is the input for an account search operation.
@@ -154,8 +154,8 @@ type Project struct {
 	ClosureStatus    *ClosureStatus   `json:"closureStatus"`
 	StartDate        time.Time        `json:"startDate"`
 	EndDate          time.Time        `json:"endDate"`
-	CreatedAt        time.Time        `json:"createdAt"`
-	UpdatedAt        time.Time        `json:"updatedAt"`
+	CreatedOn        time.Time        `json:"createdOn"`
+	UpdatedOn        time.Time        `json:"updatedOn"`
 }
 
 // ProjectAccountRef is the embedded account summary returned in project detail responses.
@@ -227,8 +227,8 @@ type Product struct {
 	ID        string       `json:"id"`
 	Name      string       `json:"name"`
 	Class     ProductClass `json:"class"`
-	CreatedAt time.Time    `json:"createdAt"`
-	UpdatedAt time.Time    `json:"updatedAt"`
+	CreatedOn time.Time    `json:"createdOn"`
+	UpdatedOn time.Time    `json:"updatedOn"`
 }
 
 // SearchProductsRequest is the input for a product search operation.
@@ -268,8 +268,8 @@ type ProductVersion struct {
 	ReleaseDate                    time.Time     `json:"releaseDate"`
 	SupportEOLDate                 *time.Time    `json:"supportEolDate"`
 	EarliestPossibleSupportEOLDate *time.Time    `json:"earliestPossibleSupportEolDate"`
-	CreatedAt                      time.Time     `json:"createdAt"`
-	UpdatedAt                      time.Time     `json:"updatedAt"`
+	CreatedOn                      time.Time     `json:"createdOn"`
+	UpdatedOn                      time.Time     `json:"updatedOn"`
 }
 
 // SearchProductVersionsRequest is the input for a product version search operation.
@@ -311,8 +311,8 @@ type Deployment struct {
 	Type        DeploymentType `json:"type"`
 	Description *string        `json:"description"`
 	CreatedBy   string         `json:"createdBy"`
-	CreatedAt   time.Time      `json:"createdAt"`
-	UpdatedAt   time.Time      `json:"updatedAt"`
+	CreatedOn   time.Time      `json:"createdOn"`
+	UpdatedOn   time.Time      `json:"updatedOn"`
 }
 
 // DeploymentView is the enriched search result for a deployment. It embeds
@@ -356,8 +356,8 @@ type DeployedProduct struct {
 	DeploymentID     string    `json:"deploymentId"`
 	ProductID        string    `json:"productId"`
 	ProductVersionID *string   `json:"productVersionId"`
-	CreatedAt        time.Time `json:"createdAt"`
-	UpdatedAt        time.Time `json:"updatedAt"`
+	CreatedOn        time.Time `json:"createdOn"`
+	UpdatedOn        time.Time `json:"updatedOn"`
 }
 
 // DeployedProductVersionRef is the version sub-object in a DeployedProductView.
@@ -467,24 +467,25 @@ type CaseSort struct {
 }
 
 // Case represents a customer support case as stored in the database.
-// ClosedAt is the only nullable field; all others are required.
-// Used as the response for write operations (create).
+// ClosedAt and WorkState are the only nullable fields; all others are required.
+// Used as the response for write operations (create/update).
 type Case struct {
-	ID                string        `json:"id"`
-	Number            string        `json:"number"`
-	InternalID        string        `json:"internalId"`
-	CreatedBy         string        `json:"createdBy"`
-	ProjectID         string        `json:"projectId"`
-	DeploymentID      string        `json:"deploymentId"`
-	DeployedProductID string        `json:"deployedProductId"`
-	Subject           string        `json:"subject"`
-	Description       string        `json:"description"`
-	Priority          CasePriority  `json:"priority"`
-	IssueType         CaseIssueType `json:"issueType"`
-	State             CaseState     `json:"state"`
-	CreatedAt         time.Time     `json:"createdAt"`
-	UpdatedAt         time.Time     `json:"updatedAt"`
-	ClosedAt          *time.Time    `json:"closedAt"`
+	ID                string         `json:"id"`
+	Number            string         `json:"number"`
+	InternalID        string         `json:"internalId"`
+	CreatedBy         string         `json:"createdBy"`
+	ProjectID         string         `json:"projectId"`
+	DeploymentID      string         `json:"deploymentId"`
+	DeployedProductID string         `json:"deployedProductId"`
+	Subject           string         `json:"subject"`
+	Description       string         `json:"description"`
+	Priority          CasePriority   `json:"priority"`
+	IssueType         CaseIssueType  `json:"issueType"`
+	State             CaseState      `json:"state"`
+	WorkState         *CaseWorkState `json:"workState"`
+	CreatedOn         time.Time      `json:"createdOn"`
+	UpdatedOn         time.Time      `json:"updatedOn"`
+	ClosedOn          *time.Time     `json:"closedOn"`
 }
 
 // UserRef is a reference to a user with key display fields.
@@ -546,6 +547,7 @@ type CaseView struct {
 	WorkState              *CaseWorkState       `json:"workState"`
 	CreatedOn              time.Time            `json:"createdOn"`
 	UpdatedOn              time.Time            `json:"updatedOn"`
+	ClosedOn               *time.Time           `json:"closedOn"`
 	CreatedByDetails       UserRef              `json:"createdBy"`
 	ProjectDetails         EntityRef            `json:"project"`
 	DeploymentDetails      EntityRef            `json:"deployment"`
@@ -590,7 +592,7 @@ type SearchCaseView struct {
 	WorkState              *CaseWorkState     `json:"workState"`
 	CreatedOn              time.Time          `json:"createdOn"`
 	UpdatedOn              time.Time          `json:"updatedOn"`
-	ClosedAt               *time.Time         `json:"closedAt"`
+	ClosedOn               *time.Time         `json:"closedOn"`
 	CreatedBy              UserIDEmailRef     `json:"createdBy"`
 	ProjectDetails         EntityRef          `json:"project"`
 	DeploymentDetails      EntityRef          `json:"deployment"`
@@ -608,14 +610,15 @@ type SearchCasesResponse struct {
 }
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
-// Exactly one of State, Priority, WatchList, or AssigneeEmail must be provided.
+// Exactly one of State, Priority, WorkState, WatchList, or AssigneeEmail must be provided.
 // WatchList and AssigneeEmail are only supported for the ServiceNow data source.
 type UpdateCaseRequest struct {
-	ID            string        `json:"-"`
-	State         *CaseState    `json:"state"`
-	Priority      *CasePriority `json:"priority"`
-	WatchList     []string      `json:"watchList"`
-	AssigneeEmail *string       `json:"assigneeEmail"`
+	ID            string         `json:"-"`
+	State         *CaseState     `json:"state"`
+	Priority      *CasePriority  `json:"priority"`
+	WorkState     *CaseWorkState `json:"workState"`
+	WatchList     []string       `json:"watchList"`
+	AssigneeEmail *string        `json:"assigneeEmail"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -631,6 +634,7 @@ type UpdatedCase struct {
 	UpdatedBy  string               `json:"updatedBy,omitempty"`
 	State      CaseState            `json:"state,omitempty"`
 	Priority   CasePriority         `json:"priority,omitempty"`
+	WorkState  *CaseWorkState       `json:"workState"`
 	WatchList  []WatchListUser      `json:"watchList,omitempty"`
 	AssignedTo *AssignedEngineerRef `json:"assignedTo,omitempty"`
 }
@@ -697,7 +701,7 @@ type CaseComment struct {
 	Type      CommentType    `json:"type"`
 	Content   string         `json:"content"`
 	CreatedBy CommentUserRef `json:"createdBy"`
-	CreatedAt time.Time      `json:"createdOn"`
+	CreatedOn time.Time      `json:"createdOn"`
 }
 
 // CreateCaseCommentRequest is the input for creating a new case comment.

--- a/entity-service/internal/repository/account_repo.go
+++ b/entity-service/internal/repository/account_repo.go
@@ -105,7 +105,7 @@ func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccou
 				&a.ActivationDate, &a.DeactivationDate,
 				&a.OwnerID, &a.TechnicalOwnerID,
 				&a.AgentEnabled, &a.KbReferencesEnabled,
-				&a.CreatedAt, &a.UpdatedAt,
+				&a.CreatedOn, &a.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan account: %w", err)
 			}
@@ -138,7 +138,7 @@ func (r *accountRepo) GetAccountByID(ctx context.Context, id string) (domain.Acc
 		&a.ActivationDate, &a.DeactivationDate,
 		&a.OwnerID, &a.TechnicalOwnerID,
 		&a.AgentEnabled, &a.KbReferencesEnabled,
-		&a.CreatedAt, &a.UpdatedAt,
+		&a.CreatedOn, &a.UpdatedOn,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.Account{}, &apierror.NotFoundError{Msg: "account not found"}

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -85,7 +85,7 @@ func (r *caseRepo) CreateCase(ctx context.Context, req domain.CreateCaseRequest)
 		&c.ID, &c.Number, &c.InternalID, &c.CreatedBy,
 		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
 		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State,
-		&c.CreatedAt, &c.UpdatedAt, &c.ClosedAt,
+		&c.CreatedOn, &c.UpdatedOn, &c.ClosedOn,
 	)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
@@ -114,7 +114,7 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 	err := r.db.QueryRow(ctx,
 		`SELECT c.id, c.number, c.internal_id,
 		        c.subject, c.description, c.priority, c.issue_type, c.state, c.work_state,
-		        c.created_at, c.updated_at,
+		        c.created_at, c.updated_at, c.closed_at,
 		        u.id, u.first_name || ' ' || u.last_name, u.user_name, u.email,
 		        p.id, p.name,
 		        d.id, d.name,
@@ -139,7 +139,7 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 	).Scan(
 		&cv.ID, &cv.Number, &cv.InternalID,
 		&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
-		&cv.CreatedOn, &cv.UpdatedOn,
+		&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedOn,
 		&cv.CreatedByDetails.ID, &cv.CreatedByDetails.Name, &cv.CreatedByDetails.UserID, &cv.CreatedByDetails.Email,
 		&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
 		&cv.DeploymentDetails.ID, &cv.DeploymentDetails.Name,
@@ -183,7 +183,7 @@ func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseC
 	var c domain.CaseComment
 	err := r.db.QueryRow(ctx, query,
 		req.CaseID, string(req.Type), req.Content, req.CreatedBy,
-	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedAt)
+	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedOn)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 			switch pgErr.Code {
@@ -246,7 +246,7 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 			if err := rows.Scan(
 				&c.ID, &c.CaseID, &c.Type, &c.Content,
 				&c.CreatedBy.ID, &c.CreatedBy.FirstName, &c.CreatedBy.LastName,
-				&c.CreatedBy.FullName, &c.CreatedAt,
+				&c.CreatedBy.FullName, &c.CreatedOn,
 			); err != nil {
 				return fmt.Errorf("scan case comment: %w", err)
 			}
@@ -276,28 +276,38 @@ func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest)
 	if req.Priority != nil {
 		priority = string(*req.Priority)
 	}
+	workState := ""
+	if req.WorkState != nil {
+		workState = string(*req.WorkState)
+	}
 	const query = `
 		UPDATE cases
 		SET state      = CASE WHEN $2 <> '' THEN $2::case_state_enum ELSE state END,
 		    priority   = CASE WHEN $3 <> '' THEN $3::case_priority_enum ELSE priority END,
+		    work_state = CASE WHEN $4 <> '' THEN $4::case_work_state_enum ELSE work_state END,
 		    updated_at = NOW(),
 		    closed_at  = CASE WHEN $2 = 'closed' THEN NOW() WHEN $2 <> '' AND $2 <> 'closed' THEN NULL ELSE closed_at END
 		WHERE id = $1
 		RETURNING id, number, internal_id, created_by, project_id, deployment_id, deployed_product_id,
-		          subject, description, priority, issue_type, state, created_at, updated_at, closed_at`
+		          subject, description, priority, issue_type, state, work_state, created_at, updated_at, closed_at`
 
 	var c domain.Case
-	err := r.db.QueryRow(ctx, query, req.ID, state, priority).Scan(
+	var workStateRaw *string
+	err := r.db.QueryRow(ctx, query, req.ID, state, priority, workState).Scan(
 		&c.ID, &c.Number, &c.InternalID, &c.CreatedBy,
 		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
-		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State,
-		&c.CreatedAt, &c.UpdatedAt, &c.ClosedAt,
+		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State, &workStateRaw,
+		&c.CreatedOn, &c.UpdatedOn, &c.ClosedOn,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.Case{}, &apierror.NotFoundError{Msg: "case not found"}
 	}
 	if err != nil {
 		return domain.Case{}, fmt.Errorf("update case: %w", err)
+	}
+	if workStateRaw != nil {
+		ws := domain.CaseWorkState(*workStateRaw)
+		c.WorkState = &ws
 	}
 	return c, nil
 }
@@ -419,7 +429,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 			if err := rows.Scan(
 				&cv.ID, &cv.Number, &cv.InternalID,
 				&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
-				&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedAt,
+				&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedOn,
 				&cv.CreatedBy.ID, &ignoredDisplayName, &ignoredUserID, &cv.CreatedBy.Email,
 				&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
 				&cv.DeploymentDetails.ID, &cv.DeploymentDetails.Name,

--- a/entity-service/internal/repository/product_repo.go
+++ b/entity-service/internal/repository/product_repo.go
@@ -91,7 +91,7 @@ func (r *productRepo) SearchProducts(ctx context.Context, req domain.SearchProdu
 		result := make([]domain.Product, 0, req.Pagination.Limit)
 		for rows.Next() {
 			var p domain.Product
-			if err := rows.Scan(&p.ID, &p.Name, &p.Class, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			if err := rows.Scan(&p.ID, &p.Name, &p.Class, &p.CreatedOn, &p.UpdatedOn); err != nil {
 				return fmt.Errorf("scan product: %w", err)
 			}
 			result = append(result, p)

--- a/entity-service/internal/repository/product_version_repo.go
+++ b/entity-service/internal/repository/product_version_repo.go
@@ -102,7 +102,7 @@ func (r *productVersionRepo) SearchProductVersions(ctx context.Context, req doma
 			if err := rows.Scan(
 				&pv.ID, &pv.ProductID, &pv.Version, &pv.CurrentSupportStatus,
 				&pv.ReleaseDate, &pv.SupportEOLDate, &pv.EarliestPossibleSupportEOLDate,
-				&pv.CreatedAt, &pv.UpdatedAt,
+				&pv.CreatedOn, &pv.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan product_version: %w", err)
 			}

--- a/entity-service/internal/repository/project_repo.go
+++ b/entity-service/internal/repository/project_repo.go
@@ -105,7 +105,7 @@ func (r *projectRepo) SearchProjects(ctx context.Context, req domain.SearchProje
 			var p domain.Project
 			if err := rows.Scan(
 				&p.ID, &p.AccountID, &p.SfID, &p.Name, &p.Key, &p.SubscriptionType, &p.ClosureStatus,
-				&p.StartDate, &p.EndDate, &p.CreatedAt, &p.UpdatedAt,
+				&p.StartDate, &p.EndDate, &p.CreatedOn, &p.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan project: %w", err)
 			}

--- a/entity-service/internal/repository/user_repo.go
+++ b/entity-service/internal/repository/user_repo.go
@@ -63,7 +63,7 @@ func (r *userRepo) GetUserByEmail(ctx context.Context, email string) (domain.Use
 	).Scan(
 		&u.ID, &u.UserName, &u.FirstName, &u.LastName,
 		&u.Email, &u.Phone, &u.Timezone, &u.UserType,
-		&u.CreatedAt, &u.UpdatedAt,
+		&u.CreatedOn, &u.UpdatedOn,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.User{}, &apierror.NotFoundError{Msg: "no user found with email: " + email}
@@ -130,7 +130,7 @@ func (r *userRepo) SearchUsers(ctx context.Context, req domain.SearchUsersReques
 			if err := rows.Scan(
 				&u.ID, &u.UserName, &u.FirstName, &u.LastName,
 				&u.Email, &u.Phone, &u.Timezone, &u.UserType,
-				&u.CreatedAt, &u.UpdatedAt,
+				&u.CreatedOn, &u.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan user: %w", err)
 			}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -64,6 +64,11 @@ var validCasePriority = map[domain.CasePriority]bool{
 	domain.CasePriorityLow:          true,
 }
 
+var validCaseWorkState = map[domain.CaseWorkState]bool{
+	domain.CaseWorkStateOngoing: true,
+	domain.CaseWorkStatePaused:  true,
+}
+
 var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeError:                  true,
 	domain.CaseIssueTypePartialOutage:          true,
@@ -141,7 +146,7 @@ func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseReque
 			InternalID: c.InternalID,
 			Number:     c.Number,
 			CreatedBy:  c.CreatedBy,
-			CreatedOn:  c.CreatedAt,
+			CreatedOn:  c.CreatedOn,
 			State:      string(c.State),
 		},
 	}, nil
@@ -193,7 +198,7 @@ func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCa
 		Message: "Comment created successfully",
 		Comment: domain.CaseCommentDetail{
 			ID:        c.ID,
-			CreatedOn: c.CreatedAt,
+			CreatedOn: c.CreatedOn,
 			CreatedBy: user.Email,
 		},
 	}, nil
@@ -238,17 +243,23 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if req.Priority != nil {
 		fieldCount++
 	}
+	if req.WorkState != nil {
+		fieldCount++
+	}
 	if fieldCount == 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of state or priority must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of state, priority, or workState must be provided"}
 	}
 	if fieldCount > 1 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state or priority may be provided per request"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, priority, or workState may be provided per request"}
 	}
 	if req.State != nil && !validCaseState[*req.State] {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
 	}
 	if req.Priority != nil && !validCasePriority[*req.Priority] {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
+	}
+	if req.WorkState != nil && !validCaseWorkState[*req.WorkState] {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState contains invalid value: " + string(*req.WorkState)}
 	}
 	c, err := s.repo.UpdateCase(ctx, req)
 	if err != nil {
@@ -258,9 +269,10 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 		Message: "Case updated successfully",
 		Case: domain.UpdatedCase{
 			ID:        c.ID,
-			UpdatedOn: c.UpdatedAt,
+			UpdatedOn: c.UpdatedOn,
 			State:     c.State,
 			Priority:  c.Priority,
+			WorkState: c.WorkState,
 		},
 	}, nil
 }

--- a/entity-service/internal/service/project_service.go
+++ b/entity-service/internal/service/project_service.go
@@ -54,7 +54,7 @@ func (s *projectService) SearchProjects(ctx context.Context, req domain.SearchPr
 			Name:             p.Name,
 			Key:              p.Key,
 			SubscriptionType: p.SubscriptionType,
-			CreatedOn:        p.CreatedAt,
+			CreatedOn:        p.CreatedOn,
 		}
 	}
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -532,7 +532,7 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 				LastName:  c.CreatedByLastName,
 				FullName:  c.CreatedByFullName,
 			},
-			CreatedAt: createdAt,
+			CreatedOn: createdAt,
 		})
 	}
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -319,7 +319,7 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `priority`,
-        `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        `workState`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
         only when the ServiceNow data source is active.
       operationId: patchCase
       parameters:
@@ -708,10 +708,10 @@ components:
         userType:
           type: string
           enum: [internal, customer, system]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -771,10 +771,10 @@ components:
           type: boolean
         kbReferencesEnabled:
           type: boolean
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -922,10 +922,10 @@ components:
         class:
           type: string
           enum: [software, service]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -977,10 +977,10 @@ components:
           type: string
           format: date-time
           nullable: true
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -1151,11 +1151,12 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `state`, `priority`, `watchList`, or `assigneeEmail` must be provided.
+        Exactly one of `state`, `priority`, `workState`, `watchList`, or `assigneeEmail` must be provided.
         `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
       oneOf:
         - required: [state]
         - required: [priority]
+        - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
       properties:
@@ -1167,6 +1168,10 @@ components:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new priority (severity) of the case.
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          description: The new work sub-state of the case. Only applicable when the case state is work_in_progress.
         watchList:
           type: array
           items:
@@ -1206,6 +1211,11 @@ components:
         priority:
           type: string
           enum: [catastrophic, critical, high, medium, low]
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          nullable: true
+          description: Work sub-state after the update. null when state is not work_in_progress.
         watchList:
           type: array
           items:
@@ -1441,13 +1451,13 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
-        closedAt:
+        closedOn:
           type: string
           format: date-time
           nullable: true
@@ -1486,6 +1496,11 @@ components:
         updatedOn:
           type: string
           format: date-time
+        closedOn:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the case was closed. null if not yet closed.
         createdBy:
           $ref: '#/components/schemas/UserRef'
         project:
@@ -1497,12 +1512,16 @@ components:
         product:
           $ref: '#/components/schemas/EntityRef'
         assignedEngineer:
+          nullable: true
           $ref: '#/components/schemas/AssignedEngineerRef'
         parentCase:
+          nullable: true
           $ref: '#/components/schemas/CaseNumberRef'
         relatedCase:
+          nullable: true
           $ref: '#/components/schemas/CaseNumberRef'
         account:
+          nullable: true
           $ref: '#/components/schemas/AccountRef'
 
     CaseSearchView:
@@ -1539,6 +1558,11 @@ components:
         updatedOn:
           type: string
           format: date-time
+        closedOn:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the case was closed. null if not yet closed.
         createdBy:
           $ref: '#/components/schemas/UserIDEmailRef'
         project:
@@ -1547,6 +1571,20 @@ components:
           $ref: '#/components/schemas/EntityRef'
         deployedProduct:
           $ref: '#/components/schemas/DeployedProductRef'
+        product:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+        parentCase:
+          nullable: true
+          $ref: '#/components/schemas/CaseNumberRef'
+        relatedCase:
+          nullable: true
+          $ref: '#/components/schemas/CaseNumberRef'
+        account:
+          nullable: true
+          $ref: '#/components/schemas/AccountRef'
 
     SearchCasesResponse:
       type: object
@@ -1589,7 +1627,7 @@ components:
           type: string
         createdBy:
           type: string
-        createdAt:
+        createdOn:
           type: string
           format: date-time
 


### PR DESCRIPTION
## Summary

- **Add `workState` to `PATCH /cases/{id}`** — callers can now set `workState` (`ongoing` / `paused`) as a mutually-exclusive field alongside `state` and `priority`. Validation, SQL update (`case_work_state_enum` cast), and response field all wired through the full stack.

- **Align case GET and search response schemas** — `GET /cases/{id}` was missing `closedOn`; `POST /cases/search` results were missing `product`, `assignedEngineer`, `parentCase`, `relatedCase`, and `account`. Both responses now return the full set of enriched fields. Nullable fields serialize as `null` rather than being omitted.

- **Standardize all response timestamp fields to `*On` convention** — renamed `createdAt` / `updatedAt` / `closedAt` → `createdOn` / `updatedOn` / `closedOn` across every response struct, repository scan, service reference, and the OpenAPI spec. Domain-specific date fields (`startDate`, `endDate`, `activationDate`) are unchanged. Convention documented in `CLAUDE.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `workState` field to case updates with values `ongoing` or `paused`

* **Breaking Changes**
  * Timestamp field names updated in API responses: `createdAt` → `createdOn`, `updatedAt` → `updatedOn`, `closedAt` → `closedOn` (affects User, Account, Product, ProductVersion, Case, and comments)
  * Related case reference fields (`assignedEngineer`, `parentCase`, `relatedCase`, `account`) now nullable in responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->