### PR TITLE
[Customer Entity] Add POST /service-requests/search endpoint

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -617,6 +617,68 @@ type SearchCasesResponse struct {
 	HasMore bool             `json:"hasMore"`
 }
 
+// SearchServiceRequestsFilters holds optional filter criteria for a service-request search.
+// This endpoint is only supported for the ServiceNow data source.
+type SearchServiceRequestsFilters struct {
+	ProjectIDs       []string   `json:"projectIds"`
+	SearchQuery      string     `json:"searchQuery"`
+	StateKeys        []int      `json:"stateKeys"`
+	ClosedStartDate  *time.Time `json:"closedStartDate"`
+	ClosedEndDate    *time.Time `json:"closedEndDate"`
+	StartCreatedDate *time.Time `json:"startCreatedDate"`
+	EndCreatedDate   *time.Time `json:"endCreatedDate"`
+	StartUpdatedDate *time.Time `json:"startUpdatedDate"`
+	EndUpdatedDate   *time.Time `json:"endUpdatedDate"`
+	DeploymentIDs    []string   `json:"deploymentIds"`
+	CreatedBy        []string   `json:"createdBy"`
+	CreatedByMe      bool       `json:"createdByMe"`
+}
+
+// SearchServiceRequestsRequest is the input for POST /service-request/search.
+type SearchServiceRequestsRequest struct {
+	Filters    SearchServiceRequestsFilters `json:"filters"`
+	SortBy     CaseSort                     `json:"sortBy"`
+	Pagination Pagination                   `json:"pagination"`
+}
+
+// ServiceRequestWorkStateRef is a compact reference to a service-request work state.
+type ServiceRequestWorkStateRef struct {
+	ID    *int   `json:"id"`
+	Label string `json:"label"`
+}
+
+// ServiceRequestView is the enriched representation of a service request returned in search results.
+type ServiceRequestView struct {
+	ID               string                      `json:"id"`
+	InternalID       string                      `json:"internalId"`
+	Number           string                      `json:"number"`
+	CreatedOn        string                      `json:"createdOn"`
+	CreatedBy        string                      `json:"createdBy"`
+	Title            *string                     `json:"title"`
+	Description      *string                     `json:"description"`
+	State            string                      `json:"state"`
+	Catalog          *EntityRef                  `json:"catalog"`
+	CatalogItem      *EntityRef                  `json:"catalogItem"`
+	AssignedTeam     *EntityRef                  `json:"assignedTeam"`
+	Product          *EntityRef                  `json:"product"`
+	WorkState        *ServiceRequestWorkStateRef `json:"workState"`
+	Project          EntityRef                   `json:"project"`
+	Deployment       EntityRef                   `json:"deployment"`
+	DeployedProduct  EntityRef                   `json:"deployedProduct"`
+	AssignedEngineer *EntityRef                  `json:"assignedEngineer"`
+	ParentCase       *EntityRef                  `json:"parentCase"`
+	RelatedCase      *EntityRef                  `json:"relatedCase"`
+	Conversation     *EntityRef                  `json:"conversation"`
+}
+
+// SearchServiceRequestsResponse is the paginated result of a service-request search.
+type SearchServiceRequestsResponse struct {
+	Cases        []ServiceRequestView `json:"cases"`
+	TotalRecords int                  `json:"totalRecords"`
+	Offset       int                  `json:"offset"`
+	Limit        int                  `json:"limit"`
+}
+
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
 // Exactly one of State, Priority, WorkState, WatchList, or AssigneeEmail must be provided.
 // WatchList and AssigneeEmail are only supported for the ServiceNow data source.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -634,7 +634,7 @@ type SearchServiceRequestsFilters struct {
 	CreatedByMe      bool       `json:"createdByMe"`
 }
 
-// SearchServiceRequestsRequest is the input for POST /service-request/search.
+// SearchServiceRequestsRequest is the input for POST /service-requests/search.
 type SearchServiceRequestsRequest struct {
 	Filters    SearchServiceRequestsFilters `json:"filters"`
 	SortBy     CaseSort                     `json:"sortBy"`

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -174,3 +174,18 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Content-Type", contentType)
 	_, _ = w.Write(content)
 }
