### PR TITLE
[CSM Portal][BE] fix(openapi): align service-requests schema with entity-service PR #905

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2260,6 +2260,9 @@ components:
           format: uuid
         name:
           type: string
+        email:
+          type: string
+          nullable: true
 
     CaseNumberRef:
       type: object
@@ -2635,21 +2638,17 @@ components:
           nullable: true
         assignedEngineer:
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
+            - $ref: '#/components/schemas/AssignedEngineerRef'
           nullable: true
         parentCase:
           $ref: '#/components/schemas/CaseNumberRef'
         relatedCase:
           $ref: '#/components/schemas/CaseNumberRef'
-        conversation:
-          allOf:
-            - $ref: '#/components/schemas/EntityRef'
-          nullable: true
 
     ServiceRequestSearchResponse:
       type: object
       properties:
-        cases:
+        serviceRequests:
           type: array
           items:
             $ref: '#/components/schemas/ServiceRequestView'


### PR DESCRIPTION
## Summary

Aligns the CSM Portal backend OpenAPI spec with the breaking and additive changes introduced in entity-service [PR #905](https://github.com/wso2-open-operations/cs-tools/pull/905). All affected endpoints are raw passthroughs so no Go code changes are required — only the contract needs updating.

- **`AssignedEngineerRef`**: Added `email` (nullable string) — now populated by entity-service for `GET /cases/{id}`, `POST /cases/search`, and `POST /service-requests/search`
- **`ServiceRequestView.assignedEngineer`**: Changed `$ref` from `EntityRef` to `AssignedEngineerRef` to expose the new `email` field
- **`ServiceRequestView`**: Removed `conversation` field (dropped upstream in PR #905)
- **`ServiceRequestSearchResponse`**: Renamed array key from `cases` to `serviceRequests` (breaking rename from PR #905)

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] Pre-push hook passed
- [ ] Verify `POST /service-requests/search` response uses `serviceRequests` key (not `cases`)
- [ ] Verify `assignedEngineer.email` is populated in search and get-case responses

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Backend Updates**
  * Updated service request search API response structure with improved data organization
  * Added email contact information to assigned engineer details
  * Streamlined service request data by removing unused conversation fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->