### PR TITLE
[Customer Entity] Extend POST /cases/search with date range, createdBy, and createdByMe filters

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -568,6 +568,14 @@ type SearchCasesFilters struct {
 	StateKeys          []CaseState     `json:"stateKeys"`
 	PriorityKeys       []CasePriority  `json:"priorityKeys"`
 	IssueTypeKeys      []CaseIssueType `json:"issueTypeKeys"`
+	ClosedStartDate    *time.Time      `json:"closedStartDate"`
+	ClosedEndDate      *time.Time      `json:"closedEndDate"`
+	StartCreatedDate   *time.Time      `json:"startCreatedDate"`
+	EndCreatedDate     *time.Time      `json:"endCreatedDate"`
+	StartUpdatedDate   *time.Time      `json:"startUpdatedDate"`
+	EndUpdatedDate     *time.Time      `json:"endUpdatedDate"`
+	CreatedBy          []string        `json:"createdBy"`
+	CreatedByMe        bool            `json:"createdByMe"`
 }
 
 // SearchCasesRequest is the input for a case search operation.

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -367,6 +367,43 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
+	if len(req.Filters.CreatedBy) > 0 {
+		where += fmt.Sprintf(" AND u.email = ANY($%d)", argIdx)
+		filterArgs = append(filterArgs, req.Filters.CreatedBy)
+		argIdx++
+	}
+
+	if req.Filters.ClosedStartDate != nil {
+		where += fmt.Sprintf(" AND c.closed_at >= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.ClosedStartDate)
+		argIdx++
+	}
+	if req.Filters.ClosedEndDate != nil {
+		where += fmt.Sprintf(" AND c.closed_at <= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.ClosedEndDate)
+		argIdx++
+	}
+	if req.Filters.StartCreatedDate != nil {
+		where += fmt.Sprintf(" AND c.created_at >= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.StartCreatedDate)
+		argIdx++
+	}
+	if req.Filters.EndCreatedDate != nil {
+		where += fmt.Sprintf(" AND c.created_at <= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.EndCreatedDate)
+		argIdx++
+	}
+	if req.Filters.StartUpdatedDate != nil {
+		where += fmt.Sprintf(" AND c.updated_at >= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.StartUpdatedDate)
+		argIdx++
+	}
+	if req.Filters.EndUpdatedDate != nil {
+		where += fmt.Sprintf(" AND c.updated_at <= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.EndUpdatedDate)
+		argIdx++
+	}
+
 	if req.Filters.SearchQuery != "" {
 		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.Filters.SearchQuery)
 		pattern := "%" + escaped + "%"
@@ -378,14 +415,14 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 	sortCol := "c." + string(req.SortBy.Field)
 	sortDir := string(req.SortBy.Order)
 
-	countQuery := "SELECT COUNT(*) FROM cases c " + where
-
 	joins := `JOIN users u ON u.id = c.created_by
 		 JOIN projects p ON p.id = c.project_id
 		 JOIN deployments d ON d.id = c.deployment_id
 		 JOIN deployed_products dp ON dp.id = c.deployed_product_id
 		 JOIN products prod ON prod.id = dp.product_id
 		 LEFT JOIN product_versions pv ON pv.id = dp.product_version_id`
+
+	countQuery := "SELECT COUNT(*) FROM cases c " + joins + " " + where
 
 	dataQuery := fmt.Sprintf(
 		`SELECT c.id, c.number, c.internal_id,

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -64,11 +64,6 @@ var validCasePriority = map[domain.CasePriority]bool{
 	domain.CasePriorityLow:          true,
 }
 
-var validCaseWorkState = map[domain.CaseWorkState]bool{
-	domain.CaseWorkStateOngoing: true,
-	domain.CaseWorkStatePaused:  true,
-}
-
 var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeError:                  true,
 	domain.CaseIssueTypePartialOutage:          true,
@@ -76,6 +71,11 @@ var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeQuestion:               true,
 	domain.CaseIssueTypeSecurityOrCompliance:   true,
 	domain.CaseIssueTypeTotalOutage:            true,
+}
+
+var validCaseWorkState = map[domain.CaseWorkState]bool{
+	domain.CaseWorkStateOngoing: true,
+	domain.CaseWorkStatePaused:  true,
 }
 
 // validateCreateCaseRequest validates fields common to all CreateCase data sources.
@@ -309,6 +309,31 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 		if !validCaseIssueType[it] {
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "issueTypeKeys contains invalid value: " + string(it)}
 		}
+	}
+
+	if req.Filters.CreatedByMe {
+		token := middleware.UserIDTokenFromContext(ctx)
+		if token == "" {
+			return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required for createdByMe filter"}
+		}
+		email, err := emailFromJWT(token)
+		if err != nil {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "x-user-id-token: " + err.Error()}
+		}
+		req.Filters.CreatedBy = append(req.Filters.CreatedBy, email)
+	}
+
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	if req.Filters.EndCreatedDate != nil && req.Filters.StartCreatedDate != nil &&
+		req.Filters.EndCreatedDate.Before(*req.Filters.StartCreatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endCreatedDate must not be before startCreatedDate"}
+	}
+	if req.Filters.EndUpdatedDate != nil && req.Filters.StartUpdatedDate != nil &&
+		req.Filters.EndUpdatedDate.Before(*req.Filters.StartUpdatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
 	}
 
 	if req.SortBy.Field == "" {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -116,14 +116,22 @@ var snSortFieldMap = map[domain.CaseSortField]string{
 }
 
 type snCaseFilters struct {
-	CaseTypes          []string `json:"caseTypes"`
-	SearchQuery        string   `json:"searchQuery,omitempty"`
-	ProjectIDs         []string `json:"projectIds,omitempty"`
-	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
-	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
-	StateKeys          []int    `json:"stateKeys,omitempty"`
-	SeverityKeys       []int    `json:"severityKeys,omitempty"`
-	IssueTypeKeys      []int    `json:"issueTypeKeys,omitempty"`
+	CaseTypes          []string  `json:"caseTypes"`
+	SearchQuery        string    `json:"searchQuery,omitempty"`
+	ProjectIDs         []string  `json:"projectIds,omitempty"`
+	DeploymentIDs      []string  `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string  `json:"deployedProductIds,omitempty"`
+	StateKeys          []int     `json:"stateKeys,omitempty"`
+	SeverityKeys       []int     `json:"severityKeys,omitempty"`
+	IssueTypeKeys      []int     `json:"issueTypeKeys,omitempty"`
+	ClosedStartDate    string    `json:"closedStartDate,omitempty"`
+	ClosedEndDate      string    `json:"closedEndDate,omitempty"`
+	StartCreatedDate   string    `json:"startCreatedDate,omitempty"`
+	EndCreatedDate     string    `json:"endCreatedDate,omitempty"`
+	StartUpdatedDate   string    `json:"startUpdatedDate,omitempty"`
+	EndUpdatedDate     string    `json:"endUpdatedDate,omitempty"`
+	CreatedBy          []string  `json:"createdBy,omitempty"`
+	CreatedByMe        bool      `json:"createdByMe,omitempty"`
 }
 
 // snStateIDMap maps domain CaseState enums to SN numeric state IDs.
@@ -184,6 +192,13 @@ func domainIssueTypesToSNIDs(issueTypes []domain.CaseIssueType) []int {
 		}
 	}
 	return ids
+}
+
+func formatSNDate(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format(snCreatedOnLayout)
 }
 
 type snCaseService struct {
@@ -895,6 +910,19 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		return domain.SearchCasesResponse{}, err
 	}
 
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	if req.Filters.EndCreatedDate != nil && req.Filters.StartCreatedDate != nil &&
+		req.Filters.EndCreatedDate.Before(*req.Filters.StartCreatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endCreatedDate must not be before startCreatedDate"}
+	}
+	if req.Filters.EndUpdatedDate != nil && req.Filters.StartUpdatedDate != nil &&
+		req.Filters.EndUpdatedDate.Before(*req.Filters.StartUpdatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
+	}
+
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
 		return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
@@ -923,6 +951,14 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			StateKeys:          domainStatesToSNIDs(req.Filters.StateKeys),
 			SeverityKeys:       domainPrioritiesToSNIDs(req.Filters.PriorityKeys),
 			IssueTypeKeys:      domainIssueTypesToSNIDs(req.Filters.IssueTypeKeys),
+			ClosedStartDate:    formatSNDate(req.Filters.ClosedStartDate),
+			ClosedEndDate:      formatSNDate(req.Filters.ClosedEndDate),
+			StartCreatedDate:   formatSNDate(req.Filters.StartCreatedDate),
+			EndCreatedDate:     formatSNDate(req.Filters.EndCreatedDate),
+			StartUpdatedDate:   formatSNDate(req.Filters.StartUpdatedDate),
+			EndUpdatedDate:     formatSNDate(req.Filters.EndUpdatedDate),
+			CreatedBy:          req.Filters.CreatedBy,
+			CreatedByMe:        req.Filters.CreatedByMe,
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},


### PR DESCRIPTION
## Summary
- Added `closedStartDate`, `closedEndDate`, `startCreatedDate`, `endCreatedDate`, `startUpdatedDate`, `endUpdatedDate` (UTC datetime) filters to `POST /cases/search`
- Added `createdBy` (array of emails) and `createdByMe` (boolean) filters; `createdByMe` resolves the caller's email from the JWT and appends it to `createdBy`
- For the Postgres data source, new filters are applied directly in the SQL query; for ServiceNow, `priorityKeys` is mapped to `severityKeys` integers and new filter fields are forwarded to the SN API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded case search filtering capabilities for better case discovery
    * New date-range filters for cases closed, created, or updated within specified periods
    * New creator filters to search for cases created by specific users or limit results to cases you created
    * Integrated validation ensures all date range filters maintain logical consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->