### PR TITLE
[CSM Portal] fix cases list: state chips, alignment, pagination, severity mapping

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -26,7 +26,7 @@ import {
 } from "./mappers";
 
 describe("severityFromPriority", () => {
-  it("maps each backend priority onto the S0-S4 scale", () => {
+  it("maps legacy English names onto the S0-S4 scale", () => {
     expect(severityFromPriority("catastrophic")).toBe("S0");
     expect(severityFromPriority("critical")).toBe("S1");
     expect(severityFromPriority("high")).toBe("S2");
@@ -34,8 +34,17 @@ describe("severityFromPriority", () => {
     expect(severityFromPriority("low")).toBe("S4");
   });
 
+  it("maps the backend display-string format 'Label (Px)' onto S0-S4", () => {
+    expect(severityFromPriority("Catastrophic (P0)")).toBe("S0");
+    expect(severityFromPriority("Critical (P1)")).toBe("S1");
+    expect(severityFromPriority("High (P2)")).toBe("S2");
+    expect(severityFromPriority("Medium (P3)")).toBe("S3");
+    expect(severityFromPriority("Low (P4)")).toBe("S4");
+  });
+
   it("falls back to S3 for an unknown/undefined priority", () => {
     expect(severityFromPriority(undefined)).toBe("S3");
+    expect(severityFromPriority("unknown_value")).toBe("S3");
   });
 });
 

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -46,23 +46,16 @@ import type {
  * UI's S0-S4 severity scale. Until the BE adds explicit severity, priority
  * doubles as the source.
  */
-export function severityFromPriority(
-  priority: BeCaseSeverity | undefined,
-): Severity {
-  switch (priority) {
-    case "catastrophic":
-      return "S0";
-    case "critical":
-      return "S1";
-    case "high":
-      return "S2";
-    case "medium":
-      return "S3";
-    case "low":
-      return "S4";
-    default:
-      return "S3";
-  }
+export function severityFromPriority(priority: string | undefined): Severity {
+  if (!priority) return "S3";
+  const s = priority.toLowerCase();
+  // Match both P-notation ("Low (P4)", "P4") and legacy English names.
+  if (s.includes("p0") || s === "catastrophic") return "S0";
+  if (s.includes("p1") || s === "critical") return "S1";
+  if (s.includes("p2") || s === "high") return "S2";
+  if (s.includes("p3") || s === "medium") return "S3";
+  if (s.includes("p4") || s === "low") return "S4";
+  return "S3";
 }
 
 export function priorityFromSeverity(severity: Severity): BeCaseSeverity {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -164,7 +164,8 @@ export interface BeCaseView {
   internalId?: string;
   subject?: string;
   description?: string;
-  severity?: BeCaseSeverity;
+  /** Free-form display string from the backend, e.g. "Critical (P1)", "Low (P4)". */
+  severity?: string;
   issueType?: BeCaseIssueType;
   type?: BeCaseType;
   state?: BeCaseState;
@@ -305,7 +306,8 @@ export interface BeCaseSearchView {
    */
   subject?: string;
   description?: string;
-  severity?: BeCaseSeverity;
+  /** Free-form display string from the backend, e.g. "Low (P4)", "Critical (P1)". */
+  severity?: string;
   issueType?: BeCaseIssueType;
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */

--- a/apps/csm-portal/webapp/src/components/SemanticChip.tsx
+++ b/apps/csm-portal/webapp/src/components/SemanticChip.tsx
@@ -14,9 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Chip, useTheme } from "@wso2/oxygen-ui";
+import { Chip } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
-import { pickAccessibleText } from "@utils/contrastText";
 
 /** The semantic palette roles a chip may carry. */
 export type SemanticRole = "error" | "warning" | "info" | "success" | "default";
@@ -32,15 +31,12 @@ interface SemanticChipProps {
 }
 
 /**
- * A chip whose filled label always clears WCAG AA.
- *
- * A plain `<Chip color="error">` uses MUI's `contrastText`, computed against a
- * 3:1 floor, so white-on-saturated chip labels (~13px) sit around 3:1 and fail
- * AA (4.5:1) — in every theme, because it is the contrast-target that is wrong,
- * not the palette. This keeps the vivid `*.main` fill but picks the label colour
- * (near-black vs white) by the fill's measured luminance, which clears 4.5:1 for
- * the saturated semantic colours in all shipped themes and both colour modes.
- * The `default`/grey role has no accessible solid fill, so it renders outlined.
+ * A semantic status chip that delegates colouring to MUI's built-in `color`
+ * prop so it works correctly in CSS-variables themes (where
+ * `theme.palette.info.main` returns a CSS variable reference, not a hex colour,
+ * making a manual `bgcolor` sx override unreliable). The `default` role uses
+ * the filled variant (subtle grey) rather than `outlined`, so all states render
+ * consistently as status badges rather than button-like bordered outlines.
  */
 export default function SemanticChip({
   role,
@@ -49,39 +45,14 @@ export default function SemanticChip({
   bold = false,
   clickable = false,
 }: SemanticChipProps): JSX.Element {
-  const theme = useTheme();
-
-  // Resolve the palette fill defensively: an unexpected role (e.g. a free-form
-  // value that slipped past the type) must degrade to the outlined default
-  // chip, never read `.main` off an undefined palette entry and crash the page.
-  const paletteEntry =
-    role === "default"
-      ? undefined
-      : (theme.palette[role] as { main?: string } | undefined);
-
-  if (!paletteEntry?.main) {
-    return (
-      <Chip
-        size={size}
-        variant="outlined"
-        label={label}
-        sx={clickable ? { cursor: "pointer" } : undefined}
-      />
-    );
-  }
-
-  const bg = paletteEntry.main;
-  const fg = pickAccessibleText(bg);
-
   return (
     <Chip
       size={size}
+      // "default" is a valid MUI Chip color — filled grey, no border.
+      color={role}
       label={label}
       sx={{
-        bgcolor: bg,
-        color: fg,
-        ...(bold ? { fontWeight: 600 } : {}),
-        "& .MuiChip-label": { color: fg },
+        ...(bold ? { "& .MuiChip-label": { fontWeight: 600 } } : {}),
         ...(clickable ? { cursor: "pointer" } : {}),
       }}
     />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -82,7 +82,7 @@ export default function CasesList({
             key={label}
             variant="caption"
             color="text.secondary"
-            sx={{ fontWeight: 600 }}
+            sx={{ fontWeight: 600, textAlign: "left" }}
           >
             {label}
           </Typography>
@@ -194,8 +194,12 @@ export default function CasesList({
               <Typography variant="body2" noWrap>
                 {c.product}
               </Typography>
-              <SeverityChip severity={c.severity} clickable />
-              <StateChip state={c.state} clickable />
+              <Box sx={{ justifySelf: "start" }}>
+                <SeverityChip severity={c.severity} clickable />
+              </Box>
+              <Box sx={{ justifySelf: "start" }}>
+                <StateChip state={c.state} clickable />
+              </Box>
               <Typography variant="caption" color="text.secondary" noWrap>
                 <RelativeTime iso={c.updatedAt} />
               </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -135,15 +135,21 @@ export default function CsmCasesPage(): JSX.Element {
   }, [data?.cases]);
 
   const total = data?.total ?? 0;
-  // If the total shrinks (a background refetch, or rows closing) while we're on
-  // a later page, clamp back to the last valid page so the table never shows an
-  // empty out-of-range page with a misleading range. Adjusting state during
-  // render (React's documented pattern) rather than in an effect: React
-  // re-renders with the corrected page and the hook refetches the right slice.
+  // Clamp to the last valid page when loaded data shrinks (background refetch,
+  // rows closing). Guard on `data !== undefined` so that during the loading
+  // transition — when data is undefined and total falls to 0 — we don't
+  // immediately reset a page > 0 back to 0, which would break Next navigation.
   const lastPage = total === 0 ? 0 : Math.ceil(total / rowsPerPage) - 1;
-  if (page > lastPage) {
+  if (data !== undefined && !data.hasMore && page > lastPage) {
     setPage(lastPage);
   }
+
+  // When hasMore is true the backend guarantees more pages exist, but total may
+  // reflect only the current page's count rather than the full dataset size.
+  // count={-1} tells MUI the total is unknown → keeps Next enabled; Last is
+  // hidden automatically. When hasMore is false, use exact total for accurate
+  // pagination controls.
+  const paginationCount = data?.hasMore ? -1 : total;
 
   // Counts reflect the current page only (the backend exposes no SLA/assignee
   // breakdown across pages); both are inert in LIVE where that data is absent.
@@ -219,7 +225,7 @@ export default function CsmCasesPage(): JSX.Element {
 
       <TablePagination
         component="div"
-        count={total}
+        count={paginationCount}
         page={page}
         onPageChange={(_, newPage) => setPage(newPage)}
         rowsPerPage={rowsPerPage}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -144,12 +144,12 @@ export default function CsmCasesPage(): JSX.Element {
     setPage(lastPage);
   }
 
-  // When hasMore is true the backend guarantees more pages exist, but total may
-  // reflect only the current page's count rather than the full dataset size.
-  // count={-1} tells MUI the total is unknown → keeps Next enabled; Last is
-  // hidden automatically. When hasMore is false, use exact total for accurate
-  // pagination controls.
-  const paginationCount = data?.hasMore ? -1 : total;
+  // During loading data is undefined; treat the total as unknown (-1) so the
+  // page index never goes out of range and Next stays enabled mid-transition.
+  // When hasMore is true the backend guarantees more pages exist but total may
+  // only reflect the current page count — also use -1. Only use the exact total
+  // when data has loaded and the backend says there are no more pages.
+  const paginationCount = data === undefined || data.hasMore ? -1 : total;
 
   // Counts reflect the current page only (the backend exposes no SLA/assignee
   // breakdown across pages); both are inert in LIVE where that data is absent.


### PR DESCRIPTION
## Summary

- **State chips**: `SemanticChip` now uses MUI's `color` prop instead of a manual `bgcolor` sx override; the override was silently broken in CSS-variables themes (Oxygen UI) where `theme.palette.info.main` returns a CSS variable reference, not a hex. The `default` role switches from `variant="outlined"` (looked like a button) to filled grey.
- **Column alignment / Subject truncation**: Removed `justifyItems: "start"` from row subgrids — it was forcing the Subject `Box` to take its intrinsic (fully unwrapped) width, causing overflow into the Product column. Chips are individually wrapped in `Box sx={{ justifySelf: "start" }}` so only they opt out of stretch. Added explicit `textAlign: "left"` to header labels.
- **Pagination Next button**: Added `data !== undefined` guard to the page-clamp logic. Without it, clicking Next set `page = 1`, React Query started loading (data → `undefined`), `total` fell to 0, and `lastPage` clamped the page straight back to 0 — the API call for page 1 never completed. Also derives `paginationCount` from `hasMore` so Next stays enabled when the backend signals more results.
- **Severity mapping**: `severityFromPriority` now accepts `string | undefined` and matches the backend's display-string format (`"Critical (P1)"`, `"Low (P4)"`) via case-insensitive P-notation substring, keeping legacy English-name fallbacks. `BeCaseSearchView.severity` and `BeCaseView.severity` widened to `string` to reflect the actual API contract.

## Test plan

- [ ] Cases list renders state chips as coloured pills (blue for WIP, amber for Waiting on WSO2, grey for others) — not as button-like outlines
- [ ] Subject text truncates with `…` when longer than the column; no overflow into Product
- [ ] All column headers are left-aligned
- [ ] Clicking Next in the pagination table fetches the next page from the backend (`POST /cases/search` with incremented offset)
- [ ] Severity chips show the correct level (S0–S4) based on the backend value e.g. `"Critical (P1)"` → S1 chip
- [ ] Hard-refresh the browser after deploying to clear React Query cache and verify fresh data renders with correct severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case pagination so the page no longer jumps during loading, and Next/Last navigation now matches whether more results are available.
  * Case severity values are now handled more flexibly, including legacy labels and display-style values, with a safe fallback when the value is missing or unrecognized.
  * Refined case list alignment and status badge rendering for a cleaner, more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->