### PR TITLE
[CSM Portal][BE] feat(tracing): rename X-Correlation-ID to X-CSM-Correlation-ID

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -6,7 +6,7 @@ Go HTTP server (`net/http`, Go 1.22+) that acts as a backend-for-frontend (BFF) 
 
 `CorrelationID → Auth → Logger → Mux`
 
-- `CorrelationID` (`internal/middleware/correlation.go`): reads `X-Correlation-ID` from the incoming request or generates a UUID v4; stores the ID in context for the slog handler and for the entity client to forward; echoes the ID in the response header
+- `CorrelationID` (`internal/middleware/correlation.go`): reads `X-CSM-Correlation-ID` from the incoming request or generates a UUID v4; stores the ID in context for the slog handler and for the entity client to forward; echoes the ID in the response header
 - `Auth` (`internal/middleware/auth.go`): validates the `x-jwt-assertion` JWT and sets `UserInfo` in context
 - `Logger` (`internal/middleware/logger.go`): logs every completed request (method, path, status, elapsed) via slog; runs after Auth so both `correlationID` and `userID` are present in every record
 

--- a/apps/csm-portal/backend/internal/entity/client.go
+++ b/apps/csm-portal/backend/internal/entity/client.go
@@ -37,7 +37,7 @@ var tokenFetchTimeout = 10 * time.Second
 type ctxKey string
 
 const userIDTokenKey ctxKey = "x-user-id-token"
-const correlationIDKey ctxKey = "x-correlation-id"
+const correlationIDKey ctxKey = "x-csm-correlation-id"
 
 // WithUserIDToken returns a copy of ctx carrying the x-user-id-token value to
 // be forwarded on every outgoing entity request.
@@ -51,7 +51,7 @@ func userIDTokenFromContext(ctx context.Context) string {
 }
 
 // WithCorrelationID returns a copy of ctx carrying the correlation ID to be
-// forwarded as X-Correlation-ID on every outgoing entity request.
+// forwarded as X-CSM-Correlation-ID on every outgoing entity request.
 func WithCorrelationID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, correlationIDKey, id)
 }
@@ -121,7 +121,7 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 		req.Header.Set("x-user-id-token", token)
 	}
 	if id := correlationIDFromContext(ctx); id != "" {
-		req.Header.Set("X-Correlation-ID", id)
+		req.Header.Set("X-CSM-Correlation-ID", id)
 	}
 
 	resp, err := c.http.Do(req)
@@ -159,7 +159,7 @@ func (c *Client) doBinary(ctx context.Context, path string) (body []byte, conten
 		req.Header.Set("x-user-id-token", token)
 	}
 	if id := correlationIDFromContext(ctx); id != "" {
-		req.Header.Set("X-Correlation-ID", id)
+		req.Header.Set("X-CSM-Correlation-ID", id)
 	}
 
 	resp, err := c.http.Do(req)

--- a/apps/csm-portal/backend/internal/middleware/correlation.go
+++ b/apps/csm-portal/backend/internal/middleware/correlation.go
@@ -27,11 +27,11 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/entity"
 )
 
-const correlationIDHeader = "X-Correlation-ID"
+const correlationIDHeader = "X-CSM-Correlation-ID"
 
 type correlationIDKey struct{}
 
-// CorrelationID is an HTTP middleware that reads the X-Correlation-ID request
+// CorrelationID is an HTTP middleware that reads the X-CSM-Correlation-ID request
 // header or generates a UUID v4 if absent. The ID is:
 //   - stored in the context for automatic inclusion in slog records
 //   - stored in the entity client context so it is forwarded on every outgoing

