### PR TITLE
[CSM Portal][BE] Gate workState PATCH on case being work_in_progress

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -548,11 +548,12 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate state transition before forwarding to the entity service.
+	// Validate state transition and workState guard before forwarding to the entity service.
 	var patch struct {
-		State *string `json:"state"`
+		State     *string `json:"state"`
+		WorkState *string `json:"workState"`
 	}
-	if err := json.Unmarshal(body, &patch); err == nil && patch.State != nil {
+	if err := json.Unmarshal(body, &patch); err == nil && (patch.State != nil || patch.WorkState != nil) {
 		current, err := h.entity.GetCase(r.Context(), caseID)
 		if err != nil {
 			slog.ErrorContext(r.Context(), "entity GetCase failed during state validation", "userID", user.UserID, "caseID", caseID, "err", err)
@@ -567,8 +568,12 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, ErrMsgInternal)
 			return
 		}
-		if !isValidStateTransition(currentCase.State, *patch.State) {
+		if patch.State != nil && !isValidStateTransition(currentCase.State, *patch.State) {
 			writeError(w, http.StatusBadRequest, ErrMsgInvalidTransition)
+			return
+		}
+		if patch.WorkState != nil && currentCase.State != caseStateWorkInProgress {
+			writeError(w, http.StatusBadRequest, ErrMsgWorkStateNotAllowed)
 			return
 		}
 	}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -730,6 +730,48 @@ func TestPatchCase(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects workState update when case is not work_in_progress", func(t *testing.T) {
+		t.Parallel()
+		for _, state := range []string{"open", "waiting_on_wso2", "awaiting_info", "solution_proposed", "closed"} {
+			state := state
+			t.Run("current_state="+state, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(`{"id":"` + testCaseID + `","state":"` + state + `"}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"workState":"ongoing"}`)))
+				r.SetPathValue("id", testCaseID)
+				w := httptest.NewRecorder()
+				h.PatchCase(w, r)
+				assertStatus(t, w, http.StatusBadRequest)
+				assertErrorMessage(t, w, ErrMsgWorkStateNotAllowed)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+
+	t.Run("allows workState update when case is work_in_progress", func(t *testing.T) {
+		t.Parallel()
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"id":"` + testCaseID + `","state":"work_in_progress"}`), nil
+			},
+			patchCaseFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{"id":"` + testCaseID + `","state":"work_in_progress","workState":"paused"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"workState":"paused"}`)))
+		r.SetPathValue("id", testCaseID)
+		w := httptest.NewRecorder()
+		h.PatchCase(w, r)
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+	})
+
 	t.Run("allows priority-only update without state validation", func(t *testing.T) {
 		client := &mockEntityCaseClient{
 			patchCaseFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -33,6 +33,7 @@ const (
 	ErrMsgTooLarge          = "Request body too large."
 	ErrMsgInternal          = "An internal server error occurred. Please try again later."
 	ErrMsgInvalidTransition  = "Invalid state transition."
+	ErrMsgWorkStateNotAllowed = "Work state can only be updated when the case is in progress."
 	ErrMsgCommentNotAllowed  = "Comments can only be added when the case is in progress and the work state is ongoing."
 	ErrMsgInvalidUUID       = "Invalid UUID format."
 	errMsgReadBody          = "Failed to read request body."

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -154,7 +154,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UpdateCaseResponse'
         "400":
-          description: Bad request (e.g. malformed UUID, invalid state value, or invalid state transition).
+          description: Bad request (e.g. malformed UUID, invalid state value, invalid state transition, or workState update attempted when case is not work_in_progress).
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- `PATCH /cases/{id}` with `workState` now returns `400` if the current case state is not `work_in_progress` — enforcing what the OpenAPI spec's `workState` field description already stated ("Only applicable when the case state is work_in_progress") but wasn't previously checked
- Deduplicates the upstream `GET /cases/{id}` prefetch: previously only triggered for `state` patches, now a single call covers both the state-transition guard and the new `workState` guard
- Adds `ErrMsgWorkStateNotAllowed` constant: `"Work state can only be updated when the case is in progress."`
- OpenAPI 400 description updated to mention the new condition

## Test plan
- [x] `PATCH /cases/{id}` with `{"workState":"ongoing"}` when case state is `open` → 400 with `ErrMsgWorkStateNotAllowed`
- [x] Same when case state is `waiting_on_wso2`, `awaiting_info`, `solution_proposed`, `closed` → 400
- [x] `PATCH /cases/{id}` with `{"workState":"paused"}` when case state is `work_in_progress` → 200
- [x] `PATCH /cases/{id}` with `{"state":"work_in_progress"}` still validates via state machine as before
- [x] `PATCH /cases/{id}` with `{"priority":"high"}` still passes without any upstream prefetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)