### PR TITLE
fix: prevent 500 on project contacts with empty first/last name

### DIFF
--- a/apps/customer-portal/backend/modules/user_management/types.bal
+++ b/apps/customer-portal/backend/modules/user_management/types.bal
@@ -33,9 +33,9 @@ public type Contact record {|
     # Email
     string email;
     # First name
-    string firstName;
+    string? firstName;
     # Last name
-    string lastName;
+    string? lastName;
     # Whether the contact is a customer admin or not
     boolean isCsAdmin;
     # Whether the contact is an Integration user or not


### PR DESCRIPTION
## Problem
`GET /projects/{id}/contacts` returns **500** when a contact has an empty (null) first or last name.

## Root cause
The endpoint proxies the external user-management service:
`service.bal` → `user_management:getProjectContacts` → `userManagementClient->/projects/{id}/contacts.get()`.

The response is data-bound into `UserManagementContact[]`, which embeds `*Contact`. `Contact` declared `firstName`/`lastName` as **required, non-nullable** `string` (`modules/user_management/types.bal:36,38`). When the upstream service returns a contact whose first/last name is `null` (e.g. a Salesforce contact with a blank name part), the HTTP client cannot coerce `null` into a non-nullable `string`. The data-binding fails, `check` propagates the error, and the resource returns `http:InternalServerError`.

Note: an actual empty string `""` binds fine; the breaker is `null`/absent.

## Fix
Make `firstName`/`lastName` nullable (`string?`) so binding succeeds.

## Why it's safe
- `toContact` (`user_management.bal:176-177`) passes the values through unchanged; it performs no string operations on them.
- `service.bal:193` uses a separate `userDetails` record, not this `Contact`.
- The webapp already null-guards every usage (`getInitials` uses `?? ""`, name displays use `?.` / `&&` / `.trim() ||`).

## Scope
Backend type change only; no behavioral change for contacts that have names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contact records can now be created without requiring first and last names, improving flexibility in user management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->