### PR TITLE
[CSM Portal][BE] feat(cases): add security-report-analyses search endpoint

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -6,7 +6,7 @@ Go HTTP server (`net/http`, Go 1.22+) that acts as a backend-for-frontend (BFF) 
 
 `CorrelationID → Auth → Logger → Mux`
 
-- `CorrelationID` (`internal/middleware/correlation.go`): reads `X-Correlation-ID` from the incoming request or generates a UUID v4; stores the ID in context for the slog handler and for the entity client to forward; echoes the ID in the response header
+- `CorrelationID` (`internal/middleware/correlation.go`): reads `X-CSM-Correlation-ID` from the incoming request or generates a UUID v4; stores the ID in context for the slog handler and for the entity client to forward; echoes the ID in the response header
 - `Auth` (`internal/middleware/auth.go`): validates the `x-jwt-assertion` JWT and sets `UserInfo` in context
 - `Logger` (`internal/middleware/logger.go`): logs every completed request (method, path, status, elapsed) via slog; runs after Auth so both `correlationID` and `userID` are present in every record
 

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -93,6 +93,7 @@ func main() {
 	mux.HandleFunc("POST /cases/{id}/attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /cases/{case_id}/attachments/{attachment_id}/content", caseHandler.GetCaseAttachmentContent)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
+	mux.HandleFunc("POST /security-report-analyses/search", caseHandler.SearchSecurityReportAnalyses)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)
 	mux.HandleFunc("GET /users/me", usersHandler.GetMe)

--- a/apps/csm-portal/backend/internal/entity/client.go
+++ b/apps/csm-portal/backend/internal/entity/client.go
@@ -37,7 +37,7 @@ var tokenFetchTimeout = 10 * time.Second
 type ctxKey string
 
 const userIDTokenKey ctxKey = "x-user-id-token"
-const correlationIDKey ctxKey = "x-correlation-id"
+const correlationIDKey ctxKey = "x-csm-correlation-id"
 
 // WithUserIDToken returns a copy of ctx carrying the x-user-id-token value to
 // be forwarded on every outgoing entity request.
@@ -51,7 +51,7 @@ func userIDTokenFromContext(ctx context.Context) string {
 }
 
 // WithCorrelationID returns a copy of ctx carrying the correlation ID to be
-// forwarded as X-Correlation-ID on every outgoing entity request.
+// forwarded as X-CSM-Correlation-ID on every outgoing entity request.
 func WithCorrelationID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, correlationIDKey, id)
 }
@@ -121,7 +121,7 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 		req.Header.Set("x-user-id-token", token)
 	}
 	if id := correlationIDFromContext(ctx); id != "" {
-		req.Header.Set("X-Correlation-ID", id)
+		req.Header.Set("X-CSM-Correlation-ID", id)
 	}
 
 	resp, err := c.http.Do(req)
@@ -159,7 +159,7 @@ func (c *Client) doBinary(ctx context.Context, path string) (body []byte, conten
 		req.Header.Set("x-user-id-token", token)
 	}
 	if id := correlationIDFromContext(ctx); id != "" {
-		req.Header.Set("X-Correlation-ID", id)
+		req.Header.Set("X-CSM-Correlation-ID", id)
 	}
 
 	resp, err := c.http.Do(req)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -35,6 +35,12 @@ func (c *Client) SearchCases(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/cases/search", body)
 }
 
+// SearchSecurityReportAnalyses calls POST /security-report-analyses/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) SearchSecurityReportAnalyses(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/security-report-analyses/search", body)
+}
+
 // GetCase calls GET /cases/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) GetCase(ctx context.Context, caseID string) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -179,24 +179,32 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	current, err := h.entity.GetCase(r.Context(), caseID)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "entity GetCase failed during comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
-		mapUpstreamError(w, err, "Failed to create case comment.")
-		return
+	// Work notes are internal-only and exempt from the state gate.
+	var reqMeta struct {
+		Type string `json:"type"`
 	}