--- a/apps/csm-portal/webapp/src/api/backend/client.ts
+++ b/apps/csm-portal/webapp/src/api/backend/client.ts
@@ -40,7 +40,7 @@ export class BackendApiError extends Error {
   payload?: BeErrorPayload;
   /**
    * Correlation ID for this failed request, read back from the response's
-   * `X-Correlation-ID` header (the backend echoes the ID it logged against).
+   * `X-CSM-Correlation-ID` header (the backend echoes the ID it logged against).
    * Surface it to users as a support "Reference ID". `undefined` when the
    * gateway does not expose the header on cross-origin responses (it must be
    * listed in `Access-Control-Expose-Headers`); the FE access log still records

--- a/apps/csm-portal/webapp/src/utils/correlationId.test.ts
+++ b/apps/csm-portal/webapp/src/utils/correlationId.test.ts
@@ -64,7 +64,7 @@ describe("newCorrelationId fallbacks", () => {
 
 describe("CORRELATION_ID_HEADER", () => {
   it("matches the backend header name", () => {
-    expect(CORRELATION_ID_HEADER).toBe("X-Correlation-ID");
+    expect(CORRELATION_ID_HEADER).toBe("X-CSM-Correlation-ID");
   });
 });
 

--- a/apps/csm-portal/webapp/src/utils/correlationId.ts
+++ b/apps/csm-portal/webapp/src/utils/correlationId.ts
@@ -24,7 +24,7 @@
  * Must match `correlationIDHeader` in
  * `apps/csm-portal/backend/internal/middleware/correlation.go`.
  */
-export const CORRELATION_ID_HEADER = "X-Correlation-ID";
+export const CORRELATION_ID_HEADER = "X-CSM-Correlation-ID";
 
 /**
  * Returns a fresh UUID v4 to use as a request correlation ID.

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -14,7 +14,7 @@ All wiring happens explicitly in `internal/server/routes.go` (no DI framework). 
 
 Middleware chain wraps the mux: **CorrelationID → Recovery → Logger → UserIDToken → Timeout** (10 s per request).
 
-`CorrelationID` reads the `X-Correlation-ID` request header forwarded by the portal BFF, or generates a UUID v4 if absent. The ID is stored in the request context and echoed in the response header. All access log lines and panic logs include the correlation ID for end-to-end request tracing.
+`CorrelationID` reads the `X-CSM-Correlation-ID` request header forwarded by the portal BFF, or generates a UUID v4 if absent. The ID is stored in the request context and echoed in the response header. All access log lines and panic logs include the correlation ID for end-to-end request tracing.
 
 ## Running locally
 

--- a/entity-service/internal/middleware/correlationid.go
+++ b/entity-service/internal/middleware/correlationid.go
@@ -25,11 +25,11 @@ import (
 
 // correlationIDHeader is the HTTP header used to propagate the correlation ID
 // across service boundaries.
-const correlationIDHeader = "X-Correlation-ID"
+const correlationIDHeader = "X-CSM-Correlation-ID"
 
 type correlationIDKey struct{}
 
-// CorrelationID is an HTTP middleware that reads the X-Correlation-ID request
+// CorrelationID is an HTTP middleware that reads the X-CSM-Correlation-ID request
 // header (forwarded by the portal BFF) or generates a UUID v4 if absent.
 // The ID is stored in the request context for logging and echoed in the
 // response header so callers can reference it in support requests.


### PR DESCRIPTION
## Summary

- Renames the correlation ID header from `X-Correlation-ID` to `X-CSM-Correlation-ID` across the frontend, csm-portal backend, and entity-service
- The Choreo API gateway reserves and overwrites `X-Correlation-ID` for its own internal tracing, causing the frontend-originated ID to be replaced before it reaches the backend; using a CSM-specific header name bypasses this interception
- The rename is applied consistently in all six source locations plus the two CLAUDE.md files

## Files changed

| Component | File |
|-----------|------|
| Frontend constant & test | `webapp/src/utils/correlationId.ts`, `correlationId.test.ts` |
| Frontend API client comment | `webapp/src/api/backend/client.ts` |
| CSM Portal backend middleware | `backend/internal/middleware/correlation.go` |
| CSM Portal entity client | `backend/internal/entity/client.go` |
| Entity-service middleware | `entity-service/internal/middleware/correlationid.go` |
| Docs | `apps/csm-portal/backend/CLAUDE.md`, `entity-service/CLAUDE.md` |

## Test plan

- [x] Confirm `X-CSM-Correlation-ID` is added to the Choreo CORS `Access-Control-Allow-Headers` list (replacing or alongside `x-correlation-id`)
- [x] Verify frontend console logs and backend logs show the same correlation ID for a given request in staging
- [x] Run backend unit tests (`make test` in `apps/csm-portal/backend` and `entity-service`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated request correlation ID header naming convention from `X-Correlation-ID` to `X-CSM-Correlation-ID` for consistency across backend and frontend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->