### PR TITLE
[Customer Entity] Add GET /change-requests/{id} endpoint

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -941,3 +941,20 @@ type SearchChangeRequestsResponse struct {
 	Offset         int                       `json:"offset"`
 	Limit          int                       `json:"limit"`
 }
+
+// ChangeRequest is the full change request detail returned by GET /change-requests/{id}.
+// It extends SearchChangeRequestView with additional fields.
+type ChangeRequest struct {
+	SearchChangeRequestView
+	CreatedBy           string     `json:"createdBy"`
+	Justification       *string    `json:"justification"`
+	ImpactDescription   *string    `json:"impactDescription"`
+	ServiceOutage       *string    `json:"serviceOutage"`
+	CommunicationPlan   *string    `json:"communicationPlan"`
+	RollbackPlan        *string    `json:"rollbackPlan"`
+	TestPlan            *string    `json:"testPlan"`
+	HasCustomerApproved bool       `json:"hasCustomerApproved"`
+	HasCustomerReviewed bool       `json:"hasCustomerReviewed"`
+	ApprovedBy          *EntityRef `json:"approvedBy"`
+	ApprovedOn          *string    `json:"approvedOn"`
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -927,9 +927,9 @@ type SearchChangeRequestView struct {
 	PlannedStartOn   *string    `json:"plannedStartOn"`
 	PlannedEndOn     *string    `json:"plannedEndOn"`
 	Duration         *string    `json:"duration"`
-	Impact           string     `json:"impact"`
-	State            string     `json:"state"`
-	Type             string     `json:"type"`
+	Impact           *string    `json:"impact"`
+	State            *string    `json:"state"`
+	Type             *string    `json:"type"`
 	CreatedOn        string     `json:"createdOn"`
 	UpdatedOn        string     `json:"updatedOn"`
 }

--- a/entity-service/internal/handler/change_request_handler.go
+++ b/entity-service/internal/handler/change_request_handler.go
@@ -48,3 +48,16 @@ func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *ht
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// GetChangeRequest handles GET /change-requests/{id}.
+func (h *ChangeRequestHandler) GetChangeRequest(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	result, err := h.svc.GetChangeRequest(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -126,6 +126,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 
 	if changeRequestHandler != nil {
 		mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
+		mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
 	}
 
 	return middleware.CorrelationID(

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -130,4 +130,8 @@ type ChangeRequestService interface {
 	// A ValidationError is returned for invalid input; any other error indicates an
 	// infrastructure failure.
 	SearchChangeRequests(ctx context.Context, req domain.SearchChangeRequestsRequest) (domain.SearchChangeRequestsResponse, error)
+
+	// GetChangeRequest returns the full detail of a single change request by its UUID.
+	// A NotFoundError is returned if the change request does not exist.
+	GetChangeRequest(ctx context.Context, id string) (domain.ChangeRequest, error)
 }

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -352,3 +352,97 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 		Offset:         req.Pagination.Offset,
 	}, nil
 }
+
+// snChangeRequestDetail mirrors the Choreo GET /change-requests/{id} response.
+type snChangeRequestDetail struct {
+	snChangeRequest
+	CreatedBy           string         `json:"createdBy"`
+	Justification       *string        `json:"justification"`
+	ImpactDescription   *string        `json:"impactDescription"`
+	ServiceOutage       *string        `json:"serviceOutage"`
+	CommunicationPlan   *string        `json:"communicationPlan"`
+	RollbackPlan        *string        `json:"rollbackPlan"`
+	TestPlan            *string        `json:"testPlan"`
+	HasCustomerApproved bool           `json:"hasCustomerApproved"`
+	HasCustomerReviewed bool           `json:"hasCustomerReviewed"`
+	ApprovedBy          *snCREntityRef `json:"approvedBy"`
+	ApprovedOn          *string        `json:"approvedOn"`
+}
+
+func (s *snChangeRequestService) GetChangeRequest(ctx context.Context, id string) (domain.ChangeRequest, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.ChangeRequest{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	raw, err := s.client.Get(ctx, "/change-requests/"+uuidToSysid(id), token)
+	if err != nil {
+		return domain.ChangeRequest{}, err
+	}
+
+	var cr snChangeRequestDetail
+	if err := json.Unmarshal(raw, &cr); err != nil {
+		return domain.ChangeRequest{}, fmt.Errorf("sn get change request: parse response: %w", err)
+	}
+
+	subject := cr.Title
+	description := cr.Description
+
+	updatedOn := cr.CreatedOn
+	if cr.UpdatedOn != nil && *cr.UpdatedOn != "" {
+		updatedOn = *cr.UpdatedOn
+	}
+
+	view := domain.SearchChangeRequestView{
+		ID:             sysidToUUID(cr.ID),
+		Number:         cr.Number,
+		Subject:        &subject,
+		Description:    &description,
+		Project:        domain.EntityRef{ID: sysidToUUID(cr.Project.ID), Name: cr.Project.Name},
+		PlannedStartOn: cr.PlannedStartOn,
+		PlannedEndOn:   cr.PlannedEndOn,
+		Duration:       cr.Duration,
+		Impact:         snCRImpactLabelToString(cr.Impact),
+		State:          snCRStateLabelToString(cr.State),
+		Type:           snCRTypeLabelToString(cr.Type),
+		CreatedOn:      cr.CreatedOn,
+		UpdatedOn:      updatedOn,
+	}
+	if cr.Case != nil {
+		view.Case = &domain.EntityRef{ID: sysidToUUID(cr.Case.ID), Name: cr.Case.Name}
+	}
+	if cr.Deployment != nil {
+		view.Deployment = &domain.EntityRef{ID: sysidToUUID(cr.Deployment.ID), Name: cr.Deployment.Name}
+	}
+	if cr.DeployedProduct != nil {
+		view.DeployedProduct = &domain.EntityRef{ID: sysidToUUID(cr.DeployedProduct.ID), Name: cr.DeployedProduct.Name}
+	}
+	if cr.Product != nil {
+		view.Product = &domain.EntityRef{ID: sysidToUUID(cr.Product.ID), Name: cr.Product.Name}
+	}
+	if cr.AssignedEngineer != nil {
+		view.AssignedEngineer = &domain.EntityRef{ID: sysidToUUID(cr.AssignedEngineer.ID), Name: cr.AssignedEngineer.Name}
+	}
+	if cr.AssignedTeam != nil {
+		view.AssignedTeam = &domain.EntityRef{ID: sysidToUUID(cr.AssignedTeam.ID), Name: cr.AssignedTeam.Name}
+	}
+
+	result := domain.ChangeRequest{
+		SearchChangeRequestView: view,
+		CreatedBy:               cr.CreatedBy,
+		Justification:           cr.Justification,
+		ImpactDescription:       cr.ImpactDescription,
+		ServiceOutage:           cr.ServiceOutage,
+		CommunicationPlan:       cr.CommunicationPlan,
+		RollbackPlan:            cr.RollbackPlan,
+		TestPlan:                cr.TestPlan,
+		HasCustomerApproved:     cr.HasCustomerApproved,
+		HasCustomerReviewed:     cr.HasCustomerReviewed,
+		ApprovedOn:              cr.ApprovedOn,
+	}
+	if cr.ApprovedBy != nil {
+		result.ApprovedBy = &domain.EntityRef{ID: sysidToUUID(cr.ApprovedBy.ID), Name: cr.ApprovedBy.Name}
+	}
+
+	return result, nil
+}

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -190,33 +190,38 @@ var snCRImpactLabelMap = map[string]domain.ChangeRequestImpact{
 	"low":    domain.ChangeRequestImpactLow,
 }
 
-func snCRStateLabelToString(label *snCRLabel) string {
+func snCRStateLabelToString(label *snCRLabel) *string {
 	if label == nil {
-		return ""
+		return nil
 	}
 	if v, ok := snCRStateLabelMap[strings.ToLower(label.Label)]; ok {
-		return string(v)
+		s := string(v)
+		return &s
 	}
-	return label.Label
+	s := label.Label
+	return &s
 }
 
-func snCRImpactLabelToString(label *snCRLabel) string {
+func snCRImpactLabelToString(label *snCRLabel) *string {
 	if label == nil {
-		return ""
+		return nil
 	}
 	for _, word := range strings.Fields(label.Label) {
 		if v, ok := snCRImpactLabelMap[strings.ToLower(strings.Trim(word, "()-"))]; ok {
-			return string(v)
+			s := string(v)
+			return &s
 		}
 	}
-	return label.Label
+	s := label.Label
+	return &s
 }
 
-func snCRTypeLabelToString(label *snCRLabel) string {
+func snCRTypeLabelToString(label *snCRLabel) *string {
 	if label == nil {
-		return ""
+		return nil
 	}
-	return label.Label
+	s := label.Label
+	return &s
 }
 
 type snChangeRequestService struct {

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -380,6 +380,10 @@ func (s *snChangeRequestService) GetChangeRequest(ctx context.Context, id string
 		return domain.ChangeRequest{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.ChangeRequest{}, err
+	}
+
 	raw, err := s.client.Get(ctx, "/change-requests/"+uuidToSysid(id), token)
 	if err != nil {
 		return domain.ChangeRequest{}, err

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -689,6 +689,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Change request not found.
           content:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1988,12 +1988,15 @@ components:
           nullable: true
         impact:
           type: string
+          nullable: true
           description: Impact label (e.g. "high", "medium", "low").
         state:
           type: string
+          nullable: true
           description: State label (e.g. "review", "closed").
         type:
           type: string
+          nullable: true
           description: Type label (e.g. "standard", "normal").
         createdOn:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -665,6 +665,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /change-requests/{id}:
+    get:
+      summary: Get a single change request by ID (ServiceNow data source only).
+      operationId: getChangeRequest
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The change request detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequest'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Change request not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /change-requests/search:
     post:
       summary: Search change requests (ServiceNow data source only).
@@ -1976,6 +2013,42 @@ components:
           type: integer
         limit:
           type: integer
+
+    ChangeRequest:
+      allOf:
+        - $ref: '#/components/schemas/SearchChangeRequestView'
+        - type: object
+          properties:
+            createdBy:
+              type: string
+            justification:
+              type: string
+              nullable: true
+            impactDescription:
+              type: string
+              nullable: true
+            serviceOutage:
+              type: string
+              nullable: true
+            communicationPlan:
+              type: string
+              nullable: true
+            rollbackPlan:
+              type: string
+              nullable: true
+            testPlan:
+              type: string
+              nullable: true
+            hasCustomerApproved:
+              type: boolean
+            hasCustomerReviewed:
+              type: boolean
+            approvedBy:
+              $ref: '#/components/schemas/EntityRef'
+              nullable: true
+            approvedOn:
+              type: string
+              nullable: true
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
## Summary
- Adds `GET /change-requests/{id}` endpoint backed by the ServiceNow data source
- Returns all fields from the search view plus detail-only fields: `createdBy`, `justification`, `impactDescription`, `serviceOutage`, `communicationPlan`, `rollbackPlan`, `testPlan`, `hasCustomerApproved`, `hasCustomerReviewed`, `approvedBy`, `approvedOn`
- Fixes `impact`, `state`, and `type` fields to serialize as `null` instead of `""` when ServiceNow returns no value



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve a single change request by ID.
  * Returned change request details now include additional approval, review, and planning information.

* **Bug Fixes**
  * Improved handling of change request fields so impact, state, and type can be absent when not available.
  * Unknown or missing labels now map more reliably instead of being cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->