### PR TITLE
[Customer Portal Web App] feat: usage overview environment breakdown and metrics improvements

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/types/usage.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/usage.ts
@@ -246,10 +246,12 @@ export type UsageInstanceChartBlock = {
   data: UsageTrendRow[];
 };
 
-// Item type for chart blocks for a product instance row.
-export type UsageInstanceCharts = {
-  transactions: UsageInstanceChartBlock;
-  cores: UsageInstanceChartBlock;
+// A single trend chart to render inside the product expanded view.
+export type ProductChartTrend = {
+  title: string;
+  caption: string;
+  stroke: string;
+  data: UsageTrendRow[];
 };
 
 // Item type for per-instance row when a product is expanded.
@@ -258,9 +260,9 @@ export type UsageProductInstanceRow = {
   hostName: string;
   javaVersion: string;
   u2Level: string;
-  transactionsLabel: string;
+  summaryStats: { label: string; value: string }[];
   coreSummary: CurrMinMaxAvg;
-  charts: UsageInstanceCharts;
+  charts: UsageInstanceChartBlock[];
 };
 
 // Item type for core metric pill labels on the environment product row.
@@ -275,12 +277,10 @@ export type UsageEnvironmentProduct = {
   name: string;
   version: string;
   runningInstances: number;
-  transactionsLabel: string;
-  thirdMetricLabel: string;
-  thirdMetricValue: string;
+  metricKeys: string[];
+  summaryStats: { label: string; value: string }[];
   coreMetrics: UsageCoreMetricStat[];
-  transactionTrend: UsageTrendRow[];
-  coreUsageTrend: UsageTrendRow[];
+  chartTrends: ProductChartTrend[];
   instances: UsageProductInstanceRow[];
   instanceSummary: CurrMinMaxAvg;
   coreSummary: CurrMinMaxAvg;

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -41,18 +41,12 @@ import type { JSX } from "react";
 import { useCallback, useMemo, useState } from "react";
 import {
   USAGE_LINE_CHART_MARGIN,
-  USAGE_METRICS_CHART_LINE_CORES_SHORT,
   USAGE_METRICS_ENVIRONMENT_PRODUCTS_ERROR,
-  USAGE_METRICS_INSTANCE_CHART_TX_TITLE,
   USAGE_METRICS_INSTANCE_CORE_COUNT,
   USAGE_METRICS_INSTANCE_JAVA,
-  USAGE_METRICS_INSTANCE_TOTAL_TX,
   USAGE_METRICS_INSTANCE_U2,
   USAGE_METRICS_NO_INSTANCE_DATA,
   USAGE_METRICS_NO_PRODUCTS_IN_DEPLOYMENT,
-  USAGE_METRICS_PRODUCT_PANEL_TOTAL_TRANSACTIONS,
-  USAGE_METRICS_PRODUCT_TREND_CORE_SECTION,
-  USAGE_METRICS_PRODUCT_TREND_TX_SECTION,
   USAGE_METRICS_PRODUCT_INSTANCES_SECTION,
   USAGE_METRICS_PRODUCT_INSTANCE_METRICS,
   USAGE_METRICS_PRODUCT_CORE_METRICS,
@@ -100,6 +94,10 @@ function ProductExpandedView({
     );
   }
 
+  const chartGridSize = product.chartTrends.length === 1 ? 12
+    : product.chartTrends.length === 3 ? 4
+    : 6;
+
   return (
     <>
       <Grid
@@ -107,62 +105,36 @@ function ProductExpandedView({
         spacing={2}
         sx={{ width: "100%", minWidth: 0, overflowX: "hidden" }}
       >
-        <Grid size={{ xs: 12, lg: 6 }}>
-          <Card sx={{ p: 2, borderRadius: 0 }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2 }}>
-              {USAGE_METRICS_PRODUCT_TREND_TX_SECTION}
-            </Typography>
-            <UsageChartSurface minHeight={200}>
-              <LineChart
-                data={product.transactionTrend}
-                xAxisDataKey="name"
-                height={200}
-                width="100%"
-                margin={USAGE_LINE_CHART_MARGIN}
-                accessibilityLayer={false}
-                legend={{ show: false }}
-                grid={{ show: true, strokeDasharray: "3 3" }}
-                lines={[
-                  {
-                    dataKey: "value",
-                    name: USAGE_METRICS_INSTANCE_CHART_TX_TITLE,
-                    stroke: colors.blue?.[500] ?? "#3B82F6",
-                    strokeWidth: 2.5,
-                    dot: false,
-                  },
-                ]}
-              />
-            </UsageChartSurface>
-          </Card>
-        </Grid>
-        <Grid size={{ xs: 12, lg: 6 }}>
-          <Card sx={{ p: 2, borderRadius: 0 }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2 }}>
-              {USAGE_METRICS_PRODUCT_TREND_CORE_SECTION}
-            </Typography>
-            <UsageChartSurface minHeight={200}>
-              <LineChart
-                data={product.coreUsageTrend}
-                xAxisDataKey="name"
-                height={200}
-                width="100%"
-                margin={USAGE_LINE_CHART_MARGIN}
-                accessibilityLayer={false}
-                legend={{ show: false }}
-                grid={{ show: true, strokeDasharray: "3 3" }}
-                lines={[
-                  {
-                    dataKey: "current",
-                    name: USAGE_METRICS_CHART_LINE_CORES_SHORT,
-                    stroke: colors.orange?.[500] ?? "#F97316",
-                    strokeWidth: 2.5,
-                    dot: false,
-                  },
-                ]}
-              />
-            </UsageChartSurface>
-          </Card>
-        </Grid>
+        {product.chartTrends.map((trend) => (
+          <Grid key={trend.title} size={{ xs: 12, lg: chartGridSize }}>
+            <Card sx={{ p: 2, borderRadius: 0 }}>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2 }}>
+                {trend.title}
+              </Typography>
+              <UsageChartSurface minHeight={200}>
+                <LineChart
+                  data={trend.data}
+                  xAxisDataKey="name"
+                  height={200}
+                  width="100%"
+                  margin={USAGE_LINE_CHART_MARGIN}
+                  accessibilityLayer={false}
+                  legend={{ show: false }}
+                  grid={{ show: true, strokeDasharray: "3 3" }}
+                  lines={[
+                    {
+                      dataKey: "value",
+                      name: trend.title,
+                      stroke: trend.stroke,
+                      strokeWidth: 2.5,
+                      dot: false,
+                    },
+                  ]}
+                />
+              </UsageChartSurface>
+            </Card>
+          </Grid>
+        ))}
       </Grid>
 
       <Box sx={{ mt: 2 }}>
@@ -346,11 +318,14 @@ function InstanceAccordionRow({
               label={USAGE_METRICS_INSTANCE_U2}
               value={instance.u2Level}
             />
-            <MetricPill
-              icon={<Activity size={16} color={colors.grey?.[400]} />}
-              label={USAGE_METRICS_INSTANCE_TOTAL_TX}
-              value={instance.transactionsLabel}
-            />
+            {instance.summaryStats.map((stat) => (
+              <MetricPill
+                key={stat.label}
+                icon={<Activity size={16} color={colors.grey?.[400]} />}
+                label={stat.label}
+                value={stat.value}
+              />
+            ))}
             <MetricPill
               icon={<Cpu size={16} color={colors.grey?.[400]} />}
               label={USAGE_METRICS_INSTANCE_CORE_COUNT}
@@ -371,12 +346,19 @@ function InstanceAccordionRow({
         }}
       >
         <Grid container spacing={2} sx={{ mt: 1 }}>
-          <Grid size={{ xs: 12, lg: 6 }}>
-            <InstanceMiniTrendCard block={instance.charts.transactions} />
-          </Grid>
-          <Grid size={{ xs: 12, lg: 6 }}>
-            <InstanceMiniTrendCard block={instance.charts.cores} />
-          </Grid>
+          {instance.charts.map((chart) => (
+            <Grid
+              key={chart.title}
+              size={{
+                xs: 12,
+                lg: instance.charts.length === 1 ? 12
+                  : instance.charts.length === 3 ? 4
+                  : 6,
+              }}
+            >
+              <InstanceMiniTrendCard block={chart} />
+            </Grid>
+          ))}
         </Grid>
       </AccordionDetails>
     </Accordion>
@@ -520,22 +502,16 @@ function ProductAccordionRow({
               gap: 2,
             }}
           >
-            <Box>
-              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
-                {USAGE_METRICS_PRODUCT_PANEL_TOTAL_TRANSACTIONS}
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 700 }}>
-                {product.transactionsLabel}
-              </Typography>
-            </Box>
-            <Box>
-              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
-                {product.thirdMetricLabel}
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 700 }}>
-                {product.thirdMetricValue}
-              </Typography>
-            </Box>
+            {product.summaryStats.map((stat) => (
+              <Box key={stat.label}>
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                  {stat.label}
+                </Typography>
+                <Typography variant="body1" sx={{ fontWeight: 700 }}>
+                  {stat.value}
+                </Typography>
+              </Box>
+            ))}
             <CurrMinMaxBlock
               label={USAGE_METRICS_PRODUCT_INSTANCE_METRICS}
               summary={product.instanceSummary}

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -36,7 +36,7 @@ import {
   Server as ServerIcon,
 } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import usePostProjectInstancesUsagesStats from "@features/project-details/api/usePostProjectInstancesUsagesStats";
 import DataSourceStatCard from "@features/usage-metrics/components/DataSourceStatCard";
 import type { MetricTypeSummary } from "@features/project-details/types/usage";