+
+// SearchServiceRequests handles POST /service-request/search.
+func (h *CaseHandler) SearchServiceRequests(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchServiceRequestsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchServiceRequests(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -175,7 +175,7 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 	_, _ = w.Write(content)
 }
 
-// SearchServiceRequests handles POST /service-request/search.
+// SearchServiceRequests handles POST /service-requests/search.
 func (h *CaseHandler) SearchServiceRequests(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchServiceRequestsRequest
 	if !decodeRequest(w, r, &req) {

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -118,6 +118,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/{id}/attachments", caseHandler.CreateCaseAttachment)
 	mux.HandleFunc("POST /cases/{id}/attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /cases/{case_id}/attachments/{attachment_id}/content", caseHandler.GetCaseAttachmentContent)
+	mux.HandleFunc("POST /service-requests/search", caseHandler.SearchServiceRequests)
 
 	return middleware.CorrelationID(
 		middleware.Recovery(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -372,3 +372,7 @@ func (s *caseService) SearchCaseAttachments(_ context.Context, _ domain.SearchAt
 func (s *caseService) GetCaseAttachmentContent(_ context.Context, _, _ string) ([]byte, string, error) {
 	return nil, "", &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
 }
+
+func (s *caseService) SearchServiceRequests(_ context.Context, _ domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error) {
+	return domain.SearchServiceRequestsResponse{}, &apierror.ServiceUnavailableError{Msg: "service requests are only supported for the ServiceNow data source"}
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -121,4 +121,7 @@ type CaseService interface {
 	// for the attachment identified by attachmentID on the given case.
 	// A NotFoundError is returned if absent.
 	GetCaseAttachmentContent(ctx context.Context, caseID, attachmentID string) (content []byte, contentType string, err error)
+	// SearchServiceRequests returns a paginated list of service requests.
+	// Only supported for the ServiceNow data source; returns ServiceUnavailableError otherwise.
+	SearchServiceRequests(ctx context.Context, req domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error)
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -38,6 +38,42 @@ type snCasesResponse struct {
 	Limit        int      `json:"limit"`
 }
 
+// snServiceRequestsResponse mirrors the Choreo POST /cases/search response for service_request cases.
+type snServiceRequestsResponse struct {
+	Cases        []snServiceRequestCase `json:"cases"`
+	TotalRecords int                    `json:"totalRecords"`
+	Offset       int                    `json:"offset"`
+	Limit        int                    `json:"limit"`
+}
+
+type snServiceRequestCase struct {
+	ID               string                     `json:"id"`
+	InternalID       string                     `json:"internalId"`
+	Number           string                     `json:"number"`
+	Title            *string                    `json:"title"`
+	Description      *string                    `json:"description"`
+	CreatedOn        string                     `json:"createdOn"`
+	CreatedBy        string                     `json:"createdBy"`
+	State            *snCaseState               `json:"state"`
+	WorkState        *snServiceRequestWorkState `json:"workState"`
+	Project          snCaseEntityRef            `json:"project"`
+	Deployment       snCaseEntityRef            `json:"deployment"`
+	DeployedProduct  snCaseDeployedProduct      `json:"deployedProduct"`
+	Product          *snCaseEntityRef           `json:"product"`
+	Catalog          *snCaseEntityRef           `json:"catalog"`
+	CatalogItem      *snCaseEntityRef           `json:"catalogItem"`
+	AssignedTeam     *snCaseEntityRef           `json:"assignedTeam"`
+	AssignedEngineer *snCaseEntityRef           `json:"assignedEngineer"`
+	ParentCase       *snCaseRef                 `json:"parentCase"`
+	RelatedCase      *snCaseRef                 `json:"relatedCase"`
+	Conversation     *snCaseEntityRef           `json:"conversation"`
+}
+
+type snServiceRequestWorkState struct {
+	ID    *int   `json:"id"`
+	Label string `json:"label"`
+}
+
 type snCase struct {
 	ID               string                `json:"id"`
 	InternalID       string                `json:"internalId"`
@@ -1091,4 +1127,146 @@ func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
 	default:
 		return nil
 	}
+}
+
+// SearchServiceRequests implements CaseService by calling the Choreo POST /cases/search
+// endpoint with caseTypes filtered to ["service_request"].
+func (s *snCaseService) SearchServiceRequests(ctx context.Context, req domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchServiceRequestsResponse{}, err
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchServiceRequestsResponse{}, err
+	}
+
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	if req.Filters.EndCreatedDate != nil && req.Filters.StartCreatedDate != nil &&
+		req.Filters.EndCreatedDate.Before(*req.Filters.StartCreatedDate) {
+		return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "endCreatedDate must not be before startCreatedDate"}
+	}
+	if req.Filters.EndUpdatedDate != nil && req.Filters.StartUpdatedDate != nil &&
+		req.Filters.EndUpdatedDate.Before(*req.Filters.StartUpdatedDate) {
+		return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchServiceRequestsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	var snSortBy *snCaseSort
+	if req.SortBy.Field != "" {
+		snField, ok := snSortFieldMap[req.SortBy.Field]
+		if !ok {
+			return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "sortBy.field " + string(req.SortBy.Field) + " is not supported by ServiceNow"}
+		}
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snCaseSort{Field: snField, Order: order}
+	}
+
+	payload := snCaseSearchPayload{
+		Filters: snCaseFilters{
+			CaseTypes:        []string{"service_request"},
+			SearchQuery:      req.Filters.SearchQuery,
+			ProjectIDs:       uuidsToSysids(req.Filters.ProjectIDs),
+			DeploymentIDs:    uuidsToSysids(req.Filters.DeploymentIDs),
+			StateKeys:        req.Filters.StateKeys,
+			ClosedStartDate:  formatSNDate(req.Filters.ClosedStartDate),
+			ClosedEndDate:    formatSNDate(req.Filters.ClosedEndDate),
+			StartCreatedDate: formatSNDate(req.Filters.StartCreatedDate),
+			EndCreatedDate:   formatSNDate(req.Filters.EndCreatedDate),
+			StartUpdatedDate: formatSNDate(req.Filters.StartUpdatedDate),
+			EndUpdatedDate:   formatSNDate(req.Filters.EndUpdatedDate),
+			CreatedBy:        req.Filters.CreatedBy,
+			CreatedByMe:      req.Filters.CreatedByMe,
+		},
+		SortBy:     snSortBy,
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/search", token, payload)
+	if err != nil {
+		return domain.SearchServiceRequestsResponse{}, err
+	}
+
+	var snResp snServiceRequestsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchServiceRequestsResponse{}, fmt.Errorf("sn service requests: parse response: %w", err)
+	}
+
+	views := make([]domain.ServiceRequestView, 0, len(snResp.Cases))
+	for _, c := range snResp.Cases {
+		view := domain.ServiceRequestView{
+			ID:          sysidToUUID(c.ID),
+			InternalID:  c.InternalID,
+			Number:      c.Number,
+			CreatedOn:   c.CreatedOn,
+			CreatedBy:   c.CreatedBy,
+			Title:       c.Title,
+			Description: c.Description,
+			State:       snServiceRequestStateLabel(c.State),
+			Project:     domain.EntityRef{ID: sysidToUUID(c.Project.ID), Name: c.Project.Name},
+			Deployment:  domain.EntityRef{ID: sysidToUUID(c.Deployment.ID), Name: c.Deployment.Name},
+			DeployedProduct: domain.EntityRef{
+				ID:   sysidToUUID(c.DeployedProduct.ID),
+				Name: strings.TrimSpace(c.DeployedProduct.Name + " " + c.DeployedProduct.Version),
+			},
+		}
+		if c.Product != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.Product.ID), Name: c.Product.Name}
+			view.Product = &ref
+		}
+		if c.Catalog != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.Catalog.ID), Name: c.Catalog.Name}
+			view.Catalog = &ref
+		}
+		if c.CatalogItem != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.CatalogItem.ID), Name: c.CatalogItem.Name}
+			view.CatalogItem = &ref
+		}
+		if c.AssignedTeam != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.AssignedTeam.ID), Name: c.AssignedTeam.Name}
+			view.AssignedTeam = &ref
+		}
+		if c.AssignedEngineer != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name}
+			view.AssignedEngineer = &ref
+		}
+		if c.ParentCase != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.ParentCase.ID), Name: c.ParentCase.Number}
+			view.ParentCase = &ref
+		}
+		if c.RelatedCase != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.RelatedCase.ID), Name: c.RelatedCase.Number}
+			view.RelatedCase = &ref
+		}
+		if c.Conversation != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.Conversation.ID), Name: c.Conversation.Name}
+			view.Conversation = &ref
+		}
+		if c.WorkState != nil {
+			view.WorkState = &domain.ServiceRequestWorkStateRef{ID: c.WorkState.ID, Label: c.WorkState.Label}
+		}
+		views = append(views, view)
+	}
+
+	return domain.SearchServiceRequestsResponse{
+		Cases:        views,
+		TotalRecords: snResp.TotalRecords,
+		Offset:       req.Pagination.Offset,
+		Limit:        req.Pagination.Limit,
+	}, nil
+}
+
+func snServiceRequestStateLabel(state *snCaseState) string {
+	if state == nil {
+		return ""
+	}
+	return state.Label
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -421,6 +421,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /service-requests/search:
+    post:
+      summary: Search service requests (ServiceNow data source only).
+      operationId: searchServiceRequests
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchServiceRequestsRequest'
+      responses:
+        "200":
+          description: Service requests matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchServiceRequestsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Not supported for the Postgres data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /cases/{id}/comments:
     post:
       summary: Create a comment on a support case.
@@ -1745,6 +1781,146 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    SearchServiceRequestsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                description: 32-char hex sysid
+            searchQuery:
+              type: string
+            stateKeys:
+              type: array
+              items:
+                type: integer
+            closedStartDate:
+              type: string
+              format: date-time
+            closedEndDate:
+              type: string
+              format: date-time
+            startCreatedDate:
+              type: string
+              format: date-time
+            endCreatedDate:
+              type: string
+              format: date-time
+            startUpdatedDate:
+              type: string
+              format: date-time
+            endUpdatedDate:
+              type: string
+              format: date-time
+            deploymentIds:
+              type: array
+              items:
+                type: string
+                description: 32-char hex sysid
+            createdBy:
+              type: array
+              items:
+                type: string
+                format: email
+            createdByMe:
+              type: boolean
+        sortBy:
+          type: object
+          required: [field, order]
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ServiceRequestWorkStateRef:
+      type: object
+      properties:
+        id:
+          type: integer
+          nullable: true
+        label:
+          type: string
+
+    ServiceRequestView:
+      type: object
+      properties:
+        id:
+          type: string
+          description: 32-char hex sysid
+        internalId:
+          type: string
+          nullable: true
+        number:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        title:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        state:
+          type: string
+        catalog:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        catalogItem:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTeam:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        product:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        workState:
+          $ref: '#/components/schemas/ServiceRequestWorkStateRef'
+          nullable: true
+        project:
+          $ref: '#/components/schemas/EntityRef'
+        deployment:
+          $ref: '#/components/schemas/EntityRef'
+        deployedProduct:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        parentCase:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        relatedCase:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        conversation:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+
+    SearchServiceRequestsResponse:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceRequestView'
+        totalRecords:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
## Summary
- Added `POST /service-requests/search` endpoint (ServiceNow only) — proxies to SN `POST /cases/search` with `caseTypes: ["service_request"]` and returns a service-request-specific response shape including catalog, catalogItem, assignedTeam, workState, and conversation fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service request search endpoint with filtering, sorting, and pagination capabilities
  * Supported filters include project/deployment IDs, state, date ranges, and creator information
  * Search results include enriched service request data with related entity references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->