### PR TITLE
[Customer Entity] Add typeKey to case creation with SN caseType mapping

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -701,6 +701,7 @@ type CreateCaseDetails struct {
 // CreatedBy is not accepted from the request body and will be wired from auth context later.
 type CreateCaseRequest struct {
 	CreatedBy         string        `json:"-"`
+	TypeKey           string        `json:"typeKey"`
 	ProjectID         string        `json:"projectId"`
 	DeploymentID      string        `json:"deploymentId"`
 	DeployedProductID string        `json:"deployedProductId"`

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -69,11 +69,12 @@ func (r *caseRepo) CreateCase(ctx context.Context, req domain.CreateCaseRequest)
 	const query = `
 		INSERT INTO cases (
 			created_by, project_id, deployment_id, deployed_product_id,
-			subject, description, severity, issue_type, state
+			type, subject, description, severity, issue_type, state
 		)
 		VALUES (
-			$1, $2, $3, $4, $5, $6,
-			$7::case_severity_enum, $8::case_issue_type_enum,
+			$1, $2, $3, $4,
+			$5::case_type_enum, $6, $7,
+			$8::case_severity_enum, $9::case_issue_type_enum,
 			'open'::case_state_enum
 		)
 		RETURNING id, number, internal_id, created_by, project_id, deployment_id, deployed_product_id,
@@ -82,7 +83,7 @@ func (r *caseRepo) CreateCase(ctx context.Context, req domain.CreateCaseRequest)
 	var c domain.Case
 	err := r.db.QueryRow(ctx, query,
 		req.CreatedBy, req.ProjectID, req.DeploymentID, req.DeployedProductID,
-		req.Subject, req.Description, string(req.SeverityKey), string(req.IssueTypeKey),
+		req.TypeKey, req.Subject, req.Description, string(req.SeverityKey), string(req.IssueTypeKey),
 	).Scan(
 		&c.ID, &c.Number, &c.InternalID, &c.CreatedBy,
 		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -100,6 +100,9 @@ var validCaseWorkState = map[domain.CaseWorkState]bool{
 // UUID format of ID fields is not checked here — postgres IDs are UUIDs but
 // ServiceNow IDs are opaque hex strings; callers add format checks as needed.
 func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
+	if req.TypeKey == "" {
+		return &apierror.ValidationError{Msg: "typeKey is required"}
+	}
 	if req.ProjectID == "" {
 		return &apierror.ValidationError{Msg: "projectId is required"}
 	}
@@ -128,6 +131,9 @@ func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
 func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseRequest) (domain.CreateCaseResponse, error) {
 	if err := validateCreateCaseRequest(req); err != nil {
 		return domain.CreateCaseResponse{}, err
+	}
+	if req.TypeKey != "support" {
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey must be \"support\" for the Postgres data source"}
 	}
 	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
 		return domain.CreateCaseResponse{}, err

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -133,7 +133,7 @@ func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseReque
 		return domain.CreateCaseResponse{}, err
 	}
 	if req.TypeKey != "support" {
-		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey must be \"support\" for the Postgres data source"}
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey must be \"support\" for case creation"}
 	}
 	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
 		return domain.CreateCaseResponse{}, err

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -314,10 +314,10 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 		return domain.CreateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
-	snType, ok := snCaseTypeMap[req.TypeKey]
-	if !ok {
-		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey contains invalid value: " + req.TypeKey}
+	if req.TypeKey != "support" {
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey must be \"support\" for case creation"}
 	}
+	snType := snCaseTypeMap[req.TypeKey]
 
 	payload := snCreateCasePayload{
 		Type:              snType,

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -314,8 +314,13 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 		return domain.CreateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
+	snType, ok := snCaseTypeMap[req.TypeKey]
+	if !ok {
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey contains invalid value: " + req.TypeKey}
+	}
+
 	payload := snCreateCasePayload{
-		Type:              "default_case",
+		Type:              snType,
 		ProjectID:         uuidToSysid(req.ProjectID),
 		DeploymentID:      uuidToSysid(req.DeploymentID),
 		DeployedProductID: uuidToSysid(req.DeployedProductID),

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1243,8 +1243,14 @@ components:
 
     CreateCaseRequest:
       type: object
-      required: [projectId, deploymentId, deployedProductId, subject, description, severityKey, issueTypeKey]
+      required: [typeKey, projectId, deploymentId, deployedProductId, subject, description, severityKey, issueTypeKey]
       properties:
+        typeKey:
+          type: string
+          enum: [support]
+          description: |
+            Case type. Currently only `support` is accepted for the Postgres data source.
+            For the ServiceNow data source `support` maps to `default_case` in the SN API payload.
         projectId:
           type: string
           format: uuid


### PR DESCRIPTION
## Summary

- Add `typeKey` field to `CreateCaseRequest` - required, currently only `support` is accepted
- Postgres service rejects any value other than `support` with a 400
- ServiceNow service maps `typeKey` to the SN `caseType` via the existing `snCaseTypeMap` (`support` → `default_case`), replacing the previous hardcoded value
- `type` column is now explicitly set in the Postgres INSERT (was relying on the `DEFAULT 'support'` column default)
- OpenAPI `CreateCaseRequest` schema updated with `typeKey` in the required list and enum constraint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new required `typeKey` field has been added to case creation requests. When creating cases, this field must be provided with one of the supported enum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->