### PR TITLE
[CSM Portal][BE] align with entity service PR #929: drop Key/Keys suffix, add change-requests search

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -51,7 +51,7 @@ Follow these steps in order:
 - **Auth**: always check `middleware.UserInfoFromContext(r.Context()) == nil` first → 401
 - **Body size**: cap with `http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)` (1 MiB) before reading
 - **Path params**: guard against empty string after `r.PathValue("id")`; if the param is a UUID, also validate format using the package-level `uuidRe` compiled regex and return 400 on mismatch — fail fast before calling the upstream
-- **Field naming**: case create/patch use `severityKey` (not `priorityKey`); search filters use `severityKeys`; case create requires `typeKey: "support"` (only accepted value currently)
+- **Field naming**: case create/patch use bare names without `Key`/`Keys` suffix — `state`, `severity`, `workState` (PATCH), `type`, `severity`, `issueType` (POST); search filters use `states`, `severities`, `types`, `issueTypes`, `engagementTypes`; deployment search uses `deploymentTypes`; case comments use `type` (not `typeKey`); case create requires `type: "support"` (only accepted value currently)
 - **Upstream errors**: always use `mapUpstreamError(w, err, "<fallback message>")` — never write custom status mappings inline
 - **Response**: return raw `[]byte` with `writeJSON` for simple passthroughs; unmarshal into typed structs only when the response shape needs to change
 

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -143,6 +143,7 @@ backend/
 │   └── handler/
 │       ├── cases.go            # HTTP handlers for case endpoints
 │       ├── state.go            # Case state machine (nextStates, isValidStateTransition)
+│       ├── change_requests.go  # HTTP handlers for change-request endpoints
 │       ├── accounts.go         # HTTP handlers for account endpoints
 │       ├── deployments.go      # HTTP handlers for deployment endpoints
 │       ├── products.go         # HTTP handlers for product endpoints
@@ -157,7 +158,7 @@ backend/
 
 ### Cases
 
-- `POST /cases` — Create a case (requires `typeKey: "support"`)
+- `POST /cases` — Create a case (requires `type: "support"`)
 - `GET /cases/{id}` — Get case by ID
 - `PATCH /cases/{id}` — Update a case (state, severity, workState, watchList, or assigneeEmail)
 - `POST /cases/search` — Search cases
@@ -192,6 +193,10 @@ backend/
 
 - `POST /deployments/search` — Search deployments
 - `POST /deployments/{id}/products/search` — Search deployed products
+
+### Change Requests
+
+- `POST /change-requests/search` — Search change requests (ServiceNow data source only)
 
 ### Updates
 

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -196,6 +196,7 @@ backend/
 
 ### Change Requests
 
