### PR TITLE
[Customer Portal Web App] Show list view for partner users in Project Hub

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Chip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type JSX, useState, useMemo } from "react";
+import { useNavigate } from "react-router";
+import type { ProjectListItem } from "@features/project-hub/types/projects";
+
+const DATE_LOCALE = "en-US";
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+};
+const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+const DEFAULT_ROWS_PER_PAGE = 10;
+const COL_SPAN = 7;
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "--";
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return "--";
+  return d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT_OPTIONS);
+}
+
+type ProjectListTableProps = {
+  projects: ProjectListItem[];
+  isFetchingNextPage?: boolean;
+};
+
+/**
+ * List-view table for partner users with more than 4 projects.
+ * Columns: Project Key, Name, Status, Start Date, End Date, Action Required, Outstanding Items.
+ * Clicking a row navigates to the project dashboard.
+ */
+const ProjectListTable = ({
+  projects,
+  isFetchingNextPage,
+}: ProjectListTableProps): JSX.Element => {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  const paginatedProjects = useMemo(
+    () => projects.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [projects, page, rowsPerPage],
+  );
+
+  const handleChangePage = (_: unknown, newPage: number) => setPage(newPage);
+
+  const handleChangeRowsPerPage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ width: "100%", mt: 1 }}>
+      <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+        <Table sx={{ minWidth: 800 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Project Key</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Start Date</TableCell>
+              <TableCell>End Date</TableCell>
+              <TableCell align="right">Action Required</TableCell>
+              <TableCell align="right">Outstanding Items</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {projects.length === 0 && !isFetchingNextPage ? (
+              <TableRow>
+                <TableCell colSpan={COL_SPAN} align="center">
+                  <Typography variant="body2" color="text.secondary">
+                    No projects found.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              paginatedProjects.map((project) => {
+                const isSuspended =
+                  project.closureState?.toLowerCase() === "suspended";
+                return (
+                  <TableRow
+                    key={project.id}
+                    hover
+                    sx={{ cursor: "pointer" }}
+                    onClick={() =>
+                      navigate(`/projects/${project.id}/dashboard`)
+                    }
+                  >
+                    <TableCell>
+                      <Typography variant="body2" fontWeight="medium">
+                        {project.key}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2">{project.name}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={project.closureState ?? "Active"}
+                        size="small"
+                        color={isSuspended ? "warning" : "success"}
+                        variant="outlined"
+                        sx={{ fontWeight: 500 }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {formatDate(project.startDate)}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {formatDate(project.endDate)}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2">
+                        {project.actionRequiredCount ?? 0}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2">
+                        {project.outstandingCount ?? 0}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        component="div"
+        count={projects.length}
+        page={page}
+        onPageChange={handleChangePage}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+      />
+    </Box>
+  );
+};
+
+export default ProjectListTable;

--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
@@ -66,6 +66,9 @@ const ProjectListTable = ({
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
 
+  const maxPage = Math.max(0, Math.floor((projects.length - 1) / rowsPerPage));
+  if (page > maxPage) setPage(maxPage);
+
   const paginatedProjects = useMemo(
     () => projects.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
     [projects, page, rowsPerPage],
@@ -110,10 +113,15 @@ const ProjectListTable = ({
                   <TableRow
                     key={project.id}
                     hover
+                    tabIndex={0}
                     sx={{ cursor: "pointer" }}
-                    onClick={() =>
-                      navigate(`/projects/${project.id}/dashboard`)
-                    }
+                    onClick={() => navigate(`/projects/${project.id}/dashboard`)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        navigate(`/projects/${project.id}/dashboard`);
+                      }
+                    }}
                   >
                     <TableCell>
                       <Typography variant="body2" fontWeight="medium">

--- a/apps/customer-portal/webapp/src/features/project-hub/constants/projectHubConstants.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/constants/projectHubConstants.ts
@@ -71,6 +71,9 @@ export const PROJECT_CARD_ERROR_ENTITY_OUTSTANDING_CASES =
 
 export const PROJECT_CARD_ERROR_ENTITY_ACTIVE_CHATS = "Active Chats";
 
+/** Project count threshold above which partners see the list table instead of card grid. */
+export const PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD = 4;
+
 /** ServiceNow deep-link redirect (`ServiceNowCaseRedirectPage`). */
 export const SERVICENOW_REDIRECT_NO_CASE_ID =
   "No case ID provided in the URL.";

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -38,6 +38,9 @@ import { useLoader } from "@context/linear-loader/LoaderContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import ProjectCard from "@features/project-hub/components/ProjectCard";
 import ProjectCardSkeleton from "@features/project-hub/components/project-card/ProjectCardSkeleton";
+import ProjectListTable from "@features/project-hub/components/ProjectListTable";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
+import { SETTINGS_PARTNER_ROLE } from "@features/settings/constants/settingsConstants";
 import { ChevronUp, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useAsgardeo } from "@asgardeo/react";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
@@ -51,6 +54,7 @@ import {
   PROJECT_HUB_EMPTY_SEARCH_TITLE,
   PROJECT_HUB_ERROR_SUBTITLE,
   PROJECT_HUB_ERROR_TITLE,
+  PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD,
   PROJECT_HUB_PROJECTS_PAGE_SIZE,
   PROJECT_HUB_REDIRECT_LOADER_MESSAGE,
   PROJECT_HUB_SEARCH_DEBOUNCE_MS,
@@ -80,6 +84,7 @@ export default function ProjectHub(): JSX.Element {
   const { showLoader, hideLoader } = useLoader();
   const { isLoading: isAuthLoading } = useAsgardeo();
   useGetMetadata();
+  const { data: userDetails } = useGetUserDetails();
   const [searchQuery, setSearchQuery] = useState<string>("");
   const debouncedSearchQuery = useDebouncedValue(
     searchQuery,
@@ -103,15 +108,13 @@ export default function ProjectHub(): JSX.Element {
   const totalRecords = getTotalRecords(data);
 
   // Track the unfiltered total separately so the title never shows a search-result count.
-  // Only update while not loading so the skeleton can use the previously known count.
-  const totalProjectsRef = useRef(0);
-  if (!debouncedSearchQuery && !isLoading) {
-    totalProjectsRef.current = totalRecords;
+  // Render-time setState: React re-renders synchronously in the same pass, no cascading.
+  const [cachedTotalProjects, setCachedTotalProjects] = useState(0);
+  if (!debouncedSearchQuery && !isLoading && totalRecords !== cachedTotalProjects) {
+    setCachedTotalProjects(totalRecords);
   }
   const titleTotalRecords =
-    !isLoading && !debouncedSearchQuery
-      ? totalRecords
-      : totalProjectsRef.current;
+    !isLoading && !debouncedSearchQuery ? totalRecords : cachedTotalProjects;
 
   const [showBackToTop, setShowBackToTop] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -262,10 +265,14 @@ export default function ProjectHub(): JSX.Element {
   const headerTitle = resolveProjectHubHeaderTitle(titleTotalRecords);
   const headerSubtitle = resolveProjectHubHeaderSubtitle();
 
+  const isPartner = (userDetails?.roles ?? []).includes(SETTINGS_PARTNER_ROLE);
+  const isPartnerListView =
+    isPartner && totalRecords > PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD;
+
   const colsPerRow = isXlUp ? 5 : isLgUp ? 4 : 3;
   // During loading use the cached count so the skeleton mirrors the expected layout.
   const effectiveCount = isLoading ? totalProjectsRef.current : projects.length;
-  const isCenteredLayout = effectiveCount <= colsPerRow;
+  const isCenteredLayout = !isPartnerListView && effectiveCount <= colsPerRow;
   // When effectiveCount is 0 (first-ever load), fill one full row of skeleton cards.
   const displayCount = effectiveCount === 0 ? colsPerRow : effectiveCount;
 
@@ -427,6 +434,19 @@ export default function ProjectHub(): JSX.Element {
           </Box>
         );
       case ProjectHubContentView.PROJECT_LIST: {
+        if (isPartnerListView) {
+          return (
+            <>
+              <ProjectListTable
+                projects={projects}
+                isFetchingNextPage={isFetchingNextPage}
+              />
+              {/* sentinel triggers infinite scroll to load all projects into the table */}
+              <Box ref={sentinelRef} sx={{ height: 1 }} />
+            </>
+          );
+        }
+
         const grid = (
           <Box sx={gridSx}>
             {projects.map((project) => (

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -271,7 +271,7 @@ export default function ProjectHub(): JSX.Element {
 
   const colsPerRow = isXlUp ? 5 : isLgUp ? 4 : 3;
   // During loading use the cached count so the skeleton mirrors the expected layout.
-  const effectiveCount = isLoading ? totalProjectsRef.current : projects.length;
+  const effectiveCount = isLoading ? cachedTotalProjects : projects.length;
   const isCenteredLayout = !isPartnerListView && effectiveCount <= colsPerRow;
   // When effectiveCount is 0 (first-ever load), fill one full row of skeleton cards.
   const displayCount = effectiveCount === 0 ? colsPerRow : effectiveCount;

--- a/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
@@ -37,6 +37,8 @@ export type ProjectListItem = {
   actionRequiredCount: number;
   outstandingCount?: number | null;
   slaStatus: string;
+  startDate?: string | null;
+  endDate?: string | null;
 };
 
 // Item type for account nested in project details response.

--- a/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
@@ -42,6 +42,9 @@ export const SETTINGS_NULL_PLACEHOLDER = NULL_PLACEHOLDER;
 /** Role that can see AI Assistant tab and User Management Add/Delete. */
 export const SETTINGS_CUSTOMER_ADMIN_ROLE = "sn_customerservice.customer_admin";
 
+/** ServiceNow partner role — triggers list view in ProjectHub when >4 projects. */
+export const SETTINGS_PARTNER_ROLE = "sn_customerservice.partner";
+
 export const SETTINGS_PAGE_TABS = [
   {
     id: SettingsPageTabId.USERS,


### PR DESCRIPTION
## Summary
- Add `ProjectListTable` component that renders a paginated table for users with the partner role when they have more than 4 projects
- Detect partner role via `useGetUserDetails` in `ProjectHub` and switch between card grid and list table based on role + project count
- Add `startDate` and `endDate` to `ProjectListItem` type ahead of API support

## Changes
- `ProjectListTable.tsx` — new table component with columns: Project Key, Name, Status, Start Date, End Date, Action Required, Outstanding Items; row click navigates to project dashboard
- `ProjectHub.tsx` — partner role detection, list/grid view branching, and fix for React 19 ref-during-render violation (replaced `useRef` with render-time `useState` update)
- `projects.ts` — added optional `startDate` and `endDate` to `ProjectListItem`
- `settingsConstants.ts` — added `SETTINGS_PARTNER_ROLE` constant
- `projectHubConstants.ts` — added `PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large project lists now display in a paginated table view for easier navigation.
  * Added project start and end date information to project listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->