### PR TITLE
fix: remove unused import in DataSourceStatCard

### DIFF
--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/DataSourceStatCard.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/DataSourceStatCard.tsx
@@ -19,7 +19,6 @@ import type { JSX } from "react";
 import type { DataSourceStatCardProps } from "@features/usage-metrics/types/usageMetrics";
 import {
   USAGE_METRICS_STAT_AVG,
-  USAGE_METRICS_STAT_CURR,
   USAGE_METRICS_STAT_MAX,
   USAGE_METRICS_STAT_MIN,
 } from "@features/usage-metrics/constants/usageMetricsConstants";


### PR DESCRIPTION
## Summary
- Remove unused `USAGE_METRICS_STAT_CURR` import in `DataSourceStatCard.tsx` that caused a TypeScript build error (`TS6133: declared but its value is never read`)

## Test plan
- [ ] `pnpm build` completes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused code dependencies to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->