### PR TITLE
[Customer Entity] Extend service-requests search response and add email to assignedEngineer

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -668,7 +668,6 @@ type ServiceRequestView struct {
 	AssignedEngineer *EntityRef                  `json:"assignedEngineer"`
 	ParentCase       *EntityRef                  `json:"parentCase"`
 	RelatedCase      *EntityRef                  `json:"relatedCase"`
-	Conversation     *EntityRef                  `json:"conversation"`
 }
 
 // SearchServiceRequestsResponse is the paginated result of a service-request search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -498,8 +498,9 @@ type UserRef struct {
 
 // AssignedEngineerRef is a compact reference to an assigned support engineer.
 type AssignedEngineerRef struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Email *string `json:"email"`
 }
 
 // CaseNumberRef is a compact reference to a case carrying its human-readable number.
@@ -601,10 +602,11 @@ type SearchCaseView struct {
 	CreatedOn              time.Time          `json:"createdOn"`
 	UpdatedOn              time.Time          `json:"updatedOn"`
 	ClosedOn               *time.Time         `json:"closedOn"`
-	CreatedBy              UserIDEmailRef     `json:"createdBy"`
-	ProjectDetails         EntityRef          `json:"project"`
-	DeploymentDetails      EntityRef          `json:"deployment"`
-	DeployedProductDetails DeployedProductRef `json:"deployedProduct"`
+	CreatedBy              UserIDEmailRef       `json:"createdBy"`
+	AssignedEngineer       *AssignedEngineerRef `json:"assignedEngineer"`
+	ProjectDetails         EntityRef            `json:"project"`
+	DeploymentDetails      EntityRef            `json:"deployment"`
+	DeployedProductDetails DeployedProductRef   `json:"deployedProduct"`
 }
 
 // SearchCasesResponse is the paginated result of a case search.
@@ -665,7 +667,7 @@ type ServiceRequestView struct {
 	Project          EntityRef                   `json:"project"`
 	Deployment       EntityRef                   `json:"deployment"`
 	DeployedProduct  EntityRef                   `json:"deployedProduct"`
-	AssignedEngineer *EntityRef                  `json:"assignedEngineer"`
+	AssignedEngineer *AssignedEngineerRef        `json:"assignedEngineer"`
 	ParentCase       *EntityRef                  `json:"parentCase"`
 	RelatedCase      *EntityRef                  `json:"relatedCase"`
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -674,7 +674,7 @@ type ServiceRequestView struct {
 
 // SearchServiceRequestsResponse is the paginated result of a service-request search.
 type SearchServiceRequestsResponse struct {
-	Cases        []ServiceRequestView `json:"cases"`
+	ServiceRequests []ServiceRequestView `json:"serviceRequests"`
 	TotalRecords int                  `json:"totalRecords"`
 	Offset       int                  `json:"offset"`
 	Limit        int                  `json:"limit"`

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -63,7 +63,7 @@ type snServiceRequestCase struct {
 	Catalog          *snCaseEntityRef           `json:"catalog"`
 	CatalogItem      *snCaseEntityRef           `json:"catalogItem"`
 	AssignedTeam     *snCaseEntityRef           `json:"assignedTeam"`
-	AssignedEngineer *snCaseEntityRef           `json:"assignedEngineer"`
+	AssignedEngineer *snAssignedEngineerRef      `json:"assignedEngineer"`
 	ParentCase       *snCaseRef                 `json:"parentCase"`
 	RelatedCase      *snCaseRef                 `json:"relatedCase"`
 }
@@ -90,7 +90,7 @@ type snCase struct {
 	WorkState        *snCaseLabel          `json:"workState"`
 	Severity         *snCaseLabel          `json:"severity"`
 	IssueType        *snCaseIssueType      `json:"issueType"`
-	AssignedEngineer *snCaseEntityRef      `json:"assignedEngineer"`
+	AssignedEngineer *snAssignedEngineerRef `json:"assignedEngineer"`
 	ParentCase       *snCaseRef            `json:"parentCase"`
 	RelatedCase      *snCaseRef            `json:"relatedCase"`
 	Account          *snCaseAccount        `json:"account"`
@@ -110,6 +110,12 @@ type snCaseDeployedProduct struct {
 type snCaseRef struct {
 	ID     string `json:"id"`
 	Number string `json:"number"`
+}
+
+type snAssignedEngineerRef struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Email *string `json:"email"`
 }
 
 type snCaseAccount struct {
@@ -403,7 +409,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		cv.ProductDetails = domain.EntityRef{ID: sysidToUUID(c.Product.ID), Name: c.Product.Name}
 	}
 	if c.AssignedEngineer != nil {
-		cv.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name}
+		cv.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
 	}
 	if c.ParentCase != nil {
 		cv.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(c.ParentCase.ID), Number: c.ParentCase.Number}
@@ -1046,6 +1052,10 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			DeploymentDetails:      domain.EntityRef{ID: sysidToUUID(c.Deployment.ID), Name: c.Deployment.Name},
 			DeployedProductDetails: domain.DeployedProductRef{ID: sysidToUUID(c.DeployedProduct.ID), DisplayName: strings.TrimSpace(c.DeployedProduct.Name + " " + c.DeployedProduct.Version)},
 		})
+		if c.AssignedEngineer != nil {
+			v := &views[len(views)-1]
+			v.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
+		}
 	}
 
 	total := snResp.TotalRecords
