### PR TITLE
[CSM Portal] case-type + assignee filters; align FE with BE field rename

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -185,14 +185,14 @@ export interface BeCaseView {
 
 export interface BeCaseCreatePayload {
   /** Case type. The portal only creates `support` cases. */
-  typeKey: "support";
+  type: "support";
   projectId: string;
   deploymentId: string;
   deployedProductId: string;
   subject: string;
   description: string;
-  severityKey: BeCaseSeverity;
-  issueTypeKey: BeCaseIssueType;
+  severity: BeCaseSeverity;
+  issueType: BeCaseIssueType;
 }
 
 /** The case summary embedded in the `POST /cases` success envelope. */
@@ -213,23 +213,23 @@ export interface BeCaseCreateResponse {
 
 /**
  * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
- * **Exactly one** of `stateKey` / `severityKey` / `workStateKey` /
+ * **Exactly one** of `state` / `severity` / `workState` /
  * `assigneeEmail` / `watchList` is sent per call — the backend rejects zero or
  * more than one. Encoded as a discriminated union (each variant `?: never`s the
  * others) so the exactly-one-field contract is enforced at compile time, not
  * just in docs. `assigneeEmail` and `watchList` are supported **only** for the
- * ServiceNow data source. `workStateKey` is only accepted while the case is
+ * ServiceNow data source. `workState` is only accepted while the case is
  * `work_in_progress`.
  */
 export type BeCaseUpdatePayload =
-  | { stateKey: BeCaseState; severityKey?: never; workStateKey?: never; assigneeEmail?: never; watchList?: never }
-  | { stateKey?: never; severityKey: BeCaseSeverity; workStateKey?: never; assigneeEmail?: never; watchList?: never }
+  | { state: BeCaseState; severity?: never; workState?: never; assigneeEmail?: never; watchList?: never }
+  | { state?: never; severity: BeCaseSeverity; workState?: never; assigneeEmail?: never; watchList?: never }
   /** Work sub-state toggle (`ongoing` / `paused`) for an in-progress case. */
-  | { stateKey?: never; severityKey?: never; workStateKey: BeCaseWorkState; assigneeEmail?: never; watchList?: never }
+  | { state?: never; severity?: never; workState: BeCaseWorkState; assigneeEmail?: never; watchList?: never }
   /** Email of the engineer to assign (ServiceNow only). */
-  | { stateKey?: never; severityKey?: never; workStateKey?: never; assigneeEmail: string; watchList?: never }
+  | { state?: never; severity?: never; workState?: never; assigneeEmail: string; watchList?: never }
   /** Full replacement watch list as emails (ServiceNow only). */
-  | { stateKey?: never; severityKey?: never; workStateKey?: never; assigneeEmail?: never; watchList: string[] };
+  | { state?: never; severity?: never; workState?: never; assigneeEmail?: never; watchList: string[] };
 
 /** A user in the case watch list, as echoed by `PATCH /cases/{id}`. */
 export interface BeWatchListUser {
@@ -265,10 +265,10 @@ export interface BeCaseSearchFilters {
   /** Optional project filter; omit for a cross-project search. */
   projectIds?: string[];
   deploymentIds?: string[];
-  typeKeys?: BeCaseType[];
-  stateKeys?: BeCaseState[];
-  severityKeys?: BeCaseSeverity[];
-  issueTypeKeys?: BeCaseIssueType[];
+  types?: BeCaseType[];
+  states?: BeCaseState[];
+  severities?: BeCaseSeverity[];
+  issueTypes?: BeCaseIssueType[];
   /** Filter to cases created by these emails. */
   createdBy?: string[];
   /** When true, the caller's email (from the JWT) is appended to `createdBy`. */
@@ -306,16 +306,13 @@ export interface BeCaseSearchView {
   /** Project-scoped WSO2 case reference (customer portal calls this the same). */
   internalId?: string;
   /**
-   * Case title. NOTE: the search response uses `title` (not `subject` like the
-   * `GET /cases/{id}` CaseView) — a backend naming inconsistency. The BFF
-   * openapi documents this as `subject`, but the entity returns `title`.
+   * Case subject. The search response now returns `subject`, matching the
+   * `GET /cases/{id}` CaseView (the earlier `title` naming inconsistency is gone).
    */
-  title?: string;
+  subject?: string;
   description?: string;
   severity?: BeCaseSeverity;
   issueType?: BeCaseIssueType;
-  /** Case type (entity `caseType` on the search view). */
-  caseType?: BeCaseType;
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
@@ -553,7 +550,7 @@ export interface BeDeploymentSearchPayload {
   pagination?: BePagination;
   searchQuery?: string;
   projectIds?: string[];
-  deploymentTypeKeys?: BeDeploymentType[];
+  deploymentTypes?: BeDeploymentType[];
 }
 
 export interface BeDeploymentSearchResponse extends BeSearchResponseBase {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -273,6 +273,15 @@ export interface BeCaseSearchFilters {
   createdBy?: string[];
   /** When true, the caller's email (from the JWT) is appended to `createdBy`. */
   createdByMe?: boolean;
+  /**
+   * Filter to cases assigned to these engineer emails. Mirrors the
+   * `createdBy`/`createdByMe` pair for the assigned engineer rather than the
+   * reporter. NOTE: pending backend support on `/cases/search` — the FE sends
+   * it so the assignee filter works the moment the entity/BFF add it.
+   */
+  assignedTo?: string[];
+  /** When true, the caller's email (from the JWT) is appended to `assignedTo`. */
+  assignedToMe?: boolean;
 }
 
 export interface BeCaseSearchPayload {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -273,15 +273,9 @@ export interface BeCaseSearchFilters {
   createdBy?: string[];
   /** When true, the caller's email (from the JWT) is appended to `createdBy`. */
   createdByMe?: boolean;
-  /**
-   * Filter to cases assigned to these engineer emails. Mirrors the
-   * `createdBy`/`createdByMe` pair for the assigned engineer rather than the
-   * reporter. NOTE: pending backend support on `/cases/search` — the FE sends
-   * it so the assignee filter works the moment the entity/BFF add it.
-   */
-  assignedTo?: string[];
-  /** When true, the caller's email (from the JWT) is appended to `assignedTo`. */
-  assignedToMe?: boolean;
+  // NOTE: there is no assigned-engineer filter here yet. The cases-list
+  // assignee control is disabled until the entity/BFF add one (e.g.
+  // `assignedTo`/`assignedToMe`, mirroring `createdBy`/`createdByMe`).
 }
 
 export interface BeCaseSearchPayload {

--- a/apps/csm-portal/webapp/src/api/useDirectoryUsers.ts
+++ b/apps/csm-portal/webapp/src/api/useDirectoryUsers.ts
@@ -61,7 +61,10 @@ export function useDirectoryUsers(): UseQueryResult<DirectoryUser[], Error> {
       const rows: RawDirectoryUser[] = Array.isArray(res)
         ? (res as RawDirectoryUser[])
         : ((res as { users?: RawDirectoryUser[] })?.users ?? []);
-      return rows.map(toDirectoryUser).filter((u) => u.name);
+      // Require both name (the option label) and email (the value the assignee
+      // filter sends as `assignedTo`) — a name-only user would yield an empty,
+      // invalid filter value.
+      return rows.map(toDirectoryUser).filter((u) => u.name && u.email);
     },
     staleTime: 30_000,
   });

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
@@ -17,6 +17,7 @@
 import { useCallback } from "react";
 import { useBackendApi } from "@api/backend/client";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import type {
   BeCaseSearchPayload,
   BeCaseSearchResponse,
@@ -34,7 +35,8 @@ export interface MyOngoingCase {
 // work_in_progress set is cross-customer, so page through it rather than
 // inspecting only the first page — otherwise the caller's ongoing case could
 // sit beyond the first page and the single-active-case guard would miss it.
-const SEARCH_LIMIT = 100;
+// Page size = the BE's max (requests above it are rejected).
+const SEARCH_LIMIT = BE_MAX_PAGE_LIMIT;
 // Safety bound on the scan (pages * limit) so a pathological dataset can't spin
 // this on-demand check forever.
 const MAX_PAGES = 20;

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
@@ -42,7 +42,7 @@ const SEARCH_LIMIT = 50;
  * when starting work on a case.
  *
  * Because the search endpoint exposes neither an assignee nor a work-state
- * filter, this narrows by `stateKeys: [work_in_progress]` server-side and then
+ * filter, this narrows by `states: [work_in_progress]` server-side and then
  * matches `assignedEngineer.email` against the JWT email and `workState ===
  * "ongoing"` client-side (a `null` workState is never ongoing).
  */
@@ -60,7 +60,7 @@ export function useFindMyOngoingCases(): (
       const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
         "/cases/search",
         {
-          filters: { stateKeys: ["work_in_progress"] },
+          filters: { states: ["work_in_progress"] },
           pagination: { offset: 0, limit: SEARCH_LIMIT },
         },
       );
@@ -75,7 +75,7 @@ export function useFindMyOngoingCases(): (
         )
         .map((c) => ({
           id: c.id,
-          label: c.internalId || c.number || c.title || c.id,
+          label: c.internalId || c.number || c.subject || c.id,
         }));
     },
     [api, myEmail],

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useFindMyOngoingCases.ts
@@ -30,10 +30,14 @@ export interface MyOngoingCase {
 }
 
 // The case-search API has no assignee or work-state filter, so we narrow by
-// state on the server and match assignee + ongoing on the client. Cap the page
-// at a sane size: an engineer should have very few in-progress cases, and we
-// only need to know whether *another* ongoing one exists.
-const SEARCH_LIMIT = 50;
+// state on the server and match assignee + ongoing on the client. The
+// work_in_progress set is cross-customer, so page through it rather than
+// inspecting only the first page — otherwise the caller's ongoing case could
+// sit beyond the first page and the single-active-case guard would miss it.
+const SEARCH_LIMIT = 100;
+// Safety bound on the scan (pages * limit) so a pathological dataset can't spin
+// this on-demand check forever.
+const MAX_PAGES = 20;
 
 /**
  * Returns a function that finds the **other** cases the signed-in engineer is
@@ -57,26 +61,32 @@ export function useFindMyOngoingCases(): (
       // Without our email we can't tell which cases are ours; skip the prompt.
       if (!myEmail) return [];
 
-      const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
-        "/cases/search",
-        {
-          filters: { states: ["work_in_progress"] },
-          pagination: { offset: 0, limit: SEARCH_LIMIT },
-        },
-      );
-
-      return (res.cases ?? [])
-        .filter(
-          (c) =>
+      const matches: MyOngoingCase[] = [];
+      for (let page = 0; page < MAX_PAGES; page += 1) {
+        const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+          "/cases/search",
+          {
+            filters: { states: ["work_in_progress"] },
+            pagination: { offset: page * SEARCH_LIMIT, limit: SEARCH_LIMIT },
+          },
+        );
+        const rows = res.cases ?? [];
+        for (const c of rows) {
+          if (
             c.id !== excludeCaseId &&
             // A null/absent workState is never "ongoing".
             c.workState === "ongoing" &&
-            c.assignedEngineer?.email?.toLowerCase() === myEmail,
-        )
-        .map((c) => ({
-          id: c.id,
-          label: c.internalId || c.number || c.subject || c.id,
-        }));
+            c.assignedEngineer?.email?.toLowerCase() === myEmail
+          ) {
+            matches.push({
+              id: c.id,
+              label: c.internalId || c.number || c.subject || c.id,
+            });
+          }
+        }
+        if (rows.length < SEARCH_LIMIT || !(res.hasMore ?? false)) break;
+      }
+      return matches;
     },
     [api, myEmail],
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -98,8 +98,8 @@ function accountOptionsQueryOptions(api: BackendApi) {
  * cases page already mounts for its filter options.
  *
  * Search and the severity / state / case-type / project / assignee filters are
- * pushed into the search payload (searchQuery / severityKeys / stateKeys /
- * typeKeys / projectIds / assignedTo / assignedToMe) and the BE
+ * pushed into the search payload (searchQuery / severities / states /
+ * types / projectIds / assignedTo / assignedToMe) and the BE
  * paginates the result (`pagination` → `total` / `limit` / `offset` /
  * `hasMore`).
  *
@@ -158,13 +158,13 @@ export function useGetCsmCases(
           filters: {
             ...(search.length > 0 && { searchQuery: search }),
             ...(filters.severities.length > 0 && {
-              severityKeys: filters.severities.map(priorityFromSeverity),
+              severities: filters.severities.map(priorityFromSeverity),
             }),
             ...(filters.states.length > 0 && {
-              stateKeys: filters.states.map(beStateFromUi),
+              states: filters.states.map(beStateFromUi),
             }),
             ...(filters.caseTypes.length > 0 && {
-              typeKeys: filters.caseTypes,
+              types: filters.caseTypes,
             }),
             // `filters.projects` holds project IDs (the filter is id-based).
             ...(filters.projects.length > 0 && {
@@ -214,8 +214,7 @@ export function useGetCsmCases(
           id: c.id,
           caseNumber: c.number,
           wso2CaseId: c.internalId,
-          // Search returns the title under `title` (the GET view uses `subject`).
-          subject: c.title ?? "(no subject)",
+          subject: c.subject ?? "(no subject)",
           customer: accountName.get(accountId) ?? "—",
           accountId,
           projectId,
@@ -225,7 +224,6 @@ export function useGetCsmCases(
           product: c.deployedProduct?.name ?? "—",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
-          caseType: c.caseType,
           workState: c.workState ?? null,
           assignee,
           assigneeIsMe,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -37,7 +37,10 @@ import type {
   BeCaseSearchPayload,
   BeCaseSearchResponse,
 } from "@api/backend/types";
-import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import {
+  ASSIGNEE_ME_TOKEN,
+  type CasesFilters,
+} from "@features/csm-cases/components/CasesFilterBar";
 import type {
   CsmCaseRow,
   CsmCasesListResponse,
@@ -94,8 +97,9 @@ function accountOptionsQueryOptions(api: BackendApi) {
  * go stale. The project lookup shares `useProjectOptions`' key, which the
  * cases page already mounts for its filter options.
  *
- * Search and the severity / state / project filters are pushed into the search
- * payload (searchQuery / severityKeys / stateKeys / projectIds) and the BE
+ * Search and the severity / state / case-type / project / assignee filters are
+ * pushed into the search payload (searchQuery / severityKeys / stateKeys /
+ * typeKeys / projectIds / assignedTo / assignedToMe) and the BE
  * paginates the result (`pagination` → `total` / `limit` / `offset` /
  * `hasMore`).
  *
@@ -119,6 +123,11 @@ export function useGetCsmCases(
 
   const offset = page * pageSize;
   const search = filters.search.trim();
+  // The assignee filter stores engineer emails plus the `@me` sentinel; `@me`
+  // maps to `assignedToMe` (the BE resolves the caller), the rest to
+  // `assignedTo`. Mirrors the createdBy / createdByMe split.
+  const assignedToMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
+  const assignedTo = filters.assignees.filter((a) => a !== ASSIGNEE_ME_TOKEN);
 
   return useQuery<CsmCasesListResponse, Error>({
     // Sort the array filters so selection order doesn't fragment the cache
@@ -128,6 +137,7 @@ export function useGetCsmCases(
       search,
       [...filters.severities].sort(),
       [...filters.states].sort(),
+      [...filters.caseTypes].sort(),
       [...filters.projects].sort(),
       [...filters.assignees].sort(),
       currentUserEmail ?? "",
@@ -153,10 +163,17 @@ export function useGetCsmCases(
             ...(filters.states.length > 0 && {
               stateKeys: filters.states.map(beStateFromUi),
             }),
+            ...(filters.caseTypes.length > 0 && {
+              typeKeys: filters.caseTypes,
+            }),
             // `filters.projects` holds project IDs (the filter is id-based).
             ...(filters.projects.length > 0 && {
               projectIds: filters.projects,
             }),
+            // Assignee filter (assigned engineer, by email). Pending BE support
+            // on `/cases/search`; see BeCaseSearchFilters.assignedTo.
+            ...(assignedTo.length > 0 && { assignedTo }),
+            ...(assignedToMe && { assignedToMe: true }),
           },
         }),
         queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {
@@ -208,6 +225,7 @@ export function useGetCsmCases(
           product: c.deployedProduct?.name ?? "—",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
+          caseType: c.caseType,
           workState: c.workState ?? null,
           assignee,
           assigneeIsMe,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -37,10 +37,7 @@ import type {
   BeCaseSearchPayload,
   BeCaseSearchResponse,
 } from "@api/backend/types";
-import {
-  ASSIGNEE_ME_TOKEN,
-  type CasesFilters,
-} from "@features/csm-cases/components/CasesFilterBar";
+import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import type {
   CsmCaseRow,
   CsmCasesListResponse,
@@ -97,11 +94,10 @@ function accountOptionsQueryOptions(api: BackendApi) {
  * go stale. The project lookup shares `useProjectOptions`' key, which the
  * cases page already mounts for its filter options.
  *
- * Search and the severity / state / case-type / project / assignee filters are
- * pushed into the search payload (searchQuery / severities / states /
- * types / projectIds / assignedTo / assignedToMe) and the BE
- * paginates the result (`pagination` → `total` / `limit` / `offset` /
- * `hasMore`).
+ * Search and the severity / state / case-type / project filters are pushed
+ * into the search payload (searchQuery / severities / states / types /
+ * projectIds) and the BE paginates the result (`pagination` → `total` /
+ * `limit` / `offset` / `hasMore`).
  *
  * `page` is zero-based (matching MUI `TablePagination`); `pageSize` is the row
  * limit (≤ {@link BE_MAX_PAGE_LIMIT}). With no filters the backend sorts by
@@ -123,15 +119,11 @@ export function useGetCsmCases(
 
   const offset = page * pageSize;
   const search = filters.search.trim();
-  // The assignee filter stores engineer emails plus the `@me` sentinel; `@me`
-  // maps to `assignedToMe` (the BE resolves the caller), the rest to
-  // `assignedTo`. Mirrors the createdBy / createdByMe split.
-  const assignedToMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
-  const assignedTo = filters.assignees.filter((a) => a !== ASSIGNEE_ME_TOKEN);
 
   return useQuery<CsmCasesListResponse, Error>({
     // Sort the array filters so selection order doesn't fragment the cache
-    // (["S1","S2"] and ["S2","S1"] are the same query).
+    // (["S1","S2"] and ["S2","S1"] are the same query). `assignees` is omitted:
+    // the assignee filter is disabled and not sent, so it never changes results.
     queryKey: [
       ApiQueryKeys.CSM_CASES,
       search,
@@ -139,7 +131,6 @@ export function useGetCsmCases(
       [...filters.states].sort(),
       [...filters.caseTypes].sort(),
       [...filters.projects].sort(),
-      [...filters.assignees].sort(),
       currentUserEmail ?? "",
       page,
       pageSize,
@@ -170,10 +161,8 @@ export function useGetCsmCases(
             ...(filters.projects.length > 0 && {
               projectIds: filters.projects,
             }),
-            // Assignee filter (assigned engineer, by email). Pending BE support
-            // on `/cases/search`; see BeCaseSearchFilters.assignedTo.
-            ...(assignedTo.length > 0 && { assignedTo }),
-            ...(assignedToMe && { assignedToMe: true }),
+            // No assignee filter: `/cases/search` has no assigned-engineer
+            // filter yet, so the (disabled) assignee control sends nothing.
           },
         }),
         queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -69,7 +69,7 @@ export function useQuickCaseSearch(
         id: c.id,
         caseNumber: c.number,
         wso2CaseId: c.internalId,
-        subject: c.title ?? "(no subject)",
+        subject: c.subject ?? "(no subject)",
       }));
     },
     enabled: q.length >= QUICK_CASE_MIN_QUERY_LEN,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -70,33 +70,38 @@ import {
   SUGGESTED_FILTER_VIEWS,
   useSavedFilterViews,
 } from "@features/csm-cases/utils/savedFilterViews";
+import type { BeCaseType } from "@api/backend/types";
+import {
+  ALL_CASE_TYPES,
+  CASE_TYPE_LABEL,
+} from "@features/csm-cases/utils/caseType";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 
 /** Sentinel used inside `assignees` to mean "the current user". */
 export const ASSIGNEE_ME_TOKEN = "@me";
-/** Literal assignee name used in mock data for unassigned cases. */
-export const ASSIGNEE_UNASSIGNED = "Unassigned";
 
 /**
- * Filter state for the CSM cases list. `severities` / `states` are multi-select
- * arrays driven by fixed enums. `assignees` / `projects` are free-form
- * multi-selects driven by an Autocomplete with type-to-filter: options are
- * derived from the data currently in scope. The `assignees` list accepts the
- * sentinel `@me` (resolves against `assigneeIsMe`) and the literal
- * "Unassigned"; any other entries are matched against `case.assignee` by name.
+ * Filter state for the CSM cases list. `severities` / `states` / `caseTypes`
+ * are multi-select arrays driven by fixed enums; `projects` is an id-based
+ * type-to-search multi-select. `assignees` holds engineer **emails** (the
+ * stable identity the backend filters on) plus the sentinel `@me` (resolves to
+ * the caller via `assignedToMe`). All are pushed into the `/cases/search`
+ * payload server-side.
  */
 export interface CasesFilters {
   search: string;
   severities: Severity[];
   states: CaseState[];
+  /** Case-type filter (BE `typeKeys`). Empty = all types. */
+  caseTypes: BeCaseType[];
+  /** Engineer emails (+ the `@me` sentinel) to filter by assigned engineer. */
   assignees: string[];
   projects: string[];
 }
 
 /**
- * Lightweight user directory entry surfaced in the assignee picker. The
- * filter still stores assignees as bare name strings (plus the `@me` /
- * "Unassigned" sentinels) — `email` is only used for richer rendering.
+ * Lightweight user-directory entry surfaced in the assignee picker. The filter
+ * stores the `email` as the value; the `name` is shown as the option label.
  */
 export interface AssigneeUser {
   name: string;
@@ -124,10 +129,6 @@ const PRIMARY_STATES: CaseState[] = [
   "waiting_on_wso2",
   "closed",
 ];
-/** Pretty-print an assignee value (handle the @me sentinel). */
-function assigneeLabel(value: string): string {
-  return value === ASSIGNEE_ME_TOKEN ? "Me" : value;
-}
 
 interface MultiSelectFieldProps<T extends string> {
   id: string;
@@ -357,6 +358,10 @@ export default function CasesFilterBar({
     () => PRIMARY_STATES.map((s) => ({ value: s, label: STATE_LABEL[s] })),
     [],
   );
+  const caseTypeOptions = useMemo(
+    () => ALL_CASE_TYPES.map((t) => ({ value: t, label: CASE_TYPE_LABEL[t] })),
+    [],
+  );
 
   // Project filter loads the first page of projects on open and pages through
   // the rest on scroll (and narrows as you type) rather than loading the whole
@@ -367,36 +372,40 @@ export default function CasesFilterBar({
     [availableProjects],
   );
 
-  // Pin "@me" and "Unassigned" to the top of the assignee option list, then
-  // every user from the directory (sorted by name, deduped). Pulling from
+  // Assignee options are engineer EMAILS (the value the backend filters on),
+  // pinned after the "@me" sentinel and ordered by display name. Pulling from
   // the user directory rather than only the owners present in loaded cases
   // means typing a name finds anyone, not just people who happen to own one
   // of the currently-listed cases.
-  const assigneeOptions = useMemo(() => {
-    const names = Array.from(
-      new Set(availableAssigneeUsers.map((u) => u.name).filter(Boolean)),
-    ).sort();
-    return [ASSIGNEE_ME_TOKEN, ASSIGNEE_UNASSIGNED, ...names];
-  }, [availableAssigneeUsers]);
-
-  const emailByName = useMemo(() => {
+  const nameByEmail = useMemo(() => {
     const m = new Map<string, string>();
     availableAssigneeUsers.forEach((u) => {
-      if (u.name) m.set(u.name, u.email);
+      if (u.email) m.set(u.email, u.name);
     });
     return m;
   }, [availableAssigneeUsers]);
 
-  const assigneeSecondary = (value: string): string | undefined => {
-    if (value === ASSIGNEE_ME_TOKEN || value === ASSIGNEE_UNASSIGNED) return undefined;
-    return emailByName.get(value);
-  };
+  const assigneeOptions = useMemo(() => {
+    const emails = Array.from(
+      new Set(availableAssigneeUsers.map((u) => u.email).filter(Boolean)),
+    ).sort((a, b) =>
+      (nameByEmail.get(a) ?? a).localeCompare(nameByEmail.get(b) ?? b),
+    );
+    return [ASSIGNEE_ME_TOKEN, ...emails];
+  }, [availableAssigneeUsers, nameByEmail]);
 
-  const assigneeSearchText = (value: string): string => {
-    const label = assigneeLabel(value);
-    const email = emailByName.get(value);
-    return email ? `${label} ${email}` : label;
-  };
+  // Label an assignee value: the @me sentinel reads "Me"; an email resolves to
+  // the engineer's display name (falling back to the raw email).
+  const formatAssignee = (value: string): string =>
+    value === ASSIGNEE_ME_TOKEN ? "Me" : (nameByEmail.get(value) ?? value);
+
+  const assigneeSecondary = (value: string): string | undefined =>
+    value === ASSIGNEE_ME_TOKEN ? undefined : value;
+
+  const assigneeSearchText = (value: string): string =>
+    value === ASSIGNEE_ME_TOKEN
+      ? "Me"
+      : `${nameByEmail.get(value) ?? ""} ${value}`.trim();
 
   return (
     <Paper sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
@@ -571,8 +580,8 @@ export default function CasesFilterBar({
         </DialogActions>
       </Dialog>
 
-      {/* Collapsible filter grid. Severity / state stay as fixed multi-selects;
-          assignee / project are type-to-search Autocompletes. */}
+      {/* Collapsible filter grid. Severity / state / case type are fixed
+          multi-selects; assignee / project are type-to-search Autocompletes. */}
       {isFiltersOpen && (
         <>
           <Divider />
@@ -596,27 +605,28 @@ export default function CasesFilterBar({
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Static option list for now. Once the backend supports assignee
-                  search/filtering, switch this to a type-ahead like
-                  AsyncProjectMultiSelect rather than loading every user. */}
-              <Tooltip title="Assignee filtering is coming soon.">
-                <Box>
-                  <SearchableMultiSelect
-                    id="cases-filter-assignee"
-                    label="Assignee"
-                    placeholder="Search users…"
-                    values={filters.assignees}
-                    options={assigneeOptions}
-                    formatOption={assigneeLabel}
-                    getOptionSecondary={assigneeSecondary}
-                    getOptionSearchText={assigneeSearchText}
-                    onChange={(next) =>
-                      onChange({ ...filters, assignees: next })
-                    }
-                    disabled
-                  />
-                </Box>
-              </Tooltip>
+              <MultiSelectField
+                id="cases-filter-type"
+                label="Case type"
+                values={filters.caseTypes}
+                options={caseTypeOptions}
+                onChange={(next) => onChange({ ...filters, caseTypes: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              {/* Options are engineer emails labelled by name; `@me` resolves to
+                  the caller server-side via `assignedToMe`. */}
+              <SearchableMultiSelect
+                id="cases-filter-assignee"
+                label="Assignee"
+                placeholder="Search engineers…"
+                values={filters.assignees}
+                options={assigneeOptions}
+                formatOption={formatAssignee}
+                getOptionSecondary={assigneeSecondary}
+                getOptionSearchText={assigneeSearchText}
+                onChange={(next) => onChange({ ...filters, assignees: next })}
+              />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
               <AsyncProjectMultiSelect

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -614,19 +614,29 @@ export default function CasesFilterBar({
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Options are engineer emails labelled by name; `@me` resolves to
-                  the caller server-side via `assignedToMe`. */}
-              <SearchableMultiSelect
-                id="cases-filter-assignee"
-                label="Assignee"
-                placeholder="Search engineers…"
-                values={filters.assignees}
-                options={assigneeOptions}
-                formatOption={formatAssignee}
-                getOptionSecondary={assigneeSecondary}
-                getOptionSearchText={assigneeSearchText}
-                onChange={(next) => onChange({ ...filters, assignees: next })}
-              />
+              {/* Disabled until the backend `/cases/search` supports an
+                  assigned-engineer filter. The picker is email-backed and ready
+                  to enable (options labelled by name, `@me` sentinel); the hook
+                  does NOT send any assignee field meanwhile, so the search is
+                  never broken. */}
+              <Tooltip title="Assignee filtering is coming soon.">
+                <Box>
+                  <SearchableMultiSelect
+                    id="cases-filter-assignee"
+                    label="Assignee"
+                    placeholder="Search engineers…"
+                    values={filters.assignees}
+                    options={assigneeOptions}
+                    formatOption={formatAssignee}
+                    getOptionSecondary={assigneeSecondary}
+                    getOptionSearchText={assigneeSearchText}
+                    onChange={(next) =>
+                      onChange({ ...filters, assignees: next })
+                    }
+                    disabled
+                  />
+                </Box>
+              </Tooltip>
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
               <AsyncProjectMultiSelect

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -166,14 +166,14 @@ export default function CsmCaseCreatePage(): JSX.Element {
     if (!canSubmit || !severity || !issueType || descriptionOverLimit) return;
     postCase.mutate(
       {
-        typeKey: "support",
+        type: "support",
         projectId,
         deploymentId,
         deployedProductId,
         subject: subject.trim(),
         description,
-        severityKey: priorityFromSeverity(severity),
-        issueTypeKey: issueType,
+        severity: priorityFromSeverity(severity),
+        issueType: issueType,
       },
       {
         onSuccess: (created) => navigate(`/cases/${created.id}`),

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -404,7 +404,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               return;
             }
             try {
-              await patchCase.mutateAsync({ stateKey: "work_in_progress" });
+              await patchCase.mutateAsync({ state: "work_in_progress" });
             } catch (err) {
               showError(
                 "Could not move the case to Work in progress. Please try again.",
@@ -415,7 +415,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             if (others.length === 0) {
               // No competing case → make this the active (ongoing) one.
               try {
-                await patchCase.mutateAsync({ workStateKey: "ongoing" });
+                await patchCase.mutateAsync({ workState: "ongoing" });
               } catch (err) {
                 showError(
                   "Moved to Work in progress, but could not mark it ongoing.",
@@ -440,7 +440,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           // Real state transition via PATCH /cases/{id}; the detail + list
           // queries refetch on success so the new state shows.
           patchCase.mutate(
-            { stateKey: targetState },
+            { state: targetState },
             {
               onSuccess: () =>
                 setFeedback({
@@ -474,7 +474,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
-      // Pause / resume the work sub-state via PATCH { workStateKey }. Only for an
+      // Pause / resume the work sub-state via PATCH { workState }. Only for an
       // in-progress case assigned to the current user. Pausing is a direct
       // single-field patch. Resuming sets this case `ongoing`, so it runs the
       // same single-active-case conflict check as starting work — otherwise an
@@ -486,7 +486,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
         if (!resuming) {
           patchCase.mutate(
-            { workStateKey: "paused" },
+            { workState: "paused" },
             {
               onSuccess: () =>
                 setFeedback({
@@ -521,7 +521,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           }
           if (others.length === 0) {
             try {
-              await patchCase.mutateAsync({ workStateKey: "ongoing" });
+              await patchCase.mutateAsync({ workState: "ongoing" });
             } catch (err) {
               showError(
                 "Could not resume work on this case. Please try again.",
@@ -581,9 +581,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
     setPauseConflict(null);
     try {
       for (const o of others) {
-        await patchCaseById(o.id, { workStateKey: "paused" });
+        await patchCaseById(o.id, { workState: "paused" });
       }
-      await patchCase.mutateAsync({ workStateKey: "ongoing" });
+      await patchCase.mutateAsync({ workState: "ongoing" });
       setFeedback({
         message:
           others.length === 1

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -20,6 +20,7 @@ import type {
   Severity,
   SlaClockType,
 } from "@features/csm-dashboard/types/abtDashboard";
+import type { BeCaseType } from "@api/backend/types";
 
 export interface CsmCaseRow {
   /**
@@ -50,6 +51,11 @@ export interface CsmCaseRow {
   product: string;
   severity: Severity;
   state: CaseState;
+  /**
+   * Case type (BE `typeKey` / search `caseType`). Optional: a legacy row may
+   * omit it, in which case the type filter treats it as unmatched.
+   */
+  caseType?: BeCaseType;
   /**
    * Work sub-state of an in-progress case (`ongoing` / `paused`); `null` when
    * the case is not `work_in_progress`. Drives the comment gate and the paused

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseType.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseType.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeCaseType } from "@api/backend/types";
+
+// Single source of truth for case-type ordering and labels. Lives in its own
+// (backend-client-free) module so both the filter bar and the pure URL
+// serializer can share it without dragging the API client into a unit test or
+// tripping the react-refresh "components-only export" rule.
+
+/** All case types, in the order they appear in the type dropdown. */
+export const ALL_CASE_TYPES: BeCaseType[] = [
+  "support",
+  "service_request",
+  "security_report_analysis",
+  "announcement",
+  "engagement",
+];
+
+/** Human-readable label per case type. */
+export const CASE_TYPE_LABEL: Record<BeCaseType, string> = {
+  support: "Support",
+  service_request: "Service request",
+  security_report_analysis: "Security report",
+  announcement: "Announcement",
+  engagement: "Engagement",
+};

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -32,24 +32,26 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "q=timeout&severities=S0,S2&states=open,closed&assignees=alice,bob&projects=apim",
+      "q=timeout&severities=S0,S2&states=open,closed&types=support,engagement&assignees=alice@example.com,@me&projects=apim",
     );
     expect(readCasesFiltersFromUrl(params)).toEqual({
       search: "timeout",
       severities: ["S0", "S2"],
       states: ["open", "closed"],
-      assignees: ["alice", "bob"],
+      caseTypes: ["support", "engagement"],
+      assignees: ["alice@example.com", "@me"],
       projects: ["apim"],
     });
   });
 
   it("drops values outside the allowed enums", () => {
     const params = new URLSearchParams(
-      "severities=S0,S9,wat&states=open,nonsense",
+      "severities=S0,S9,wat&states=open,nonsense&types=support,bogus_type",
     );
     const f = readCasesFiltersFromUrl(params);
     expect(f.severities).toEqual(["S0"]);
     expect(f.states).toEqual(["open"]);
+    expect(f.caseTypes).toEqual(["support"]);
   });
 
   it("strips empties and over-long free-form entries", () => {
@@ -70,7 +72,8 @@ describe("writeCasesFiltersToUrl", () => {
       search: "disk full",
       severities: ["S1"],
       states: ["work_in_progress"],
-      assignees: ["carol"],
+      caseTypes: ["service_request"],
+      assignees: ["carol@example.com"],
       projects: ["streaming"],
     };
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -18,12 +18,15 @@ import type {
   CaseState,
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
+import type { BeCaseType } from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
 
 export const DEFAULT_CASES_FILTERS: CasesFilters = {
   search: "",
   severities: [],
   states: [],
+  caseTypes: [],
   assignees: [],
   projects: [],
 };
@@ -37,6 +40,7 @@ const VALID_STATES: CaseState[] = [
   "waiting_on_wso2",
   "closed",
 ];
+const VALID_CASE_TYPES: BeCaseType[] = ALL_CASE_TYPES;
 
 function parseCsv<T extends string>(raw: string | null, allowed: T[]): T[] {
   if (!raw) return [];
@@ -47,9 +51,9 @@ function parseCsv<T extends string>(raw: string | null, allowed: T[]): T[] {
 }
 
 /**
- * Parse a CSV of free-form strings (used for assignee / project / product
- * names that aren't part of a fixed enum). Empties stripped, length-capped
- * per entry to avoid pathological URL growth.
+ * Parse a CSV of free-form strings (used for assignee / project values that
+ * aren't part of a fixed enum). Empties stripped, length-capped per entry to
+ * avoid pathological URL growth.
  */
 function parseFreeFormCsv(raw: string | null, maxEntryLen = 120): string[] {
   if (!raw) return [];
@@ -66,6 +70,7 @@ export function readCasesFiltersFromUrl(
     search: params.get("q") ?? "",
     severities: parseCsv(params.get("severities"), VALID_SEVERITIES),
     states: parseCsv(params.get("states"), VALID_STATES),
+    caseTypes: parseCsv(params.get("types"), VALID_CASE_TYPES),
     assignees: parseFreeFormCsv(params.get("assignees")),
     projects: parseFreeFormCsv(params.get("projects")),
   };
@@ -80,6 +85,7 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   if (f.search) out.set("q", f.search);
   if (f.severities.length) out.set("severities", f.severities.join(","));
   if (f.states.length) out.set("states", f.states.join(","));
+  if (f.caseTypes.length) out.set("types", f.caseTypes.join(","));
   if (f.assignees.length) out.set("assignees", f.assignees.join(","));
   if (f.projects.length) out.set("projects", f.projects.join(","));
   return out;
@@ -96,6 +102,7 @@ export function countActiveFilters(f: CasesFilters): number {
   if (f.search.trim()) n += 1;
   if (f.severities.length) n += 1;
   if (f.states.length) n += 1;
+  if (f.caseTypes.length) n += 1;
   if (f.assignees.length) n += 1;
   if (f.projects.length) n += 1;
   return n;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -103,8 +103,8 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             countTotal({
               pagination: { offset: 0, limit: 1 },
               filters: {
-                severityKeys: [priorityFromSeverity(sev)],
-                stateKeys: activeStateKeys,
+                severities: [priorityFromSeverity(sev)],
+                states: activeStateKeys,
               },
             }).then((n) => ({ key: sev, n })),
           ),
@@ -114,8 +114,8 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
             countTotal({
               pagination: { offset: 0, limit: 1 },
               filters: {
-                stateKeys: [beStateFromUi(st)],
-                severityKeys: allPriorityKeys,
+                states: [beStateFromUi(st)],
+                severities: allPriorityKeys,
               },
             }).then((n) => ({ key: st, n })),
           ),
@@ -123,8 +123,8 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
         countTotal({
           pagination: { offset: 0, limit: 1 },
           filters: {
-            stateKeys: [beStateFromUi("closed")],
-            severityKeys: allPriorityKeys,
+            states: [beStateFromUi("closed")],
+            severities: allPriorityKeys,
           },
         }),
       ]);

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -94,8 +94,8 @@ export function useCaseCountsMatrix(): UseQueryResult<CaseCountsMatrix, Error> {
             .post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
               pagination: { offset: 0, limit: 1 },
               filters: {
-                severityKeys: [priorityFromSeverity(severity)],
-                stateKeys: [beStateFromUi(state)],
+                severities: [priorityFromSeverity(severity)],
+                states: [beStateFromUi(state)],
               },
             })
             .then((res) => ({ severity, state, count: res.total ?? 0 })),


### PR DESCRIPTION
Stacked on the merged mock-removal work; rebased onto current `v2`.

## 1. Case-type + assignee filters
- **Case type** — multi-select wired to `/cases/search` `types`, URL param `types`.
- **Assignee** — email-based engineer picker + `@me`. **Disabled** ("coming soon") and **not sent** (no `/cases/search` assignee filter yet), so it can't break the search. Built to enable in one flip once the BE adds it.

## 2. Align FE with the BE Key/Keys rename (entity PR #929 / BFF #933)
- search filters `severityKeys→severities`, `stateKeys→states`, `typeKeys→types`; response `title→subject`; `POST /cases` `typeKey→type`, `severityKey→severity`, `issueTypeKey→issueType`; `PATCH /cases/{id}` `stateKey→state`/`severityKey→severity`/`workStateKey→workState`; deployment search `deploymentTypeKeys→deploymentTypes`.

## 3. Review fixes
- `useFindMyOngoingCases` pages through all `work_in_progress` results (bounded by `BE_MAX_PAGE_LIMIT`).
- `useDirectoryUsers` drops directory entries without an email.

## 4. Align FE with BE PR #938 (entity #934)
- **Case type value `support` → `case`** across `BeCaseType`, `POST /cases`, the case-type filter (label "Support" → "Case"), and `CsmCaseCreatePage`.
- `CaseView`: add nullable `type`/`engagementType` + `catalog`/`catalogItem`/`assignedTeam`/`conversation` refs; mark `deployment`/`deployedProduct` nullable.
- `CaseSearchView`: add `type` (mapped onto the row); mark `deployment`/`deployedProduct` nullable.

> ⚠️ **Merge order:** part 4 sends the new `case` value, so **merge this after BE PR #938** — otherwise the cases list/create send `case` to a BE that still expects `support`.

## Testing
`pnpm lint`, `pnpm test`, `pnpm build`, `tsc -b` all green.
