### PR TITLE
[Customer Portal][FE] feat: partner global search with live dropdown

### DIFF
--- a/apps/customer-portal/webapp/src/App.tsx
+++ b/apps/customer-portal/webapp/src/App.tsx
@@ -47,6 +47,8 @@ import EngagementsPage from "@features/engagements/pages/EngagementsPage";
 import UsageMetricsPage from "@features/usage-metrics/pages/UsageMetricsPage";
 import SettingsPage from "@features/settings/pages/SettingsPage";
 import ServiceNowCaseRedirectPage from "@features/project-hub/pages/ServiceNowCaseRedirectPage";
+import PartnerProjectsPage from "@features/project-hub/pages/PartnerProjectsPage";
+import PartnerCasesPage from "@features/project-hub/pages/PartnerCasesPage";
 import Error401Page from "@components/error/Error401Page";
 import Error403Page from "@components/error/Error403Page";
 import Error404Page from "@components/error/Error404Page";
@@ -98,6 +100,10 @@ export default function App(): JSX.Element {
                   path="support"
                   element={<ServiceNowCaseRedirectPage />}
                 />
+
+                {/* Partner global search drill-down pages */}
+                <Route path="partner/projects" element={<PartnerProjectsPage />} />
+                <Route path="partner/cases" element={<PartnerCasesPage />} />
 
                 {/* Project Specific Routes */}
                 <Route path="projects/:projectId" element={<ProjectGuard />}>

--- a/apps/customer-portal/webapp/src/api/useGetGlobalCasesPage.ts
+++ b/apps/customer-portal/webapp/src/api/useGetGlobalCasesPage.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAsgardeo } from "@asgardeo/react";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import type { CaseSearchRequest, CaseSearchResponse } from "@features/support/types/cases";
+
+export interface UseGetGlobalCasesPageOptions {
+  enabled?: boolean;
+}
+
+/**
+ * Fetches a single page of cases across all projects (global search).
+ * Uses the /cases/search endpoint which returns cases without a project scope.
+ *
+ * @param baseRequest - Search filters (no pagination).
+ * @param offset - Pagination offset.
+ * @param limit - Page size.
+ * @param options - Optional { enabled } to control query execution.
+ * @returns Query result with cases for the requested page.
+ */
+export function useGetGlobalCasesPage(
+  baseRequest: Omit<CaseSearchRequest, "pagination">,
+  offset: number,
+  limit: number,
+  options?: UseGetGlobalCasesPageOptions,
+): UseQueryResult<CaseSearchResponse, Error> {
+  const logger = useLogger();
+  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
+  const authFetch = useAuthApiClient();
+
+  return useQuery<CaseSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.GLOBAL_CASES, "page", baseRequest, offset, limit],
+    queryFn: async (): Promise<CaseSearchResponse> => {
+      const requestBody: CaseSearchRequest = {
+        ...baseRequest,
+        pagination: { offset, limit },
+      };
+      logger.debug(
+        `[useGetGlobalCasesPage] Fetching global cases, offset: ${offset}, limit: ${limit}`,
+      );
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
+      if (!baseUrl) {
+        throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
+      }
+      const response = await authFetch(`${baseUrl}/cases/search`, {
+        method: "POST",
+        body: JSON.stringify(requestBody),
+      });
+      if (!response.ok) {
+        throw new Error(`Error fetching global cases: ${response.statusText}`);
+      }
+      return response.json();
+    },
+    enabled:
+      (options?.enabled ?? true) &&
+      isSignedIn &&
+      !isAuthLoading &&
+      offset >= 0 &&
+      limit > 0,
+    staleTime: 0,
+  });
+}

--- a/apps/customer-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/apiConstants.ts
@@ -71,6 +71,7 @@ export const ApiQueryKeys = {
   DEPLOYMENT_INSTANCE_METRICS: "deployment-instance-metrics",
   DEPLOYED_PRODUCT_INSTANCE_METRICS: "deployed-product-instance-metrics",
   PROJECT_INSTANCE_USAGE_STATS: "project-instance-usage-stats",
+  GLOBAL_CASES: "global-cases",
 } as const;
 
 // Constants for API-related mutation keys.

