### PR TITLE
[Customer Entity] Add search endpoint and standardise enum field naming

### DIFF
--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -148,6 +148,21 @@ Configured in `internal/db/postgres.go`:
 | Max conn lifetime   | 30 min  |
 | Max idle time       | 5 min   |
 
+## Pagination response conventions
+
+All search responses — regardless of data source — must use `total` (not `totalRecords`) as the JSON field name for the count of matched records. This applies to every `SearchXxxResponse` struct in `internal/domain/entity.go`.
+
+ServiceNow integration responses from Choreo use `totalRecords` internally (in the private `snXxxResponse` structs inside the `sn_*` service files). Always map that value to the `Total` field of the domain response before returning:
+
+```go
+return domain.SearchFooResponse{
+    Foos:   views,
+    Total:  snResp.TotalRecords, // map SN field → domain field
+    Limit:  req.Pagination.Limit,
+    Offset: req.Pagination.Offset,
+}, nil
+```
+
 ## ServiceNow data source (`sn_*` services)
 
 ServiceNow uses 32-character hex sysids (e.g. `abc123...`) while the rest of the platform uses standard UUIDs (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). Conversion helpers live in `internal/service/sn_id.go`.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -634,10 +634,10 @@ type SearchCaseView struct {
 
 // SearchCasesResponse is the paginated result of a case search.
 type SearchCasesResponse struct {
-	Cases        []SearchCaseView `json:"cases"`
-	TotalRecords int              `json:"totalRecords"`
-	Offset       int              `json:"offset"`
-	Limit        int              `json:"limit"`
+	Cases  []SearchCaseView `json:"cases"`
+	Total  int              `json:"total"`
+	Offset int              `json:"offset"`
+	Limit  int              `json:"limit"`
 }
 
 
@@ -939,7 +939,7 @@ type SearchChangeRequestView struct {
 // SearchChangeRequestsResponse is the paginated result of a change request search.
 type SearchChangeRequestsResponse struct {
 	ChangeRequests []SearchChangeRequestView `json:"changeRequests"`
-	TotalRecords   int                       `json:"totalRecords"`
+	Total          int                       `json:"total"`
 	Offset         int                       `json:"offset"`
 	Limit          int                       `json:"limit"`
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -838,3 +838,108 @@ type SearchAttachmentsResponse struct {
 	Offset      int          `json:"offset"`
 	HasMore     bool         `json:"hasMore"`
 }
+
+// ChangeRequestType classifies the change request type.
+type ChangeRequestType string
+
+const (
+	ChangeRequestTypeStandard           ChangeRequestType = "standard"
+	ChangeRequestTypeNormal             ChangeRequestType = "normal"
+	ChangeRequestTypeEmergency          ChangeRequestType = "emergency"
+	ChangeRequestTypeModel              ChangeRequestType = "model"
+	ChangeRequestTypeSiteReliabilityOps ChangeRequestType = "site_reliability_ops"
+	ChangeRequestTypeAzure              ChangeRequestType = "azure"
+)
+
+// ChangeRequestState represents the current workflow state of a change request.
+type ChangeRequestState string
+
+const (
+	ChangeRequestStateCustomerApproval ChangeRequestState = "customer_approval"
+	ChangeRequestStateScheduled        ChangeRequestState = "scheduled"
+	ChangeRequestStateImplement        ChangeRequestState = "implement"
+	ChangeRequestStateReview           ChangeRequestState = "review"
+	ChangeRequestStateCustomerReview   ChangeRequestState = "customer_review"
+	ChangeRequestStateRollback         ChangeRequestState = "rollback"
+	ChangeRequestStateClosed           ChangeRequestState = "closed"
+	ChangeRequestStateCanceled         ChangeRequestState = "canceled"
+)
+
+// ChangeRequestImpact represents the impact level of a change request.
+type ChangeRequestImpact string
+
+const (
+	ChangeRequestImpactHigh   ChangeRequestImpact = "high"
+	ChangeRequestImpactMedium ChangeRequestImpact = "medium"
+	ChangeRequestImpactLow    ChangeRequestImpact = "low"
+)
+
+// ChangeRequestSortField enumerates the columns available for sorting change request search results.
+type ChangeRequestSortField string
+
+const (
+	ChangeRequestSortFieldCreatedOn ChangeRequestSortField = "createdOn"
+	ChangeRequestSortFieldUpdatedOn ChangeRequestSortField = "updatedOn"
+)
+
+// ChangeRequestSortOrder controls the sort direction.
+type ChangeRequestSortOrder string
+
+const (
+	ChangeRequestSortOrderAsc  ChangeRequestSortOrder = "asc"
+	ChangeRequestSortOrderDesc ChangeRequestSortOrder = "desc"
+)
+
+// ChangeRequestSort specifies the sort field and direction for change request search results.
+type ChangeRequestSort struct {
+	Field ChangeRequestSortField `json:"field"`
+	Order ChangeRequestSortOrder `json:"order"`
+}
+
+// SearchChangeRequestsFilters holds all optional filter criteria for a change request search.
+type SearchChangeRequestsFilters struct {
+	ProjectIDs      []string              `json:"projectIds"`
+	SearchQuery     string                `json:"searchQuery"`
+	StateKeys       []ChangeRequestState  `json:"stateKeys"`
+	ImpactKeys      []ChangeRequestImpact `json:"impactKeys"`
+	ClosedStartDate *time.Time            `json:"closedStartDate"`
+	ClosedEndDate   *time.Time            `json:"closedEndDate"`
+}
+
+// SearchChangeRequestsRequest is the input for a change request search operation.
+type SearchChangeRequestsRequest struct {
+	Filters    SearchChangeRequestsFilters `json:"filters"`
+	SortBy     ChangeRequestSort           `json:"sortBy"`
+	Pagination Pagination                  `json:"pagination"`
+}
+
+// SearchChangeRequestView is the unified change request representation returned in search results.
+type SearchChangeRequestView struct {
+	ID               string     `json:"id"`
+	Number           string     `json:"number"`
+	Subject          *string    `json:"subject"`
+	Description      *string    `json:"description"`
+	Project          EntityRef  `json:"project"`
+	Case             *EntityRef `json:"case"`
+	Deployment       *EntityRef `json:"deployment"`
+	DeployedProduct  *EntityRef `json:"deployedProduct"`
+	Product          *EntityRef `json:"product"`
+	AssignedEngineer *EntityRef `json:"assignedEngineer"`
+	AssignedTeam     *EntityRef `json:"assignedTeam"`
+	PlannedStartOn   *string    `json:"plannedStartOn"`
+	PlannedEndOn     *string    `json:"plannedEndOn"`
+	Duration         *string    `json:"duration"`
+	Impact           string     `json:"impact"`
+	State            string     `json:"state"`
+	Type             string     `json:"type"`
+	CreatedOn        string     `json:"createdOn"`
+	UpdatedOn        string     `json:"updatedOn"`
+}
+
+// SearchChangeRequestsResponse is the paginated result of a change request search.
+type SearchChangeRequestsResponse struct {
+	ChangeRequests []SearchChangeRequestView `json:"changeRequests"`
+	TotalRecords   int                       `json:"totalRecords"`
+	Offset         int                       `json:"offset"`
+	Limit          int                       `json:"limit"`
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -331,13 +331,13 @@ type DeploymentView struct {
 
 // SearchDeploymentsRequest is the input for a deployment search operation.
 // All filter fields are optional. ProjectIDs scopes results to specific projects;
-// DeploymentTypeKeys filters by deployment type; SearchQuery is matched
+// DeploymentTypes filters by deployment type; SearchQuery is matched
 // case-insensitively against name.
 type SearchDeploymentsRequest struct {
-	Pagination         Pagination       `json:"pagination"`
-	SearchQuery        string           `json:"searchQuery"`
-	ProjectIDs         []string         `json:"projectIds"`
-	DeploymentTypeKeys []DeploymentType `json:"deploymentTypeKeys"`
+	Pagination      Pagination       `json:"pagination"`
+	SearchQuery     string           `json:"searchQuery"`
+	ProjectIDs      []string         `json:"projectIds"`
+	DeploymentTypes []DeploymentType `json:"deploymentTypes"`
 }
 
 // SearchDeploymentsResponse is the paginated result of a deployment search.
@@ -574,17 +574,15 @@ type CaseView struct {
 }
 
 // SearchCasesFilters holds all optional filter criteria for a case search.
-// StateKeys, SeverityKeys, IssueTypeKeys, and EngagementTypeKeys use the same
-// integer IDs as the ServiceNow integration layer.
 type SearchCasesFilters struct {
-	TypeKeys           []string         `json:"typeKeys"`
-	SearchQuery        string           `json:"searchQuery"`
-	ProjectIDs         []string         `json:"projectIds"`
-	DeploymentIDs      []string         `json:"deploymentIds"`
-	StateKeys          []CaseState      `json:"stateKeys"`
-	SeverityKeys       []CaseSeverity   `json:"severityKeys"`
-	IssueTypeKeys      []CaseIssueType  `json:"issueTypeKeys"`
-	EngagementTypeKeys []EngagementType `json:"engagementTypeKeys"`
+	Types           []string         `json:"types"`
+	SearchQuery     string           `json:"searchQuery"`
+	ProjectIDs      []string         `json:"projectIds"`
+	DeploymentIDs   []string         `json:"deploymentIds"`
+	States          []CaseState      `json:"states"`
+	Severities      []CaseSeverity   `json:"severities"`
+	IssueTypes      []CaseIssueType  `json:"issueTypes"`
+	EngagementTypes []EngagementType `json:"engagementTypes"`
 	ClosedStartDate    *time.Time `json:"closedStartDate"`
 	ClosedEndDate      *time.Time `json:"closedEndDate"`
 	StartCreatedDate   *time.Time `json:"startCreatedDate"`
@@ -647,9 +645,9 @@ type SearchCasesResponse struct {
 // WatchList and AssigneeEmail are only supported for the ServiceNow data source.
 type UpdateCaseRequest struct {
 	ID            string         `json:"-"`
-	StateKey      *CaseState     `json:"stateKey"`
-	SeverityKey   *CaseSeverity  `json:"severityKey"`
-	WorkStateKey  *CaseWorkState `json:"workStateKey"`
+	State         *CaseState     `json:"state"`
+	Severity      *CaseSeverity  `json:"severity"`
+	WorkState     *CaseWorkState `json:"workState"`
 	WatchList     []string       `json:"watchList"`
 	AssigneeEmail *string        `json:"assigneeEmail"`
 }
@@ -701,14 +699,14 @@ type CreateCaseDetails struct {
 // CreatedBy is not accepted from the request body and will be wired from auth context later.
 type CreateCaseRequest struct {
 	CreatedBy         string        `json:"-"`
-	TypeKey           string        `json:"typeKey"`
+	Type              string        `json:"type"`
 	ProjectID         string        `json:"projectId"`
 	DeploymentID      string        `json:"deploymentId"`
 	DeployedProductID string        `json:"deployedProductId"`
 	Subject           string        `json:"subject"`
 	Description       string        `json:"description"`
-	SeverityKey       CaseSeverity  `json:"severityKey"`
-	IssueTypeKey      CaseIssueType `json:"issueTypeKey"`
+	Severity          CaseSeverity  `json:"severity"`
+	IssueType         CaseIssueType `json:"issueType"`
 }
 
 // CommentType classifies the type of a case comment.
@@ -743,7 +741,7 @@ type CaseComment struct {
 type CreateCaseCommentRequest struct {
 	CaseID    string      `json:"-"`
 	CreatedBy string      `json:"-"`
-	TypeKey   CommentType `json:"typeKey"`
+	Type      CommentType `json:"type"`
 	Content   string      `json:"content"`
 }
 
@@ -770,7 +768,7 @@ type SearchCaseCommentsRequest struct {
 
 // CommentFilters holds optional filter criteria for searching case comments.
 type CommentFilters struct {
-	TypeKey *CommentType `json:"typeKey"`
+	Type *CommentType `json:"type"`
 }
 
 // SearchCaseCommentsResponse is the paginated result of a case comment search.
@@ -900,8 +898,8 @@ type ChangeRequestSort struct {
 type SearchChangeRequestsFilters struct {
 	ProjectIDs      []string              `json:"projectIds"`
 	SearchQuery     string                `json:"searchQuery"`
-	StateKeys       []ChangeRequestState  `json:"stateKeys"`
-	ImpactKeys      []ChangeRequestImpact `json:"impactKeys"`
+	States          []ChangeRequestState  `json:"states"`
+	Impacts         []ChangeRequestImpact `json:"impacts"`
 	ClosedStartDate *time.Time            `json:"closedStartDate"`
 	ClosedEndDate   *time.Time            `json:"closedEndDate"`
 }

--- a/entity-service/internal/handler/change_request_handler.go
+++ b/entity-service/internal/handler/change_request_handler.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// ChangeRequestHandler handles HTTP requests for the change-request resource.
+type ChangeRequestHandler struct {
+	svc service.ChangeRequestService
+}
+
+// NewChangeRequestHandler constructs a ChangeRequestHandler with the given service.
+func NewChangeRequestHandler(svc service.ChangeRequestService) *ChangeRequestHandler {
+	return &ChangeRequestHandler{svc: svc}
+}
+
+// SearchChangeRequests handles POST /change-requests/search.
+func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchChangeRequestsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchChangeRequests(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -83,7 +83,7 @@ func (r *caseRepo) CreateCase(ctx context.Context, req domain.CreateCaseRequest)
 	var c domain.Case
 	err := r.db.QueryRow(ctx, query,
 		req.CreatedBy, req.ProjectID, req.DeploymentID, req.DeployedProductID,
-		req.TypeKey, req.Subject, req.Description, string(req.SeverityKey), string(req.IssueTypeKey),
+		req.Type, req.Subject, req.Description, string(req.Severity), string(req.IssueType),
 	).Scan(
 		&c.ID, &c.Number, &c.InternalID, &c.CreatedBy,
 		&c.ProjectID, &c.DeploymentID, &c.DeployedProductID,
@@ -185,7 +185,7 @@ func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseC
 
 	var c domain.CaseComment
 	err := r.db.QueryRow(ctx, query,
-		req.CaseID, string(req.TypeKey), req.Content, req.CreatedBy,
+		req.CaseID, string(req.Type), req.Content, req.CreatedBy,
 	).Scan(&c.ID, &c.CaseID, &c.Type, &c.Content, &c.CreatedBy, &c.CreatedOn)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
@@ -205,8 +205,8 @@ func (r *caseRepo) CreateCaseComment(ctx context.Context, req domain.CreateCaseC
 func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) ([]domain.CaseComment, int, error) {
 	args := []any{req.CaseID}
 	typeFilter := ""
-	if req.Filters != nil && req.Filters.TypeKey != nil {
-		args = append(args, string(*req.Filters.TypeKey))
+	if req.Filters != nil && req.Filters.Type != nil {
+		args = append(args, string(*req.Filters.Type))
 		typeFilter = fmt.Sprintf(" AND cc.type = $%d::comment_type_enum", len(args))
 	}
 
@@ -272,16 +272,16 @@ func (r *caseRepo) SearchCaseComments(ctx context.Context, req domain.SearchCase
 // UpdateCase implements CaseRepository.
 func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error) {
 	state := ""
-	if req.StateKey != nil {
-		state = string(*req.StateKey)
+	if req.State != nil {
+		state = string(*req.State)
 	}
 	severity := ""
-	if req.SeverityKey != nil {
-		severity = string(*req.SeverityKey)
+	if req.Severity != nil {
+		severity = string(*req.Severity)
 	}
 	workState := ""
-	if req.WorkStateKey != nil {
-		workState = string(*req.WorkStateKey)
+	if req.WorkState != nil {
+		workState = string(*req.WorkState)
 	}
 	const query = `
 		UPDATE cases
@@ -330,9 +330,9 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 
 	where := "WHERE 1=1"
 
-	if len(req.Filters.TypeKeys) > 0 {
+	if len(req.Filters.Types) > 0 {
 		where += fmt.Sprintf(" AND c.type = ANY($%d::case_type_enum[])", argIdx)
-		filterArgs = append(filterArgs, req.Filters.TypeKeys)
+		filterArgs = append(filterArgs, req.Filters.Types)
 		argIdx++
 	}
 
@@ -348,9 +348,9 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
-	if len(req.Filters.StateKeys) > 0 {
-		stateStrings := make([]string, len(req.Filters.StateKeys))
-		for i, s := range req.Filters.StateKeys {
+	if len(req.Filters.States) > 0 {
+		stateStrings := make([]string, len(req.Filters.States))
+		for i, s := range req.Filters.States {
 			stateStrings[i] = string(s)
 		}
 		where += fmt.Sprintf(" AND c.state = ANY($%d::case_state_enum[])", argIdx)
@@ -358,9 +358,9 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
-	if len(req.Filters.SeverityKeys) > 0 {
-		severityStrings := make([]string, len(req.Filters.SeverityKeys))
-		for i, s := range req.Filters.SeverityKeys {
+	if len(req.Filters.Severities) > 0 {
+		severityStrings := make([]string, len(req.Filters.Severities))
+		for i, s := range req.Filters.Severities {
 			severityStrings[i] = string(s)
 		}
 		where += fmt.Sprintf(" AND c.severity = ANY($%d::case_severity_enum[])", argIdx)
@@ -368,9 +368,9 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
-	if len(req.Filters.IssueTypeKeys) > 0 {
-		issueTypeStrings := make([]string, len(req.Filters.IssueTypeKeys))
-		for i, it := range req.Filters.IssueTypeKeys {
+	if len(req.Filters.IssueTypes) > 0 {
+		issueTypeStrings := make([]string, len(req.Filters.IssueTypes))
+		for i, it := range req.Filters.IssueTypes {
 			issueTypeStrings[i] = string(it)
 		}
 		where += fmt.Sprintf(" AND c.issue_type = ANY($%d::case_issue_type_enum[])", argIdx)
@@ -378,9 +378,9 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
-	if len(req.Filters.EngagementTypeKeys) > 0 {
-		engTypeStrings := make([]string, len(req.Filters.EngagementTypeKeys))
-		for i, et := range req.Filters.EngagementTypeKeys {
+	if len(req.Filters.EngagementTypes) > 0 {
+		engTypeStrings := make([]string, len(req.Filters.EngagementTypes))
+		for i, et := range req.Filters.EngagementTypes {
 			engTypeStrings[i] = string(et)
 		}
 		where += fmt.Sprintf(" AND c.engagement_type = ANY($%d::engagement_type_enum[])", argIdx)

--- a/entity-service/internal/repository/deployment_repo.go
+++ b/entity-service/internal/repository/deployment_repo.go
@@ -57,11 +57,11 @@ func (r *deploymentRepo) SearchDeployments(ctx context.Context, req domain.Searc
 		argIdx++
 	}
 
-	if len(req.DeploymentTypeKeys) > 0 {
+	if len(req.DeploymentTypes) > 0 {
 		// Convert []DeploymentType to []string — pgx has no codec for named string types.
 		// Cast the parameter to deployment_type_enum[] so the column stays uncast and idx_deployments_type is usable.
-		typeStrings := make([]string, len(req.DeploymentTypeKeys))
-		for i, t := range req.DeploymentTypeKeys {
+		typeStrings := make([]string, len(req.DeploymentTypes))
+		for i, t := range req.DeploymentTypes {
 			typeStrings[i] = string(t)
 		}
 		where += fmt.Sprintf(" AND d.type = ANY($%d::deployment_type_enum[])", argIdx)

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -97,6 +97,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	}
 	caseHandler := handler.NewCaseHandler(activeCaseSvc)
 
+	var changeRequestHandler *handler.ChangeRequestHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		changeRequestHandler = handler.NewChangeRequestHandler(service.NewServiceNowChangeRequestService(serviceNowIntegrationServiceClient))
+	}
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /health", handler.HealthCheck)
@@ -119,6 +124,9 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/{id}/attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /cases/{case_id}/attachments/{attachment_id}/content", caseHandler.GetCaseAttachmentContent)
 
+	if changeRequestHandler != nil {
+		mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
+	}
 
 	return middleware.CorrelationID(
 		middleware.Recovery(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -133,7 +133,7 @@ func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseReque
 		return domain.CreateCaseResponse{}, err
 	}
 	if req.Type != "support" {
-		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey must be \"support\" for case creation"}
+		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "type must be \"support\" for case creation"}
 	}
 	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
 		return domain.CreateCaseResponse{}, err

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -388,7 +388,7 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 
 	return domain.SearchCasesResponse{
 		Cases:        cases,
-		TotalRecords: total,
+		Total: total,
 		Limit:        req.Pagination.Limit,
 		Offset:       req.Pagination.Offset,
 	}, nil

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -100,8 +100,8 @@ var validCaseWorkState = map[domain.CaseWorkState]bool{
 // UUID format of ID fields is not checked here — postgres IDs are UUIDs but
 // ServiceNow IDs are opaque hex strings; callers add format checks as needed.
 func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
-	if req.TypeKey == "" {
-		return &apierror.ValidationError{Msg: "typeKey is required"}
+	if req.Type == "" {
+		return &apierror.ValidationError{Msg: "type is required"}
 	}
 	if req.ProjectID == "" {
 		return &apierror.ValidationError{Msg: "projectId is required"}
@@ -118,11 +118,11 @@ func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
 	if req.Description == "" {
 		return &apierror.ValidationError{Msg: "description is required"}
 	}
-	if !validCaseSeverity[req.SeverityKey] {
-		return &apierror.ValidationError{Msg: "severityKey contains invalid value: " + string(req.SeverityKey)}
+	if !validCaseSeverity[req.Severity] {
+		return &apierror.ValidationError{Msg: "severity contains invalid value: " + string(req.Severity)}
 	}
-	if !validCaseIssueType[req.IssueTypeKey] {
-		return &apierror.ValidationError{Msg: "issueTypeKey contains invalid value: " + string(req.IssueTypeKey)}
+	if !validCaseIssueType[req.IssueType] {
+		return &apierror.ValidationError{Msg: "issueType contains invalid value: " + string(req.IssueType)}
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func (s *caseService) CreateCase(ctx context.Context, req domain.CreateCaseReque
 	if err := validateCreateCaseRequest(req); err != nil {
 		return domain.CreateCaseResponse{}, err
 	}
-	if req.TypeKey != "support" {
+	if req.Type != "support" {
 		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey must be \"support\" for case creation"}
 	}
 	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
@@ -195,8 +195,8 @@ func (s *caseService) CreateCaseComment(ctx context.Context, req domain.CreateCa
 	if err := validateUUIDs("caseId", []string{req.CaseID}); err != nil {
 		return domain.CreateCaseCommentResponse{}, err
 	}
-	if !validCommentType[req.TypeKey] {
-		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "typeKey contains invalid value: " + string(req.TypeKey)}
+	if !validCommentType[req.Type] {
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}
 	}
 	if req.Content == "" {
 		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "content is required"}
@@ -236,8 +236,8 @@ func (s *caseService) SearchCaseComments(ctx context.Context, req domain.SearchC
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchCaseCommentsResponse{}, err
 	}
-	if req.Filters != nil && req.Filters.TypeKey != nil && !validCommentType[*req.Filters.TypeKey] {
-		return domain.SearchCaseCommentsResponse{}, &apierror.ValidationError{Msg: "filters.typeKey contains invalid value: " + string(*req.Filters.TypeKey)}
+	if req.Filters != nil && req.Filters.Type != nil && !validCommentType[*req.Filters.Type] {
+		return domain.SearchCaseCommentsResponse{}, &apierror.ValidationError{Msg: "filters.type contains invalid value: " + string(*req.Filters.Type)}
 	}
 	comments, total, err := s.repo.SearchCaseComments(ctx, req)
 	if err != nil {
@@ -261,29 +261,29 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList and assigneeEmail are only supported for the ServiceNow data source"}
 	}
 	fieldCount := 0
-	if req.StateKey != nil {
+	if req.State != nil {
 		fieldCount++
 	}
-	if req.SeverityKey != nil {
+	if req.Severity != nil {
 		fieldCount++
 	}
-	if req.WorkStateKey != nil {
+	if req.WorkState != nil {
 		fieldCount++
 	}
 	if fieldCount == 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of stateKey, severityKey, or workStateKey must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "exactly one of state, severity, or workState must be provided"}
 	}
 	if fieldCount > 1 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of stateKey, severityKey, or workStateKey may be provided per request"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, severity, or workState may be provided per request"}
 	}
-	if req.StateKey != nil && !validCaseState[*req.StateKey] {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "stateKey contains invalid value: " + string(*req.StateKey)}
+	if req.State != nil && !validCaseState[*req.State] {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
 	}
-	if req.SeverityKey != nil && !validCaseSeverity[*req.SeverityKey] {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "severityKey contains invalid value: " + string(*req.SeverityKey)}
+	if req.Severity != nil && !validCaseSeverity[*req.Severity] {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "severity contains invalid value: " + string(*req.Severity)}
 	}
-	if req.WorkStateKey != nil && !validCaseWorkState[*req.WorkStateKey] {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workStateKey contains invalid value: " + string(*req.WorkStateKey)}
+	if req.WorkState != nil && !validCaseWorkState[*req.WorkState] {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState contains invalid value: " + string(*req.WorkState)}
 	}
 	c, err := s.repo.UpdateCase(ctx, req)
 	if err != nil {
@@ -319,29 +319,29 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 		return domain.SearchCasesResponse{}, err
 	}
 
-	for _, t := range req.Filters.TypeKeys {
+	for _, t := range req.Filters.Types {
 		if !validCaseType[t] {
-			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "typeKeys contains invalid value: " + t}
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "types contains invalid value: " + t}
 		}
 	}
-	for _, s := range req.Filters.StateKeys {
+	for _, s := range req.Filters.States {
 		if !validCaseState[s] {
-			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "stateKeys contains invalid value: " + string(s)}
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "states contains invalid value: " + string(s)}
 		}
 	}
-	for _, s := range req.Filters.SeverityKeys {
+	for _, s := range req.Filters.Severities {
 		if !validCaseSeverity[s] {
-			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "severityKeys contains invalid value: " + string(s)}
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "severities contains invalid value: " + string(s)}
 		}
 	}
-	for _, it := range req.Filters.IssueTypeKeys {
+	for _, it := range req.Filters.IssueTypes {
 		if !validCaseIssueType[it] {
-			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "issueTypeKeys contains invalid value: " + string(it)}
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "issueTypes contains invalid value: " + string(it)}
 		}
 	}
-	for _, et := range req.Filters.EngagementTypeKeys {
+	for _, et := range req.Filters.EngagementTypes {
 		if !validEngagementType[et] {
-			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "engagementTypeKeys contains invalid value: " + string(et)}
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "engagementTypes contains invalid value: " + string(et)}
 		}
 	}
 

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -122,3 +122,12 @@ type CaseService interface {
 	// A NotFoundError is returned if absent.
 	GetCaseAttachmentContent(ctx context.Context, caseID, attachmentID string) (content []byte, contentType string, err error)
 }
+
+// ChangeRequestService defines the operations available on the change_requests entity.
+type ChangeRequestService interface {
+	// SearchChangeRequests returns a paginated list of change requests filtered by optional
+	// project IDs, state keys, impact keys, date ranges, and search query.
+	// A ValidationError is returned for invalid input; any other error indicates an
+	// infrastructure failure.
+	SearchChangeRequests(ctx context.Context, req domain.SearchChangeRequestsRequest) (domain.SearchChangeRequestsResponse, error)
+}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1123,10 +1123,10 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	}
 
 	return domain.SearchCasesResponse{
-		Cases:        views,
-		TotalRecords: snResp.TotalRecords,
-		Limit:        req.Pagination.Limit,
-		Offset:       req.Pagination.Offset,
+		Cases:  views,
+		Total:  snResp.TotalRecords,
+		Limit:  req.Pagination.Limit,
+		Offset: req.Pagination.Offset,
 	}, nil
 }
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -314,10 +314,10 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 		return domain.CreateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
-	if req.TypeKey != "support" {
+	if req.Type != "support" {
 		return domain.CreateCaseResponse{}, &apierror.ValidationError{Msg: "typeKey must be \"support\" for case creation"}
 	}
-	snType := snCaseTypeMap[req.TypeKey]
+	snType := snCaseTypeMap[req.Type]
 
 	payload := snCreateCasePayload{
 		Type:              snType,
@@ -326,8 +326,8 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 		DeployedProductID: uuidToSysid(req.DeployedProductID),
 		Title:             req.Subject,
 		Description:       req.Description,
-		SeverityKey:       snSeverityIDMap[req.SeverityKey],
-		IssueTypeKey:      snIssueTypeID[req.IssueTypeKey],
+		SeverityKey:       snSeverityIDMap[req.Severity],
+		IssueTypeKey:      snIssueTypeID[req.IssueType],
 	}
 
 	raw, err := s.client.Post(ctx, "/cases", token, payload)
@@ -455,14 +455,14 @@ type snCreateCommentResponse struct {
 }
 
 func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CreateCaseCommentResponse, error) {
-	if !validCommentType[req.TypeKey] {
-		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "typeKey contains invalid value: " + string(req.TypeKey)}
+	if !validCommentType[req.Type] {
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}
 	}
 	if req.Content == "" {
 		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "content is required"}
 	}
-	if req.TypeKey == domain.CommentTypeActivity {
-		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "typeKey 'activity' is not supported for ServiceNow"}
+	if req.Type == domain.CommentTypeActivity {
+		return domain.CreateCaseCommentResponse{}, &apierror.ValidationError{Msg: "type 'activity' is not supported for ServiceNow"}
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
@@ -470,7 +470,7 @@ func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.Create
 		return domain.CreateCaseCommentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
-	snType := snCommentTypeMap[req.TypeKey]
+	snType := snCommentTypeMap[req.Type]
 
 	payload := snCreateCommentPayload{
 		ReferenceID:   uuidToSysid(req.CaseID),
@@ -554,11 +554,11 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 		ReferenceType: "case",
 		Pagination:    snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
-	if req.Filters != nil && req.Filters.TypeKey != nil {
-		snType, ok := snCommentTypeMap[*req.Filters.TypeKey]
+	if req.Filters != nil && req.Filters.Type != nil {
+		snType, ok := snCommentTypeMap[*req.Filters.Type]
 		if !ok {
 			return domain.SearchCaseCommentsResponse{}, &apierror.ValidationError{
-				Msg: "filters.typeKey is not supported for ServiceNow: " + string(*req.Filters.TypeKey),
+				Msg: "filters.type is not supported for ServiceNow: " + string(*req.Filters.Type),
 			}
 		}
 		payload.Filters = &snCommentFilters{Type: snType}
@@ -657,13 +657,13 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	}
 
 	fieldCount := 0
-	if req.StateKey != nil {
+	if req.State != nil {
 		fieldCount++
 	}
-	if req.SeverityKey != nil {
+	if req.Severity != nil {
 		fieldCount++
 	}
-	if req.WorkStateKey != nil {
+	if req.WorkState != nil {
 		fieldCount++
 	}
 	if len(req.WatchList) > 0 {
@@ -673,10 +673,10 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		fieldCount++
 	}
 	if fieldCount == 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of stateKey, severityKey, workStateKey, watchList, or assigneeEmail must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state, severity, workState, watchList, or assigneeEmail must be provided"}
 	}
 	if fieldCount > 1 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of stateKey, severityKey, workStateKey, watchList, or assigneeEmail may be provided per request"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, severity, workState, watchList, or assigneeEmail may be provided per request"}
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
@@ -685,33 +685,33 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	}
 
 	payload := snUpdateCasePayload{}
-	if req.StateKey != nil {
-		if !validCaseState[*req.StateKey] {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "stateKey contains invalid value: " + string(*req.StateKey)}
+	if req.State != nil {
+		if !validCaseState[*req.State] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(*req.State)}
 		}
-		id, ok := snStateIDMap[*req.StateKey]
+		id, ok := snStateIDMap[*req.State]
 		if !ok {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state " + string(*req.StateKey) + " is not supported by ServiceNow"}
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state " + string(*req.State) + " is not supported by ServiceNow"}
 		}
 		payload.StateKey = &id
 	}
-	if req.SeverityKey != nil {
-		if !validCaseSeverity[*req.SeverityKey] {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "severityKey contains invalid value: " + string(*req.SeverityKey)}
+	if req.Severity != nil {
+		if !validCaseSeverity[*req.Severity] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "severity contains invalid value: " + string(*req.Severity)}
 		}
-		id, ok := snSeverityIDMap[*req.SeverityKey]
+		id, ok := snSeverityIDMap[*req.Severity]
 		if !ok {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "severityKey " + string(*req.SeverityKey) + " is not supported by ServiceNow"}
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "severity " + string(*req.Severity) + " is not supported by ServiceNow"}
 		}
 		payload.SeverityKey = &id
 	}
-	if req.WorkStateKey != nil {
-		if !validCaseWorkState[*req.WorkStateKey] {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workStateKey contains invalid value: " + string(*req.WorkStateKey)}
+	if req.WorkState != nil {
+		if !validCaseWorkState[*req.WorkState] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState contains invalid value: " + string(*req.WorkState)}
 		}
-		id, ok := snWorkStateIDMap[*req.WorkStateKey]
+		id, ok := snWorkStateIDMap[*req.WorkState]
 		if !ok {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState " + string(*req.WorkStateKey) + " is not supported by ServiceNow"}
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "workState " + string(*req.WorkState) + " is not supported by ServiceNow"}
 		}
 		payload.WorkStateKey = &id
 	}
@@ -1016,12 +1016,12 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		snSortBy = &snCaseSort{Field: snField, Order: order}
 	}
 
-	for _, t := range req.Filters.TypeKeys {
+	for _, t := range req.Filters.Types {
 		if _, ok := snCaseTypeMap[t]; !ok {
-			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "typeKeys contains invalid value: " + t}
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "types contains invalid value: " + t}
 		}
 	}
-	snCaseTypes := domainTypeKeysToSN(req.Filters.TypeKeys)
+	snCaseTypes := domainTypeKeysToSN(req.Filters.Types)
 	if len(snCaseTypes) == 0 {
 		snCaseTypes = []string{"default_case"}
 	}
@@ -1032,10 +1032,10 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			SearchQuery:        req.Filters.SearchQuery,
 			ProjectIDs:         uuidsToSysids(req.Filters.ProjectIDs),
 			DeploymentIDs:      uuidsToSysids(req.Filters.DeploymentIDs),
-			StateKeys:          domainStatesToSNIDs(req.Filters.StateKeys),
-			SeverityKeys:       domainSeveritiesToSNIDs(req.Filters.SeverityKeys),
-			IssueTypeKeys:      domainIssueTypesToSNIDs(req.Filters.IssueTypeKeys),
-			EngagementTypeKeys: domainEngagementTypesToSNIDs(req.Filters.EngagementTypeKeys),
+			StateKeys:          domainStatesToSNIDs(req.Filters.States),
+			SeverityKeys:       domainSeveritiesToSNIDs(req.Filters.Severities),
+			IssueTypeKeys:      domainIssueTypesToSNIDs(req.Filters.IssueTypes),
+			EngagementTypeKeys: domainEngagementTypesToSNIDs(req.Filters.EngagementTypes),
 			ClosedStartDate:    formatSNDate(req.Filters.ClosedStartDate),
 			ClosedEndDate:      formatSNDate(req.Filters.ClosedEndDate),
 			StartCreatedDate:   formatSNDate(req.Filters.StartCreatedDate),

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snChangeRequestsResponse mirrors the Choreo POST /change-requests/search response.
+type snChangeRequestsResponse struct {
+	ChangeRequests []snChangeRequest `json:"changeRequests"`
+	TotalRecords   int               `json:"totalRecords"`
+	Offset         int               `json:"offset"`
+	Limit          int               `json:"limit"`
+}
+
+type snChangeRequest struct {
+	ID               string                `json:"id"`
+	Number           string                `json:"number"`
+	Title            string                `json:"title"`
+	Description      string                `json:"description"`
+	CreatedOn        string                `json:"createdOn"`
+	UpdatedOn        *string               `json:"updatedOn"`
+	Project          snCREntityRef         `json:"project"`
+	Case             *snCREntityRef        `json:"case"`
+	Deployment       *snCREntityRef        `json:"deployment"`
+	DeployedProduct  *snCREntityRef        `json:"deployedProduct"`
+	Product          *snCREntityRef        `json:"product"`
+	AssignedEngineer *snCREntityRef        `json:"assignedEngineer"`
+	AssignedTeam     *snCREntityRef        `json:"assignedTeam"`
+	PlannedStartOn   *string               `json:"plannedStartOn"`
+	PlannedEndOn     *string               `json:"plannedEndOn"`
+	Duration         *string               `json:"duration"`
+	Impact           *snCRLabel            `json:"impact"`
+	State            *snCRLabel            `json:"state"`
+	Type             *snCRLabel            `json:"type"`
+}
+
+type snCREntityRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type snCRLabel struct {
+	Label string `json:"label"`
+}
+
+// snChangeRequestSearchPayload is the Choreo POST /change-requests/search request body.
+type snChangeRequestSearchPayload struct {
+	Filters    snChangeRequestFilters `json:"filters,omitempty"`
+	SortBy     *snCRSort              `json:"sortBy,omitempty"`
+	Pagination snProjectPagination    `json:"pagination"`
+}
+
+type snCRSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+type snChangeRequestFilters struct {
+	ProjectIDs      []string `json:"projectIds,omitempty"`
+	SearchQuery     string   `json:"searchQuery,omitempty"`
+	StateKeys       []int    `json:"stateKeys,omitempty"`
+	ImpactKeys      []int    `json:"impactKeys,omitempty"`
+	ClosedStartDate string   `json:"closedStartDate,omitempty"`
+	ClosedEndDate   string   `json:"closedEndDate,omitempty"`
+}
+
+// snCRTypeIDMap maps domain ChangeRequestType enums to SN numeric type IDs.
+var snCRTypeIDMap = map[domain.ChangeRequestType]int{
+	domain.ChangeRequestTypeStandard:           1,
+	domain.ChangeRequestTypeNormal:             2,
+	domain.ChangeRequestTypeEmergency:          3,
+	domain.ChangeRequestTypeModel:              4,
+	domain.ChangeRequestTypeSiteReliabilityOps: 100,
+	domain.ChangeRequestTypeAzure:              200,
+}
+
+// snCRStateIDMap maps domain ChangeRequestState enums to SN numeric state IDs.
+var snCRStateIDMap = map[domain.ChangeRequestState]int{
+	domain.ChangeRequestStateCustomerApproval: 5,
+	domain.ChangeRequestStateScheduled:        -2,
+	domain.ChangeRequestStateImplement:        -1,
+	domain.ChangeRequestStateReview:           0,
+	domain.ChangeRequestStateCustomerReview:   1,
+	domain.ChangeRequestStateRollback:         2,
+	domain.ChangeRequestStateClosed:           3,
+	domain.ChangeRequestStateCanceled:         4,
+}
+
+// snCRImpactIDMap maps domain ChangeRequestImpact enums to SN numeric impact IDs.
+var snCRImpactIDMap = map[domain.ChangeRequestImpact]int{
+	domain.ChangeRequestImpactHigh:   1,
+	domain.ChangeRequestImpactMedium: 2,
+	domain.ChangeRequestImpactLow:    3,
+}
+
+// snCRSortFieldMap maps domain ChangeRequestSortField values to SN field names.
+var snCRSortFieldMap = map[domain.ChangeRequestSortField]string{
+	domain.ChangeRequestSortFieldCreatedOn: "createdOn",
+	domain.ChangeRequestSortFieldUpdatedOn: "updatedOn",
+}
+
+var validChangeRequestState = map[domain.ChangeRequestState]bool{
+	domain.ChangeRequestStateCustomerApproval: true,
+	domain.ChangeRequestStateScheduled:        true,
+	domain.ChangeRequestStateImplement:        true,
+	domain.ChangeRequestStateReview:           true,
+	domain.ChangeRequestStateCustomerReview:   true,
+	domain.ChangeRequestStateRollback:         true,
+	domain.ChangeRequestStateClosed:           true,
+	domain.ChangeRequestStateCanceled:         true,
+}
+
+var validChangeRequestImpact = map[domain.ChangeRequestImpact]bool{
+	domain.ChangeRequestImpactHigh:   true,
+	domain.ChangeRequestImpactMedium: true,
+	domain.ChangeRequestImpactLow:    true,
+}
+
+var validChangeRequestSortField = map[domain.ChangeRequestSortField]bool{
+	domain.ChangeRequestSortFieldCreatedOn: true,
+	domain.ChangeRequestSortFieldUpdatedOn: true,
+}
+
+var validChangeRequestSortOrder = map[domain.ChangeRequestSortOrder]bool{
+	domain.ChangeRequestSortOrderAsc:  true,
+	domain.ChangeRequestSortOrderDesc: true,
+}
+
+func domainCRStatesToSNIDs(states []domain.ChangeRequestState) []int {
+	ids := make([]int, 0, len(states))
+	for _, s := range states {
+		if id, ok := snCRStateIDMap[s]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func domainCRImpactsToSNIDs(impacts []domain.ChangeRequestImpact) []int {
+	ids := make([]int, 0, len(impacts))
+	for _, i := range impacts {
+		if id, ok := snCRImpactIDMap[i]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// snCRStateLabelMap maps SN state labels (lowercased) to domain ChangeRequestState enums.
+var snCRStateLabelMap = map[string]domain.ChangeRequestState{
+	"customer approval": domain.ChangeRequestStateCustomerApproval,
+	"scheduled":         domain.ChangeRequestStateScheduled,
+	"implement":         domain.ChangeRequestStateImplement,
+	"review":            domain.ChangeRequestStateReview,
+	"customer review":   domain.ChangeRequestStateCustomerReview,
+	"rollback":          domain.ChangeRequestStateRollback,
+	"closed":            domain.ChangeRequestStateClosed,
+	"canceled":          domain.ChangeRequestStateCanceled,
+	"cancelled":         domain.ChangeRequestStateCanceled,
+}
+
+// snCRImpactLabelMap maps SN impact labels (lowercased word) to domain ChangeRequestImpact enums.
+var snCRImpactLabelMap = map[string]domain.ChangeRequestImpact{
+	"high":   domain.ChangeRequestImpactHigh,
+	"medium": domain.ChangeRequestImpactMedium,
+	"low":    domain.ChangeRequestImpactLow,
+}
+
+func snCRStateLabelToString(label *snCRLabel) string {
+	if label == nil {
+		return ""
+	}
+	if v, ok := snCRStateLabelMap[strings.ToLower(label.Label)]; ok {
+		return string(v)
+	}
+	return label.Label
+}
+
+func snCRImpactLabelToString(label *snCRLabel) string {
+	if label == nil {
+		return ""
+	}
+	for _, word := range strings.Fields(label.Label) {
+		if v, ok := snCRImpactLabelMap[strings.ToLower(strings.Trim(word, "()-"))]; ok {
+			return string(v)
+		}
+	}
+	return label.Label
+}
+
+func snCRTypeLabelToString(label *snCRLabel) string {
+	if label == nil {
+		return ""
+	}
+	return label.Label
+}
+
+type snChangeRequestService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowChangeRequestService constructs a ChangeRequestService backed by the Choreo API.
+func NewServiceNowChangeRequestService(client *integrationservice.Client) ChangeRequestService {
+	return &snChangeRequestService{client: client}
+}
+
+func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req domain.SearchChangeRequestsRequest) (domain.SearchChangeRequestsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchChangeRequestsResponse{}, err
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchChangeRequestsResponse{}, err
+	}
+
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+
+	for _, s := range req.Filters.StateKeys {
+		if !validChangeRequestState[s] {
+			return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "stateKeys contains invalid value: " + string(s)}
+		}
+	}
+	for _, i := range req.Filters.ImpactKeys {
+		if !validChangeRequestImpact[i] {
+			return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "impactKeys contains invalid value: " + string(i)}
+		}
+	}
+	if req.SortBy.Field != "" && !validChangeRequestSortField[req.SortBy.Field] {
+		return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "sortBy.field contains invalid value: " + string(req.SortBy.Field)}
+	}
+	if req.SortBy.Order != "" && !validChangeRequestSortOrder[req.SortBy.Order] {
+		return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + string(req.SortBy.Order)}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchChangeRequestsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	var snSortBy *snCRSort
+	if req.SortBy.Field != "" {
+		snField := snCRSortFieldMap[req.SortBy.Field]
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snCRSort{Field: snField, Order: order}
+	}
+
+	payload := snChangeRequestSearchPayload{
+		Filters: snChangeRequestFilters{
+			ProjectIDs:      uuidsToSysids(req.Filters.ProjectIDs),
+			SearchQuery:     req.Filters.SearchQuery,
+			StateKeys:       domainCRStatesToSNIDs(req.Filters.StateKeys),
+			ImpactKeys:      domainCRImpactsToSNIDs(req.Filters.ImpactKeys),
+			ClosedStartDate: formatSNDate(req.Filters.ClosedStartDate),
+			ClosedEndDate:   formatSNDate(req.Filters.ClosedEndDate),
+		},
+		SortBy:     snSortBy,
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/change-requests/search", token, payload)
+	if err != nil {
+		return domain.SearchChangeRequestsResponse{}, err
+	}
+
+	var snResp snChangeRequestsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchChangeRequestsResponse{}, fmt.Errorf("sn change requests: parse response: %w", err)
+	}
+
+	views := make([]domain.SearchChangeRequestView, 0, len(snResp.ChangeRequests))
+	for _, cr := range snResp.ChangeRequests {
+		subject := cr.Title
+		description := cr.Description
+
+		updatedOn := cr.CreatedOn
+		if cr.UpdatedOn != nil && *cr.UpdatedOn != "" {
+			updatedOn = *cr.UpdatedOn
+		}
+
+		view := domain.SearchChangeRequestView{
+			ID:             sysidToUUID(cr.ID),
+			Number:         cr.Number,
+			Subject:        &subject,
+			Description:    &description,
+			Project:        domain.EntityRef{ID: sysidToUUID(cr.Project.ID), Name: cr.Project.Name},
+			PlannedStartOn: cr.PlannedStartOn,
+			PlannedEndOn:   cr.PlannedEndOn,
+			Duration:       cr.Duration,
+			Impact:         snCRImpactLabelToString(cr.Impact),
+			State:          snCRStateLabelToString(cr.State),
+			Type:           snCRTypeLabelToString(cr.Type),
+			CreatedOn:      cr.CreatedOn,
+			UpdatedOn:      updatedOn,
+		}
+		if cr.Case != nil {
+			view.Case = &domain.EntityRef{ID: sysidToUUID(cr.Case.ID), Name: cr.Case.Name}
+		}
+		if cr.Deployment != nil {
+			view.Deployment = &domain.EntityRef{ID: sysidToUUID(cr.Deployment.ID), Name: cr.Deployment.Name}
+		}
+		if cr.DeployedProduct != nil {
+			view.DeployedProduct = &domain.EntityRef{ID: sysidToUUID(cr.DeployedProduct.ID), Name: cr.DeployedProduct.Name}
+		}
+		if cr.Product != nil {
+			view.Product = &domain.EntityRef{ID: sysidToUUID(cr.Product.ID), Name: cr.Product.Name}
+		}
+		if cr.AssignedEngineer != nil {
+			view.AssignedEngineer = &domain.EntityRef{ID: sysidToUUID(cr.AssignedEngineer.ID), Name: cr.AssignedEngineer.Name}
+		}
+		if cr.AssignedTeam != nil {
+			view.AssignedTeam = &domain.EntityRef{ID: sysidToUUID(cr.AssignedTeam.ID), Name: cr.AssignedTeam.Name}
+		}
+		views = append(views, view)
+	}
+
+	return domain.SearchChangeRequestsResponse{
+		ChangeRequests: views,
+		TotalRecords:   snResp.TotalRecords,
+		Limit:          req.Pagination.Limit,
+		Offset:         req.Pagination.Offset,
+	}, nil
+}

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -344,7 +344,7 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 
 	return domain.SearchChangeRequestsResponse{
 		ChangeRequests: views,
-		TotalRecords:   snResp.TotalRecords,
+		Total:          snResp.TotalRecords,
 		Limit:          req.Pagination.Limit,
 		Offset:         req.Pagination.Offset,
 	}, nil

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -257,6 +257,9 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 	if req.SortBy.Order != "" && !validChangeRequestSortOrder[req.SortBy.Order] {
 		return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + string(req.SortBy.Order)}
 	}
+	if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
+		return domain.SearchChangeRequestsResponse{}, err
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -241,14 +241,14 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 		return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
 	}
 
-	for _, s := range req.Filters.StateKeys {
+	for _, s := range req.Filters.States {
 		if !validChangeRequestState[s] {
-			return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "stateKeys contains invalid value: " + string(s)}
+			return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "states contains invalid value: " + string(s)}
 		}
 	}
-	for _, i := range req.Filters.ImpactKeys {
+	for _, i := range req.Filters.Impacts {
 		if !validChangeRequestImpact[i] {
-			return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "impactKeys contains invalid value: " + string(i)}
+			return domain.SearchChangeRequestsResponse{}, &apierror.ValidationError{Msg: "impacts contains invalid value: " + string(i)}
 		}
 	}
 	if req.SortBy.Field != "" && !validChangeRequestSortField[req.SortBy.Field] {
@@ -277,8 +277,8 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 		Filters: snChangeRequestFilters{
 			ProjectIDs:      uuidsToSysids(req.Filters.ProjectIDs),
 			SearchQuery:     req.Filters.SearchQuery,
-			StateKeys:       domainCRStatesToSNIDs(req.Filters.StateKeys),
-			ImpactKeys:      domainCRImpactsToSNIDs(req.Filters.ImpactKeys),
+			StateKeys:       domainCRStatesToSNIDs(req.Filters.States),
+			ImpactKeys:      domainCRImpactsToSNIDs(req.Filters.Impacts),
 			ClosedStartDate: formatSNDate(req.Filters.ClosedStartDate),
 			ClosedEndDate:   formatSNDate(req.Filters.ClosedEndDate),
 		},

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -688,6 +688,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error.
           content:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1689,7 +1689,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CaseSearchView'
-        totalRecords:
+        total:
           type: integer
         offset:
           type: integer
@@ -1964,7 +1964,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SearchChangeRequestView'
-        totalRecords:
+        total:
           type: integer
         offset:
           type: integer

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -665,6 +665,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /change-requests/search:
+    post:
+      summary: Search change requests (ServiceNow data source only).
+      operationId: searchChangeRequests
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchChangeRequestsRequest'
+      responses:
+        "200":
+          description: Change requests matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchChangeRequestsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     Pagination:
@@ -1815,6 +1845,131 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    SearchChangeRequestsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+            searchQuery:
+              type: string
+            stateKeys:
+              type: array
+              items:
+                type: string
+                enum: [customer_approval, scheduled, implement, review, customer_review, rollback, closed, canceled]
+            impactKeys:
+              type: array
+              items:
+                type: string
+                enum: [high, medium, low]
+            closedStartDate:
+              type: string
+              format: date-time
+              description: "ISO-8601 UTC datetime (YYYY-MM-DDTHH:MM:SSZ)"
+            closedEndDate:
+              type: string
+              format: date-time
+              description: "ISO-8601 UTC datetime (YYYY-MM-DDTHH:MM:SSZ)"
+        sortBy:
+          type: object
+          required: [field, order]
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          type: object
+          properties:
+            offset:
+              type: integer
+              minimum: 0
+              default: 0
+            limit:
+              type: integer
+              minimum: 1
+              maximum: 100
+              default: 20
+
+    SearchChangeRequestView:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+        subject:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        project:
+          $ref: '#/components/schemas/EntityRef'
+        case:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        deployment:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        deployedProduct:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        product:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedEngineer:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTeam:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        plannedStartOn:
+          type: string
+          nullable: true
+        plannedEndOn:
+          type: string
+          nullable: true
+        duration:
+          type: string
+          nullable: true
+        impact:
+          type: string
+          description: Impact label (e.g. "high", "medium", "low").
+        state:
+          type: string
+          description: State label (e.g. "review", "closed").
+        type:
+          type: string
+          description: Type label (e.g. "standard", "normal").
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    SearchChangeRequestsResponse:
+      type: object
+      properties:
+        changeRequests:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchChangeRequestView'
+        totalRecords:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
 
     ErrorResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -318,8 +318,8 @@ paths:
     patch:
       summary: Update a support case.
       description: |
-        Updates exactly one field of the case. Provide exactly one of: `stateKey`, `severityKey`,
-        `workStateKey`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
+        `workState`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
         only when the ServiceNow data source is active.
       operationId: patchCase
       parameters:
@@ -1044,7 +1044,7 @@ components:
             type: string
             format: uuid
           description: Filter by project UUIDs.
-        deploymentTypeKeys:
+        deploymentTypes:
           type: array
           items:
             type: string
@@ -1183,24 +1183,24 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `stateKey`, `severityKey`, `workStateKey`, `watchList`, or `assigneeEmail` must be provided.
+        Exactly one of `state`, `severity`, `workState`, `watchList`, or `assigneeEmail` must be provided.
         `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
       oneOf:
-        - required: [stateKey]
-        - required: [severityKey]
-        - required: [workStateKey]
+        - required: [state]
+        - required: [severity]
+        - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
       properties:
-        stateKey:
+        state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
           description: The new state to transition the case to.
-        severityKey:
+        severity:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new severity of the case.
-        workStateKey:
+        workState:
           type: string
           enum: [ongoing, paused]
           description: The new work sub-state of the case. Only applicable when the case state is work_in_progress.
@@ -1273,9 +1273,9 @@ components:
 
     CreateCaseRequest:
       type: object
-      required: [typeKey, projectId, deploymentId, deployedProductId, subject, description, severityKey, issueTypeKey]
+      required: [type, projectId, deploymentId, deployedProductId, subject, description, severity, issueType]
       properties:
-        typeKey:
+        type:
           type: string
           enum: [support]
           description: |
@@ -1294,10 +1294,10 @@ components:
           type: string
         description:
           type: string
-        severityKey:
+        severity:
           type: string
           enum: [catastrophic, critical, high, medium, low]
-        issueTypeKey:
+        issueType:
           type: string
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
 
@@ -1326,7 +1326,7 @@ components:
     SearchCasesFilters:
       type: object
       properties:
-        typeKeys:
+        types:
           type: array
           items:
             type: string
@@ -1349,30 +1349,30 @@ components:
             type: string
             format: uuid
           description: Filter by deployment UUIDs.
-        stateKeys:
+        states:
           type: array
           items:
             type: string
             enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
           description: Filter by case states.
-        severityKeys:
+        severities:
           type: array
           items:
             type: string
             enum: [catastrophic, critical, high, medium, low]
-          description: Filter by severity. Only applicable when typeKeys includes support.
-        issueTypeKeys:
+          description: Filter by severity. Only applicable when types includes support.
+        issueTypes:
           type: array
           items:
             type: string
             enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
           description: Filter by issue type.
-        engagementTypeKeys:
+        engagementTypes:
           type: array
           items:
             type: string
             enum: [migration, consultancy, new_feature_improvement, follow_up, onboarding]
-          description: Filter by engagement type. Only applicable when typeKeys includes engagement.
+          description: Filter by engagement type. Only applicable when types includes engagement.
         closedStartDate:
           type: string
           format: date-time
@@ -1698,9 +1698,9 @@ components:
 
     CreateCaseCommentRequest:
       type: object
-      required: [typeKey, content]
+      required: [type, content]
       properties:
-        typeKey:
+        type:
           type: string
           enum: [work_note, comment, activity]
           description: work_note is restricted to internal users; activity to internal and system users.
@@ -1731,7 +1731,7 @@ components:
         filters:
           type: object
           properties:
-            typeKey:
+            type:
               type: string
               enum: [work_note, comment, activity]
         pagination:
@@ -1859,12 +1859,12 @@ components:
                 format: uuid
             searchQuery:
               type: string
-            stateKeys:
+            states:
               type: array
               items:
                 type: string
                 enum: [customer_approval, scheduled, implement, review, customer_review, rollback, closed, canceled]
-            impactKeys:
+            impacts:
               type: array
               items:
                 type: string


### PR DESCRIPTION
## Summary

- Add `POST /change-requests/search` endpoint backed by ServiceNow, following the same pattern as case search (domain types → service interface → SN service implementation → handler → route → OpenAPI spec)
- Standardise search response `total` field across all data sources (SN internal `totalRecords` mapped to domain `total`)
- Remove `Key`/`Keys` suffix from enum fields in request structs across domain, services, repositories, and OpenAPI spec (e.g. `StateKeys` → `States`, `TypeKey` → `Type`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added change-request search, including filtering, sorting, pagination, and result details.
  * Expanded API support for case searches, case comments, and deployment searches with updated field names.

* **Bug Fixes**
  * Standardized search totals to return `total` across responses.
  * Improved update and create flows to accept direct values like `state`, `severity`, `type`, and `issueType` instead of legacy field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->