### PR TITLE
[CSM Portal][BE] Add typeKey to case create payload

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -51,7 +51,7 @@ Follow these steps in order:
 - **Auth**: always check `middleware.UserInfoFromContext(r.Context()) == nil` first → 401
 - **Body size**: cap with `http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)` (1 MiB) before reading
 - **Path params**: guard against empty string after `r.PathValue("id")`; if the param is a UUID, also validate format using the package-level `uuidRe` compiled regex and return 400 on mismatch — fail fast before calling the upstream
-- **Field naming**: case create/patch use `severityKey` (not `priorityKey`); search filters use `severityKeys`
+- **Field naming**: case create/patch use `severityKey` (not `priorityKey`); search filters use `severityKeys`; case create requires `typeKey: "support"` (only accepted value currently)
 - **Upstream errors**: always use `mapUpstreamError(w, err, "<fallback message>")` — never write custom status mappings inline
 - **Response**: return raw `[]byte` with `writeJSON` for simple passthroughs; unmarshal into typed structs only when the response shape needs to change
 

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -157,7 +157,7 @@ backend/
 
 ### Cases
 
-- `POST /cases` — Create a case
+- `POST /cases` — Create a case (requires `typeKey: "support"`)
 - `GET /cases/{id}` — Get case by ID
 - `PATCH /cases/{id}` — Update a case (state, severity, workState, watchList, or assigneeEmail)
 - `POST /cases/search` — Search cases

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -56,7 +56,7 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 // ----- CreateCase -----
 
 func TestCreateCase(t *testing.T) {
-	const validPayload = `{"projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","severityKey":"high","issueTypeKey":"error"}`
+	const validPayload = `{"typeKey":"support","projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","severityKey":"high","issueTypeKey":"error"}`
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1213,6 +1213,7 @@ components:
     CaseCreatePayload:
       type: object
       required:
+        - typeKey
         - projectId
         - deploymentId
         - deployedProductId
@@ -1221,6 +1222,10 @@ components:
         - severityKey
         - issueTypeKey
       properties:
+        typeKey:
+          type: string
+          enum: [support]
+          description: Case type. Currently only `support` is accepted.
         projectId:
           type: string
           description: UUID of the project this case belongs to


### PR DESCRIPTION
## Summary

Aligns with entity service PR #921 which made `typeKey` a required field on `CreateCaseRequest`.

- **`openapi.yaml`** — Added `typeKey` (required, `enum: [support]`) to `CaseCreatePayload`; the frontend must now include this field when creating a case
- **`cases_test.go`** — Updated `TestCreateCase` `validPayload` to include `typeKey:"support"`

No Go handler code changes are needed — the BFF forwards the request body as raw bytes, so the entity service enforces the field constraint directly.

## Test plan

- [x] `make test` passes
- [x] `TestCreateCase` updated to include `typeKey` in the valid payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated case creation API documentation and specifications with refined requirements.

* **Tests**
  * Updated test cases for case creation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->