### PR TITLE
[Customer Portal] Add data source filter toggle and usage stats cards to Usage & Metrics

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2338,6 +2338,8 @@ public type InstanceUsageStatsPayload record {|
         IdString[] deploymentIds?;
         # List of deployed product IDs (mutually exclusive with projectIds and deploymentIds)
         IdString[] deployedProductIds?;
+        # Data source filter: 1 = API Call, 2 = File Upload
+        int dataSource?;
     |} filters;
 |};
 
@@ -2355,6 +2357,8 @@ public type InstanceMetricStatsPayload record {|
         IdString[] deploymentIds?;
         # List of deployed product IDs (mutually exclusive with projectIds and deploymentIds)
         IdString[] deployedProductIds?;
+        # Data source filter: 1 = API Call, 2 = File Upload
+        int dataSource?;
     |} filters;
 |};
 

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1769,6 +1769,8 @@ public type InstanceUsageStatsPayload record {|
         entity:Date startDate;
         # End date filter, required
         entity:Date endDate;
+        # Data source filter: 1 = API Call, 2 = File Upload
+        int dataSource?;
     |} filters;
 |};
 
@@ -1780,6 +1782,8 @@ public type InstanceMetricStatsPayload record {|
         entity:Date startDate;
         # End date filter, required
         entity:Date endDate;
+        # Data source filter: 1 = API Call, 2 = File Upload
+        int dataSource?;
     |} filters;
 |};
 

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5684,7 +5684,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                     filters: {
                         projectIds: [id],
                         startDate: payload.filters.startDate,
-                        endDate: payload.filters.endDate
+                        endDate: payload.filters.endDate,
+                        dataSource: payload.filters.dataSource
                     }
                 });
         if response is error {
@@ -5747,7 +5748,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                     filters: {
                         deploymentIds: [id],
                         startDate: payload.filters.startDate,
-                        endDate: payload.filters.endDate
+                        endDate: payload.filters.endDate,
+                        dataSource: payload.filters.dataSource
                     }
                 });
         if response is error {
@@ -5810,7 +5812,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                     filters: {
                         deployedProductIds: [id],
                         startDate: payload.filters.startDate,
-                        endDate: payload.filters.endDate
+                        endDate: payload.filters.endDate,
+                        dataSource: payload.filters.dataSource
                     }
                 });
         if response is error {

--- a/apps/customer-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/apiConstants.ts
@@ -70,6 +70,7 @@ export const ApiQueryKeys = {
   PROJECT_INSTANCE_METRICS: "project-instance-metrics",
   DEPLOYMENT_INSTANCE_METRICS: "deployment-instance-metrics",
   DEPLOYED_PRODUCT_INSTANCE_METRICS: "deployed-product-instance-metrics",
+  PROJECT_INSTANCE_USAGE_STATS: "project-instance-usage-stats",
 } as const;
 
 // Constants for API-related mutation keys.

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesStats.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesStats.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useAsgardeo } from "@asgardeo/react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import type { InstanceUsageStatsResponse, DataSource } from "@features/project-details/types/usage";
+
+type Payload = {
+  filters: {
+    startDate: string;
+    endDate: string;
+    dataSource?: DataSource;
+  };
+};
+
+export default function usePostProjectInstancesUsagesStats(
+  projectId: string | undefined,
+  payload: Payload,
+) {
+  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
+  const authFetch = useAuthApiClient();
+
+  return useQuery<InstanceUsageStatsResponse>({
+    queryKey: [ApiQueryKeys.PROJECT_INSTANCE_USAGE_STATS, projectId, payload],
+    queryFn: async () => {
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL ?? "";
+      const response = await authFetch(
+        `${baseUrl}/projects/${projectId}/instances/stats/usages/search`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to fetch instance usage stats: ${response.status}`);
+      }
+      return response.json() as Promise<InstanceUsageStatsResponse>;
+    },
+    enabled: !!projectId && isSignedIn && !isAuthLoading,
+    staleTime: 0,
+  });
+}

--- a/apps/customer-portal/webapp/src/features/project-details/types/usage.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/usage.ts
@@ -202,6 +202,31 @@ export type UsageAggregatedMetricDefinition = {
   secondaryName?: string;
 };
 
+// Data source values for filtering usage stats.
+export enum DataSource {
+  API_CALL = 1,
+  FILE_UPLOAD = 2,
+}
+
+// Response type for POST .../instances/stats/usages/search.
+export type InstanceUsageStatsResponse = {
+  stats: Record<string, Record<string, number>>;
+  totalRecords: number;
+  startDate: string;
+  endDate: string;
+};
+
+// Summary statistics derived from a date-keyed stats map for a single metric type.
+export type MetricTypeSummary = {
+  id: string;
+  label: string;
+  curr: number;
+  min: number;
+  max: number;
+  avg: number;
+  trend: { date: string; value: number }[];
+};
+
 // Item type for a mini line chart shown when an instance row is expanded.
 export type UsageInstanceChartBlock = {
   title: string;

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -693,6 +693,7 @@ export default function NoveraChatPage(): JSX.Element {
         type: "token_increase_request",
         accountId,
         reason,
+        period: "daily",
       });
     },
     [accountId, connect, projectId, sendUserMessage],

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -249,6 +249,7 @@ export type ChatWebSocketPayload =
       type: "token_increase_request";
       accountId: string;
       reason: string;
+      period: "daily" | "monthly";
     };
 
 // Model type for chat WebSocket hook options.

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/DataSourceStatCard.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/DataSourceStatCard.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Card, Divider, Skeleton, Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import type { DataSourceStatCardProps } from "@features/usage-metrics/types/usageMetrics";
+import {
+  USAGE_METRICS_STAT_AVG,
+  USAGE_METRICS_STAT_CURR,
+  USAGE_METRICS_STAT_MAX,
+  USAGE_METRICS_STAT_MIN,
+} from "@features/usage-metrics/constants/usageMetricsConstants";
+import { formatUsageMetricCount } from "@features/project-details/utils/usageMetrics";
+
+function StatTile({ label, value }: { label: string; value: string }): JSX.Element {
+  return (
+    <Box sx={{ textAlign: "center" }}>
+      <Typography variant="caption" color="text.secondary" display="block">
+        {label}
+      </Typography>
+      <Typography variant="body2" fontWeight={600}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+export default function DataSourceStatCard({
+  summary,
+  isLoading,
+}: DataSourceStatCardProps): JSX.Element {
+  if (isLoading) {
+    return (
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Skeleton variant="text" width={120} height={24} sx={{ mb: 1 }} />
+        <Skeleton variant="text" width={80} height={40} sx={{ mb: 1.5 }} />
+        <Skeleton variant="rounded" height={32} />
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
+        {summary.label}
+      </Typography>
+      <Typography variant="h5" fontWeight={700} sx={{ mb: 1.5 }}>
+        {formatUsageMetricCount(summary.curr)}
+      </Typography>
+      <Divider sx={{ mb: 1.5 }} />
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: 1,
+        }}
+      >
+        <StatTile label={USAGE_METRICS_STAT_MIN} value={formatUsageMetricCount(summary.min)} />
+        <StatTile label={USAGE_METRICS_STAT_MAX} value={formatUsageMetricCount(summary.max)} />
+        <StatTile
+          label={USAGE_METRICS_STAT_AVG}
+          value={formatUsageMetricCount(Math.round(summary.avg))}
+        />
+      </Box>
+    </Card>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
@@ -14,11 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button } from "@wso2/oxygen-ui";
+import { Box, Button, ToggleButton, ToggleButtonGroup } from "@wso2/oxygen-ui";
 import { Upload } from "@wso2/oxygen-ui-icons-react";
 import type { ReactNode } from "react";
 import type { JSX } from "react";
 import { useCallback, useMemo, useState } from "react";
+import { DataSource } from "@features/project-details/types/usage";
+import {
+  USAGE_METRICS_DATA_SOURCE_API_CALL,
+  USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD,
+  USAGE_METRICS_DATA_SOURCE_LABEL,
+} from "@features/usage-metrics/constants/usageMetricsConstants";
 import { useParams } from "react-router";
 import TabBar from "@components/tab-bar/TabBar";
 import UsageOverviewPanel from "@features/usage-metrics/components/UsageOverviewPanel";
@@ -59,6 +65,7 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
   const [appliedCustomStart, setAppliedCustomStart] = useState<string>("");
   const [appliedCustomEnd, setAppliedCustomEnd] = useState<string>("");
   const [uploadOpen, setUploadOpen] = useState<boolean>(false);
+  const [dataSource, setDataSource] = useState<DataSource | null>(null);
 
   const dateRange = useMemo(
     () => resolveUsagePresetDateRange(timeRange),
@@ -131,6 +138,31 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
     setTimeRange(UsageTimeRange.ONE_MONTH);
   };
 
+  const dataSourceToggle: ReactNode = (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexShrink: 0 }}>
+      <Box
+        component="span"
+        sx={{ fontSize: "0.75rem", color: "text.secondary", whiteSpace: "nowrap" }}
+      >
+        {USAGE_METRICS_DATA_SOURCE_LABEL}
+      </Box>
+      <ToggleButtonGroup
+        size="small"
+        exclusive
+        value={dataSource}
+        onChange={(_e, val: DataSource | null) => setDataSource(val)}
+        aria-label="data source filter"
+      >
+        <ToggleButton value={DataSource.API_CALL} aria-label={USAGE_METRICS_DATA_SOURCE_API_CALL}>
+          {USAGE_METRICS_DATA_SOURCE_API_CALL}
+        </ToggleButton>
+        <ToggleButton value={DataSource.FILE_UPLOAD} aria-label={USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD}>
+          {USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD}
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
+  );
+
   const uploadButton: ReactNode = (
     <Button
       variant="outlined"
@@ -157,7 +189,12 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
       onCancelCustom={handleCancelCustom}
       appliedCustomStart={appliedCustomStart}
       appliedCustomEnd={appliedCustomEnd}
-      rightAction={uploadButton}
+      rightAction={
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexShrink: 0 }}>
+          {dataSourceToggle}
+          {uploadButton}
+        </Box>
+      }
     />
   );
 
@@ -242,6 +279,7 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
           expandedEnvironmentIds={expandedEnvironmentIds}
           onToggleEnvironment={toggleEnvironment}
           timeRangeSelector={timeRangeSelector}
+          dataSource={dataSource}
         />
       )}
 

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -37,6 +37,14 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import { useMemo } from "react";
+import usePostProjectInstancesUsagesStats from "@features/project-details/api/usePostProjectInstancesUsagesStats";
+import DataSourceStatCard from "@features/usage-metrics/components/DataSourceStatCard";
+import type { MetricTypeSummary } from "@features/project-details/types/usage";
+import {
+  METRIC_TYPE_LABELS,
+  USAGE_METRICS_DATA_SOURCE_STATS_SECTION,
+  USAGE_METRICS_NO_DATA_SOURCE_STATS,
+} from "@features/usage-metrics/constants/usageMetricsConstants";
 import { usePostProjectDeploymentsSearchAll } from "@api/usePostProjectDeploymentsSearch";
 import usePostProjectInstancesSearch from "@features/project-details/api/usePostProjectInstancesSearch";
 import usePostProjectInstancesUsagesSearch from "@features/project-details/api/usePostProjectInstancesUsagesSearch";
@@ -399,12 +407,48 @@ function EnvironmentBreakdownAccordion({
  * @param onToggleEnvironment - Toggle handler for an environment row id.
  * @returns {JSX.Element} Overview tab content.
  */
+function deriveMetricSummaries(
+  stats: Record<string, Record<string, number>>,
+): MetricTypeSummary[] {
+  const metricKeys = new Set<string>();
+  for (const dayStats of Object.values(stats)) {
+    for (const key of Object.keys(dayStats)) {
+      metricKeys.add(key);
+    }
+  }
+
+  const sortedDates = Object.keys(stats).sort();
+  const summaries: MetricTypeSummary[] = [];
+
+  for (const key of metricKeys) {
+    const values = sortedDates.map((d) => stats[d][key] ?? 0);
+    const nonZero = values.filter((v) => v > 0);
+    if (nonZero.length === 0) continue;
+    const curr = values[values.length - 1] ?? 0;
+    const min = Math.min(...nonZero);
+    const max = Math.max(...nonZero);
+    const avg = nonZero.reduce((a, b) => a + b, 0) / nonZero.length;
+    summaries.push({
+      id: key,
+      label: METRIC_TYPE_LABELS[key] ?? key,
+      curr,
+      min,
+      max,
+      avg,
+      trend: sortedDates.map((d) => ({ date: d, value: stats[d][key] ?? 0 })),
+    });
+  }
+
+  return summaries;
+}
+
 export default function UsageOverviewPanel({
   projectId,
   dateRange,
   expandedEnvironmentIds,
   onToggleEnvironment,
   timeRangeSelector,
+  dataSource,
 }: UsageOverviewPanelProps): JSX.Element {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
@@ -465,6 +509,31 @@ export default function UsageOverviewPanel({
     statsError;
 
   const isStatCardsLoading = statsLoading;
+
+  // ── Data source stats ──────────────────────────────────────────────────────
+  const dataSourceStatsPayload = useMemo(
+    () => ({
+      filters: {
+        startDate: dateRange.startDate,
+        endDate: dateRange.endDate,
+        dataSource: dataSource ?? undefined,
+      },
+    }),
+    [dateRange, dataSource],
+  );
+
+  const {
+    data: dataSourceStatsData,
+    isLoading: dataSourceStatsLoading,
+  } = usePostProjectInstancesUsagesStats(
+    dataSource != null ? projectId : undefined,
+    dataSourceStatsPayload,
+  );
+
+  const dataSourceSummaries = useMemo(() => {
+    if (!dataSourceStatsData?.stats) return [];
+    return deriveMetricSummaries(dataSourceStatsData.stats);
+  }, [dataSourceStatsData]);
 
   // ── Overview summary stats ─────────────────────────────────────────────────
   const overviewStats = useMemo(() => {
@@ -593,6 +662,38 @@ export default function UsageOverviewPanel({
       </Grid>
 
       {timeRangeSelector && <Box sx={{ mt: 1 }}>{timeRangeSelector}</Box>}
+
+      {dataSource != null && (
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+            {USAGE_METRICS_DATA_SOURCE_STATS_SECTION}
+          </Typography>
+          {dataSourceStatsLoading ? (
+            <Grid container spacing={2}>
+              {[0, 1, 2].map((i) => (
+                <Grid key={i} size={{ xs: 12, sm: 6, md: 4 }}>
+                  <DataSourceStatCard
+                    summary={{ id: "", label: "", curr: 0, min: 0, max: 0, avg: 0, trend: [] }}
+                    isLoading
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          ) : dataSourceSummaries.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              {USAGE_METRICS_NO_DATA_SOURCE_STATS}
+            </Typography>
+          ) : (
+            <Grid container spacing={2}>
+              {dataSourceSummaries.map((summary) => (
+                <Grid key={summary.id} size={{ xs: 12, sm: 6, md: 4 }}>
+                  <DataSourceStatCard summary={summary} />
+                </Grid>
+              ))}
+            </Grid>
+          )}
+        </Box>
+      )}
 
       <Box>
         <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -154,3 +154,27 @@ export const USAGE_AGGREGATED_ORG_COUNT_CAPTION =
 export const USAGE_METRICS_TREND_LINE_AVERAGE = "Average";
 
 export const USAGE_METRICS_TREND_LINE_CURRENT_FALLBACK = "Current";
+
+export const USAGE_METRICS_DATA_SOURCE_LABEL = "Data Source:";
+
+export const USAGE_METRICS_DATA_SOURCE_API_CALL = "API Call";
+
+export const USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD = "File Upload";
+
+export const USAGE_METRICS_DATA_SOURCE_STATS_SECTION = "Usage by Data Source";
+
+export const USAGE_METRICS_STAT_CURR = "Current";
+
+export const USAGE_METRICS_STAT_MIN = "Min";
+
+export const USAGE_METRICS_STAT_MAX = "Max";
+
+export const USAGE_METRICS_STAT_AVG = "Avg";
+
+export const USAGE_METRICS_NO_DATA_SOURCE_STATS = "No data available for the selected data source and date range.";
+
+export const METRIC_TYPE_LABELS: Record<string, string> = {
+  TRANSACTION_COUNT: "Transactions",
+  TOTAL_USERS: "Total Users",
+  TOTAL_ROOT_ORGS: "Organizations",
+};

--- a/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
@@ -17,10 +17,12 @@
 import type { ReactNode } from "react";
 import type { UsageAggregatedMetricDefinition } from "@features/project-details/types/usage";
 import type {
+  DataSource,
   UsageEnvironmentProduct,
   UsageInstanceChartBlock,
   UsageProductInstanceRow,
   UsageTimeRange,
+  MetricTypeSummary,
 } from "@features/project-details/types/usage";
 
 /** ISO date strings (YYYY-MM-DD) for usage API filters. */
@@ -82,6 +84,17 @@ export type UsageOverviewPanelProps = {
   expandedEnvironmentIds: Set<string>;
   onToggleEnvironment: (id: string) => void;
   timeRangeSelector?: ReactNode;
+  dataSource?: DataSource | null;
+};
+
+export type DataSourceStatCardProps = {
+  summary: MetricTypeSummary;
+  isLoading?: boolean;
+};
+
+export type DataSourceToggleProps = {
+  value: DataSource | null;
+  onChange: (value: DataSource | null) => void;
 };
 
 export type UsageEnvironmentProductsPanelProps = {


### PR DESCRIPTION
## Summary
- Add `dataSource?` field to `InstanceUsageStatsPayload` and `InstanceMetricStatsPayload` in backend types, and pass it through in `service.bal` to the entity service calls
- Add data source toggle (API Call / File Upload) to the Usage & Metrics time range toolbar
- When a data source is selected, fetch aggregated usage stats filtered by source and display Current / Min / Max / Avg cards per metric type (Transactions, Total Users, Organizations) above the Environment Breakdown
- Fix: add `period` field to Novera token increase request WebSocket payload

## Test plan
- [ ] Navigate to a project → Usage & Metrics → Overview tab
- [ ] Set a custom date range covering the test data period
- [ ] Click **File Upload** toggle — "Usage by Data Source" cards appear with Transactions / Total Users / Organizations showing current, min, max, avg values
- [ ] Click **API Call** toggle — cards update for API Call data source
- [ ] Deselect the active toggle — section hides
- [ ] Verify existing Aggregated Metrics charts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added data source filtering for usage statistics, allowing you to view metrics by API Call or File Upload separately.
  * Introduced a data source selector toggle in the usage metrics view for easy filtering.
  * Added data source summary statistics display showing current, minimum, maximum, and average metrics.
  * Enhanced token increase requests with period field support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->