-	var currentCase struct {
-		State     string  `json:"state"`
-		WorkState *string `json:"workState"`
-	}
-	if err := json.Unmarshal(current, &currentCase); err != nil {
-		slog.ErrorContext(r.Context(), "failed to parse case state for comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
-		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
-		return
-	}
-	if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
-		writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
-		return
+	_ = json.Unmarshal(body, &reqMeta) // body is already validated JSON
+
+	if reqMeta.Type != "work_note" {
+		current, err := h.entity.GetCase(r.Context(), caseID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "entity GetCase failed during comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
+			mapUpstreamError(w, err, "Failed to create case comment.")
+			return
+		}
+		var currentCase struct {
+			State     string  `json:"state"`
+			WorkState *string `json:"workState"`
+		}
+		if err := json.Unmarshal(current, &currentCase); err != nil {
+			slog.ErrorContext(r.Context(), "failed to parse case state for comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
+			writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+			return
+		}
+		if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
+			writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
+			return
+		}
 	}
 
 	result, err := h.entity.CreateCaseComment(r.Context(), caseID, body)

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -48,6 +48,7 @@ type entityCaseClient interface {
 	CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
+	SearchSecurityReportAnalyses(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
 	CreateCaseAttachment(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCaseAttachments(ctx context.Context, caseID string, body []byte) ([]byte, error)
@@ -286,6 +287,40 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchCases failed", "userID", user.UserID, "err", err)
 		mapUpstreamError(w, err, "Failed to search cases.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// SearchSecurityReportAnalyses handles POST /security-report-analyses/search.
+func (h *CaseHandler) SearchSecurityReportAnalyses(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchSecurityReportAnalyses(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchSecurityReportAnalyses failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search security report analyses.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -194,9 +194,7 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
 		return
 	}
-	// TODO: tighten to include workState once entity service ships the field
-	// if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
-	if currentCase.State != "work_in_progress" {
+	if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
 		writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
 		return
 	}
@@ -404,7 +402,7 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 }
 
 // PatchCase handles PATCH /cases/{id}.
-// Accepts {"state":"<new_state>"} and forwards to the entity service.
+// Accepts state, priority, watchList, or assigneeEmail and forwards to the entity service.
 func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -467,13 +465,6 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity PatchCase failed", "userID", user.UserID, "caseID", caseID, "err", err)
 		mapUpstreamError(w, err, "Failed to update case.")
-		return
-	}
-
-	result, err = injectNextStates(result)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to inject nextStates", "userID", user.UserID, "caseID", caseID, "err", err)
-		writeError(w, http.StatusInternalServerError, "Failed to process case details.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -658,6 +658,14 @@ func TestPatchCase(t *testing.T) {
 			t.Errorf("upstream received invalid JSON body: %s", capturedBody)
 		}
 
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+			t.Fatalf("decode raw response body: %v; raw: %s", err, w.Body.String())
+		}
+		if _, ok := raw["nextStates"]; ok {
+			t.Errorf("response must not include legacy top-level nextStates")
+		}
+
 		type patchCaseResp struct {
 			Message string `json:"message"`
 			Case    struct {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -264,6 +264,34 @@ func TestCreateCaseComment(t *testing.T) {
 		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
 	})
 
+	t.Run("allows work_note in any case state without calling GetCase", func(t *testing.T) {
+		for _, state := range []string{"open", "work_in_progress", "waiting_on_wso2", "awaiting_info", "solution_proposed", "closed"} {
+			state := state
+			t.Run(state, func(t *testing.T) {
+				t.Parallel()
+				getCalled := false
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						getCalled = true
+						return []byte(`{"state":"` + state + `"}`), nil
+					},
+					createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return []byte(`{"id":"wn-1"}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(`{"type":"work_note","content":"internal note"}`)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.CreateCaseComment(w, r)
+				assertStatus(t, w, http.StatusCreated)
+				if getCalled {
+					t.Errorf("GetCase should not be called for work_note")
+				}
+			})
+		}
+	})
+
 	t.Run("forwards body to entity and returns response", func(t *testing.T) {
 		var capturedCaseID string
 		var capturedBody []byte

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -234,9 +234,35 @@ func TestCreateCaseComment(t *testing.T) {
 		}
 	})
 
-	// TODO: re-enable once entity service ships workState
-	// t.Run("rejects comment when work_state is not ongoing", ...)
-	// t.Run("rejects comment when workState is absent", ...)
+	t.Run("rejects comment when work_state is not ongoing", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress","workState":"paused"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+	})
+
+	t.Run("rejects comment when workState is absent", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+	})
 
 	t.Run("forwards body to entity and returns response", func(t *testing.T) {
 		var capturedCaseID string
@@ -602,9 +628,10 @@ func TestPatchCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("forwards case ID and body, returns 200 with nextStates injected", func(t *testing.T) {
+	t.Run("forwards case ID and body, returns 200 with upstream response", func(t *testing.T) {
 		var capturedID string
 		var capturedBody []byte
+		const upstreamResp = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-06-18T10:00:00Z","state":"work_in_progress"}}`
 		client := &mockEntityCaseClient{
 			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
 				return []byte(`{"id":"` + testCaseID + `","state":"open"}`), nil
@@ -612,7 +639,7 @@ func TestPatchCase(t *testing.T) {
 			patchCaseFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
 				capturedID = caseID
 				capturedBody = body
-				return []byte(`{"id":"` + testCaseID + `","state":"work_in_progress"}`), nil
+				return []byte(upstreamResp), nil
 			},
 		}
 		h := NewCaseHandler(client)
@@ -632,25 +659,21 @@ func TestPatchCase(t *testing.T) {
 		}
 
 		type patchCaseResp struct {
-			ID         string   `json:"id"`
-			State      string   `json:"state"`
-			NextStates []string `json:"nextStates"`
+			Message string `json:"message"`
+			Case    struct {
+				ID    string `json:"id"`
+				State string `json:"state"`
+			} `json:"case"`
 		}
 		resp := decodeJSON[patchCaseResp](t, w)
-		if resp.ID != testCaseID {
-			t.Errorf("response id = %q, want %q", resp.ID, testCaseID)
+		if resp.Message != "Case updated successfully" {
+			t.Errorf("response message = %q, want %q", resp.Message, "Case updated successfully")
 		}
-		if resp.State != caseStateWorkInProgress {
-			t.Errorf("response state = %q, want %q", resp.State, caseStateWorkInProgress)
+		if resp.Case.ID != testCaseID {
+			t.Errorf("response case.id = %q, want %q", resp.Case.ID, testCaseID)
 		}
-		wantNext := []string{caseStateWaitingOnWSO2, caseStateAwaitingInfo, caseStateSolutionProposed, caseStateClosed}
-		if len(resp.NextStates) != len(wantNext) {
-			t.Fatalf("nextStates = %v, want %v", resp.NextStates, wantNext)
-		}
-		for i, got := range resp.NextStates {
-			if got != wantNext[i] {
-				t.Errorf("nextStates[%d] = %q, want %q", i, got, wantNext[i])
-			}
+		if resp.Case.State != caseStateWorkInProgress {
+			t.Errorf("response case.state = %q, want %q", resp.Case.State, caseStateWorkInProgress)
 		}
 	})
 

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -85,15 +85,16 @@ func decodeJSON[T any](t *testing.T, w *httptest.ResponseRecorder) T {
 // ----- mock entity case client -----
 
 type mockEntityCaseClient struct {
-	createCaseFn                func(ctx context.Context, body []byte) ([]byte, error)
-	patchCaseFn                 func(ctx context.Context, caseID string, body []byte) ([]byte, error)
-	createCaseCommentFn         func(ctx context.Context, caseID string, body []byte) ([]byte, error)
-	searchCaseCommentsFn        func(ctx context.Context, caseID string, body []byte) ([]byte, error)
-	searchCasesFn               func(ctx context.Context, body []byte) ([]byte, error)
-	getCaseFn                   func(ctx context.Context, caseID string) ([]byte, error)
-	createCaseAttachmentFn      func(ctx context.Context, caseID string, body []byte) ([]byte, error)
-	searchCaseAttachmentsFn     func(ctx context.Context, caseID string, body []byte) ([]byte, error)
-	getCaseAttachmentContentFn  func(ctx context.Context, caseID, attachmentID string) ([]byte, string, error)
+	createCaseFn                       func(ctx context.Context, body []byte) ([]byte, error)
+	patchCaseFn                        func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	createCaseCommentFn                func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	searchCaseCommentsFn               func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	searchCasesFn                      func(ctx context.Context, body []byte) ([]byte, error)
+	searchSecurityReportAnalysesFn     func(ctx context.Context, body []byte) ([]byte, error)
+	getCaseFn                          func(ctx context.Context, caseID string) ([]byte, error)
+	createCaseAttachmentFn             func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	searchCaseAttachmentsFn            func(ctx context.Context, caseID string, body []byte) ([]byte, error)
+	getCaseAttachmentContentFn         func(ctx context.Context, caseID, attachmentID string) ([]byte, string, error)
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
@@ -127,6 +128,13 @@ func (m *mockEntityCaseClient) SearchCaseComments(ctx context.Context, caseID st
 func (m *mockEntityCaseClient) SearchCases(ctx context.Context, body []byte) ([]byte, error) {
 	if m.searchCasesFn != nil {
 		return m.searchCasesFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) SearchSecurityReportAnalyses(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchSecurityReportAnalysesFn != nil {
+		return m.searchSecurityReportAnalysesFn(ctx, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/middleware/correlation.go
+++ b/apps/csm-portal/backend/internal/middleware/correlation.go
@@ -27,11 +27,11 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/entity"
 )
 
-const correlationIDHeader = "X-Correlation-ID"
+const correlationIDHeader = "X-CSM-Correlation-ID"
 
 type correlationIDKey struct{}
 
-// CorrelationID is an HTTP middleware that reads the X-Correlation-ID request
+// CorrelationID is an HTTP middleware that reads the X-CSM-Correlation-ID request
 // header or generates a UUID v4 if absent. The ID is:
 //   - stored in the context for automatic inclusion in slog records
 //   - stored in the entity client context so it is forwarded on every outgoing

--- a/apps/csm-portal/backend/internal/updates/mapper.go
+++ b/apps/csm-portal/backend/internal/updates/mapper.go
@@ -68,7 +68,10 @@ func groupByUpdateLevel(src []upstreamUpdateDescription) map[string]UpdateLevelG
 			if d.UpdateType == updateTypeSecurity {
 				updateType = updateTypeSecurity
 			}
-			group = UpdateLevelGroup{UpdateType: updateType}
+			group = UpdateLevelGroup{
+				UpdateType:              updateType,
+				UpdateDescriptionLevels: make([]UpdateDescription, 0),
+			}
 		}
 
 		if d.UpdateType == updateTypeSecurity {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -253,7 +253,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
         "409":
-          description: Conflict — customer-visible comments (type=comment) can only be posted when the case is work_in_progress with workState=ongoing. Work notes (type=work_note) are exempt and allowed in any state.
+          description: Conflict — comments and activities (type=comment or type=activity) require the case to be work_in_progress with workState=ongoing. Work notes (type=work_note) are exempt and allowed in any state.
           content:
             application/json:
               schema:
@@ -2038,10 +2038,10 @@ components:
     CaseCommentCreatePayload:
       type: object
       required:
-        - commentType
+        - type
         - body
       properties:
-        commentType:
+        type:
           type: string
           enum: [work_note, comment, activity]
           description: work_note is restricted to internal users; activity to internal and system users
@@ -2056,7 +2056,7 @@ components:
           type: string
         caseId:
           type: string
-        commentType:
+        type:
           type: string
           enum: [work_note, comment, activity]
         body:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -253,7 +253,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
         "409":
-          description: Conflict — comment posting is not allowed in the current case state (case must be work_in_progress with work_state ongoing).
+          description: Conflict — customer-visible comments (type=comment) can only be posted when the case is work_in_progress with workState=ongoing. Work notes (type=work_note) are exempt and allowed in any state.
           content:
             application/json:
               schema:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1165,7 +1165,8 @@ components:
             $ref: '#/components/schemas/WatchListUser'
         assignedTo:
           nullable: true
-          $ref: '#/components/schemas/AssignedEngineerRef'
+          allOf:
+            - $ref: '#/components/schemas/AssignedEngineerRef'
 
     WatchListUser:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1155,7 +1155,7 @@ components:
           description: Email or display name of the user who performed the update.
         state:
           type: string
-          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
         priority:
           type: string
           enum: [catastrophic, critical, high, medium, low]

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1165,8 +1165,13 @@ components:
             $ref: '#/components/schemas/WatchListUser'
         assignedTo:
           nullable: true
-          allOf:
-            - $ref: '#/components/schemas/AssignedEngineerRef'
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
 
     WatchListUser:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -126,7 +126,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
     patch:
-      summary: Update the state and/or priority of a support case.
+      summary: Update a support case.
+      description: |
+        Updates exactly one field of the case. Provide exactly one of: `state`, `priority`,
+        `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        only when the ServiceNow data source is active.
       operationId: patchCasesId
       parameters:
         - name: id
@@ -148,7 +152,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CaseView'
+                $ref: '#/components/schemas/UpdateCaseResponse'
         "400":
           description: Bad request (e.g. malformed UUID, invalid state value, or invalid state transition).
           content:
@@ -1099,10 +1103,14 @@ components:
 
     UpdateCaseRequest:
       type: object
-      description: At least one of state or priority must be provided.
-      anyOf:
+      description: |
+        Exactly one of `state`, `priority`, `watchList`, or `assigneeEmail` must be provided.
+        `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
+      oneOf:
         - required: [state]
         - required: [priority]
+        - required: [watchList]
+        - required: [assigneeEmail]
       properties:
         state:
           type: string
@@ -1112,6 +1120,67 @@ components:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new priority (severity) of the case.
+        watchList:
+          type: array
+          items:
+            type: string
+            format: email
+          description: List of email addresses to set as the case watch list (ServiceNow only).
+        assigneeEmail:
+          type: string
+          format: email
+          description: Email of the engineer to assign to this case (ServiceNow only).
+
+    UpdateCaseResponse:
+      type: object
+      required: [message, case]
+      properties:
+        message:
+          type: string
+        case:
+          $ref: '#/components/schemas/UpdatedCase'
+
+    UpdatedCase:
+      type: object
+      required: [id, updatedOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
+          description: Email or display name of the user who performed the update.
+        state:
+          type: string
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        priority:
+          type: string
+          enum: [catastrophic, critical, high, medium, low]
+        watchList:
+          type: array
+          items:
+            $ref: '#/components/schemas/WatchListUser'
+        assignedTo:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+
+    WatchListUser:
+      type: object
+      required: [id, userName]
+      properties:
+        id:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
 
     CaseCreatePayload:
       type: object
@@ -1307,7 +1376,7 @@ components:
           nullable: true
           enum:
             - ongoing
-            - on_hold
+            - paused
           description: Sub-state of work_in_progress. Null when state is not work_in_progress.
         closedAt:
           type: string

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -129,7 +129,7 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `priority`,
-        `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        `workState`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
         only when the ServiceNow data source is active.
       operationId: patchCasesId
       parameters:
@@ -1104,11 +1104,12 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `state`, `priority`, `watchList`, or `assigneeEmail` must be provided.
+        Exactly one of `state`, `priority`, `workState`, `watchList`, or `assigneeEmail` must be provided.
         `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
       oneOf:
         - required: [state]
         - required: [priority]
+        - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
       properties:
@@ -1120,6 +1121,10 @@ components:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new priority (severity) of the case.
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          description: The new work sub-state of the case. Only applicable when the case state is work_in_progress.
         watchList:
           type: array
           items:
@@ -1159,6 +1164,11 @@ components:
         priority:
           type: string
           enum: [catastrophic, critical, high, medium, low]
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          nullable: true
+          description: Work sub-state after the update. null when state is not work_in_progress.
         watchList:
           type: array
           items:
@@ -1371,12 +1381,6 @@ components:
             - reopened
             - solution_proposed
             - closed
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
         workState:
           type: string
           nullable: true
@@ -1384,9 +1388,16 @@ components:
             - ongoing
             - paused
           description: Sub-state of work_in_progress. Null when state is not work_in_progress.
-        closedAt:
+        createdOn:
           type: string
           format: date-time
+        updatedOn:
+          type: string
+          format: date-time
+        closedOn:
+          type: string
+          format: date-time
+          nullable: true
 
     UserRef:
       type: object
@@ -1471,16 +1482,24 @@ components:
             - reopened
             - solution_proposed
             - closed
-        createdAt:
+        workState:
+          type: string
+          nullable: true
+          enum:
+            - ongoing
+            - paused
+          description: Sub-state of work_in_progress. Null when state is not work_in_progress.
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
-        closedAt:
+        closedOn:
           type: string
           format: date-time
           nullable: true
+          description: Timestamp when the case was closed. null if not yet closed.
         createdBy:
           $ref: '#/components/schemas/UserRef'
         project:
@@ -1543,16 +1562,24 @@ components:
             - reopened
             - solution_proposed
             - closed
-        createdAt:
+        workState:
+          type: string
+          nullable: true
+          enum:
+            - ongoing
+            - paused
+          description: Sub-state of work_in_progress. Null when state is not work_in_progress.
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
-        closedAt:
+        closedOn:
           type: string
           format: date-time
           nullable: true
+          description: Timestamp when the case was closed. null if not yet closed.
         createdBy:
           $ref: '#/components/schemas/UserIDEmailRef'
         project:
@@ -1561,6 +1588,20 @@ components:
           $ref: '#/components/schemas/EntityRef'
         deployedProduct:
           $ref: '#/components/schemas/DeployedProductRef'
+        product:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+        parentCase:
+          nullable: true
+          $ref: '#/components/schemas/CaseNumberRef'
+        relatedCase:
+          nullable: true
+          $ref: '#/components/schemas/CaseNumberRef'
+        account:
+          nullable: true
+          $ref: '#/components/schemas/AccountRef'
 
     UpdateDescriptionRequest:
       type: object
@@ -1657,10 +1698,10 @@ components:
         userType:
           type: string
           enum: [internal, customer]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -1723,10 +1764,10 @@ components:
           type: boolean
         kbReferencesEnabled:
           type: boolean
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -1792,10 +1833,10 @@ components:
         endDate:
           type: string
           format: date-time
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -1869,10 +1910,10 @@ components:
           type: string
         createdBy:
           type: string
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -1917,10 +1958,10 @@ components:
         class:
           type: string
           enum: [software, service]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -1976,10 +2017,10 @@ components:
         earliestPossibleSupportEolDate:
           type: string
           format: date-time
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -2022,10 +2063,10 @@ components:
           type: string
         productVersionId:
           type: string
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -2069,7 +2110,7 @@ components:
           type: string
         createdBy:
           type: string
-        createdAt:
+        createdOn:
           type: string
           format: date-time
 
@@ -2102,6 +2143,35 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    AssignedEngineerRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+
+    CaseNumberRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+
+    AccountRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
 
     AttachmentCreatePayload:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -865,6 +865,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /security-report-analyses/search:
+    post:
+      summary: Search security report analyses.
+      description: Only supported for the ServiceNow data source; returns 503 otherwise.
+      operationId: postSecurityReportAnalysesSearch
+      requestBody:
+        description: Security report analysis search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityReportAnalysisSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityReportAnalysisSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "503":
+          description: Upstream service unavailable (Postgres data source does not support security report analyses).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /deployments/search:
     post:
       summary: Search deployments.
@@ -2406,3 +2462,149 @@ components:
           type: string
         credits:
           type: string
+
+    SecurityReportAnalysisSearchFilters:
+      type: object
+      properties:
+        projectIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Filter by project UUIDs (optional)
+        searchQuery:
+          type: string
+          description: Searches across title and number (case-insensitive)
+        stateKeys:
+          type: array
+          items:
+            type: integer
+          description: Filter by state keys (optional)
+        closedStartDate:
+          type: string
+          format: date-time
+          description: Filter analyses closed on or after this UTC datetime (optional)
+        closedEndDate:
+          type: string
+          format: date-time
+          description: Filter analyses closed on or before this UTC datetime (optional)
+        startCreatedDate:
+          type: string
+          format: date-time
+          description: Filter analyses created on or after this UTC datetime (optional)
+        endCreatedDate:
+          type: string
+          format: date-time
+          description: Filter analyses created on or before this UTC datetime (optional)
+        startUpdatedDate:
+          type: string
+          format: date-time
+          description: Filter analyses updated on or after this UTC datetime (optional)
+        endUpdatedDate:
+          type: string
+          format: date-time
+          description: Filter analyses updated on or before this UTC datetime (optional)
+        deploymentIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Filter by deployment UUIDs (optional)
+        createdBy:
+          type: array
+          items:
+            type: string
+            format: email
+          description: Filter to analyses created by these email addresses (optional)
+        createdByMe:
+          type: boolean
+          description: When true, the caller's email (from JWT) is appended to createdBy (optional)
+
+    SecurityReportAnalysisSearchPayload:
+      type: object
+      nullable: true
+      properties:
+        filters:
+          $ref: '#/components/schemas/SecurityReportAnalysisSearchFilters'
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+              default: createdOn
+            order:
+              type: string
+              enum: [asc, desc]
+              default: desc
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+
+    SecurityReportAnalysisView:
+      type: object
+      properties:
+        id:
+          type: string
+        internalId:
+          type: string
+          nullable: true
+        number:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        title:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        state:
+          type: string
+        workState:
+          type: string
+          nullable: true
+        product:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        project:
+          $ref: '#/components/schemas/EntityRef'
+        deployment:
+          $ref: '#/components/schemas/EntityRef'
+        deployedProduct:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          allOf:
+            - $ref: '#/components/schemas/AssignedEngineerRef'
+          nullable: true
+        parentCase:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        relatedCase:
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+          nullable: true
+
+    SecurityReportAnalysisSearchResponse:
+      type: object
+      properties:
+        securityReportAnalyses:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecurityReportAnalysisView'
+        totalRecords:
+          type: integer
+          description: Total number of matching security report analyses
+        offset:
+          type: integer
+        limit:
+          type: integer

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -507,6 +507,12 @@ paths:
       responses:
         "200":
           description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductUpdateLevel'
         "401":
           description: Unauthorized
         "500":
@@ -1071,6 +1077,12 @@ paths:
       responses:
         "200":
           description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/UpdateLevelGroup'
         "400":
           description: BadRequest
           content:
@@ -2280,3 +2292,117 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    ProductUpdateLevel:
+      type: object
+      required: [productName, productUpdateLevels]
+      properties:
+        productName:
+          type: string
+        productUpdateLevels:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdateLevel'
+
+    UpdateLevel:
+      type: object
+      required: [productBaseVersion, channel, updateLevels]
+      properties:
+        productBaseVersion:
+          type: string
+        channel:
+          type: string
+        updateLevels:
+          type: array
+          items:
+            type: integer
+
+    UpdateLevelGroup:
+      type: object
+      required: [updateType, updateDescriptionLevels]
+      properties:
+        updateType:
+          type: string
+        updateDescriptionLevels:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdateDescription'
+
+    UpdateDescription:
+      type: object
+      required: [updateLevel, productName, productVersion, channel, updateType, updateNumber, timestamp, securityAdvisories]
+      properties:
+        updateLevel:
+          type: integer
+        productName:
+          type: string
+        productVersion:
+          type: string
+        channel:
+          type: string
+        updateType:
+          type: string
+        updateNumber:
+          type: integer
+        description:
+          type: string
+          nullable: true
+        instructions:
+          type: string
+          nullable: true
+        bugFixes:
+          type: string
+          nullable: true
+        filesAdded:
+          type: string
+          nullable: true
+        filesModified:
+          type: string
+          nullable: true
+        filesRemoved:
+          type: string
+          nullable: true
+        bundlesInfoChanges:
+          type: string
+          nullable: true
+        dependantReleases:
+          type: array
+          items:
+            $ref: '#/components/schemas/DependantRelease'
+        timestamp:
+          type: integer
+          format: int64
+        securityAdvisories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecurityAdvisory'
+
+    DependantRelease:
+      type: object
+      required: [repository, releaseVersion]
+      properties:
+        repository:
+          type: string
+        releaseVersion:
+          type: string
+
+    SecurityAdvisory:
+      type: object
+      required: [id, overview, severity, description, impact, solution, notes, credits]
+      properties:
+        id:
+          type: string
+        overview:
+          type: string
+        severity:
+          type: string
+        description:
+          type: string
+        impact:
+          type: string
+        solution:
+          type: string
+        notes:
+          type: string
+        credits:
+          type: string

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1508,6 +1508,16 @@ components:
           $ref: '#/components/schemas/EntityRef'
         deployedProduct:
           $ref: '#/components/schemas/DeployedProductRef'
+        product:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          $ref: '#/components/schemas/AssignedEngineerRef'
+        parentCase:
+          $ref: '#/components/schemas/CaseNumberRef'
+        relatedCase:
+          $ref: '#/components/schemas/CaseNumberRef'
+        account:
+          $ref: '#/components/schemas/AccountRef'
         nextStates:
           type: array
           readOnly: true
@@ -1591,16 +1601,12 @@ components:
         product:
           $ref: '#/components/schemas/EntityRef'
         assignedEngineer:
-          nullable: true
           $ref: '#/components/schemas/AssignedEngineerRef'
         parentCase:
-          nullable: true
           $ref: '#/components/schemas/CaseNumberRef'
         relatedCase:
-          nullable: true
           $ref: '#/components/schemas/CaseNumberRef'
         account:
-          nullable: true
           $ref: '#/components/schemas/AccountRef'
 
     UpdateDescriptionRequest:
@@ -2150,6 +2156,7 @@ components:
       properties:
         id:
           type: string
+          format: uuid
         name:
           type: string
 
@@ -2159,6 +2166,7 @@ components:
       properties:
         id:
           type: string
+          format: uuid
         number:
           type: string
 
@@ -2168,6 +2176,7 @@ components:
       properties:
         id:
           type: string
+          format: uuid
         name:
           type: string
         type:

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -59,8 +59,14 @@ const CsmUsersPage = lazy(
 const CsmAccountsPage = lazy(
   () => import("@features/csm-accounts/pages/CsmAccountsPage"),
 );
+const CsmAccountDetailPage = lazy(
+  () => import("@features/csm-accounts/pages/CsmAccountDetailPage"),
+);
 const CsmProjectsPage = lazy(
   () => import("@features/csm-projects/pages/CsmProjectsPage"),
+);
+const CsmProjectDetailPage = lazy(
+  () => import("@features/csm-projects/pages/CsmProjectDetailPage"),
 );
 const CsmUpdatesPage = lazy(
   () => import("@features/updates/pages/CsmUpdatesPage"),
@@ -113,9 +119,11 @@ export default function App(): JSX.Element {
               <Route element={<AuthGuard />}>
                 <Route path="/" element={<RootLanding />} />
 
-                {/* BFF-backed pages (entity-service search endpoints) */}
+                {/* BFF-backed pages (entity-service search + by-id endpoints) */}
                 <Route path="accounts" element={<CsmAccountsPage />} />
+                <Route path="accounts/:id" element={<CsmAccountDetailPage />} />
                 <Route path="projects" element={<CsmProjectsPage />} />
+                <Route path="projects/:id" element={<CsmProjectDetailPage />} />
 
                 {/* Administration — Users tab is real, others are WIP */}
                 <Route path="admin" element={<CsmAdminLayout />}>

--- a/apps/csm-portal/webapp/src/api/backend/client.ts
+++ b/apps/csm-portal/webapp/src/api/backend/client.ts
@@ -40,7 +40,7 @@ export class BackendApiError extends Error {
   payload?: BeErrorPayload;
   /**
    * Correlation ID for this failed request, read back from the response's
-   * `X-Correlation-ID` header (the backend echoes the ID it logged against).
+   * `X-CSM-Correlation-ID` header (the backend echoes the ID it logged against).
    * Surface it to users as a support "Reference ID". `undefined` when the
    * gateway does not expose the header on cross-origin responses (it must be
    * listed in `Access-Control-Expose-Headers`); the FE access log still records

--- a/apps/csm-portal/webapp/src/api/backend/client.ts
+++ b/apps/csm-portal/webapp/src/api/backend/client.ts
@@ -88,6 +88,12 @@ export interface BackendApi {
   post<TRequest, TResponse>(path: string, body: TRequest): Promise<TResponse>;
   patch<TRequest, TResponse>(path: string, body: TRequest): Promise<TResponse>;
   postEmpty<TResponse>(path: string): Promise<TResponse>;
+  /**
+   * Authenticated binary GET. Used for endpoints that stream raw file content
+   * (e.g. attachment download) rather than JSON. Unlike {@link BackendApi.get},
+   * a 404 throws like any other error — there is no "null" body for a binary.
+   */
+  getBlob(path: string): Promise<Blob>;
 }
 
 /**
@@ -146,6 +152,11 @@ export function useBackendApi(): BackendApi {
         });
         if (!response.ok) throw await readError(response);
         return (await response.json()) as TResponse;
+      },
+      async getBlob(path: string): Promise<Blob> {
+        const response = await authFetch(buildUrl(path), { method: "GET" });
+        if (!response.ok) throw await readError(response);
+        return await response.blob();
       },
     }),
     [authFetch, buildUrl],

--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -50,18 +50,12 @@ describe("priorityFromSeverity", () => {
 });
 
 describe("uiStateFromBe / beStateFromUi", () => {
-  it("passes reopened through unchanged (UI and backend now share the spelling)", () => {
-    expect(uiStateFromBe("reopened")).toBe("reopened");
-    expect(beStateFromUi("reopened")).toBe("reopened");
-  });
-
   it("passes through shared states unchanged", () => {
     for (const s of [
       "open",
       "work_in_progress",
       "waiting_on_wso2",
       "awaiting_info",
-      "reopened",
       "solution_proposed",
       "closed",
     ] as const) {

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -21,12 +21,14 @@
  */
 
 import type {
+  BeAttachment,
   BeCaseComment,
   BeCreatableCommentType,
   BeCasePriority,
   BeCaseState,
 } from "@api/backend/types";
 import type {
+  CaseAttachment,
   CsmCaseComment,
   CsmCommentAuthorRole,
 } from "@features/csm-cases/types/csmCases";
@@ -132,5 +134,21 @@ export function uiCommentFromBe(comment: BeCaseComment): CsmCaseComment {
     bodyHtml: comment.content ?? "",
     createdAt: comment.createdOn,
     internal: comment.type === "work_note",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+/** Map a backend attachment onto the UI's `CaseAttachment` shape. */
+export function uiAttachmentFromBe(att: BeAttachment): CaseAttachment {
+  return {
+    id: att.id,
+    filename: att.name,
+    size: att.sizeBytes,
+    contentType: att.type,
+    uploadedBy: att.createdBy || "Unknown",
+    uploadedAt: att.createdOn,
   };
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -188,8 +188,9 @@ export interface BeCaseUpdatePayload {
 }
 
 /** Request body for `POST /cases/search` (the flat, cross-project search). */
-export interface BeCaseSearchPayload {
-  pagination?: BePagination;
+/** Filter block for `POST /cases/search`; all fields are optional. */
+export interface BeCaseSearchFilters {
+  /** Searches across subject, number, and wso2Id (case-insensitive). */
   searchQuery?: string;
   /** Optional project filter; omit for a cross-project search. */
   projectIds?: string[];
@@ -198,6 +199,12 @@ export interface BeCaseSearchPayload {
   stateKeys?: BeCaseState[];
   priorityKeys?: BeCasePriority[];
   issueTypeKeys?: BeCaseIssueType[];
+}
+
+export interface BeCaseSearchPayload {
+  /** All filter fields are nested here; `sortBy`/`pagination` stay top-level. */
+  filters?: BeCaseSearchFilters;
+  pagination?: BePagination;
   sortBy?: {
     field?: BeCaseSortField;
     order?: "asc" | "desc";

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -275,6 +275,58 @@ export interface BeCaseCommentSearchResponse extends BeSearchResponseBase {
 }
 
 // ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+/** A case attachment as returned by `POST /cases/{id}/attachments/search`. */
+export interface BeAttachment {
+  id: string;
+  caseId: string;
+  name: string;
+  /** MIME type (e.g. image/png, application/pdf). */
+  type: string;
+  sizeBytes: number;
+  description?: string | null;
+  createdBy: string;
+  createdOn: string;
+  downloadUrl?: string | null;
+  previewUrl?: string | null;
+}
+
+export interface BeAttachmentSearchPayload {
+  pagination?: BePagination;
+}
+
+export interface BeAttachmentSearchResponse extends BeSearchResponseBase {
+  attachments: BeAttachment[];
+}
+
+/**
+ * Upload payload for `POST /cases/{id}/attachments`. `file` is a base64 data
+ * URI (e.g. `data:image/png;base64,...`); the BE caps the decoded size at 10 MB.
+ */
+export interface BeAttachmentCreatePayload {
+  name: string;
+  type: string;
+  file: string;
+  description?: string | null;
+}
+
+/** Thin ack returned by `POST /cases/{id}/attachments`. */
+export interface BeAttachmentDetail {
+  id: string;
+  sizeBytes: number;
+  createdOn: string;
+  createdBy: string;
+  downloadUrl: string;
+}
+
+export interface BeAttachmentCreateResponse {
+  message?: string;
+  attachment?: BeAttachmentDetail;
+}
+
+// ---------------------------------------------------------------------------
 // Users
 // ---------------------------------------------------------------------------
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -68,7 +68,6 @@ export type BeCaseState =
   | "work_in_progress"
   | "waiting_on_wso2"
   | "awaiting_info"
-  | "reopened"
   | "solution_proposed"
   | "closed";
 

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -43,6 +43,7 @@ import Toolbar, {
 } from "@components/rich-text-editor/ToolBar";
 import type { JSX } from "react";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import { ImageNode } from "@components/rich-text-editor/ImageNode";
 import ImagesPlugin from "@components/rich-text-editor/ImagesPlugin";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
@@ -312,6 +313,7 @@ const Editor = ({
   id,
   showKeyboardHint = false,
   maxHeight = "300px",
+  autoFocus = false,
   onFocus,
   onBlur,
   overlayElement,
@@ -333,6 +335,8 @@ const Editor = ({
   id?: string;
   showKeyboardHint?: boolean;
   maxHeight?: string | number;
+  /** Focus the editor on mount (e.g. when a reply composer opens). */
+  autoFocus?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
   /** Optional element rendered as an absolute overlay at the bottom-right inside the editor. */
@@ -510,6 +514,7 @@ const Editor = ({
             }
             ErrorBoundary={LexicalErrorBoundary}
           />
+          {autoFocus && <AutoFocusPlugin />}
           <HistoryPlugin />
           <ListPlugin />
           <ImagesPlugin />

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -87,6 +87,7 @@ export const ApiQueryKeys = {
   CSM_CASE_DETAIL: "csm-case-detail",
   CSM_CASE_COMMENTS: "csm-case-comments",
   CSM_PROJECTS: "csm-projects",
+  CSM_PROJECT_DETAIL: "csm-project-detail",
   CSM_ACCOUNTS: "csm-accounts",
   CSM_ACCOUNT_DETAIL: "csm-account-detail",
   CSM_ACCOUNT_PROJECTS: "csm-account-projects",

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -86,6 +86,7 @@ export const ApiQueryKeys = {
   CSM_CASE_COUNTS: "csm-case-counts",
   CSM_CASE_DETAIL: "csm-case-detail",
   CSM_CASE_COMMENTS: "csm-case-comments",
+  CSM_CASE_ATTACHMENTS: "csm-case-attachments",
   CSM_PROJECTS: "csm-projects",
   CSM_PROJECT_DETAIL: "csm-project-detail",
   CSM_ACCOUNTS: "csm-accounts",

--- a/apps/csm-portal/webapp/src/features/csm-accounts/api/useGetAccount.ts
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/api/useGetAccount.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAuthApiClient } from "@hooks/useAuthApiClient";
+import { apiConfig } from "@config/apiConfig";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
+import type { Account } from "@features/csm-accounts/types/csmAccounts";
+
+/**
+ * Look up a single account by id via `GET /accounts/{id}` (BFF passthrough to
+ * the entity service). Returns `null` (not an error) on 404 so the page can
+ * render a not-found state instead of an error banner. The query stays disabled
+ * until an id is present so a bare `/accounts/` never fires a request.
+ */
+export function useGetAccount(
+  id: string | undefined,
+): UseQueryResult<Account | null, Error> {
+  const authFetch = useAuthApiClient();
+
+  return useQuery<Account | null, Error>({
+    queryKey: [ApiQueryKeys.CSM_ACCOUNT_DETAIL, id ?? ""],
+    queryFn: async (): Promise<Account | null> => {
+      if (!id) return null;
+
+      const res = await authFetch(
+        `${apiConfig.backendUrl}/accounts/${encodeURIComponent(id)}`,
+      );
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ApiError(
+          res.status,
+          res.statusText,
+          parseApiResponseMessage(body, res.status, res.statusText),
+        );
+      }
+      return (await res.json()) as Account;
+    },
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode } from "react";
+import { useNavigate, useParams } from "react-router";
+import { useGetAccount } from "@features/csm-accounts/api/useGetAccount";
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString();
+}
+
+function MetaCell({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function Mono({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <Typography variant="body2" sx={{ fontFamily: "monospace", wordBreak: "break-all" }}>
+      {children}
+    </Typography>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={onClick}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back to accounts
+    </Button>
+  );
+}
+
+export default function CsmAccountDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useGetAccount(id);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rectangular" height={32} width={240} />
+        <Skeleton variant="rectangular" height={220} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/accounts")} />
+        <Typography variant="body1" color="error">
+          Could not load account {id}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/accounts")} />
+        <Typography variant="h5">Account not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No account with id <code>{id}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const a = data;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <BackButton onClick={() => navigate("/accounts")} />
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="h5">{a.name}</Typography>
+          <Chip
+            size="small"
+            label={a.tier}
+            color={a.tier === "enterprise" ? "primary" : "default"}
+            variant="outlined"
+          />
+          {a.deactivationDate && (
+            <Chip size="small" label="Deactivated" color="default" variant="outlined" />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+          {a.sfId}
+        </Typography>
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Tier">
+            <Typography variant="body2" sx={{ textTransform: "capitalize" }}>
+              {a.tier}
+            </Typography>
+          </MetaCell>
+          <MetaCell label="Region">
+            <Typography variant="body2">{a.region ?? "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Salesforce ID">
+            <Mono>{a.sfId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Activated">
+            <Typography variant="body2">{formatDate(a.activationDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="Deactivated">
+            <Typography variant="body2">{formatDate(a.deactivationDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="AI agent">
+            <Chip
+              size="small"
+              variant="outlined"
+              color={a.agentEnabled ? "success" : "default"}
+              label={a.agentEnabled ? "Enabled" : "Disabled"}
+            />
+          </MetaCell>
+          <MetaCell label="KB references">
+            <Chip
+              size="small"
+              variant="outlined"
+              color={a.kbReferencesEnabled ? "success" : "default"}
+              label={a.kbReferencesEnabled ? "Enabled" : "Disabled"}
+            />
+          </MetaCell>
+          <MetaCell label="Owner ID">
+            <Mono>{a.ownerId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Technical owner ID">
+            <Mono>{a.technicalOwnerId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Created">
+            <Typography variant="body2">{formatDate(a.createdAt)}</Typography>
+          </MetaCell>
+          <MetaCell label="Last updated">
+            <Typography variant="body2">{formatDate(a.updatedAt)}</Typography>
+          </MetaCell>
+          <MetaCell label="Account ID">
+            <Mono>{a.id}</Mono>
+          </MetaCell>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -31,6 +31,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts";
 import type { SearchAccountsRequest } from "@features/csm-accounts/types/csmAccounts";
@@ -132,7 +133,21 @@ export default function CsmAccountsPage(): JSX.Element {
               ) : (
                 accounts.map((a) => (
                   <TableRow key={a.id} hover>
-                    <TableCell>{a.name}</TableCell>
+                    <TableCell>
+                      <Typography
+                        component={RouterLink}
+                        to={`/accounts/${a.id}`}
+                        variant="body2"
+                        sx={(t) => ({
+                          textDecoration: "none",
+                          color: t.palette.primary.dark,
+                          ...t.applyStyles("dark", { color: t.palette.primary.main }),
+                          "&:hover": { textDecoration: "underline" },
+                        })}
+                      >
+                        {a.name}
+                      </Typography>
+                    </TableCell>
                     <TableCell>{a.sfId}</TableCell>
                     <TableCell>
                       <Chip

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
@@ -357,7 +357,7 @@ const ABT_CASE_SEEDS: CaseSeed[] = [
     projectId: "prj-acme-iam-prod",
     projectName: "IAM Production",
     severity: "S2",
-    state: "reopened",
+    state: "waiting_on_wso2",
     assignee: "Sajith Ekanayaka",
     assigneeIsMe: true,
     slaClockType: "ack",
@@ -809,8 +809,6 @@ function deriveTags(c: CsmCaseRow): CaseTag[] {
     tags.push({ id: "t-priority", label: "high-priority", color: "error" });
   if (c.minutesToBreach < 0)
     tags.push({ id: "t-breach", label: "sla-breached", color: "warning" });
-  if (c.state === "reopened")
-    tags.push({ id: "t-reopen", label: "reopened", color: "warning" });
   const subjLower = c.subject.toLowerCase();
   if (subjLower.includes("ldap")) tags.push({ id: "t-ldap", label: "ldap", color: "info" });
   if (subjLower.includes("saml") || subjLower.includes("oidc"))
@@ -915,15 +913,6 @@ function deriveAudit(c: CsmCaseRow): CaseAuditEntry[] {
       kind: "state_change",
       actor: assignee,
       description: "Case closed",
-      createdAt: c.updatedAt,
-    });
-  }
-  if (c.state === "reopened") {
-    events.push({
-      id: `a-${c.id}-3`,
-      kind: "state_change",
-      actor: "Customer",
-      description: "Customer reopened the case",
       createdAt: c.updatedAt,
     });
   }
@@ -1198,7 +1187,6 @@ const MOCK_NEXT_STATES: Record<CaseState, CaseState[]> = {
   ],
   waiting_on_wso2: ["work_in_progress"],
   awaiting_info: ["waiting_on_wso2"],
-  reopened: ["waiting_on_wso2"],
   solution_proposed: ["closed", "waiting_on_wso2"],
   closed: [],
 };

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/mocks/casesMocks.ts
@@ -1147,6 +1147,41 @@ function deriveAttachments(c: CsmCaseRow): CaseAttachment[] {
   return sets[seedIdx % 4] ?? [];
 }
 
+// Attachments uploaded during a mock session, keyed by case id, so a mock
+// upload is visible on the next list refetch (the seeded set is deterministic).
+const mockUploadedAttachments = new Map<string, CaseAttachment[]>();
+
+/** Mock attachment list: seeded set plus anything uploaded this session. */
+export function getMockCsmCaseAttachments(caseId: string): CaseAttachment[] {
+  const row = getMockCsmCaseById(caseId);
+  const seeded = row ? deriveAttachments(row) : [];
+  const uploaded = mockUploadedAttachments.get(caseId) ?? [];
+  // Newest first matches how the widget sorts; concat is enough since the
+  // widget re-sorts by uploadedAt.
+  return [...uploaded, ...seeded];
+}
+
+/** Mock attachment upload: records and echoes back a fresh `CaseAttachment`. */
+export function postMockCsmCaseAttachment(input: {
+  caseId: string;
+  filename: string;
+  size: number;
+  contentType: string;
+  uploadedBy: string;
+}): CaseAttachment {
+  const created: CaseAttachment = {
+    id: `att-${input.caseId}-${Date.now()}`,
+    filename: input.filename,
+    size: input.size,
+    contentType: input.contentType,
+    uploadedBy: input.uploadedBy,
+    uploadedAt: new Date().toISOString(),
+  };
+  const existing = mockUploadedAttachments.get(input.caseId) ?? [];
+  mockUploadedAttachments.set(input.caseId, [created, ...existing]);
+  return created;
+}
+
 /**
  * Mirror of the backend transition graph in
  * `apps/csm-portal/backend/internal/handler/state.go` (`nextStates`). The mock

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -123,6 +123,8 @@ export function useGetCsmCaseAttachments(
 export interface PostCsmCaseAttachmentInput {
   caseId: string;
   file: File;
+  /** Display name for the attachment; defaults to the file's own name. */
+  name?: string;
   /** Optional free-text note stored with the attachment. */
   description?: string;
   /** Display name of the uploader (used by the mock; the BE sets its own). */
@@ -160,7 +162,7 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
         await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
         return postMockCsmCaseAttachment({
           caseId: input.caseId,
-          filename: input.file.name,
+          filename: input.name?.trim() || input.file.name,
           size: input.file.size,
           contentType: input.file.type || "application/octet-stream",
           uploadedBy: input.uploadedBy,
@@ -169,7 +171,7 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
 
       const dataUri = await readFileAsDataUrl(input.file);
       const payload: BeAttachmentCreatePayload = {
-        name: input.file.name,
+        name: input.name?.trim() || input.file.name,
         type: input.file.type || "application/octet-stream",
         file: dataUri,
         description: input.description?.trim() || null,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import type {
+  BeAttachmentCreatePayload,
+  BeAttachmentCreateResponse,
+  BeAttachmentSearchPayload,
+  BeAttachmentSearchResponse,
+} from "@api/backend/types";
+import { uiAttachmentFromBe } from "@api/backend/mappers";
+import {
+  getMockCsmCaseAttachments,
+  postMockCsmCaseAttachment,
+} from "@features/csm-cases/api/mocks/casesMocks";
+import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
+
+const MOCK_LATENCY_MS = 150;
+
+/**
+ * Page size used by the attachments list. A single wide page is enough for the
+ * case-detail view. If a case ever exceeds this, switch to an explicit
+ * pagination wrapper rather than chasing pages.
+ */
+const ATTACHMENTS_PAGE_LIMIT = 50;
+
+/**
+ * Max upload size in bytes. The BE caps the decoded file at 10 MB (the
+ * request body itself is capped higher to allow base64 inflation). Validate
+ * here so the user gets a clear message instead of a 413.
+ */
+export const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Read a File as a base64 data URI (`data:<mime>;base64,...`). */
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") resolve(reader.result);
+      else reject(new Error("Failed to read the file."));
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read the file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+/** Trigger a browser "save as" for a fetched blob. */
+function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Load all attachments on a case. In LIVE mode calls
+ * `POST /cases/{id}/attachments/search` with a single wide page.
+ */
+export function useGetCsmCaseAttachments(
+  caseId: string | undefined,
+): UseQueryResult<CaseAttachment[], Error> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useQuery<CaseAttachment[], Error>({
+    queryKey: [ApiQueryKeys.CSM_CASE_ATTACHMENTS, caseId ?? ""],
+    queryFn: async (): Promise<CaseAttachment[]> => {
+      if (!caseId) return [];
+
+      if (isMockMode()) {
+        logger.debug(
+          `[useGetCsmCaseAttachments] Returning mock attachments for ${caseId}`,
+        );
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return getMockCsmCaseAttachments(caseId);
+      }
+
+      const payload: BeAttachmentSearchPayload = {
+        pagination: { offset: 0, limit: ATTACHMENTS_PAGE_LIMIT },
+      };
+      const response = await api.post<
+        BeAttachmentSearchPayload,
+        BeAttachmentSearchResponse
+      >(
+        `/cases/${encodeURIComponent(caseId)}/attachments/search`,
+        payload,
+      );
+      return response.attachments.map(uiAttachmentFromBe);
+    },
+    enabled: !!caseId,
+    staleTime: 10_000,
+  });
+}
+
+export interface PostCsmCaseAttachmentInput {
+  caseId: string;
+  file: File;
+  /** Optional free-text note stored with the attachment. */
+  description?: string;
+  /** Display name of the uploader (used by the mock; the BE sets its own). */
+  uploadedBy: string;
+}
+
+/**
+ * Upload a file attachment to a case via `POST /cases/{id}/attachments`. The
+ * file is sent as a base64 data URI. The create response is a thin ack, so the
+ * list is refetched on success to hydrate the new entry from search.
+ */
+export function usePostCsmCaseAttachment(): UseMutationResult<
+  CaseAttachment | null,
+  Error,
+  PostCsmCaseAttachmentInput
+> {
+  const logger = useLogger();
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<CaseAttachment | null, Error, PostCsmCaseAttachmentInput>({
+    mutationFn: async (input): Promise<CaseAttachment | null> => {
+      if (input.file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+        throw new Error(
+          `"${input.file.name}" is too large. The maximum attachment size is ${
+            MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)
+          } MB.`,
+        );
+      }
+
+      if (isMockMode()) {
+        logger.debug(
+          `[usePostCsmCaseAttachment] Posting mock attachment for ${input.caseId}`,
+        );
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+        return postMockCsmCaseAttachment({
+          caseId: input.caseId,
+          filename: input.file.name,
+          size: input.file.size,
+          contentType: input.file.type || "application/octet-stream",
+          uploadedBy: input.uploadedBy,
+        });
+      }
+
+      const dataUri = await readFileAsDataUrl(input.file);
+      const payload: BeAttachmentCreatePayload = {
+        name: input.file.name,
+        type: input.file.type || "application/octet-stream",
+        file: dataUri,
+        description: input.description?.trim() || null,
+      };
+      await api.post<BeAttachmentCreatePayload, BeAttachmentCreateResponse>(
+        `/cases/${encodeURIComponent(input.caseId)}/attachments`,
+        payload,
+      );
+      // The create response is a thin ack; refetch hydrates the full entry.
+      return null;
+    },
+    onSuccess: (_created, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CSM_CASE_ATTACHMENTS, variables.caseId],
+      });
+    },
+  });
+}
+
+/**
+ * Returns a function that downloads an attachment's content and saves it. The
+ * content endpoint streams raw bytes behind auth, so it is fetched as a blob
+ * (a plain `<a href>` would miss the auth headers) and handed to the browser.
+ */
+export function useDownloadCsmCaseAttachment(): (
+  caseId: string,
+  attachment: CaseAttachment,
+) => Promise<void> {
+  const logger = useLogger();
+  const api = useBackendApi();
+
+  return useCallback(
+    async (caseId: string, attachment: CaseAttachment): Promise<void> => {
+      if (isMockMode()) {
+        logger.debug(
+          `[useDownloadCsmCaseAttachment] Mock download of ${attachment.filename}`,
+        );
+        const placeholder = new Blob(
+          [`Mock content for ${attachment.filename}`],
+          { type: "text/plain" },
+        );
+        saveBlob(placeholder, attachment.filename);
+        return;
+      }
+
+      const blob = await api.getBlob(
+        `/cases/${encodeURIComponent(caseId)}/attachments/${encodeURIComponent(
+          attachment.id,
+        )}/content`,
+      );
+      saveBlob(blob, attachment.filename);
+    },
+    [api, logger],
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -171,17 +171,20 @@ export function useGetCsmCases(
         api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
           pagination: { offset, limit: pageSize },
           sortBy: { field: "updated_at", order: "desc" },
-          ...(search.length > 0 && { searchQuery: search }),
-          ...(filters.severities.length > 0 && {
-            priorityKeys: filters.severities.map(priorityFromSeverity),
-          }),
-          ...(filters.states.length > 0 && {
-            stateKeys: filters.states.map(beStateFromUi),
-          }),
-          // `filters.projects` holds project IDs (the filter is id-based).
-          ...(filters.projects.length > 0 && {
-            projectIds: filters.projects,
-          }),
+          // Filter fields are nested under `filters` (BE payload restructure).
+          filters: {
+            ...(search.length > 0 && { searchQuery: search }),
+            ...(filters.severities.length > 0 && {
+              priorityKeys: filters.severities.map(priorityFromSeverity),
+            }),
+            ...(filters.states.length > 0 && {
+              stateKeys: filters.states.map(beStateFromUi),
+            }),
+            // `filters.projects` holds project IDs (the filter is id-based).
+            ...(filters.projects.length > 0 && {
+              projectIds: filters.projects,
+            }),
+          },
         }),
         queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {
           logger.warn(

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -89,7 +89,7 @@ export function useQuickCaseSearch(
         "/cases/search",
         {
           pagination: { offset: 0, limit: QUICK_CASE_LIMIT },
-          searchQuery: q,
+          filters: { searchQuery: q },
         },
       );
       return (res.cases ?? []).map((c) => ({

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -174,17 +174,4 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
     // The state-independent "More" overflow is unaffected.
     expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
   });
-
-  it("keeps the lead-only Reopen override on a closed case regardless of nextStates", () => {
-    render(
-      <CaseActionBar
-        caseDetail={caseInState("closed", [])}
-        onAction={() => {}}
-        canReopenClosed
-      />,
-    );
-    // The button carries a tooltip, so its accessible name is the tooltip text;
-    // assert the visible "Reopened" label (the BE state name) instead.
-    expect(screen.getByText("Reopened")).toBeInTheDocument();
-  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -40,7 +40,6 @@ import {
   PauseCircle,
   Phone,
   Play,
-  RotateCcw,
   Send,
   ShieldAlert,
   TriangleAlert,
@@ -85,8 +84,6 @@ type PrimaryButton = TargetConfig & {
 
 const CLOSE_CONFIRM: ActionConfirm = {
   title: "Close this case?",
-  // No "cannot be reopened" claim — reopen is a lead-only override, so that
-  // assertion would be false for leads.
   body: "The customer receives a closure notification and the case moves to “Closed”.",
   confirmLabel: "Close case",
   confirmColor: "warning",
@@ -97,8 +94,7 @@ const CLOSE_CONFIRM: ActionConfirm = {
  * Customer-notifying / hard-to-undo transitions carry a confirm gate so a stray
  * click in a busy queue can't silently close a case or email the customer.
  */
-const TARGET_CONFIG: Record<CaseState, TargetConfig> = {
-  open: { action: "reopen", color: "primary", icon: <RotateCcw size={16} /> },
+const TARGET_CONFIG: Partial<Record<CaseState, TargetConfig>> = {
   work_in_progress: {
     action: "resume_work",
     color: "primary",
@@ -125,7 +121,6 @@ const TARGET_CONFIG: Record<CaseState, TargetConfig> = {
       confirmColor: "primary",
     },
   },
-  reopened: { action: "reopen", color: "primary", icon: <RotateCcw size={16} /> },
   closed: {
     action: "close",
     color: "warning",
@@ -167,7 +162,6 @@ const DISPLAY_ORDER: CaseState[] = [
   "work_in_progress",
   "awaiting_info",
   "waiting_on_wso2",
-  "reopened",
   "open",
   "closed",
 ];
@@ -176,28 +170,6 @@ function orderRank(s: CaseState): number {
   const i = DISPLAY_ORDER.indexOf(s);
   return i === -1 ? CLOSED_RANK - 0.5 : i;
 }
-
-/**
- * Lead-only override to reopen a closed case. Not part of the normal
- * `nextStates` flow — the backend reports a closed case as terminal
- * (`nextStates: []`) — so it is appended for the `closed` state only when the
- * caller grants the `canReopenClosed` capability. Labelled by the BE state it
- * lands in (`reopened` → "Reopened") like every other button.
- */
-const REOPEN_BUTTON: PrimaryButton = {
-  targetState: "reopened",
-  label: stateLabel("reopened"),
-  action: "reopen",
-  color: "warning",
-  icon: <RotateCcw size={16} />,
-  tooltip: "Lead-only: reopen a closed case for an exceptional follow-up.",
-  confirm: {
-    title: "Reopen this closed case?",
-    body: "The case returns to an active state and the customer is notified.",
-    confirmLabel: "Reopen case",
-    confirmColor: "warning",
-  },
-};
 
 interface SecondaryItem {
   key: string;
@@ -252,11 +224,6 @@ interface CaseActionBarProps {
     action: CaseLifecycleAction | { secondary: string },
     targetState?: CaseState,
   ) => void | Promise<unknown>;
-  /**
-   * Grants the lead-only "Reopen" action on a closed case. Defaults to false,
-   * so a closed case is terminal unless the caller is a lead.
-   */
-  canReopenClosed?: boolean;
 }
 
 /**
@@ -269,14 +236,12 @@ interface CaseActionBarProps {
 export default function CaseActionBar({
   caseDetail,
   onAction,
-  canReopenClosed = false,
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [pendingConfirm, setPendingConfirm] = useState<PrimaryButton | null>(
     null,
   );
 
-  const from = caseDetail.state;
   // Render a button for every state the backend says the case can move to. The
   // backend `nextStates` is the single source of truth: an empty/terminal list
   // (e.g. Closed) yields no lifecycle buttons, and a missing field also yields
@@ -285,12 +250,7 @@ export default function CaseActionBar({
   const lifecycle = [...new Set(targets)]
     .sort((a, b) => orderRank(a) - orderRank(b))
     .map(buttonFor);
-  const primary = [
-    ...lifecycle,
-    // Lead-only reopen is an override outside the normal `nextStates` flow, so
-    // it is gated by capability rather than by the backend transition list.
-    ...(from === "closed" && canReopenClosed ? [REOPEN_BUTTON] : []),
-  ];
+  const primary = lifecycle;
   const secondary = buildSecondaryItems();
 
   const runPrimary = (p: PrimaryButton): void => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -240,7 +240,7 @@ export default function CaseActivitiesFeed({
                   >
                     {AUDIT_ICON[e.entry.kind]}
                   </Box>
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Box sx={{ flex: 1, minWidth: 0, overflowWrap: "anywhere" }}>
                     <Typography variant="body2">
                       {e.entry.description}
                     </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -15,7 +15,9 @@
 // under the License.
 
 import {
+  Avatar,
   Box,
+  Button,
   Checkbox,
   Chip,
   ListItemText,
@@ -30,6 +32,7 @@ import {
   ArrowUp,
   ArrowUpRight,
   CheckCircle,
+  Download,
   Link as LinkIcon,
   ListFilter,
   Paperclip,
@@ -57,6 +60,8 @@ interface CaseActivitiesFeedProps {
   comments: CsmCaseComment[];
   audit: CaseAuditEntry[];
   attachments: CaseAttachment[];
+  /** Download a file surfaced in the timeline. */
+  onDownloadAttachment?: (attachment: CaseAttachment) => void;
 }
 
 const AUDIT_ICON: Record<CaseAuditEntry["kind"], JSX.Element> = {
@@ -76,6 +81,7 @@ export default function CaseActivitiesFeed({
   comments,
   audit,
   attachments,
+  onDownloadAttachment,
 }: CaseActivitiesFeedProps): JSX.Element {
   const [showWorkNotes, setShowWorkNotes] = useState(true);
   const [showLifecycle, setShowLifecycle] = useState(true);
@@ -261,43 +267,95 @@ export default function CaseActivitiesFeed({
                 </Paper>
               );
             }
-            // attachment
+            // attachment — rendered like a comment: avatar + card carrying the
+            // file description and a download action.
             return (
-              <Paper
+              <Box
                 id={e.attachment.id}
                 key={`f-${e.attachment.id}`}
-                variant="outlined"
                 sx={{
-                  p: 1,
                   display: "flex",
-                  alignItems: "center",
-                  gap: 1.25,
-                  backgroundColor: "background.default",
+                  gap: 1.5,
+                  alignItems: "flex-start",
                   scrollMarginTop: 96,
                 }}
               >
-                <Paperclip size={14} />
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography variant="body2">
-                    <strong>{e.attachment.filename}</strong>{" "}
-                    <Typography
-                      component="span"
-                      variant="caption"
-                      color="text.secondary"
-                    >
-                      ({formatBytes(e.attachment.size)} · {e.attachment.contentType})
+                <Avatar
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "action.selected",
+                    color: "text.secondary",
+                  }}
+                >
+                  <Paperclip size={16} />
+                </Avatar>
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    p: 1.5,
+                    flex: 1,
+                    minWidth: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 0.75,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <Typography variant="subtitle2">
+                      {e.attachment.uploadedBy}
                     </Typography>
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    Uploaded by {e.attachment.uploadedBy} ·{" "}
-                    <RelativeTime
-                      iso={e.attachment.uploadedAt}
-                      href={`#${e.attachment.id}`}
-                    />
-                  </Typography>
-                </Box>
-                <Chip size="small" variant="outlined" label="Attachment" />
-              </Paper>
+                    <Chip size="small" variant="outlined" label="Attachment" />
+                    <Typography variant="caption" color="text.secondary">
+                      <RelativeTime
+                        iso={e.attachment.uploadedAt}
+                        href={`#${e.attachment.id}`}
+                      />
+                    </Typography>
+                  </Box>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      gap: 1,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{ fontWeight: 600, overflowWrap: "anywhere" }}
+                      >
+                        {e.attachment.filename}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {formatBytes(e.attachment.size)} ·{" "}
+                        {e.attachment.contentType}
+                      </Typography>
+                    </Box>
+                    {onDownloadAttachment && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<Download size={14} />}
+                        onClick={() => onDownloadAttachment(e.attachment)}
+                        aria-label={`Download ${e.attachment.filename}`}
+                        sx={{ flexShrink: 0 }}
+                      >
+                        Download
+                      </Button>
+                    )}
+                  </Box>
+                </Paper>
+              </Box>
             );
           })}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -20,9 +20,7 @@ import {
   Button,
   Card,
   Chip,
-  IconButton,
   LinearProgress,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import {
@@ -792,15 +790,16 @@ export function AttachmentsWidget({
                   {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />
                 </Typography>
               </Box>
-              <Tooltip title="Download">
-                <IconButton
-                  size="small"
-                  aria-label={`Download ${a.filename}`}
-                  onClick={() => onDownload?.(a)}
-                >
-                  <Download size={16} />
-                </IconButton>
-              </Tooltip>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<Download size={14} />}
+                onClick={() => onDownload?.(a)}
+                aria-label={`Download ${a.filename}`}
+                sx={{ flexShrink: 0 }}
+              >
+                Download
+              </Button>
             </Box>
           ))}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -42,10 +42,11 @@ import {
   Server,
   Shield,
   TriangleAlert,
+  Upload,
   User,
   Users,
 } from "@wso2/oxygen-ui-icons-react";
-import type { JSX } from "react";
+import { useRef, type ChangeEvent, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
 import { initialsOf } from "@utils/userClaims";
 import { formatBytes } from "@utils/formatBytes";
@@ -666,34 +667,103 @@ export function TimeLogsWidget({
  */
 export function AttachmentsWidget({
   attachments,
+  loading = false,
+  error = false,
+  onRetry,
+  uploading = false,
+  uploadError,
+  onUpload,
   onDownloadAll,
   onDownload,
 }: {
   attachments: CaseAttachment[];
+  /** List query is loading. */
+  loading?: boolean;
+  /** List query failed. */
+  error?: boolean;
+  onRetry?: () => void;
+  /** An upload is in flight. */
+  uploading?: boolean;
+  /** Message shown when the last upload failed (size, network, 413, …). */
+  uploadError?: string | null;
+  onUpload?: (file: File) => void;
   onDownloadAll?: () => void;
   onDownload?: (attachment: CaseAttachment) => void;
 }): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const sorted = [...attachments].sort(
     (a, b) =>
       new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime(),
   );
+
+  const pickFile = (): void => fileInputRef.current?.click();
+  const onFileChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const file = e.target.files?.[0];
+    if (file) onUpload?.(file);
+    // Reset so re-selecting the same file still fires onChange.
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
   return (
     <WidgetCard
       title={`Attachments (${sorted.length})`}
       icon={<Paperclip size={16} />}
       action={
-        <Button
-          size="small"
-          variant="text"
-          startIcon={<Download size={14} />}
-          onClick={onDownloadAll}
-          disabled={sorted.length === 0}
-        >
-          Download all
-        </Button>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          {onUpload && (
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Upload size={14} />}
+              onClick={pickFile}
+              disabled={uploading}
+            >
+              {uploading ? "Uploading…" : "Upload"}
+            </Button>
+          )}
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<Download size={14} />}
+            onClick={onDownloadAll}
+            disabled={sorted.length === 0}
+          >
+            Download all
+          </Button>
+        </Box>
       }
     >
-      {sorted.length === 0 ? (
+      {onUpload && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          hidden
+          onChange={onFileChange}
+          aria-hidden
+        />
+      )}
+      {uploading && <LinearProgress sx={{ mb: 1 }} />}
+      {uploadError && (
+        <Typography variant="body2" color="error" sx={{ mb: 1 }}>
+          {uploadError}
+        </Typography>
+      )}
+      {loading ? (
+        <Typography variant="body2" color="text.secondary">
+          Loading attachments…
+        </Typography>
+      ) : error ? (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="body2" color="error">
+            Could not load attachments.
+          </Typography>
+          {onRetry && (
+            <Button size="small" variant="outlined" onClick={onRetry}>
+              Retry
+            </Button>
+          )}
+        </Box>
+      ) : sorted.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No attachments on this case.
         </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -778,13 +778,42 @@ export function AttachmentsWidget({
                 borderRadius: 1,
                 border: 1,
                 borderColor: "divider",
+                transition: "background-color 120ms, border-color 120ms",
+                "&:hover": {
+                  borderColor: "primary.main",
+                  backgroundColor: "action.hover",
+                },
               }}
             >
               <Paperclip size={16} />
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
-                  {a.filename}
-                </Typography>
+                {onDownload ? (
+                  <Typography
+                    component="button"
+                    variant="body2"
+                    noWrap
+                    onClick={() => onDownload(a)}
+                    title={`Download ${a.filename}`}
+                    sx={{
+                      display: "block",
+                      width: "100%",
+                      textAlign: "left",
+                      p: 0,
+                      border: 0,
+                      bgcolor: "transparent",
+                      cursor: "pointer",
+                      fontWeight: 600,
+                      color: "primary.main",
+                      "&:hover": { textDecoration: "underline" },
+                    }}
+                  >
+                    {a.filename}
+                  </Typography>
+                ) : (
+                  <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                    {a.filename}
+                  </Typography>
+                )}
                 <Typography variant="caption" color="text.secondary" noWrap>
                   {formatBytes(a.size)} · {a.contentType} · uploaded by{" "}
                   {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -131,7 +131,6 @@ const PRIMARY_STATES: CaseState[] = [
   "awaiting_info",
   "solution_proposed",
   "waiting_on_wso2",
-  "reopened",
   "closed",
 ];
 const SLA_OPTIONS: { value: SlaFilter; label: string }[] = [

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -71,11 +71,25 @@ const PURIFY_CONFIG = {
   ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
 };
 
+/**
+ * Comment bodies are usually rich-text HTML authored in the editor, but some
+ * (ServiceNow-sourced or API-created notes) are plain text. Detect a real tag so
+ * plain text isn't fed through `innerHTML`, where its line breaks would collapse;
+ * plain text is rendered as text with `white-space: pre-wrap` instead.
+ */
+const HTML_TAG_RE = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
+function isHtmlContent(s: string): boolean {
+  return HTML_TAG_RE.test(s);
+}
+
 export default function CsmCaseCommentBubble({
   comment,
 }: CsmCaseCommentBubbleProps): JSX.Element {
   const theme = useTheme();
-  const safeHtml = DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG);
+  const isHtml = isHtmlContent(comment.bodyHtml);
+  const safeHtml = isHtml
+    ? DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG)
+    : "";
   const isSystem = comment.authorRole === "system";
 
   if (isSystem) {
@@ -93,18 +107,33 @@ export default function CsmCaseCommentBubble({
         }}
       >
         <SemanticChip role="warning" label="System" />
-        <Box
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            overflowWrap: "anywhere",
-            wordBreak: "break-word",
-            "& p": { m: 0 },
-            "& a": { color: "primary.main" },
-            ...{ "& *": { fontSize: "0.875rem" } },
-          }}
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+        {isHtml ? (
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflowWrap: "anywhere",
+              wordBreak: "break-word",
+              "& p": { m: 0 },
+              "& a": { color: "primary.main" },
+              ...{ "& *": { fontSize: "0.875rem" } },
+            }}
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        ) : (
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflowWrap: "anywhere",
+              wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
+              fontSize: "0.875rem",
+            }}
+          >
+            {comment.bodyHtml}
+          </Box>
+        )}
         <Typography variant="caption" color="text.secondary">
           <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
         </Typography>
@@ -168,45 +197,60 @@ export default function CsmCaseCommentBubble({
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
           </Typography>
         </Box>
-        <Box
-          sx={{
-            minWidth: 0,
-            overflowWrap: "anywhere",
-            wordBreak: "break-word",
-            "& p": { m: 0 },
-            "& p + p": { mt: 0.75 },
-            "& ul, & ol": { ml: 3, my: 0.5 },
-            "& code": {
-              bgcolor: "background.default",
-              px: 0.5,
-              borderRadius: 0.5,
-              fontFamily: "monospace",
-              fontSize: "0.85em",
+        {isHtml ? (
+          <Box
+            sx={{
+              minWidth: 0,
               overflowWrap: "anywhere",
-            },
-            "& pre": {
-              bgcolor: "background.default",
-              p: 1,
-              borderRadius: 1,
-              overflowX: "auto",
-              fontFamily: "monospace",
-              fontSize: "0.85em",
-            },
-            "& a": { color: "primary.main" },
-            "& img": { maxWidth: "100%" },
-            "& blockquote": {
-              borderLeft: 3,
-              borderColor: "divider",
-              pl: 1.5,
-              ml: 0,
-              my: 0.75,
-              color: "text.secondary",
-              fontStyle: "italic",
-            },
-            "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
-          }}
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+              wordBreak: "break-word",
+              "& p": { m: 0 },
+              "& p + p": { mt: 0.75 },
+              "& ul, & ol": { ml: 3, my: 0.5 },
+              "& code": {
+                bgcolor: "background.default",
+                px: 0.5,
+                borderRadius: 0.5,
+                fontFamily: "monospace",
+                fontSize: "0.85em",
+                overflowWrap: "anywhere",
+              },
+              "& pre": {
+                bgcolor: "background.default",
+                p: 1,
+                borderRadius: 1,
+                overflowX: "auto",
+                fontFamily: "monospace",
+                fontSize: "0.85em",
+              },
+              "& a": { color: "primary.main" },
+              "& img": { maxWidth: "100%" },
+              "& blockquote": {
+                borderLeft: 3,
+                borderColor: "divider",
+                pl: 1.5,
+                ml: 0,
+                my: 0.75,
+                color: "text.secondary",
+                fontStyle: "italic",
+              },
+              "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
+            }}
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        ) : (
+          // Plain-text body: render as text and honour newlines/whitespace.
+          <Typography
+            variant="body2"
+            sx={{
+              minWidth: 0,
+              overflowWrap: "anywhere",
+              wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {comment.bodyHtml}
+          </Typography>
+        )}
       </Paper>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -96,6 +96,9 @@ export default function CsmCaseCommentBubble({
         <Box
           sx={{
             flex: 1,
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
             "& p": { m: 0 },
             "& a": { color: "primary.main" },
             ...{ "& *": { fontSize: "0.875rem" } },
@@ -148,7 +151,6 @@ export default function CsmCaseCommentBubble({
           gap: 0.75,
           backgroundColor: isInternal ? "warning.50" : undefined,
           borderColor: isInternal ? "warning.main" : undefined,
-          borderLeft: isInternal ? 3 : undefined,
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
@@ -159,15 +161,18 @@ export default function CsmCaseCommentBubble({
             color={ROLE_COLOR[comment.authorRole]}
             variant="outlined"
           />
-          {isInternal && (
-            <SemanticChip role="warning" label="Internal work note" />
-          )}
+          {/* A filled chip "bubble" marks the work note; paired with the tinted
+              background it reads as internal without a heavy banner. */}
+          {isInternal && <SemanticChip role="warning" label="Internal note" />}
           <Typography variant="caption" color="text.secondary">
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
           </Typography>
         </Box>
         <Box
           sx={{
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
             "& p": { m: 0 },
             "& p + p": { mt: 0.75 },
             "& ul, & ol": { ml: 3, my: 0.5 },
@@ -177,6 +182,7 @@ export default function CsmCaseCommentBubble({
               borderRadius: 0.5,
               fontFamily: "monospace",
               fontSize: "0.85em",
+              overflowWrap: "anywhere",
             },
             "& pre": {
               bgcolor: "background.default",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
+import { alpha, Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
 import type { JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
@@ -149,7 +149,9 @@ export default function CsmCaseCommentBubble({
           display: "flex",
           flexDirection: "column",
           gap: 0.75,
-          backgroundColor: isInternal ? "warning.50" : undefined,
+          backgroundColor: isInternal
+            ? alpha(theme.palette.warning.main, 0.15)
+            : undefined,
           borderColor: isInternal ? "warning.main" : undefined,
         }}
       >

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -71,25 +71,11 @@ const PURIFY_CONFIG = {
   ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
 };
 
-/**
- * Comment bodies are usually rich-text HTML authored in the editor, but some
- * (ServiceNow-sourced or API-created notes) are plain text. Detect a real tag so
- * plain text isn't fed through `innerHTML`, where its line breaks would collapse;
- * plain text is rendered as text with `white-space: pre-wrap` instead.
- */
-const HTML_TAG_RE = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
-function isHtmlContent(s: string): boolean {
-  return HTML_TAG_RE.test(s);
-}
-
 export default function CsmCaseCommentBubble({
   comment,
 }: CsmCaseCommentBubbleProps): JSX.Element {
   const theme = useTheme();
-  const isHtml = isHtmlContent(comment.bodyHtml);
-  const safeHtml = isHtml
-    ? DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG)
-    : "";
+  const safeHtml = DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG);
   const isSystem = comment.authorRole === "system";
 
   if (isSystem) {
@@ -107,33 +93,18 @@ export default function CsmCaseCommentBubble({
         }}
       >
         <SemanticChip role="warning" label="System" />
-        {isHtml ? (
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              "& p": { m: 0 },
-              "& a": { color: "primary.main" },
-              ...{ "& *": { fontSize: "0.875rem" } },
-            }}
-            dangerouslySetInnerHTML={{ __html: safeHtml }}
-          />
-        ) : (
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              whiteSpace: "pre-wrap",
-              fontSize: "0.875rem",
-            }}
-          >
-            {comment.bodyHtml}
-          </Box>
-        )}
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
+            "& p": { m: 0 },
+            "& a": { color: "primary.main" },
+            ...{ "& *": { fontSize: "0.875rem" } },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
         <Typography variant="caption" color="text.secondary">
           <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
         </Typography>
@@ -197,60 +168,45 @@ export default function CsmCaseCommentBubble({
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
           </Typography>
         </Box>
-        {isHtml ? (
-          <Box
-            sx={{
-              minWidth: 0,
+        <Box
+          sx={{
+            minWidth: 0,
+            overflowWrap: "anywhere",
+            wordBreak: "break-word",
+            "& p": { m: 0 },
+            "& p + p": { mt: 0.75 },
+            "& ul, & ol": { ml: 3, my: 0.5 },
+            "& code": {
+              bgcolor: "background.default",
+              px: 0.5,
+              borderRadius: 0.5,
+              fontFamily: "monospace",
+              fontSize: "0.85em",
               overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              "& p": { m: 0 },
-              "& p + p": { mt: 0.75 },
-              "& ul, & ol": { ml: 3, my: 0.5 },
-              "& code": {
-                bgcolor: "background.default",
-                px: 0.5,
-                borderRadius: 0.5,
-                fontFamily: "monospace",
-                fontSize: "0.85em",
-                overflowWrap: "anywhere",
-              },
-              "& pre": {
-                bgcolor: "background.default",
-                p: 1,
-                borderRadius: 1,
-                overflowX: "auto",
-                fontFamily: "monospace",
-                fontSize: "0.85em",
-              },
-              "& a": { color: "primary.main" },
-              "& img": { maxWidth: "100%" },
-              "& blockquote": {
-                borderLeft: 3,
-                borderColor: "divider",
-                pl: 1.5,
-                ml: 0,
-                my: 0.75,
-                color: "text.secondary",
-                fontStyle: "italic",
-              },
-              "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
-            }}
-            dangerouslySetInnerHTML={{ __html: safeHtml }}
-          />
-        ) : (
-          // Plain-text body: render as text and honour newlines/whitespace.
-          <Typography
-            variant="body2"
-            sx={{
-              minWidth: 0,
-              overflowWrap: "anywhere",
-              wordBreak: "break-word",
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            {comment.bodyHtml}
-          </Typography>
-        )}
+            },
+            "& pre": {
+              bgcolor: "background.default",
+              p: 1,
+              borderRadius: 1,
+              overflowX: "auto",
+              fontFamily: "monospace",
+              fontSize: "0.85em",
+            },
+            "& a": { color: "primary.main" },
+            "& img": { maxWidth: "100%" },
+            "& blockquote": {
+              borderLeft: 3,
+              borderColor: "divider",
+              pl: 1.5,
+              ml: 0,
+              my: 0.75,
+              color: "text.secondary",
+              fontStyle: "italic",
+            },
+            "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
       </Paper>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -42,6 +42,7 @@ import {
 } from "react";
 import Editor from "@components/rich-text-editor/Editor";
 import { formatBytes } from "@utils/formatBytes";
+import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/csm-cases/api/useCsmCaseAttachments";
 
 interface CsmCaseCommentInputProps {
   onSubmit: (
@@ -138,6 +139,18 @@ export default function CsmCaseCommentInput({
     }
     if (overSizeLimit) {
       setError(sizeError);
+      return;
+    }
+    // Pre-validate file sizes before posting anything: the send is multi-step
+    // (comment then uploads), so catching an oversized file here avoids posting
+    // the comment and then failing on the upload (which would double-post on retry).
+    const tooLarge = attachments.find((f) => f.size > MAX_ATTACHMENT_SIZE_BYTES);
+    if (tooLarge) {
+      setError(
+        `"${tooLarge.name}" is too large. The maximum attachment size is ${formatBytes(
+          MAX_ATTACHMENT_SIZE_BYTES,
+        )}.`,
+      );
       return;
     }
     setError(null);

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -32,15 +32,31 @@ import {
   Minimize2,
   Send,
 } from "@wso2/oxygen-ui-icons-react";
-import { useCallback, useMemo, useRef, useState, type JSX } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type JSX,
+} from "react";
 import Editor from "@components/rich-text-editor/Editor";
 import { formatBytes } from "@utils/formatBytes";
 
 interface CsmCaseCommentInputProps {
-  onSubmit: (html: string, internal: boolean) => Promise<unknown> | void;
+  onSubmit: (
+    html: string,
+    internal: boolean,
+    files: File[],
+  ) => Promise<unknown> | void;
   disabled?: boolean;
   /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
   autoFocus?: boolean;
+}
+
+/** Stable identity for an attached File, used to dedupe re-picked files. */
+function fileSignature(f: File): string {
+  return `${f.name}-${f.size}-${f.lastModified}`;
 }
 
 // Mirrors the BE request-body cap for POST /cases/{id}/comments
@@ -68,6 +84,28 @@ export default function CsmCaseCommentInput({
   const [sourceMode, setSourceMode] = useState(false);
   const [internal, setInternal] = useState(false);
   const [maximized, setMaximized] = useState(false);
+  // Files attached to this comment; uploaded to the case on send.
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const onAttachmentClick = useCallback(() => fileInputRef.current?.click(), []);
+  const onFilesPicked = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const picked = Array.from(e.target.files ?? []);
+      if (picked.length) {
+        setAttachments((prev) => {
+          const seen = new Set(prev.map(fileSignature));
+          return [...prev, ...picked.filter((f) => !seen.has(fileSignature(f)))];
+        });
+      }
+      // Reset so re-selecting the same file still fires onChange.
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    },
+    [],
+  );
+  const onAttachmentRemove = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  }, []);
 
   // Incrementing this trigger clears the editor (see Editor's ResetPlugin).
   const resetTriggerRef = useRef(0);
@@ -93,8 +131,9 @@ export default function CsmCaseCommentInput({
 
   const submit = useCallback(async () => {
     if (submitting || disabled) return;
-    if (isEmpty(html)) {
-      setError("Comment is empty.");
+    // Allow an attachment-only post (no text) — the case still gets the files.
+    if (isEmpty(html) && attachments.length === 0) {
+      setError("Add a comment or an attachment.");
       return;
     }
     if (overSizeLimit) {
@@ -104,8 +143,9 @@ export default function CsmCaseCommentInput({
     setError(null);
     setSubmitting(true);
     try {
-      await onSubmit(html, internal);
+      await onSubmit(html, internal, attachments);
       setHtml("");
+      setAttachments([]);
       resetTriggerRef.current += 1;
       setResetTrigger(resetTriggerRef.current);
       setEditorMountKey((k) => k + 1);
@@ -114,7 +154,16 @@ export default function CsmCaseCommentInput({
     } finally {
       setSubmitting(false);
     }
-  }, [disabled, html, internal, onSubmit, overSizeLimit, sizeError, submitting]);
+  }, [
+    disabled,
+    html,
+    attachments,
+    internal,
+    onSubmit,
+    overSizeLimit,
+    sizeError,
+    submitting,
+  ]);
 
   const toggleSourceMode = useCallback(
     (nextSource: boolean) => {
@@ -259,11 +308,24 @@ export default function CsmCaseCommentInput({
           showKeyboardHint
           autoFocus={autoFocus}
           enterToSubmit={false}
+          onAttachmentClick={onAttachmentClick}
+          attachments={attachments}
+          onAttachmentRemove={onAttachmentRemove}
           onSubmitKeyDown={() => {
             void submit();
           }}
         />
       )}
+
+      {/* Hidden picker driven by the editor toolbar's attach button. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        hidden
+        onChange={onFilesPicked}
+        aria-hidden
+      />
 
       <Box
         sx={{
@@ -288,7 +350,12 @@ export default function CsmCaseCommentInput({
           color={internal ? "warning" : "primary"}
           size="small"
           startIcon={internal ? <Lock size={16} /> : <Send size={16} />}
-          disabled={disabled || submitting || isEmpty(html) || overSizeLimit}
+          disabled={
+            disabled ||
+            submitting ||
+            (isEmpty(html) && attachments.length === 0) ||
+            overSizeLimit
+          }
           onClick={() => {
             void submit();
           }}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -31,13 +31,22 @@ import {
   Minimize2,
   Send,
 } from "@wso2/oxygen-ui-icons-react";
-import { useCallback, useRef, useState, type JSX } from "react";
+import { useCallback, useMemo, useRef, useState, type JSX } from "react";
 import Editor from "@components/rich-text-editor/Editor";
+import { formatBytes } from "@utils/formatBytes";
 
 interface CsmCaseCommentInputProps {
   onSubmit: (html: string, internal: boolean) => Promise<unknown> | void;
   disabled?: boolean;
 }
+
+// Mirrors the BE request-body cap for POST /cases/{id}/comments
+// (handler `maxCommentBodyBytes = 10 << 20`). Comments carry inline images as
+// base64 data URIs, so the body can get large; the BE returns 413 past this.
+const MAX_COMMENT_BODY_BYTES = 10 * 1024 * 1024;
+// Reserve headroom for the JSON envelope ({ type, content }) + string escaping
+// so the FE blocks before the BE rejects with 413.
+const MAX_COMMENT_CONTENT_BYTES = MAX_COMMENT_BODY_BYTES - 1024;
 
 /** Strip tags + collapse whitespace to decide if the editor is effectively empty. */
 function isEmpty(html: string): boolean {
@@ -65,10 +74,27 @@ export default function CsmCaseCommentInput({
   // per mount).
   const [editorMountKey, setEditorMountKey] = useState(0);
 
+  // UTF-8 byte size of the comment body. The BE caps the whole request body, so
+  // mirror it here to fail fast with a clear message instead of a 413.
+  const bodyBytes = useMemo(
+    () => new TextEncoder().encode(html).length,
+    [html],
+  );
+  const overSizeLimit = bodyBytes > MAX_COMMENT_CONTENT_BYTES;
+  const sizeError = overSizeLimit
+    ? `Comment is too large (${formatBytes(bodyBytes)}). Maximum is ${formatBytes(
+        MAX_COMMENT_BODY_BYTES,
+      )} — remove or shrink inline images.`
+    : null;
+
   const submit = useCallback(async () => {
     if (submitting || disabled) return;
     if (isEmpty(html)) {
       setError("Comment is empty.");
+      return;
+    }
+    if (overSizeLimit) {
+      setError(sizeError);
       return;
     }
     setError(null);
@@ -84,7 +110,7 @@ export default function CsmCaseCommentInput({
     } finally {
       setSubmitting(false);
     }
-  }, [disabled, html, internal, onSubmit, submitting]);
+  }, [disabled, html, internal, onSubmit, overSizeLimit, sizeError, submitting]);
 
   const toggleSourceMode = useCallback(
     (nextSource: boolean) => {
@@ -242,9 +268,10 @@ export default function CsmCaseCommentInput({
       >
         <Typography
           variant="caption"
-          color={error ? "error" : "text.secondary"}
+          color={sizeError || error ? "error" : "text.secondary"}
         >
-          {error ??
+          {sizeError ??
+            error ??
             (sourceMode
               ? "Output is sent as-is. Use this to fix paste-formatting or insert tables."
               : "Ctrl/Cmd + Enter to send.")}
@@ -254,7 +281,7 @@ export default function CsmCaseCommentInput({
           color={internal ? "warning" : "primary"}
           size="small"
           startIcon={internal ? <Lock size={16} /> : <Send size={16} />}
-          disabled={disabled || submitting || isEmpty(html)}
+          disabled={disabled || submitting || isEmpty(html) || overSizeLimit}
           onClick={() => {
             void submit();
           }}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -37,18 +37,24 @@ import {
   useMemo,
   useRef,
   useState,
-  type ChangeEvent,
   type JSX,
 } from "react";
 import Editor from "@components/rich-text-editor/Editor";
 import { formatBytes } from "@utils/formatBytes";
 import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/csm-cases/api/useCsmCaseAttachments";
+import CsmUploadAttachmentModal from "@features/csm-cases/components/CsmUploadAttachmentModal";
+
+/** A file staged for upload, with the display name chosen in the modal. */
+export interface CommentAttachmentDraft {
+  file: File;
+  name: string;
+}
 
 interface CsmCaseCommentInputProps {
   onSubmit: (
     html: string,
     internal: boolean,
-    files: File[],
+    attachments: CommentAttachmentDraft[],
   ) => Promise<unknown> | void;
   disabled?: boolean;
   /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
@@ -86,24 +92,19 @@ export default function CsmCaseCommentInput({
   const [internal, setInternal] = useState(false);
   const [maximized, setMaximized] = useState(false);
   // Files attached to this comment; uploaded to the case on send.
-  const [attachments, setAttachments] = useState<File[]>([]);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [attachments, setAttachments] = useState<CommentAttachmentDraft[]>([]);
+  const [attachModalOpen, setAttachModalOpen] = useState(false);
 
-  const onAttachmentClick = useCallback(() => fileInputRef.current?.click(), []);
-  const onFilesPicked = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const picked = Array.from(e.target.files ?? []);
-      if (picked.length) {
-        setAttachments((prev) => {
-          const seen = new Set(prev.map(fileSignature));
-          return [...prev, ...picked.filter((f) => !seen.has(fileSignature(f)))];
-        });
+  const onAttachmentClick = useCallback(() => setAttachModalOpen(true), []);
+  const onSelectAttachment = useCallback((file: File, name: string) => {
+    setAttachments((prev) => {
+      // Dedupe re-picked files by identity (the chosen name may still differ).
+      if (prev.some((a) => fileSignature(a.file) === fileSignature(file))) {
+        return prev;
       }
-      // Reset so re-selecting the same file still fires onChange.
-      if (fileInputRef.current) fileInputRef.current.value = "";
-    },
-    [],
-  );
+      return [...prev, { file, name }];
+    });
+  }, []);
   const onAttachmentRemove = useCallback((index: number) => {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
   }, []);
@@ -144,7 +145,9 @@ export default function CsmCaseCommentInput({
     // Pre-validate file sizes before posting anything: the send is multi-step
     // (comment then uploads), so catching an oversized file here avoids posting
     // the comment and then failing on the upload (which would double-post on retry).
-    const tooLarge = attachments.find((f) => f.size > MAX_ATTACHMENT_SIZE_BYTES);
+    const tooLarge = attachments.find(
+      (a) => a.file.size > MAX_ATTACHMENT_SIZE_BYTES,
+    );
     if (tooLarge) {
       setError(
         `"${tooLarge.name}" is too large. The maximum attachment size is ${formatBytes(
@@ -322,7 +325,7 @@ export default function CsmCaseCommentInput({
           autoFocus={autoFocus}
           enterToSubmit={false}
           onAttachmentClick={onAttachmentClick}
-          attachments={attachments}
+          attachments={attachments.map((a) => a.file)}
           onAttachmentRemove={onAttachmentRemove}
           onSubmitKeyDown={() => {
             void submit();
@@ -330,14 +333,11 @@ export default function CsmCaseCommentInput({
         />
       )}
 
-      {/* Hidden picker driven by the editor toolbar's attach button. */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        multiple
-        hidden
-        onChange={onFilesPicked}
-        aria-hidden
+      {/* Naming picker driven by the editor toolbar's attach button. */}
+      <CsmUploadAttachmentModal
+        open={attachModalOpen}
+        onClose={() => setAttachModalOpen(false)}
+        onSelect={onSelectAttachment}
       />
 
       <Box

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -15,6 +15,7 @@
 // under the License.
 
 import {
+  alpha,
   Box,
   Button,
   FormControlLabel,
@@ -133,7 +134,9 @@ export default function CsmCaseCommentInput({
         gap: 1,
         p: internal ? 1.25 : 0,
         borderRadius: internal ? 1 : 0,
-        backgroundColor: internal ? "warning.50" : undefined,
+        backgroundColor: internal
+          ? (theme) => alpha(theme.palette.warning.main, 0.15)
+          : undefined,
         border: internal ? 1 : 0,
         borderColor: internal ? "warning.main" : undefined,
       }}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -38,6 +38,8 @@ import { formatBytes } from "@utils/formatBytes";
 interface CsmCaseCommentInputProps {
   onSubmit: (html: string, internal: boolean) => Promise<unknown> | void;
   disabled?: boolean;
+  /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
+  autoFocus?: boolean;
 }
 
 // Mirrors the BE request-body cap for POST /cases/{id}/comments
@@ -57,6 +59,7 @@ function isEmpty(html: string): boolean {
 export default function CsmCaseCommentInput({
   onSubmit,
   disabled = false,
+  autoFocus = false,
 }: CsmCaseCommentInputProps): JSX.Element {
   const [html, setHtml] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
@@ -251,6 +254,7 @@ export default function CsmCaseCommentInput({
           maxHeight={maximized ? 720 : 260}
           toolbarVariant="full"
           showKeyboardHint
+          autoFocus={autoFocus}
           enterToSubmit={false}
           onSubmitKeyDown={() => {
             void submit();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
@@ -160,7 +160,16 @@ export default function CsmUploadAttachmentModal({
         />
         {!file ? (
           <Box
+            role="button"
+            tabIndex={0}
+            aria-label="Choose a file to attach"
             onClick={() => fileInputRef.current?.click()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                fileInputRef.current?.click();
+              }
+            }}
             onDrop={onDrop}
             onDragOver={(e) => {
               e.preventDefault();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmUploadAttachmentModal.tsx
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Paperclip, Upload, X } from "@wso2/oxygen-ui-icons-react";
+import {
+  useCallback,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type JSX,
+} from "react";
+import { formatBytes } from "@utils/formatBytes";
+import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/csm-cases/api/useCsmCaseAttachments";
+
+interface CsmUploadAttachmentModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Hand the chosen file + display name back to the composer. */
+  onSelect: (file: File, name: string) => void;
+}
+
+function fileExtension(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  return dot < 0 || dot === fileName.length - 1 ? "" : fileName.slice(dot);
+}
+
+function baseFileName(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  return dot < 0 || dot === fileName.length - 1 ? fileName : fileName.slice(0, dot);
+}
+
+/** Keep the original extension on a renamed file so the type stays obvious. */
+function withExtension(name: string, ext: string): string {
+  if (!ext) return name;
+  return name.toLowerCase().endsWith(ext.toLowerCase()) ? name : `${name}${ext}`;
+}
+
+/**
+ * Pick (or drop) a single file and give it a display name before attaching it
+ * to a comment. Mirrors the customer portal's UploadAttachmentModal `onSelect`
+ * flow — the file isn't uploaded here; the composer uploads it on send.
+ */
+export default function CsmUploadAttachmentModal({
+  open,
+  onClose,
+  onSelect,
+}: CsmUploadAttachmentModalProps): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState("");
+  const [dragOver, setDragOver] = useState(false);
+
+  const tooLarge = !!file && file.size > MAX_ATTACHMENT_SIZE_BYTES;
+  const displayName = name.trim() || (file ? baseFileName(file.name) : "");
+  const canAdd = !!file && !tooLarge && !!displayName;
+
+  const reset = useCallback(() => {
+    setFile(null);
+    setName("");
+    setDragOver(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [onClose, reset]);
+
+  const pickFile = useCallback((selected: File | null) => {
+    setFile(selected);
+    if (selected) setName(baseFileName(selected.name));
+  }, []);
+
+  const onInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      pickFile(e.target.files?.[0] ?? null);
+      e.target.value = "";
+    },
+    [pickFile],
+  );
+
+  const onDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const dropped = e.dataTransfer.files?.[0];
+      if (dropped) pickFile(dropped);
+    },
+    [pickFile],
+  );
+
+  const handleAdd = useCallback(() => {
+    if (!file || tooLarge) return;
+    const finalName = withExtension(
+      name.trim() || baseFileName(file.name),
+      fileExtension(file.name),
+    );
+    if (!finalName) return;
+    onSelect(file, finalName);
+    handleClose();
+  }, [file, name, tooLarge, onSelect, handleClose]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="csm-upload-attachment-title"
+    >
+      <DialogTitle id="csm-upload-attachment-title" sx={{ pr: 6 }}>
+        Attach a file
+        <IconButton
+          aria-label="Close"
+          onClick={handleClose}
+          size="small"
+          sx={{ position: "absolute", right: 12, top: 12 }}
+        >
+          <X size={20} aria-hidden />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        {tooLarge && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {file?.name} is {formatBytes(file.size)}. The maximum attachment size
+            is {formatBytes(MAX_ATTACHMENT_SIZE_BYTES)}.
+          </Alert>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          hidden
+          onChange={onInputChange}
+          aria-hidden
+        />
+        {!file ? (
+          <Box
+            onClick={() => fileInputRef.current?.click()}
+            onDrop={onDrop}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragOver(true);
+            }}
+            onDragLeave={() => setDragOver(false)}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1,
+              py: 4,
+              px: 2,
+              borderRadius: 1,
+              border: "1px dashed",
+              borderColor: dragOver ? "primary.main" : "divider",
+              backgroundColor: dragOver ? "action.hover" : "transparent",
+              cursor: "pointer",
+              textAlign: "center",
+            }}
+          >
+            <Upload size={24} />
+            <Typography variant="body2">
+              Drag a file here, or click to choose
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Up to {formatBytes(MAX_ATTACHMENT_SIZE_BYTES)}
+            </Typography>
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              p: 1,
+              borderRadius: 1,
+              border: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Paperclip size={16} />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography variant="body2" noWrap>
+                {file.name}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {formatBytes(file.size)} · {file.type || "unknown type"}
+              </Typography>
+            </Box>
+            <Button size="small" variant="text" onClick={() => pickFile(null)}>
+              Change
+            </Button>
+          </Box>
+        )}
+
+        <TextField
+          fullWidth
+          label="Attachment name"
+          placeholder="Leave empty to use the file name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={!file}
+          sx={{ mt: 2 }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2, pt: 1 }}>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleAdd}
+          disabled={!canAdd}
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -27,13 +27,14 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import { priorityFromSeverity } from "@api/backend/mappers";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
+import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
@@ -61,7 +62,16 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const navigate = useNavigate();
   const { showError } = useErrorBanner();
 
-  const [projectId, setProjectId] = useState("");
+  // When the form is opened from a project's page (`/cases/new?projectId=…`),
+  // the project is fixed and shown read-only: the engineer can't accidentally
+  // file the case against the wrong project. The id seeds the form's project
+  // state once and the picker is replaced by a locked field. Opened without the
+  // param (the cases-list "New case" entry), the searchable picker is shown.
+  const [searchParams] = useSearchParams();
+  const lockedProjectId = searchParams.get("projectId") ?? "";
+  const isProjectLocked = !!lockedProjectId;
+
+  const [projectId, setProjectId] = useState(lockedProjectId);
   const [deploymentId, setDeploymentId] = useState("");
   const [deployedProductId, setDeployedProductId] = useState("");
   const [severity, setSeverity] = useState<Severity | "">("");
@@ -72,6 +82,15 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
+
+  // Resolve the locked project's display name so the read-only field shows the
+  // name (not the raw id). Only fetched when the form is project-scoped.
+  const lockedProject = useGetProject(isProjectLocked ? lockedProjectId : undefined);
+  const lockedProjectLabel = lockedProject.data?.name
+    ? lockedProject.data.name
+    : lockedProject.isLoading
+      ? "Loading project…"
+      : lockedProjectId;
 
   // When a selector query fails the form becomes non-completable, so surface it
   // with an explicit retry rather than leaving an empty dropdown. (Projects are
@@ -170,11 +189,31 @@ export default function CsmCaseCreatePage(): JSX.Element {
         )}
         <Grid container spacing={2.5}>
           <Grid size={{ xs: 12, md: 4 }}>
-            <AsyncProjectSelect
-              value={projectId}
-              onChange={onProjectChange}
-              required
-            />
+            {isProjectLocked ? (
+              <TextField
+                fullWidth
+                size="small"
+                label="Project"
+                required
+                value={lockedProjectLabel}
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    endAdornment: (
+                      <Lock size={16} aria-hidden style={{ opacity: 0.6 }} />
+                    ),
+                  },
+                  htmlInput: { "aria-readonly": true },
+                }}
+                helperText="Locked to the project you opened this from. To file against another project, open that project first."
+              />
+            ) : (
+              <AsyncProjectSelect
+                value={projectId}
+                onChange={onProjectChange}
+                required
+              />
+            )}
           </Grid>
 
           <Grid size={{ xs: 12, md: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -31,6 +31,7 @@ import { ArrowLeft, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { priorityFromSeverity } from "@api/backend/mappers";
+import { formatBytes } from "@utils/formatBytes";
 import Editor from "@components/rich-text-editor/Editor";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
@@ -57,6 +58,16 @@ const ISSUE_TYPES: { value: BeCaseIssueType; label: string }[] = [
 function isEmptyHtml(html: string): boolean {
   return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
 }
+
+// Cap the case-create body, which carries the description HTML (with base64
+// inline images). FOLLOW-UP: the CSM backend currently caps POST /cases at
+// 1 MiB (maxRequestBodyBytes); this 10 MiB FE cap assumes the endpoint is
+// raised to match the comment endpoint (maxCommentBodyBytes = 10 MiB). Until
+// the BE matches, it still returns 413 past 1 MiB.
+const MAX_DESCRIPTION_BODY_BYTES = 10 * 1024 * 1024;
+// Reserve headroom for the other create fields (ids, subject) + JSON envelope
+// so the FE blocks before the BE rejects.
+const MAX_DESCRIPTION_CONTENT_BYTES = MAX_DESCRIPTION_BODY_BYTES - 4 * 1024;
 
 export default function CsmCaseCreatePage(): JSX.Element {
   const navigate = useNavigate();
@@ -101,6 +112,21 @@ export default function CsmCaseCreatePage(): JSX.Element {
     if (deployedProducts.isError) void deployedProducts.refetch();
   };
 
+  // UTF-8 byte size of the description; the BE caps the whole create body, so
+  // mirror it here to fail fast with a clear message instead of a 413.
+  const descriptionBytes = useMemo(
+    () => new TextEncoder().encode(description).length,
+    [description],
+  );
+  const descriptionOverLimit = descriptionBytes > MAX_DESCRIPTION_CONTENT_BYTES;
+  const descriptionError = descriptionOverLimit
+    ? `The case description is too large (${formatBytes(
+        descriptionBytes,
+      )}). Maximum is ${formatBytes(
+        MAX_DESCRIPTION_BODY_BYTES,
+      )} — reduce the size or the number of inline images and try again.`
+    : null;
+
   const canSubmit = useMemo(
     () =>
       !!projectId &&
@@ -110,6 +136,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       !!issueType &&
       subject.trim().length > 0 &&
       !isEmptyHtml(description) &&
+      !descriptionOverLimit &&
       !postCase.isPending,
     [
       projectId,
@@ -119,6 +146,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       issueType,
       subject,
       description,
+      descriptionOverLimit,
       postCase.isPending,
     ],
   );
@@ -135,7 +163,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
   };
 
   const handleSubmit = (): void => {
-    if (!canSubmit || !severity || !issueType) return;
+    if (!canSubmit || !severity || !issueType || descriptionOverLimit) return;
     postCase.mutate(
       {
         projectId,
@@ -336,6 +364,15 @@ export default function CsmCaseCreatePage(): JSX.Element {
                 disabled={postCase.isPending}
               />
             </Box>
+            {descriptionError && (
+              <Typography
+                variant="caption"
+                color="error"
+                sx={{ display: "block", mt: 0.5 }}
+              >
+                {descriptionError}
+              </Typography>
+            )}
           </Grid>
         </Grid>
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -464,12 +464,16 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
   const onDownloadAllAttachments = useCallback(() => {
     if (!caseId) return;
-    // No bulk endpoint; fetch each sequentially and save.
-    attachmentList.forEach((a) => {
-      void downloadAttachment(caseId, a).catch((err) =>
-        showError(`Could not download ${a.filename}.`, err),
-      );
-    });
+    // No bulk endpoint; fetch each sequentially (not a parallel burst) and save.
+    void (async () => {
+      for (const a of attachmentList) {
+        try {
+          await downloadAttachment(caseId, a);
+        } catch (err) {
+          showError(`Could not download ${a.filename}.`, err);
+        }
+      }
+    })();
   }, [caseId, attachmentList, downloadAttachment, showError]);
 
   if (isLoading) {

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -780,16 +780,34 @@ export default function CsmCaseDetailPage(): JSX.Element {
               <CsmCaseCommentInput
                 disabled={!caseId}
                 autoFocus
-                onSubmit={async (bodyHtml, internal) => {
+                onSubmit={async (bodyHtml, internal, files) => {
                   if (!caseId) return;
-                  await postComment.mutateAsync({
-                    caseId,
-                    bodyHtml,
-                    authorName: engineerName,
-                    internal,
-                  });
+                  // Post the comment only when there's text; an attachment-only
+                  // send skips the comment endpoint and just uploads the files.
+                  const hasText =
+                    bodyHtml
+                      .replace(/<[^>]*>/g, "")
+                      .replace(/&nbsp;/g, " ")
+                      .trim().length > 0;
+                  if (hasText) {
+                    await postComment.mutateAsync({
+                      caseId,
+                      bodyHtml,
+                      authorName: engineerName,
+                      internal,
+                    });
+                  }
+                  // Attachments are case-level (no comment linkage on the BE);
+                  // upload each sequentially so a failure surfaces clearly.
+                  for (const file of files) {
+                    await postAttachment.mutateAsync({
+                      caseId,
+                      file,
+                      uploadedBy: engineerName,
+                    });
+                  }
                   // Collapse only on success; on error the input keeps its
-                  // draft and surfaces the failure.
+                  // draft + files and surfaces the failure.
                   setComposerOpen(false);
                 }}
               />

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -760,7 +760,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               <CsmCaseCommentInput
                 disabled={!caseId}
                 autoFocus
-                onSubmit={async (bodyHtml, internal, files) => {
+                onSubmit={async (bodyHtml, internal, commentAttachments) => {
                   if (!caseId) return;
                   // Post the comment only when there's text; an attachment-only
                   // send skips the comment endpoint and just uploads the files.
@@ -779,10 +779,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   }
                   // Attachments are case-level (no comment linkage on the BE);
                   // upload each sequentially so a failure surfaces clearly.
-                  for (const file of files) {
+                  for (const { file, name } of commentAttachments) {
                     await postAttachment.mutateAsync({
                       caseId,
                       file,
+                      name,
                       uploadedBy: engineerName,
                     });
                   }

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -37,7 +37,7 @@ import {
   TriangleAlert,
   X,
 } from "@wso2/oxygen-ui-icons-react";
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
 import { usePatchCsmCase } from "@features/csm-cases/api/usePatchCsmCase";
@@ -47,6 +47,11 @@ import {
   useGetCsmCaseComments,
   usePostCsmCaseComment,
 } from "@features/csm-cases/api/useCsmCaseComments";
+import {
+  useGetCsmCaseAttachments,
+  usePostCsmCaseAttachment,
+  useDownloadCsmCaseAttachment,
+} from "@features/csm-cases/api/useCsmCaseAttachments";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
@@ -73,7 +78,10 @@ import {
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
-import type { CaseLifecycleAction } from "@features/csm-cases/types/csmCases";
+import type {
+  CaseAttachment,
+  CaseLifecycleAction,
+} from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 
 function MetaCell({
@@ -182,8 +190,6 @@ const SECONDARY_TOAST: Record<string, string> = {
   request_call: "Request a call dialog (mock).",
   log_time: "Log time dialog (mock).",
   copy_link: "Case link copied to clipboard.",
-  download_all_attachments: "Preparing all attachments for download (mock).",
-  download_attachment: "Downloading attachment (mock).",
 };
 
 type CaseTabId =
@@ -239,6 +245,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
     isError: isCommentsError,
   } = useGetCsmCaseComments(caseId);
   const postComment = usePostCsmCaseComment();
+  const {
+    data: attachments,
+    isLoading: isAttachmentsLoading,
+    isError: isAttachmentsError,
+    refetch: refetchAttachments,
+  } = useGetCsmCaseAttachments(caseId);
+  const postAttachment = usePostCsmCaseAttachment();
+  const downloadAttachment = useDownloadCsmCaseAttachment();
   const patchCase = usePatchCsmCase(caseId);
   const recordView = useRecordRecentView();
   const claims = useIdTokenClaims();
@@ -416,6 +430,47 @@ export default function CsmCaseDetailPage(): JSX.Element {
     },
     [data, showError, patchCase],
   );
+
+  const attachmentList = useMemo(() => attachments ?? [], [attachments]);
+
+  const onUploadAttachment = useCallback(
+    (file: File) => {
+      if (!caseId) return;
+      postAttachment.mutate(
+        { caseId, file, uploadedBy: engineerName },
+        {
+          onSuccess: () =>
+            setFeedback({
+              message: `Uploaded ${file.name}.`,
+              severity: "success",
+              sticky: false,
+            }),
+          // Failures surface inline on the widget via postAttachment.error.
+        },
+      );
+    },
+    [caseId, engineerName, postAttachment],
+  );
+
+  const onDownloadAttachment = useCallback(
+    (attachment: CaseAttachment) => {
+      if (!caseId) return;
+      void downloadAttachment(caseId, attachment).catch((err) =>
+        showError(`Could not download ${attachment.filename}.`, err),
+      );
+    },
+    [caseId, downloadAttachment, showError],
+  );
+
+  const onDownloadAllAttachments = useCallback(() => {
+    if (!caseId) return;
+    // No bulk endpoint; fetch each sequentially and save.
+    attachmentList.forEach((a) => {
+      void downloadAttachment(caseId, a).catch((err) =>
+        showError(`Could not download ${a.filename}.`, err),
+      );
+    });
+  }, [caseId, attachmentList, downloadAttachment, showError]);
 
   if (isLoading) {
     return (
@@ -675,7 +730,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             // Counts shown only where the tab IS the list (unambiguous).
             const count =
               t.id === "attachments"
-                ? c.attachments.length
+                ? attachmentList.length
                 : t.id === "time"
                   ? c.timeLogs.length
                   : undefined;
@@ -771,7 +826,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 <Chip
                   size="small"
                   variant="outlined"
-                  label={`${safeComments.length + c.audit.length + c.attachments.length} entries`}
+                  label={`${safeComments.length + c.audit.length + attachmentList.length} entries`}
                 />
               )}
             </Box>
@@ -796,7 +851,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 <CaseActivitiesFeed
                   comments={safeComments}
                   audit={c.audit}
-                  attachments={c.attachments}
+                  attachments={attachmentList}
                 />
               </>
             )}
@@ -884,9 +939,20 @@ export default function CsmCaseDetailPage(): JSX.Element {
       {activeTab === "attachments" && (
         <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
           <AttachmentsWidget
-            attachments={c.attachments}
-            onDownloadAll={() => onAction({ secondary: "download_all_attachments" })}
-            onDownload={() => onAction({ secondary: "download_attachment" })}
+            attachments={attachmentList}
+            loading={isAttachmentsLoading}
+            error={isAttachmentsError}
+            onRetry={() => void refetchAttachments()}
+            uploading={postAttachment.isPending}
+            uploadError={
+              postAttachment.isError
+                ? (postAttachment.error?.message ??
+                  "Could not upload the attachment.")
+                : null
+            }
+            onUpload={onUploadAttachment}
+            onDownloadAll={onDownloadAllAttachments}
+            onDownload={onDownloadAttachment}
           />
         </Box>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -779,6 +779,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </Box>
               <CsmCaseCommentInput
                 disabled={!caseId}
+                autoFocus
                 onSubmit={async (bodyHtml, internal) => {
                   if (!caseId) return;
                   await postComment.mutateAsync({

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -101,16 +101,6 @@ function MetaCell({
   );
 }
 
-// Reopening a closed case is a lead-only override. We match the lead role from
-// the ID-token group claims.
-// TODO(authz): confirm the exact Asgardeo group(s)/role(s) that designate a
-// "lead" with the gateway/permission model — these identifiers are provisional.
-const LEAD_REOPEN_ROLES = new Set([
-  "cre_lead",
-  "CRE_LEADS_GROUP",
-  "leadership",
-]);
-
 const LIFECYCLE_TOAST: Record<CaseLifecycleAction, string> = {
   start_work: "Started work on this case.",
   assign_to_me: "Assigned to you.",
@@ -120,7 +110,6 @@ const LIFECYCLE_TOAST: Record<CaseLifecycleAction, string> = {
   resume_work: "Resumed work on this case.",
   close: "Case closed.",
   close_no_response: "Closed (no response received).",
-  reopen: "Case reopened.",
   transition: "Case updated.",
 };
 
@@ -145,7 +134,6 @@ const LIFECYCLE_SEVERITY: Record<CaseLifecycleAction, FeedbackSeverity> = {
   resume_work: "info",
   close: "success",
   close_no_response: "success",
-  reopen: "info",
   transition: "info",
 };
 
@@ -162,7 +150,6 @@ const LIFECYCLE_TARGET_STATE: Partial<
   wait_on_wso2: "waiting_on_wso2",
   close: "closed",
   close_no_response: "closed",
-  reopen: "reopened",
 };
 
 const FEEDBACK_PALETTE: Record<
@@ -533,9 +520,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // both wrong and the main source of orange on the screen. Only show SLA
   // affordances when we actually have clock data (mock, and LIVE once wired).
   const hasSlaData = c.slaClocks.length > 0;
-  const canReopenClosed = (claims?.groups ?? []).some((g) =>
-    LEAD_REOPEN_ROLES.has(g),
-  );
   // The case description is already returned by `comments/search` as the
   // opening comment, so the stream renders it directly — no synthetic entry is
   // injected (that duplicated the first comment).
@@ -659,11 +643,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           <Typography variant="h5">{c.subject}</Typography>
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
-          <CaseActionBar
-            caseDetail={c}
-            onAction={onAction}
-            canReopenClosed={canReopenClosed}
-          />
+          <CaseActionBar caseDetail={c} onAction={onAction} />
         </Box>
       </Box>
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -857,6 +857,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   comments={safeComments}
                   audit={c.audit}
                   attachments={attachmentList}
+                  onDownloadAttachment={onDownloadAttachment}
                 />
               </>
             )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -221,7 +221,6 @@ export type CaseLifecycleAction =
   | "resume_work"
   | "close"
   | "close_no_response"
-  | "reopen"
   // Generic transition into a state the frontend has no curated action for
   // (e.g. a state added on the backend). Drives the post-transition toast only;
   // the PATCH target always comes from the backend `nextStates` value.

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -43,7 +43,6 @@ const VALID_STATES: CaseState[] = [
   "solution_proposed",
   "awaiting_info",
   "waiting_on_wso2",
-  "reopened",
   "closed",
 ];
 const VALID_SLA: SlaFilter[] = ["any", "at_risk", "breached"];

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.test.ts
@@ -67,10 +67,10 @@ describe("savedFilterViews", () => {
   });
 
   it("persists across a fresh hook mount (reload)", () => {
-    act(() => saveFilterView("Persisted", "states=reopened"));
+    act(() => saveFilterView("Persisted", "states=waiting_on_wso2"));
     const remount = renderHook(() => useSavedFilterViews());
     expect(remount.result.current).toEqual([
-      { name: "Persisted", qs: "states=reopened" },
+      { name: "Persisted", qs: "states=waiting_on_wso2" },
     ]);
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/savedFilterViews.ts
@@ -40,7 +40,7 @@ const MAX_VIEWS = 50;
  * not yet).
  */
 export const SUGGESTED_FILTER_VIEWS: readonly SavedFilterView[] = [
-  { name: "S0/S1 active", qs: "severities=S0,S1&states=open,work_in_progress,reopened" },
+  { name: "S0/S1 active", qs: "severities=S0,S1&states=open,work_in_progress" },
   { name: "Awaiting info", qs: "states=awaiting_info" },
   { name: "Open (unstarted)", qs: "states=open" },
 ];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/mocks/dashboardMocks.ts
@@ -293,7 +293,7 @@ const sumQueue = (cases: CsmQueueCase[]) => {
   let inProgress = 0;
   let awaitingInfo = 0;
   for (const c of cases) {
-    if (c.state === "open" || c.state === "reopened") actionRequired += 1;
+    if (c.state === "open") actionRequired += 1;
     else if (c.state === "work_in_progress") inProgress += 1;
     else if (c.state === "awaiting_info") awaitingInfo += 1;
   }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -102,6 +102,13 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
         // scoped to active cases (priority AND active-state), not the whole
         // population.
         const activeStateKeys = COMPOSITION_STATES.map(beStateFromUi);
+        // The state/closed counts don't filter by severity. The backend,
+        // however, counts only catastrophic cases when `priorityKeys` is absent
+        // (an empty priority filter is not treated as "all"), which made the
+        // state pie show the S0 row only and disagree with the matrix totals.
+        // Pass every priority explicitly so these counts span all severities.
+        // BE follow-up: treat an absent/empty priorityKeys as "all priorities".
+        const allPriorityKeys = MATRIX_SEVERITIES.map(priorityFromSeverity);
 
         // All severity + state counts (plus the closed total) fire in one wave.
         const [severityCounts, stateCounts, closedCount] = await Promise.all([
@@ -120,13 +127,19 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             COMPOSITION_STATES.map((st) =>
               countTotal({
                 pagination: { offset: 0, limit: 1 },
-                filters: { stateKeys: [beStateFromUi(st)] },
+                filters: {
+                  stateKeys: [beStateFromUi(st)],
+                  priorityKeys: allPriorityKeys,
+                },
               }).then((n) => ({ key: st, n })),
             ),
           ),
           countTotal({
             pagination: { offset: 0, limit: 1 },
-            filters: { stateKeys: [beStateFromUi("closed")] },
+            filters: {
+              stateKeys: [beStateFromUi("closed")],
+              priorityKeys: allPriorityKeys,
+            },
           }),
         ]);
         severityCounts.forEach(({ key, n }) => (bySeverity[key] = n));

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -109,8 +109,10 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             MATRIX_SEVERITIES.map((sev) =>
               countTotal({
                 pagination: { offset: 0, limit: 1 },
-                priorityKeys: [priorityFromSeverity(sev)],
-                stateKeys: activeStateKeys,
+                filters: {
+                  priorityKeys: [priorityFromSeverity(sev)],
+                  stateKeys: activeStateKeys,
+                },
               }).then((n) => ({ key: sev, n })),
             ),
           ),
@@ -118,13 +120,13 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             COMPOSITION_STATES.map((st) =>
               countTotal({
                 pagination: { offset: 0, limit: 1 },
-                stateKeys: [beStateFromUi(st)],
+                filters: { stateKeys: [beStateFromUi(st)] },
               }).then((n) => ({ key: st, n })),
             ),
           ),
           countTotal({
             pagination: { offset: 0, limit: 1 },
-            stateKeys: [beStateFromUi("closed")],
+            filters: { stateKeys: [beStateFromUi("closed")] },
           }),
         ]);
         severityCounts.forEach(({ key, n }) => (bySeverity[key] = n));

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -37,7 +37,6 @@ export const MATRIX_STATES: CaseState[] = [
   "waiting_on_wso2",
   "awaiting_info",
   "solution_proposed",
-  "reopened",
 ];
 
 export interface CaseCountsMatrix {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -106,8 +106,10 @@ export function useCaseCountsMatrix(): UseQueryResult<CaseCountsMatrix, Error> {
           api
             .post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
               pagination: { offset: 0, limit: 1 },
-              priorityKeys: [priorityFromSeverity(severity)],
-              stateKeys: [beStateFromUi(state)],
+              filters: {
+                priorityKeys: [priorityFromSeverity(severity)],
+                stateKeys: [beStateFromUi(state)],
+              },
             })
             .then((res) => ({ severity, state, count: res.total ?? 0 })),
         ),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
@@ -50,7 +50,6 @@ const STATE_SLICE_COLOR: Record<CaseState, string> = {
   waiting_on_wso2: paletteColor("amber", 700, "#b45309"),
   awaiting_info: paletteColor("cyan", 500, "#06b6d4"),
   solution_proposed: paletteColor("teal", 500, "#14b8a6"),
-  reopened: paletteColor("deepOrange", 400, "#ff7043"),
   closed: paletteColor("grey", 500, "#6b7280"),
 };
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -67,9 +67,9 @@ function CountCell({
         underline="hover"
         color="inherit"
         sx={{
-          // Larger, heavier numbers so the counts read at a glance from across
-          // the dashboard, not just on close inspection.
-          fontSize: bold ? "1.35rem" : "1.2rem",
+          // Keep the counts readable but compact — totals a touch larger/heavier
+          // so the row/column sums still stand out from the per-cell values.
+          fontSize: bold ? "1rem" : "0.9rem",
           fontWeight: bold ? 700 : 600,
           lineHeight: 1,
         }}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyQueueSection.tsx
@@ -116,7 +116,7 @@ export default function MyQueueSection({
         <StatPill
           label="Action required"
           value={isLoading ? "—" : (queue?.actionRequiredCount ?? 0)}
-          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN], states: ["open", "reopened"] })}
+          href={casesHref({ assignees: [ASSIGNEE_ME_TOKEN], states: ["open"] })}
           onNavigate={go}
         />
         <StatPill

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
@@ -22,7 +22,6 @@ export type CaseState =
   | "solution_proposed"
   | "awaiting_info"
   | "waiting_on_wso2"
-  | "reopened"
   | "closed";
 
 export type SlaClockType = "ack" | "first_response" | "resolution";

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
@@ -46,7 +46,6 @@ export const STATE_LABEL: Record<CaseState, string> = {
   solution_proposed: "Solution proposed",
   awaiting_info: "Awaiting info",
   waiting_on_wso2: "Waiting on WSO2",
-  reopened: "Reopened",
   closed: "Closed",
 };
 
@@ -55,7 +54,7 @@ export const STATE_LABEL: Record<CaseState, string> = {
 // brand orange (the old `isClosed ? "success" : "primary"`, which also failed
 // WCAG contrast). The four buckets:
 //   info (blue)    = active, on us, normal      -> open, work_in_progress
-//   warning (amber)= active, on us, elevated    -> waiting_on_wso2, reopened
+//   warning (amber)= active, on us, elevated    -> waiting_on_wso2
 //   default (grey) = waiting on the customer     -> solution_proposed, awaiting_info
 //   success (green)= done                        -> closed
 // All four roles have a dark `contrastText` in this theme, so filled chips pass
@@ -68,7 +67,6 @@ export const STATE_COLOR: Record<
   open: "info",
   work_in_progress: "info",
   waiting_on_wso2: "warning",
-  reopened: "warning",
   solution_proposed: "default",
   awaiting_info: "default",
   closed: "success",

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useGetProject.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useGetProject.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAuthApiClient } from "@hooks/useAuthApiClient";
+import { apiConfig } from "@config/apiConfig";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
+import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
+
+/**
+ * Look up a single project by id via `GET /projects/{id}` (BFF passthrough to
+ * the entity service). The response is the enriched {@link ProjectDetails} shape
+ * with the parent `account` embedded. Returns `null` (not an error) on 404 so
+ * the page can render a not-found state instead of an error banner. The query
+ * stays disabled until an id is present so a bare `/projects/` never fires.
+ */
+export function useGetProject(
+  id: string | undefined,
+): UseQueryResult<ProjectDetails | null, Error> {
+  const authFetch = useAuthApiClient();
+
+  return useQuery<ProjectDetails | null, Error>({
+    queryKey: [ApiQueryKeys.CSM_PROJECT_DETAIL, id ?? ""],
+    queryFn: async (): Promise<ProjectDetails | null> => {
+      if (!id) return null;
+
+      const res = await authFetch(
+        `${apiConfig.backendUrl}/projects/${encodeURIComponent(id)}`,
+      );
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ApiError(
+          res.status,
+          res.statusText,
+          parseApiResponseMessage(body, res.status, res.statusText),
+        );
+      }
+      return (await res.json()) as ProjectDetails;
+    },
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode } from "react";
+import { Link as RouterLink, useNavigate, useParams } from "react-router";
+import { useGetProject } from "@features/csm-projects/api/useGetProject";
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString();
+}
+
+function formatSubscriptionType(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function MetaCell({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+// Real anchor (RouterLink) so the account link is cmd/middle-clickable and
+// copyable, with plain left-click staying in-app. Colour is picked per colour
+// scheme: brand orange (`primary.main`) fails WCAG AA on a light surface, while
+// `primary.dark` fails on the dark surface, so we apply the dark shade only in
+// the light scheme and vice versa (matching the case meta band's links).
+function LinkText({ to, children }: { to: string; children: ReactNode }): JSX.Element {
+  return (
+    <Typography
+      component={RouterLink}
+      to={to}
+      variant="body2"
+      sx={(t) => ({
+        cursor: "pointer",
+        textDecoration: "none",
+        color: t.palette.primary.dark,
+        ...t.applyStyles("dark", { color: t.palette.primary.main }),
+        "&:hover": { textDecoration: "underline" },
+        "&:focus-visible": {
+          outline: "2px solid",
+          outlineColor: "primary.main",
+          outlineOffset: 2,
+          borderRadius: 0.5,
+        },
+      })}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+function Mono({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <Typography variant="body2" sx={{ fontFamily: "monospace", wordBreak: "break-all" }}>
+      {children}
+    </Typography>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={onClick}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back to projects
+    </Button>
+  );
+}
+
+export default function CsmProjectDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useGetProject(id);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rectangular" height={32} width={240} />
+        <Skeleton variant="rectangular" height={220} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/projects")} />
+        <Typography variant="body1" color="error">
+          Could not load project {id}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate("/projects")} />
+        <Typography variant="h5">Project not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No project with id <code>{id}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const p = data;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <BackButton onClick={() => navigate("/projects")} />
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+            <Typography variant="h5">{p.name}</Typography>
+            <Chip
+              size="small"
+              label={formatSubscriptionType(p.subscriptionType)}
+              variant="outlined"
+            />
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+            {p.key}
+          </Typography>
+        </Box>
+        {/* File a case already scoped to this project — the create form locks the
+            project field, so it can't be filed against the wrong one. */}
+        <Button
+          variant="contained"
+          startIcon={<Plus size={16} />}
+          onClick={() => navigate(`/cases/new?projectId=${encodeURIComponent(p.id)}`)}
+          sx={{ flexShrink: 0 }}
+        >
+          Create case
+        </Button>
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Project key">
+            <Mono>{p.key}</Mono>
+          </MetaCell>
+          <MetaCell label="Subscription">
+            <Typography variant="body2">{formatSubscriptionType(p.subscriptionType)}</Typography>
+          </MetaCell>
+          <MetaCell label="Account">
+            {p.account?.id ? (
+              <LinkText to={`/accounts/${p.account.id}`}>
+                {p.account.name || p.account.id}
+              </LinkText>
+            ) : (
+              <Typography variant="body2">—</Typography>
+            )}
+          </MetaCell>
+          <MetaCell label="Account tier">
+            <Typography variant="body2">{p.account?.tier || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Start date">
+            <Typography variant="body2">{formatDate(p.startDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="End date">
+            <Typography variant="body2">{formatDate(p.endDate)}</Typography>
+          </MetaCell>
+          <MetaCell label="Salesforce ID">
+            <Mono>{p.sfId || "—"}</Mono>
+          </MetaCell>
+          <MetaCell label="Created">
+            <Typography variant="body2">{formatDate(p.createdOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Last updated">
+            <Typography variant="body2">{formatDate(p.updatedOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Project ID">
+            <Mono>{p.id}</Mono>
+          </MetaCell>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -31,6 +31,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects";
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
@@ -135,8 +136,22 @@ export default function CsmProjectsPage(): JSX.Element {
               ) : (
                 projects.map((p) => (
                   <TableRow key={p.id} hover>
-                    <TableCell>{p.name}</TableCell>
-                    <TableCell>{p.projectKey}</TableCell>
+                    <TableCell>
+                      <Typography
+                        component={RouterLink}
+                        to={`/projects/${p.id}`}
+                        variant="body2"
+                        sx={(t) => ({
+                          textDecoration: "none",
+                          color: t.palette.primary.dark,
+                          ...t.applyStyles("dark", { color: t.palette.primary.main }),
+                          "&:hover": { textDecoration: "underline" },
+                        })}
+                      >
+                        {p.name}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{p.key}</TableCell>
                     <TableCell>
                       <Chip
                         size="small"

--- a/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
@@ -30,12 +30,48 @@ export interface Project {
   accountId: string;
   sfId: string;
   name: string;
-  projectKey: string;
+  // The search endpoint returns this as `key` (not `projectKey`).
+  key: string;
   subscriptionType: SubscriptionType;
   startDate: string;
   endDate: string;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Parent-account reference embedded in the project detail response
+ * (`GET /projects/{id}`). The backend JOINs the account, so the project view
+ * gets the account name (and a few account facts) with no extra call. `tier` is
+ * free-form here (e.g. "Enterprise"), not the lowercase {@link AccountTier} enum.
+ */
+export interface ProjectAccountRef {
+  id: string;
+  name: string;
+  activationDate: string | null;
+  tier: string;
+  region?: string | null;
+  agentEnabled: boolean;
+  kbReferencesEnabled: boolean;
+}
+
+/**
+ * Enriched single-project shape returned by `GET /projects/{id}`. Distinct from
+ * {@link Project} (the search-result row): it embeds the parent `account`, and
+ * uses `createdOn` / `updatedOn` rather than the search row's
+ * `createdAt` / `updatedAt`.
+ */
+export interface ProjectDetails {
+  id: string;
+  account: ProjectAccountRef;
+  sfId: string;
+  name: string;
+  key: string;
+  subscriptionType: SubscriptionType;
+  startDate: string;
+  endDate: string;
+  createdOn: string;
+  updatedOn: string;
 }
 
 export interface SearchProjectsRequest {

--- a/apps/csm-portal/webapp/src/utils/correlationId.test.ts
+++ b/apps/csm-portal/webapp/src/utils/correlationId.test.ts
@@ -64,7 +64,7 @@ describe("newCorrelationId fallbacks", () => {
 
 describe("CORRELATION_ID_HEADER", () => {
   it("matches the backend header name", () => {
-    expect(CORRELATION_ID_HEADER).toBe("X-Correlation-ID");
+    expect(CORRELATION_ID_HEADER).toBe("X-CSM-Correlation-ID");
   });
 });
 

--- a/apps/csm-portal/webapp/src/utils/correlationId.ts
+++ b/apps/csm-portal/webapp/src/utils/correlationId.ts
@@ -24,7 +24,7 @@
  * Must match `correlationIDHeader` in
  * `apps/csm-portal/backend/internal/middleware/correlation.go`.
  */
-export const CORRELATION_ID_HEADER = "X-Correlation-ID";
+export const CORRELATION_ID_HEADER = "X-CSM-Correlation-ID";
 
 /**
  * Returns a fresh UUID v4 to use as a request correlation ID.

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -98,7 +98,7 @@ const viteConfig = defineConfig({
   },
   envPrefix: ["CSM_PORTAL_"],
   server: {
-    port: 3001,
+    port: 3000,
     strictPort: true,
   },
 });
@@ -152,6 +152,13 @@ window.config.CSM_PORTAL_AUTH_CLIENT_ID = "csm-local-dev";
 // hits the Vite /local-api proxy instead of a hardcoded localhost that would
 // break the same-origin contract.
 window.config.CSM_PORTAL_BACKEND_BASE_URL = window.location.origin + "/local-api";
+// Sign-in/out redirects back to the dev server's OWN origin. The base config
+// pins these to a fixed host:port (e.g. http://localhost:3000); left unchanged,
+// the mock-IdP PKCE callback redirects to that port instead of the port the dev
+// server actually runs on, so the SPA never completes the code exchange and
+// loops on sign-in. Same same-origin rationale as the backend URL above.
+window.config.CSM_PORTAL_AUTH_SIGN_IN_REDIRECT_URL = window.location.origin;
+window.config.CSM_PORTAL_AUTH_SIGN_OUT_REDIRECT_URL = window.location.origin;
 window.config.CSM_PORTAL_USE_MOCKS = false;
 // Pin the runtime mock toggle off so a stale localStorage flag cannot
 // silently re-enable mock data in front of the real local backend.

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -105,6 +105,7 @@ All shared types live in `internal/domain/entity.go`. Conventions:
 - Request structs include only the fields a caller can supply; ID fields injected from path params use `json:"-"`
 - Optional fields in request structs use pointer types (`*CasePriority`) so absent fields are distinguishable from zero values
 - Response structs return the full entity row
+- **Date/time field naming:** all timestamp fields in response structs must use the `On` suffix: `createdOn`, `updatedOn`, `closedOn`. Never use `At` (`createdAt`, `updatedAt`, `closedAt`). Domain-specific date fields that carry a business meaning (e.g. `startDate`, `endDate`, `activationDate`) keep the `Date` suffix. This applies to both Go struct field names and JSON tags.
 
 ## Error types (`internal/apierror`)
 

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -14,7 +14,7 @@ All wiring happens explicitly in `internal/server/routes.go` (no DI framework). 
 
 Middleware chain wraps the mux: **CorrelationID → Recovery → Logger → UserIDToken → Timeout** (10 s per request).
 
-`CorrelationID` reads the `X-Correlation-ID` request header forwarded by the portal BFF, or generates a UUID v4 if absent. The ID is stored in the request context and echoed in the response header. All access log lines and panic logs include the correlation ID for end-to-end request tracing.
+`CorrelationID` reads the `X-CSM-Correlation-ID` request header forwarded by the portal BFF, or generates a UUID v4 if absent. The ID is stored in the request context and echoed in the response header. All access log lines and panic logs include the correlation ID for end-to-end request tracing.
 
 ## Running locally
 

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -435,6 +435,14 @@ const (
 	CaseStateClosed           CaseState = "closed"
 )
 
+// CaseWorkState represents the work sub-state of a work_in_progress case.
+type CaseWorkState string
+
+const (
+	CaseWorkStateOngoing CaseWorkState = "ongoing"
+	CaseWorkStatePaused  CaseWorkState = "paused"
+)
+
 // CaseSortField enumerates the columns available for sorting case search results.
 type CaseSortField string
 
@@ -535,6 +543,7 @@ type CaseView struct {
 	Priority               CasePriority         `json:"priority"`
 	IssueType              CaseIssueType        `json:"issueType"`
 	State                  CaseState            `json:"state"`
+	WorkState              *CaseWorkState       `json:"workState"`
 	CreatedOn              time.Time            `json:"createdOn"`
 	UpdatedOn              time.Time            `json:"updatedOn"`
 	CreatedByDetails       UserRef              `json:"createdBy"`
@@ -578,6 +587,7 @@ type SearchCaseView struct {
 	Priority               CasePriority       `json:"priority"`
 	IssueType              CaseIssueType      `json:"issueType"`
 	State                  CaseState          `json:"state"`
+	WorkState              *CaseWorkState     `json:"workState"`
 	CreatedOn              time.Time          `json:"createdOn"`
 	UpdatedOn              time.Time          `json:"updatedOn"`
 	ClosedAt               *time.Time         `json:"closedAt"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -608,11 +608,39 @@ type SearchCasesResponse struct {
 }
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
-// State and Priority may be changed through this endpoint.
+// Exactly one of State, Priority, WatchList, or AssigneeEmail must be provided.
+// WatchList and AssigneeEmail are only supported for the ServiceNow data source.
 type UpdateCaseRequest struct {
-	ID       string        `json:"-"`
-	State    *CaseState    `json:"state"`
-	Priority *CasePriority `json:"priority"`
+	ID            string        `json:"-"`
+	State         *CaseState    `json:"state"`
+	Priority      *CasePriority `json:"priority"`
+	WatchList     []string      `json:"watchList"`
+	AssigneeEmail *string       `json:"assigneeEmail"`
+}
+
+// UpdateCaseResponse is the response for PATCH /cases/{id}.
+type UpdateCaseResponse struct {
+	Message string      `json:"message"`
+	Case    UpdatedCase `json:"case"`
+}
+
+// UpdatedCase carries the fields of a case that may change after an update.
+type UpdatedCase struct {
+	ID         string               `json:"id"`
+	UpdatedOn  time.Time            `json:"updatedOn"`
+	UpdatedBy  string               `json:"updatedBy,omitempty"`
+	State      CaseState            `json:"state,omitempty"`
+	Priority   CasePriority         `json:"priority,omitempty"`
+	WatchList  []WatchListUser      `json:"watchList,omitempty"`
+	AssignedTo *AssignedEngineerRef `json:"assignedTo,omitempty"`
+}
+
+// WatchListUser is a compact user reference within the watch list.
+type WatchListUser struct {
+	ID       string `json:"id"`
+	UserName string `json:"userName"`
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
 }
 
 // CreateCaseResponse is the unified response for POST /cases across all data sources.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -568,6 +568,14 @@ type SearchCasesFilters struct {
 	StateKeys          []CaseState     `json:"stateKeys"`
 	PriorityKeys       []CasePriority  `json:"priorityKeys"`
 	IssueTypeKeys      []CaseIssueType `json:"issueTypeKeys"`
+	ClosedStartDate    *time.Time      `json:"closedStartDate"`
+	ClosedEndDate      *time.Time      `json:"closedEndDate"`
+	StartCreatedDate   *time.Time      `json:"startCreatedDate"`
+	EndCreatedDate     *time.Time      `json:"endCreatedDate"`
+	StartUpdatedDate   *time.Time      `json:"startUpdatedDate"`
+	EndUpdatedDate     *time.Time      `json:"endUpdatedDate"`
+	CreatedBy          []string        `json:"createdBy"`
+	CreatedByMe        bool            `json:"createdByMe"`
 }
 
 // SearchCasesRequest is the input for a case search operation.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -467,7 +467,7 @@ type CaseSort struct {
 }
 
 // Case represents a customer support case as stored in the database.
-// ClosedAt and WorkState are the only nullable fields; all others are required.
+// ClosedOn and WorkState are the only nullable fields; all others are required.
 // Used as the response for write operations (create/update).
 type Case struct {
 	ID                string         `json:"id"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -43,8 +43,8 @@ type User struct {
 	Phone     *string   `json:"phone"`
 	Timezone  *string   `json:"timezone"`
 	UserType  UserType  `json:"userType"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	CreatedOn time.Time `json:"createdOn"`
+	UpdatedOn time.Time `json:"updatedOn"`
 }
 
 // Pagination controls which page of results is returned.
@@ -95,8 +95,8 @@ type Account struct {
 	TechnicalOwnerID    *string     `json:"technicalOwnerId"`
 	AgentEnabled        bool        `json:"agentEnabled"`
 	KbReferencesEnabled bool        `json:"kbReferencesEnabled"`
-	CreatedAt           time.Time   `json:"createdAt"`
-	UpdatedAt           time.Time   `json:"updatedAt"`
+	CreatedOn           time.Time   `json:"createdOn"`
+	UpdatedOn           time.Time   `json:"updatedOn"`
 }
 
 // SearchAccountsRequest is the input for an account search operation.
@@ -154,8 +154,8 @@ type Project struct {
 	ClosureStatus    *ClosureStatus   `json:"closureStatus"`
 	StartDate        time.Time        `json:"startDate"`
 	EndDate          time.Time        `json:"endDate"`
-	CreatedAt        time.Time        `json:"createdAt"`
-	UpdatedAt        time.Time        `json:"updatedAt"`
+	CreatedOn        time.Time        `json:"createdOn"`
+	UpdatedOn        time.Time        `json:"updatedOn"`
 }
 
 // ProjectAccountRef is the embedded account summary returned in project detail responses.
@@ -227,8 +227,8 @@ type Product struct {
 	ID        string       `json:"id"`
 	Name      string       `json:"name"`
 	Class     ProductClass `json:"class"`
-	CreatedAt time.Time    `json:"createdAt"`
-	UpdatedAt time.Time    `json:"updatedAt"`
+	CreatedOn time.Time    `json:"createdOn"`
+	UpdatedOn time.Time    `json:"updatedOn"`
 }
 
 // SearchProductsRequest is the input for a product search operation.
@@ -268,8 +268,8 @@ type ProductVersion struct {
 	ReleaseDate                    time.Time     `json:"releaseDate"`
 	SupportEOLDate                 *time.Time    `json:"supportEolDate"`
 	EarliestPossibleSupportEOLDate *time.Time    `json:"earliestPossibleSupportEolDate"`
-	CreatedAt                      time.Time     `json:"createdAt"`
-	UpdatedAt                      time.Time     `json:"updatedAt"`
+	CreatedOn                      time.Time     `json:"createdOn"`
+	UpdatedOn                      time.Time     `json:"updatedOn"`
 }
 
 // SearchProductVersionsRequest is the input for a product version search operation.
@@ -311,8 +311,8 @@ type Deployment struct {
 	Type        DeploymentType `json:"type"`
 	Description *string        `json:"description"`
 	CreatedBy   string         `json:"createdBy"`
-	CreatedAt   time.Time      `json:"createdAt"`
-	UpdatedAt   time.Time      `json:"updatedAt"`
+	CreatedOn   time.Time      `json:"createdOn"`
+	UpdatedOn   time.Time      `json:"updatedOn"`
 }
 
 // DeploymentView is the enriched search result for a deployment. It embeds
@@ -356,8 +356,8 @@ type DeployedProduct struct {
 	DeploymentID     string    `json:"deploymentId"`
 	ProductID        string    `json:"productId"`
 	ProductVersionID *string   `json:"productVersionId"`
-	CreatedAt        time.Time `json:"createdAt"`
-	UpdatedAt        time.Time `json:"updatedAt"`
+	CreatedOn        time.Time `json:"createdOn"`
+	UpdatedOn        time.Time `json:"updatedOn"`
 }
 
 // DeployedProductVersionRef is the version sub-object in a DeployedProductView.
@@ -467,24 +467,25 @@ type CaseSort struct {
 }
 
 // Case represents a customer support case as stored in the database.
-// ClosedAt is the only nullable field; all others are required.
-// Used as the response for write operations (create).
+// ClosedAt and WorkState are the only nullable fields; all others are required.
+// Used as the response for write operations (create/update).
 type Case struct {
-	ID                string        `json:"id"`
-	Number            string        `json:"number"`
-	InternalID        string        `json:"internalId"`
-	CreatedBy         string        `json:"createdBy"`
-	ProjectID         string        `json:"projectId"`
-	DeploymentID      string        `json:"deploymentId"`
-	DeployedProductID string        `json:"deployedProductId"`
-	Subject           string        `json:"subject"`
-	Description       string        `json:"description"`
-	Priority          CasePriority  `json:"priority"`
-	IssueType         CaseIssueType `json:"issueType"`
-	State             CaseState     `json:"state"`
-	CreatedAt         time.Time     `json:"createdAt"`
-	UpdatedAt         time.Time     `json:"updatedAt"`
-	ClosedAt          *time.Time    `json:"closedAt"`
+	ID                string         `json:"id"`
+	Number            string         `json:"number"`
+	InternalID        string         `json:"internalId"`
+	CreatedBy         string         `json:"createdBy"`
+	ProjectID         string         `json:"projectId"`
+	DeploymentID      string         `json:"deploymentId"`
+	DeployedProductID string         `json:"deployedProductId"`
+	Subject           string         `json:"subject"`
+	Description       string         `json:"description"`
+	Priority          CasePriority   `json:"priority"`
+	IssueType         CaseIssueType  `json:"issueType"`
+	State             CaseState      `json:"state"`
+	WorkState         *CaseWorkState `json:"workState"`
+	CreatedOn         time.Time      `json:"createdOn"`
+	UpdatedOn         time.Time      `json:"updatedOn"`
+	ClosedOn          *time.Time     `json:"closedOn"`
 }
 
 // UserRef is a reference to a user with key display fields.
@@ -546,6 +547,7 @@ type CaseView struct {
 	WorkState              *CaseWorkState       `json:"workState"`
 	CreatedOn              time.Time            `json:"createdOn"`
 	UpdatedOn              time.Time            `json:"updatedOn"`
+	ClosedOn               *time.Time           `json:"closedOn"`
 	CreatedByDetails       UserRef              `json:"createdBy"`
 	ProjectDetails         EntityRef            `json:"project"`
 	DeploymentDetails      EntityRef            `json:"deployment"`
@@ -590,7 +592,7 @@ type SearchCaseView struct {
 	WorkState              *CaseWorkState     `json:"workState"`
 	CreatedOn              time.Time          `json:"createdOn"`
 	UpdatedOn              time.Time          `json:"updatedOn"`
-	ClosedAt               *time.Time         `json:"closedAt"`
+	ClosedOn               *time.Time         `json:"closedOn"`
 	CreatedBy              UserIDEmailRef     `json:"createdBy"`
 	ProjectDetails         EntityRef          `json:"project"`
 	DeploymentDetails      EntityRef          `json:"deployment"`
@@ -608,14 +610,15 @@ type SearchCasesResponse struct {
 }
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
-// Exactly one of State, Priority, WatchList, or AssigneeEmail must be provided.
+// Exactly one of State, Priority, WorkState, WatchList, or AssigneeEmail must be provided.
 // WatchList and AssigneeEmail are only supported for the ServiceNow data source.
 type UpdateCaseRequest struct {
-	ID            string        `json:"-"`
-	State         *CaseState    `json:"state"`
-	Priority      *CasePriority `json:"priority"`
-	WatchList     []string      `json:"watchList"`
-	AssigneeEmail *string       `json:"assigneeEmail"`
+	ID            string         `json:"-"`
+	State         *CaseState     `json:"state"`
+	Priority      *CasePriority  `json:"priority"`
+	WorkState     *CaseWorkState `json:"workState"`
+	WatchList     []string       `json:"watchList"`
+	AssigneeEmail *string        `json:"assigneeEmail"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -631,6 +634,7 @@ type UpdatedCase struct {
 	UpdatedBy  string               `json:"updatedBy,omitempty"`
 	State      CaseState            `json:"state,omitempty"`
 	Priority   CasePriority         `json:"priority,omitempty"`
+	WorkState  *CaseWorkState       `json:"workState"`
 	WatchList  []WatchListUser      `json:"watchList,omitempty"`
 	AssignedTo *AssignedEngineerRef `json:"assignedTo,omitempty"`
 }
@@ -697,7 +701,7 @@ type CaseComment struct {
 	Type      CommentType    `json:"type"`
 	Content   string         `json:"content"`
 	CreatedBy CommentUserRef `json:"createdBy"`
-	CreatedAt time.Time      `json:"createdOn"`
+	CreatedOn time.Time      `json:"createdOn"`
 }
 
 // CreateCaseCommentRequest is the input for creating a new case comment.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -617,6 +617,68 @@ type SearchCasesResponse struct {
 	HasMore bool             `json:"hasMore"`
 }
 
+// SearchServiceRequestsFilters holds optional filter criteria for a service-request search.
+// This endpoint is only supported for the ServiceNow data source.
+type SearchServiceRequestsFilters struct {
+	ProjectIDs       []string   `json:"projectIds"`
+	SearchQuery      string     `json:"searchQuery"`
+	StateKeys        []int      `json:"stateKeys"`
+	ClosedStartDate  *time.Time `json:"closedStartDate"`
+	ClosedEndDate    *time.Time `json:"closedEndDate"`
+	StartCreatedDate *time.Time `json:"startCreatedDate"`
+	EndCreatedDate   *time.Time `json:"endCreatedDate"`
+	StartUpdatedDate *time.Time `json:"startUpdatedDate"`
+	EndUpdatedDate   *time.Time `json:"endUpdatedDate"`
+	DeploymentIDs    []string   `json:"deploymentIds"`
+	CreatedBy        []string   `json:"createdBy"`
+	CreatedByMe      bool       `json:"createdByMe"`
+}
+
+// SearchServiceRequestsRequest is the input for POST /service-request/search.
+type SearchServiceRequestsRequest struct {
+	Filters    SearchServiceRequestsFilters `json:"filters"`
+	SortBy     CaseSort                     `json:"sortBy"`
+	Pagination Pagination                   `json:"pagination"`
+}
+
+// ServiceRequestWorkStateRef is a compact reference to a service-request work state.
+type ServiceRequestWorkStateRef struct {
+	ID    *int   `json:"id"`
+	Label string `json:"label"`
+}
+
+// ServiceRequestView is the enriched representation of a service request returned in search results.
+type ServiceRequestView struct {
+	ID               string                      `json:"id"`
+	InternalID       string                      `json:"internalId"`
+	Number           string                      `json:"number"`
+	CreatedOn        string                      `json:"createdOn"`
+	CreatedBy        string                      `json:"createdBy"`
+	Title            *string                     `json:"title"`
+	Description      *string                     `json:"description"`
+	State            string                      `json:"state"`
+	Catalog          *EntityRef                  `json:"catalog"`
+	CatalogItem      *EntityRef                  `json:"catalogItem"`
+	AssignedTeam     *EntityRef                  `json:"assignedTeam"`
+	Product          *EntityRef                  `json:"product"`
+	WorkState        *ServiceRequestWorkStateRef `json:"workState"`
+	Project          EntityRef                   `json:"project"`
+	Deployment       EntityRef                   `json:"deployment"`
+	DeployedProduct  EntityRef                   `json:"deployedProduct"`
+	AssignedEngineer *EntityRef                  `json:"assignedEngineer"`
+	ParentCase       *EntityRef                  `json:"parentCase"`
+	RelatedCase      *EntityRef                  `json:"relatedCase"`
+	Conversation     *EntityRef                  `json:"conversation"`
+}
+
+// SearchServiceRequestsResponse is the paginated result of a service-request search.
+type SearchServiceRequestsResponse struct {
+	Cases        []ServiceRequestView `json:"cases"`
+	TotalRecords int                  `json:"totalRecords"`
+	Offset       int                  `json:"offset"`
+	Limit        int                  `json:"limit"`
+}
+
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
 // Exactly one of State, Priority, WorkState, WatchList, or AssigneeEmail must be provided.
 // WatchList and AssigneeEmail are only supported for the ServiceNow data source.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -634,7 +634,7 @@ type SearchServiceRequestsFilters struct {
 	CreatedByMe      bool       `json:"createdByMe"`
 }
 
-// SearchServiceRequestsRequest is the input for POST /service-request/search.
+// SearchServiceRequestsRequest is the input for POST /service-requests/search.
 type SearchServiceRequestsRequest struct {
 	Filters    SearchServiceRequestsFilters `json:"filters"`
 	SortBy     CaseSort                     `json:"sortBy"`

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -63,20 +63,22 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(c)
 }
 
-// PatchCase handles PATCH /cases/{id} and allows updating the case state and priority.
+// PatchCase handles PATCH /cases/{id}.
+// Accepts state, priority (both data sources), or watchList, assigneeEmail (ServiceNow only).
+// Exactly one field must be provided per request.
 func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	var req domain.UpdateCaseRequest
 	if !decodeRequest(w, r, &req) {
 		return
 	}
 	req.ID = r.PathValue("id")
-	c, err := h.svc.UpdateCase(r.Context(), req)
+	resp, err := h.svc.UpdateCase(r.Context(), req)
 	if err != nil {
 		writeServiceError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(c)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // CreateCaseComment handles POST /cases/{id}/comments.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -174,3 +174,18 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Content-Type", contentType)
 	_, _ = w.Write(content)
 }
+
+// SearchServiceRequests handles POST /service-request/search.
+func (h *CaseHandler) SearchServiceRequests(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchServiceRequestsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchServiceRequests(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -175,7 +175,7 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 	_, _ = w.Write(content)
 }
 
-// SearchServiceRequests handles POST /service-request/search.
+// SearchServiceRequests handles POST /service-requests/search.
 func (h *CaseHandler) SearchServiceRequests(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchServiceRequestsRequest
 	if !decodeRequest(w, r, &req) {

--- a/entity-service/internal/middleware/correlationid.go
+++ b/entity-service/internal/middleware/correlationid.go
@@ -25,11 +25,11 @@ import (
 
 // correlationIDHeader is the HTTP header used to propagate the correlation ID
 // across service boundaries.
-const correlationIDHeader = "X-Correlation-ID"
+const correlationIDHeader = "X-CSM-Correlation-ID"
 
 type correlationIDKey struct{}
 
-// CorrelationID is an HTTP middleware that reads the X-Correlation-ID request
+// CorrelationID is an HTTP middleware that reads the X-CSM-Correlation-ID request
 // header (forwarded by the portal BFF) or generates a UUID v4 if absent.
 // The ID is stored in the request context for logging and echoed in the
 // response header so callers can reference it in support requests.

--- a/entity-service/internal/repository/account_repo.go
+++ b/entity-service/internal/repository/account_repo.go
@@ -105,7 +105,7 @@ func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccou
 				&a.ActivationDate, &a.DeactivationDate,
 				&a.OwnerID, &a.TechnicalOwnerID,
 				&a.AgentEnabled, &a.KbReferencesEnabled,
-				&a.CreatedAt, &a.UpdatedAt,
+				&a.CreatedOn, &a.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan account: %w", err)
 			}
@@ -138,7 +138,7 @@ func (r *accountRepo) GetAccountByID(ctx context.Context, id string) (domain.Acc
 		&a.ActivationDate, &a.DeactivationDate,
 		&a.OwnerID, &a.TechnicalOwnerID,
 		&a.AgentEnabled, &a.KbReferencesEnabled,
-		&a.CreatedAt, &a.UpdatedAt,
+		&a.CreatedOn, &a.UpdatedOn,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.Account{}, &apierror.NotFoundError{Msg: "account not found"}

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -367,6 +367,43 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
+	if len(req.Filters.CreatedBy) > 0 {
+		where += fmt.Sprintf(" AND u.email = ANY($%d)", argIdx)
+		filterArgs = append(filterArgs, req.Filters.CreatedBy)
+		argIdx++
+	}
+
+	if req.Filters.ClosedStartDate != nil {
+		where += fmt.Sprintf(" AND c.closed_at >= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.ClosedStartDate)
+		argIdx++
+	}
+	if req.Filters.ClosedEndDate != nil {
+		where += fmt.Sprintf(" AND c.closed_at <= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.ClosedEndDate)
+		argIdx++
+	}
+	if req.Filters.StartCreatedDate != nil {
+		where += fmt.Sprintf(" AND c.created_at >= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.StartCreatedDate)
+		argIdx++
+	}
+	if req.Filters.EndCreatedDate != nil {
+		where += fmt.Sprintf(" AND c.created_at <= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.EndCreatedDate)
+		argIdx++
+	}
+	if req.Filters.StartUpdatedDate != nil {
+		where += fmt.Sprintf(" AND c.updated_at >= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.StartUpdatedDate)
+		argIdx++
+	}
+	if req.Filters.EndUpdatedDate != nil {
+		where += fmt.Sprintf(" AND c.updated_at <= $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.EndUpdatedDate)
+		argIdx++
+	}
+
 	if req.Filters.SearchQuery != "" {
 		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.Filters.SearchQuery)
 		pattern := "%" + escaped + "%"
@@ -378,14 +415,14 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 	sortCol := "c." + string(req.SortBy.Field)
 	sortDir := string(req.SortBy.Order)
 
-	countQuery := "SELECT COUNT(*) FROM cases c " + where
-
 	joins := `JOIN users u ON u.id = c.created_by
 		 JOIN projects p ON p.id = c.project_id
 		 JOIN deployments d ON d.id = c.deployment_id
 		 JOIN deployed_products dp ON dp.id = c.deployed_product_id
 		 JOIN products prod ON prod.id = dp.product_id
 		 LEFT JOIN product_versions pv ON pv.id = dp.product_version_id`
+
+	countQuery := "SELECT COUNT(*) FROM cases c " + joins + " " + where
 
 	dataQuery := fmt.Sprintf(
 		`SELECT c.id, c.number, c.internal_id,

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -109,10 +109,11 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 		pcID, pcNum                         *string
 		rcID, rcNum                         *string
 		accountID, accountName, accountTier string
+		workState                           *string
 	)
 	err := r.db.QueryRow(ctx,
 		`SELECT c.id, c.number, c.internal_id,
-		        c.subject, c.description, c.priority, c.issue_type, c.state,
+		        c.subject, c.description, c.priority, c.issue_type, c.state, c.work_state,
 		        c.created_at, c.updated_at,
 		        u.id, u.first_name || ' ' || u.last_name, u.user_name, u.email,
 		        p.id, p.name,
@@ -137,7 +138,7 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 		 WHERE c.id = $1`, id,
 	).Scan(
 		&cv.ID, &cv.Number, &cv.InternalID,
-		&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State,
+		&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
 		&cv.CreatedOn, &cv.UpdatedOn,
 		&cv.CreatedByDetails.ID, &cv.CreatedByDetails.Name, &cv.CreatedByDetails.UserID, &cv.CreatedByDetails.Email,
 		&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
@@ -156,6 +157,10 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 		return domain.CaseView{}, fmt.Errorf("get case by id: %w", err)
 	}
 	cv.AccountDetails = &domain.AccountRef{ID: accountID, Name: accountName, Type: accountTier}
+	if workState != nil {
+		ws := domain.CaseWorkState(*workState)
+		cv.WorkState = &ws
+	}
 	if aeID != nil {
 		cv.AssignedEngineer = &domain.AssignedEngineerRef{ID: *aeID, Name: *aeName}
 	}
@@ -374,7 +379,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 
 	dataQuery := fmt.Sprintf(
 		`SELECT c.id, c.number, c.internal_id,
-		        c.subject, c.description, c.priority, c.issue_type, c.state,
+		        c.subject, c.description, c.priority, c.issue_type, c.state, c.work_state,
 		        c.created_at, c.updated_at, c.closed_at,
 		        u.id, u.first_name || ' ' || u.last_name, u.user_name, u.email,
 		        p.id, p.name,
@@ -410,9 +415,10 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		for rows.Next() {
 			var cv domain.SearchCaseView
 			var ignoredDisplayName, ignoredUserID string
+			var workState *string
 			if err := rows.Scan(
 				&cv.ID, &cv.Number, &cv.InternalID,
-				&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State,
+				&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
 				&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedAt,
 				&cv.CreatedBy.ID, &ignoredDisplayName, &ignoredUserID, &cv.CreatedBy.Email,
 				&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
@@ -420,6 +426,10 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 				&cv.DeployedProductDetails.ID, &cv.DeployedProductDetails.DisplayName,
 			); err != nil {
 				return fmt.Errorf("scan case: %w", err)
+			}
+			if workState != nil {
+				ws := domain.CaseWorkState(*workState)
+				cv.WorkState = &ws
 			}
 			result = append(result, cv)
 		}

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -85,7 +85,7 @@ func (r *caseRepo) CreateCase(ctx context.Context, req domain.CreateCaseRequest)
 		&c.ID, &c.Number, &c.InternalID, &c.CreatedBy,
 		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
 		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State,
-		&c.CreatedAt, &c.UpdatedAt, &c.ClosedAt,
+		&c.CreatedOn, &c.UpdatedOn, &c.ClosedOn,
 	)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
@@ -114,7 +114,7 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 	err := r.db.QueryRow(ctx,
 		`SELECT c.id, c.number, c.internal_id,
 		        c.subject, c.description, c.priority, c.issue_type, c.state, c.work_state,
-		        c.created_at, c.updated_at,
+		        c.created_at, c.updated_at, c.closed_at,
 		        u.id, u.first_name || ' ' || u.last_name, u.user_name, u.email,
 		        p.id, p.name,
 		        d.id, d.name,
@@ -139,7 +139,7 @@ func (r *caseRepo) GetCaseByID(ctx context.Context, id string) (domain.CaseView,
 	).Scan(
 		&cv.ID, &cv.Number, &cv.InternalID,
 		&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
-		&cv.CreatedOn, &cv.UpdatedOn,
+		&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedOn,
 		&cv.CreatedByDetails.ID, &cv.CreatedByDetails.Name, &cv.CreatedByDetails.UserID, &cv.CreatedByDetails.Email,
 		&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
 		&cv.DeploymentDetails.ID, &cv.DeploymentDetails.Name,
@@ -183,7 +183,7 @@ func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseC
 	var c domain.CaseComment
 	err := r.db.QueryRow(ctx, query,
 		req.CaseID, string(req.Type), req.Content, req.CreatedBy,
-	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedAt)
+	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedOn)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 			switch pgErr.Code {
@@ -246,7 +246,7 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 			if err := rows.Scan(
 				&c.ID, &c.CaseID, &c.Type, &c.Content,
 				&c.CreatedBy.ID, &c.CreatedBy.FirstName, &c.CreatedBy.LastName,
-				&c.CreatedBy.FullName, &c.CreatedAt,
+				&c.CreatedBy.FullName, &c.CreatedOn,
 			); err != nil {
 				return fmt.Errorf("scan case comment: %w", err)
 			}
@@ -276,28 +276,38 @@ func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest)
 	if req.Priority != nil {
 		priority = string(*req.Priority)
 	}
+	workState := ""
+	if req.WorkState != nil {
+		workState = string(*req.WorkState)
+	}
 	const query = `
 		UPDATE cases
 		SET state      = CASE WHEN $2 <> '' THEN $2::case_state_enum ELSE state END,
 		    priority   = CASE WHEN $3 <> '' THEN $3::case_priority_enum ELSE priority END,
+		    work_state = CASE WHEN $4 <> '' THEN $4::case_work_state_enum ELSE work_state END,
 		    updated_at = NOW(),
 		    closed_at  = CASE WHEN $2 = 'closed' THEN NOW() WHEN $2 <> '' AND $2 <> 'closed' THEN NULL ELSE closed_at END
 		WHERE id = $1
 		RETURNING id, number, internal_id, created_by, project_id, deployment_id, deployed_product_id,
-		          subject, description, priority, issue_type, state, created_at, updated_at, closed_at`
+		          subject, description, priority, issue_type, state, work_state, created_at, updated_at, closed_at`
 
 	var c domain.Case
-	err := r.db.QueryRow(ctx, query, req.ID, state, priority).Scan(
+	var workStateRaw *string
+	err := r.db.QueryRow(ctx, query, req.ID, state, priority, workState).Scan(
 		&c.ID, &c.Number, &c.InternalID, &c.CreatedBy,
 		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
-		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State,
-		&c.CreatedAt, &c.UpdatedAt, &c.ClosedAt,
+		&c.Subject, &c.Description, &c.Priority, &c.IssueType, &c.State, &workStateRaw,
+		&c.CreatedOn, &c.UpdatedOn, &c.ClosedOn,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.Case{}, &apierror.NotFoundError{Msg: "case not found"}
 	}
 	if err != nil {
 		return domain.Case{}, fmt.Errorf("update case: %w", err)
+	}
+	if workStateRaw != nil {
+		ws := domain.CaseWorkState(*workStateRaw)
+		c.WorkState = &ws
 	}
 	return c, nil
 }
@@ -419,7 +429,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 			if err := rows.Scan(
 				&cv.ID, &cv.Number, &cv.InternalID,
 				&cv.Subject, &cv.Description, &cv.Priority, &cv.IssueType, &cv.State, &workState,
-				&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedAt,
+				&cv.CreatedOn, &cv.UpdatedOn, &cv.ClosedOn,
 				&cv.CreatedBy.ID, &ignoredDisplayName, &ignoredUserID, &cv.CreatedBy.Email,
 				&cv.ProjectDetails.ID, &cv.ProjectDetails.Name,
 				&cv.DeploymentDetails.ID, &cv.DeploymentDetails.Name,

--- a/entity-service/internal/repository/product_repo.go
+++ b/entity-service/internal/repository/product_repo.go
@@ -91,7 +91,7 @@ func (r *productRepo) SearchProducts(ctx context.Context, req domain.SearchProdu
 		result := make([]domain.Product, 0, req.Pagination.Limit)
 		for rows.Next() {
 			var p domain.Product
-			if err := rows.Scan(&p.ID, &p.Name, &p.Class, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			if err := rows.Scan(&p.ID, &p.Name, &p.Class, &p.CreatedOn, &p.UpdatedOn); err != nil {
 				return fmt.Errorf("scan product: %w", err)
 			}
 			result = append(result, p)

--- a/entity-service/internal/repository/product_version_repo.go
+++ b/entity-service/internal/repository/product_version_repo.go
@@ -102,7 +102,7 @@ func (r *productVersionRepo) SearchProductVersions(ctx context.Context, req doma
 			if err := rows.Scan(
 				&pv.ID, &pv.ProductID, &pv.Version, &pv.CurrentSupportStatus,
 				&pv.ReleaseDate, &pv.SupportEOLDate, &pv.EarliestPossibleSupportEOLDate,
-				&pv.CreatedAt, &pv.UpdatedAt,
+				&pv.CreatedOn, &pv.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan product_version: %w", err)
 			}

--- a/entity-service/internal/repository/project_repo.go
+++ b/entity-service/internal/repository/project_repo.go
@@ -105,7 +105,7 @@ func (r *projectRepo) SearchProjects(ctx context.Context, req domain.SearchProje
 			var p domain.Project
 			if err := rows.Scan(
 				&p.ID, &p.AccountID, &p.SfID, &p.Name, &p.Key, &p.SubscriptionType, &p.ClosureStatus,
-				&p.StartDate, &p.EndDate, &p.CreatedAt, &p.UpdatedAt,
+				&p.StartDate, &p.EndDate, &p.CreatedOn, &p.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan project: %w", err)
 			}

--- a/entity-service/internal/repository/user_repo.go
+++ b/entity-service/internal/repository/user_repo.go
@@ -63,7 +63,7 @@ func (r *userRepo) GetUserByEmail(ctx context.Context, email string) (domain.Use
 	).Scan(
 		&u.ID, &u.UserName, &u.FirstName, &u.LastName,
 		&u.Email, &u.Phone, &u.Timezone, &u.UserType,
-		&u.CreatedAt, &u.UpdatedAt,
+		&u.CreatedOn, &u.UpdatedOn,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.User{}, &apierror.NotFoundError{Msg: "no user found with email: " + email}
@@ -130,7 +130,7 @@ func (r *userRepo) SearchUsers(ctx context.Context, req domain.SearchUsersReques
 			if err := rows.Scan(
 				&u.ID, &u.UserName, &u.FirstName, &u.LastName,
 				&u.Email, &u.Phone, &u.Timezone, &u.UserType,
-				&u.CreatedAt, &u.UpdatedAt,
+				&u.CreatedOn, &u.UpdatedOn,
 			); err != nil {
 				return fmt.Errorf("scan user: %w", err)
 			}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -118,6 +118,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/{id}/attachments", caseHandler.CreateCaseAttachment)
 	mux.HandleFunc("POST /cases/{id}/attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /cases/{case_id}/attachments/{attachment_id}/content", caseHandler.GetCaseAttachmentContent)
+	mux.HandleFunc("POST /service-requests/search", caseHandler.SearchServiceRequests)
 
 	return middleware.CorrelationID(
 		middleware.Recovery(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -64,6 +64,11 @@ var validCasePriority = map[domain.CasePriority]bool{
 	domain.CasePriorityLow:          true,
 }
 
+var validCaseWorkState = map[domain.CaseWorkState]bool{
+	domain.CaseWorkStateOngoing: true,
+	domain.CaseWorkStatePaused:  true,
+}
+
 var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeError:                  true,
 	domain.CaseIssueTypePartialOutage:          true,
@@ -141,7 +146,7 @@ func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseReque
 			InternalID: c.InternalID,
 			Number:     c.Number,
 			CreatedBy:  c.CreatedBy,
-			CreatedOn:  c.CreatedAt,
+			CreatedOn:  c.CreatedOn,
 			State:      string(c.State),
 		},
 	}, nil
@@ -193,7 +198,7 @@ func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCa
 		Message: "Comment created successfully",
 		Comment: domain.CaseCommentDetail{
 			ID:        c.ID,
-			CreatedOn: c.CreatedAt,
+			CreatedOn: c.CreatedOn,
 			CreatedBy: user.Email,
 		},
 	}, nil
@@ -238,17 +243,23 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if req.Priority != nil {
 		fieldCount++
 	}
+	if req.WorkState != nil {
+		fieldCount++
+	}
 	if fieldCount == 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of state or priority must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of state, priority, or workState must be provided"}
 	}
 	if fieldCount > 1 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state or priority may be provided per request"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, priority, or workState may be provided per request"}
 	}
 	if req.State != nil && !validCaseState[*req.State] {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
 	}
 	if req.Priority != nil && !validCasePriority[*req.Priority] {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
+	}
+	if req.WorkState != nil && !validCaseWorkState[*req.WorkState] {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState contains invalid value: " + string(*req.WorkState)}
 	}
 	c, err := s.repo.UpdateCase(ctx, req)
 	if err != nil {
@@ -258,9 +269,10 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 		Message: "Case updated successfully",
 		Case: domain.UpdatedCase{
 			ID:        c.ID,
-			UpdatedOn: c.UpdatedAt,
+			UpdatedOn: c.UpdatedOn,
 			State:     c.State,
 			Priority:  c.Priority,
+			WorkState: c.WorkState,
 		},
 	}, nil
 }

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -231,8 +231,18 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if len(req.WatchList) > 0 || req.AssigneeEmail != nil {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList and assigneeEmail are only supported for the ServiceNow data source"}
 	}
-	if req.State == nil && req.Priority == nil {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state or priority must be provided"}
+	fieldCount := 0
+	if req.State != nil {
+		fieldCount++
+	}
+	if req.Priority != nil {
+		fieldCount++
+	}
+	if fieldCount == 0 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of state or priority must be provided"}
+	}
+	if fieldCount > 1 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state or priority may be provided per request"}
 	}
 	if req.State != nil && !validCaseState[*req.State] {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -224,20 +224,35 @@ func (s *caseService) SearchCaseComments(ctx context.Context, req domain.SearchC
 }
 
 // UpdateCase implements CaseService.
-func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
+func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error) {
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
-		return domain.Case{}, err
+		return domain.UpdateCaseResponse{}, err
+	}
+	if len(req.WatchList) > 0 || req.AssigneeEmail != nil {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList and assigneeEmail are only supported for the ServiceNow data source"}
 	}
 	if req.State == nil && req.Priority == nil {
-		return domain.Case{}, &apierror.ValidationError{Msg: "at least one of state or priority must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state or priority must be provided"}
 	}
 	if req.State != nil && !validCaseState[*req.State] {
-		return domain.Case{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
 	}
 	if req.Priority != nil && !validCasePriority[*req.Priority] {
-		return domain.Case{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
 	}
-	return s.repo.UpdateCase(ctx, req)
+	c, err := s.repo.UpdateCase(ctx, req)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+	return domain.UpdateCaseResponse{
+		Message: "Case updated successfully",
+		Case: domain.UpdatedCase{
+			ID:        c.ID,
+			UpdatedOn: c.UpdatedAt,
+			State:     c.State,
+			Priority:  c.Priority,
+		},
+	}, nil
 }
 
 // SearchCases implements CaseService.

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -64,11 +64,6 @@ var validCasePriority = map[domain.CasePriority]bool{
 	domain.CasePriorityLow:          true,
 }
 
-var validCaseWorkState = map[domain.CaseWorkState]bool{
-	domain.CaseWorkStateOngoing: true,
-	domain.CaseWorkStatePaused:  true,
-}
-
 var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeError:                  true,
 	domain.CaseIssueTypePartialOutage:          true,
@@ -76,6 +71,11 @@ var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeQuestion:               true,
 	domain.CaseIssueTypeSecurityOrCompliance:   true,
 	domain.CaseIssueTypeTotalOutage:            true,
+}
+
+var validCaseWorkState = map[domain.CaseWorkState]bool{
+	domain.CaseWorkStateOngoing: true,
+	domain.CaseWorkStatePaused:  true,
 }
 
 // validateCreateCaseRequest validates fields common to all CreateCase data sources.
@@ -309,6 +309,31 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 		if !validCaseIssueType[it] {
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "issueTypeKeys contains invalid value: " + string(it)}
 		}
+	}
+
+	if req.Filters.CreatedByMe {
+		token := middleware.UserIDTokenFromContext(ctx)
+		if token == "" {
+			return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required for createdByMe filter"}
+		}
+		email, err := emailFromJWT(token)
+		if err != nil {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "x-user-id-token: " + err.Error()}
+		}
+		req.Filters.CreatedBy = append(req.Filters.CreatedBy, email)
+	}
+
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	if req.Filters.EndCreatedDate != nil && req.Filters.StartCreatedDate != nil &&
+		req.Filters.EndCreatedDate.Before(*req.Filters.StartCreatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endCreatedDate must not be before startCreatedDate"}
+	}
+	if req.Filters.EndUpdatedDate != nil && req.Filters.StartUpdatedDate != nil &&
+		req.Filters.EndUpdatedDate.Before(*req.Filters.StartUpdatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
 	}
 
 	if req.SortBy.Field == "" {

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -372,3 +372,7 @@ func (s *caseService) SearchCaseAttachments(_ context.Context, _ domain.SearchAt
 func (s *caseService) GetCaseAttachmentContent(_ context.Context, _, _ string) ([]byte, string, error) {
 	return nil, "", &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
 }
+
+func (s *caseService) SearchServiceRequests(_ context.Context, _ domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error) {
+	return domain.SearchServiceRequestsResponse{}, &apierror.ServiceUnavailableError{Msg: "service requests are only supported for the ServiceNow data source"}
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -107,9 +107,10 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
-	// UpdateCase updates the state and/or priority of a case. A ValidationError is
-	// returned for invalid values or malformed UUID; a NotFoundError if no case matches.
-	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
+	// UpdateCase updates the state, priority, watch list, or assignee of a case.
+	// A ValidationError is returned for invalid values or malformed UUID; a NotFoundError if no case matches.
+	// WatchList and AssigneeEmail are only supported for the ServiceNow data source.
+	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error)
 	// CreateCaseAttachment uploads a new attachment for the case identified by req.CaseID.
 	// A ValidationError is returned for invalid input.
 	CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error)

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -121,4 +121,7 @@ type CaseService interface {
 	// for the attachment identified by attachmentID on the given case.
 	// A NotFoundError is returned if absent.
 	GetCaseAttachmentContent(ctx context.Context, caseID, attachmentID string) (content []byte, contentType string, err error)
+	// SearchServiceRequests returns a paginated list of service requests.
+	// Only supported for the ServiceNow data source; returns ServiceUnavailableError otherwise.
+	SearchServiceRequests(ctx context.Context, req domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error)
 }

--- a/entity-service/internal/service/project_service.go
+++ b/entity-service/internal/service/project_service.go
@@ -54,7 +54,7 @@ func (s *projectService) SearchProjects(ctx context.Context, req domain.SearchPr
 			Name:             p.Name,
 			Key:              p.Key,
 			SubscriptionType: p.SubscriptionType,
-			CreatedOn:        p.CreatedAt,
+			CreatedOn:        p.CreatedOn,
 		}
 	}
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -52,6 +52,7 @@ type snCase struct {
 	DeployedProduct  snCaseDeployedProduct `json:"deployedProduct"`
 	Product          *snCaseEntityRef      `json:"product"`
 	State            *snCaseState          `json:"state"`
+	WorkState        *snCaseLabel          `json:"workState"`
 	Severity         *snCaseLabel          `json:"severity"`
 	IssueType        *snCaseIssueType      `json:"issueType"`
 	AssignedEngineer *snCaseEntityRef      `json:"assignedEngineer"`
@@ -334,6 +335,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		Priority:    snSeverityToPriority(c.Severity),
 		IssueType:   snIssueTypeToEnum(c.IssueType),
 		State:       state,
+		WorkState:   snWorkStateLabelToEnum(c.WorkState),
 		CreatedOn:   createdOn,
 		UpdatedOn:   updatedOn,
 		CreatedByDetails: domain.UserRef{
@@ -828,6 +830,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			Priority:               snSeverityToPriority(c.Severity),
 			IssueType:              snIssueTypeToEnum(c.IssueType),
 			State:                  state,
+			WorkState:              snWorkStateLabelToEnum(c.WorkState),
 			CreatedOn:              createdOn,
 			UpdatedOn:              updatedOn,
 			CreatedBy:              domain.UserIDEmailRef{Email: c.CreatedBy},
@@ -902,4 +905,17 @@ func snIssueTypeToEnum(issueType *snCaseIssueType) domain.CaseIssueType {
 		return it
 	}
 	return ""
+}
+
+func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
+	if ws == nil {
+		return nil
+	}
+	v := domain.CaseWorkState(strings.ToLower(ws.Label))
+	switch v {
+	case domain.CaseWorkStateOngoing, domain.CaseWorkStatePaused:
+		return &v
+	default:
+		return nil
+	}
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -116,14 +116,22 @@ var snSortFieldMap = map[domain.CaseSortField]string{
 }
 
 type snCaseFilters struct {
-	CaseTypes          []string `json:"caseTypes"`
-	SearchQuery        string   `json:"searchQuery,omitempty"`
-	ProjectIDs         []string `json:"projectIds,omitempty"`
-	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
-	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
-	StateKeys          []int    `json:"stateKeys,omitempty"`
-	SeverityKeys       []int    `json:"severityKeys,omitempty"`
-	IssueTypeKeys      []int    `json:"issueTypeKeys,omitempty"`
+	CaseTypes          []string  `json:"caseTypes"`
+	SearchQuery        string    `json:"searchQuery,omitempty"`
+	ProjectIDs         []string  `json:"projectIds,omitempty"`
+	DeploymentIDs      []string  `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string  `json:"deployedProductIds,omitempty"`
+	StateKeys          []int     `json:"stateKeys,omitempty"`
+	SeverityKeys       []int     `json:"severityKeys,omitempty"`
+	IssueTypeKeys      []int     `json:"issueTypeKeys,omitempty"`
+	ClosedStartDate    string    `json:"closedStartDate,omitempty"`
+	ClosedEndDate      string    `json:"closedEndDate,omitempty"`
+	StartCreatedDate   string    `json:"startCreatedDate,omitempty"`
+	EndCreatedDate     string    `json:"endCreatedDate,omitempty"`
+	StartUpdatedDate   string    `json:"startUpdatedDate,omitempty"`
+	EndUpdatedDate     string    `json:"endUpdatedDate,omitempty"`
+	CreatedBy          []string  `json:"createdBy,omitempty"`
+	CreatedByMe        bool      `json:"createdByMe,omitempty"`
 }
 
 // snStateIDMap maps domain CaseState enums to SN numeric state IDs.
@@ -184,6 +192,13 @@ func domainIssueTypesToSNIDs(issueTypes []domain.CaseIssueType) []int {
 		}
 	}
 	return ids
+}
+
+func formatSNDate(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format(snCreatedOnLayout)
 }
 
 type snCaseService struct {
@@ -895,6 +910,19 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		return domain.SearchCasesResponse{}, err
 	}
 
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	if req.Filters.EndCreatedDate != nil && req.Filters.StartCreatedDate != nil &&
+		req.Filters.EndCreatedDate.Before(*req.Filters.StartCreatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endCreatedDate must not be before startCreatedDate"}
+	}
+	if req.Filters.EndUpdatedDate != nil && req.Filters.StartUpdatedDate != nil &&
+		req.Filters.EndUpdatedDate.Before(*req.Filters.StartUpdatedDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
+	}
+
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
 		return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
@@ -923,6 +951,14 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			StateKeys:          domainStatesToSNIDs(req.Filters.StateKeys),
 			SeverityKeys:       domainPrioritiesToSNIDs(req.Filters.PriorityKeys),
 			IssueTypeKeys:      domainIssueTypesToSNIDs(req.Filters.IssueTypeKeys),
+			ClosedStartDate:    formatSNDate(req.Filters.ClosedStartDate),
+			ClosedEndDate:      formatSNDate(req.Filters.ClosedEndDate),
+			StartCreatedDate:   formatSNDate(req.Filters.StartCreatedDate),
+			EndCreatedDate:     formatSNDate(req.Filters.EndCreatedDate),
+			StartUpdatedDate:   formatSNDate(req.Filters.StartUpdatedDate),
+			EndUpdatedDate:     formatSNDate(req.Filters.EndUpdatedDate),
+			CreatedBy:          req.Filters.CreatedBy,
+			CreatedByMe:        req.Filters.CreatedByMe,
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -546,8 +546,145 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 	}, nil
 }
 
-func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
-	return s.pgFallback.UpdateCase(ctx, req)
+type snUpdateCasePayload struct {
+	StateKey      *int     `json:"stateKey,omitempty"`
+	SeverityKey   *int     `json:"severityKey,omitempty"`
+	WatchList     []string `json:"watchList,omitempty"`
+	AssigneeEmail *string  `json:"assigneeEmail,omitempty"`
+}
+
+type snUpdateCaseResponse struct {
+	Message string `json:"message"`
+	Case    struct {
+		ID        string        `json:"id"`
+		UpdatedOn string        `json:"updatedOn"`
+		UpdatedBy string        `json:"updatedBy"`
+		State     *snCaseState  `json:"state"`
+		Severity  *snCaseLabel  `json:"severity"`
+		WatchList []struct {
+			ID       string `json:"id"`
+			UserName string `json:"userName"`
+			Name     string `json:"name"`
+			Email    string `json:"email"`
+		} `json:"watchList"`
+		AssignedTo *struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"assignedTo"`
+	} `json:"case"`
+}
+
+func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+
+	fieldCount := 0
+	if req.State != nil {
+		fieldCount++
+	}
+	if req.Priority != nil {
+		fieldCount++
+	}
+	if len(req.WatchList) > 0 {
+		fieldCount++
+	}
+	if req.AssigneeEmail != nil {
+		fieldCount++
+	}
+	if fieldCount == 0 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state, priority, watchList, or assigneeEmail must be provided"}
+	}
+	if fieldCount > 1 {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, priority, watchList, or assigneeEmail may be provided per request"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.UpdateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snUpdateCasePayload{}
+	if req.State != nil {
+		if !validCaseState[*req.State] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
+		}
+		id, ok := snStateIDMap[*req.State]
+		if !ok {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state " + string(*req.State) + " is not supported by ServiceNow"}
+		}
+		payload.StateKey = &id
+	}
+	if req.Priority != nil {
+		if !validCasePriority[*req.Priority] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority contains invalid value: " + string(*req.Priority)}
+		}
+		id, ok := snSeverityIDMap[*req.Priority]
+		if !ok {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "priority " + string(*req.Priority) + " is not supported by ServiceNow"}
+		}
+		payload.SeverityKey = &id
+	}
+	if len(req.WatchList) > 0 {
+		payload.WatchList = req.WatchList
+	}
+	if req.AssigneeEmail != nil {
+		payload.AssigneeEmail = req.AssigneeEmail
+	}
+
+	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, err
+	}
+
+	var snResp snUpdateCaseResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse response: %w", err)
+	}
+
+	updatedOn, err := time.Parse(snCreatedOnLayout, snResp.Case.UpdatedOn)
+	if err != nil {
+		return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse updatedOn %q: %w", snResp.Case.UpdatedOn, err)
+	}
+
+	resp := domain.UpdateCaseResponse{
+		Message: snResp.Message,
+		Case: domain.UpdatedCase{
+			ID:        sysidToUUID(snResp.Case.ID),
+			UpdatedOn: updatedOn,
+			UpdatedBy: snResp.Case.UpdatedBy,
+		},
+	}
+
+	if snResp.Case.State != nil {
+		state, err := snCaseStateLabelToEnum(snResp.Case.State)
+		if err == nil {
+			resp.Case.State = state
+		}
+	}
+	if snResp.Case.Severity != nil {
+		resp.Case.Priority = snSeverityToPriority(snResp.Case.Severity)
+	}
+	if snResp.Case.AssignedTo != nil {
+		resp.Case.AssignedTo = &domain.AssignedEngineerRef{
+			ID:   sysidToUUID(snResp.Case.AssignedTo.ID),
+			Name: snResp.Case.AssignedTo.Name,
+		}
+	}
+	if len(snResp.Case.WatchList) > 0 {
+		wl := make([]domain.WatchListUser, 0, len(snResp.Case.WatchList))
+		for _, u := range snResp.Case.WatchList {
+			wl = append(wl, domain.WatchListUser{
+				ID:       sysidToUUID(u.ID),
+				UserName: u.UserName,
+				Name:     u.Name,
+				Email:    u.Email,
+			})
+		}
+		resp.Case.WatchList = wl
+	}
+
+	return resp, nil
 }
 
 type snCreateAttachmentPayload struct {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -532,7 +532,7 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 				LastName:  c.CreatedByLastName,
 				FullName:  c.CreatedByFullName,
 			},
-			CreatedAt: createdAt,
+			CreatedOn: createdAt,
 		})
 	}
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -38,6 +38,42 @@ type snCasesResponse struct {
 	Limit        int      `json:"limit"`
 }
 
+// snServiceRequestsResponse mirrors the Choreo POST /cases/search response for service_request cases.
+type snServiceRequestsResponse struct {
+	Cases        []snServiceRequestCase `json:"cases"`
+	TotalRecords int                    `json:"totalRecords"`
+	Offset       int                    `json:"offset"`
+	Limit        int                    `json:"limit"`
+}
+
+type snServiceRequestCase struct {
+	ID               string                     `json:"id"`
+	InternalID       string                     `json:"internalId"`
+	Number           string                     `json:"number"`
+	Title            *string                    `json:"title"`
+	Description      *string                    `json:"description"`
+	CreatedOn        string                     `json:"createdOn"`
+	CreatedBy        string                     `json:"createdBy"`
+	State            *snCaseState               `json:"state"`
+	WorkState        *snServiceRequestWorkState `json:"workState"`
+	Project          snCaseEntityRef            `json:"project"`
+	Deployment       snCaseEntityRef            `json:"deployment"`
+	DeployedProduct  snCaseDeployedProduct      `json:"deployedProduct"`
+	Product          *snCaseEntityRef           `json:"product"`
+	Catalog          *snCaseEntityRef           `json:"catalog"`
+	CatalogItem      *snCaseEntityRef           `json:"catalogItem"`
+	AssignedTeam     *snCaseEntityRef           `json:"assignedTeam"`
+	AssignedEngineer *snCaseEntityRef           `json:"assignedEngineer"`
+	ParentCase       *snCaseRef                 `json:"parentCase"`
+	RelatedCase      *snCaseRef                 `json:"relatedCase"`
+	Conversation     *snCaseEntityRef           `json:"conversation"`
+}
+
+type snServiceRequestWorkState struct {
+	ID    *int   `json:"id"`
+	Label string `json:"label"`
+}
+
 type snCase struct {
 	ID               string                `json:"id"`
 	InternalID       string                `json:"internalId"`
@@ -1091,4 +1127,146 @@ func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
 	default:
 		return nil
 	}
+}
+
+// SearchServiceRequests implements CaseService by calling the Choreo POST /cases/search
+// endpoint with caseTypes filtered to ["service_request"].
+func (s *snCaseService) SearchServiceRequests(ctx context.Context, req domain.SearchServiceRequestsRequest) (domain.SearchServiceRequestsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchServiceRequestsResponse{}, err
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchServiceRequestsResponse{}, err
+	}
+
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	if req.Filters.EndCreatedDate != nil && req.Filters.StartCreatedDate != nil &&
+		req.Filters.EndCreatedDate.Before(*req.Filters.StartCreatedDate) {
+		return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "endCreatedDate must not be before startCreatedDate"}
+	}
+	if req.Filters.EndUpdatedDate != nil && req.Filters.StartUpdatedDate != nil &&
+		req.Filters.EndUpdatedDate.Before(*req.Filters.StartUpdatedDate) {
+		return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchServiceRequestsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	var snSortBy *snCaseSort
+	if req.SortBy.Field != "" {
+		snField, ok := snSortFieldMap[req.SortBy.Field]
+		if !ok {
+			return domain.SearchServiceRequestsResponse{}, &apierror.ValidationError{Msg: "sortBy.field " + string(req.SortBy.Field) + " is not supported by ServiceNow"}
+		}
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snCaseSort{Field: snField, Order: order}
+	}
+
+	payload := snCaseSearchPayload{
+		Filters: snCaseFilters{
+			CaseTypes:        []string{"service_request"},
+			SearchQuery:      req.Filters.SearchQuery,
+			ProjectIDs:       uuidsToSysids(req.Filters.ProjectIDs),
+			DeploymentIDs:    uuidsToSysids(req.Filters.DeploymentIDs),
+			StateKeys:        req.Filters.StateKeys,
+			ClosedStartDate:  formatSNDate(req.Filters.ClosedStartDate),
+			ClosedEndDate:    formatSNDate(req.Filters.ClosedEndDate),
+			StartCreatedDate: formatSNDate(req.Filters.StartCreatedDate),
+			EndCreatedDate:   formatSNDate(req.Filters.EndCreatedDate),
+			StartUpdatedDate: formatSNDate(req.Filters.StartUpdatedDate),
+			EndUpdatedDate:   formatSNDate(req.Filters.EndUpdatedDate),
+			CreatedBy:        req.Filters.CreatedBy,
+			CreatedByMe:      req.Filters.CreatedByMe,
+		},
+		SortBy:     snSortBy,
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/search", token, payload)
+	if err != nil {
+		return domain.SearchServiceRequestsResponse{}, err
+	}
+
+	var snResp snServiceRequestsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchServiceRequestsResponse{}, fmt.Errorf("sn service requests: parse response: %w", err)
+	}
+
+	views := make([]domain.ServiceRequestView, 0, len(snResp.Cases))
+	for _, c := range snResp.Cases {
+		view := domain.ServiceRequestView{
+			ID:          sysidToUUID(c.ID),
+			InternalID:  c.InternalID,
+			Number:      c.Number,
+			CreatedOn:   c.CreatedOn,
+			CreatedBy:   c.CreatedBy,
+			Title:       c.Title,
+			Description: c.Description,
+			State:       snServiceRequestStateLabel(c.State),
+			Project:     domain.EntityRef{ID: sysidToUUID(c.Project.ID), Name: c.Project.Name},
+			Deployment:  domain.EntityRef{ID: sysidToUUID(c.Deployment.ID), Name: c.Deployment.Name},
+			DeployedProduct: domain.EntityRef{
+				ID:   sysidToUUID(c.DeployedProduct.ID),
+				Name: strings.TrimSpace(c.DeployedProduct.Name + " " + c.DeployedProduct.Version),
+			},
+		}
+		if c.Product != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.Product.ID), Name: c.Product.Name}
+			view.Product = &ref
+		}
+		if c.Catalog != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.Catalog.ID), Name: c.Catalog.Name}
+			view.Catalog = &ref
+		}
+		if c.CatalogItem != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.CatalogItem.ID), Name: c.CatalogItem.Name}
+			view.CatalogItem = &ref
+		}
+		if c.AssignedTeam != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.AssignedTeam.ID), Name: c.AssignedTeam.Name}
+			view.AssignedTeam = &ref
+		}
+		if c.AssignedEngineer != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name}
+			view.AssignedEngineer = &ref
+		}
+		if c.ParentCase != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.ParentCase.ID), Name: c.ParentCase.Number}
+			view.ParentCase = &ref
+		}
+		if c.RelatedCase != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.RelatedCase.ID), Name: c.RelatedCase.Number}
+			view.RelatedCase = &ref
+		}
+		if c.Conversation != nil {
+			ref := domain.EntityRef{ID: sysidToUUID(c.Conversation.ID), Name: c.Conversation.Name}
+			view.Conversation = &ref
+		}
+		if c.WorkState != nil {
+			view.WorkState = &domain.ServiceRequestWorkStateRef{ID: c.WorkState.ID, Label: c.WorkState.Label}
+		}
+		views = append(views, view)
+	}
+
+	return domain.SearchServiceRequestsResponse{
+		Cases:        views,
+		TotalRecords: snResp.TotalRecords,
+		Offset:       req.Pagination.Offset,
+		Limit:        req.Pagination.Limit,
+	}, nil
+}
+
+func snServiceRequestStateLabel(state *snCaseState) string {
+	if state == nil {
+		return ""
+	}
+	return state.Label
 }

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -216,6 +216,31 @@ func (c *Client) GetBinary(ctx context.Context, path string, userIDToken string)
 	}
 }
 
+// Patch sends a PATCH request to the given path. The OAuth2 bearer token is
+// added as Authorization header; userIDToken is forwarded as x-user-id-token.
+// Returns the raw response body on 2xx.
+func (c *Client) Patch(ctx context.Context, path string, userIDToken string, payload any) (json.RawMessage, error) {
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("snclient: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("snclient: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("x-user-id-token", userIDToken)
+
+	return c.do(req, path)
+}
+
 // Post sends a POST request to the given path. The OAuth2 bearer token is
 // added as Authorization header; userIDToken is forwarded as x-user-id-token.
 // Returns the raw response body on 2xx.

--- a/entity-service/migrations/000008_create_cases.up.sql
+++ b/entity-service/migrations/000008_create_cases.up.sql
@@ -1,3 +1,8 @@
+CREATE TYPE case_work_state_enum AS ENUM (
+  'ongoing',
+  'paused'
+);
+
 CREATE TYPE case_priority_enum AS ENUM (
   'catastrophic',
   'critical',
@@ -45,6 +50,7 @@ CREATE TABLE cases (
   updated_at          TIMESTAMP DEFAULT NOW(),
   closed_at           TIMESTAMP,
   assigned_engineer   UUID NULL REFERENCES users(id),
+  work_state          case_work_state_enum NULL,
   parent_case_id      UUID NULL REFERENCES cases(id),
   related_case_id     UUID NULL REFERENCES cases(id),
 
@@ -52,7 +58,14 @@ CREATE TABLE cases (
     CHECK (state != 'closed' OR closed_at IS NOT NULL),
 
   CONSTRAINT chk_closed_at_not_on_open
-    CHECK (closed_at IS NULL OR state = 'closed')
+    CHECK (closed_at IS NULL OR state = 'closed'),
+
+  CONSTRAINT chk_work_state_only_on_wip
+    CHECK (
+      (state = 'work_in_progress' AND work_state IS NOT NULL)
+      OR
+      (state != 'work_in_progress' AND work_state IS NULL)
+    )
 );
 
 CREATE OR REPLACE FUNCTION check_case_deployment_belongs_to_project()
@@ -112,6 +125,20 @@ CREATE TRIGGER trg_case_catastrophic_priority
   BEFORE INSERT OR UPDATE ON cases
   FOR EACH ROW EXECUTE FUNCTION check_case_catastrophic_priority();
 
+CREATE OR REPLACE FUNCTION sync_work_state_on_state_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.state != 'work_in_progress' THEN
+    NEW.work_state := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_work_state_on_state_change
+  BEFORE INSERT OR UPDATE ON cases
+  FOR EACH ROW EXECUTE FUNCTION sync_work_state_on_state_change();
+
 -- Enable trigram extension for ILIKE '%...%' support
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
@@ -133,6 +160,19 @@ CREATE INDEX idx_cases_closed_at           ON cases(closed_at);
 CREATE INDEX idx_cases_project_state         ON cases(project_id, state);
 CREATE INDEX idx_cases_priority_state        ON cases(priority, state);
 CREATE INDEX idx_cases_priority_issue_type   ON cases(priority, issue_type);
+
+-- work_state indexes
+CREATE UNIQUE INDEX uidx_cases_one_ongoing_per_engineer
+  ON cases (assigned_engineer)
+  WHERE work_state = 'ongoing';
+
+CREATE INDEX idx_cases_work_state
+  ON cases(work_state)
+  WHERE work_state IS NOT NULL;
+
+CREATE INDEX idx_cases_engineer_work_state
+  ON cases(assigned_engineer, work_state)
+  WHERE work_state IS NOT NULL;
 
 -- Trigram indexes for ILIKE search on subject, number, internal_id
 CREATE INDEX idx_cases_subject_trgm  ON cases USING GIN (subject  gin_trgm_ops);

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -316,7 +316,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     patch:
-      summary: Update the state and/or priority of a support case.
+      summary: Update a support case.
+      description: |
+        Updates exactly one field of the case. Provide exactly one of: `state`, `priority`,
+        `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        only when the ServiceNow data source is active.
       operationId: patchCase
       parameters:
         - name: id
@@ -337,7 +341,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Case'
+                $ref: '#/components/schemas/UpdateCaseResponse'
         "400":
           description: Bad request.
           content:
@@ -1146,10 +1150,14 @@ components:
 
     UpdateCaseRequest:
       type: object
-      description: At least one of state or priority must be provided.
-      anyOf:
+      description: |
+        Exactly one of `state`, `priority`, `watchList`, or `assigneeEmail` must be provided.
+        `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
+      oneOf:
         - required: [state]
         - required: [priority]
+        - required: [watchList]
+        - required: [assigneeEmail]
       properties:
         state:
           type: string
@@ -1159,6 +1167,67 @@ components:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new priority (severity) of the case.
+        watchList:
+          type: array
+          items:
+            type: string
+            format: email
+          description: List of email addresses to set as the case watch list (ServiceNow only).
+        assigneeEmail:
+          type: string
+          format: email
+          description: Email of the engineer to assign to this case (ServiceNow only).
+
+    UpdateCaseResponse:
+      type: object
+      required: [message, case]
+      properties:
+        message:
+          type: string
+        case:
+          $ref: '#/components/schemas/UpdatedCase'
+
+    UpdatedCase:
+      type: object
+      required: [id, updatedOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
+          description: Email or display name of the user who performed the update.
+        state:
+          type: string
+          enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        priority:
+          type: string
+          enum: [catastrophic, critical, high, medium, low]
+        watchList:
+          type: array
+          items:
+            $ref: '#/components/schemas/WatchListUser'
+        assignedTo:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+
+    WatchListUser:
+      type: object
+      required: [id, userName]
+      properties:
+        id:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
 
     CreateCaseRequest:
       type: object
@@ -1406,6 +1475,11 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          nullable: true
+          description: Work sub-state, present only when state is work_in_progress.
         createdOn:
           type: string
           format: date-time
@@ -1454,6 +1528,11 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          nullable: true
+          description: Work sub-state, present only when state is work_in_progress.
         createdOn:
           type: string
           format: date-time

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -319,7 +319,7 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `priority`,
-        `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        `workState`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
         only when the ServiceNow data source is active.
       operationId: patchCase
       parameters:
@@ -708,10 +708,10 @@ components:
         userType:
           type: string
           enum: [internal, customer, system]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -771,10 +771,10 @@ components:
           type: boolean
         kbReferencesEnabled:
           type: boolean
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -922,10 +922,10 @@ components:
         class:
           type: string
           enum: [software, service]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -977,10 +977,10 @@ components:
           type: string
           format: date-time
           nullable: true
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
 
@@ -1151,11 +1151,12 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `state`, `priority`, `watchList`, or `assigneeEmail` must be provided.
+        Exactly one of `state`, `priority`, `workState`, `watchList`, or `assigneeEmail` must be provided.
         `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
       oneOf:
         - required: [state]
         - required: [priority]
+        - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
       properties:
@@ -1167,6 +1168,10 @@ components:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new priority (severity) of the case.
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          description: The new work sub-state of the case. Only applicable when the case state is work_in_progress.
         watchList:
           type: array
           items:
@@ -1206,6 +1211,11 @@ components:
         priority:
           type: string
           enum: [catastrophic, critical, high, medium, low]
+        workState:
+          type: string
+          enum: [ongoing, paused]
+          nullable: true
+          description: Work sub-state after the update. null when state is not work_in_progress.
         watchList:
           type: array
           items:
@@ -1441,13 +1451,13 @@ components:
         state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, solution_proposed, closed]
-        createdAt:
+        createdOn:
           type: string
           format: date-time
-        updatedAt:
+        updatedOn:
           type: string
           format: date-time
-        closedAt:
+        closedOn:
           type: string
           format: date-time
           nullable: true
@@ -1486,6 +1496,11 @@ components:
         updatedOn:
           type: string
           format: date-time
+        closedOn:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the case was closed. null if not yet closed.
         createdBy:
           $ref: '#/components/schemas/UserRef'
         project:
@@ -1497,12 +1512,16 @@ components:
         product:
           $ref: '#/components/schemas/EntityRef'
         assignedEngineer:
+          nullable: true
           $ref: '#/components/schemas/AssignedEngineerRef'
         parentCase:
+          nullable: true
           $ref: '#/components/schemas/CaseNumberRef'
         relatedCase:
+          nullable: true
           $ref: '#/components/schemas/CaseNumberRef'
         account:
+          nullable: true
           $ref: '#/components/schemas/AccountRef'
 
     CaseSearchView:
@@ -1539,6 +1558,11 @@ components:
         updatedOn:
           type: string
           format: date-time
+        closedOn:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the case was closed. null if not yet closed.
         createdBy:
           $ref: '#/components/schemas/UserIDEmailRef'
         project:
@@ -1547,6 +1571,20 @@ components:
           $ref: '#/components/schemas/EntityRef'
         deployedProduct:
           $ref: '#/components/schemas/DeployedProductRef'
+        product:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+        parentCase:
+          nullable: true
+          $ref: '#/components/schemas/CaseNumberRef'
+        relatedCase:
+          nullable: true
+          $ref: '#/components/schemas/CaseNumberRef'
+        account:
+          nullable: true
+          $ref: '#/components/schemas/AccountRef'
 
     SearchCasesResponse:
       type: object
@@ -1589,7 +1627,7 @@ components:
           type: string
         createdBy:
           type: string
-        createdAt:
+        createdOn:
           type: string
           format: date-time
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -421,6 +421,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /service-requests/search:
+    post:
+      summary: Search service requests (ServiceNow data source only).
+      operationId: searchServiceRequests
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchServiceRequestsRequest'
+      responses:
+        "200":
+          description: Service requests matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchServiceRequestsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Not supported for the Postgres data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /cases/{id}/comments:
     post:
       summary: Create a comment on a support case.
@@ -1745,6 +1781,146 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    SearchServiceRequestsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                description: 32-char hex sysid
+            searchQuery:
+              type: string
+            stateKeys:
+              type: array
+              items:
+                type: integer
+            closedStartDate:
+              type: string
+              format: date-time
+            closedEndDate:
+              type: string
+              format: date-time
+            startCreatedDate:
+              type: string
+              format: date-time
+            endCreatedDate:
+              type: string
+              format: date-time
+            startUpdatedDate:
+              type: string
+              format: date-time
+            endUpdatedDate:
+              type: string
+              format: date-time
+            deploymentIds:
+              type: array
+              items:
+                type: string
+                description: 32-char hex sysid
+            createdBy:
+              type: array
+              items:
+                type: string
+                format: email
+            createdByMe:
+              type: boolean
+        sortBy:
+          type: object
+          required: [field, order]
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ServiceRequestWorkStateRef:
+      type: object
+      properties:
+        id:
+          type: integer
+          nullable: true
+        label:
+          type: string
+
+    ServiceRequestView:
+      type: object
+      properties:
+        id:
+          type: string
+          description: 32-char hex sysid
+        internalId:
+          type: string
+          nullable: true
+        number:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        title:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        state:
+          type: string
+        catalog:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        catalogItem:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTeam:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        product:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        workState:
+          $ref: '#/components/schemas/ServiceRequestWorkStateRef'
+          nullable: true
+        project:
+          $ref: '#/components/schemas/EntityRef'
+        deployment:
+          $ref: '#/components/schemas/EntityRef'
+        deployedProduct:
+          $ref: '#/components/schemas/EntityRef'
+        assignedEngineer:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        parentCase:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        relatedCase:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        conversation:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+
+    SearchServiceRequestsResponse:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceRequestView'
+        totalRecords:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
## Summary

Adds `POST /security-report-analyses/search` to the CSM Portal backend, corresponding to entity-service [PR #906](https://github.com/wso2-open-operations/cs-tools/pull/906). Follows the same raw-passthrough pattern as the other case-type search endpoints. Only supported for the ServiceNow data source (entity-service returns 503 for Postgres).

- Add `SearchSecurityReportAnalyses` method to entity client (`POST /security-report-analyses/search`)
- Extend `entityCaseClient` interface with `SearchSecurityReportAnalyses`
- Add `CaseHandler.SearchSecurityReportAnalyses` handler (auth → body validation → upstream call → passthrough response)
- Register `POST /security-report-analyses/search` route in mux
- Add `SecurityReportAnalysisSearchFilters`, `SecurityReportAnalysisSearchPayload`, `SecurityReportAnalysisView`, and `SecurityReportAnalysisSearchResponse` schemas to OpenAPI spec
- Add `searchSecurityReportAnalysesFn` field and method to test mock

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] Pre-push hook passed
- [ ] Verify `POST /security-report-analyses/search` proxies to entity service correctly
- [ ] Verify 503 is returned when entity service is backed by Postgres

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new search endpoint for security report analyses with advanced filtering options (project, deployment, state, and date ranges), sorting, and pagination capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->