+- `GET /change-requests/{id}` — Get change request by ID (ServiceNow data source only)
 - `POST /change-requests/search` — Search change requests (ServiceNow data source only)
 
 ### Updates

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -51,6 +51,7 @@ func main() {
 	projectHandler := handler.NewProjectHandler(entityClient)
 	productHandler := handler.NewProductHandler(entityClient)
 	deploymentHandler := handler.NewDeploymentHandler(entityClient)
+	changeRequestHandler := handler.NewChangeRequestHandler(entityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
@@ -106,6 +107,7 @@ func main() {
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("POST /deployments/{id}/products/search", deploymentHandler.SearchDeployedProducts)
+	mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
 
 	addr := envOrDefault("PORT", ":8080")
 

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -107,6 +107,7 @@ func main() {
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("POST /deployments/{id}/products/search", deploymentHandler.SearchDeployedProducts)
+	mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
 	mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
 
 	addr := envOrDefault("PORT", ":8080")

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -113,6 +113,12 @@ func (c *Client) SearchDeployedProducts(ctx context.Context, body []byte) ([]byt
 	return c.do(ctx, http.MethodPost, "/deployed-products/search", body)
 }
 
+// SearchChangeRequests calls POST /change-requests/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/change-requests/search", body)
+}
+
 // CreateCaseAttachment calls POST /cases/{id}/attachments on the entity service.
 // Response is returned as raw JSON.
 func (c *Client) CreateCaseAttachment(ctx context.Context, caseID string, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -119,6 +119,12 @@ func (c *Client) SearchChangeRequests(ctx context.Context, body []byte) ([]byte,
 	return c.do(ctx, http.MethodPost, "/change-requests/search", body)
 }
 
+// GetChangeRequest calls GET /change-requests/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) GetChangeRequest(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/change-requests/%s", url.PathEscape(id)), nil)
+}
+
 // CreateCaseAttachment calls POST /cases/{id}/attachments on the entity service.
 // Response is returned as raw JSON.
 func (c *Client) CreateCaseAttachment(ctx context.Context, caseID string, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -181,7 +181,7 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 
 	// Work notes are internal-only and exempt from the state gate.
 	var reqMeta struct {
-		Type string `json:"typeKey"`
+		Type string `json:"type"`
 	}
 	_ = json.Unmarshal(body, &reqMeta) // body is already validated JSON
 
@@ -409,7 +409,7 @@ func (h *CaseHandler) GetCaseAttachmentContent(w http.ResponseWriter, r *http.Re
 }
 
 // PatchCase handles PATCH /cases/{id}.
-// Accepts stateKey, severityKey, workStateKey, watchList, or assigneeEmail and forwards to the entity service.
+// Accepts state, severity, workState, watchList, or assigneeEmail and forwards to the entity service.
 func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -445,8 +445,8 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 
 	// Validate state transition and workState guard before forwarding to the entity service.
 	var patch struct {
-		State     *string `json:"stateKey"`
-		WorkState *string `json:"workStateKey"`
+		State     *string `json:"state"`
+		WorkState *string `json:"workState"`
 	}
 	if err := json.Unmarshal(body, &patch); err == nil && (patch.State != nil || patch.WorkState != nil) {
 		current, err := h.entity.GetCase(r.Context(), caseID)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -56,7 +56,7 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 // ----- CreateCase -----
 
 func TestCreateCase(t *testing.T) {
-	const validPayload = `{"typeKey":"support","projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","severityKey":"high","issueTypeKey":"error"}`
+	const validPayload = `{"type":"support","projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","severity":"high","issueType":"error"}`
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
@@ -167,7 +167,7 @@ func TestCreateCase(t *testing.T) {
 // ----- CreateCaseComment -----
 
 func TestCreateCaseComment(t *testing.T) {
-	const validPayload = `{"typeKey":"comment","content":"Looking into this now."}`
+	const validPayload = `{"type":"comment","content":"Looking into this now."}`
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
@@ -280,7 +280,7 @@ func TestCreateCaseComment(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(`{"typeKey":"work_note","content":"internal note"}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(`{"type":"work_note","content":"internal note"}`)))
 				r.SetPathValue("id", "case-1")
 				w := httptest.NewRecorder()
 				h.CreateCaseComment(w, r)
@@ -497,7 +497,7 @@ func TestSearchCases(t *testing.T) {
 		}
 		h := NewCaseHandler(client)
 		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search",
-			strings.NewReader(`{"filters":{"projectIds":["proj-1"],"stateKeys":["open"]},"pagination":{"limit":10,"offset":0}}`)))
+			strings.NewReader(`{"filters":{"projectIds":["proj-1"],"states":["open"]},"pagination":{"limit":10,"offset":0}}`)))
 		w := httptest.NewRecorder()
 		h.SearchCases(w, r)
 
@@ -533,7 +533,7 @@ func TestSearchCases(t *testing.T) {
 		}
 		h := NewCaseHandler(client)
 		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search",
-			strings.NewReader(`{"filters":{"stateKeys":["open"]},"pagination":{"limit":10,"offset":0}}`)))
+			strings.NewReader(`{"filters":{"states":["open"]},"pagination":{"limit":10,"offset":0}}`)))
 		w := httptest.NewRecorder()
 		h.SearchCases(w, r)
 
@@ -576,7 +576,7 @@ func TestSearchCases(t *testing.T) {
 
 func TestPatchCase(t *testing.T) {
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const validPayload = `{"stateKey":"work_in_progress"}`
+	const validPayload = `{"state":"work_in_progress"}`
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
@@ -721,7 +721,7 @@ func TestPatchCase(t *testing.T) {
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"stateKey":"work_in_progress"}`)))
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"state":"work_in_progress"}`)))
 		r.SetPathValue("id", testCaseID)
 		w := httptest.NewRecorder()
 		h.PatchCase(w, r)
@@ -742,7 +742,7 @@ func TestPatchCase(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"workStateKey":"ongoing"}`)))
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"workState":"ongoing"}`)))
 				r.SetPathValue("id", testCaseID)
 				w := httptest.NewRecorder()
 				h.PatchCase(w, r)
@@ -764,7 +764,7 @@ func TestPatchCase(t *testing.T) {
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"workStateKey":"paused"}`)))
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"workState":"paused"}`)))
 		r.SetPathValue("id", testCaseID)
 		w := httptest.NewRecorder()
 		h.PatchCase(w, r)
@@ -779,7 +779,7 @@ func TestPatchCase(t *testing.T) {
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"severityKey":"high"}`)))
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(`{"severity":"high"}`)))
 		r.SetPathValue("id", testCaseID)
 		w := httptest.NewRecorder()
 		h.PatchCase(w, r)

