### PR TITLE
[Customer Portal][Fix] Prevent layout shift on tab return by keeping usage-metrics cache indefinitely

### DIFF
--- a/apps/customer-portal/webapp/src/api/usePostProjectDeploymentsSearch.ts
+++ b/apps/customer-portal/webapp/src/api/usePostProjectDeploymentsSearch.ts
@@ -136,6 +136,7 @@ export function usePostProjectDeploymentsSearchInfinite(
     },
     enabled: enabled && !!projectId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
@@ -218,6 +219,7 @@ export function usePostProjectDeploymentsSearchAll(
     },
     enabled: enabled && !!projectId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/useGetProjectUsageStats.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useGetProjectUsageStats.ts
@@ -47,6 +47,7 @@ export default function useGetProjectUsageStats(projectId: string | undefined) {
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesMetricsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesMetricsSearch.ts
@@ -57,6 +57,7 @@ export default function usePostDeploymentInstancesMetricsSearch(
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesSearch.ts
@@ -57,6 +57,7 @@ export default function usePostDeploymentInstancesSearch(
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesUsagesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostDeploymentInstancesUsagesSearch.ts
@@ -57,6 +57,7 @@ export default function usePostDeploymentInstancesUsagesSearch(
     },
     enabled: !!deploymentId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesMetricsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesMetricsSearch.ts
@@ -58,6 +58,7 @@ export default function usePostProjectInstancesMetricsSearch(
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesSearch.ts
@@ -57,6 +57,7 @@ export default function usePostProjectInstancesSearch(
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesSearch.ts
@@ -57,6 +57,7 @@ export default function usePostProjectInstancesUsagesSearch(
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesStats.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/usePostProjectInstancesUsagesStats.ts
@@ -54,6 +54,7 @@ export default function usePostProjectInstancesUsagesStats(
     },
     enabled: !!projectId && isSignedIn && !isAuthLoading,
     staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });


### PR DESCRIPTION
## Summary

- Add `gcTime: Infinity` to all 9 usage-metrics hooks alongside the existing `staleTime: Infinity` + `refetchOnWindowFocus: false` + `refetchOnReconnect: false`
- Without this, React Query evicts unused cache after the default 5-minute `gcTime`. Switching back to the Usage & Metrics tab after 5+ minutes causes all 8+ hooks to refetch simultaneously, producing rapid layout shifts that appear as UI shaking/reload
- With `gcTime: Infinity`, cached data persists for the entire browser session — returning to the tab at any time instantly serves the cached data with no loading state

## Affected hooks

- `usePostProjectInstancesSearch`
- `usePostProjectInstancesUsagesSearch`
- `usePostProjectInstancesMetricsSearch`
- `usePostDeploymentInstancesSearch`
- `usePostDeploymentInstancesUsagesSearch`
- `usePostDeploymentInstancesMetricsSearch`
- `useGetProjectUsageStats`
- `usePostProjectInstancesUsagesStats`
- `usePostProjectDeploymentsSearch` (both infinite and all-pages variants)

## Test plan

- [ ] Open Usage & Metrics tab, switch to another project tab, wait 5+ minutes, switch back — no skeleton flash or layout shift
- [ ] Verify data still displays correctly after returning (no stale/empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache retention for several project details and search queries, reducing the chance of data being dropped and reloaded unexpectedly.
  * Kept frequently viewed deployment, instance, usage, and metrics results available longer in the customer portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->