@@ -361,23 +361,26 @@ function EnvironmentBreakdownAccordion({
 }: EnvironmentBreakdownAccordionProps): JSX.Element {
   const a = getUsageOverviewAccentForTypeId(row.kind);
 
+  // Track whether this row has ever been expanded. Once true the hooks stay
+  // enabled so the query key remains stable and React Query can serve cached
+  // data on collapse — without making any calls on initial mount.
+  const hasExpandedRef = useRef(false);
+  if (expanded) hasExpandedRef.current = true;
+  const fetchDeploymentId = hasExpandedRef.current ? row.deploymentId : undefined;
+
   const metricsPayload = useMemo(
     () => ({ filters: { startDate: dateRange.startDate, endDate: dateRange.endDate } }),
     [dateRange],
   );
 
-  // Both hooks gated on expanded — avoids N concurrent calls on mount and prevents
-  // API gateway throttling when many accordion rows are rendered simultaneously.
-  const { data: depInstancesData } = usePostDeploymentInstancesSearch(
-    expanded ? row.deploymentId : undefined,
-  );
+  const { data: depInstancesData } = usePostDeploymentInstancesSearch(fetchDeploymentId);
   const { data: depUsagesData } = usePostDeploymentInstancesUsagesSearch(
-    expanded ? row.deploymentId : undefined,
+    fetchDeploymentId,
     metricsPayload,
   );
 
   const { productCount, instanceCount, totalCores, transactionsLabel } = useMemo(() => {
-    if (!expanded || !depInstancesData) {
+    if (!depInstancesData) {
       return {
         productCount: row.productCount,
         instanceCount: row.instanceCount,
@@ -393,12 +396,12 @@ function EnvironmentBreakdownAccordion({
     ]);
     const totalTx = usages.reduce((sum, u) => sum + sumUsageEntryTransactions(u), 0);
     return {
-      productCount: productIds.size,
+      productCount: depUsagesData ? productIds.size : row.productCount,
       instanceCount: instances.length,
       totalCores: instances.reduce((sum, i) => sum + (i.metadata?.coreCount ?? 0), 0),
       transactionsLabel: formatUsageMetricCount(totalTx),
     };
-  }, [expanded, depInstancesData, depUsagesData, row]);
+  }, [depInstancesData, depUsagesData, row]);
 
   return (
     <Accordion

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -36,7 +36,7 @@ import {
   Server as ServerIcon,
 } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import usePostProjectInstancesUsagesStats from "@features/project-details/api/usePostProjectInstancesUsagesStats";
 import DataSourceStatCard from "@features/usage-metrics/components/DataSourceStatCard";
 import type { MetricTypeSummary } from "@features/project-details/types/usage";
@@ -361,12 +361,13 @@ function EnvironmentBreakdownAccordion({
 }: EnvironmentBreakdownAccordionProps): JSX.Element {
   const a = getUsageOverviewAccentForTypeId(row.kind);
 
-  // Track whether this row has ever been expanded. Once true the hooks stay
-  // enabled so the query key remains stable and React Query can serve cached
-  // data on collapse — without making any calls on initial mount.
+  // Track whether this row has ever been expanded so hooks stay enabled after
+  // the first expansion and React Query can serve cached data on collapse.
   const hasExpandedRef = useRef(false);
-  if (expanded) hasExpandedRef.current = true;
-  const fetchDeploymentId = hasExpandedRef.current ? row.deploymentId : undefined;
+  useEffect(() => {
+    if (expanded) hasExpandedRef.current = true;
+  }, [expanded]);
+  const fetchDeploymentId = (expanded || hasExpandedRef.current) ? row.deploymentId : undefined;
 
   const metricsPayload = useMemo(
     () => ({ filters: { startDate: dateRange.startDate, endDate: dateRange.endDate } }),

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/__tests__/UsageEnvironmentProductsPanel.test.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/__tests__/UsageEnvironmentProductsPanel.test.tsx
@@ -40,16 +40,18 @@ vi.mock("@features/usage-metrics/utils/usageMetricsEnvironmentProducts", () => (
     {
       id: "prod-1",
       name: "Gateway",
-      transactionsLabel: "10",
-      thirdMetricLabel: "APIs",
-      thirdMetricValue: "2",
+      version: "",
+      runningInstances: 1,
+      metricKeys: ["TRANSACTION_COUNT"],
+      summaryStats: [{ label: "Transactions", value: "10" }],
       coreMetrics: [
         { label: "Total Cores", value: "4" },
         { label: "Instances", value: "1" },
       ],
-      transactionTrend: [],
-      coreUsageTrend: [],
+      chartTrends: [],
       instances: [],
+      instanceSummary: { label: "", curr: 0, min: 0, max: 0, avg: 0, trend: [] },
+      coreSummary: { label: "", curr: 0, min: 0, max: 0, avg: 0, trend: [] },
     },
   ],
 }));

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsEnvironmentProducts.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsEnvironmentProducts.ts
@@ -18,6 +18,7 @@ import { colors } from "@wso2/oxygen-ui";
 import type {
   InstanceMetricEntry,
   InstanceUsageEntry,
+  ProductChartTrend,
   UsageEnvironmentProduct,
   UsageInstanceChartBlock,
   UsageProductInstanceRow,
@@ -33,13 +34,16 @@ import {
 import {
   USAGE_METRICS_INSTANCE_CHART_CORE_CAPTION,
   USAGE_METRICS_INSTANCE_CHART_CORE_TITLE,
-  USAGE_METRICS_INSTANCE_CHART_TX_CAPTION,
-  USAGE_METRICS_INSTANCE_CHART_TX_TITLE,
   USAGE_METRICS_PRODUCT_CORE_METRIC_INSTANCES,
   USAGE_METRICS_PRODUCT_CORE_METRIC_TOTAL_CORES,
-  USAGE_METRICS_PRODUCT_THIRD_METRIC_LABEL,
   USAGE_METRICS_VALUE_EM_DASH,
 } from "@features/usage-metrics/constants/usageMetricsConstants";
+import {
+  CORE_CHART_CONFIG,
+  METRIC_CHART_CONFIG,
+  METRIC_CHART_CONFIG_FALLBACK,
+  getProductMetricKeys,
+} from "@features/usage-metrics/utils/usageMetricsProductClassifier";
 
 /**
  * Short period label (MM-DD) for environment product charts.
@@ -68,6 +72,7 @@ export function buildUsageProductInstanceAccordionKey(
 /**
  * Derives product rows from deployment-scoped usages + metrics.
  * Groups entries by deployedProduct.id (falling back to product.id then instanceId).
+ * Metric keys and chart trends are determined per-product by the WSO2 product classifier.
  *
  * @param usages - Usage rows for the deployment.
  * @param metrics - Metric rows for the deployment.
@@ -103,21 +108,53 @@ export function deriveUsageEnvironmentProducts(
 
   return Array.from(productMap.entries()).map(
     ([pid, { label, usages: pUsages, metrics: pMetrics }]) => {
-      const txTrend = buildUsageTrendFromUsages(
-        pUsages,
-        "TRANSACTION_COUNT",
-        formatUsageEnvironmentPeriodLabel,
-      );
+      const metricKeys = getProductMetricKeys(label);
+
+      // Compute total for each metric key across all usage entries
+      const metricTotals = new Map<string, number>();
+      for (const key of metricKeys) {
+        const total = pUsages.reduce(
+          (sum, u) =>
+            sum + u.periodSummaries.reduce((s, ps) => s + (ps.counts[key] ?? 0), 0),
+          0,
+        );
+        metricTotals.set(key, total);
+      }
+
+      // Product-level summary stats (shown in accordion header)
+      const summaryStats = metricKeys.map((key) => {
+        const cfg = METRIC_CHART_CONFIG[key] ?? METRIC_CHART_CONFIG_FALLBACK;
+        const total = metricTotals.get(key) ?? 0;
+        return {
+          label: cfg.title,
+          value: formatUsageMetricCount(total),
+        };
+      });
+
+      // Product-level chart trends (shown in expanded view)
       const coreTrend = buildCoreAverageTrendFromMetrics(pMetrics);
-      const totalTx = pUsages.reduce(
-        (sum, u) =>
-          sum +
-          u.periodSummaries.reduce(
-            (s, ps) => s + (ps.counts["TRANSACTION_COUNT"] ?? 0),
-            0,
-          ),
-        0,
-      );
+      const chartTrends: ProductChartTrend[] = [
+        ...metricKeys.map((key) => {
+          const cfg = METRIC_CHART_CONFIG[key] ?? METRIC_CHART_CONFIG_FALLBACK;
+          return {
+            title: cfg.title,
+            caption: cfg.caption,
+            stroke: cfg.stroke,
+            data: buildUsageTrendFromUsages(
+              pUsages,
+              key,
+              formatUsageEnvironmentPeriodLabel,
+            ),
+          };
+        }),
+        {
+          title: CORE_CHART_CONFIG.title,
+          caption: CORE_CHART_CONFIG.caption,
+          stroke: CORE_CHART_CONFIG.stroke,
+          data: coreTrend.map((r) => ({ name: r.name, value: r.current })),
+        },
+      ];
+
       const totalCores = pMetrics.reduce(
         (sum, m) =>
           sum +
@@ -132,28 +169,24 @@ export function deriveUsageEnvironmentProducts(
           }, 0),
         0,
       );
-      const totalApis = pUsages.reduce(
-        (sum, u) =>
-          sum +
-          u.periodSummaries.reduce(
-            (s, ps) => s + (ps.counts["API_COUNT"] ?? 0),
-            0,
-          ),
-        0,
-      );
 
       const instanceRows: UsageProductInstanceRow[] = pUsages.map((u) => {
-        const instUsageTrend = buildUsageTrendFromUsages(
-          [u],
-          "TRANSACTION_COUNT",
-          formatUsageEnvironmentPeriodLabel,
-        );
-        const instTxHD = computeUsageHeadlineDeltaSigned(instUsageTrend);
         const instMetric = pMetrics.find((m) => m.instanceId === u.instanceId);
+
+        // Instance-level stats: one formatted value per metric key
+        const instSummaryStats = metricKeys.map((key) => {
+          const cfg = METRIC_CHART_CONFIG[key] ?? METRIC_CHART_CONFIG_FALLBACK;
+          const total = u.periodSummaries.reduce(
+            (s, ps) => s + (ps.counts[key] ?? 0),
+            0,
+          );
+          return { label: cfg.title, value: formatUsageMetricCount(total) };
+        });
+
+        // Instance-level charts: one per metric key + cores
         const instCoreTrend = instMetric
           ? buildCoreAverageTrendFromMetrics([instMetric])
           : [];
-
         const instCoreValues = (instMetric?.dataPoints ?? [])
           .slice()
           .sort((a, b) => a.date.localeCompare(b.date))
@@ -165,10 +198,39 @@ export function deriveUsageEnvironmentProducts(
                 : 0,
           );
         const instCoreSummary = computeSeriesSummary(instCoreValues);
-
         const coreHD = computeUsageHeadlineDeltaSigned(
           instCoreTrend.map((r) => ({ name: r.name, value: r.current })),
         );
+
+        const instCharts: UsageInstanceChartBlock[] = [
+          ...metricKeys.map((key) => {
+            const cfg = METRIC_CHART_CONFIG[key] ?? METRIC_CHART_CONFIG_FALLBACK;
+            const instTrend = buildUsageTrendFromUsages(
+              [u],
+              key,
+              formatUsageEnvironmentPeriodLabel,
+            );
+            const instHD = computeUsageHeadlineDeltaSigned(instTrend);
+            return {
+              title: cfg.title,
+              caption: cfg.caption,
+              headlineValue: instHD.headline,
+              deltaLabel: instHD.delta,
+              deltaPositive: instHD.deltaPositive,
+              stroke: cfg.stroke,
+              data: instTrend,
+            };
+          }),
+          {
+            title: USAGE_METRICS_INSTANCE_CHART_CORE_TITLE,
+            caption: USAGE_METRICS_INSTANCE_CHART_CORE_CAPTION,
+            headlineValue: String(instCoreSummary.curr),
+            deltaLabel: coreHD.delta,
+            deltaPositive: coreHD.deltaPositive,
+            stroke: colors.orange?.[500] ?? "#F97316",
+            data: instCoreTrend.map((r) => ({ name: r.name, value: r.current })),
+          },
+        ];
 
         const javaVer =
           instMetric?.dataPoints.at(-1)?.jdkVersion ??
@@ -177,35 +239,15 @@ export function deriveUsageEnvironmentProducts(
         const u2Level =
           instMetric?.dataPoints.at(-1)?.deploymentMetadata?.updateLevel ??
           USAGE_METRICS_VALUE_EM_DASH;
-        const instanceStroke = colors.blue?.[500] ?? "#3B82F6";
-
-        const txBlock: UsageInstanceChartBlock = {
-          title: USAGE_METRICS_INSTANCE_CHART_TX_TITLE,
-          caption: USAGE_METRICS_INSTANCE_CHART_TX_CAPTION,
-          headlineValue: instTxHD.headline,
-          deltaLabel: instTxHD.delta,
-          deltaPositive: instTxHD.deltaPositive,
-          stroke: instanceStroke,
-          data: instUsageTrend,
-        };
-        const coresBlock: UsageInstanceChartBlock = {
-          title: USAGE_METRICS_INSTANCE_CHART_CORE_TITLE,
-          caption: USAGE_METRICS_INSTANCE_CHART_CORE_CAPTION,
-          headlineValue: String(instCoreSummary.curr),
-          deltaLabel: coreHD.delta,
-          deltaPositive: coreHD.deltaPositive,
-          stroke: colors.orange?.[500] ?? "#F97316",
-          data: instCoreTrend.map((r) => ({ name: r.name, value: r.current })),
-        };
 
         return {
           id: u.instanceId,
           hostName: u.instanceKey,
           javaVersion: javaVer,
           u2Level,
-          transactionsLabel: instTxHD.headline,
+          summaryStats: instSummaryStats,
           coreSummary: instCoreSummary,
-          charts: { transactions: txBlock, cores: coresBlock },
+          charts: instCharts,
         };
       });
 
@@ -217,9 +259,8 @@ export function deriveUsageEnvironmentProducts(
         name: label,
         version: "",
         runningInstances: pUsages.length,
-        transactionsLabel: formatUsageMetricCount(totalTx),
-        thirdMetricLabel: USAGE_METRICS_PRODUCT_THIRD_METRIC_LABEL,
-        thirdMetricValue: String(totalApis),
+        metricKeys,
+        summaryStats,
         coreMetrics: [
           {
             label: USAGE_METRICS_PRODUCT_CORE_METRIC_TOTAL_CORES,
@@ -230,8 +271,7 @@ export function deriveUsageEnvironmentProducts(
             value: String(pUsages.length),
           },
         ],
-        transactionTrend: txTrend,
-        coreUsageTrend: coreTrend,
+        chartTrends,
         instances: instanceRows,
         instanceSummary,
         coreSummary,

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
@@ -108,11 +108,14 @@ export function classifyProductLabel(label: string): {
  * Returns the ordered metric keys relevant for a given product label.
  * UNKNOWN products fall back to showing all common metric keys.
  *
- * @param label - Product display label.
+ * @param label - Product display label used for type detection.
+ * @param version - Explicit product version string (e.g. "7.0.0") as the primary
+ *   source for major version selection. Falls back to parsing the label when omitted.
  * @returns Ordered list of metric keys to display.
  */
-export function getProductMetricKeys(label: string): string[] {
-  const { type, majorVersion } = classifyProductLabel(label);
+export function getProductMetricKeys(label: string, version?: string): string[] {
+  const { type, majorVersion: labelMajorVersion } = classifyProductLabel(label);
+  const majorVersion = version != null ? parseMajorVersion(version) : labelMajorVersion;
   switch (type) {
     case WsoProductType.APIM:
       return majorVersion >= 7

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/** WSO2 product families that have known metric mappings. */
+export enum WsoProductType {
+  APIM = "APIM",
+  IS = "IS",
+  MI = "MI",
+  UNKNOWN = "UNKNOWN",
+}
+
+/** Chart appearance config for a single usage metric key. */
+export type MetricChartConfig = {
+  title: string;
+  caption: string;
+  stroke: string;
+};
+
+/** Appearance config for each known metric key. */
+export const METRIC_CHART_CONFIG: Record<string, MetricChartConfig> = {
+  TRANSACTION_COUNT: {
+    title: "Transactions",
+    caption: "Periodic transaction count",
+    stroke: "#3B82F6",
+  },
+  API_COUNT: {
+    title: "API Count",
+    caption: "Unique APIs accessed per period",
+    stroke: "#8B5CF6",
+  },
+  MCP_API_COUNT: {
+    title: "MCP API Count",
+    caption: "MCP API calls per period",
+    stroke: "#14B8A6",
+  },
+  TOTAL_USERS: {
+    title: "Total Users",
+    caption: "Active users over time",
+    stroke: "#22C55E",
+  },
+  TOTAL_ROOT_ORGS: {
+    title: "Root Organizations",
+    caption: "Root organizations over time",
+    stroke: "#F59E0B",
+  },
+  TOTAL_B2B_ORGS: {
+    title: "B2B Organizations",
+    caption: "B2B organizations over time",
+    stroke: "#F97316",
+  },
+};
+
+export const METRIC_CHART_CONFIG_FALLBACK: MetricChartConfig = {
+  title: "Metric",
+  caption: "Metric over time",
+  stroke: "#6B7280",
+};
+
+export const CORE_CHART_CONFIG: MetricChartConfig = {
+  title: "Core Usage",
+  caption: "Cores over time",
+  stroke: "#F97316",
+};
+
+function parseMajorVersion(label: string): number {
+  const m = label.match(/(\d+)\.\d+/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Classifies a product label into a WSO2 product type and extracts major version.
+ *
+ * @param label - Product display label (e.g. "WSO2 API Manager 4.4.0 All In One").
+ * @returns Product type and major version number.
+ */
+export function classifyProductLabel(label: string): {
+  type: WsoProductType;
+  majorVersion: number;
+} {
+  const lower = label.toLowerCase();
+  const majorVersion = parseMajorVersion(label);
+  if (lower.includes("api manager") || lower.includes("apim")) {
+    return { type: WsoProductType.APIM, majorVersion };
+  }
+  if (lower.includes("identity server")) {
+    return { type: WsoProductType.IS, majorVersion };
+  }
+  if (lower.includes("micro integrator")) {
+    return { type: WsoProductType.MI, majorVersion };
+  }
+  return { type: WsoProductType.UNKNOWN, majorVersion };
+}
+
+/**
+ * Returns the ordered metric keys relevant for a given product label.
+ * UNKNOWN products fall back to showing all common metric keys.
+ *
+ * @param label - Product display label.
+ * @returns Ordered list of metric keys to display.
+ */
+export function getProductMetricKeys(label: string): string[] {
+  const { type, majorVersion } = classifyProductLabel(label);
+  switch (type) {
+    case WsoProductType.APIM:
+      return majorVersion >= 7
+        ? ["TRANSACTION_COUNT", "API_COUNT", "MCP_API_COUNT"]
+        : ["TRANSACTION_COUNT", "API_COUNT"];
+    case WsoProductType.IS:
+      return majorVersion >= 7
+        ? ["TOTAL_B2B_ORGS", "TOTAL_ROOT_ORGS", "TOTAL_USERS"]
+        : ["TOTAL_ROOT_ORGS", "TOTAL_USERS"];
+    case WsoProductType.MI:
+      return ["TRANSACTION_COUNT"];
+    default:
+      return ["TRANSACTION_COUNT", "API_COUNT", "TOTAL_USERS", "TOTAL_ROOT_ORGS"];
+  }
+}


### PR DESCRIPTION
 ## Summary

  - **Environment breakdown product cards**: Fall back to `product.id`/`product.label` when `deployedProduct` is null so instances and usages with only a product reference render as product
  cards
  - **Row header counts**: Use deployment-level data for accurate product/instance/core counts; both hooks gated on `expanded` via a ref so no API calls fire on mount and cached data is served
  on collapse
  - **Product count correctness**: Count distinct products from both instances and usages so usage-only products (0 instances) are included
  - **Lazy usages in DeploymentExpandedView**: `usePostDeploymentInstancesUsagesSearch` now gated on `expanded` prop to prevent firing for every collapsed row
  - **Overview stat cards**: Wire `useGetProjectUsageStats` current values into Environments/Products/Instances cards; include `usagesLoading` in `isStatCardsLoading`
  - **curr fix**: Use latest datapoint directly instead of last non-zero so current value reflects actual latest day
  - **UI**: Core count pill now shows `Curr/Avg/Min/Max` labels; metric row wraps on narrow screens
  - **Naming**: Rename `b2bTrend`/`b2bHD` → `rootOrgTrend`/`rootOrgHD` in aggregated metrics
  - **Asgardeo**: Upgrade `@asgardeo/react` from `0.25.5` → `0.25.6`

  ## Test plan
 
  - [ ] Page load with multiple environment rows — no 500 throttle errors in network tab
  - [ ] Expand an environment row — correct product/instance/core counts appear in header and cards
  - [ ] Collapse the row — header counts stay the same (no jump back to 0)
  - [ ] Overview stat cards show correct current values
  - [ ] Core count pill reads `Curr X / Avg X / Min X / Max X`
  - [ ] Metric row wraps cleanly on a narrow viewport
  - [ ] Asgardeo auth flow works (login, token refresh, logout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the usage metrics accordion so environment-scoped data only stays disabled until the row is first expanded, then continues using cached results on collapse/reopen.
  * Refined usage summary counts to reflect fetched environment data when available (products, instances, cores, and transaction labels).

* **New Features**
  * Updated the usage metrics UI to render product and instance trends dynamically from computed chart definitions (instead of fixed transaction/core charts).
  * Introduced product label classification to select the appropriate metric keys and trend configuration.

* **Tests**
  * Updated usage metrics panel test data to match the new chart/trend model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->