### PR TITLE
[CSM Portal][BE] Add security response headers middleware

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -4,8 +4,9 @@ Go HTTP server (`net/http`, Go 1.22+) that acts as a backend-for-frontend (BFF) 
 
 ## Middleware chain
 
-`CorrelationID → Auth → Logger → Mux`
+`SecurityHeaders → CorrelationID → Auth → Logger → Mux`
 
+- `SecurityHeaders` (`internal/middleware/security_headers.go`): sets `X-Content-Type-Options: nosniff`, `Content-Security-Policy: upgrade-insecure-requests`, and `Strict-Transport-Security: max-age=31536000; includeSubDomains` on every response; outermost so headers are present even on auth failures
 - `CorrelationID` (`internal/middleware/correlation.go`): reads `X-CSM-Correlation-ID` from the incoming request or generates a UUID v4; stores the ID in context for the slog handler and for the entity client to forward; echoes the ID in the response header
 - `Auth` (`internal/middleware/auth.go`): validates the `x-jwt-assertion` JWT and sets `UserInfo` in context
 - `Logger` (`internal/middleware/logger.go`): logs every completed request (method, path, status, elapsed) via slog; runs after Auth so both `correlationID` and `userID` are present in every record

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -120,9 +120,11 @@ func main() {
 	slog.Info("CSM Portal Backend started", "addr", addr)
 
 	srv := &http.Server{
-		Handler: middleware.CorrelationID(
-			middleware.Auth(authCfg)(
-				middleware.Logger(mux),
+		Handler: middleware.SecurityHeaders(
+			middleware.CorrelationID(
+				middleware.Auth(authCfg)(
+					middleware.Logger(mux),
+				),
 			),
 		),
 		ReadHeaderTimeout: 10 * time.Second,

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -510,7 +510,6 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 	}
 	w.Header().Set("Content-Type", ct)
 	w.Header().Set("Content-Disposition", "attachment")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
 	_, _ = w.Write(content)
 }
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1163,9 +1163,6 @@ func TestGetCaseAttachmentContent(t *testing.T) {
 		if w.Header().Get("Content-Disposition") != "attachment" {
 			t.Errorf("Content-Disposition = %q, want %q", w.Header().Get("Content-Disposition"), "attachment")
 		}
-		if w.Header().Get("X-Content-Type-Options") != "nosniff" {
-			t.Errorf("X-Content-Type-Options = %q, want %q", w.Header().Get("X-Content-Type-Options"), "nosniff")
-		}
 	})
 
 	t.Run("coerces unsafe Content-Type to octet-stream", func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/middleware/security_headers.go
+++ b/apps/csm-portal/backend/internal/middleware/security_headers.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import "net/http"
+
+// SecurityHeaders sets security-related response headers on every response,
+// mirroring the ResponseInterceptor in the customer portal's authorization module.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Content-Security-Policy", "upgrade-insecure-requests")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/apps/csm-portal/backend/internal/middleware/security_headers_test.go
+++ b/apps/csm-portal/backend/internal/middleware/security_headers_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	t.Parallel()
+
+	handler := middleware.SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"X-Content-Type-Options", "nosniff"},
+		{"Content-Security-Policy", "upgrade-insecure-requests"},
+		{"Strict-Transport-Security", "max-age=31536000; includeSubDomains"},
+	}
+	for _, tc := range cases {
+		if got := w.Header().Get(tc.header); got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.header, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/middleware/security_headers.go` — a new `SecurityHeaders` middleware that sets three security headers on every response, mirroring the `ResponseInterceptor` in the customer portal's `authorization.bal`
- Headers applied globally: `X-Content-Type-Options: nosniff`, `Content-Security-Policy: upgrade-insecure-requests`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`
- Wires `SecurityHeaders` as the outermost layer in `main.go` so headers are present on all responses including auth failures
- Removes the now-redundant inline `X-Content-Type-Options: nosniff` from the attachment content handler
- Adds `security_headers_test.go` to verify all three headers are present on every response

## Test plan
- [x] All three security headers present on a successful response (e.g. `GET /health`)
- [x] All three security headers present on a 401 unauthorized response
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security posture with additional protective headers applied to all API responses.

* **Documentation**
  * Updated middleware chain documentation.

* **Tests**
  * Added tests to verify security header implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->