### PR TITLE
[Customer Entity] Rename case title to subject in search/get responses

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -611,7 +611,7 @@ type SearchCaseView struct {
 	Number           string               `json:"number"`
 	CreatedOn        string               `json:"createdOn"`
 	CreatedBy        string               `json:"createdBy"`
-	Title            *string              `json:"title"`
+	Subject          *string              `json:"subject"`
 	Description      *string              `json:"description"`
 	IssueType        *string              `json:"issueType"`
 	State            string               `json:"state"`

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -512,7 +512,7 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 				return fmt.Errorf("scan case: %w", err)
 			}
 			cv.CaseType = caseType
-			cv.Title = &subject
+			cv.Subject = &subject
 			cv.Description = &description
 			cv.Severity = severity
 			cv.IssueType = issueType

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1083,7 +1083,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			InternalID:      c.InternalID,
 			CreatedOn:       c.CreatedOn,
 			CreatedBy:       c.CreatedBy,
-			Title:           &title,
+			Subject:         &title,
 			Description:     &description,
 			IssueType:       issueTypeLabel,
 			State:           stateLabel,

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1590,7 +1590,7 @@ components:
         createdBy:
           type: string
           format: email
-        title:
+        subject:
           type: string
           nullable: true
         description:


### PR DESCRIPTION
## Summary
- `SearchCaseView.title` renamed to `subject` to match the Postgres column name and API contract
- SN data source returns the field as `title` internally - mapped to `subject` on the way out in both `SearchCases` and `GetCase`
- OpenAPI spec updated to reflect the renamed field
