### PR TITLE
[CSM Portal] Operations tab + SR creation; align FE with BE #938; stop calling missing /csm/dashboard

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -50,6 +50,12 @@ const CsmCaseCreatePage = lazy(
 const CsmCaseDetailPage = lazy(
   () => import("@features/csm-cases/pages/CsmCaseDetailPage"),
 );
+const OperationsPage = lazy(
+  () => import("@features/csm-operations/pages/OperationsPage"),
+);
+const CreateServiceRequestPage = lazy(
+  () => import("@features/csm-operations/pages/CreateServiceRequestPage"),
+);
 const CsmAdminLayout = lazy(
   () => import("@features/csm-admin/pages/CsmAdminLayout"),
 );
@@ -166,17 +172,13 @@ export default function App(): JSX.Element {
                 <Route path="cases/new" element={<CsmCaseCreatePage />} />
                 <Route path="cases/:caseId" element={<CsmCaseDetailPage />} />
 
-                {/* WIP placeholders for top-level features awaiting BFF support */}
+                <Route path="operations" element={<OperationsPage />} />
                 <Route
-                  path="operations"
-                  element={
-                    <CsmComingSoonPage
-                      title="Operations"
-                      description="Service requests and change requests across customers."
-                      blockedOn="csm-portal/backend operations endpoints"
-                    />
-                  }
+                  path="operations/service-requests/new"
+                  element={<CreateServiceRequestPage />}
                 />
+
+                {/* WIP placeholders for top-level features awaiting BFF support */}
                 <Route
                   path="engagements"
                   element={

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -63,9 +63,9 @@ export type BeCaseIssueType =
   | "security_or_compliance"
   | "total_outage";
 
-/** Case type (entity `typeKey`). Only `support` is creatable from the portal. */
+/** Case type (entity `type`). Only `case` is creatable from the portal. */
 export type BeCaseType =
-  | "support"
+  | "case"
   | "service_request"
   | "security_report_analysis"
   | "announcement"
@@ -166,7 +166,9 @@ export interface BeCaseView {
   description?: string;
   severity?: BeCaseSeverity;
   issueType?: BeCaseIssueType;
-  type?: BeCaseType;
+  type?: BeCaseType | null;
+  /** Engagement type; only meaningful for `engagement` cases. Null otherwise. */
+  engagementType?: string | null;
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
@@ -176,16 +178,23 @@ export interface BeCaseView {
   assignedEngineer?: BeAssignedEngineerRef | null;
   account?: BeCaseAccountRef;
   project?: BeEntityRef;
-  deployment?: BeEntityRef;
-  deployedProduct?: BeDeployedProductRef;
+  /** Nullable: ServiceNow-sourced cases may have no deployment / product. */
+  deployment?: BeEntityRef | null;
+  deployedProduct?: BeDeployedProductRef | null;
+  /** SR catalog refs (managed-cloud); null for non-catalog cases. */
+  catalog?: BeEntityRef | null;
+  catalogItem?: BeEntityRef | null;
+  /** Assigned team and linked chat conversation; null when not set. */
+  assignedTeam?: BeEntityRef | null;
+  conversation?: BeEntityRef | null;
   createdOn?: string;
   updatedOn?: string;
   closedAt?: string | null;
 }
 
 export interface BeCaseCreatePayload {
-  /** Case type. The portal only creates `support` cases. */
-  type: "support";
+  /** Case type. The portal only creates `case` (standard support) cases. */
+  type: "case";
   projectId: string;
   deploymentId: string;
   deployedProductId: string;
@@ -307,6 +316,8 @@ export interface BeCaseSearchView {
   description?: string;
   severity?: BeCaseSeverity;
   issueType?: BeCaseIssueType;
+  /** Case type (e.g. `case`, `service_request`). */
+  type?: BeCaseType;
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
@@ -318,10 +329,11 @@ export interface BeCaseSearchView {
   /** Created-by is a bare email string here (not a UserRef like the GET view). */
   createdBy?: string;
   project?: BeEntityRef;
-  deployment?: BeEntityRef;
+  /** Nullable: ServiceNow-sourced cases may have no deployment / product. */
+  deployment?: BeEntityRef | null;
   /** Embedded as `{ id, name }` (name already includes the version), not the
    * `displayName`-shaped ref the GET view uses. */
-  deployedProduct?: BeEntityRef;
+  deployedProduct?: BeEntityRef | null;
 }
 
 export interface BeCaseSearchResponse extends BeSearchResponseBase {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -213,6 +213,7 @@ export function useGetCsmCases(
           product: c.deployedProduct?.name ?? "—",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
+          caseType: c.type,
           workState: c.workState ?? null,
           assignee,
           assigneeIsMe,

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -166,7 +166,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
     if (!canSubmit || !severity || !issueType || descriptionOverLimit) return;
     postCase.mutate(
       {
-        type: "support",
+        type: "case",
         projectId,
         deploymentId,
         deployedProductId,

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseType.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseType.ts
@@ -23,7 +23,7 @@ import type { BeCaseType } from "@api/backend/types";
 
 /** All case types, in the order they appear in the type dropdown. */
 export const ALL_CASE_TYPES: BeCaseType[] = [
-  "support",
+  "case",
   "service_request",
   "security_report_analysis",
   "announcement",
@@ -32,7 +32,7 @@ export const ALL_CASE_TYPES: BeCaseType[] = [
 
 /** Human-readable label per case type. */
 export const CASE_TYPE_LABEL: Record<BeCaseType, string> = {
-  support: "Support",
+  case: "Case",
   service_request: "Service request",
   security_report_analysis: "Security report",
   announcement: "Announcement",

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -32,13 +32,13 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "q=timeout&severities=S0,S2&states=open,closed&types=support,engagement&assignees=alice@example.com,@me&projects=apim",
+      "q=timeout&severities=S0,S2&states=open,closed&types=case,engagement&assignees=alice@example.com,@me&projects=apim",
     );
     expect(readCasesFiltersFromUrl(params)).toEqual({
       search: "timeout",
       severities: ["S0", "S2"],
       states: ["open", "closed"],
-      caseTypes: ["support", "engagement"],
+      caseTypes: ["case", "engagement"],
       assignees: ["alice@example.com", "@me"],
       projects: ["apim"],
     });
@@ -46,12 +46,12 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("drops values outside the allowed enums", () => {
     const params = new URLSearchParams(
-      "severities=S0,S9,wat&states=open,nonsense&types=support,bogus_type",
+      "severities=S0,S9,wat&states=open,nonsense&types=case,bogus_type",
     );
     const f = readCasesFiltersFromUrl(params);
     expect(f.severities).toEqual(["S0"]);
     expect(f.states).toEqual(["open"]);
-    expect(f.caseTypes).toEqual(["support"]);
+    expect(f.caseTypes).toEqual(["case"]);
   });
 
   it("strips empties and over-long free-form entries", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type JSX } from "react";
+import { useNavigate } from "react-router";
+import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
+import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+
+const SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+
+// Submission is disabled until the backend exposes a service-request create
+// endpoint. SR is currently only a case *type* (`service_request`) in the
+// contract; there is no SR entity/endpoint and `POST /cases` accepts only
+// `type: "support"`. The form is built and validated so it can be wired the
+// moment the BE adds the endpoint (and its catalog/category model) — flip this
+// flag and add the mutation in `handleSubmit`.
+const SR_CREATE_ENABLED = false;
+
+export default function CreateServiceRequestPage(): JSX.Element {
+  const navigate = useNavigate();
+
+  const [projectId, setProjectId] = useState("");
+  const [priority, setPriority] = useState<Severity | "">("");
+  const [subject, setSubject] = useState("");
+  const [description, setDescription] = useState("");
+
+  const isValid = useMemo(
+    () =>
+      !!projectId &&
+      !!priority &&
+      subject.trim().length > 0 &&
+      description.trim().length > 0,
+    [projectId, priority, subject, description],
+  );
+
+  // Wire the real mutation here when SR_CREATE_ENABLED flips on.
+  const handleSubmit = (): void => {
+    if (!SR_CREATE_ENABLED || !isValid) return;
+  };
+
+  return (
+    <Box sx={{ width: "100%", px: 3, py: 3 }}>
+      <Button
+        variant="text"
+        startIcon={<ArrowLeft size={16} />}
+        onClick={() => navigate("/operations")}
+        sx={{ mb: 1 }}
+      >
+        Back to operations
+      </Button>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        New service request
+      </Typography>
+
+      <Card variant="outlined" sx={{ p: 3 }}>
+        <Alert severity="info" sx={{ mb: 2.5 }}>
+          Service request creation isn&apos;t available yet — the backend
+          endpoint (and the request catalog) are still to come. You can review
+          the form below; submitting is disabled for now.
+        </Alert>
+
+        <Grid container spacing={2.5}>
+          <Grid size={{ xs: 12, md: 8 }}>
+            <AsyncProjectSelect
+              value={projectId}
+              onChange={setProjectId}
+              required
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="sr-priority-label">Priority</InputLabel>
+              <Select
+                labelId="sr-priority-label"
+                label="Priority"
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as Severity)}
+              >
+                {SEVERITIES.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {s} · {SEVERITY_LABEL[s]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <TextField
+              label="Subject"
+              size="small"
+              fullWidth
+              required
+              value={subject}
+              onChange={(e) => setSubject(e.target.value.slice(0, 200))}
+              helperText={
+                subject.length >= 160 ? `${subject.length}/200` : undefined
+              }
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <TextField
+              label="Description"
+              size="small"
+              fullWidth
+              required
+              multiline
+              minRows={5}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe what the customer is requesting…"
+            />
+          </Grid>
+        </Grid>
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, mt: 2.5 }}>
+          <Button variant="outlined" onClick={() => navigate("/operations")}>
+            Cancel
+          </Button>
+          <Tooltip
+            title={
+              SR_CREATE_ENABLED
+                ? ""
+                : "Service request creation will be enabled once the backend supports it."
+            }
+          >
+            <Box component="span">
+              <Button
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={!SR_CREATE_ENABLED || !isValid}
+              >
+                Create service request
+              </Button>
+            </Box>
+          </Tooltip>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Chip, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { Plus } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX, type ReactNode } from "react";
+import { useNavigate } from "react-router";
+
+type OperationsTabId = "service_requests" | "change_requests" | "incidents";
+
+/**
+ * Operations landing — the home for the managed-cloud operational entities,
+ * split into Service Requests / Change Requests / Incidents tabs. Only the
+ * Service Request create entry point is live; the list views and the
+ * CR/Incident tabs are awaiting their backend endpoints, so they render
+ * "coming soon" placeholders. Replaces the previous blanket coming-soon page.
+ */
+export default function OperationsPage(): JSX.Element {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box>
+        <Typography variant="h5">Operations</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Service requests, change requests, and incidents across customers.
+        </Typography>
+      </Box>
+
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, v) => setActiveTab(v as OperationsTabId)}
+        >
+          <Tab value="service_requests" label="Service requests" />
+          <Tab value="change_requests" label="Change requests" />
+          <Tab value="incidents" label="Incidents" />
+        </Tabs>
+      </Box>
+
+      {activeTab === "service_requests" && (
+        <TabPanel
+          description="Catalog-driven requests raised on behalf of a customer (e.g. configuration, access, infrastructure changes)."
+          action={
+            <Button
+              variant="contained"
+              color="primary"
+              size="small"
+              startIcon={<Plus size={16} />}
+              onClick={() => navigate("/operations/service-requests/new")}
+            >
+              Create service request
+            </Button>
+          }
+        >
+          <Typography variant="body2" color="text.secondary">
+            The service request list will appear here once the backend search
+            endpoint is available.
+          </Typography>
+        </TabPanel>
+      )}
+
+      {activeTab === "change_requests" && (
+        <TabPanel
+          description="Controlled changes, linked to service requests, with peer / CAB approval."
+          comingSoon
+        />
+      )}
+
+      {activeTab === "incidents" && (
+        <TabPanel
+          description="SaaS incidents raised by CRE or automation; may link to a case."
+          comingSoon
+        />
+      )}
+    </Box>
+  );
+}
+
+interface TabPanelProps {
+  description: string;
+  action?: ReactNode;
+  comingSoon?: boolean;
+  children?: ReactNode;
+}
+
+function TabPanel({
+  description,
+  action,
+  comingSoon,
+  children,
+}: TabPanelProps): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1.5,
+          flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            {description}
+          </Typography>
+          {comingSoon && (
+            <Chip
+              size="small"
+              label="Coming soon"
+              color="warning"
+              variant="outlined"
+            />
+          )}
+        </Box>
+        {action}
+      </Box>
+      {children}
+    </Box>
+  );
+}


### PR DESCRIPTION


## 1. Operations tab + Service Request creation
- **Operations landing** — SR / CR / Incident as **tabs**. The Service Requests tab has a **Create service request** entry point; CR/Incident are "coming soon".
- **Create-SR form** (`/operations/service-requests/new`) — project, priority (S0–S4), subject, description. **Submission gated off** (`SR_CREATE_ENABLED = false`): no SR create endpoint yet (SR is only a case *type*; `POST /cases` takes `case` only). Validates and is ready to wire; **no API call made**.

## 2. Align FE with BE PR #938 (entity #934)
- Case type value **`support` → `case`** across `BeCaseType`, `POST /cases`, the case-type filter (label "Support" → "Case"), `CsmCaseCreatePage`. (v2's FE still sent `support` while the merged BFF expects `case` — this fixes that inconsistency.)
- `CaseView`: nullable `type`/`engagementType` + `catalog`/`catalogItem`/`assignedTeam`/`conversation` refs; `deployment`/`deployedProduct` nullable.
- `CaseSearchView`: add `type` (mapped onto the row); refs nullable.

## 3. Stop calling the missing `/csm/dashboard` endpoint (folds in #941)
- The dashboard fired `GET /csm/dashboard` on every load — a guaranteed 404 (no such BFF endpoint). Query **disabled** (`DASHBOARD_ENDPOINT_READY = false`); one-line flip to re-enable. Header degrades to a neutral "Engineer overview" subtitle (no perpetual "Loading…"); unused `isError` prop dropped. The live `/cases/search`-backed widgets are unaffected.

## Testing
`pnpm lint`, `pnpm test`, `pnpm build`, `tsc -b` all green.