--- a/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
@@ -1,0 +1,785 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  Divider,
+  Menu,
+  MenuItem,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ChevronDown, Download, FileText, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type MouseEvent, useCallback, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { useGetGlobalCasesPage } from "@api/useGetGlobalCasesPage";
+import useInfiniteProjects from "@api/useGetProjects";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { PROJECT_HUB_SEARCH_DEBOUNCE_MS } from "@features/project-hub/constants/projectHubConstants";
+import {
+  downloadProjectListCsv,
+  downloadProjectListPdf,
+  fetchAllProjectsForExport,
+} from "@features/project-hub/utils/projectsExport";
+import { mapSeverityToDisplay } from "@features/support/utils/support";
+
+type ExportFormat = "csv" | "pdf";
+
+const GLOBAL_SEARCH_PAGE_SIZE = 10;
+const SKELETON_ROW_COUNT = 5;
+const DROPDOWN_RESULT_LIMIT = 5;
+const DATE_LOCALE = "en-US";
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "--";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? "--" : d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT_OPTIONS);
+}
+
+function getSeverityChipColor(
+  label?: string,
+): "default" | "error" | "info" | "secondary" | "success" | "warning" {
+  const display = mapSeverityToDisplay(label);
+  const token = display.replace(/\s*\(.*$/, "").toUpperCase();
+  switch (token) {
+    case "S0":
+      return "error";
+    case "S1":
+      return "warning";
+    case "S2":
+      return "info";
+    case "S3":
+      return "secondary";
+    case "S4":
+      return "success";
+    default:
+      return "default";
+  }
+}
+
+function highlightMatch(text: string, query: string): JSX.Element {
+  if (!query.trim()) return <>{text}</>;
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase().trim();
+  const idx = lowerText.indexOf(lowerQuery);
+  if (idx === -1) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <strong>{text.slice(idx, idx + lowerQuery.length)}</strong>
+      {text.slice(idx + lowerQuery.length)}
+    </>
+  );
+}
+
+function SkeletonRows({ cols }: { cols: number }): JSX.Element {
+  return (
+    <>
+      {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+        <TableRow key={`sk-${i}`}>
+          {Array.from({ length: cols }).map((_, j) => (
+            <TableCell key={j}>
+              <Skeleton variant="text" width="80%" />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Salesforce-style global search for partner users.
+ * Shows the first 10 projects and first 10 cases in separate table sections,
+ * each with a "View More" placeholder button.
+ */
+export default function PartnerGlobalSearch(): JSX.Element {
+  const navigate = useNavigate();
+  const authFetch = useAuthApiClient();
+  const { showError } = useErrorBanner();
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
+
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
+  const isExportingRef = useRef(false);
+  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingRef.current) setExportAnchorEl(e.currentTarget);
+  };
+  const handleExportClose = () => setExportAnchorEl(null);
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingRef.current) return;
+      handleExportClose();
+      isExportingRef.current = true;
+      setExportingFormat(format);
+      try {
+        const allProjects = await fetchAllProjectsForExport(authFetch);
+        if (allProjects.length === 0) {
+          showError("No projects to export.");
+          return;
+        }
+        if (format === "csv") {
+          downloadProjectListCsv(allProjects);
+        } else {
+          downloadProjectListPdf(allProjects);
+        }
+      } catch {
+        showError("Failed to export projects.");
+      } finally {
+        isExportingRef.current = false;
+        setExportingFormat(null);
+      }
+    },
+    [authFetch, showError],
+  );
+
+  const isExporting = exportingFormat !== null;
+
+  // Table queries — always unfiltered; do not react to the search input
+  const {
+    data: projectsData,
+    isLoading: isLoadingProjects,
+    isError: isErrorProjects,
+  } = useInfiniteProjects({ pageSize: GLOBAL_SEARCH_PAGE_SIZE });
+
+  const {
+    data: casesData,
+    isLoading: isLoadingCases,
+    isError: isErrorCases,
+  } = useGetGlobalCasesPage({}, 0, GLOBAL_SEARCH_PAGE_SIZE);
+
+  // Dropdown queries — filtered by the live search query
+  const {
+    data: dropdownProjectsData,
+    isLoading: isLoadingDropdownProjects,
+  } = useInfiniteProjects({
+    pageSize: DROPDOWN_RESULT_LIMIT,
+    searchQuery: debouncedSearchQuery || undefined,
+  });
+
+  const {
+    data: dropdownCasesData,
+    isLoading: isLoadingDropdownCases,
+  } = useGetGlobalCasesPage(
+    { filters: debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : undefined },
+    0,
+    DROPDOWN_RESULT_LIMIT,
+  );
+
+  const projects = useMemo(
+    () => (projectsData?.pages[0]?.projects ?? []).slice(0, GLOBAL_SEARCH_PAGE_SIZE),
+    [projectsData],
+  );
+  const projectsTotal = projectsData?.pages[0]?.totalRecords ?? 0;
+  const cases = casesData?.cases ?? [];
+  const casesTotal = casesData?.totalRecords ?? 0;
+
+  const projectsMoreCount = Math.max(0, projectsTotal - projects.length);
+  const casesMoreCount = Math.max(0, casesTotal - cases.length);
+
+  const isDebouncing = searchQuery.trim() !== debouncedSearchQuery.trim();
+  const dropdownProjects = isDebouncing || isLoadingDropdownProjects
+    ? []
+    : (dropdownProjectsData?.pages[0]?.projects ?? []).slice(0, DROPDOWN_RESULT_LIMIT);
+  const dropdownCases = isDebouncing || isLoadingDropdownCases
+    ? []
+    : (dropdownCasesData?.cases ?? []).slice(0, DROPDOWN_RESULT_LIMIT);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flex: 1,
+        flexDirection: "column",
+        minHeight: 0,
+        overflow: "hidden",
+        width: "100%",
+      }}
+    >
+      {/* Page header + search bar */}
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexDirection: "column",
+          flexShrink: 0,
+          pb: 2,
+          pt: 2.5,
+          px: 2,
+          textAlign: "center",
+        }}
+      >
+        <Box sx={{ maxWidth: 560, position: "relative", width: "100%" }}>
+          <TextField
+            fullWidth
+            inputProps={{ autoComplete: "off" }}
+            InputProps={{
+              endAdornment: searchQuery ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="Clear search"
+                    edge="end"
+                    onClick={() => {
+                      setSearchQuery("");
+                      setDropdownOpen(false);
+                    }}
+                    size="small"
+                  >
+                    <X size={16} />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
+              startAdornment: <Search size={20} style={{ marginRight: 8 }} />,
+            }}
+            onBlur={() => setDropdownOpen(false)}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setDropdownOpen(Boolean(e.target.value.trim()));
+            }}
+            onFocus={() => {
+              if (searchQuery.trim()) setDropdownOpen(true);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setDropdownOpen(false);
+            }}
+            placeholder="Search projects and cases..."
+            size="small"
+            sx={{
+              "& input:-webkit-autofill, & input:-webkit-autofill:focus, & input:-webkit-autofill:hover":
+                {
+                  WebkitBoxShadow: "0 0 0 100px transparent inset",
+                  WebkitTextFillColor: "inherit",
+                  transition: "background-color 5000s ease-in-out 0s",
+                },
+            }}
+            value={searchQuery}
+          />
+          {dropdownOpen && (
+            <Paper
+              elevation={4}
+              onMouseDown={(e) => e.preventDefault()}
+              sx={{
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+                left: 0,
+                maxHeight: 400,
+                mt: 0.5,
+                overflowY: "auto",
+                position: "absolute",
+                right: 0,
+                textAlign: "left",
+                top: "100%",
+                zIndex: 1300,
+              }}
+            >
+              {/* Projects section */}
+              {(isDebouncing || isLoadingProjects || dropdownProjects.length > 0) && (
+                <>
+                  {isDebouncing || isLoadingProjects ? (
+                    [1, 2, 3].map((i) => (
+                      <Box
+                        key={i}
+                        sx={{
+                          alignItems: "center",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1,
+                        }}
+                      >
+                        <Skeleton height={36} variant="circular" width={36} />
+                        <Box sx={{ flex: 1 }}>
+                          <Skeleton variant="text" width="70%" />
+                          <Skeleton variant="text" width="30%" />
+                        </Box>
+                      </Box>
+                    ))
+                  ) : (
+                    dropdownProjects.map((project) => (
+                      <Box
+                        key={project.id}
+                        onClick={() => {
+                          setDropdownOpen(false);
+                          navigate(`/projects/${project.id}/dashboard`);
+                        }}
+                        sx={{
+                          alignItems: "center",
+                          cursor: "pointer",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1.25,
+                          "&:hover": { bgcolor: "action.hover" },
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            alignItems: "center",
+                            bgcolor: "primary.main",
+                            borderRadius: "50%",
+                            color: "primary.contrastText",
+                            display: "flex",
+                            flexShrink: 0,
+                            height: 36,
+                            justifyContent: "center",
+                            width: 36,
+                          }}
+                        >
+                          <FolderOpen size={16} />
+                        </Box>
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography noWrap variant="body2">
+                            {highlightMatch(
+                              project.key
+                                ? `${project.key} · ${project.name}`
+                                : project.name,
+                              debouncedSearchQuery,
+                            )}
+                          </Typography>
+                          <Typography color="text.secondary" variant="caption">
+                            Project
+                          </Typography>
+                        </Box>
+                      </Box>
+                    ))
+                  )}
+                </>
+              )}
+
+              {/* Divider between sections — only when both have results */}
+              {!isDebouncing &&
+                !isLoadingProjects &&
+                !isLoadingCases &&
+                dropdownProjects.length > 0 &&
+                dropdownCases.length > 0 && <Divider />}
+
+              {/* Cases section */}
+              {(isDebouncing || isLoadingCases || dropdownCases.length > 0) && (
+                <>
+                  {isDebouncing || isLoadingCases ? (
+                    [1, 2, 3].map((i) => (
+                      <Box
+                        key={i}
+                        sx={{
+                          alignItems: "center",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1,
+                        }}
+                      >
+                        <Skeleton height={36} variant="circular" width={36} />
+                        <Box sx={{ flex: 1 }}>
+                          <Skeleton variant="text" width="70%" />
+                          <Skeleton variant="text" width="30%" />
+                        </Box>
+                      </Box>
+                    ))
+                  ) : (
+                    dropdownCases.map((c) => (
+                      <Box
+                        key={c.id}
+                        onClick={() => {
+                          setDropdownOpen(false);
+                          navigate(
+                            `/projects/${c.project?.id}/support/cases/${c.id}`,
+                          );
+                        }}
+                        sx={{
+                          alignItems: "center",
+                          cursor: "pointer",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1.25,
+                          "&:hover": { bgcolor: "action.hover" },
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            alignItems: "center",
+                            bgcolor: "warning.main",
+                            borderRadius: "50%",
+                            color: "warning.contrastText",
+                            display: "flex",
+                            flexShrink: 0,
+                            height: 36,
+                            justifyContent: "center",
+                            width: 36,
+                          }}
+                        >
+                          <FileText size={16} />
+                        </Box>
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography noWrap variant="body2">
+                            {highlightMatch(
+                              c.number
+                                ? `${c.number} · ${c.title ?? ""}`
+                                : (c.title ?? ""),
+                              debouncedSearchQuery,
+                            )}
+                          </Typography>
+                          <Typography color="text.secondary" variant="caption">
+                            Case
+                          </Typography>
+                        </Box>
+                      </Box>
+                    ))
+                  )}
+                </>
+              )}
+
+              {/* No results */}
+              {!isDebouncing &&
+                !isLoadingProjects &&
+                !isLoadingCases &&
+                dropdownProjects.length === 0 &&
+                dropdownCases.length === 0 && (
+                  <Box sx={{ px: 2, py: 2, textAlign: "center" }}>
+                    <Typography color="text.secondary" variant="body2">
+                      No results found.
+                    </Typography>
+                  </Box>
+                )}
+            </Paper>
+          )}
+        </Box>
+      </Box>
+
+      {/* Scrollable content: projects + cases sections */}
+      <Box
+        sx={{
+          display: "flex",
+          flex: "1 1 auto",
+          flexDirection: "column",
+          gap: 3,
+          overflowX: "hidden",
+          overflowY: "auto",
+          pb: 4,
+          px: 2,
+        }}
+      >
+        {/* Projects section */}
+        <Box>
+          <Box sx={{ alignItems: "center", display: "flex", mb: 1.5 }}>
+            <Box sx={{ alignItems: "center", display: "flex", flex: 1, gap: 1 }}>
+              <FolderOpen size={20} />
+              <Typography variant="h6">
+                Projects
+                {!isLoadingProjects && (
+                  <Typography
+                    color="text.secondary"
+                    component="span"
+                    variant="h6"
+                  >
+                    {" "}
+                    ({projectsTotal})
+                  </Typography>
+                )}
+              </Typography>
+            </Box>
+            <Button
+              aria-controls="partner-export-menu"
+              aria-expanded={Boolean(exportAnchorEl)}
+              aria-haspopup="menu"
+              disabled={isExporting || (!isLoadingProjects && projectsTotal === 0)}
+              endIcon={<ChevronDown size={16} />}
+              onClick={handleExportOpen}
+              size="small"
+              startIcon={
+                isExporting ? (
+                  <CircularProgress color="inherit" size={16} />
+                ) : (
+                  <Download size={16} />
+                )
+              }
+              type="button"
+              variant="outlined"
+            >
+              {isExporting ? "Exporting..." : "Export"}
+            </Button>
+            <Menu
+              anchorEl={exportAnchorEl}
+              id="partner-export-menu"
+              onClose={handleExportClose}
+              open={Boolean(exportAnchorEl)}
+            >
+              <MenuItem onClick={() => void handleExport("csv")}>Export to CSV</MenuItem>
+              <MenuItem onClick={() => void handleExport("pdf")}>Export to PDF</MenuItem>
+            </Menu>
+          </Box>
+
+          <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+            <Table sx={{ minWidth: 680 }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Project Key</TableCell>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Start Date</TableCell>
+                  <TableCell>End Date</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {isLoadingProjects ? (
+                  <SkeletonRows cols={5} />
+                ) : isErrorProjects ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={5}>
+                      <Typography color="text.secondary" variant="body2">
+                        Failed to load projects.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : projects.length === 0 ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={5}>
+                      <Typography color="text.secondary" variant="body2">
+                        No projects found.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  projects.map((project) => {
+                    const isSuspended =
+                      project.closureState?.toLowerCase() === "suspended";
+                    return (
+                      <TableRow
+                        hover
+                        key={project.id}
+                        onClick={() => navigate(`/projects/${project.id}/dashboard`)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            navigate(`/projects/${project.id}/dashboard`);
+                          }
+                        }}
+                        sx={{ cursor: "pointer" }}
+                        tabIndex={0}
+                      >
+                        <TableCell>
+                          <Typography fontWeight="medium" variant="body2">
+                            {project.key}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2">{project.name}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            color={isSuspended ? "warning" : "success"}
+                            label={project.closureState ?? "Active"}
+                            size="small"
+                            sx={{ fontWeight: 500 }}
+                            variant="outlined"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Typography color="text.secondary" variant="body2">
+                            {formatDate(project.startDate)}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography color="text.secondary" variant="body2">
+                            {formatDate(project.endDate)}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+            <Button
+              onClick={() => {
+                const params = debouncedSearchQuery
+                  ? `?q=${encodeURIComponent(debouncedSearchQuery)}`
+                  : "";
+                navigate(`/partner/projects${params}`);
+              }}
+              size="small"
+              variant="text"
+            >
+              View More
+              {projectsMoreCount > 0 && ` (${projectsMoreCount} more)`}
+            </Button>
+          </Box>
+        </Box>
+
+        {/* Cases section */}
+        <Box>
+          <Box sx={{ alignItems: "center", display: "flex", gap: 1, mb: 1.5 }}>
+            <FileText size={20} />
+            <Typography variant="h6">
+              Cases
+              {!isLoadingCases && (
+                <Typography
+                  color="text.secondary"
+                  component="span"
+                  variant="h6"
+                >
+                  {" "}
+                  ({casesTotal})
+                </Typography>
+              )}
+            </Typography>
+          </Box>
+
+          <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+            <Table sx={{ minWidth: 720 }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Case #</TableCell>
+                  <TableCell>Title</TableCell>
+                  <TableCell>Severity</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Project</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {isLoadingCases ? (
+                  <SkeletonRows cols={5} />
+                ) : isErrorCases ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={5}>
+                      <Typography color="text.secondary" variant="body2">
+                        Failed to load cases.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : cases.length === 0 ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={5}>
+                      <Typography color="text.secondary" variant="body2">
+                        No cases found.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  cases.map((c) => {
+                    const severityLabel = c.severity?.label;
+                    const severityDisplay = mapSeverityToDisplay(severityLabel);
+                    const severityColor = getSeverityChipColor(severityLabel);
+                    return (
+                      <TableRow
+                        hover
+                        key={c.id}
+                        onClick={() =>
+                          navigate(
+                            `/projects/${c.project?.id}/support/cases/${c.id}`,
+                          )
+                        }
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            navigate(
+                              `/projects/${c.project?.id}/support/cases/${c.id}`,
+                            );
+                          }
+                        }}
+                        sx={{ cursor: "pointer" }}
+                        tabIndex={0}
+                      >
+                        <TableCell>
+                          <Typography fontWeight="medium" variant="body2">
+                            {c.number}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2">{c.title}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          {severityLabel ? (
+                            <Chip
+                              color={severityColor}
+                              label={severityDisplay}
+                              size="small"
+                              sx={{ fontWeight: 500 }}
+                              variant="outlined"
+                            />
+                          ) : (
+                            <Typography color="text.secondary" variant="body2">
+                              --
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2">
+                            {c.status?.label ?? "--"}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography color="text.secondary" variant="body2">
+                            {c.project?.label ?? "--"}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+            <Button
+              onClick={() => {
+                const params = debouncedSearchQuery
+                  ? `?q=${encodeURIComponent(debouncedSearchQuery)}`
+                  : "";
+                navigate(`/partner/cases${params}`);
+              }}
+              size="small"
+              variant="text"
+            >
+              View More
+              {casesMoreCount > 0 && ` (${casesMoreCount} more)`}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerCasesPage.tsx
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Chip,
+  IconButton,
+  InputAdornment,
+  LinearProgress,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, FileText, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { type ChangeEvent, type JSX, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { useGetGlobalCasesPage } from "@api/useGetGlobalCasesPage";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { PROJECT_HUB_SEARCH_DEBOUNCE_MS } from "@features/project-hub/constants/projectHubConstants";
+import { mapSeverityToDisplay } from "@features/support/utils/support";
+
+const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+const DEFAULT_ROWS_PER_PAGE = 10;
+const SKELETON_ROW_COUNT = 5;
+const COL_SPAN = 5;
+
+function getSeverityChipColor(
+  label?: string,
+): "default" | "error" | "info" | "secondary" | "success" | "warning" {
+  const display = mapSeverityToDisplay(label);
+  const token = display.replace(/\s*\(.*$/, "").toUpperCase();
+  switch (token) {
+    case "S0":
+      return "error";
+    case "S1":
+      return "warning";
+    case "S2":
+      return "info";
+    case "S3":
+      return "secondary";
+    case "S4":
+      return "success";
+    default:
+      return "default";
+  }
+}
+
+/**
+ * Full-page cases search for partner users.
+ * Navigated to via "View More" on the partner global search page.
+ * Pre-fills the search bar from the `?q=` URL parameter.
+ */
+export default function PartnerCasesPage(): JSX.Element {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlQuery = searchParams.get("q") ?? "";
+
+  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
+
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  // Reset to first page when the search query changes.
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearchQuery]);
+
+  // Sync debounced value back to URL.
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (debouncedSearchQuery.trim()) params.q = debouncedSearchQuery.trim();
+    setSearchParams(params, { replace: true });
+  }, [debouncedSearchQuery, setSearchParams]);
+
+  const { data, isLoading, isError } = useGetGlobalCasesPage(
+    {
+      filters: debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : undefined,
+    },
+    page * rowsPerPage,
+    rowsPerPage,
+  );
+
+  const cases = data?.cases ?? [];
+  const totalRecords = data?.totalRecords ?? 0;
+
+  const handleChangePage = (_: unknown, newPage: number) => setPage(newPage);
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flex: 1,
+        flexDirection: "column",
+        minHeight: 0,
+        overflow: "hidden",
+        width: "100%",
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexShrink: 0,
+          gap: 1.5,
+          pb: 1.5,
+          pt: 2,
+          px: 2,
+        }}
+      >
+        <IconButton
+          aria-label="Back to search"
+          onClick={() => navigate("/")}
+          size="small"
+        >
+          <ArrowLeft size={20} />
+        </IconButton>
+        <FileText size={22} />
+        <Typography sx={{ flex: 1 }} variant="h5">
+          Cases
+          {!isLoading && (
+            <Typography color="text.secondary" component="span" variant="h5">
+              {" "}({totalRecords})
+            </Typography>
+          )}
+          {isLoading && (
+            <Skeleton
+              sx={{ display: "inline-block", ml: 0.5 }}
+              variant="text"
+              width={36}
+            />
+          )}
+        </Typography>
+      </Box>
+
+      {/* Search bar */}
+      <Box sx={{ flexShrink: 0, pb: 1.5, px: 2 }}>
+        <TextField
+          fullWidth
+          inputProps={{ autoComplete: "off" }}
+          InputProps={{
+            endAdornment: searchQuery ? (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="Clear search"
+                  edge="end"
+                  onClick={() => setSearchQuery("")}
+                  size="small"
+                >
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
+            startAdornment: <Search size={20} style={{ marginRight: 8 }} />,
+          }}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search cases..."
+          size="small"
+          sx={{
+            maxWidth: 560,
+            "& input:-webkit-autofill, & input:-webkit-autofill:focus, & input:-webkit-autofill:hover":
+              {
+                WebkitBoxShadow: "0 0 0 100px transparent inset",
+                WebkitTextFillColor: "inherit",
+                transition: "background-color 5000s ease-in-out 0s",
+              },
+          }}
+          value={searchQuery}
+        />
+      </Box>
+
+      {/* Loading indicator */}
+      {isLoading && (
+        <LinearProgress
+          color="inherit"
+          sx={{ flexShrink: 0, height: 2, mx: 2 }}
+        />
+      )}
+
+      {/* Scrollable table */}
+      <Box
+        sx={{
+          flex: "1 1 auto",
+          overflowX: "hidden",
+          overflowY: "auto",
+          pb: 3,
+          px: 2,
+        }}
+      >
+        <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+          <Table sx={{ minWidth: 720 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Case #</TableCell>
+                <TableCell>Title</TableCell>
+                <TableCell>Severity</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Project</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+                  <TableRow key={`sk-${i}`}>
+                    {Array.from({ length: COL_SPAN }).map((_, j) => (
+                      <TableCell key={j}>
+                        <Skeleton variant="text" width="80%" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell align="center" colSpan={COL_SPAN}>
+                    <Typography color="text.secondary" variant="body2">
+                      Failed to load cases. Please try again.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : cases.length === 0 ? (
+                <TableRow>
+                  <TableCell align="center" colSpan={COL_SPAN}>
+                    <Typography color="text.secondary" variant="body2">
+                      No cases found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                cases.map((c) => {
+                  const severityLabel = c.severity?.label;
+                  const severityDisplay = mapSeverityToDisplay(severityLabel);
+                  const severityColor = getSeverityChipColor(severityLabel);
+                  return (
+                    <TableRow
+                      hover
+                      key={c.id}
+                      onClick={() =>
+                        navigate(
+                          `/projects/${c.project?.id}/support/cases/${c.id}`,
+                        )
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          navigate(
+                            `/projects/${c.project?.id}/support/cases/${c.id}`,
+                          );
+                        }
+                      }}
+                      sx={{ cursor: "pointer" }}
+                      tabIndex={0}
+                    >
+                      <TableCell>
+                        <Typography fontWeight="medium" variant="body2">
+                          {c.number}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2">{c.title}</Typography>
+                      </TableCell>
+                      <TableCell>
+                        {severityLabel ? (
+                          <Chip
+                            color={severityColor}
+                            label={severityDisplay}
+                            size="small"
+                            sx={{ fontWeight: 500 }}
+                            variant="outlined"
+                          />
+                        ) : (
+                          <Typography color="text.secondary" variant="body2">
+                            --
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2">
+                          {c.status?.label ?? "--"}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography color="text.secondary" variant="body2">
+                          {c.project?.label ?? "--"}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={totalRecords}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          page={page}
+          rowsPerPage={rowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerProjectsPage.tsx
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  IconButton,
+  InputAdornment,
+  LinearProgress,
+  Skeleton,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import useInfiniteProjects, {
+  flattenProjectPages,
+  getTotalRecords,
+} from "@api/useGetProjects";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import ProjectListTable from "@features/project-hub/components/ProjectListTable";
+import { PROJECT_HUB_SEARCH_DEBOUNCE_MS } from "@features/project-hub/constants/projectHubConstants";
+
+const PAGE_SIZE = 25;
+
+/**
+ * Full-page projects search for partner users.
+ * Navigated to via "View More" on the partner global search page.
+ * Pre-fills the search bar from the `?q=` URL parameter.
+ */
+export default function PartnerProjectsPage(): JSX.Element {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlQuery = searchParams.get("q") ?? "";
+
+  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Sync debounced value back to URL so the link is shareable.
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (debouncedSearchQuery.trim()) params.q = debouncedSearchQuery.trim();
+    setSearchParams(params, { replace: true });
+  }, [debouncedSearchQuery, setSearchParams]);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteProjects({
+    pageSize: PAGE_SIZE,
+    searchQuery: debouncedSearchQuery || undefined,
+  });
+
+  const projects = useMemo(() => flattenProjectPages(data), [data]);
+  const totalRecords = getTotalRecords(data);
+
+  // Infinite scroll: load next page when sentinel enters view.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { root: scrollContainerRef.current, rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flex: 1,
+        flexDirection: "column",
+        minHeight: 0,
+        overflow: "hidden",
+        width: "100%",
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexShrink: 0,
+          gap: 1.5,
+          pb: 1.5,
+          pt: 2,
+          px: 2,
+        }}
+      >
+        <IconButton
+          aria-label="Back to search"
+          onClick={() => navigate("/")}
+          size="small"
+        >
+          <ArrowLeft size={20} />
+        </IconButton>
+        <FolderOpen size={22} />
+        <Typography sx={{ flex: 1 }} variant="h5">
+          Projects
+          {!isLoading && (
+            <Typography color="text.secondary" component="span" variant="h5">
+              {" "}({totalRecords})
+            </Typography>
+          )}
+          {isLoading && (
+            <Skeleton
+              sx={{ display: "inline-block", ml: 0.5 }}
+              variant="text"
+              width={36}
+            />
+          )}
+        </Typography>
+      </Box>
+
+      {/* Search bar */}
+      <Box sx={{ flexShrink: 0, px: 2, pb: 1.5 }}>
+        <TextField
+          fullWidth
+          inputProps={{ autoComplete: "off" }}
+          InputProps={{
+            endAdornment: searchQuery ? (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="Clear search"
+                  edge="end"
+                  onClick={() => setSearchQuery("")}
+                  size="small"
+                >
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
+            startAdornment: <Search size={20} style={{ marginRight: 8 }} />,
+          }}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search projects..."
+          size="small"
+          sx={{
+            maxWidth: 560,
+            "& input:-webkit-autofill, & input:-webkit-autofill:focus, & input:-webkit-autofill:hover":
+              {
+                WebkitBoxShadow: "0 0 0 100px transparent inset",
+                WebkitTextFillColor: "inherit",
+                transition: "background-color 5000s ease-in-out 0s",
+              },
+          }}
+          value={searchQuery}
+        />
+      </Box>
+
+      {/* Loading progress bar */}
+      {isLoading && (
+        <LinearProgress
+          color="inherit"
+          sx={{ flexShrink: 0, height: 2, mx: 2 }}
+        />
+      )}
+
+      {/* Error state */}
+      {isError && !isLoading && (
+        <Box sx={{ flex: 1, px: 2, pt: 2 }}>
+          <Typography color="text.secondary" variant="body2">
+            Failed to load projects. Please try again.
+          </Typography>
+        </Box>
+      )}
+
+      {/* Scrollable table */}
+      {!isError && (
+        <Box
+          ref={scrollContainerRef}
+          sx={{
+            flex: "1 1 auto",
+            overflowX: "hidden",
+            overflowY: "auto",
+            px: 2,
+            pb: 3,
+          }}
+        >
+          <ProjectListTable
+            isFetchingNextPage={isFetchingNextPage}
+            projects={projects}
+          />
+          {/* Sentinel triggers the next page when scrolled into view */}
+          <Box ref={sentinelRef} sx={{ height: 1 }} />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -38,9 +38,10 @@ import { useLoader } from "@context/linear-loader/LoaderContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import ProjectCard from "@features/project-hub/components/ProjectCard";
 import ProjectCardSkeleton from "@features/project-hub/components/project-card/ProjectCardSkeleton";
-import ProjectListTable from "@features/project-hub/components/ProjectListTable";
+import PartnerGlobalSearch from "@features/project-hub/components/PartnerGlobalSearch";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import { SETTINGS_PARTNER_ROLE } from "@features/settings/constants/settingsConstants";
+import { clearLastSelectedProject } from "@features/settings/utils/settingsStorage";
 import { ChevronUp, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useAsgardeo } from "@asgardeo/react";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
@@ -54,7 +55,6 @@ import {
   PROJECT_HUB_EMPTY_SEARCH_TITLE,
   PROJECT_HUB_ERROR_SUBTITLE,
   PROJECT_HUB_ERROR_TITLE,
-  PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD,
   PROJECT_HUB_PROJECTS_PAGE_SIZE,
   PROJECT_HUB_REDIRECT_LOADER_MESSAGE,
   PROJECT_HUB_SEARCH_DEBOUNCE_MS,
@@ -84,7 +84,7 @@ export default function ProjectHub(): JSX.Element {
   const { showLoader, hideLoader } = useLoader();
   const { isLoading: isAuthLoading } = useAsgardeo();
   useGetMetadata();
-  const { data: userDetails } = useGetUserDetails();
+  const { data: userDetails, isLoading: isLoadingUserDetails } = useGetUserDetails();
   const [searchQuery, setSearchQuery] = useState<string>("");
   const debouncedSearchQuery = useDebouncedValue(
     searchQuery,
@@ -174,11 +174,9 @@ export default function ProjectHub(): JSX.Element {
     }
   }, [isLoading, showLoader, hideLoader]);
 
-  const isPartner = (userDetails?.roles ?? []).includes(SETTINGS_PARTNER_ROLE);
-  // Use the unfiltered cached total so a search returning fewer results doesn't
-  // switch a partner back to card view.
-  const isPartnerListView =
-    isPartner && cachedTotalProjects > PROJECT_HUB_PARTNER_LIST_VIEW_THRESHOLD;
+  const isPartner =
+    !isLoadingUserDetails &&
+    (userDetails?.roles ?? []).includes(SETTINGS_PARTNER_ROLE);
 
   const isCheckingAllSuspended =
     !isLoading &&
@@ -200,14 +198,14 @@ export default function ProjectHub(): JSX.Element {
     projects.every((p) => p.closureState === ProjectClosureState.SUSPENDED);
 
   const isRedirectingToSingleProject =
+    !isPartner &&
     !isLoading &&
     !isAuthLoading &&
     !isError &&
     projects.length === 1 &&
     !searchQuery &&
     !allProjectsSuspended &&
-    !isCheckingAllSuspended &&
-    !isPartnerListView;
+    !isCheckingAllSuspended;
 
   useEffect(() => {
     if (isRedirectingToSingleProject) {
@@ -234,6 +232,16 @@ export default function ProjectHub(): JSX.Element {
       logger.debug(`${projects.length} projects loaded in ProjectHub`);
     }
   }, [projects.length, logger]);
+
+  // Clear the stored last-selected project so the next login doesn't skip this page.
+  useEffect(() => {
+    clearLastSelectedProject();
+  }, []);
+
+  // Partner users always see the global search page (projects + cases).
+  if (isPartner && !isAuthLoading && !isLoadingUserDetails) {
+    return <PartnerGlobalSearch />;
+  }
 
   const hasSearchQuery = Boolean(searchQuery.trim());
 
@@ -275,7 +283,7 @@ export default function ProjectHub(): JSX.Element {
   const colsPerRow = isXlUp ? 5 : isLgUp ? 4 : 3;
   // During loading use the cached count so the skeleton mirrors the expected layout.
   const effectiveCount = isLoading ? cachedTotalProjects : projects.length;
-  const isCenteredLayout = !isPartnerListView && effectiveCount <= colsPerRow;
+  const isCenteredLayout = effectiveCount <= colsPerRow;
   // When effectiveCount is 0 (first-ever load), fill one full row of skeleton cards.
   const displayCount = effectiveCount === 0 ? colsPerRow : effectiveCount;
 
@@ -437,19 +445,6 @@ export default function ProjectHub(): JSX.Element {
           </Box>
         );
       case ProjectHubContentView.PROJECT_LIST: {
-        if (isPartnerListView) {
-          return (
-            <>
-              <ProjectListTable
-                projects={projects}
-                isFetchingNextPage={isFetchingNextPage}
-              />
-              {/* sentinel triggers infinite scroll to load all projects into the table */}
-              <Box ref={sentinelRef} sx={{ height: 1 }} />
-            </>
-          );
-        }
-
         const grid = (
           <Box sx={gridSx}>
             {projects.map((project) => (

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/projectsExport.ts
@@ -16,7 +16,14 @@
 
 import { buildCsvContent, downloadCsvFile } from "@utils/csv";
 import { downloadPdfFile, type PdfColumnStyle } from "@utils/pdf";
-import type { ProjectListItem } from "@features/project-hub/types/projects";
+import type { ProjectListItem, SearchProjectsResponse } from "@features/project-hub/types/projects";
+
+export type AuthFetchFn = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+const EXPORT_ALL_PAGE_SIZE = 100;
 
 const EXPORT_HEADERS = [
   "Project Key",
@@ -72,6 +79,49 @@ function mapProjectsToRows(projects: ProjectListItem[]): string[][] {
     String(p.actionRequiredCount ?? 0),
     String(p.outstandingCount ?? 0),
   ]);
+}
+
+/**
+ * Fetches every page of projects matching an optional search query.
+ * Use this to collect the full dataset before exporting.
+ */
+export async function fetchAllProjectsForExport(
+  authFetch: AuthFetchFn,
+  searchQuery?: string,
+): Promise<ProjectListItem[]> {
+  const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
+  if (!baseUrl) throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
+
+  const allProjects: ProjectListItem[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const body = {
+      pagination: { offset, limit: EXPORT_ALL_PAGE_SIZE },
+      ...(searchQuery?.trim() ? { filters: { searchQuery: searchQuery.trim() } } : {}),
+    };
+
+    const response = await authFetch(`${baseUrl}/projects/search`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error fetching projects for export: ${response.statusText}`);
+    }
+
+    const data: SearchProjectsResponse = await response.json();
+    const page = data.projects ?? [];
+    allProjects.push(...page);
+
+    const nextOffset = offset + EXPORT_ALL_PAGE_SIZE;
+    if (page.length === 0 || allProjects.length >= data.totalRecords || nextOffset <= offset) {
+      break;
+    }
+    offset = nextOffset;
+  }
+
+  return allProjects;
 }
 
 export function downloadProjectListCsv(projects: ProjectListItem[]): void {

--- a/apps/customer-portal/webapp/src/features/settings/utils/settingsStorage.ts
+++ b/apps/customer-portal/webapp/src/features/settings/utils/settingsStorage.ts
@@ -132,6 +132,19 @@ export function setLastSelectedProjectId(projectId: string): void {
 }
 
 /**
+ * Removes the last selected project from localStorage (both keys).
+ * Call when the user returns to the project selection page.
+ */
+export function clearLastSelectedProject(): void {
+  try {
+    localStorage.removeItem(LAST_SELECTED_PROJECT_KEY);
+    localStorage.removeItem(LAST_SELECTED_PROJECT_ID_KEY);
+  } catch {
+    return;
+  }
+}
+
+/**
  * Reads whether Novera chat is enabled from localStorage.
  *
  * @returns {boolean} True when enabled, false otherwise.

--- a/apps/customer-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/customer-portal/webapp/src/layouts/AppLayout.tsx
@@ -168,6 +168,7 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
 
   // Path Logic Constants
   const isProjectHub = location.pathname === "/" || location.pathname === "";
+  const isPartnerPage = location.pathname.startsWith("/partner/");
 
   const isCaseDetailsPage =
     /\/(?:projects\/[^/]+|[^/]+)\/support\/cases\/[^/]+$/.test(
@@ -237,7 +238,7 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
             />
           }
           sidebar={
-            !isProjectHub && !hasPortalAccessError && !isErrorPageDisplayed ? (
+            !isProjectHub && !isPartnerPage && !hasPortalAccessError && !isErrorPageDisplayed ? (
               <SideBar
                 collapsed={
                   isSidebarOverlay ? false : shellState.sidebarCollapsed


### PR DESCRIPTION
## Summary

- Replace the old partner project list view with a Salesforce-style global search page visible only to `sn_customerservice.partner` role users
- Add live search dropdown showing up to 5 matching projects and 5 cases with bold-highlighted text and direct click navigation
- Table data is decoupled from the search input (always unfiltered); only the dropdown responds to the live query
- Add `/partner/projects` and `/partner/cases` full-search pages reachable via View More
- Suppress sidebar on all `/partner/*` routes
- Clear last_selected_project localStorage keys on project hub home page visit
- Add `useGetGlobalCasesPage` hook targeting `POST /cases/search` — cases will show empty until the backend endpoint is available

## Draft — pending backend integration

The cases section relies on `POST /cases/search` (cross-project global case search) which is not yet available. Keep as draft until the backend endpoint is implemented.

## Test plan

- [ ] Sign in as a partner role user and verify global search page loads
- [ ] Type in the search bar and confirm dropdown appears with matching projects
- [ ] Click a dropdown result and confirm navigation to project dashboard
- [ ] Click View More and confirm navigation to full search page without sidebar
- [ ] Verify non-partner users still see the normal project grid