### PR TITLE
[CSM Portal][BE] align with entity service PR #934: case type rename and nullable fields

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -51,7 +51,7 @@ Follow these steps in order:
 - **Auth**: always check `middleware.UserInfoFromContext(r.Context()) == nil` first → 401
 - **Body size**: cap with `http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)` (1 MiB) before reading
 - **Path params**: guard against empty string after `r.PathValue("id")`; if the param is a UUID, also validate format using the package-level `uuidRe` compiled regex and return 400 on mismatch — fail fast before calling the upstream
-- **Field naming**: case create/patch use bare names without `Key`/`Keys` suffix — `state`, `severity`, `workState` (PATCH), `type`, `severity`, `issueType` (POST); search filters use `states`, `severities`, `types`, `issueTypes`, `engagementTypes`; deployment search uses `deploymentTypes`; case comments use `type` (not `typeKey`); case create requires `type: "support"` (only accepted value currently)
+- **Field naming**: case create/patch use bare names without `Key`/`Keys` suffix — `state`, `severity`, `workState` (PATCH), `type`, `severity`, `issueType` (POST); search filters use `states`, `severities`, `types`, `issueTypes`, `engagementTypes`; deployment search uses `deploymentTypes`; case comments use `type` (not `typeKey`); case create requires `type: "case"` (only accepted value currently)
 - **Upstream errors**: always use `mapUpstreamError(w, err, "<fallback message>")` — never write custom status mappings inline
 - **Response**: return raw `[]byte` with `writeJSON` for simple passthroughs; unmarshal into typed structs only when the response shape needs to change
 

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -158,7 +158,7 @@ backend/
 
 ### Cases
 
-- `POST /cases` — Create a case (requires `type: "support"`)
+- `POST /cases` — Create a case (requires `type: "case"`)
 - `GET /cases/{id}` — Get case by ID
 - `PATCH /cases/{id}` — Update a case (state, severity, workState, watchList, or assigneeEmail)
 - `POST /cases/search` — Search cases

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -56,7 +56,7 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 // ----- CreateCase -----
 
 func TestCreateCase(t *testing.T) {
-	const validPayload = `{"type":"support","projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","severity":"high","issueType":"error"}`
+	const validPayload = `{"type":"case","projectId":"proj-1","deploymentId":"dep-1","deployedProductId":"dp-1","subject":"Login failure","description":"Users cannot log in","severity":"high","issueType":"error"}`
 
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1322,8 +1322,8 @@ components:
       properties:
         type:
           type: string
-          enum: [support]
-          description: Case type. Currently only `support` is accepted.
+          enum: [case]
+          description: Case type. Currently only `case` is accepted.
         projectId:
           type: string
           description: UUID of the project this case belongs to
@@ -1356,7 +1356,7 @@ components:
           items:
             type: string
             enum:
-              - support
+              - case
               - service_request
               - security_report_analysis
               - announcement
@@ -1654,6 +1654,14 @@ components:
             - ongoing
             - paused
           description: Sub-state of work_in_progress. Null when state is not work_in_progress.
+        type:
+          type: string
+          nullable: true
+          description: Case type (e.g. case, service_request). Null if not set.
+        engagementType:
+          type: string
+          nullable: true
+          description: Engagement type. Null if not set.
         createdOn:
           type: string
           format: date-time
@@ -1670,11 +1678,33 @@ components:
         project:
           $ref: '#/components/schemas/EntityRef'
         deployment:
-          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
         deployedProduct:
-          $ref: '#/components/schemas/DeployedProductRef'
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/DeployedProductRef'
         product:
-          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        catalog:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        catalogItem:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        assignedTeam:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        conversation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
         assignedEngineer:
           $ref: '#/components/schemas/AssignedEngineerRef'
         parentCase:
@@ -1745,6 +1775,9 @@ components:
             - ongoing
             - paused
           description: Sub-state of work_in_progress. Null when state is not work_in_progress.
+        type:
+          type: string
+          description: Case type (e.g. case, service_request).
         createdOn:
           type: string
           format: date-time
@@ -1761,11 +1794,17 @@ components:
         project:
           $ref: '#/components/schemas/EntityRef'
         deployment:
-          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
         deployedProduct:
-          $ref: '#/components/schemas/DeployedProductRef'
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
         product:
-          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
         assignedEngineer:
           $ref: '#/components/schemas/AssignedEngineerRef'
         parentCase:


### PR DESCRIPTION
## Summary

Aligns the CSM portal BFF with entity service [PR #934](https://github.com/wso2-open-operations/cs-tools/pull/934) (improve case API response consistency for ServiceNow data source).

- Rename `type` enum value `support` → `case` in `CaseCreatePayload` and `CaseSearchFilters`
- Add `type` (nullable) and `engagementType` (nullable) fields to `CaseView`
- Add `catalog`, `catalogItem`, `assignedTeam`, `conversation` as nullable `EntityRef` fields to `CaseView`
- Mark `deployment`, `deployedProduct`, `product` as nullable in `CaseView`
- Add `type` field and mark `deployment`, `deployedProduct`, `product` as nullable in `CaseSearchView`
- Update test payload (`"type":"case"`) and docs accordingly

> **Note:** This branch builds on `csm-portal-be-pr929-alignment` and should be merged after that PR lands.

## Test plan

- [x] `go test ./...` passes (verified via pre-push hook)
- [x] `openapi.yaml` updated: `CaseCreatePayload.type` enum, `CaseSearchFilters.types` enum, `CaseView` and `CaseSearchView` response schemas
- [x] `POST /cases` with `"type":"case"` forwards correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Case creation now accepts the correct case type value, improving request validation and consistency.
  * Case-related responses and search results now include additional case metadata and handle missing related fields more gracefully.

* **Documentation**
  * Updated backend and API docs to reflect the current case type requirements and response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->