### PR TITLE
[CSM Portal] stop calling missing /csm/dashboard endpoint

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetCsmDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetCsmDashboard.ts
@@ -23,10 +23,15 @@ import type {
 } from "@features/csm-dashboard/types/abtDashboard";
 
 /**
- * Loads the CSM ABT dashboard payload.
+ * Loads the CSM ABT dashboard payload from `GET ${BACKEND_BASE_URL}/csm/dashboard`.
  *
- * Calls `GET ${BACKEND_BASE_URL}/csm/dashboard?scope=...`.
+ * NOTE: that endpoint does not exist on the backend yet, so the query is
+ * **disabled** — it never fires (avoiding a guaranteed 404 on every dashboard
+ * load). The fetch logic is kept so it can be re-enabled in one line once the
+ * BE ships `/csm/dashboard`: flip `DASHBOARD_ENDPOINT_READY` to true.
  */
+const DASHBOARD_ENDPOINT_READY = false;
+
 export function useGetCsmDashboard(
   scope: DashboardScope,
 ): UseQueryResult<CsmAbtDashboardData, Error> {
@@ -49,6 +54,7 @@ export function useGetCsmDashboard(
       }
       return (await response.json()) as CsmAbtDashboardData;
     },
+    enabled: DASHBOARD_ENDPOINT_READY,
     staleTime: 30_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -48,7 +48,6 @@ interface AbtDashboardHeaderProps {
   onScopeChange: (scope: DashboardScope) => void;
   dashboardKey: DashboardKey;
   onDashboardChange: (key: DashboardKey) => void;
-  isError?: boolean;
 }
 
 export default function AbtDashboardHeader({
@@ -57,7 +56,6 @@ export default function AbtDashboardHeader({
   onScopeChange,
   dashboardKey,
   onDashboardChange,
-  isError,
 }: AbtDashboardHeaderProps): JSX.Element {
   const currentOption = DASHBOARD_OPTIONS.find((o) => o.key === dashboardKey);
   const showScopeButtons = currentOption?.scopeBased ?? false;
@@ -78,11 +76,7 @@ export default function AbtDashboardHeader({
           sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}
         >
           <Typography variant="body2" color="text.secondary">
-            {engineer
-              ? engineer.name
-              : isError
-                ? "Engineer overview"
-                : "Loading engineer…"}
+            {engineer ? engineer.name : "Engineer overview"}
           </Typography>
           {engineer?.abtName && (
             <Chip

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -43,10 +43,11 @@ export default function CsmDashboardPage(): JSX.Element {
   // Locked to the Engineer dashboard: the switcher is disabled in the header
   // (the other dashboards are mock placeholders), so this never changes today.
   const [dashboardKey, setDashboardKey] = useState<DashboardKey>("engineer");
-  // Only the engineer-overview header consumes this now; the queue/SLA/customer/
-  // activity widgets are hidden, leaving the standalone severity-by-state matrix
-  // (CaseCountsMatrix, which loads from its own source) as the only widget.
-  const { data, isError } = useGetCsmDashboard(scope);
+  // The engineer-overview header would consume this, but `/csm/dashboard` isn't
+  // implemented yet so the query is disabled (see useGetCsmDashboard) — `data`
+  // stays undefined and the header shows a neutral subtitle. The only live
+  // widget is the severity-by-state matrix (CaseCountsMatrix, own source).
+  const { data } = useGetCsmDashboard(scope);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -56,7 +57,6 @@ export default function CsmDashboardPage(): JSX.Element {
         onScopeChange={setScope}
         dashboardKey={dashboardKey}
         onDashboardChange={setDashboardKey}
-        isError={isError}
       />
       {dashboardKey === "engineer" ? (
         <>


### PR DESCRIPTION
## What

The CSM dashboard fired `GET /csm/dashboard?scope=…` on every load, but the BFF has **no such endpoint** — so it was a guaranteed 404 (and left the header stuck on "Loading engineer…").

- **Disable the query** (`DASHBOARD_ENDPOINT_READY = false`) in `useGetCsmDashboard` so it never fires. The fetch logic is kept — flip the flag to re-enable in one line once the BE ships `/csm/dashboard`.
- Header engineer-overview line degrades to a neutral **"Engineer overview"** subtitle instead of a perpetual "Loading engineer…"; drops the now-unused `isError` prop.
- The live **severity-by-state matrix** (`CaseCountsMatrix`, backed by `/cases/search`) and the composition charts are unaffected.

Independent of the open CSM PRs; mergeable on its own.

## Testing

`pnpm lint`, `pnpm test`, `pnpm build`, `tsc -b` all green.
