### PR TITLE
[Customer Portal Web App] feat: partner project list view with CSV/PDF export

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
@@ -139,6 +139,9 @@ const ProjectListTable = ({
           size="small"
           onClick={handleExportOpen}
           disabled={isExporting || projects.length === 0}
+          aria-haspopup="menu"
+          aria-expanded={Boolean(exportAnchorEl)}
+          aria-controls="project-list-export-menu"
           startIcon={
             isExporting ? (
               <CircularProgress size={16} color="inherit" />
@@ -151,6 +154,7 @@ const ProjectListTable = ({
           {isExporting ? "Exporting..." : "Export"}
         </Button>
         <Menu
+          id="project-list-export-menu"
           anchorEl={exportAnchorEl}
           open={Boolean(exportAnchorEl)}
           onClose={handleExportClose}

--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
@@ -16,7 +16,11 @@
 
 import {
   Box,
+  Button,
   Chip,
+  CircularProgress,
+  Menu,
+  MenuItem,
   Paper,
   Table,
   TableBody,
@@ -27,9 +31,15 @@ import {
   TableRow,
   Typography,
 } from "@wso2/oxygen-ui";
-import { type JSX, useState, useMemo } from "react";
+import { ChevronDown, Download } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, useState, useMemo, useRef, useCallback, type MouseEvent } from "react";
 import { useNavigate } from "react-router";
 import type { ProjectListItem } from "@features/project-hub/types/projects";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import {
+  downloadProjectListCsv,
+  downloadProjectListPdf,
+} from "@features/project-hub/utils/projectsExport";
 
 const DATE_LOCALE = "en-US";
 const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
@@ -58,13 +68,50 @@ type ProjectListTableProps = {
  * Columns: Project Key, Name, Status, Start Date, End Date, Action Required, Outstanding Items.
  * Clicking a row navigates to the project dashboard.
  */
+type ExportFormat = "csv" | "pdf";
+
 const ProjectListTable = ({
   projects,
   isFetchingNextPage,
 }: ProjectListTableProps): JSX.Element => {
   const navigate = useNavigate();
+  const { showError } = useErrorBanner();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
+  const isExportingRef = useRef(false);
+  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingRef.current) setExportAnchorEl(e.currentTarget);
+  };
+  const handleExportClose = () => setExportAnchorEl(null);
+
+  const handleExport = useCallback(
+    (format: ExportFormat) => {
+      if (isExportingRef.current) return;
+      handleExportClose();
+      if (projects.length === 0) {
+        showError("No projects to export.");
+        return;
+      }
+      isExportingRef.current = true;
+      setExportingFormat(format);
+      try {
+        if (format === "csv") {
+          downloadProjectListCsv(projects);
+        } else {
+          downloadProjectListPdf(projects);
+        }
+      } catch {
+        showError("Failed to export projects.");
+      } finally {
+        isExportingRef.current = false;
+        setExportingFormat(null);
+      }
+    },
+    [projects, showError],
+  );
 
   const maxPage = Math.max(0, Math.floor((projects.length - 1) / rowsPerPage));
   if (page > maxPage) setPage(maxPage);
@@ -81,8 +128,37 @@ const ProjectListTable = ({
     setPage(0);
   };
 
+  const isExporting = exportingFormat !== null;
+
   return (
     <Box sx={{ width: "100%", mt: 1 }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
+        <Button
+          type="button"
+          variant="outlined"
+          size="small"
+          onClick={handleExportOpen}
+          disabled={isExporting || projects.length === 0}
+          startIcon={
+            isExporting ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <Download size={16} />
+            )
+          }
+          endIcon={<ChevronDown size={16} />}
+        >
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+        <Menu
+          anchorEl={exportAnchorEl}
+          open={Boolean(exportAnchorEl)}
+          onClose={handleExportClose}
+        >
+          <MenuItem onClick={() => handleExport("csv")}>Export to CSV</MenuItem>
+          <MenuItem onClick={() => handleExport("pdf")}>Export to PDF</MenuItem>
+        </Menu>
+      </Box>
       <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
         <Table sx={{ minWidth: 800 }}>
           <TableHead>

--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
@@ -168,8 +168,8 @@ const ProjectListTable = ({
               <TableCell>Status</TableCell>
               <TableCell>Start Date</TableCell>
               <TableCell>End Date</TableCell>
-              <TableCell align="right">Action Required Items</TableCell>
-              <TableCell align="right">Outstanding Items</TableCell>
+              <TableCell>Action Required Items</TableCell>
+              <TableCell>Outstanding Items</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -226,12 +226,12 @@ const ProjectListTable = ({
                         {formatDate(project.endDate)}
                       </Typography>
                     </TableCell>
-                    <TableCell align="right">
+                    <TableCell>
                       <Typography variant="body2">
                         {project.actionRequiredCount ?? 0}
                       </Typography>
                     </TableCell>
-                    <TableCell align="right">
+                    <TableCell>
                       <Typography variant="body2">
                         {project.outstandingCount ?? 0}
                       </Typography>

--- a/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/ProjectListTable.tsx
@@ -65,7 +65,7 @@ type ProjectListTableProps = {
 
 /**
  * List-view table for partner users with more than 4 projects.
- * Columns: Project Key, Name, Status, Start Date, End Date, Action Required, Outstanding Items.
+ * Columns: Project Key, Name, Status, Start Date, End Date, Action Required Items, Outstanding Items.
  * Clicking a row navigates to the project dashboard.
  */
 type ExportFormat = "csv" | "pdf";
@@ -168,7 +168,7 @@ const ProjectListTable = ({
               <TableCell>Status</TableCell>
               <TableCell>Start Date</TableCell>
               <TableCell>End Date</TableCell>
-              <TableCell align="right">Action Required</TableCell>
+              <TableCell align="right">Action Required Items</TableCell>
               <TableCell align="right">Outstanding Items</TableCell>
             </TableRow>
           </TableHead>

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -174,6 +174,12 @@ export default function ProjectHub(): JSX.Element {
     }
   }, [isLoading, showLoader, hideLoader]);
 
+  const isPartner = (userDetails?.roles ?? []).includes(SETTINGS_PARTNER_ROLE);
+  // Use the unfiltered cached total so a search returning fewer results doesn't
+  // switch a partner back to card view.
+  const isPartnerListView =
+    isPartner && cachedTotalProjects > PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD;
+
   const isCheckingAllSuspended =
     !isLoading &&
     !isAuthLoading &&
@@ -200,7 +206,8 @@ export default function ProjectHub(): JSX.Element {
     projects.length === 1 &&
     !searchQuery &&
     !allProjectsSuspended &&
-    !isCheckingAllSuspended;
+    !isCheckingAllSuspended &&
+    !isPartnerListView;
 
   useEffect(() => {
     if (isRedirectingToSingleProject) {
@@ -264,10 +271,6 @@ export default function ProjectHub(): JSX.Element {
 
   const headerTitle = resolveProjectHubHeaderTitle(titleTotalRecords);
   const headerSubtitle = resolveProjectHubHeaderSubtitle();
-
-  const isPartner = (userDetails?.roles ?? []).includes(SETTINGS_PARTNER_ROLE);
-  const isPartnerListView =
-    isPartner && totalRecords > PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD;
 
   const colsPerRow = isXlUp ? 5 : isLgUp ? 4 : 3;
   // During loading use the cached count so the skeleton mirrors the expected layout.

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
@@ -48,13 +48,18 @@ const DATE_FORMAT: Intl.DateTimeFormatOptions = {
 
 function formatDate(value: string | null | undefined): string {
   if (!value) return "--";
-  const d = new Date(value);
+  // Append T00:00:00 so the string is parsed as local time, not UTC.
+  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
+  const d = new Date(normalized);
   return isNaN(d.getTime()) ? "--" : d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT);
 }
 
 function buildFilename(ext: "csv" | "pdf"): string {
-  const date = new Date().toISOString().slice(0, 10);
-  return `projects-${date}.${ext}`;
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `projects-${yyyy}-${mm}-${dd}.${ext}`;
 }
 
 function mapProjectsToRows(projects: ProjectListItem[]): string[][] {

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
@@ -24,7 +24,7 @@ const EXPORT_HEADERS = [
   "Status",
   "Start Date",
   "End Date",
-  "Action Required",
+  "Action Required Items",
   "Outstanding Items",
 ];
 
@@ -35,7 +35,7 @@ const PDF_COLUMN_STYLES: Record<number, PdfColumnStyle> = {
   2: { cellWidth: 24, halign: "center" },        // Status
   3: { cellWidth: 28, halign: "center" },        // Start Date
   4: { cellWidth: 28, halign: "center" },        // End Date
-  5: { cellWidth: 30, halign: "right" },         // Action Required
+  5: { cellWidth: 30, halign: "right" },         // Action Required Items
   6: { cellWidth: 35, halign: "right" },         // Outstanding Items
 };
 

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { buildCsvContent, downloadCsvFile } from "@utils/csv";
+import { downloadPdfFile, type PdfColumnStyle } from "@utils/pdf";
+import type { ProjectListItem } from "@features/project-hub/types/projects";
+
+const EXPORT_HEADERS = [
+  "Project Key",
+  "Name",
+  "Status",
+  "Start Date",
+  "End Date",
+  "Action Required",
+  "Outstanding Items",
+];
+
+// A4 landscape usable width ~269mm, 7 columns.
+const PDF_COLUMN_STYLES: Record<number, PdfColumnStyle> = {
+  0: { cellWidth: 30 },                          // Project Key
+  1: { cellWidth: 80 },                          // Name
+  2: { cellWidth: 24, halign: "center" },        // Status
+  3: { cellWidth: 28, halign: "center" },        // Start Date
+  4: { cellWidth: 28, halign: "center" },        // End Date
+  5: { cellWidth: 30, halign: "right" },         // Action Required
+  6: { cellWidth: 35, halign: "right" },         // Outstanding Items
+};
+
+const DATE_LOCALE = "en-US";
+const DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "--";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? "--" : d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT);
+}
+
+function buildFilename(ext: "csv" | "pdf"): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return `projects-${date}.${ext}`;
+}
+
+function mapProjectsToRows(projects: ProjectListItem[]): string[][] {
+  return projects.map((p) => [
+    p.key,
+    p.name,
+    p.closureState ?? "Active",
+    formatDate(p.startDate),
+    formatDate(p.endDate),
+    String(p.actionRequiredCount ?? 0),
+    String(p.outstandingCount ?? 0),
+  ]);
+}
+
+export function downloadProjectListCsv(projects: ProjectListItem[]): void {
+  const rows = mapProjectsToRows(projects);
+  const content = buildCsvContent(EXPORT_HEADERS, rows);
+  downloadCsvFile(buildFilename("csv"), content);
+}
+
+export function downloadProjectListPdf(projects: ProjectListItem[]): void {
+  const rows = mapProjectsToRows(projects);
+  downloadPdfFile(
+    buildFilename("pdf"),
+    "Projects",
+    EXPORT_HEADERS,
+    rows,
+    PDF_COLUMN_STYLES,
+  );
+}


### PR DESCRIPTION
## Summary
- Render a paginated list table instead of card grid for users with the `sn_customerservice.partner` role when they have more than 4 projects
- Add CSV and PDF export for the partner project list table
- Fix partner list view to persist during search (single result still shows table)

## Changes

### New Files
- `ProjectListTable.tsx` — paginated table with columns: Project Key, Name, Status, Start Date, End Date, Action Required Items, Outstanding Items; row click navigates to project dashboard; keyboard accessible (Enter/Space); Export dropdown (CSV + PDF) top-right above table; all headers/cells left-aligned
- `projectsExport.ts` — export utility using shared `utils/csv.ts` and `utils/pdf.ts`; filename stamped `projects-YYYY-MM-DD.{ext}`

<img width="1510" height="826" alt="image" src="https://github.com/user-attachments/assets/208f2e36-0dfb-4808-93e7-a01336d96262" />

### Exported pdf
<img width="1121" height="770" alt="image" src="https://github.com/user-attachments/assets/a30c7cd0-8f6f-4c31-b024-68f3366f1a1e" />

### Exported csv
<img width="991" height="529" alt="image" src="https://github.com/user-attachments/assets/6a9f01df-1c01-4dc9-8cd1-497d9f050845" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to export project list as CSV or PDF using a dropdown menu
  * Export button displays loading indicator during processing with error handling for empty datasets

* **Improvements**
  * Refined project table column headers for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->