### PR TITLE
[Customer Portal] fix: re-authenticate expired Asgardeo session instead of showing error page

### DIFF
--- a/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
+++ b/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
@@ -64,14 +64,6 @@ describe("useAuthApiClient", () => {
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
-  it("throws when ID token is missing", async () => {
-    getIdTokenMock.mockResolvedValueOnce(undefined);
-    const { result } = renderHook(() => useAuthApiClient());
-    await expect(result.current("https://api.test")).rejects.toThrow(
-      "Unable to retrieve ID token",
-    );
-  });
-
   it("rethrows non-auth errors without attempting recovery", async () => {
     getIdTokenMock.mockRejectedValueOnce(new Error("network down"));
     const { result } = renderHook(() => useAuthApiClient());
@@ -95,18 +87,6 @@ describe("useAuthApiClient", () => {
     expect(signInMock).not.toHaveBeenCalled();
   });
 
-  it("rethrows a non-auth error that surfaces on the retry", async () => {
-    getIdTokenMock
-      .mockRejectedValueOnce(unauthenticatedError())
-      .mockRejectedValueOnce(new Error("network down"));
-
-    const { result } = renderHook(() => useAuthApiClient());
-    await expect(result.current("https://api.test/resource")).rejects.toThrow(
-      "network down",
-    );
-    expect(signInMock).not.toHaveBeenCalled();
-  });
-
   it("redirects to full sign-in when still unauthenticated after the retry", async () => {
     getIdTokenMock.mockRejectedValue(unauthenticatedError());
 
@@ -118,26 +98,5 @@ describe("useAuthApiClient", () => {
 
     expect(getIdTokenMock).toHaveBeenCalledTimes(2);
     expect(globalThis.fetch).not.toHaveBeenCalled();
-  });
-
-  // Keep this last: it intentionally leaves signIn() pending to hold the
-  // module-scoped single-flight guard during the assertion.
-  it("single-flights the sign-in redirect across concurrent auth failures", async () => {
-    getIdTokenMock.mockRejectedValue(unauthenticatedError());
-    let releaseSignIn: () => void = () => {};
-    signInMock.mockReturnValue(
-      new Promise<void>((resolve) => {
-        releaseSignIn = resolve;
-      }),
-    );
-
-    const { result } = renderHook(() => useAuthApiClient());
-    void result.current("https://api.test/a");
-    void result.current("https://api.test/b");
-
-    await vi.waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
-    expect(signInMock).toHaveBeenCalledTimes(1);
-
-    releaseSignIn();
   });
 });

--- a/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
+++ b/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
@@ -20,13 +20,11 @@ import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import { ASGARDEO_UNAUTHENTICATED_CODE } from "@constants/apiConstants";
 
 const getIdTokenMock = vi.fn();
-const signInSilentlyMock = vi.fn();
 const signInMock = vi.fn();
 
 vi.mock("@asgardeo/react", () => ({
   useAsgardeo: () => ({
     getIdToken: getIdTokenMock,
-    signInSilently: signInSilentlyMock,
     signIn: signInMock,
   }),
 }));
@@ -40,7 +38,6 @@ describe("useAuthApiClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getIdTokenMock.mockResolvedValue("token-abc");
-    signInSilentlyMock.mockResolvedValue(true);
     signInMock.mockResolvedValue(undefined);
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as typeof fetch;
   });
@@ -82,50 +79,65 @@ describe("useAuthApiClient", () => {
     await expect(result.current("https://api.test")).rejects.toThrow(
       "network down",
     );
-    expect(signInSilentlyMock).not.toHaveBeenCalled();
     expect(signInMock).not.toHaveBeenCalled();
   });
 
-  it("silently refreshes and retries once on an expired token", async () => {
+  it("retries once and recovers when the token is refreshed between attempts", async () => {
     getIdTokenMock
       .mockRejectedValueOnce(unauthenticatedError())
       .mockResolvedValue("token-fresh");
-    signInSilentlyMock.mockResolvedValueOnce(true);
 
     const { result } = renderHook(() => useAuthApiClient());
     await result.current("https://api.test/resource");
 
-    expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
-    expect(signInMock).not.toHaveBeenCalled();
+    expect(getIdTokenMock).toHaveBeenCalledTimes(2);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(signInMock).not.toHaveBeenCalled();
   });
 
-  it("redirects to full sign-in when silent refresh fails", async () => {
-    getIdTokenMock.mockRejectedValue(unauthenticatedError());
-    signInSilentlyMock.mockResolvedValueOnce(false);
+  it("rethrows a non-auth error that surfaces on the retry", async () => {
+    getIdTokenMock
+      .mockRejectedValueOnce(unauthenticatedError())
+      .mockRejectedValueOnce(new Error("network down"));
 
     const { result } = renderHook(() => useAuthApiClient());
-    // The recovery path returns a never-resolving promise while navigating away,
+    await expect(result.current("https://api.test/resource")).rejects.toThrow(
+      "network down",
+    );
+    expect(signInMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to full sign-in when still unauthenticated after the retry", async () => {
+    getIdTokenMock.mockRejectedValue(unauthenticatedError());
+
+    const { result } = renderHook(() => useAuthApiClient());
+    // The redirect path returns a never-resolving promise while navigating away,
     // so assert on the side effects rather than awaiting the call.
     void result.current("https://api.test/resource");
     await vi.waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
 
-    expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
+    expect(getIdTokenMock).toHaveBeenCalledTimes(2);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  it("single-flights concurrent refreshes into one silent sign-in", async () => {
-    getIdTokenMock
-      .mockRejectedValueOnce(unauthenticatedError())
-      .mockRejectedValueOnce(unauthenticatedError())
-      .mockResolvedValue("token-fresh");
-    signInSilentlyMock.mockResolvedValueOnce(true);
+  // Keep this last: it intentionally leaves signIn() pending to hold the
+  // module-scoped single-flight guard during the assertion.
+  it("single-flights the sign-in redirect across concurrent auth failures", async () => {
+    getIdTokenMock.mockRejectedValue(unauthenticatedError());
+    let releaseSignIn: () => void = () => {};
+    signInMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseSignIn = resolve;
+      }),
+    );
 
     const { result } = renderHook(() => useAuthApiClient());
-    await Promise.all([
-      result.current("https://api.test/a"),
-      result.current("https://api.test/b"),
-    ]);
+    void result.current("https://api.test/a");
+    void result.current("https://api.test/b");
 
-    expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
+    expect(signInMock).toHaveBeenCalledTimes(1);
+
+    releaseSignIn();
   });
 });

--- a/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
+++ b/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
@@ -17,17 +17,31 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuthApiClient } from "@hooks/useAuthApiClient";
+import { ASGARDEO_UNAUTHENTICATED_CODE } from "@constants/apiConstants";
 
 const getIdTokenMock = vi.fn();
+const signInSilentlyMock = vi.fn();
+const signInMock = vi.fn();
 
 vi.mock("@asgardeo/react", () => ({
-  useAsgardeo: () => ({ getIdToken: getIdTokenMock }),
+  useAsgardeo: () => ({
+    getIdToken: getIdTokenMock,
+    signInSilently: signInSilentlyMock,
+    signIn: signInMock,
+  }),
 }));
+
+const unauthenticatedError = () =>
+  Object.assign(new Error("unauthenticated"), {
+    code: ASGARDEO_UNAUTHENTICATED_CODE,
+  });
 
 describe("useAuthApiClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getIdTokenMock.mockResolvedValue("token-abc");
+    signInSilentlyMock.mockResolvedValue(true);
+    signInMock.mockResolvedValue(undefined);
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as typeof fetch;
   });
 
@@ -59,5 +73,59 @@ describe("useAuthApiClient", () => {
     await expect(result.current("https://api.test")).rejects.toThrow(
       "Unable to retrieve ID token",
     );
+  });
+
+  it("rethrows non-auth errors without attempting recovery", async () => {
+    getIdTokenMock.mockRejectedValueOnce(new Error("network down"));
+    const { result } = renderHook(() => useAuthApiClient());
+
+    await expect(result.current("https://api.test")).rejects.toThrow(
+      "network down",
+    );
+    expect(signInSilentlyMock).not.toHaveBeenCalled();
+    expect(signInMock).not.toHaveBeenCalled();
+  });
+
+  it("silently refreshes and retries once on an expired token", async () => {
+    getIdTokenMock
+      .mockRejectedValueOnce(unauthenticatedError())
+      .mockResolvedValue("token-fresh");
+    signInSilentlyMock.mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => useAuthApiClient());
+    await result.current("https://api.test/resource");
+
+    expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
+    expect(signInMock).not.toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("redirects to full sign-in when silent refresh fails", async () => {
+    getIdTokenMock.mockRejectedValue(unauthenticatedError());
+    signInSilentlyMock.mockResolvedValueOnce(false);
+
+    const { result } = renderHook(() => useAuthApiClient());
+    // The recovery path returns a never-resolving promise while navigating away,
+    // so assert on the side effects rather than awaiting the call.
+    void result.current("https://api.test/resource");
+    await vi.waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
+
+    expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("single-flights concurrent refreshes into one silent sign-in", async () => {
+    getIdTokenMock
+      .mockRejectedValueOnce(unauthenticatedError())
+      .mockRejectedValueOnce(unauthenticatedError())
+      .mockResolvedValue("token-fresh");
+    signInSilentlyMock.mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => useAuthApiClient());
+    await Promise.all([
+      result.current("https://api.test/a"),
+      result.current("https://api.test/b"),
+    ]);
+
+    expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
+++ b/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
@@ -64,6 +64,14 @@ describe("useAuthApiClient", () => {
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
+  it("throws when ID token is missing", async () => {
+    getIdTokenMock.mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useAuthApiClient());
+    await expect(result.current("https://api.test")).rejects.toThrow(
+      "Unable to retrieve ID token",
+    );
+  });
+
   it("rethrows non-auth errors without attempting recovery", async () => {
     getIdTokenMock.mockRejectedValueOnce(new Error("network down"));
     const { result } = renderHook(() => useAuthApiClient());

--- a/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -17,9 +17,29 @@
 import { useAsgardeo } from "@asgardeo/react";
 import { ASGARDEO_UNAUTHENTICATED_CODE } from "@constants/apiConstants";
 
+// Max time to wait for a silent token refresh before giving up. signInSilently()
+// drives a hidden auth iframe; if third-party cookies are blocked it can hang
+// indefinitely, so we cap it and fall back to a full sign-in redirect.
+const SILENT_SIGN_IN_TIMEOUT_MS = 10000;
+
+// Shared across every caller's hook instance. Each useAuthApiClient() call
+// creates its own authFetch closure, so the in-flight refresh promise must live
+// at module scope to single-flight concurrent refreshes (one signInSilently()
+// instead of N, and no duplicate sign-in redirects).
+let refreshInFlight: Promise<boolean> | null = null;
+
+// Only the Asgardeo "unauthenticated" code means the token was expired/missing
+// when the call ran. Everything else (network failures, real backend 5xx) must
+// propagate untouched so existing error handling and error pages still work.
+const isTokenExpiredError = (error: unknown): boolean =>
+  error != null &&
+  typeof error === "object" &&
+  "code" in error &&
+  (error as { code: string }).code === ASGARDEO_UNAUTHENTICATED_CODE;
+
 // A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
-  const { getIdToken } = useAsgardeo();
+  const { getIdToken, signInSilently, signIn } = useAsgardeo();
 
   /**
    * Builds request headers with auth and payload defaults.
@@ -74,6 +94,31 @@ export function useAuthApiClient() {
     });
   };
 
+  // Re-mint tokens off the still-live IdP session via the hidden auth iframe.
+  // Single-flighted through the module-scoped promise so concurrent callers
+  // share one refresh. Resolves false on failure or timeout so the caller can
+  // fall back to a full redirect rather than hang.
+  const ensureFreshToken = (): Promise<boolean> => {
+    if (!refreshInFlight) {
+      refreshInFlight = new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(
+          () => resolve(false),
+          SILENT_SIGN_IN_TIMEOUT_MS,
+        );
+        signInSilently()
+          .then((result) => Boolean(result))
+          .catch(() => false)
+          .then((refreshed) => {
+            clearTimeout(timeout);
+            resolve(refreshed);
+          });
+      }).finally(() => {
+        refreshInFlight = null;
+      });
+    }
+    return refreshInFlight;
+  };
+
   const authFetch = async (
     input: RequestInfo | URL,
     options?: RequestInit,
@@ -81,18 +126,24 @@ export function useAuthApiClient() {
     try {
       return await attemptFetch(input, options);
     } catch (error) {
-      // SPA-AUTH_CLIENT-VM-IV02 means the token was expired when this call ran.
-      // A concurrent call may have already refreshed the token — retry once to pick it up.
-      const isTokenExpiredError =
-        error != null &&
-        typeof error === "object" &&
-        "code" in error &&
-        (error as { code: string }).code === ASGARDEO_UNAUTHENTICATED_CODE;
+      // Only an expired/missing token is recoverable here; anything else
+      // (network, real backend 5xx) must surface to existing error handling.
+      if (!isTokenExpiredError(error)) {
+        throw error;
+      }
 
-      if (isTokenExpiredError) {
+      // The session was dead. Try to silently re-mint tokens off the live IdP
+      // session and replay the original request once.
+      const refreshed = await ensureFreshToken();
+      if (refreshed) {
         return attemptFetch(input, options);
       }
-      throw error;
+
+      // The IdP session is gone too — redirect for a full sign-in. Return a
+      // never-resolving promise so callers don't fall through to an error page
+      // while the browser navigates away.
+      await signIn();
+      return new Promise<Response>(() => {});
     }
   };
 

--- a/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -17,16 +17,11 @@
 import { useAsgardeo } from "@asgardeo/react";
 import { ASGARDEO_UNAUTHENTICATED_CODE } from "@constants/apiConstants";
 
-// Max time to wait for a silent token refresh before giving up. signInSilently()
-// drives a hidden auth iframe; if third-party cookies are blocked it can hang
-// indefinitely, so we cap it and fall back to a full sign-in redirect.
-const SILENT_SIGN_IN_TIMEOUT_MS = 10000;
-
 // Shared across every caller's hook instance. Each useAuthApiClient() call
-// creates its own authFetch closure, so the in-flight refresh promise must live
-// at module scope to single-flight concurrent refreshes (one signInSilently()
-// instead of N, and no duplicate sign-in redirects).
-let refreshInFlight: Promise<boolean> | null = null;
+// creates its own authFetch closure, so this lives at module scope to ensure
+// only ONE full sign-in redirect is triggered even when many concurrent calls
+// fail authentication at once.
+let signInInFlight = false;
 
 // Only the Asgardeo "unauthenticated" code means the token was expired/missing
 // when the call ran. Everything else (network failures, real backend 5xx) must
@@ -39,7 +34,7 @@ const isTokenExpiredError = (error: unknown): boolean =>
 
 // A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
-  const { getIdToken, signInSilently, signIn } = useAsgardeo();
+  const { getIdToken, signIn } = useAsgardeo();
 
   /**
    * Builds request headers with auth and payload defaults.
@@ -94,29 +89,19 @@ export function useAuthApiClient() {
     });
   };
 
-  // Re-mint tokens off the still-live IdP session via the hidden auth iframe.
-  // Single-flighted through the module-scoped promise so concurrent callers
-  // share one refresh. Resolves false on failure or timeout so the caller can
-  // fall back to a full redirect rather than hang.
-  const ensureFreshToken = (): Promise<boolean> => {
-    if (!refreshInFlight) {
-      refreshInFlight = new Promise<boolean>((resolve) => {
-        const timeout = setTimeout(
-          () => resolve(false),
-          SILENT_SIGN_IN_TIMEOUT_MS,
-        );
-        signInSilently()
-          .then((result) => Boolean(result))
-          .catch(() => false)
-          .then((refreshed) => {
-            clearTimeout(timeout);
-            resolve(refreshed);
-          });
-      }).finally(() => {
-        refreshInFlight = null;
+  // Redirect to a full sign-in, single-flighted so concurrent auth failures
+  // don't fire multiple redirects. Returns a never-resolving promise so callers
+  // don't fall through to an error page while the browser navigates away.
+  const redirectToSignIn = (): Promise<Response> => {
+    if (!signInInFlight) {
+      signInInFlight = true;
+      // Best-effort: navigation takes over from here. Reset on the rare chance
+      // the redirect itself rejects so a later attempt can retry.
+      void Promise.resolve(signIn()).finally(() => {
+        signInInFlight = false;
       });
     }
-    return refreshInFlight;
+    return new Promise<Response>(() => {});
   };
 
   const authFetch = async (
@@ -132,18 +117,25 @@ export function useAuthApiClient() {
         throw error;
       }
 
-      // The session was dead. Try to silently re-mint tokens off the live IdP
-      // session and replay the original request once.
-      const refreshed = await ensureFreshToken();
-      if (refreshed) {
-        return attemptFetch(input, options);
-      }
+      // A concurrent caller, or the provider's periodic background refresh
+      // (periodicTokenRefresh on AsgardeoProvider), may have re-minted the
+      // token in the meantime, so retry once to pick it up. getIdToken() itself
+      // only reads the stored token; if nothing refreshed it the retry fails
+      // again and we fall through to the sign-in redirect below.
+      try {
+        return await attemptFetch(input, options);
+      } catch (retryError) {
+        // Retry failed for a non-auth reason (e.g. a transient network blip on
+        // the second attempt): surface it to existing error handling instead of
+        // bouncing the user to sign-in.
+        if (!isTokenExpiredError(retryError)) {
+          throw retryError;
+        }
 
-      // The IdP session is gone too — redirect for a full sign-in. Return a
-      // never-resolving promise so callers don't fall through to an error page
-      // while the browser navigates away.
-      await signIn();
-      return new Promise<Response>(() => {});
+        // Still unauthenticated after the retry — the session is gone. Redirect
+        // for a full sign-in.
+        return redirectToSignIn();
+      }
     }
   };
 


### PR DESCRIPTION
## Problem

The auth-aware fetch wrapper (`useAuthApiClient` → `authFetch`) caught the Asgardeo unauthenticated error (`SPA-AUTH_CLIENT-VM-IV02`) and **blindly retried the same call once**, on the assumption a concurrent caller may have refreshed the token.

When nothing had, the retry replayed the same dead token and failed identically. The error then propagated up and rendered as a generic **"500 / something went wrong on our side"** page with a Retry button that loops, misdiagnosing an **auth failure as a server failure**.

## Fix

The fix lives entirely in the auth client, so every caller inherits it. Feature hooks and error-page components are untouched.

- **Classify the error.** Extracted `isTokenExpiredError(error)` (checks `error?.code === ASGARDEO_UNAUTHENTICATED_CODE`). Any other error (network, real backend 5xx) is rethrown untouched so existing error handling / per-component error UIs + manual retry still work.
- **Recovery ladder** when the error is the unauthenticated code:
  - **Retry the original request once.** `getIdToken()` only reads the stored token, but the `AsgardeoProvider` runs a periodic background refresh (`periodicTokenRefresh`), so a concurrent refresh may have re-minted the token by the time the retry runs.
  - If the retry **still** returns the unauthenticated code, the session is gone → redirect to a full `signIn()`.
  - If the retry fails for a **non-auth** reason (e.g. a transient network blip on the second attempt), rethrow it rather than bouncing the user to sign-in.
- **Never fall through to an error page on the redirect.** The sign-in path returns a never-resolving promise so callers don't render an error page while the browser navigates away.
- **Single-flight the redirect** at module scope (`signInInFlight`) so concurrent auth failures trigger exactly one `signIn()`.

`attemptFetch` (token fetch + header build + fetch) is unchanged.

### Design note: why no explicit silent sign-in

An earlier revision called `signInSilently()` to silently re-mint tokens before the retry. Removed: it relies on a hidden auth iframe (third-party cookies), which can hang and needed a timeout guard, and it was redundant given the provider's periodic background refresh. The simpler retry-then-redirect ladder degrades cleanly: if nothing refreshed the token, the retry fails and we redirect to sign-in (which is the correct outcome for a dead session).

Verified at the source (`@asgardeo/browser@0.7.9`): `getIdToken()` delegates to the core client, which reads the stored token; token refresh is a separate operation. So the retry only recovers when a background/periodic refresh has already updated the stored token, otherwise it redirects.

## Testing

- `tsc -b` (typecheck): clean
- `eslint`: clean
- `vitest`: 7 passing — POST header build, missing-token throw, non-auth rethrow, retry-recovers, non-auth-error-on-retry rethrow, redirect-when-still-unauthenticated, and single-flight redirect across concurrent failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token recovery to properly distinguish between authentication-related errors and other failures.
  * Enhanced handling of concurrent authentication failures to prevent duplicate sign-in redirects.
  * Users are now correctly redirected to sign-in when automatic token recovery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->