--- a/apps/csm-portal/backend/internal/handler/change_requests.go
+++ b/apps/csm-portal/backend/internal/handler/change_requests.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityChangeRequestClient abstracts the entity service change-request operations.
+type entityChangeRequestClient interface {
+	SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// ChangeRequestHandler handles HTTP requests for change-request operations.
+type ChangeRequestHandler struct {
+	entity entityChangeRequestClient
+}
+
+// NewChangeRequestHandler creates a ChangeRequestHandler backed by the given entity client.
+func NewChangeRequestHandler(entity entityChangeRequestClient) *ChangeRequestHandler {
+	return &ChangeRequestHandler{entity: entity}
+}
+
+// SearchChangeRequests handles POST /change-requests/search.
+func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchChangeRequests(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchChangeRequests failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search change requests.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/change_requests.go
+++ b/apps/csm-portal/backend/internal/handler/change_requests.go
@@ -30,6 +30,7 @@ import (
 // entityChangeRequestClient abstracts the entity service change-request operations.
 type entityChangeRequestClient interface {
 	SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error)
+	GetChangeRequest(ctx context.Context, id string) ([]byte, error)
 }
 
 // ChangeRequestHandler handles HTTP requests for change-request operations.
@@ -40,6 +41,30 @@ type ChangeRequestHandler struct {
 // NewChangeRequestHandler creates a ChangeRequestHandler backed by the given entity client.
 func NewChangeRequestHandler(entity entityChangeRequestClient) *ChangeRequestHandler {
 	return &ChangeRequestHandler{entity: entity}
+}
+
+// GetChangeRequest handles GET /change-requests/{id}.
+func (h *ChangeRequestHandler) GetChangeRequest(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetChangeRequest(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetChangeRequest failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamError(w, err, "Failed to retrieve change request.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // SearchChangeRequests handles POST /change-requests/search.

--- a/apps/csm-portal/backend/internal/handler/change_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/change_requests_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSearchChangeRequests(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := httptest.NewRequest(http.MethodPost, "/change-requests/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchChangeRequests(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/change-requests/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchChangeRequests(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/change-requests/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchChangeRequests(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200", func(t *testing.T) {
+		var capturedBody []byte
+		client := &mockEntityChangeRequestClient{
+			searchChangeRequestsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"changeRequests":[{"id":"cr-1"}],"total":1,"limit":20,"offset":0}`), nil
+			},
+		}
+		h := NewChangeRequestHandler(client)
+		const payload = `{"filters":{"states":["scheduled"]},"pagination":{"limit":20,"offset":0}}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/change-requests/search", strings.NewReader(payload)))
+		w := httptest.NewRecorder()
+		h.SearchChangeRequests(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if string(capturedBody) != payload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, payload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search change requests.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityChangeRequestClient{
+					searchChangeRequestsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewChangeRequestHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/change-requests/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchChangeRequests(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+

--- a/apps/csm-portal/backend/internal/handler/change_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/change_requests_test.go
@@ -24,6 +24,89 @@ import (
 	"testing"
 )
 
+const testCRID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+func TestGetChangeRequest(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := httptest.NewRequest(http.MethodGet, "/change-requests/"+testCRID, nil)
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.GetChangeRequest(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests/not-a-uuid", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.GetChangeRequest(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty id", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests/", nil))
+		w := httptest.NewRecorder()
+		h.GetChangeRequest(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards id to upstream and returns 200", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityChangeRequestClient{
+			getChangeRequestFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"id":"` + testCRID + `","number":"CHG001","state":"scheduled"}`), nil
+			},
+		}
+		h := NewChangeRequestHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests/"+testCRID, nil))
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.GetChangeRequest(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedID != testCRID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testCRID)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["number"] != "CHG001" {
+			t.Errorf("response number = %v, want CHG001", resp["number"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to retrieve change request.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityChangeRequestClient{
+					getChangeRequestFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewChangeRequestHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests/"+testCRID, nil))
+				r.SetPathValue("id", testCRID)
+				w := httptest.NewRecorder()
+				h.GetChangeRequest(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestSearchChangeRequests(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -277,6 +277,19 @@ func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, pro
 	return []byte(`{}`), nil
 }
 
+// ----- mock entity change request client -----
+
+type mockEntityChangeRequestClient struct {
+	searchChangeRequestsFn func(ctx context.Context, body []byte) ([]byte, error)
+}
+
+func (m *mockEntityChangeRequestClient) SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchChangeRequestsFn != nil {
+		return m.searchChangeRequestsFn(ctx, body)
+	}
+	return []byte(`{"changeRequests":[],"total":0,"limit":20,"offset":0}`), nil
+}
+
 // ----- mock entity deployment client -----
 
 type mockEntityDeploymentClient struct {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -281,6 +281,7 @@ func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, pro
 
 type mockEntityChangeRequestClient struct {
 	searchChangeRequestsFn func(ctx context.Context, body []byte) ([]byte, error)
+	getChangeRequestFn     func(ctx context.Context, id string) ([]byte, error)
 }
 
 func (m *mockEntityChangeRequestClient) SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error) {
@@ -288,6 +289,13 @@ func (m *mockEntityChangeRequestClient) SearchChangeRequests(ctx context.Context
 		return m.searchChangeRequestsFn(ctx, body)
 	}
 	return []byte(`{"changeRequests":[],"total":0,"limit":20,"offset":0}`), nil
+}
+
+func (m *mockEntityChangeRequestClient) GetChangeRequest(ctx context.Context, id string) ([]byte, error) {
+	if m.getChangeRequestFn != nil {
+		return m.getChangeRequestFn(ctx, id)
+	}
+	return []byte(`{}`), nil
 }
 
 // ----- mock entity deployment client -----

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -128,8 +128,8 @@ paths:
     patch:
       summary: Update a support case.
       description: |
-        Updates exactly one field of the case. Provide exactly one of: `stateKey`, `severityKey`,
-        `workStateKey`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
+        Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
+        `workState`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
         only when the ServiceNow data source is active.
       operationId: patchCasesId
       parameters:
@@ -1100,6 +1100,54 @@ paths:
         "500":
           description: InternalServerError
 
+  /change-requests/search:
+    post:
+      summary: Search change requests (ServiceNow data source only).
+      operationId: postChangeRequestsSearch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeRequestSearchPayload'
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1116,24 +1164,24 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `stateKey`, `severityKey`, `workStateKey`, `watchList`, or `assigneeEmail` must be provided.
+        Exactly one of `state`, `severity`, `workState`, `watchList`, or `assigneeEmail` must be provided.
         `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
       oneOf:
-        - required: [stateKey]
-        - required: [severityKey]
-        - required: [workStateKey]
+        - required: [state]
+        - required: [severity]
+        - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
       properties:
-        stateKey:
+        state:
           type: string
           enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
           description: The new state to transition the case to.
-        severityKey:
+        severity:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: The new severity of the case.
-        workStateKey:
+        workState:
           type: string
           enum: [ongoing, paused]
           description: The new work sub-state of the case. Only applicable when the case state is work_in_progress.
@@ -1213,16 +1261,16 @@ components:
     CaseCreatePayload:
       type: object
       required:
-        - typeKey
+        - type
         - projectId
         - deploymentId
         - deployedProductId
         - subject
         - description
-        - severityKey
-        - issueTypeKey
+        - severity
+        - issueType
       properties:
-        typeKey:
+        type:
           type: string
           enum: [support]
           description: Case type. Currently only `support` is accepted.
@@ -1241,11 +1289,11 @@ components:
         description:
           type: string
           description: Full description of the issue
-        severityKey:
+        severity:
           type: string
           enum: [catastrophic, critical, high, medium, low]
           description: Severity level of the case
-        issueTypeKey:
+        issueType:
           type: string
           enum: [error, partial_outage, performance_degradation, question, security_or_compliance, total_outage]
           description: Nature of the issue
@@ -1253,7 +1301,7 @@ components:
     CaseSearchFilters:
       type: object
       properties:
-        typeKeys:
+        types:
           type: array
           items:
             type: string
@@ -1277,7 +1325,7 @@ components:
           items:
             type: string
           description: Filter by deployment IDs (optional)
-        stateKeys:
+        states:
           type: array
           items:
             type: string
@@ -1290,7 +1338,7 @@ components:
               - solution_proposed
               - closed
           description: Filter by case state (optional)
-        severityKeys:
+        severities:
           type: array
           items:
             type: string
@@ -1301,7 +1349,7 @@ components:
               - medium
               - low
           description: Filter by severity (optional)
-        engagementTypeKeys:
+        engagementTypes:
           type: array
           items:
             type: string
@@ -1312,7 +1360,7 @@ components:
               - follow_up
               - onboarding
           description: Filter by engagement type (optional; only applies to engagement cases)
-        issueTypeKeys:
+        issueTypes:
           type: array
           items:
             type: string
@@ -1932,7 +1980,7 @@ components:
           items:
             type: string
           description: Filter by project IDs (optional)
-        deploymentTypeKeys:
+        deploymentTypes:
           type: array
           items:
             type: string
@@ -2159,10 +2207,10 @@ components:
     CaseCommentCreatePayload:
       type: object
       required:
-        - typeKey
+        - type
         - content
       properties:
-        typeKey:
+        type:
           type: string
           enum: [work_note, comment, activity]
           description: work_note is restricted to internal users; activity to internal and system users
@@ -2465,3 +2513,141 @@ components:
           type: string
         credits:
           type: string
+
+    ChangeRequestSearchPayload:
+      type: object
+      nullable: true
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+              description: Filter by project UUIDs (optional)
+            searchQuery:
+              type: string
+              description: Search across subject and number (case-insensitive)
+            states:
+              type: array
+              items:
+                type: string
+                enum:
+                  - customer_approval
+                  - scheduled
+                  - implement
+                  - review
+                  - customer_review
+                  - rollback
+                  - closed
+                  - canceled
+              description: Filter by change request state (optional)
+            impacts:
+              type: array
+              items:
+                type: string
+                enum:
+                  - high
+                  - medium
+                  - low
+              description: Filter by impact level (optional)
+            closedStartDate:
+              type: string
+              format: date-time
+              description: Filter change requests closed on or after this UTC datetime (optional)
+            closedEndDate:
+              type: string
+              format: date-time
+              description: Filter change requests closed on or before this UTC datetime (optional)
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+              default: createdOn
+            order:
+              type: string
+              enum: [asc, desc]
+              default: desc
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+
+    ChangeRequestSearchView:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+        subject:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        project:
+          $ref: '#/components/schemas/EntityRef'
+        case:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        deployment:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        deployedProduct:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        product:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedEngineer:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTeam:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        plannedStartOn:
+          type: string
+          nullable: true
+        plannedEndOn:
+          type: string
+          nullable: true
+        duration:
+          type: string
+          nullable: true
+        impact:
+          type: string
+          description: Impact level (e.g. "high", "medium", "low")
+        state:
+          type: string
+          description: Current workflow state (e.g. "scheduled", "closed")
+        type:
+          type: string
+          description: Change request type (e.g. "standard", "normal")
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    ChangeRequestSearchResponse:
+      type: object
+      properties:
+        changeRequests:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestSearchView'
+        total:
+          type: integer
+          description: Total number of matching change requests
+        limit:
+          type: integer
+        offset:
+          type: integer

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1100,6 +1100,56 @@ paths:
         "500":
           description: InternalServerError
 
+  /change-requests/{id}:
+    get:
+      summary: Get a single change request by ID (ServiceNow data source only).
+      operationId: getChangeRequest
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID of the change request.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestDetail'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /change-requests/search:
     post:
       summary: Search change requests (ServiceNow data source only).
@@ -2625,12 +2675,15 @@ components:
           nullable: true
         impact:
           type: string
+          nullable: true
           description: Impact level (e.g. "high", "medium", "low")
         state:
           type: string
+          nullable: true
           description: Current workflow state (e.g. "scheduled", "closed")
         type:
           type: string
+          nullable: true
           description: Change request type (e.g. "standard", "normal")
         createdOn:
           type: string
@@ -2651,3 +2704,39 @@ components:
           type: integer
         offset:
           type: integer
+
+    ChangeRequestDetail:
+      allOf:
+        - $ref: '#/components/schemas/ChangeRequestSearchView'
+        - type: object
+          properties:
+            createdBy:
+              type: string
+            justification:
+              type: string
+              nullable: true
+            impactDescription:
+              type: string
+              nullable: true
+            serviceOutage:
+              type: string
+              nullable: true
+            communicationPlan:
+              type: string
+              nullable: true
+            rollbackPlan:
+              type: string
+              nullable: true
+            testPlan:
+              type: string
+              nullable: true
+            hasCustomerApproved:
+              type: boolean
+            hasCustomerReviewed:
+              type: boolean
+            approvedBy:
+              $ref: '#/components/schemas/EntityRef'
+              nullable: true
+            approvedOn:
+              type: string
+              nullable: true


### PR DESCRIPTION
## Summary

- Remove `Key`/`Keys` suffix from all enum request fields to match the entity service PR #929 contract: `stateKey`→`state`, `severityKey`→`severity`, `workStateKey`→`workState` (PATCH case); `typeKey`→`type`, `issueTypeKey`→`issueType` (create case/comment); `typeKeys`→`types`, `stateKeys`→`states`, `severityKeys`→`severities`, `engagementTypeKeys`→`engagementTypes`, `issueTypeKeys`→`issueTypes` (case search); `deploymentTypeKeys`→`deploymentTypes` (deployment search)
- Fix BFF Go handler code to read the renamed fields from JSON (`state`/`workState` in `PatchCase`, `type` in `CreateCaseComment`)
- Add `POST /change-requests/search` endpoint: entity client method, `ChangeRequestHandler`, interface, mock, tests, route registration, and full OpenAPI spec entry

## Test plan

- [x] All existing handler tests pass (`go test ./...`)
- [x] New `TestSearchChangeRequests` tests cover auth, body size, invalid JSON, happy path, and upstream error mapping
- [x] PATCH case state/workState validation still works with new field names
- [x] CreateCaseComment work_note bypass still works with new field name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new change request search endpoint to the portal API.
  * Updated request formats for case creation, case updates, comments, and search filters to use simpler field names.

* **Bug Fixes**
  * Improved validation handling for case updates and comments so requests are checked against the updated API contract.
  * Added consistent error responses for unauthenticated, invalid, and oversized requests on change request search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->