### PR TITLE
[Customer Portal] Add token increase request feature for Novera AI chat

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatInput.tsx
@@ -44,6 +44,7 @@ export default function ChatInput({
   isCreateCaseLoading = false,
   disabled = false,
   typingDisabled = false,
+  onRequestTokens,
 }: ChatInputProps): JSX.Element | null {
   const isTooLong = inputValue.length > CHAT_MAX_CHARS;
   const isInputBlocked = isSending || typingDisabled;
@@ -55,6 +56,36 @@ export default function ChatInput({
 
   return (
     <Box sx={{ flexShrink: 0 }}>
+      {/* Session Limit Banner */}
+      {typingDisabled && (
+        <Box
+          sx={{
+            px: 6,
+            py: 1.5,
+            bgcolor: alpha(colors.red[800], 0.05),
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 2,
+          }}
+        >
+          <Typography variant="body2" color="error">
+            You have reached your session token limit.
+          </Typography>
+          {onRequestTokens && (
+            <Button
+              onClick={onRequestTokens}
+              variant="outlined"
+              size="small"
+              color="error"
+              sx={{ flexShrink: 0, textTransform: "none" }}
+            >
+              Request More Tokens
+            </Button>
+          )}
+        </Box>
+      )}
+
       {/* Create Case Banner */}
       <Box
         sx={{

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/TokenRequestModal.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/TokenRequestModal.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+
+export type TokenRequestModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (reason: string) => Promise<void>;
+};
+
+/**
+ * Modal for requesting a session token limit increase with a reason.
+ *
+ * @param {TokenRequestModalProps} props - Component props.
+ * @returns {JSX.Element} The rendered modal.
+ */
+export default function TokenRequestModal({
+  open,
+  onClose,
+  onSubmit,
+}: TokenRequestModalProps): JSX.Element {
+  const [reason, setReason] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    setReason("");
+    setSubmitted(false);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!reason.trim() || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      await onSubmit(reason.trim());
+      setSubmitted(true);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Request More Session Tokens</DialogTitle>
+      <DialogContent>
+        {submitted ? (
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            Your request has been submitted. Our team will review it and get back to you.
+          </Typography>
+        ) : (
+          <>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2, mt: 1 }}>
+              You have reached your session token limit. Please provide a reason for requesting
+              additional tokens and our team will review your request.
+            </Typography>
+            <TextField
+              label="Reason"
+              placeholder="Describe why you need more tokens for this session..."
+              multiline
+              rows={4}
+              fullWidth
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              disabled={isSubmitting}
+              autoFocus
+            />
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={isSubmitting} variant="outlined">
+          {submitted ? "Close" : "Cancel"}
+        </Button>
+        {!submitted && (
+          <Button
+            onClick={() => void handleSubmit()}
+            disabled={!reason.trim() || isSubmitting}
+            loading={isSubmitting}
+            variant="contained"
+          >
+            Submit Request
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/TokenRequestModal.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/TokenRequestModal.tsx
@@ -23,7 +23,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useState, type JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 
 export type TokenRequestModalProps = {
   open: boolean;
@@ -45,6 +45,16 @@ export default function TokenRequestModal({
   const [reason, setReason] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setReason("");
+      setIsSubmitting(false);
+      setSubmitted(false);
+      setSubmitError(null);
+    }
+  }, [open]);
 
   const handleClose = () => {
     if (isSubmitting) return;
@@ -56,9 +66,12 @@ export default function TokenRequestModal({
   const handleSubmit = async () => {
     if (!reason.trim() || isSubmitting) return;
     setIsSubmitting(true);
+    setSubmitError(null);
     try {
       await onSubmit(reason.trim());
       setSubmitted(true);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Failed to submit request. Please try again.");
     } finally {
       setIsSubmitting(false);
     }
@@ -89,6 +102,11 @@ export default function TokenRequestModal({
               disabled={isSubmitting}
               autoFocus
             />
+            {submitError && (
+              <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+                {submitError}
+              </Typography>
+            )}
           </>
         )}
       </DialogContent>

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -66,6 +66,7 @@ import ChatHeader from "@features/support/components/novera-ai-assistant/novera-
 import ChatInput from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatInput";
 import ChatMessageList from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList";
 import ChatSkeleton from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatSkeleton";
+import TokenRequestModal from "@features/support/components/novera-ai-assistant/novera-chat-page/TokenRequestModal";
 import {
   displayTextFromConversationContent,
   getFinalMessageFromPayload,
@@ -348,6 +349,7 @@ export default function NoveraChatPage(): JSX.Element {
   const [showRichText, setShowRichText] = useState(false);
   const [isInputDisabled, setIsInputDisabled] = useState(false);
   const [isTypingDisabled, setIsTypingDisabled] = useState(false);
+  const [isTokenRequestModalOpen, setIsTokenRequestModalOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputValueRef = useRef("");
   const [resetTrigger, setResetTrigger] = useState(0);
@@ -560,6 +562,9 @@ export default function NoveraChatPage(): JSX.Element {
           }
           break;
         }
+        case "token_request_ack":
+          setIsTokenRequestModalOpen(false);
+          break;
         case "error":
           pendingFinalRef.current = null;
           tokenQueueRef.current = [];
@@ -680,6 +685,19 @@ export default function NoveraChatPage(): JSX.Element {
     return sendViaWebSocket(text);
   }, [isSending, projectId, sendViaWebSocket, setInputValueAndRef]);
 
+  const handleTokenRequestSubmit = useCallback(
+    async (reason: string) => {
+      if (!projectId || !accountId) return;
+      await connect(projectId);
+      await sendUserMessage({
+        type: "token_increase_request",
+        accountId,
+        reason,
+      });
+    },
+    [accountId, connect, projectId, sendUserMessage],
+  );
+
   useEffect(() => {
     if (!initialUserMessage?.trim()) return;
     if (urlConversationId) return;
@@ -752,9 +770,16 @@ export default function NoveraChatPage(): JSX.Element {
             forceRichText={showRichText}
             disabled={isInputDisabled}
             typingDisabled={isTypingDisabled}
+            onRequestTokens={() => setIsTokenRequestModalOpen(true)}
           />
         </Paper>
       </Box>
+
+      <TokenRequestModal
+        open={isTokenRequestModalOpen}
+        onClose={() => setIsTokenRequestModalOpen(false)}
+        onSubmit={handleTokenRequestSubmit}
+      />
     </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -237,13 +237,19 @@ export type ChatWebSocketEvent = {
 };
 
 // Request type for chat WebSocket user message payload.
-export type ChatWebSocketPayload = {
-  type: "user_message";
-  accountId: string;
-  conversationId: string;
-  message: string;
-  envProducts: Record<string, string[]>;
-};
+export type ChatWebSocketPayload =
+  | {
+      type: "user_message";
+      accountId: string;
+      conversationId: string;
+      message: string;
+      envProducts: Record<string, string[]>;
+    }
+  | {
+      type: "token_increase_request";
+      accountId: string;
+      reason: string;
+    };
 
 // Model type for chat WebSocket hook options.
 export type UseChatWebSocketOptions = {

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -468,6 +468,7 @@ export type ChatInputProps = {
   forceRichText?: boolean;
   disabled?: boolean;
   typingDisabled?: boolean;
+  onRequestTokens?: () => void;
 };
 
 export type ChatHeaderProps = {


### PR DESCRIPTION
## Summary

- **Novera chat token increase request** — When a user hits the session token limit, a banner appears in the chat input area with a \"Request More Tokens\" button. Clicking it opens a modal where the user enters a reason; the request is sent as a `token_increase_request` WebSocket message (accountId + reason). The modal closes automatically on `token_request_ack` from the server.

## Changes

- `ChatInput.tsx` — Session limit banner + \"Request More Tokens\" button
- `TokenRequestModal.tsx` — New: reason dialog with success/ack state
- `NoveraChatPage.tsx` — Wire modal, submit handler, `token_request_ack` event
- `conversations.ts` — Extend `ChatWebSocketPayload` to union type
- `supportComponents.ts` — Add `onRequestTokens` to `ChatInputProps`

## Test plan

- [ ] Trigger session limit (or mock `TOKEN_WARNING_SESSION_LIMIT_REACHED`) — confirm banner and \"Request More Tokens\" button appear in the chat input area
- [ ] Click button, enter a reason, submit — verify WebSocket sends `token_increase_request` with correct `accountId` and `reason` payload
- [ ] Confirm modal closes automatically on `token_request_ack` from the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token request functionality: Users can now request additional chat session tokens when hitting session limits. A "Request More Tokens" button displays when the limit is reached, allowing users to submit a reason for their request through a modal dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->