### PR TITLE
[Customer Portal Web App] feat: usage overview environment breakdown and metrics improvements

### DIFF
--- a/apps/customer-portal/webapp/package.json
+++ b/apps/customer-portal/webapp/package.json
@@ -11,7 +11,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@asgardeo/react": "0.25.5",
+    "@asgardeo/react": "0.25.6",
     "@asgardeo/react-router": "2.0.0",
     "@lexical/code": "0.40.0",
     "@lexical/html": "0.40.0",

--- a/apps/customer-portal/webapp/pnpm-lock.yaml
+++ b/apps/customer-portal/webapp/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@asgardeo/react':
-        specifier: 0.25.5
-        version: 0.25.5(@types/react@19.2.5)(react@19.2.0)
+        specifier: 0.25.6
+        version: 0.25.6(@types/react@19.2.5)(react@19.2.0)
       '@asgardeo/react-router':
         specifier: 2.0.0
-        version: 2.0.0(@asgardeo/react@0.25.5(@types/react@19.2.5)(react@19.2.0))(react-router@7.1.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.0.0(@asgardeo/react@0.25.6(@types/react@19.2.5)(react@19.2.0))(react-router@7.1.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@lexical/code':
         specifier: 0.40.0
         version: 0.40.0
@@ -177,8 +177,8 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@asgardeo/browser@0.7.9':
-    resolution: {integrity: sha512-kwQ+brGx5+AqVwHaupLBRv13HNSjqcH7qkDNktL2b4oL0dVwWqrs3oeGFcNxbaS71Fege1cN5KMHGnh6hGszqg==}
+  '@asgardeo/browser@0.7.10':
+    resolution: {integrity: sha512-5KSO6xqFCl4YMNvIwQik+fxWrsoofQgvhKLipEkzYHk3o8tpOcFldi26lszARwFBhvRW+qUF6UfY323CsrEBmw==}
 
   '@asgardeo/i18n@0.4.5':
     resolution: {integrity: sha512-p1DVVI7lNu7KeDqhRNgAuSrHvVgCbbVXc04koyiiwjDx+sJaXychuC9pwVJ2PDUnIyEp3Xgdb3KqMq+Sx4e7xA==}
@@ -193,8 +193,8 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@asgardeo/react@0.25.5':
-    resolution: {integrity: sha512-ng8G9f55mSFciG1+L9n93q3wJWFx/kB+6Gge2lNZ+Hjnmw82AJVa15mbKFvH4FS9qm3G0cI7FSYhEW67PYkugw==}
+  '@asgardeo/react@0.25.6':
+    resolution: {integrity: sha512-tjnqwRQXfAVOmUmC1Q5TJt4wPcUtiHG/ksR3VtSWgsOKR8E7Spbn/jGtXR8Mn4Kz0jfSGObdneW8Q11TVYY2qQ==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -3226,7 +3226,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@asgardeo/browser@0.7.9':
+  '@asgardeo/browser@0.7.10':
     dependencies:
       '@asgardeo/javascript': 0.23.0
       base64url: 3.0.1
@@ -3250,16 +3250,16 @@ snapshots:
       jose: 5.10.0
       tslib: 2.8.1
 
-  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.25.5(@types/react@19.2.5)(react@19.2.0))(react-router@7.1.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.25.6(@types/react@19.2.5)(react@19.2.0))(react-router@7.1.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@asgardeo/react': 0.25.5(@types/react@19.2.5)(react@19.2.0)
+      '@asgardeo/react': 0.25.6(@types/react@19.2.5)(react@19.2.0)
       react: 19.2.0
       react-router: 7.1.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.25.5(@types/react@19.2.5)(react@19.2.0)':
+  '@asgardeo/react@0.25.6(@types/react@19.2.5)(react@19.2.0)':
     dependencies:
-      '@asgardeo/browser': 0.7.9
+      '@asgardeo/browser': 0.7.10
       '@asgardeo/i18n': 0.4.5
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.4(react@19.2.0))(react@19.2.0)

--- a/apps/customer-portal/webapp/pnpm-workspace.yaml
+++ b/apps/customer-portal/webapp/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 allowBuilds:
   core-js: true
   esbuild: true
+minimumReleaseAgeExclude:
+  - '@asgardeo/browser@0.7.10'
+  - '@asgardeo/react@0.25.6'

--- a/apps/customer-portal/webapp/src/features/project-details/types/usage.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/usage.ts
@@ -202,6 +202,14 @@ export type UsageAggregatedMetricDefinition = {
   secondaryName?: string;
 };
 
+// Curr/Avg/Min/Max summary for a metric over a time range.
+export type CurrMinMaxAvg = {
+  curr: number;
+  avg: number;
+  min: number;
+  max: number;
+};
+
 // Data source values for filtering usage stats.
 export enum DataSource {
   API_CALL = 1,
@@ -251,7 +259,7 @@ export type UsageProductInstanceRow = {
   javaVersion: string;
   u2Level: string;
   transactionsLabel: string;
-  coreCount: number;
+  coreSummary: CurrMinMaxAvg;
   charts: UsageInstanceCharts;
 };
 
@@ -274,4 +282,6 @@ export type UsageEnvironmentProduct = {
   transactionTrend: UsageTrendRow[];
   coreUsageTrend: UsageTrendRow[];
   instances: UsageProductInstanceRow[];
+  instanceSummary: CurrMinMaxAvg;
+  coreSummary: CurrMinMaxAvg;
 };

--- a/apps/customer-portal/webapp/src/features/project-details/utils/usageMetrics.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/utils/usageMetrics.ts
@@ -15,6 +15,7 @@
 // under the License.
 
 import type {
+  CurrMinMaxAvg,
   InstanceMetricEntry,
   InstanceUsageEntry,
   UsageTrendRow,
@@ -201,6 +202,128 @@ export function computeUsageHeadlineDeltaSigned(trend: UsageTrendRow[]): {
     headline: formatUsageMetricCount(last),
     delta: `${sign}${pct.toFixed(1)}%`,
     deltaPositive: pct >= 0,
+  };
+}
+
+/**
+ * Computes curr/avg/min/max from a sorted values array.
+ * curr = last value, min/max/avg from all values (ignoring leading zeros only when all are zero).
+ *
+ * @param values - Time-ordered values (oldest → newest).
+ * @returns Summary stats.
+ */
+export function computeSeriesSummary(values: number[]): CurrMinMaxAvg {
+  if (values.length === 0) return { curr: 0, avg: 0, min: 0, max: 0 };
+  const curr = values[values.length - 1];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const avg = Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+  return { curr, min, max, avg };
+}
+
+/**
+ * Derives per-date counts for instances, products, and environments from metrics.
+ * Returns curr/avg/min/max for each dimension over the selected date range.
+ *
+ * @param metrics - Project-wide instance metric entries.
+ * @returns Summary stats for instances, products, and environments.
+ */
+export function computeOverviewSummaries(metrics: InstanceMetricEntry[]): {
+  instanceSummary: CurrMinMaxAvg;
+  productSummary: CurrMinMaxAvg;
+  environmentSummary: CurrMinMaxAvg;
+} {
+  const dayInstances = new Map<string, Set<string>>();
+  const dayProducts = new Map<string, Set<string>>();
+  const dayEnvironments = new Map<string, Set<string>>();
+
+  for (const m of metrics) {
+    for (const dp of m.dataPoints) {
+      if (!dp.date) continue;
+
+      const instSet = dayInstances.get(dp.date) ?? new Set<string>();
+      instSet.add(m.instanceId);
+      dayInstances.set(dp.date, instSet);
+
+      const prodId = m.deployedProduct?.id ?? m.product?.id;
+      if (prodId) {
+        const prodSet = dayProducts.get(dp.date) ?? new Set<string>();
+        prodSet.add(prodId);
+        dayProducts.set(dp.date, prodSet);
+      }
+
+      const envId = m.deployment?.id;
+      if (envId) {
+        const envSet = dayEnvironments.get(dp.date) ?? new Set<string>();
+        envSet.add(envId);
+        dayEnvironments.set(dp.date, envSet);
+      }
+    }
+  }
+
+  const sortedDates = Array.from(
+    new Set([
+      ...dayInstances.keys(),
+      ...dayProducts.keys(),
+      ...dayEnvironments.keys(),
+    ]),
+  ).sort();
+
+  return {
+    instanceSummary: computeSeriesSummary(
+      sortedDates.map((d) => dayInstances.get(d)?.size ?? 0),
+    ),
+    productSummary: computeSeriesSummary(
+      sortedDates.map((d) => dayProducts.get(d)?.size ?? 0),
+    ),
+    environmentSummary: computeSeriesSummary(
+      sortedDates.map((d) => dayEnvironments.get(d)?.size ?? 0),
+    ),
+  };
+}
+
+/**
+ * Derives instance-count and core-count curr/avg/min/max from metric data points.
+ * Instance count per date = number of distinct instances that have a data point on that date.
+ * Core count per date = sum of coreCount across all data points on that date.
+ *
+ * @param metrics - Instance metric entries for a product or project scope.
+ * @returns Instance and core summaries.
+ */
+export function computeInstanceAndCoreSummary(metrics: InstanceMetricEntry[]): {
+  instanceSummary: CurrMinMaxAvg;
+  coreSummary: CurrMinMaxAvg;
+} {
+  const dayInstances = new Map<string, Set<string>>();
+  const dayCores = new Map<string, number>();
+
+  for (const m of metrics) {
+    for (const dp of m.dataPoints) {
+      if (!dp.date) continue;
+      const instSet = dayInstances.get(dp.date) ?? new Set<string>();
+      instSet.add(m.instanceId);
+      dayInstances.set(dp.date, instSet);
+
+      const cores =
+        dp.coreCount != null
+          ? dp.coreCount
+          : dp.deploymentMetadata?.numberOfCores != null
+            ? Number(dp.deploymentMetadata.numberOfCores)
+            : 0;
+      dayCores.set(dp.date, (dayCores.get(dp.date) ?? 0) + cores);
+    }
+  }
+
+  const sortedDates = Array.from(
+    new Set([...dayInstances.keys(), ...dayCores.keys()]),
+  ).sort();
+
+  const instanceValues = sortedDates.map((d) => dayInstances.get(d)?.size ?? 0);
+  const coreValues = sortedDates.map((d) => dayCores.get(d) ?? 0);
+
+  return {
+    instanceSummary: computeSeriesSummary(instanceValues),
+    coreSummary: computeSeriesSummary(coreValues),
   };
 }
 

--- a/apps/customer-portal/webapp/src/features/project-details/utils/usageMetrics.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/utils/usageMetrics.ts
@@ -222,64 +222,68 @@ export function computeSeriesSummary(values: number[]): CurrMinMaxAvg {
 }
 
 /**
- * Derives per-date counts for instances, products, and environments from metrics.
- * Returns curr/avg/min/max for each dimension over the selected date range.
+ * Derives per-period counts for instances, products, and environments.
+ * - Instances: derived from metric dataPoints (per date, count distinct instanceIds).
+ * - Products / Environments: derived from usage periodSummaries (per period, count distinct IDs).
+ *   Usages reliably carry deployment.id and deployedProduct.id; metrics often have them null.
  *
  * @param metrics - Project-wide instance metric entries.
+ * @param usages - Project-wide instance usage entries.
  * @returns Summary stats for instances, products, and environments.
  */
-export function computeOverviewSummaries(metrics: InstanceMetricEntry[]): {
+export function computeOverviewSummaries(
+  metrics: InstanceMetricEntry[],
+  usages: InstanceUsageEntry[],
+): {
   instanceSummary: CurrMinMaxAvg;
   productSummary: CurrMinMaxAvg;
   environmentSummary: CurrMinMaxAvg;
 } {
+  // Instances — from metric dataPoints (daily granularity)
   const dayInstances = new Map<string, Set<string>>();
-  const dayProducts = new Map<string, Set<string>>();
-  const dayEnvironments = new Map<string, Set<string>>();
-
   for (const m of metrics) {
     for (const dp of m.dataPoints) {
       if (!dp.date) continue;
+      const s = dayInstances.get(dp.date) ?? new Set<string>();
+      s.add(m.instanceId);
+      dayInstances.set(dp.date, s);
+    }
+  }
+  const sortedDays = Array.from(dayInstances.keys()).sort();
+  const instanceSummary = computeSeriesSummary(
+    sortedDays.map((d) => dayInstances.get(d)?.size ?? 0),
+  );
 
-      const instSet = dayInstances.get(dp.date) ?? new Set<string>();
-      instSet.add(m.instanceId);
-      dayInstances.set(dp.date, instSet);
-
-      const prodId = m.deployedProduct?.id ?? m.product?.id;
+  // Products / Environments — from usage periodSummaries (period granularity)
+  const periodProducts = new Map<string, Set<string>>();
+  const periodEnvironments = new Map<string, Set<string>>();
+  for (const u of usages) {
+    const prodId = u.deployedProduct?.id ?? u.product?.id;
+    const envId = u.deployment?.id;
+    for (const ps of u.periodSummaries) {
       if (prodId) {
-        const prodSet = dayProducts.get(dp.date) ?? new Set<string>();
-        prodSet.add(prodId);
-        dayProducts.set(dp.date, prodSet);
+        const s = periodProducts.get(ps.period) ?? new Set<string>();
+        s.add(prodId);
+        periodProducts.set(ps.period, s);
       }
-
-      const envId = m.deployment?.id;
       if (envId) {
-        const envSet = dayEnvironments.get(dp.date) ?? new Set<string>();
-        envSet.add(envId);
-        dayEnvironments.set(dp.date, envSet);
+        const s = periodEnvironments.get(ps.period) ?? new Set<string>();
+        s.add(envId);
+        periodEnvironments.set(ps.period, s);
       }
     }
   }
-
-  const sortedDates = Array.from(
-    new Set([
-      ...dayInstances.keys(),
-      ...dayProducts.keys(),
-      ...dayEnvironments.keys(),
-    ]),
+  const sortedPeriods = Array.from(
+    new Set([...periodProducts.keys(), ...periodEnvironments.keys()]),
   ).sort();
+  const productSummary = computeSeriesSummary(
+    sortedPeriods.map((p) => periodProducts.get(p)?.size ?? 0),
+  );
+  const environmentSummary = computeSeriesSummary(
+    sortedPeriods.map((p) => periodEnvironments.get(p)?.size ?? 0),
+  );
 
-  return {
-    instanceSummary: computeSeriesSummary(
-      sortedDates.map((d) => dayInstances.get(d)?.size ?? 0),
-    ),
-    productSummary: computeSeriesSummary(
-      sortedDates.map((d) => dayProducts.get(d)?.size ?? 0),
-    ),
-    environmentSummary: computeSeriesSummary(
-      sortedDates.map((d) => dayEnvironments.get(d)?.size ?? 0),
-    ),
-  };
+  return { instanceSummary, productSummary, environmentSummary };
 }
 
 /**

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -50,16 +50,21 @@ import {
   USAGE_METRICS_INSTANCE_U2,
   USAGE_METRICS_NO_INSTANCE_DATA,
   USAGE_METRICS_NO_PRODUCTS_IN_DEPLOYMENT,
-  USAGE_METRICS_PRODUCT_CORE_METRIC_INSTANCES,
-  USAGE_METRICS_PRODUCT_CORE_METRIC_TOTAL_CORES,
   USAGE_METRICS_PRODUCT_PANEL_TOTAL_TRANSACTIONS,
   USAGE_METRICS_PRODUCT_TREND_CORE_SECTION,
   USAGE_METRICS_PRODUCT_TREND_TX_SECTION,
   USAGE_METRICS_PRODUCT_INSTANCES_SECTION,
+  USAGE_METRICS_PRODUCT_INSTANCE_METRICS,
+  USAGE_METRICS_PRODUCT_CORE_METRICS,
+  USAGE_METRICS_STAT_LABEL_CURR,
+  USAGE_METRICS_STAT_LABEL_AVG,
+  USAGE_METRICS_STAT_LABEL_MIN,
+  USAGE_METRICS_STAT_LABEL_MAX,
 } from "@features/usage-metrics/constants/usageMetricsConstants";
 import { UsageChartSurface } from "@features/usage-metrics/components/UsageChartSurface";
 import usePostDeploymentInstancesUsagesSearch from "@features/project-details/api/usePostDeploymentInstancesUsagesSearch";
 import usePostDeploymentInstancesMetricsSearch from "@features/project-details/api/usePostDeploymentInstancesMetricsSearch";
+import type { CurrMinMaxAvg } from "@features/project-details/types/usage";
 import type {
   InstanceAccordionRowProps,
   InstanceMiniTrendCardProps,
@@ -349,7 +354,7 @@ function InstanceAccordionRow({
             <MetricPill
               icon={<Cpu size={16} color={colors.grey?.[400]} />}
               label={USAGE_METRICS_INSTANCE_CORE_COUNT}
-              value={String(instance.coreCount)}
+              value={`${instance.coreSummary.curr} / ${instance.coreSummary.avg} / ${instance.coreSummary.min} / ${instance.coreSummary.max}`}
             />
           </Box>
         </Box>
@@ -375,6 +380,52 @@ function InstanceAccordionRow({
         </Grid>
       </AccordionDetails>
     </Accordion>
+  );
+}
+
+// ─── Curr/Avg/Min/Max metric block ────────────────────────────────────────────
+
+function CurrMinMaxBlock({
+  label,
+  summary,
+}: {
+  label: string;
+  summary: CurrMinMaxAvg;
+}): JSX.Element {
+  const cols = [
+    { l: USAGE_METRICS_STAT_LABEL_CURR, v: summary.curr, highlight: true },
+    { l: USAGE_METRICS_STAT_LABEL_AVG, v: summary.avg, highlight: false },
+    { l: USAGE_METRICS_STAT_LABEL_MIN, v: summary.min, highlight: false },
+    { l: USAGE_METRICS_STAT_LABEL_MAX, v: summary.max, highlight: false },
+  ];
+
+  return (
+    <Box>
+      <Typography
+        variant="body2"
+        sx={{ fontWeight: 700, display: "block", mb: 1 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ display: "flex", gap: 2 }}>
+        {cols.map(({ l, v, highlight }) => (
+          <Box key={l} sx={{ textAlign: "left" }}>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.25 }}>
+              {l}
+            </Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                fontWeight: 700,
+                color: highlight ? "primary.main" : "text.primary",
+              }}
+            >
+              {v}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
   );
 }
 
@@ -425,7 +476,7 @@ function ProductAccordionRow({
           sx={{
             display: "flex",
             flexDirection: { xs: "column", lg: "row" },
-            alignItems: { xs: "stretch", lg: "flex-start" },
+            alignItems: { xs: "stretch", lg: "center" },
             gap: 2,
             width: "100%",
             minWidth: 0,
@@ -437,7 +488,8 @@ function ProductAccordionRow({
               display: "flex",
               alignItems: "center",
               gap: 2,
-              minWidth: { lg: 250 },
+              minWidth: { lg: 240 },
+              maxWidth: { lg: 280 },
             }}
           >
             <Box
@@ -448,10 +500,10 @@ function ProductAccordionRow({
                 flexShrink: 0,
               }}
             >
-              <Package size={24} color={a.iconColor} />
+              <Package size={20} color={a.iconColor} />
             </Box>
-            <Box sx={{ textAlign: "left" }}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+            <Box sx={{ textAlign: "left", minWidth: 0 }}>
+              <Typography variant="body2" sx={{ fontWeight: 700 }} noWrap>
                 {product.name}
               </Typography>
             </Box>
@@ -461,46 +513,36 @@ function ProductAccordionRow({
             sx={{
               flex: 1,
               minWidth: 0,
-              display: "grid",
-              gridTemplateColumns: { xs: "1fr", sm: "repeat(4, 1fr)" },
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "flex-start",
               gap: 2,
-              alignItems: "start",
             }}
           >
-            <Box sx={{ textAlign: "center" }}>
-              <Typography variant="caption" color="text.secondary">
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
                 {USAGE_METRICS_PRODUCT_PANEL_TOTAL_TRANSACTIONS}
               </Typography>
-              <Typography variant="h6" sx={{ fontWeight: 600 }}>
+              <Typography variant="body1" sx={{ fontWeight: 700 }}>
                 {product.transactionsLabel}
               </Typography>
             </Box>
-            <Box sx={{ textAlign: "center" }}>
-              <Typography variant="caption" color="text.secondary">
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
                 {product.thirdMetricLabel}
               </Typography>
-              <Typography variant="h6" sx={{ fontWeight: 600 }}>
+              <Typography variant="body1" sx={{ fontWeight: 700 }}>
                 {product.thirdMetricValue}
               </Typography>
             </Box>
-            <Box sx={{ textAlign: "center" }}>
-              <Typography variant="caption" color="text.secondary">
-                {product.coreMetrics[0]?.label ||
-                  USAGE_METRICS_PRODUCT_CORE_METRIC_TOTAL_CORES}
-              </Typography>
-              <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                {product.coreMetrics[0]?.value}
-              </Typography>
-            </Box>
-            <Box sx={{ textAlign: "center" }}>
-              <Typography variant="caption" color="text.secondary">
-                {product.coreMetrics[1]?.label ||
-                  USAGE_METRICS_PRODUCT_CORE_METRIC_INSTANCES}
-              </Typography>
-              <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                {product.coreMetrics[1]?.value}
-              </Typography>
-            </Box>
+            <CurrMinMaxBlock
+              label={USAGE_METRICS_PRODUCT_INSTANCE_METRICS}
+              summary={product.instanceSummary}
+            />
+            <CurrMinMaxBlock
+              label={USAGE_METRICS_PRODUCT_CORE_METRICS}
+              summary={product.coreSummary}
+            />
           </Box>
         </Box>
       </AccordionSummary>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -354,7 +354,7 @@ function InstanceAccordionRow({
             <MetricPill
               icon={<Cpu size={16} color={colors.grey?.[400]} />}
               label={USAGE_METRICS_INSTANCE_CORE_COUNT}
-              value={`${instance.coreSummary.curr} / ${instance.coreSummary.avg} / ${instance.coreSummary.min} / ${instance.coreSummary.max}`}
+              value={`Curr ${instance.coreSummary.curr} / Avg ${instance.coreSummary.avg} / Min ${instance.coreSummary.min} / Max ${instance.coreSummary.max}`}
             />
           </Box>
         </Box>
@@ -514,7 +514,8 @@ function ProductAccordionRow({
               flex: 1,
               minWidth: 0,
               display: "flex",
-              justifyContent: "space-between",
+              flexWrap: "wrap",
+              justifyContent: { xs: "flex-start", sm: "space-between" },
               alignItems: "flex-start",
               gap: 2,
             }}

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -361,46 +361,44 @@ function EnvironmentBreakdownAccordion({
 }: EnvironmentBreakdownAccordionProps): JSX.Element {
   const a = getUsageOverviewAccentForTypeId(row.kind);
 
-  // Instances fetched eagerly — needed for collapsed row header counts (product/instance).
-  const { data: depInstancesData } = usePostDeploymentInstancesSearch(row.deploymentId);
-
   const metricsPayload = useMemo(
     () => ({ filters: { startDate: dateRange.startDate, endDate: dateRange.endDate } }),
     [dateRange],
   );
 
-  // Usages only fetched when expanded — avoids N concurrent calls on mount.
+  // Both hooks gated on expanded — avoids N concurrent calls on mount and prevents
+  // API gateway throttling when many accordion rows are rendered simultaneously.
+  const { data: depInstancesData } = usePostDeploymentInstancesSearch(
+    expanded ? row.deploymentId : undefined,
+  );
   const { data: depUsagesData } = usePostDeploymentInstancesUsagesSearch(
     expanded ? row.deploymentId : undefined,
     metricsPayload,
   );
 
   const { productCount, instanceCount, totalCores, transactionsLabel } = useMemo(() => {
-    const instances = depInstancesData?.instances ?? [];
+    if (!expanded || !depInstancesData) {
+      return {
+        productCount: row.productCount,
+        instanceCount: row.instanceCount,
+        totalCores: row.totalCores,
+        transactionsLabel: row.transactionsLabel,
+      };
+    }
+    const instances = depInstancesData.instances ?? [];
     const usages = depUsagesData?.usages ?? [];
     const productIds = new Set([
       ...instances.map((i) => i.deployedProduct?.id ?? i.product?.id).filter(Boolean),
       ...usages.map((u) => u.deployedProduct?.id ?? u.product?.id).filter(Boolean),
     ]);
-    const totalTx = usages.reduce(
-      (sum, u) => sum + sumUsageEntryTransactions(u),
-      0,
-    );
+    const totalTx = usages.reduce((sum, u) => sum + sumUsageEntryTransactions(u), 0);
     return {
-      // productCount needs both instances+usages to be accurate; fall back to
-      // row.productCount until usages have been fetched at least once (React
-      // Query keeps cached usages data even when the query is disabled, so after
-      // the first expansion the count stays stable on collapse).
-      productCount: depInstancesData && depUsagesData ? productIds.size : row.productCount,
-      instanceCount: depInstancesData ? instances.length : row.instanceCount,
-      totalCores: depInstancesData
-        ? instances.reduce((sum, i) => sum + (i.metadata?.coreCount ?? 0), 0)
-        : row.totalCores,
-      transactionsLabel: depUsagesData
-        ? formatUsageMetricCount(totalTx)
-        : row.transactionsLabel,
+      productCount: productIds.size,
+      instanceCount: instances.length,
+      totalCores: instances.reduce((sum, i) => sum + (i.metadata?.coreCount ?? 0), 0),
+      transactionsLabel: formatUsageMetricCount(totalTx),
     };
-  }, [depInstancesData, depUsagesData, row]);
+  }, [expanded, depInstancesData, depUsagesData, row]);
 
   return (
     <Accordion

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -21,9 +21,9 @@ import {
   Alert,
   Box,
   Card,
+  Divider,
   Grid,
   Skeleton,
-  StatCard,
   Typography,
   useTheme,
   useMediaQuery,
@@ -51,7 +51,6 @@ import usePostProjectInstancesUsagesSearch from "@features/project-details/api/u
 import usePostProjectInstancesMetricsSearch from "@features/project-details/api/usePostProjectInstancesMetricsSearch";
 import usePostDeploymentInstancesSearch from "@features/project-details/api/usePostDeploymentInstancesSearch";
 import usePostDeploymentInstancesUsagesSearch from "@features/project-details/api/usePostDeploymentInstancesUsagesSearch";
-import useGetProjectUsageStats from "@features/project-details/api/useGetProjectUsageStats";
 import type { UsageAggregatedMetricDefinition } from "@features/project-details/types/usage";
 import type {
   InstanceItem,
@@ -83,11 +82,84 @@ import type {
 } from "@features/usage-metrics/types/usageMetrics";
 import { deriveAggregatedMetrics } from "@features/usage-metrics/utils/usageMetricsAggregated";
 import { getUsageOverviewAccentForTypeId } from "@features/usage-metrics/utils/usageMetricsAccent";
-import { formatUsageMetricCount, sumUsageEntryTransactions } from "@features/project-details/utils/usageMetrics";
+import {
+  computeOverviewSummaries,
+  formatUsageMetricCount,
+  sumUsageEntryTransactions,
+} from "@features/project-details/utils/usageMetrics";
+import type { CurrMinMaxAvg } from "@features/project-details/types/usage";
+import {
+  USAGE_METRICS_STAT_LABEL_AVG,
+  USAGE_METRICS_STAT_LABEL_MIN,
+  USAGE_METRICS_STAT_LABEL_MAX,
+} from "@features/usage-metrics/constants/usageMetricsConstants";
 
 function EnvironmentIcon({ typeId }: { typeId: string }): JSX.Element {
   const color = getUsageOverviewAccentForTypeId(typeId).iconColor;
   return <Server size={20} color={color} />;
+}
+
+// ─── Flat overview summary card (replaces plain StatCard) ────────────────────
+
+function OverviewSummaryCard({
+  label,
+  icon,
+  iconColor,
+  summary,
+  isLoading,
+}: {
+  label: string;
+  icon: JSX.Element;
+  iconColor: string;
+  summary: CurrMinMaxAvg;
+  isLoading: boolean;
+}): JSX.Element {
+  if (isLoading) {
+    return (
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Skeleton variant="text" width={100} height={20} sx={{ mb: 1 }} />
+        <Skeleton variant="text" width={60} height={36} sx={{ mb: 1.5 }} />
+        <Skeleton variant="rounded" height={28} />
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+        <Box sx={{ color: iconColor, display: "flex" }}>{icon}</Box>
+        <Typography variant="subtitle2" color="text.secondary">
+          {label}
+        </Typography>
+      </Box>
+      <Typography variant="h5" fontWeight={700} sx={{ mb: 1.5 }}>
+        {summary.curr}
+      </Typography>
+      <Divider sx={{ mb: 1.5 }} />
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: 1,
+        }}
+      >
+        {[
+          { label: USAGE_METRICS_STAT_LABEL_MIN, value: summary.min },
+          { label: USAGE_METRICS_STAT_LABEL_MAX, value: summary.max },
+          { label: USAGE_METRICS_STAT_LABEL_AVG, value: summary.avg },
+        ].map(({ label: l, value: v }) => (
+          <Box key={l} sx={{ textAlign: "center" }}>
+            <Typography variant="caption" color="text.secondary" display="block">
+              {l}
+            </Typography>
+            <Typography variant="body2" fontWeight={600}>
+              {v}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Card>
+  );
 }
 
 // ─── Per-deployment expanded product cards (sourced from deployment-scoped APIs) ───
@@ -235,7 +307,7 @@ function DeploymentExpandedView({
     }
 
     return Array.from(productMap.entries()).map(([id, p]) => ({ id, ...p }));
-  }, [instancesData, usagesData, deploymentId]);
+  }, [instancesData, usagesData]);
 
   if (isError) {
     return (
@@ -424,7 +496,8 @@ function deriveMetricSummaries(
     const values = sortedDates.map((d) => stats[d][key] ?? 0);
     const nonZero = values.filter((v) => v > 0);
     if (nonZero.length === 0) continue;
-    const curr = values[values.length - 1] ?? 0;
+    const lastNonZero = [...values].reverse().find((v) => v > 0) ?? 0;
+    const curr = lastNonZero;
     const min = Math.min(...nonZero);
     const max = Math.max(...nonZero);
     const avg = nonZero.reduce((a, b) => a + b, 0) / nonZero.length;
@@ -488,27 +561,18 @@ export default function UsageOverviewPanel({
     isError: metricsError,
   } = usePostProjectInstancesMetricsSearch(projectId, metricsPayload);
 
-  // Project-wide stats — for the 3 top stat cards
-  const {
-    data: statsData,
-    isLoading: statsLoading,
-    isError: statsError,
-  } = useGetProjectUsageStats(projectId);
-
   const isLoading =
     deploymentsLoading ||
     instancesLoading ||
     usagesLoading ||
-    metricsLoading ||
-    statsLoading;
+    metricsLoading;
   const isError =
     deploymentsError ||
     instancesError ||
     usagesError ||
-    metricsError ||
-    statsError;
+    metricsError;
 
-  const isStatCardsLoading = statsLoading;
+  const isStatCardsLoading = metricsLoading;
 
   // ── Data source stats ──────────────────────────────────────────────────────
   const dataSourceStatsPayload = useMemo(
@@ -535,14 +599,19 @@ export default function UsageOverviewPanel({
     return deriveMetricSummaries(dataSourceStatsData.stats);
   }, [dataSourceStatsData]);
 
-  // ── Overview summary stats ─────────────────────────────────────────────────
-  const overviewStats = useMemo(() => {
-    return {
-      environments: statsData?.deploymentCount ?? 0,
-      products: statsData?.deployedProductCount ?? 0,
-      instances: statsData?.instanceCount ?? 0,
-    };
-  }, [statsData]);
+  // ── Overview summary stats (derived from metrics time-series) ─────────────
+  const overviewSummaries = useMemo(() => {
+    const metrics = metricsData?.metrics ?? [];
+    if (metrics.length === 0) {
+      const fallback: CurrMinMaxAvg = { curr: 0, avg: 0, min: 0, max: 0 };
+      return {
+        instanceSummary: fallback,
+        productSummary: fallback,
+        environmentSummary: fallback,
+      };
+    }
+    return computeOverviewSummaries(metrics);
+  }, [metricsData]);
 
   // ── Environment breakdown rows ─────────────────────────────────────────────
   const environmentBreakdown = useMemo((): EnvironmentBreakdownRow[] => {
@@ -618,45 +687,30 @@ export default function UsageOverviewPanel({
         sx={{ width: "100%", minWidth: 0, overflowX: "hidden" }}
       >
         <Grid size={{ xs: 12, sm: 6, lg: 4 }} sx={{ minWidth: 0 }}>
-          <StatCard
+          <OverviewSummaryCard
             label={USAGE_METRICS_STAT_ENVIRONMENTS}
-            value={
-              isStatCardsLoading
-                ? ((
-                    <Skeleton variant="rounded" width={60} height={24} />
-                  ) as unknown as number)
-                : overviewStats.environments
-            }
-            icon={<Layers />}
-            iconColor="info"
+            icon={<Layers size={18} />}
+            iconColor="var(--oxygen-palette-info-main, #0288d1)"
+            summary={overviewSummaries.environmentSummary}
+            isLoading={isStatCardsLoading}
           />
         </Grid>
         <Grid size={{ xs: 12, sm: 6, lg: 4 }} sx={{ minWidth: 0 }}>
-          <StatCard
+          <OverviewSummaryCard
             label={USAGE_METRICS_STAT_PRODUCTS}
-            value={
-              isStatCardsLoading
-                ? ((
-                    <Skeleton variant="rounded" width={60} height={24} />
-                  ) as unknown as number)
-                : overviewStats.products
-            }
-            icon={<Package />}
-            iconColor="primary"
+            icon={<Package size={18} />}
+            iconColor="var(--oxygen-palette-primary-main, #8457ad)"
+            summary={overviewSummaries.productSummary}
+            isLoading={isStatCardsLoading}
           />
         </Grid>
         <Grid size={{ xs: 12, sm: 6, lg: 4 }} sx={{ minWidth: 0 }}>
-          <StatCard
+          <OverviewSummaryCard
             label={USAGE_METRICS_STAT_INSTANCES}
-            value={
-              isStatCardsLoading
-                ? ((
-                    <Skeleton variant="rounded" width={60} height={24} />
-                  ) as unknown as number)
-                : overviewStats.instances
-            }
-            icon={<ServerIcon />}
-            iconColor="success"
+            icon={<ServerIcon size={18} />}
+            iconColor="var(--oxygen-palette-success-main, #2e7d32)"
+            summary={overviewSummaries.instanceSummary}
+            isLoading={isStatCardsLoading}
           />
         </Grid>
       </Grid>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -234,6 +234,7 @@ function DeploymentExpandedView({
   deploymentId,
   typeId,
   dateRange,
+  expanded,
 }: DeploymentExpandedViewProps): JSX.Element {
   const a = getUsageOverviewAccentForTypeId(typeId);
 
@@ -251,12 +252,15 @@ function DeploymentExpandedView({
     isError: instancesError,
   } = usePostDeploymentInstancesSearch(deploymentId);
 
-  // Fetch usages for this deployment — gives us transactions per deployedProduct
+  // Fetch usages only when expanded — avoids firing for every collapsed row.
   const {
     data: usagesData,
     isLoading: usagesLoading,
     isError: usagesError,
-  } = usePostDeploymentInstancesUsagesSearch(deploymentId, metricsPayload);
+  } = usePostDeploymentInstancesUsagesSearch(
+    expanded ? deploymentId : undefined,
+    metricsPayload,
+  );
 
   const isLoading = instancesLoading || usagesLoading;
   const isError = instancesError || usagesError;
@@ -505,6 +509,7 @@ function EnvironmentBreakdownAccordion({
           deploymentId={row.deploymentId}
           typeId={row.kind}
           dateRange={dateRange}
+          expanded={expanded}
         />
       </AccordionDetails>
     </Accordion>
@@ -541,8 +546,7 @@ function deriveMetricSummaries(
     const values = sortedDates.map((d) => stats[d][key] ?? 0);
     const nonZero = values.filter((v) => v > 0);
     if (nonZero.length === 0) continue;
-    const lastNonZero = [...values].reverse().find((v) => v > 0) ?? 0;
-    const curr = lastNonZero;
+    const curr = values[values.length - 1] ?? 0;
     const min = Math.min(...nonZero);
     const max = Math.max(...nonZero);
     const avg = nonZero.reduce((a, b) => a + b, 0) / nonZero.length;
@@ -626,7 +630,7 @@ export default function UsageOverviewPanel({
     metricsError ||
     statsError;
 
-  const isStatCardsLoading = metricsLoading || statsLoading;
+  const isStatCardsLoading = metricsLoading || statsLoading || usagesLoading;
 
   // ── Data source stats ──────────────────────────────────────────────────────
   const dataSourceStatsPayload = useMemo(

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -41,6 +41,7 @@ import usePostProjectInstancesUsagesStats from "@features/project-details/api/us
 import DataSourceStatCard from "@features/usage-metrics/components/DataSourceStatCard";
 import type { MetricTypeSummary } from "@features/project-details/types/usage";
 import {
+  DATA_SOURCE_STAT_KEYS,
   METRIC_TYPE_LABELS,
   USAGE_METRICS_DATA_SOURCE_STATS_SECTION,
   USAGE_METRICS_NO_DATA_SOURCE_STATS,
@@ -51,6 +52,7 @@ import usePostProjectInstancesUsagesSearch from "@features/project-details/api/u
 import usePostProjectInstancesMetricsSearch from "@features/project-details/api/usePostProjectInstancesMetricsSearch";
 import usePostDeploymentInstancesSearch from "@features/project-details/api/usePostDeploymentInstancesSearch";
 import usePostDeploymentInstancesUsagesSearch from "@features/project-details/api/usePostDeploymentInstancesUsagesSearch";
+import useGetProjectUsageStats from "@features/project-details/api/useGetProjectUsageStats";
 import type { UsageAggregatedMetricDefinition } from "@features/project-details/types/usage";
 import type {
   InstanceItem,
@@ -276,8 +278,8 @@ function DeploymentExpandedView({
     >();
 
     for (const inst of instances) {
-      const pid = inst.deployedProduct?.id;
-      const label = inst.deployedProduct?.label ?? USAGE_METRICS_UNKNOWN_LABEL;
+      const pid = inst.deployedProduct?.id ?? inst.product?.id;
+      const label = inst.deployedProduct?.label ?? inst.product?.label ?? USAGE_METRICS_UNKNOWN_LABEL;
       if (!pid) continue;
       const existing = productMap.get(pid) ?? {
         label,
@@ -292,10 +294,10 @@ function DeploymentExpandedView({
 
     // Accumulate transactions from deployment-scoped usages per deployedProduct
     for (const usage of usages) {
-      const pid = usage.deployedProduct?.id;
+      const pid = usage.deployedProduct?.id ?? usage.product?.id;
       if (!pid) continue;
       // Ensure entry exists if it came only from usages (edge case)
-      const label = usage.deployedProduct?.label ?? USAGE_METRICS_UNKNOWN_LABEL;
+      const label = usage.deployedProduct?.label ?? usage.product?.label ?? USAGE_METRICS_UNKNOWN_LABEL;
       const existing = productMap.get(pid) ?? {
         label,
         instanceCount: 0,
@@ -354,6 +356,43 @@ function EnvironmentBreakdownAccordion({
   dateRange,
 }: EnvironmentBreakdownAccordionProps): JSX.Element {
   const a = getUsageOverviewAccentForTypeId(row.kind);
+
+  // Instances fetched eagerly — needed for collapsed row header counts (product/instance).
+  const { data: depInstancesData } = usePostDeploymentInstancesSearch(row.deploymentId);
+
+  const metricsPayload = useMemo(
+    () => ({ filters: { startDate: dateRange.startDate, endDate: dateRange.endDate } }),
+    [dateRange],
+  );
+
+  // Usages only fetched when expanded — avoids N concurrent calls on mount.
+  const { data: depUsagesData } = usePostDeploymentInstancesUsagesSearch(
+    expanded ? row.deploymentId : undefined,
+    metricsPayload,
+  );
+
+  const { productCount, instanceCount, totalCores, transactionsLabel } = useMemo(() => {
+    const instances = depInstancesData?.instances ?? [];
+    const usages = depUsagesData?.usages ?? [];
+    const productIds = new Set([
+      ...instances.map((i) => i.deployedProduct?.id ?? i.product?.id).filter(Boolean),
+      ...usages.map((u) => u.deployedProduct?.id ?? u.product?.id).filter(Boolean),
+    ]);
+    const totalTx = usages.reduce(
+      (sum, u) => sum + sumUsageEntryTransactions(u),
+      0,
+    );
+    return {
+      productCount: depInstancesData ? productIds.size : row.productCount,
+      instanceCount: depInstancesData ? instances.length : row.instanceCount,
+      totalCores: depInstancesData
+        ? instances.reduce((sum, i) => sum + (i.metadata?.coreCount ?? 0), 0)
+        : row.totalCores,
+      transactionsLabel: depUsagesData
+        ? formatUsageMetricCount(totalTx)
+        : row.transactionsLabel,
+    };
+  }, [depInstancesData, depUsagesData, row]);
 
   return (
     <Accordion
@@ -414,11 +453,11 @@ function EnvironmentBreakdownAccordion({
                 {row.title}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                {row.productCount} product{row.productCount !== 1 ? "s" : ""}
+                {productCount} product{productCount !== 1 ? "s" : ""}
                 <Box component="span" sx={{ mx: 0.75, opacity: 0.4 }}>
                   |
                 </Box>
-                {row.instanceCount} instance{row.instanceCount !== 1 ? "s" : ""}
+                {instanceCount} instance{instanceCount !== 1 ? "s" : ""}
               </Typography>
             </Box>
           </Box>
@@ -434,7 +473,7 @@ function EnvironmentBreakdownAccordion({
                 {USAGE_METRICS_PRODUCT_CORE_METRIC_TOTAL_CORES}
               </Typography>
               <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {row.totalCores}
+                {totalCores}
               </Typography>
             </Box>
             <Box sx={{ textAlign: "right" }}>
@@ -442,7 +481,7 @@ function EnvironmentBreakdownAccordion({
                 {USAGE_METRICS_ENVIRONMENT_ROW_TRANSACTIONS}
               </Typography>
               <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {row.transactionsLabel}
+                {transactionsLabel}
               </Typography>
             </Box>
           </Box>
@@ -492,7 +531,9 @@ function deriveMetricSummaries(
   const sortedDates = Object.keys(stats).sort();
   const summaries: MetricTypeSummary[] = [];
 
-  for (const key of metricKeys) {
+  const orderedKeys = DATA_SOURCE_STAT_KEYS.filter((k) => metricKeys.has(k));
+
+  for (const key of orderedKeys) {
     const values = sortedDates.map((d) => stats[d][key] ?? 0);
     const nonZero = values.filter((v) => v > 0);
     if (nonZero.length === 0) continue;
@@ -561,18 +602,27 @@ export default function UsageOverviewPanel({
     isError: metricsError,
   } = usePostProjectInstancesMetricsSearch(projectId, metricsPayload);
 
+  // Current totals — for the curr value on the top 3 stat cards
+  const {
+    data: statsData,
+    isLoading: statsLoading,
+    isError: statsError,
+  } = useGetProjectUsageStats(projectId);
+
   const isLoading =
     deploymentsLoading ||
     instancesLoading ||
     usagesLoading ||
-    metricsLoading;
+    metricsLoading ||
+    statsLoading;
   const isError =
     deploymentsError ||
     instancesError ||
     usagesError ||
-    metricsError;
+    metricsError ||
+    statsError;
 
-  const isStatCardsLoading = metricsLoading;
+  const isStatCardsLoading = metricsLoading || statsLoading;
 
   // ── Data source stats ──────────────────────────────────────────────────────
   const dataSourceStatsPayload = useMemo(
@@ -599,19 +649,26 @@ export default function UsageOverviewPanel({
     return deriveMetricSummaries(dataSourceStatsData.stats);
   }, [dataSourceStatsData]);
 
-  // ── Overview summary stats (derived from metrics time-series) ─────────────
+  // ── Overview summary stats — curr from stats API, min/avg/max from time-series
   const overviewSummaries = useMemo(() => {
     const metrics = metricsData?.metrics ?? [];
-    if (metrics.length === 0) {
-      const fallback: CurrMinMaxAvg = { curr: 0, avg: 0, min: 0, max: 0 };
-      return {
-        instanceSummary: fallback,
-        productSummary: fallback,
-        environmentSummary: fallback,
-      };
-    }
-    return computeOverviewSummaries(metrics);
-  }, [metricsData]);
+    const usages = usagesData?.usages ?? [];
+    const base = computeOverviewSummaries(metrics, usages);
+    return {
+      environmentSummary: {
+        ...base.environmentSummary,
+        curr: statsData?.deploymentCount ?? base.environmentSummary.curr,
+      },
+      productSummary: {
+        ...base.productSummary,
+        curr: statsData?.deployedProductCount ?? base.productSummary.curr,
+      },
+      instanceSummary: {
+        ...base.instanceSummary,
+        curr: statsData?.instanceCount ?? base.instanceSummary.curr,
+      },
+    };
+  }, [metricsData, usagesData, statsData]);
 
   // ── Environment breakdown rows ─────────────────────────────────────────────
   const environmentBreakdown = useMemo((): EnvironmentBreakdownRow[] => {
@@ -620,9 +677,13 @@ export default function UsageOverviewPanel({
 
     return deploymentsData.map((dep) => {
       const depInstances = instances.filter((i) => i.deployment?.id === dep.id);
-      const productIds = new Set(
-        depInstances.map((i) => i.deployedProduct?.id).filter(Boolean),
+      const depUsagesForDep = (usagesData?.usages ?? []).filter(
+        (u) => u.deployment?.id === dep.id,
       );
+      const productIds = new Set([
+        ...depInstances.map((i) => i.deployedProduct?.id ?? i.product?.id).filter(Boolean),
+        ...depUsagesForDep.map((u) => u.deployedProduct?.id ?? u.product?.id).filter(Boolean),
+      ]);
       const productCount = productIds.size;
       const instanceCount = depInstances.length;
       const totalCores = depInstances.reduce(
@@ -639,9 +700,7 @@ export default function UsageOverviewPanel({
         instanceCount,
         totalCores,
         transactionsLabel: (() => {
-          const depUsages = (usagesData?.usages ?? []).filter(
-            (u) => u.deployment?.id === dep.id,
-          );
+          const depUsages = depUsagesForDep;
           const total = depUsages.reduce(
             (sum, u) => sum + sumUsageEntryTransactions(u),
             0,

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -383,7 +383,11 @@ function EnvironmentBreakdownAccordion({
       0,
     );
     return {
-      productCount: depInstancesData ? productIds.size : row.productCount,
+      // productCount needs both instances+usages to be accurate; fall back to
+      // row.productCount until usages have been fetched at least once (React
+      // Query keeps cached usages data even when the query is disabled, so after
+      // the first expansion the count stays stable on collapse).
+      productCount: depInstancesData && depUsagesData ? productIds.size : row.productCount,
       instanceCount: depInstancesData ? instances.length : row.instanceCount,
       totalCores: depInstancesData
         ? instances.reduce((sum, i) => sum + (i.metadata?.coreCount ?? 0), 0)

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -95,7 +95,7 @@ export const USAGE_METRICS_INSTANCE_U2 = "U2 Level";
 
 export const USAGE_METRICS_INSTANCE_TOTAL_TX = "Total Transactions";
 
-export const USAGE_METRICS_INSTANCE_CORE_COUNT = "Core Count";
+export const USAGE_METRICS_INSTANCE_CORE_COUNT = "Core Count (Curr/Avg/Min/Max)";
 
 export const USAGE_METRICS_INSTANCE_CHART_TX_TITLE = "Transactions";
 
@@ -177,4 +177,18 @@ export const METRIC_TYPE_LABELS: Record<string, string> = {
   TRANSACTION_COUNT: "Transactions",
   TOTAL_USERS: "Total Users",
   TOTAL_ROOT_ORGS: "Organizations",
+  TOTAL_B2B_ORGS: "Organizations",
+  API_COUNT: "API Count",
 };
+
+export const USAGE_METRICS_PRODUCT_INSTANCE_METRICS = "Instance Metrics";
+
+export const USAGE_METRICS_PRODUCT_CORE_METRICS = "Core Metrics";
+
+export const USAGE_METRICS_STAT_LABEL_CURR = "Curr";
+
+export const USAGE_METRICS_STAT_LABEL_AVG = "Avg";
+
+export const USAGE_METRICS_STAT_LABEL_MIN = "Min";
+
+export const USAGE_METRICS_STAT_LABEL_MAX = "Max";

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -177,9 +177,16 @@ export const METRIC_TYPE_LABELS: Record<string, string> = {
   TRANSACTION_COUNT: "Transactions",
   TOTAL_USERS: "Total Users",
   TOTAL_ROOT_ORGS: "Organizations",
-  TOTAL_B2B_ORGS: "Organizations",
   API_COUNT: "API Count",
 };
+
+// Ordered list of stat keys to display in the data source stats section.
+export const DATA_SOURCE_STAT_KEYS = [
+  "TRANSACTION_COUNT",
+  "TOTAL_USERS",
+  "TOTAL_ROOT_ORGS",
+  "API_COUNT",
+];
 
 export const USAGE_METRICS_PRODUCT_INSTANCE_METRICS = "Instance Metrics";
 

--- a/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
@@ -133,6 +133,7 @@ export type DeploymentExpandedViewProps = {
   deploymentId: string;
   typeId: string;
   dateRange: UsageDateRangeIso;
+  expanded: boolean;
 };
 
 export type EnvironmentBreakdownRow = {

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsAggregated.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsAggregated.ts
@@ -92,7 +92,7 @@ export function deriveAggregatedMetrics(
   );
   const b2bTrend = buildUsageTrendFromUsages(
     usages,
-    "TOTAL_B2B_ORGS",
+    "TOTAL_ROOT_ORGS",
     periodLabel,
   );
   const coreTrend = buildDailyCoreTrendFromMetrics(metrics, dateLabel);

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsAggregated.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsAggregated.ts
@@ -90,7 +90,7 @@ export function deriveAggregatedMetrics(
     "TOTAL_USERS",
     periodLabel,
   );
-  const b2bTrend = buildUsageTrendFromUsages(
+  const rootOrgTrend = buildUsageTrendFromUsages(
     usages,
     "TOTAL_ROOT_ORGS",
     periodLabel,
@@ -100,7 +100,7 @@ export function deriveAggregatedMetrics(
   const txHD = computeUsageHeadlineDelta(txTrend);
   const apiHD = computeUsageHeadlineDelta(apiTrend);
   const userHD = computeUsageHeadlineDelta(userTrend);
-  const b2bHD = computeUsageHeadlineDelta(b2bTrend);
+  const rootOrgHD = computeUsageHeadlineDelta(rootOrgTrend);
   const coreHD = computeUsageHeadlineDelta(coreTrend);
 
   return [
@@ -150,12 +150,12 @@ export function deriveAggregatedMetrics(
       id: UsageAggregatedMetricCardId.TOTAL_ORGANIZATION_COUNT,
       title: USAGE_AGGREGATED_ORG_COUNT_TITLE,
       caption: USAGE_AGGREGATED_ORG_COUNT_CAPTION,
-      headlineValue: b2bHD.headline,
-      deltaLabel: b2bHD.delta,
+      headlineValue: rootOrgHD.headline,
+      deltaLabel: rootOrgHD.delta,
       stroke: resolveAggregatedMetricStroke(
         UsageAggregatedMetricCardId.TOTAL_ORGANIZATION_COUNT,
       ),
-      data: b2bTrend,
+      data: rootOrgTrend,
     },
   ];
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsEnvironmentProducts.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsEnvironmentProducts.ts
@@ -25,6 +25,8 @@ import type {
 import {
   buildCoreAverageTrendFromMetrics,
   buildUsageTrendFromUsages,
+  computeInstanceAndCoreSummary,
+  computeSeriesSummary,
   computeUsageHeadlineDeltaSigned,
   formatUsageMetricCount,
 } from "@features/project-details/utils/usageMetrics";
@@ -151,15 +153,19 @@ export function deriveUsageEnvironmentProducts(
         const instCoreTrend = instMetric
           ? buildCoreAverageTrendFromMetrics([instMetric])
           : [];
-        const lastCore =
-          instMetric?.dataPoints.at(-1)?.coreCount ??
-          (instMetric?.dataPoints.at(-1)?.deploymentMetadata?.numberOfCores !=
-          null
-            ? Number(
-                instMetric.dataPoints.at(-1)!.deploymentMetadata!.numberOfCores,
-              )
-            : 0) ??
-          0;
+
+        const instCoreValues = (instMetric?.dataPoints ?? [])
+          .slice()
+          .sort((a, b) => a.date.localeCompare(b.date))
+          .map((dp) =>
+            dp.coreCount != null
+              ? dp.coreCount
+              : dp.deploymentMetadata?.numberOfCores != null
+                ? Number(dp.deploymentMetadata.numberOfCores)
+                : 0,
+          );
+        const instCoreSummary = computeSeriesSummary(instCoreValues);
+
         const coreHD = computeUsageHeadlineDeltaSigned(
           instCoreTrend.map((r) => ({ name: r.name, value: r.current })),
         );
@@ -185,7 +191,7 @@ export function deriveUsageEnvironmentProducts(
         const coresBlock: UsageInstanceChartBlock = {
           title: USAGE_METRICS_INSTANCE_CHART_CORE_TITLE,
           caption: USAGE_METRICS_INSTANCE_CHART_CORE_CAPTION,
-          headlineValue: String(lastCore),
+          headlineValue: String(instCoreSummary.curr),
           deltaLabel: coreHD.delta,
           deltaPositive: coreHD.deltaPositive,
           stroke: colors.orange?.[500] ?? "#F97316",
@@ -194,14 +200,17 @@ export function deriveUsageEnvironmentProducts(
 
         return {
           id: u.instanceId,
-          hostName: u.instanceId,
+          hostName: u.instanceKey,
           javaVersion: javaVer,
           u2Level,
           transactionsLabel: instTxHD.headline,
-          coreCount: lastCore,
+          coreSummary: instCoreSummary,
           charts: { transactions: txBlock, cores: coresBlock },
         };
       });
+
+      const { instanceSummary, coreSummary } =
+        computeInstanceAndCoreSummary(pMetrics);
 
       return {
         id: pid,
@@ -224,6 +233,8 @@ export function deriveUsageEnvironmentProducts(
         transactionTrend: txTrend,
         coreUsageTrend: coreTrend,
         instances: instanceRows,
+        instanceSummary,
+        coreSummary,
       };
     },
   );


### PR DESCRIPTION
 Description:
  ## Summary
  
  - **Environment breakdown product cards**: Fixed product/instance counts showing zero by falling back to `product.id`/`product.label` when `deployedProduct` is null
  - **Row header counts**: Switch to deployment-level instance data for accurate product/instance/core counts in the collapsed row header; usages fetched lazily on first expand to avoid N
  concurrent API calls on mount
  - **Product count stability**: Product count stays consistent between collapsed and expanded states — falls back to project-level count until usages are cached, then uses deployment-level
  data thereafter
  - **Product count correctness**: Count distinct products from both instances and usages so usage-only products (0 instances) are included in the count
  - **Overview stat cards**: Wire `useGetProjectUsageStats` current values into the Environments/Products/Instances stat cards; derive min/avg/max from time-series metrics
  - **Asgardeo**: Upgrade `@asgardeo/react` from `0.25.5` → `0.25.6`
  
  ## Test plan

  - [ ] Expand an environment accordion — product cards show with correct names, instance counts, and core counts
  - [ ] Collapse the accordion — product count and instance count in the row header match the expanded view
  - [ ] Verify no continuous loading on page load (usages only fire for the currently expanded row)
  - [ ] Overview stat cards (Environments, Products, Instances) show correct current values
  - [ ] Asgardeo auth flow works as before (login, token refresh, logout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage metrics now show richer summaries with current, average, minimum, and maximum values across several cards and breakdowns.
  * Environment and product usage views now include expanded instance and core summary metrics for clearer comparison.

* **Bug Fixes**
  * Improved how usage charts and summary cards pick the most relevant current value from recent data.
  * Updated organization usage trends to use the correct metric source.
  * Refined loading and fallback behavior so usage panels display more reliably when data is still arriving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->