### PR TITLE
[Customer Entity] Add POST /security-report-analyses/search endpoint

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -680,6 +680,59 @@ type SearchServiceRequestsResponse struct {
 	Limit        int                  `json:"limit"`
 }
 
+// SearchSecurityReportAnalysisFilters holds optional filter criteria for a security-report-analysis search.
+// This endpoint is only supported for the ServiceNow data source.
+type SearchSecurityReportAnalysisFilters struct {
+	ProjectIDs       []string   `json:"projectIds"`
+	SearchQuery      string     `json:"searchQuery"`
+	StateKeys        []int      `json:"stateKeys"`
+	ClosedStartDate  *time.Time `json:"closedStartDate"`
+	ClosedEndDate    *time.Time `json:"closedEndDate"`
+	StartCreatedDate *time.Time `json:"startCreatedDate"`
+	EndCreatedDate   *time.Time `json:"endCreatedDate"`
+	StartUpdatedDate *time.Time `json:"startUpdatedDate"`
+	EndUpdatedDate   *time.Time `json:"endUpdatedDate"`
+	DeploymentID     string     `json:"deploymentId"`
+	DeploymentIDs    []string   `json:"deploymentIds"`
+	CreatedBy        []string   `json:"createdBy"`
+	CreatedByMe      bool       `json:"createdByMe"`
+}
+
+// SearchSecurityReportAnalysisRequest is the input for POST /security-report-analysis/search.
+type SearchSecurityReportAnalysisRequest struct {
+	Filters    SearchSecurityReportAnalysisFilters `json:"filters"`
+	SortBy     CaseSort                            `json:"sortBy"`
+	Pagination Pagination                          `json:"pagination"`
+}
+
+// SecurityReportAnalysisView is the enriched representation of a security report analysis returned in search results.
+type SecurityReportAnalysisView struct {
+	ID               string               `json:"id"`
+	InternalID       string               `json:"internalId"`
+	Number           string               `json:"number"`
+	CreatedOn        string               `json:"createdOn"`
+	CreatedBy        string               `json:"createdBy"`
+	Title            *string              `json:"title"`
+	Description      *string              `json:"description"`
+	State            string               `json:"state"`
+	WorkState        *string              `json:"workState"`
+	Product          *EntityRef           `json:"product"`
+	Project          EntityRef            `json:"project"`
+	Deployment       EntityRef            `json:"deployment"`
+	DeployedProduct  EntityRef            `json:"deployedProduct"`
+	AssignedEngineer *AssignedEngineerRef `json:"assignedEngineer"`
+	ParentCase       *EntityRef           `json:"parentCase"`
+	RelatedCase      *EntityRef           `json:"relatedCase"`
+}
+
+// SearchSecurityReportAnalysisResponse is the paginated result of a security-report-analysis search.
+type SearchSecurityReportAnalysisResponse struct {
+	SecurityReportAnalyses []SecurityReportAnalysisView `json:"securityReportAnalyses"`
+	TotalRecords           int                          `json:"totalRecords"`
+	Offset                 int                          `json:"offset"`
+	Limit                  int                          `json:"limit"`
+}
+
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
 // Exactly one of State, Priority, WorkState, WatchList, or AssigneeEmail must be provided.
 // WatchList and AssigneeEmail are only supported for the ServiceNow data source.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -692,7 +692,6 @@ type SearchSecurityReportAnalysisFilters struct {
 	EndCreatedDate   *time.Time `json:"endCreatedDate"`
 	StartUpdatedDate *time.Time `json:"startUpdatedDate"`
 	EndUpdatedDate   *time.Time `json:"endUpdatedDate"`
