### PR TITLE
[CSM Portal][BE] feat(cases): add service-requests search and extend case search filters

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -93,6 +93,7 @@ func main() {
 	mux.HandleFunc("POST /cases/{id}/attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /cases/{case_id}/attachments/{attachment_id}/content", caseHandler.GetCaseAttachmentContent)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
+	mux.HandleFunc("POST /service-requests/search", caseHandler.SearchServiceRequests)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)
 	mux.HandleFunc("GET /users/me", usersHandler.GetMe)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -35,6 +35,12 @@ func (c *Client) SearchCases(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/cases/search", body)
 }
 
+// SearchServiceRequests calls POST /service-requests/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) SearchServiceRequests(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/service-requests/search", body)
+}
+
 // GetCase calls GET /cases/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) GetCase(ctx context.Context, caseID string) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -48,6 +48,7 @@ type entityCaseClient interface {
 	CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
+	SearchServiceRequests(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
 	CreateCaseAttachment(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCaseAttachments(ctx context.Context, caseID string, body []byte) ([]byte, error)
@@ -286,6 +287,40 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchCases failed", "userID", user.UserID, "err", err)
 		mapUpstreamError(w, err, "Failed to search cases.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// SearchServiceRequests handles POST /service-requests/search.
+func (h *CaseHandler) SearchServiceRequests(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchServiceRequests(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchServiceRequests failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search service requests.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -90,6 +90,7 @@ type mockEntityCaseClient struct {
 	createCaseCommentFn         func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCaseCommentsFn        func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCasesFn               func(ctx context.Context, body []byte) ([]byte, error)
+	searchServiceRequestsFn     func(ctx context.Context, body []byte) ([]byte, error)
 	getCaseFn                   func(ctx context.Context, caseID string) ([]byte, error)
 	createCaseAttachmentFn      func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCaseAttachmentsFn     func(ctx context.Context, caseID string, body []byte) ([]byte, error)
@@ -127,6 +128,13 @@ func (m *mockEntityCaseClient) SearchCaseComments(ctx context.Context, caseID st
 func (m *mockEntityCaseClient) SearchCases(ctx context.Context, body []byte) ([]byte, error) {
 	if m.searchCasesFn != nil {
 		return m.searchCasesFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) SearchServiceRequests(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchServiceRequestsFn != nil {
+		return m.searchServiceRequestsFn(ctx, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -865,6 +865,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /service-requests/search:
+    post:
+      summary: Search service requests.
+      description: Only supported for the ServiceNow data source; returns 503 otherwise.
+      operationId: postServiceRequestsSearch
+      requestBody:
+        description: Service request search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceRequestSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceRequestSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "503":
+          description: Upstream service unavailable (Postgres data source does not support service requests).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /deployments/search:
     post:
       summary: Search deployments.
@@ -1302,6 +1358,39 @@ components:
               - security_or_compliance
               - total_outage
           description: Filter by issue type (optional)
+        closedStartDate:
+          type: string
+          format: date-time
+          description: Filter cases closed on or after this UTC datetime (optional)
+        closedEndDate:
+          type: string
+          format: date-time
+          description: Filter cases closed on or before this UTC datetime (optional)
+        startCreatedDate:
+          type: string
+          format: date-time
+          description: Filter cases created on or after this UTC datetime (optional)
+        endCreatedDate:
+          type: string
+          format: date-time
+          description: Filter cases created on or before this UTC datetime (optional)
+        startUpdatedDate:
+          type: string
+          format: date-time
+          description: Filter cases updated on or after this UTC datetime (optional)
+        endUpdatedDate:
+          type: string
+          format: date-time
+          description: Filter cases updated on or before this UTC datetime (optional)
+        createdBy:
+          type: array
+          items:
+            type: string
+            format: email
+          description: Filter to cases created by these email addresses (optional)
+        createdByMe:
+          type: boolean
+          description: When true, the caller's email (from JWT) is appended to createdBy (optional)
 
     CaseSearchPayload:
       type: object
@@ -2406,3 +2495,168 @@ components:
           type: string
         credits:
           type: string
+
+    ServiceRequestSearchFilters:
+      type: object
+      properties:
+        searchQuery:
+          type: string
+          description: Searches across subject and number (case-insensitive)
+        projectIds:
+          type: array
+          items:
+            type: string
+          description: Filter by project IDs (optional)
+        deploymentIds:
+          type: array
+          items:
+            type: string
+          description: Filter by deployment IDs (optional)
+        stateKeys:
+          type: array
+          items:
+            type: integer
+          description: Filter by service request state keys (optional)
+        closedStartDate:
+          type: string
+          format: date-time
+          description: Filter service requests closed on or after this UTC datetime (optional)
+        closedEndDate:
+          type: string
+          format: date-time
+          description: Filter service requests closed on or before this UTC datetime (optional)
+        startCreatedDate:
+          type: string
+          format: date-time
+          description: Filter service requests created on or after this UTC datetime (optional)
+        endCreatedDate:
+          type: string
+          format: date-time
+          description: Filter service requests created on or before this UTC datetime (optional)
+        startUpdatedDate:
+          type: string
+          format: date-time
+          description: Filter service requests updated on or after this UTC datetime (optional)
+        endUpdatedDate:
+          type: string
+          format: date-time
+          description: Filter service requests updated on or before this UTC datetime (optional)
+        createdBy:
+          type: array
+          items:
+            type: string
+            format: email
+          description: Filter to service requests created by these email addresses (optional)
+        createdByMe:
+          type: boolean
+          description: When true, the caller's email (from JWT) is appended to createdBy (optional)
+
+    ServiceRequestSearchPayload:
+      type: object
+      nullable: true
+      properties:
+        filters:
+          $ref: '#/components/schemas/ServiceRequestSearchFilters'
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [created_at, updated_at, closed_at]
+              default: created_at
+            order:
+              type: string
+              enum: [asc, desc]
+              default: desc
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+
+    ServiceRequestWorkStateRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: integer
+          nullable: true
+        label:
+          type: string
+
+    ServiceRequestView:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        internalId:
+          type: string
+        number:
+          type: string
+        title:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        state:
+          type: string
+        workState:
+          $ref: '#/components/schemas/ServiceRequestWorkStateRef'
+        project:
+          $ref: '#/components/schemas/EntityRef'
+        deployment:
+          $ref: '#/components/schemas/EntityRef'
+        deployedProduct:
+          $ref: '#/components/schemas/EntityRef'
+        catalog:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        catalogItem:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTeam:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        product:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedEngineer:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        parentCase:
+          $ref: '#/components/schemas/CaseNumberRef'
+        relatedCase:
+          $ref: '#/components/schemas/CaseNumberRef'
+        conversation:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+
+    ServiceRequestSearchResponse:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceRequestView'
+        totalRecords:
+          type: integer
+          description: Total number of matching service requests
+        offset:
+          type: integer
+        limit:
+          type: integer


### PR DESCRIPTION
## Summary

- **PR #902 (case search filters)**: Extends `POST /cases/search` with 8 new optional filter fields — `closedStartDate`, `closedEndDate`, `startCreatedDate`, `endCreatedDate`, `startUpdatedDate`, `endUpdatedDate`, `createdBy` (array of emails), and `createdByMe` (bool). The portal raw-passthroughs the request body so no handler logic changes were needed — only the OpenAPI spec was updated.
- **PR #903 (service-requests search)**: Adds a new `POST /service-requests/search` endpoint that proxies to the entity service. Only supported for the ServiceNow data source (entity service returns 503 for Postgres).
- Updates the OpenAPI spec with the new path, 5 new schemas (`ServiceRequestSearchFilters`, `ServiceRequestSearchPayload`, `ServiceRequestWorkStateRef`, `ServiceRequestView`, `ServiceRequestSearchResponse`), and all new filter fields.
- Extends `entityCaseClient` interface and updates the test mock to match.

## Test plan

- [x] All existing unit tests pass (`go test ./...`)
- [x] Pre-push hook ran tests successfully
- [x] Verify `POST /cases/search` correctly forwards new filter fields to entity service
- [x] Verify `POST /service-requests/search` proxies to entity service `/service-requests/search`
- [x] Verify `POST /service-requests/search` returns 503 when entity service is backed by Postgres

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added service request search functionality with filtering capabilities for date ranges and creator information
  * Search results now include pagination metadata and work-state references for enhanced visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->