@@ -1234,8 +1244,7 @@ func (s *snCaseService) SearchServiceRequests(ctx context.Context, req domain.Se
 			view.AssignedTeam = &ref
 		}
 		if c.AssignedEngineer != nil {
-			ref := domain.EntityRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name}
-			view.AssignedEngineer = &ref
+			view.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
 		}
 		if c.ParentCase != nil {
 			ref := domain.EntityRef{ID: sysidToUUID(c.ParentCase.ID), Name: c.ParentCase.Number}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -66,7 +66,6 @@ type snServiceRequestCase struct {
 	AssignedEngineer *snCaseEntityRef           `json:"assignedEngineer"`
 	ParentCase       *snCaseRef                 `json:"parentCase"`
 	RelatedCase      *snCaseRef                 `json:"relatedCase"`
-	Conversation     *snCaseEntityRef           `json:"conversation"`
 }
 
 type snServiceRequestWorkState struct {
@@ -1245,10 +1244,6 @@ func (s *snCaseService) SearchServiceRequests(ctx context.Context, req domain.Se
 		if c.RelatedCase != nil {
 			ref := domain.EntityRef{ID: sysidToUUID(c.RelatedCase.ID), Name: c.RelatedCase.Number}
 			view.RelatedCase = &ref
-		}
-		if c.Conversation != nil {
-			ref := domain.EntityRef{ID: sysidToUUID(c.Conversation.ID), Name: c.Conversation.Name}
-			view.Conversation = &ref
 		}
 		if c.WorkState != nil {
 			view.WorkState = &domain.ServiceRequestWorkStateRef{ID: c.WorkState.ID, Label: c.WorkState.Label}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1261,7 +1261,7 @@ func (s *snCaseService) SearchServiceRequests(ctx context.Context, req domain.Se
 	}
 
 	return domain.SearchServiceRequestsResponse{
-		Cases:        views,
+		ServiceRequests: views,
 		TotalRecords: snResp.TotalRecords,
 		Offset:       req.Pagination.Offset,
 		Limit:        req.Pagination.Limit,

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1904,9 +1904,7 @@ components:
         relatedCase:
           $ref: '#/components/schemas/EntityRef'
           nullable: true
-        conversation:
-          $ref: '#/components/schemas/EntityRef'
-          nullable: true
+
 
     SearchServiceRequestsResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1407,6 +1407,9 @@ components:
           type: string
         name:
           type: string
+        email:
+          type: string
+          nullable: true
 
     CaseNumberRef:
       type: object
@@ -1601,6 +1604,9 @@ components:
           description: Timestamp when the case was closed. null if not yet closed.
         createdBy:
           $ref: '#/components/schemas/UserIDEmailRef'
+        assignedEngineer:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
         project:
           $ref: '#/components/schemas/EntityRef'
         deployment:
@@ -1609,9 +1615,6 @@ components:
           $ref: '#/components/schemas/DeployedProductRef'
         product:
           $ref: '#/components/schemas/EntityRef'
-        assignedEngineer:
-          nullable: true
-          $ref: '#/components/schemas/AssignedEngineerRef'
         parentCase:
           nullable: true
           $ref: '#/components/schemas/CaseNumberRef'
@@ -1896,7 +1899,7 @@ components:
         deployedProduct:
           $ref: '#/components/schemas/EntityRef'
         assignedEngineer:
-          $ref: '#/components/schemas/EntityRef'
+          $ref: '#/components/schemas/AssignedEngineerRef'
           nullable: true
         parentCase:
           $ref: '#/components/schemas/EntityRef'
@@ -1904,7 +1907,6 @@ components:
         relatedCase:
           $ref: '#/components/schemas/EntityRef'
           nullable: true
-
 
     SearchServiceRequestsResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1911,7 +1911,7 @@ components:
     SearchServiceRequestsResponse:
       type: object
       properties:
-        cases:
+        serviceRequests:
           type: array
           items:
             $ref: '#/components/schemas/ServiceRequestView'


### PR DESCRIPTION
## Summary
- Removed `conversation` field from `POST /service-requests/search` response
- Added `email` field to `assignedEngineer` in `POST /cases/search`, `POST /service-requests/search`, and `GET /cases/{id}` responses
- Updated OpenAPI spec to reflect both changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Engineer email addresses are now included in assigned engineer information across all API responses, enabling users to directly contact assigned engineers without additional lookups
  * Case search results now display comprehensive assigned engineer details alongside project and deployment reference information for enhanced visibility and context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->