-	DeploymentID     string     `json:"deploymentId"`
 	DeploymentIDs    []string   `json:"deploymentIds"`
 	CreatedBy        []string   `json:"createdBy"`
 	CreatedByMe      bool       `json:"createdByMe"`

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -189,3 +189,18 @@ func (h *CaseHandler) SearchServiceRequests(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// SearchSecurityReportAnalysis handles POST /security-report-analyses/search.
+func (h *CaseHandler) SearchSecurityReportAnalysis(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchSecurityReportAnalysisRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchSecurityReportAnalysis(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -119,6 +119,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/{id}/attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /cases/{case_id}/attachments/{attachment_id}/content", caseHandler.GetCaseAttachmentContent)
 	mux.HandleFunc("POST /service-requests/search", caseHandler.SearchServiceRequests)
+	mux.HandleFunc("POST /security-report-analyses/search", caseHandler.SearchSecurityReportAnalysis)
 
 	return middleware.CorrelationID(
 		middleware.Recovery(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -376,3 +376,7 @@ func (s *caseService) GetCaseAttachmentContent(_ context.Context, _, _ string) (
 func (s *caseService) SearchServiceRequests(_ context.Context, _ domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error) {
 	return domain.SearchServiceRequestsResponse{}, &apierror.ServiceUnavailableError{Msg: "service requests are only supported for the ServiceNow data source"}
 }
+
+func (s *caseService) SearchSecurityReportAnalysis(_ context.Context, _ domain.SearchSecurityReportAnalysisRequest) (domain.SearchSecurityReportAnalysisResponse, error) {
+	return domain.SearchSecurityReportAnalysisResponse{}, &apierror.ServiceUnavailableError{Msg: "security report analysis is only supported for the ServiceNow data source"}
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -124,4 +124,7 @@ type CaseService interface {
 	// SearchServiceRequests returns a paginated list of service requests.
 	// Only supported for the ServiceNow data source; returns ServiceUnavailableError otherwise.
 	SearchServiceRequests(ctx context.Context, req domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error)
+	// SearchSecurityReportAnalysis returns a paginated list of security report analyses.
+	// Only supported for the ServiceNow data source; returns ServiceUnavailableError otherwise.
+	SearchSecurityReportAnalysis(ctx context.Context, req domain.SearchSecurityReportAnalysisRequest) (domain.SearchSecurityReportAnalysisResponse, error)
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1336,18 +1336,12 @@ func (s *snCaseService) SearchSecurityReportAnalysis(ctx context.Context, req do
 		snSortBy = &snCaseSort{Field: snField, Order: order}
 	}
 
-	// Merge singular deploymentId into deploymentIds for the SN payload.
-	deploymentIDs := uuidsToSysids(req.Filters.DeploymentIDs)
-	if req.Filters.DeploymentID != "" {
-		deploymentIDs = append(deploymentIDs, uuidToSysid(req.Filters.DeploymentID))
-	}
-
 	payload := snCaseSearchPayload{
 		Filters: snCaseFilters{
 			CaseTypes:        []string{"security_report_analysis"},
 			SearchQuery:      req.Filters.SearchQuery,
 			ProjectIDs:       uuidsToSysids(req.Filters.ProjectIDs),
-			DeploymentIDs:    deploymentIDs,
+			DeploymentIDs:    uuidsToSysids(req.Filters.DeploymentIDs),
 			StateKeys:        req.Filters.StateKeys,
 			ClosedStartDate:  formatSNDate(req.Filters.ClosedStartDate),
 			ClosedEndDate:    formatSNDate(req.Filters.ClosedEndDate),

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1268,6 +1268,170 @@ func (s *snCaseService) SearchServiceRequests(ctx context.Context, req domain.Se
 	}, nil
 }
 
+// snSecurityReportAnalysisCase mirrors the Choreo POST /cases/search response item for security_report_analysis cases.
+type snSecurityReportAnalysisCase struct {
+	ID               string                 `json:"id"`
+	InternalID       string                 `json:"internalId"`
+	Number           string                 `json:"number"`
+	Title            *string                `json:"title"`
+	Description      *string                `json:"description"`
+	CreatedOn        string                 `json:"createdOn"`
+	CreatedBy        string                 `json:"createdBy"`
+	State            *snCaseState           `json:"state"`
+	WorkState        *snCaseLabel           `json:"workState"`
+	Project          snCaseEntityRef        `json:"project"`
+	Deployment       snCaseEntityRef        `json:"deployment"`
+	DeployedProduct  snCaseDeployedProduct  `json:"deployedProduct"`
+	Product          *snCaseEntityRef       `json:"product"`
+	AssignedEngineer *snAssignedEngineerRef `json:"assignedEngineer"`
+	ParentCase       *snCaseRef             `json:"parentCase"`
+	RelatedCase      *snCaseRef             `json:"relatedCase"`
+}
+
+type snSecurityReportAnalysisResponse struct {
+	Cases        []snSecurityReportAnalysisCase `json:"cases"`
+	TotalRecords int                            `json:"totalRecords"`
+	Offset       int                            `json:"offset"`
+	Limit        int                            `json:"limit"`
+}
+
+// SearchSecurityReportAnalysis implements CaseService by calling the Choreo POST /cases/search
+// endpoint with caseTypes filtered to ["security_report_analysis"].
+func (s *snCaseService) SearchSecurityReportAnalysis(ctx context.Context, req domain.SearchSecurityReportAnalysisRequest) (domain.SearchSecurityReportAnalysisResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchSecurityReportAnalysisResponse{}, err
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchSecurityReportAnalysisResponse{}, err
+	}
+
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchSecurityReportAnalysisResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	if req.Filters.EndCreatedDate != nil && req.Filters.StartCreatedDate != nil &&
+		req.Filters.EndCreatedDate.Before(*req.Filters.StartCreatedDate) {
+		return domain.SearchSecurityReportAnalysisResponse{}, &apierror.ValidationError{Msg: "endCreatedDate must not be before startCreatedDate"}
+	}
+	if req.Filters.EndUpdatedDate != nil && req.Filters.StartUpdatedDate != nil &&
+		req.Filters.EndUpdatedDate.Before(*req.Filters.StartUpdatedDate) {
+		return domain.SearchSecurityReportAnalysisResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchSecurityReportAnalysisResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	var snSortBy *snCaseSort
+	if req.SortBy.Field != "" {
+		snField, ok := snSortFieldMap[req.SortBy.Field]
+		if !ok {
+			return domain.SearchSecurityReportAnalysisResponse{}, &apierror.ValidationError{Msg: "sortBy.field " + string(req.SortBy.Field) + " is not supported by ServiceNow"}
+		}
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snCaseSort{Field: snField, Order: order}
+	}
+
+	// Merge singular deploymentId into deploymentIds for the SN payload.
+	deploymentIDs := uuidsToSysids(req.Filters.DeploymentIDs)
+	if req.Filters.DeploymentID != "" {
+		deploymentIDs = append(deploymentIDs, uuidToSysid(req.Filters.DeploymentID))
+	}
+
+	payload := snCaseSearchPayload{
+		Filters: snCaseFilters{
+			CaseTypes:        []string{"security_report_analysis"},
+			SearchQuery:      req.Filters.SearchQuery,
+			ProjectIDs:       uuidsToSysids(req.Filters.ProjectIDs),
+			DeploymentIDs:    deploymentIDs,
+			StateKeys:        req.Filters.StateKeys,
+			ClosedStartDate:  formatSNDate(req.Filters.ClosedStartDate),
+			ClosedEndDate:    formatSNDate(req.Filters.ClosedEndDate),
+			StartCreatedDate: formatSNDate(req.Filters.StartCreatedDate),
+			EndCreatedDate:   formatSNDate(req.Filters.EndCreatedDate),
+			StartUpdatedDate: formatSNDate(req.Filters.StartUpdatedDate),
+			EndUpdatedDate:   formatSNDate(req.Filters.EndUpdatedDate),
+			CreatedBy:        req.Filters.CreatedBy,
+			CreatedByMe:      req.Filters.CreatedByMe,
+		},
+		SortBy:     snSortBy,
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/search", token, payload)
+	if err != nil {
+		return domain.SearchSecurityReportAnalysisResponse{}, err
+	}
+
+	var snResp snSecurityReportAnalysisResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchSecurityReportAnalysisResponse{}, fmt.Errorf("sn security report analysis: parse response: %w", err)
+	}
+
+	views := make([]domain.SecurityReportAnalysisView, 0, len(snResp.Cases))
+	for _, c := range snResp.Cases {
+		view := domain.SecurityReportAnalysisView{
+			ID:          sysidToUUID(c.ID),
+			InternalID:  c.InternalID,
+			Number:      c.Number,
+			CreatedOn:   c.CreatedOn,
+			CreatedBy:   c.CreatedBy,
+			Title:       c.Title,
+			Description: c.Description,
+			State:     snCaseStateLabel(c.State),
+			WorkState: snCaseLabelPtr(c.WorkState),
+			Project:     domain.EntityRef{ID: sysidToUUID(c.Project.ID), Name: c.Project.Name},
+			Deployment:  domain.EntityRef{ID: sysidToUUID(c.Deployment.ID), Name: c.Deployment.Name},
+			DeployedProduct: domain.EntityRef{
+				ID:   sysidToUUID(c.DeployedProduct.ID),
+				Name: strings.TrimSpace(c.DeployedProduct.Name + " " + c.DeployedProduct.Version),
+			},
+		}
+		if c.Product != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.Product.ID), Name: c.Product.Name}
+			view.Product = &ref
+		}
+		if c.AssignedEngineer != nil {
+			view.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
+		}
+		if c.ParentCase != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.ParentCase.ID), Name: c.ParentCase.Number}
+			view.ParentCase = &ref
+		}
+		if c.RelatedCase != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.RelatedCase.ID), Name: c.RelatedCase.Number}
+			view.RelatedCase = &ref
+		}
+		views = append(views, view)
+	}
+
+	return domain.SearchSecurityReportAnalysisResponse{
+		SecurityReportAnalyses: views,
+		TotalRecords:           snResp.TotalRecords,
+		Offset:                 req.Pagination.Offset,
+		Limit:                  req.Pagination.Limit,
+	}, nil
+}
+
+func snCaseStateLabel(state *snCaseState) string {
+	if state == nil {
+		return ""
+	}
+	return state.Label
+}
+
+func snCaseLabelPtr(label *snCaseLabel) *string {
+	if label == nil {
+		return nil
+	}
+	s := label.Label
+	return &s
+}
+
 func snServiceRequestStateLabel(state *snCaseState) string {
 	if state == nil {
 		return ""

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1968,7 +1968,7 @@ components:
               type: array
               items:
                 type: string
-                description: 32-char hex sysid
+                format: uuid
             searchQuery:
               type: string
             stateKeys:
@@ -1993,14 +1993,11 @@ components:
             endUpdatedDate:
               type: string
               format: date-time
-            deploymentId:
-              type: string
-              description: 32-char hex sysid
             deploymentIds:
               type: array
               items:
                 type: string
-                description: 32-char hex sysid
+                format: uuid
             createdBy:
               type: array
               items:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1084,6 +1084,7 @@ components:
           type: array
           items:
             type: string
+            format: uuid
           description: Filter by project UUIDs.
         deploymentTypeKeys:
           type: array
@@ -1157,6 +1158,7 @@ components:
           type: array
           items:
             type: string
+            format: uuid
           description: Filter by deployment UUIDs.
 
     DeployedProductVersionRef:
@@ -1367,16 +1369,19 @@ components:
           type: array
           items:
             type: string
+            format: uuid
           description: Filter by project UUIDs.
         deploymentIds:
           type: array
           items:
             type: string
+            format: uuid
           description: Filter by deployment UUIDs.
         deployedProductIds:
           type: array
           items:
             type: string
+            format: uuid
           description: Filter by deployed product UUIDs.
         stateKeys:
           type: array
@@ -1831,7 +1836,7 @@ components:
               type: array
               items:
                 type: string
-                description: 32-char hex sysid
+                format: uuid
             searchQuery:
               type: string
             stateKeys:
@@ -1860,7 +1865,7 @@ components:
               type: array
               items:
                 type: string
-                description: 32-char hex sysid
+                format: uuid
             createdBy:
               type: array
               items:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -457,6 +457,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /security-report-analyses/search:
+    post:
+      summary: Search security report analyses (ServiceNow data source only).
+      operationId: searchSecurityReportAnalysis
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchSecurityReportAnalysisRequest'
+      responses:
+        "200":
+          description: Security report analyses matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchSecurityReportAnalysisResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Not supported for the Postgres data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /cases/{id}/comments:
     post:
       summary: Create a comment on a support case.
@@ -1915,6 +1951,128 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ServiceRequestView'
+        totalRecords:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    SearchSecurityReportAnalysisRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                description: 32-char hex sysid
+            searchQuery:
+              type: string
+            stateKeys:
+              type: array
+              items:
+                type: integer
+            closedStartDate:
+              type: string
+              format: date-time
+            closedEndDate:
+              type: string
+              format: date-time
+            startCreatedDate:
+              type: string
+              format: date-time
+            endCreatedDate:
+              type: string
+              format: date-time
+            startUpdatedDate:
+              type: string
+              format: date-time
+            endUpdatedDate:
+              type: string
+              format: date-time
+            deploymentId:
+              type: string
+              description: 32-char hex sysid
+            deploymentIds:
+              type: array
+              items:
+                type: string
+                description: 32-char hex sysid
+            createdBy:
+              type: array
+              items:
+                type: string
+                format: email
+            createdByMe:
+              type: boolean
+        sortBy:
+          type: object
+          required: [field, order]
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    SecurityReportAnalysisView:
+      type: object
+      properties:
+        id:
+          type: string
+          description: 32-char hex sysid
+        internalId:
+          type: string
+          nullable: true
+        number:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        title:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        state:
+          type: string
+        workState:
+          type: string
+          nullable: true
+        product:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        project:
+          $ref: '#/components/schemas/EntityRef'
+        deployment:
+          $ref: '#/components/schemas/EntityRef'
+        deployedProduct:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          $ref: '#/components/schemas/AssignedEngineerRef'
+          nullable: true
+        parentCase:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        relatedCase:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+
+    SearchSecurityReportAnalysisResponse:
+      type: object
+      properties:
+        securityReportAnalyses:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecurityReportAnalysisView'
         totalRecords:
           type: integer
         offset:


### PR DESCRIPTION
## Summary
- Adds `POST /security-report-analyses/search` endpoint backed exclusively by the ServiceNow data source (returns 503 for Postgres)
- Calls the existing SN `POST /cases/search` API with `caseTypes: ["security_report_analysis"]`
- Supports filters: `projectIds`, `searchQuery`, `stateKeys`, date ranges (`closedStart/EndDate`, `startCreatedDate`/`endCreatedDate`, `startUpdatedDate`/`endUpdatedDate`), `deploymentId`, `deploymentIds`, `createdBy`, `createdByMe`
- Response includes `securityReportAnalyses[]` with `id`, `internalId`, `number`, `createdOn`, `createdBy`, `title`, `description`, `state`, `workState` (nullable string label), `product`, `project`, `deployment`, `deployedProduct`, `assignedEngineer`, `parentCase`, `relatedCase`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality for security report analyses with filtering by project, deployment, date ranges, and creator
  * Results support custom sorting and pagination
  * Currently available for ServiceNow data source

<!-- end of auto-generated comment: release notes by coderabbit.ai -->