### PR TITLE
[CSM Portal] case work-state actions, claim flow, and v2 contract realignment

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -24,7 +24,7 @@ import type {
   BeAttachment,
   BeCaseComment,
   BeCreatableCommentType,
-  BeCasePriority,
+  BeCaseSeverity,
   BeCaseState,
 } from "@api/backend/types";
 import type {
@@ -47,7 +47,7 @@ import type {
  * doubles as the source.
  */
 export function severityFromPriority(
-  priority: BeCasePriority | undefined,
+  priority: BeCaseSeverity | undefined,
 ): Severity {
   switch (priority) {
     case "catastrophic":
@@ -65,7 +65,7 @@ export function severityFromPriority(
   }
 }
 
-export function priorityFromSeverity(severity: Severity): BeCasePriority {
+export function priorityFromSeverity(severity: Severity): BeCaseSeverity {
   switch (severity) {
     case "S0":
       return "catastrophic";

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -185,7 +185,7 @@ export interface BeCaseView {
 
 export interface BeCaseCreatePayload {
   /** Case type. The portal only creates `support` cases. */
-  typeKey: BeCaseType;
+  typeKey: "support";
   projectId: string;
   deploymentId: string;
   deployedProductId: string;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -87,7 +87,7 @@ export type BeCaseState =
  */
 export type BeCaseWorkState = "ongoing" | "paused";
 
-export type BeCaseSortField = "created_at" | "updated_at" | "closed_at";
+export type BeCaseSortField = "createdOn" | "updatedOn" | "severity" | "state";
 
 export interface BeCase {
   id: string;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -48,7 +48,7 @@ export interface BeSearchResponseBase {
 // Cases
 // ---------------------------------------------------------------------------
 
-export type BeCasePriority =
+export type BeCaseSeverity =
   | "catastrophic"
   | "critical"
   | "high"
@@ -63,11 +63,20 @@ export type BeCaseIssueType =
   | "security_or_compliance"
   | "total_outage";
 
+/** Case type (entity `typeKey`). Only `support` is creatable from the portal. */
+export type BeCaseType =
+  | "support"
+  | "service_request"
+  | "security_report_analysis"
+  | "announcement"
+  | "engagement";
+
 export type BeCaseState =
   | "open"
   | "work_in_progress"
   | "waiting_on_wso2"
   | "awaiting_info"
+  | "reopened"
   | "solution_proposed"
   | "closed";
 
@@ -90,8 +99,9 @@ export interface BeCase {
   deployedProductId?: string;
   subject?: string;
   description?: string;
-  priority?: BeCasePriority;
+  severity?: BeCaseSeverity;
   issueType?: BeCaseIssueType;
+  type?: BeCaseType;
   state?: BeCaseState;
   createdAt?: string;
   updatedAt?: string;
@@ -110,6 +120,18 @@ export interface BeUserRef {
 export interface BeEntityRef {
   id: string;
   name: string;
+}
+
+/**
+ * The assigned CS engineer embedded in case views. Carries `email` so the FE
+ * can tell whether the case is assigned to the signed-in user (the only stable
+ * identity the FE has from the JWT). `email` may be `null` depending on the data
+ * source / endpoint — the GET populates it where available.
+ */
+export interface BeAssignedEngineerRef {
+  id: string;
+  name?: string;
+  email?: string | null;
 }
 
 /** A referenced deployed product (its display name is the product + version). */
@@ -142,15 +164,16 @@ export interface BeCaseView {
   internalId?: string;
   subject?: string;
   description?: string;
-  priority?: BeCasePriority;
+  severity?: BeCaseSeverity;
   issueType?: BeCaseIssueType;
+  type?: BeCaseType;
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
   nextStates?: BeCaseState[];
   createdBy?: BeUserRef;
   /** The CS engineer the case is assigned to; null when unassigned. */
-  assignedEngineer?: BeEntityRef | null;
+  assignedEngineer?: BeAssignedEngineerRef | null;
   account?: BeCaseAccountRef;
   project?: BeEntityRef;
   deployment?: BeEntityRef;
@@ -161,13 +184,15 @@ export interface BeCaseView {
 }
 
 export interface BeCaseCreatePayload {
+  /** Case type. The portal only creates `support` cases. */
+  typeKey: BeCaseType;
   projectId: string;
   deploymentId: string;
   deployedProductId: string;
   subject: string;
   description: string;
-  priority: BeCasePriority;
-  issueType: BeCaseIssueType;
+  severityKey: BeCaseSeverity;
+  issueTypeKey: BeCaseIssueType;
 }
 
 /** The case summary embedded in the `POST /cases` success envelope. */
@@ -188,20 +213,23 @@ export interface BeCaseCreateResponse {
 
 /**
  * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
- * **Exactly one** of `state` / `priority` / `assigneeEmail` / `watchList` is
- * sent per call — the backend rejects zero or more than one. Encoded as a
- * discriminated union (each variant `?: never`s the others) so the
- * exactly-one-field contract is enforced at compile time, not just in docs.
- * `assigneeEmail` and `watchList` are supported **only** for the ServiceNow
- * data source.
+ * **Exactly one** of `stateKey` / `severityKey` / `workStateKey` /
+ * `assigneeEmail` / `watchList` is sent per call — the backend rejects zero or
+ * more than one. Encoded as a discriminated union (each variant `?: never`s the
+ * others) so the exactly-one-field contract is enforced at compile time, not
+ * just in docs. `assigneeEmail` and `watchList` are supported **only** for the
+ * ServiceNow data source. `workStateKey` is only accepted while the case is
+ * `work_in_progress`.
  */
 export type BeCaseUpdatePayload =
-  | { state: BeCaseState; priority?: never; assigneeEmail?: never; watchList?: never }
-  | { state?: never; priority: BeCasePriority; assigneeEmail?: never; watchList?: never }
+  | { stateKey: BeCaseState; severityKey?: never; workStateKey?: never; assigneeEmail?: never; watchList?: never }
+  | { stateKey?: never; severityKey: BeCaseSeverity; workStateKey?: never; assigneeEmail?: never; watchList?: never }
+  /** Work sub-state toggle (`ongoing` / `paused`) for an in-progress case. */
+  | { stateKey?: never; severityKey?: never; workStateKey: BeCaseWorkState; assigneeEmail?: never; watchList?: never }
   /** Email of the engineer to assign (ServiceNow only). */
-  | { state?: never; priority?: never; assigneeEmail: string; watchList?: never }
+  | { stateKey?: never; severityKey?: never; workStateKey?: never; assigneeEmail: string; watchList?: never }
   /** Full replacement watch list as emails (ServiceNow only). */
-  | { state?: never; priority?: never; assigneeEmail?: never; watchList: string[] };
+  | { stateKey?: never; severityKey?: never; workStateKey?: never; assigneeEmail?: never; watchList: string[] };
 
 /** A user in the case watch list, as echoed by `PATCH /cases/{id}`. */
 export interface BeWatchListUser {
@@ -217,7 +245,8 @@ export interface BeUpdatedCase {
   updatedOn?: string;
   updatedBy?: string;
   state?: BeCaseState;
-  priority?: BeCasePriority;
+  severity?: BeCaseSeverity;
+  workState?: BeCaseWorkState | null;
   watchList?: BeWatchListUser[];
   assignedTo?: BeEntityRef | null;
 }
@@ -236,10 +265,14 @@ export interface BeCaseSearchFilters {
   /** Optional project filter; omit for a cross-project search. */
   projectIds?: string[];
   deploymentIds?: string[];
-  deployedProductIds?: string[];
+  typeKeys?: BeCaseType[];
   stateKeys?: BeCaseState[];
-  priorityKeys?: BeCasePriority[];
+  severityKeys?: BeCaseSeverity[];
   issueTypeKeys?: BeCaseIssueType[];
+  /** Filter to cases created by these emails. */
+  createdBy?: string[];
+  /** When true, the caller's email (from the JWT) is appended to `createdBy`. */
+  createdByMe?: boolean;
 }
 
 export interface BeCaseSearchPayload {
@@ -265,11 +298,14 @@ export interface BeCaseSearchView {
   internalId?: string;
   subject?: string;
   description?: string;
-  priority?: BeCasePriority;
+  severity?: BeCaseSeverity;
   issueType?: BeCaseIssueType;
+  type?: BeCaseType;
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
+  /** The CS engineer the case is assigned to; null when unassigned. */
+  assignedEngineer?: BeAssignedEngineerRef | null;
   createdOn?: string;
   updatedOn?: string;
   closedAt?: string | null;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -296,23 +296,32 @@ export interface BeCaseSearchView {
   number?: string;
   /** Project-scoped WSO2 case reference (customer portal calls this the same). */
   internalId?: string;
-  subject?: string;
+  /**
+   * Case title. NOTE: the search response uses `title` (not `subject` like the
+   * `GET /cases/{id}` CaseView) — a backend naming inconsistency. The BFF
+   * openapi documents this as `subject`, but the entity returns `title`.
+   */
+  title?: string;
   description?: string;
   severity?: BeCaseSeverity;
   issueType?: BeCaseIssueType;
-  type?: BeCaseType;
+  /** Case type (entity `caseType` on the search view). */
+  caseType?: BeCaseType;
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
   /** The CS engineer the case is assigned to; null when unassigned. */
   assignedEngineer?: BeAssignedEngineerRef | null;
   createdOn?: string;
+  /** Often absent on the search view (unlike the GET view); tolerate it missing. */
   updatedOn?: string;
-  closedAt?: string | null;
-  createdBy?: BeUserRef;
+  /** Created-by is a bare email string here (not a UserRef like the GET view). */
+  createdBy?: string;
   project?: BeEntityRef;
   deployment?: BeEntityRef;
-  deployedProduct?: BeDeployedProductRef;
+  /** Embedded as `{ id, name }` (name already includes the version), not the
+   * `displayName`-shaped ref the GET view uses. */
+  deployedProduct?: BeEntityRef;
 }
 
 export interface BeCaseSearchResponse extends BeSearchResponseBase {

--- a/apps/csm-portal/webapp/src/components/StateChip.tsx
+++ b/apps/csm-portal/webapp/src/components/StateChip.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import {
+  stateColor,
+  stateLabel,
+} from "@features/csm-dashboard/utils/abtDashboard";
+import SemanticChip from "@components/SemanticChip";
+
+interface StateChipProps {
+  state: string;
+  size?: "small" | "medium";
+  /** Render a pointer cursor when the chip sits inside a link / clickable row. */
+  clickable?: boolean;
+}
+
+/**
+ * The single source of truth for rendering a case lifecycle-state badge. Renders
+ * as a solid {@link SemanticChip} so the state reads as a status pill rather than
+ * quiet text — but, unlike {@link SeverityChip}, it is NOT bold, so severity
+ * stays the top scan signal in a row. Colour follows the "whose move is it"
+ * STATE_COLOR semantics; the neutral `default` states (e.g. awaiting info) have
+ * no accessible solid fill and fall back to an outlined chip.
+ */
+export default function StateChip({
+  state,
+  size = "small",
+  clickable = false,
+}: StateChipProps): JSX.Element {
+  return (
+    <SemanticChip
+      role={stateColor(state)}
+      label={stateLabel(state)}
+      size={size}
+      clickable={clickable}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -51,7 +51,7 @@ export const CSM_NAV_ITEMS: CsmNavItem[] = [
   { id: "time-cards", label: "Time cards", path: "/time-cards", icon: Clock },
   { id: "accounts", label: "Accounts", path: "/accounts", icon: Building },
   { id: "projects", label: "Projects", path: "/projects", icon: FolderOpen },
-  { id: "admin", label: "Administration", path: "/admin", icon: Settings },
+  { id: "admin", label: "Settings", path: "/admin", icon: Settings },
 ];
 
 /** The nav item whose path is (a prefix of) `pathname`, if any. */

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.tsx
@@ -49,7 +49,7 @@ export default function CsmAdminLayout(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Typography variant="h5">Administration</Typography>
+      <Typography variant="h5">Settings</Typography>
 
       <Tabs
         value={active}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback } from "react";
+import { isMockMode, useBackendApi } from "@api/backend/client";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import type {
+  BeCaseSearchPayload,
+  BeCaseSearchResponse,
+} from "@api/backend/types";
+import { getMockCsmCases } from "@features/csm-cases/api/mocks/casesMocks";
+
+/** A case the current user is actively working (in-progress + ongoing). */
+export interface MyOngoingCase {
+  id: string;
+  /** Human label for the confirm dialog (WSO2 id / case number / subject). */
+  label: string;
+}
+
+// The case-search API has no assignee or work-state filter, so we narrow by
+// state on the server and match assignee + ongoing on the client. Cap the page
+// at a sane size: an engineer should have very few in-progress cases, and we
+// only need to know whether *another* ongoing one exists.
+const SEARCH_LIMIT = 50;
+
+/**
+ * Returns a function that finds the **other** cases the signed-in engineer is
+ * actively working — `work_in_progress`, `workState` `ongoing`, and assigned to
+ * them — excluding `excludeCaseId`. Used to enforce the single-active-case rule
+ * when starting work on a case.
+ *
+ * Because the search endpoint exposes neither an assignee nor a work-state
+ * filter, this narrows by `stateKeys: [work_in_progress]` server-side and then
+ * matches `assignedEngineer.email` against the JWT email and `workState ===
+ * "ongoing"` client-side (a `null` workState is never ongoing).
+ */
+export function useFindMyOngoingCases(): (
+  excludeCaseId: string,
+) => Promise<MyOngoingCase[]> {
+  const api = useBackendApi();
+  const myEmail = useIdTokenClaims()?.email?.toLowerCase();
+
+  return useCallback(
+    async (excludeCaseId: string): Promise<MyOngoingCase[]> => {
+      if (isMockMode()) {
+        return getMockCsmCases("all_customers")
+          .filter(
+            (c) =>
+              c.id !== excludeCaseId &&
+              c.assigneeIsMe &&
+              c.state === "work_in_progress" &&
+              c.workState === "ongoing",
+          )
+          .map((c) => ({
+            id: c.id,
+            label: c.wso2CaseId || c.caseNumber || c.subject,
+          }));
+      }
+
+      // Without our email we can't tell which cases are ours; skip the prompt.
+      if (!myEmail) return [];
+
+      const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+        "/cases/search",
+        {
+          filters: { stateKeys: ["work_in_progress"] },
+          pagination: { offset: 0, limit: SEARCH_LIMIT },
+        },
+      );
+
+      return (res.cases ?? [])
+        .filter(
+          (c) =>
+            c.id !== excludeCaseId &&
+            // A null/absent workState is never "ongoing".
+            c.workState === "ongoing" &&
+            c.assignedEngineer?.email?.toLowerCase() === myEmail,
+        )
+        .map((c) => ({
+          id: c.id,
+          label: c.internalId || c.number || c.subject || c.id,
+        }));
+    },
+    [api, myEmail],
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
@@ -91,7 +91,7 @@ export function useFindMyOngoingCases(): (
         )
         .map((c) => ({
           id: c.id,
-          label: c.internalId || c.number || c.subject || c.id,
+          label: c.internalId || c.number || c.title || c.id,
         }));
     },
     [api, myEmail],

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -16,6 +16,7 @@
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
 import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
@@ -33,12 +34,24 @@ const MOCK_LATENCY_MS = 150;
  * watchers, tags, time logs, attachments, linked items) default to empty /
  * placeholder values.
  */
-function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
+function detailFromBeCase(
+  c: BeCaseView,
+  currentUserEmail?: string,
+): CsmCaseDetail {
   const account = c.account;
   const customer = account?.name ?? "—";
   // createdBy.name can be empty for unhydrated users, so fall back to the email.
   const reporter = c.createdBy?.name?.trim() || c.createdBy?.email;
   const assignee = c.assignedEngineer?.name?.trim() || "Unassigned";
+  // "Is me" by comparing the assignee's email (the only stable identity the FE
+  // shares with the JWT) to the signed-in user's, case-insensitively. Falls back
+  // to false when either is absent — e.g. the data source doesn't return the
+  // assignee email — so the gate stays closed rather than guessing.
+  const assigneeEmail = c.assignedEngineer?.email ?? undefined;
+  const assigneeIsMe =
+    !!assigneeEmail &&
+    !!currentUserEmail &&
+    assigneeEmail.toLowerCase() === currentUserEmail.toLowerCase();
   const product = c.deployedProduct?.displayName ?? "—";
   return {
     id: c.id,
@@ -50,14 +63,12 @@ function detailFromBeCase(c: BeCaseView): CsmCaseDetail {
     projectId: c.project?.id ?? "",
     projectName: c.project?.name ?? "—",
     product,
-    severity: severityFromPriority(c.priority),
+    severity: severityFromPriority(c.severity),
     state: uiStateFromBe(c.state),
     workState: c.workState ?? null,
     nextStates: (c.nextStates ?? []).map(uiStateFromBe),
     assignee,
-    // "Is me" needs the signed-in user's entity id, which this mapper doesn't
-    // have; left false until the assignee can be compared to the current user.
-    assigneeIsMe: false,
+    assigneeIsMe,
     slaClockType: "ack",
     minutesToBreach: 0,
     createdAt: c.createdOn ?? "",
@@ -109,9 +120,12 @@ export function useGetCsmCaseDetail(
 ): UseQueryResult<CsmCaseDetail | null, Error> {
   const logger = useLogger();
   const api = useBackendApi();
+  // Signed-in user's email, used to resolve `assigneeIsMe` against the case's
+  // assigned-engineer email. In the query key so a late-arriving claim recomputes.
+  const currentUserEmail = useIdTokenClaims()?.email;
 
   return useQuery<CsmCaseDetail | null, Error>({
-    queryKey: [ApiQueryKeys.CSM_CASE_DETAIL, caseId ?? ""],
+    queryKey: [ApiQueryKeys.CSM_CASE_DETAIL, caseId ?? "", currentUserEmail ?? ""],
     queryFn: async (): Promise<CsmCaseDetail | null> => {
       if (!caseId) return null;
 
@@ -129,7 +143,7 @@ export function useGetCsmCaseDetail(
       // The CaseView embeds account / project / deployment / deployed-product /
       // reporter, so the whole detail builds from this one response — no
       // follow-up lookups.
-      return detailFromBeCase(beCase);
+      return detailFromBeCase(beCase, currentUserEmail);
     },
     enabled: !!caseId,
     staleTime: 30_000,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -20,6 +20,7 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { isMockMode, useBackendApi, type BackendApi } from "@api/backend/client";
 import {
@@ -120,6 +121,9 @@ export function useGetCsmCases(
   const logger = useLogger();
   const api = useBackendApi();
   const queryClient = useQueryClient();
+  // Signed-in email, to resolve `assigneeIsMe` per row against the assigned
+  // engineer's email. In the key so a late-arriving claim recomputes.
+  const currentUserEmail = useIdTokenClaims()?.email;
 
   const offset = page * pageSize;
   const search = filters.search.trim();
@@ -138,6 +142,7 @@ export function useGetCsmCases(
       filters.sla,
       [...filters.assignees].sort(),
       [...filters.products].sort(),
+      currentUserEmail ?? "",
       page,
       pageSize,
     ],
@@ -211,9 +216,15 @@ export function useGetCsmCases(
           .map((a) => [a.id, a.name as string]),
       );
 
+      const myEmail = currentUserEmail?.toLowerCase();
       const cases: CsmCaseRow[] = (casesResponse.cases ?? []).map((c) => {
         const projectId = c.project?.id ?? "";
         const accountId = projectAccount.get(projectId) ?? "";
+        const assigneeEmail = c.assignedEngineer?.email;
+        const assignee =
+          c.assignedEngineer?.name?.trim() || assigneeEmail || "Unassigned";
+        const assigneeIsMe =
+          !!assigneeEmail && !!myEmail && assigneeEmail.toLowerCase() === myEmail;
         return {
           id: c.id,
           caseNumber: c.number,
@@ -230,9 +241,8 @@ export function useGetCsmCases(
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
           workState: c.workState ?? null,
-          // No assignee field on the backend yet; surfaced as "Unassigned".
-          assignee: "Unassigned",
-          assigneeIsMe: false,
+          assignee,
+          assigneeIsMe,
           slaClockType: "ack",
           minutesToBreach: 0,
           // No SLA data from the backend yet — keep the SLA column neutral

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -170,7 +170,7 @@ export function useGetCsmCases(
       const [casesResponse, projects, accounts] = await Promise.all([
         api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
           pagination: { offset, limit: pageSize },
-          sortBy: { field: "updated_at", order: "desc" },
+          sortBy: { field: "updatedOn", order: "desc" },
           // Filter fields are nested under `filters` (BE payload restructure).
           filters: {
             ...(search.length > 0 && { searchQuery: search }),

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -100,7 +100,7 @@ function accountOptionsQueryOptions(api: BackendApi) {
  * cases page already mounts for its filter options.
  *
  * Search and the severity / state / project filters are pushed into the search
- * payload (searchQuery / priorityKeys / stateKeys / projectIds) and the BE
+ * payload (searchQuery / severityKeys / stateKeys / projectIds) and the BE
  * paginates the result (`pagination` → `total` / `limit` / `offset` /
  * `hasMore`). The remaining filters (assignee, SLA, product) have no BE support
  * and are disabled in LIVE; they only do anything in MOCK mode, where the whole
@@ -175,7 +175,7 @@ export function useGetCsmCases(
           filters: {
             ...(search.length > 0 && { searchQuery: search }),
             ...(filters.severities.length > 0 && {
-              priorityKeys: filters.severities.map(priorityFromSeverity),
+              severityKeys: filters.severities.map(priorityFromSeverity),
             }),
             ...(filters.states.length > 0 && {
               stateKeys: filters.states.map(beStateFromUi),
@@ -224,7 +224,7 @@ export function useGetCsmCases(
           projectId,
           projectName: c.project?.name ?? "—",
           product: c.deployedProduct?.displayName ?? "—",
-          severity: severityFromPriority(c.priority),
+          severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
           workState: c.workState ?? null,
           // No assignee field on the backend yet; surfaced as "Unassigned".

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -218,12 +218,15 @@ export function useGetCsmCases(
           id: c.id,
           caseNumber: c.number,
           wso2CaseId: c.internalId,
-          subject: c.subject ?? "(no subject)",
+          // Search returns the title under `title` (the GET view uses `subject`).
+          subject: c.title ?? "(no subject)",
           customer: accountName.get(accountId) ?? "—",
           accountId,
           projectId,
           projectName: c.project?.name ?? "—",
-          product: c.deployedProduct?.displayName ?? "—",
+          // Search embeds deployedProduct as { id, name } (name includes the
+          // version); the GET view uses a displayName-shaped ref instead.
+          product: c.deployedProduct?.name ?? "—",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
           workState: c.workState ?? null,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/usePatchCsmCase.ts
@@ -19,6 +19,7 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import { useCallback } from "react";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { isMockMode, useBackendApi } from "@api/backend/client";
 import type {
@@ -30,8 +31,9 @@ const MOCK_LATENCY_MS = 200;
 
 /**
  * Update a case via `PATCH /cases/{id}` — state transitions, priority changes,
- * assignee (`assigneeEmail`), or watch list (`watchList`). The backend requires
- * **exactly one** of those fields per call, so callers must not combine them.
+ * work sub-state (`workState`), assignee (`assigneeEmail`), or watch list
+ * (`watchList`). The backend requires **exactly one** of those fields per call,
+ * so callers must not combine them.
  * The response is `BeUpdateCaseResponse` ({ message, case }), but on success we
  * ignore the body and invalidate this case's detail query and the cross-project
  * list so both refetch the authoritative state (incl. fresh `nextStates`).
@@ -69,4 +71,38 @@ export function usePatchCsmCase(
       queryClient.invalidateQueries({ queryKey: [ApiQueryKeys.CSM_CASES] });
     },
   });
+}
+
+/**
+ * Patch an **arbitrary** case by id (not bound to a single case like
+ * {@link usePatchCsmCase}). Used when one action must update other cases too —
+ * e.g. pausing the engineer's other ongoing case(s) when they start work on a
+ * new one. Same single-field-per-call contract; invalidates the patched case's
+ * detail and the cross-project list so both refetch.
+ */
+export function usePatchCsmCaseById(): (
+  caseId: string,
+  input: BeCaseUpdatePayload,
+) => Promise<void> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (caseId: string, input: BeCaseUpdatePayload): Promise<void> => {
+      if (!caseId) throw new Error("Cannot update a case without an id.");
+      if (isMockMode()) {
+        await new Promise((r) => setTimeout(r, MOCK_LATENCY_MS));
+      } else {
+        await api.patch<BeCaseUpdatePayload, BeUpdateCaseResponse>(
+          `/cases/${encodeURIComponent(caseId)}`,
+          input,
+        );
+      }
+      queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CSM_CASE_DETAIL, caseId],
+      });
+      queryClient.invalidateQueries({ queryKey: [ApiQueryKeys.CSM_CASES] });
+    },
+    [api, queryClient],
+  );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectSearch.ts
@@ -16,9 +16,11 @@
 
 import {
   keepPreviousData,
+  useInfiniteQuery,
   useQuery,
   type UseQueryResult,
 } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
@@ -29,6 +31,9 @@ import type {
 
 /** A single page of matches is plenty for a type-ahead picker. */
 const PROJECT_SEARCH_LIMIT = 20;
+
+/** Page size for the lazy-loaded (scroll-to-load-more) project filter. */
+export const PROJECT_PAGE_SIZE = 10;
 
 /**
  * Type-ahead project search for the cases project filter. Unlike
@@ -62,4 +67,71 @@ export function useProjectSearch(
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });
+}
+
+/** Flattened, paginated result for the lazy-loaded project filter. */
+export interface InfiniteProjectSearch {
+  /** All projects loaded so far, across every fetched page. */
+  projects: BeProject[];
+  isFetching: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  isError: boolean;
+  /** Fetch the next page (wired to the dropdown's scroll). */
+  fetchNextPage: () => void;
+}
+
+/**
+ * Paginated project search for the cases project filter. Loads the first
+ * {@link PROJECT_PAGE_SIZE} projects as soon as it is enabled (the dropdown
+ * opens) — no typing required — and pages through the rest on demand via
+ * {@link InfiniteProjectSearch.fetchNextPage} (wired to the listbox scroll). An
+ * empty query lists the whole catalogue a page at a time; a typed query narrows
+ * it and re-pages from the first match.
+ */
+export function useInfiniteProjectSearch(
+  query: string,
+  enabled: boolean,
+): InfiniteProjectSearch {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  const result = useInfiniteQuery<BeProjectSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.CSM_PROJECTS, "search-paged", q],
+    queryFn: ({ pageParam }) => {
+      const pagination = { offset: pageParam as number, limit: PROJECT_PAGE_SIZE };
+      return api.post<BeProjectSearchPayload, BeProjectSearchResponse>(
+        "/projects/search",
+        q.length > 0 ? { searchQuery: q, pagination } : { pagination },
+      );
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.hasMore) return undefined;
+      // Next offset = rows already loaded; robust even if the backend does not
+      // echo back the offset we sent.
+      return allPages.reduce((n, p) => n + (p.projects?.length ?? 0), 0);
+    },
+    enabled,
+    // Keep prior pages on screen while a new query's first page loads, so the
+    // dropdown doesn't flash empty between searches.
+    placeholderData: keepPreviousData,
+    staleTime: 60_000,
+  });
+
+  const projects = useMemo(
+    () => (result.data?.pages ?? []).flatMap((p) => p.projects ?? []),
+    [result.data],
+  );
+
+  return {
+    projects,
+    isFetching: result.isFetching,
+    isFetchingNextPage: result.isFetchingNextPage,
+    hasNextPage: result.hasNextPage,
+    isError: result.isError,
+    fetchNextPage: () => {
+      void result.fetchNextPage();
+    },
+  };
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProjectSearch.ts
@@ -108,6 +108,9 @@ export function useInfiniteProjectSearch(
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (!lastPage.hasMore) return undefined;
+      // Stop if the last page came back empty: the offset wouldn't advance, so
+      // scroll-fetching would otherwise loop on the same page forever.
+      if ((lastPage.projects?.length ?? 0) === 0) return undefined;
       // Next offset = rows already loaded; robust even if the backend does not
       // echo back the offset we sent.
       return allPages.reduce((n, p) => n + (p.projects?.length ?? 0), 0);

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -96,7 +96,7 @@ export function useQuickCaseSearch(
         id: c.id,
         caseNumber: c.number,
         wso2CaseId: c.internalId,
-        subject: c.subject ?? "(no subject)",
+        subject: c.title ?? "(no subject)",
       }));
     },
     enabled: q.length >= QUICK_CASE_MIN_QUERY_LEN,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
@@ -24,7 +24,7 @@ import {
 import { useMemo, useState, type JSX } from "react";
 import type * as React from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
-import { useProjectSearch } from "@features/csm-cases/api/useProjectSearch";
+import { useInfiniteProjectSearch } from "@features/csm-cases/api/useProjectSearch";
 
 interface ProjectOption {
   id: string;
@@ -58,10 +58,32 @@ export default function AsyncProjectMultiSelect({
   nameSeed,
 }: AsyncProjectMultiSelectProps): JSX.Element {
   const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
   const debounced = useDebouncedValue(input, 300);
   const query = debounced.trim();
 
-  const { data, isFetching } = useProjectSearch(query, query.length > 0);
+  // Enabled while the dropdown is open, so it loads the first page of projects
+  // on open (no typing needed) and re-pages as the user types. Closed → the
+  // query idles (cached pages stay for an instant re-open).
+  const {
+    projects,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteProjectSearch(query, open);
+
+  // Lazy-load the next page when the listbox is scrolled near its end.
+  const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
+    const el = event.currentTarget;
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    ) {
+      fetchNextPage();
+    }
+  };
 
   // Names captured when the user picks a project, so a chip keeps its label
   // even once the search moves on to a different term.
@@ -71,12 +93,12 @@ export default function AsyncProjectMultiSelect({
 
   const nameById = useMemo(() => {
     const m = new Map<string, string>(nameSeed);
-    (data ?? []).forEach((p) => {
+    projects.forEach((p) => {
       if (p.name) m.set(p.id, p.name);
     });
     pickedNames.forEach((name, pid) => m.set(pid, name));
     return m;
-  }, [nameSeed, data, pickedNames]);
+  }, [nameSeed, projects, pickedNames]);
 
   const selectedOptions: ProjectOption[] = useMemo(
     () => values.map((v) => ({ id: v, name: nameById.get(v) ?? v })),
@@ -86,10 +108,10 @@ export default function AsyncProjectMultiSelect({
   // Pool = current selection (so the field can render its chips) + the search
   // results, de-duplicated by id.
   const options: ProjectOption[] = useMemo(() => {
-    const results = (data ?? []).map((p) => ({ id: p.id, name: p.name || p.id }));
+    const results = projects.map((p) => ({ id: p.id, name: p.name || p.id }));
     const seen = new Set(values);
     return [...selectedOptions, ...results.filter((o) => !seen.has(o.id))];
-  }, [data, values, selectedOptions]);
+  }, [projects, values, selectedOptions]);
 
   return (
     <Autocomplete<ProjectOption, true>
@@ -98,12 +120,17 @@ export default function AsyncProjectMultiSelect({
       id={id}
       options={options}
       value={selectedOptions}
-      loading={isFetching}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      // Spinner only while the first page loads; later pages append on scroll.
+      loading={isFetching && projects.length === 0}
       disableCloseOnSelect
       // The backend already filtered by the typed term; don't re-filter locally.
       filterOptions={(opts) => opts}
       getOptionLabel={(opt) => opt.name}
       isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      slotProps={{ listbox: { onScroll: handleListboxScroll } }}
       onChange={(_event, next) => {
         setPickedNames((prev) => {
           const m = new Map(prev);
@@ -118,13 +145,7 @@ export default function AsyncProjectMultiSelect({
         // pick several from one search; clear only on explicit input/clear.
         if (reason === "input" || reason === "clear") setInput(value);
       }}
-      noOptionsText={
-        query.length === 0
-          ? "Type to search projects…"
-          : isFetching
-            ? "Searching…"
-            : "No projects found"
-      }
+      noOptionsText={isFetching ? "Loading projects…" : "No projects found"}
       renderTags={(value, getTagProps) =>
         value.map((option, index) => {
           const { key, ...tagProps } = getTagProps({ index });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
@@ -70,6 +70,7 @@ export default function AsyncProjectMultiSelect({
     isFetching,
     isFetchingNextPage,
     hasNextPage,
+    isError,
     fetchNextPage,
   } = useInfiniteProjectSearch(query, open);
 
@@ -145,7 +146,13 @@ export default function AsyncProjectMultiSelect({
         // pick several from one search; clear only on explicit input/clear.
         if (reason === "input" || reason === "clear") setInput(value);
       }}
-      noOptionsText={isFetching ? "Loading projects…" : "No projects found"}
+      noOptionsText={
+        isError
+          ? "Couldn't load projects. Try again."
+          : isFetching
+            ? "Loading projects…"
+            : "No projects found"
+      }
       renderTags={(value, getTagProps) =>
         value.map((option, index) => {
           const { key, ...tagProps } = getTagProps({ index });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -198,11 +198,30 @@ interface SecondaryItem {
  *   - Watch / unwatch  → managed via the Watchers widget in Details (ISSU-018)
  *   - Open in ServiceNow → this platform replaces ServiceNow; no back-link
  */
-function buildSecondaryItems(): SecondaryItem[] {
+function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
+  const items: SecondaryItem[] = [];
+
+  // Pause / resume the work sub-state. Offered only for an in-progress case
+  // assigned to the current user — pausing/resuming is the assignee's own
+  // workflow control, not something to do to someone else's active case.
+  if (
+    caseDetail.assigneeIsMe &&
+    caseDetail.state === "work_in_progress" &&
+    caseDetail.workState
+  ) {
+    const paused = caseDetail.workState === "paused";
+    items.push({
+      key: "toggle_work_state",
+      label: paused ? "Resume work" : "Pause work",
+      icon: paused ? <Play size={16} /> : <PauseCircle size={16} />,
+      divider: true,
+    });
+  }
+
   // Only "Copy case link" is wired up for now. The rest are disabled until
   // their backend flows land, so the menu advertises the roadmap without
   // exposing dead actions that would no-op or toast a mock message.
-  return [
+  items.push(
     { key: "reassign_engineer", label: "Assign / reassign engineer…", icon: <User size={16} /> },
     { key: "reassign_group", label: "Reassign to group…", icon: <Users size={16} />, divider: true, disabled: true },
     { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} />, disabled: true },
@@ -215,7 +234,9 @@ function buildSecondaryItems(): SecondaryItem[] {
     { key: "request_call", label: "Request a call…", icon: <Phone size={16} />, disabled: true },
     { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true, disabled: true },
     { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },
-  ];
+  );
+
+  return items;
 }
 
 interface CaseActionBarProps {
@@ -251,7 +272,7 @@ export default function CaseActionBar({
     .sort((a, b) => orderRank(a) - orderRank(b))
     .map(buttonFor);
   const primary = lifecycle;
-  const secondary = buildSecondaryItems();
+  const secondary = buildSecondaryItems(caseDetail);
 
   const runPrimary = (p: PrimaryButton): void => {
     if (p.confirm) {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -204,16 +204,15 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   // Pause / resume the work sub-state. Offered only for an in-progress case
   // assigned to the current user — pausing/resuming is the assignee's own
   // workflow control, not something to do to someone else's active case.
-  if (
-    caseDetail.assigneeIsMe &&
-    caseDetail.state === "work_in_progress" &&
-    caseDetail.workState
-  ) {
-    const paused = caseDetail.workState === "paused";
+  if (caseDetail.assigneeIsMe && caseDetail.state === "work_in_progress") {
+    // Only `ongoing` is pausable; anything else (paused OR a null work-state
+    // in-progress case) is resumable — otherwise the only action that can set
+    // `ongoing` would be hidden for null work-state cases.
+    const ongoing = caseDetail.workState === "ongoing";
     items.push({
       key: "toggle_work_state",
-      label: paused ? "Resume work" : "Pause work",
-      icon: paused ? <Play size={16} /> : <PauseCircle size={16} />,
+      label: ongoing ? "Pause work" : "Resume work",
+      icon: ongoing ? <PauseCircle size={16} /> : <Play size={16} />,
       divider: true,
     });
   }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -425,9 +425,10 @@ export default function CasesFilterBar({
     [],
   );
 
-  // Project filter searches the backend as you type rather than loading the
-  // whole catalogue. `availableProjects` (projects on the loaded cases) only
-  // seeds chip labels for already-selected ids before a search runs.
+  // Project filter loads the first page of projects on open and pages through
+  // the rest on scroll (and narrows as you type) rather than loading the whole
+  // catalogue at once. `availableProjects` (projects on the loaded cases) only
+  // seeds chip labels for already-selected ids before any page loads.
   const projectNameSeed = useMemo(
     () => new Map(availableProjects.map((p) => [p.id, p.name])),
     [availableProjects],

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -14,12 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import { Box, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 import { Link as RouterLink } from "react-router";
-import { stateColor, stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
+import StateChip from "@components/StateChip";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 
 interface CasesListProps {
@@ -27,13 +27,14 @@ interface CasesListProps {
   isLoading: boolean;
 }
 
-const HEADER_CELLS: { label: string; align?: "left" | "right" }[] = [
-  { label: "Case ID" },
-  { label: "Subject" },
-  { label: "Product" },
-  { label: "Severity" },
-  { label: "State" },
-  { label: "Updated", align: "right" },
+// Every column is left-aligned for a consistent scan line down the table.
+const HEADER_CELLS: string[] = [
+  "Case ID",
+  "Subject",
+  "Product",
+  "Severity",
+  "State",
+  "Updated",
 ];
 
 // Subject gets the lion's share of the row; the ids sit in their own narrow
@@ -76,14 +77,14 @@ export default function CasesList({
           borderColor: "divider",
         }}
       >
-        {HEADER_CELLS.map((h) => (
+        {HEADER_CELLS.map((label) => (
           <Typography
-            key={h.label}
+            key={label}
             variant="caption"
             color="text.secondary"
-            sx={{ textAlign: h.align ?? "left", fontWeight: 600 }}
+            sx={{ fontWeight: 600 }}
           >
-            {h.label}
+            {label}
           </Typography>
         ))}
       </Box>
@@ -193,19 +194,9 @@ export default function CasesList({
               <Typography variant="body2" noWrap>
                 {c.product}
               </Typography>
-              <SeverityChip severity={c.severity} />
-              <Chip
-                size="small"
-                variant="outlined"
-                label={stateLabel(c.state)}
-                color={stateColor(c.state)}
-              />
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ textAlign: "right" }}
-                noWrap
-              >
+              <SeverityChip severity={c.severity} clickable />
+              <StateChip state={c.state} clickable />
+              <Typography variant="caption" color="text.secondary" noWrap>
                 <RelativeTime iso={c.updatedAt} />
               </Typography>
             </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -166,13 +166,14 @@ export default function CsmCaseCreatePage(): JSX.Element {
     if (!canSubmit || !severity || !issueType || descriptionOverLimit) return;
     postCase.mutate(
       {
+        typeKey: "support",
         projectId,
         deploymentId,
         deployedProductId,
         subject: subject.trim(),
         description,
-        priority: priorityFromSeverity(severity),
-        issueType,
+        severityKey: priorityFromSeverity(severity),
+        issueTypeKey: issueType,
       },
       {
         onSuccess: (created) => navigate(`/cases/${created.id}`),

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -383,18 +383,25 @@ export default function CsmCaseDetailPage(): JSX.Element {
           ? beStateFromUi(nextState)
           : LIFECYCLE_TARGET_STATE[action];
 
-        // Starting (or resuming) work: enforce the single-active-case rule.
-        // 1) look up the engineer's other ongoing cases, 2) move this case to
+        // Starting work: enforce the single-active-case rule.
+        // 1) look up the engineer's other ongoing cases (abort on failure — we
+        //    must not transition without knowing), 2) move this case to
         // work_in_progress, 3) if none ongoing → mark this one ongoing; if some
         // exist → ask before pausing them (handled in onConfirmStartWork).
         if (targetState === "work_in_progress" && data) {
           const caseId = data.id;
           void (async () => {
-            let others: MyOngoingCase[] = [];
+            let others: MyOngoingCase[];
             try {
               others = await findMyOngoingCases(caseId);
-            } catch {
-              // Non-fatal: if the lookup fails, fall through to a plain move.
+            } catch (err) {
+              // Don't proceed blind: marking this ongoing without knowing the
+              // other active cases would break the single-active-case rule.
+              showError(
+                "Couldn't check your other active cases. Please try again.",
+                err,
+              );
+              return;
             }
             try {
               await patchCase.mutateAsync({ stateKey: "work_in_progress" });
@@ -467,35 +474,70 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
-      // Pause / resume the work sub-state via PATCH { workState } (single-field;
-      // does not touch state or assignee). The action bar only offers this for
-      // an in-progress case assigned to the current user. Pausing disables
-      // customer replies (the composer locks to work-note mode); resuming
-      // re-enables them. The single-active-case invariant (resuming auto-pauses
-      // the engineer's other ongoing case) is a backend follow-up; until then
-      // this is a direct toggle.
+      // Pause / resume the work sub-state via PATCH { workStateKey }. Only for an
+      // in-progress case assigned to the current user. Pausing is a direct
+      // single-field patch. Resuming sets this case `ongoing`, so it runs the
+      // same single-active-case conflict check as starting work — otherwise an
+      // engineer with another ongoing case would end up with two.
       if (action.secondary === "toggle_work_state") {
-        if (!data || data.state !== "work_in_progress" || !data.workState) return;
-        const next = data.workState === "ongoing" ? "paused" : "ongoing";
-        patchCase.mutate(
-          { workStateKey: next },
-          {
-            onSuccess: () =>
-              setFeedback({
-                message:
-                  next === "paused"
-                    ? "Work paused — customer replies are disabled until you resume."
-                    : "Resumed work on this case.",
-                severity: next === "paused" ? "warning" : "info",
-                sticky: true,
-              }),
-            onError: (err) =>
+        if (!data || data.state !== "work_in_progress") return;
+        // Anything other than `ongoing` (paused OR a null work-state) resumes.
+        const resuming = data.workState !== "ongoing";
+
+        if (!resuming) {
+          patchCase.mutate(
+            { workStateKey: "paused" },
+            {
+              onSuccess: () =>
+                setFeedback({
+                  message:
+                    "Work paused — customer replies are disabled until you resume.",
+                  severity: "warning",
+                  sticky: true,
+                }),
+              onError: (err) =>
+                showError(
+                  "Could not update the work state. Please try again.",
+                  err,
+                ),
+            },
+          );
+          return;
+        }
+
+        // Resuming → ongoing: check for other active cases first (abort on
+        // failure), then either mark ongoing or prompt to pause the others.
+        const caseId = data.id;
+        void (async () => {
+          let others: MyOngoingCase[];
+          try {
+            others = await findMyOngoingCases(caseId);
+          } catch (err) {
+            showError(
+              "Couldn't check your other active cases. Please try again.",
+              err,
+            );
+            return;
+          }
+          if (others.length === 0) {
+            try {
+              await patchCase.mutateAsync({ workStateKey: "ongoing" });
+            } catch (err) {
               showError(
-                "Could not update the work state. Please try again.",
+                "Could not resume work on this case. Please try again.",
                 err,
-              ),
-          },
-        );
+              );
+              return;
+            }
+            setFeedback({
+              message: "Resumed work on this case.",
+              severity: "info",
+              sticky: true,
+            });
+            return;
+          }
+          setPauseConflict(others);
+        })();
         return;
       }
 
@@ -530,8 +572,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
   );
 
   // Confirm pausing the engineer's other ongoing case(s) and making this case
-  // the active one. The state was already moved to work_in_progress when the
-  // dialog opened; here we pause each other case then mark this one ongoing.
+  // the active one. By the time the dialog opens this case is already
+  // work_in_progress (whether via start-work or resume); here we pause each
+  // other case then mark this one ongoing.
   const onConfirmStartWork = useCallback(async () => {
     const others = pauseConflict;
     if (!others || !data) return;
@@ -544,8 +587,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
       setFeedback({
         message:
           others.length === 1
-            ? `Paused ${others[0].label} and started work on this case.`
-            : `Paused ${others.length} other ongoing cases and started work on this case.`,
+            ? `Paused ${others[0].label} and made this your active case.`
+            : `Paused ${others.length} other ongoing cases and made this your active case.`,
         severity: "info",
         sticky: true,
       });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -19,6 +19,10 @@ import {
   Button,
   Card,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
   IconButton,
   Skeleton,
@@ -40,7 +44,14 @@ import {
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
-import { usePatchCsmCase } from "@features/csm-cases/api/usePatchCsmCase";
+import {
+  usePatchCsmCase,
+  usePatchCsmCaseById,
+} from "@features/csm-cases/api/usePatchCsmCase";
+import {
+  useFindMyOngoingCases,
+  type MyOngoingCase,
+} from "@features/csm-cases/api/useFindMyOngoingCases";
 import type { BeCaseState } from "@api/backend/types";
 import { beStateFromUi } from "@api/backend/mappers";
 import {
@@ -78,11 +89,10 @@ import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import {
   SLA_CLOCK_LABEL,
   formatTimeToBreach,
-  stateColor,
-  stateLabel,
 } from "@features/csm-dashboard/utils/abtDashboard";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
+import StateChip from "@components/StateChip";
 import type {
   CaseAttachment,
   CaseLifecycleAction,
@@ -246,6 +256,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const postAttachment = usePostCsmCaseAttachment();
   const downloadAttachment = useDownloadCsmCaseAttachment();
   const patchCase = usePatchCsmCase(caseId);
+  const patchCaseById = usePatchCsmCaseById();
+  const findMyOngoingCases = useFindMyOngoingCases();
   const recordView = useRecordRecentView();
   const claims = useIdTokenClaims();
   // Display name for comments authored in this session, resolved from the
@@ -262,6 +274,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [metaCollapsed, setMetaCollapsed] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
+  // When starting work would leave the engineer with more than one ongoing case,
+  // hold the other ongoing case(s) here to drive the confirm dialog.
+  const [pauseConflict, setPauseConflict] = useState<MyOngoingCase[] | null>(
+    null,
+  );
   // Email of the signed-in engineer, for the "Assign to me" shortcut.
   const currentUserEmail = claims?.email ?? undefined;
 
@@ -365,11 +382,58 @@ export default function CsmCaseDetailPage(): JSX.Element {
         const targetState = nextState
           ? beStateFromUi(nextState)
           : LIFECYCLE_TARGET_STATE[action];
+
+        // Starting (or resuming) work: enforce the single-active-case rule.
+        // 1) look up the engineer's other ongoing cases, 2) move this case to
+        // work_in_progress, 3) if none ongoing → mark this one ongoing; if some
+        // exist → ask before pausing them (handled in onConfirmStartWork).
+        if (targetState === "work_in_progress" && data) {
+          const caseId = data.id;
+          void (async () => {
+            let others: MyOngoingCase[] = [];
+            try {
+              others = await findMyOngoingCases(caseId);
+            } catch {
+              // Non-fatal: if the lookup fails, fall through to a plain move.
+            }
+            try {
+              await patchCase.mutateAsync({ stateKey: "work_in_progress" });
+            } catch (err) {
+              showError(
+                "Could not move the case to Work in progress. Please try again.",
+                err,
+              );
+              return;
+            }
+            if (others.length === 0) {
+              // No competing case → make this the active (ongoing) one.
+              try {
+                await patchCase.mutateAsync({ workStateKey: "ongoing" });
+              } catch (err) {
+                showError(
+                  "Moved to Work in progress, but could not mark it ongoing.",
+                  err,
+                );
+                return;
+              }
+              setFeedback({
+                message: LIFECYCLE_TOAST[action],
+                severity: LIFECYCLE_SEVERITY[action],
+                sticky: true,
+              });
+              return;
+            }
+            // Others are ongoing → confirm before pausing them.
+            setPauseConflict(others);
+          })();
+          return;
+        }
+
         if (targetState) {
           // Real state transition via PATCH /cases/{id}; the detail + list
           // queries refetch on success so the new state shows.
           patchCase.mutate(
-            { state: targetState },
+            { stateKey: targetState },
             {
               onSuccess: () =>
                 setFeedback({
@@ -403,6 +467,38 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Pause / resume the work sub-state via PATCH { workState } (single-field;
+      // does not touch state or assignee). The action bar only offers this for
+      // an in-progress case assigned to the current user. Pausing disables
+      // customer replies (the composer locks to work-note mode); resuming
+      // re-enables them. The single-active-case invariant (resuming auto-pauses
+      // the engineer's other ongoing case) is a backend follow-up; until then
+      // this is a direct toggle.
+      if (action.secondary === "toggle_work_state") {
+        if (!data || data.state !== "work_in_progress" || !data.workState) return;
+        const next = data.workState === "ongoing" ? "paused" : "ongoing";
+        patchCase.mutate(
+          { workStateKey: next },
+          {
+            onSuccess: () =>
+              setFeedback({
+                message:
+                  next === "paused"
+                    ? "Work paused — customer replies are disabled until you resume."
+                    : "Resumed work on this case.",
+                severity: next === "paused" ? "warning" : "info",
+                sticky: true,
+              }),
+            onError: (err) =>
+              showError(
+                "Could not update the work state. Please try again.",
+                err,
+              ),
+          },
+        );
+        return;
+      }
+
       // Copy-link is async: only confirm success once the clipboard write
       // actually resolves, otherwise a failure shows both a false "copied"
       // toast and an error.
@@ -430,8 +526,45 @@ export default function CsmCaseDetailPage(): JSX.Element {
         sticky: false,
       });
     },
-    [data, showError, patchCase],
+    [data, showError, patchCase, findMyOngoingCases],
   );
+
+  // Confirm pausing the engineer's other ongoing case(s) and making this case
+  // the active one. The state was already moved to work_in_progress when the
+  // dialog opened; here we pause each other case then mark this one ongoing.
+  const onConfirmStartWork = useCallback(async () => {
+    const others = pauseConflict;
+    if (!others || !data) return;
+    setPauseConflict(null);
+    try {
+      for (const o of others) {
+        await patchCaseById(o.id, { workStateKey: "paused" });
+      }
+      await patchCase.mutateAsync({ workStateKey: "ongoing" });
+      setFeedback({
+        message:
+          others.length === 1
+            ? `Paused ${others[0].label} and started work on this case.`
+            : `Paused ${others.length} other ongoing cases and started work on this case.`,
+        severity: "info",
+        sticky: true,
+      });
+    } catch (err) {
+      showError("Could not update the work states. Please try again.", err);
+    }
+  }, [pauseConflict, data, patchCaseById, patchCase, showError]);
+
+  // Decline: keep the move to work_in_progress (already applied) but leave this
+  // case not-ongoing and the other case(s) ongoing.
+  const onDeclineStartWork = useCallback(() => {
+    setPauseConflict(null);
+    setFeedback({
+      message:
+        "Moved to Work in progress. Your other case stays your active one.",
+      severity: "info",
+      sticky: true,
+    });
+  }, []);
 
   // Assign the case to the chosen engineer via PATCH { assigneeEmail }. The
   // detail query is invalidated by the hook, so the assignee display refreshes
@@ -656,13 +789,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               state doesn't get lost among the tag chips. */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
             <SeverityChip severity={c.severity} withLabel />
-            <Chip
-              size="small"
-              variant="outlined"
-              label={stateLabel(c.state)}
-              color={stateColor(c.state)}
-              sx={{ fontWeight: 600 }}
-            />
+            <StateChip state={c.state} />
             {c.state === "work_in_progress" && c.workState && (
               <Chip
                 size="small"
@@ -1039,6 +1166,41 @@ export default function CsmCaseDetailPage(): JSX.Element {
           onAssign={onAssign}
         />
       )}
+
+      <Dialog
+        open={!!pauseConflict}
+        onClose={onDeclineStartWork}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>
+          {pauseConflict && pauseConflict.length > 1
+            ? "Pause your other active cases?"
+            : "Pause your other active case?"}
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            You're already working on{" "}
+            <strong>
+              {pauseConflict?.map((o) => o.label).join(", ")}
+            </strong>
+            . Pause {pauseConflict && pauseConflict.length > 1 ? "them" : "it"}{" "}
+            and make this case your active (ongoing) one?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button color="inherit" onClick={onDeclineStartWork}>
+            No, keep it active
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => void onConfirmStartWork()}
+            disabled={patchCase.isPending}
+          >
+            Pause and start this
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -103,11 +103,11 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
         // population.
         const activeStateKeys = COMPOSITION_STATES.map(beStateFromUi);
         // The state/closed counts don't filter by severity. The backend,
-        // however, counts only catastrophic cases when `priorityKeys` is absent
+        // however, counts only catastrophic cases when `severityKeys` is absent
         // (an empty priority filter is not treated as "all"), which made the
         // state pie show the S0 row only and disagree with the matrix totals.
         // Pass every priority explicitly so these counts span all severities.
-        // BE follow-up: treat an absent/empty priorityKeys as "all priorities".
+        // BE follow-up: treat an absent/empty severityKeys as "all priorities".
         const allPriorityKeys = MATRIX_SEVERITIES.map(priorityFromSeverity);
 
         // All severity + state counts (plus the closed total) fire in one wave.
@@ -117,7 +117,7 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
               countTotal({
                 pagination: { offset: 0, limit: 1 },
                 filters: {
-                  priorityKeys: [priorityFromSeverity(sev)],
+                  severityKeys: [priorityFromSeverity(sev)],
                   stateKeys: activeStateKeys,
                 },
               }).then((n) => ({ key: sev, n })),
@@ -129,7 +129,7 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
                 pagination: { offset: 0, limit: 1 },
                 filters: {
                   stateKeys: [beStateFromUi(st)],
-                  priorityKeys: allPriorityKeys,
+                  severityKeys: allPriorityKeys,
                 },
               }).then((n) => ({ key: st, n })),
             ),
@@ -138,7 +138,7 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             pagination: { offset: 0, limit: 1 },
             filters: {
               stateKeys: [beStateFromUi("closed")],
-              priorityKeys: allPriorityKeys,
+              severityKeys: allPriorityKeys,
             },
           }),
         ]);

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -106,7 +106,7 @@ export function useCaseCountsMatrix(): UseQueryResult<CaseCountsMatrix, Error> {
             .post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
               pagination: { offset: 0, limit: 1 },
               filters: {
-                priorityKeys: [priorityFromSeverity(severity)],
+                severityKeys: [priorityFromSeverity(severity)],
                 stateKeys: [beStateFromUi(state)],
               },
             })


### PR DESCRIPTION
Depends on PR #893 - merge that first please.

## Work state + claim flow
- Surface the work sub-state (ongoing/paused) on the case detail header.
- **Pause/Resume** the work sub-state from the action-bar **More** menu, shown only when the case is in progress **and assigned to the current user**.
- **Start work** (open/waiting → in progress) enforces a single active case: look up the engineer's other ongoing cases, move this case to in progress, then either mark it ongoing (no conflict) or prompt to pause the other ongoing case(s) and make this one active.
- Resolve *assignee == me* from `assignedEngineer.email` vs the JWT email. Search has no assignee/work-state filter, so "my ongoing cases" is narrowed by `stateKeys:[work_in_progress]` server-side and matched on assignee + `workState === "ongoing"` client-side (null work state is never ongoing).

## UX
- Case lifecycle **state** as a solid status chip (shared `StateChip`), consistent on list + detail; **all case-list columns left-aligned**.
- Rename the **Administration** nav item and page heading to **Settings**.
- Cases **project filter** loads the first page on open and lazy-loads more on scroll.
- Rename the FE correlation header to **`X-CSM-Correlation-ID`** to match the gateway-safe backend header.

## v2 contract realignment
- `PATCH /cases/{id}`: `stateKey` / `severityKey` / `workStateKey`.
- Case create: `typeKey` + `severityKey` + `issueTypeKey`.
- Search filters: `severityKeys` (was `priorityKeys`); responses: `severity` (was `priority`); added `reopened` state and case `type`.

## Notes
- Backend still has **no assignee search filter**, so the cases-list Assignee filter stays disabled against live; the claim lookup uses the client-side match above.

## Testing
- `pnpm build` green · `pnpm test` 90 passed · `pnpm lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added work state management to pause and resume case work.
  * Introduced case type and severity-based filtering for searches.
  * Added engineer reassignment with conflict detection for ongoing cases.
  * Enabled infinite scroll pagination for project selection during case creation.

* **Improvements**
  * Refined case model: replaced priority with severity for better categorization.
  * Fixed current user assignment detection in case views.
  * Updated navigation label from "Administration" to "Settings."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->