### PR TITLE
Add GitHub Actions workflow to auto-label PRs and assign author

### DIFF
--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     steps:
       - name: Apply labels and assignee
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -72,10 +72,14 @@ jobs:
             }
 
             // Assign the PR author
-            await github.rest.issues.addAssignees({
-              owner,
-              repo,
-              issue_number: prNumber,
-              assignees: [pr.user.login],
-            });
-            core.info(`Assigned: ${pr.user.login}`);
+            try {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: prNumber,
+                assignees: [pr.user.login],
+              });
+              core.info(`Assigned: ${pr.user.login}`);
+            } catch (error) {
+              core.warning(`Could not assign ${pr.user.login}: ${error.message}`);
+            }

--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Auto Label and Assign PR
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  auto-label-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Apply labels and assignee
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const prNumber = pr.number;
+
+            // Fetch all changed files (handles PRs with >30 files via pagination)
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: prNumber, per_page: 100 }
+            );
+            const filenames = files.map(f => f.filename);
+            core.info(`Changed files:\n${filenames.join('\n')}`);
+
+            // Label rules — order does not matter, all matching labels are applied
+            const labelRules = [
+              { label: 'App/CSM Portal',       test: f => f.startsWith('apps/csm-portal/') },
+              { label: 'App/Customer Portal',  test: f => f.startsWith('apps/customer-portal/') },
+              { label: 'Area/Frontend',        test: f => /^apps\/[^/]+\/webapp\//.test(f) },
+              { label: 'Area/Backend',         test: f => /^apps\/[^/]+\/backend\//.test(f) },
+              { label: 'Platform/Microapp',    test: f => /^apps\/[^/]+\/microapp\//.test(f) },
+              { label: 'Platform/Web',         test: f => /^apps\/[^/]+\/webapp\//.test(f) },
+              { label: 'Entity Service',       test: f => f.startsWith('entity-service/') },
+            ];
+
+            const labelsToApply = labelRules
+              .filter(({ test }) => filenames.some(test))
+              .map(({ label }) => label);
+
+            core.info(`Labels to apply: ${labelsToApply.join(', ') || '(none)'}`);
+
+            if (labelsToApply.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: labelsToApply,
+              });
+            }
+
+            // Assign the PR author
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: prNumber,
+              assignees: [pr.user.login],
+            });
+            core.info(`Assigned: ${pr.user.login}`);

--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -17,7 +17,7 @@
 name: Auto Label and Assign PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -11,12 +11,25 @@ Open-source tools built by WSO2 for customer success operations. This repository
 ```
 cs-tools/
 ├── apps/
+│   ├── csm-portal/          # CSM Portal (Go backend + React webapp)
 │   └── customer-portal/     # Customer Portal (Ballerina backend + React webapp + React microapp)
+├── entity-service/          # Shared entity service
 └── integrations/
     └── customer-service/    # Customer operations related integration Ballerina service
 ```
 
 ## Components
+
+### CSM Portal (`apps/csm-portal/`)
+
+An internal portal for Customer Success Managers to manage and track customer cases, assignments, and support operations.
+
+| Component | Description |
+|-----------|-------------|
+| `backend` | Go RESTful service providing CSM Portal APIs |
+| `webapp` | Browser-based portal for CSMs (React + TypeScript) |
+
+See the [CSM Portal README](./apps/csm-portal/README.md) for full setup and usage documentation.
 
 ### Customer Portal (`apps/customer-portal/`)
 
@@ -35,6 +48,24 @@ See the [Customer Portal README](./apps/customer-portal/README.md) for full setu
 ### Customer Service Integration (`integrations/customer-service/`)
 
 A Ballerina REST service that aggregates and exposes customer data from multiple backend systems. Provides endpoints for contact lookup, deployment search, and deployed product queries. Includes an in-memory cache layer to reduce upstream load.
+
+## GitHub Actions
+
+### Auto Label and Assign PR
+
+When a pull request is opened, the workflow automatically:
+
+- Assigns the PR author as the assignee
+- Applies labels based on changed file paths:
+
+| Files changed under… | Label applied |
+|---|---|
+| `apps/csm-portal/**` | `App/CSM Portal` |
+| `apps/customer-portal/**` | `App/Customer Portal` |
+| `apps/*/webapp/**` | `Area/Frontend`, `Platform/Web` |
+| `apps/*/backend/**` | `Area/Backend` |
+| `apps/*/microapp/**` | `Platform/Microapp` |
+| `entity-service/**` | `Entity Service` |
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Delivered through two frontend experiences alongside a shared backend:
 
 See the [Customer Portal README](./apps/customer-portal/README.md) for full setup and usage documentation.
 
+### Entity Service (`entity-service/`)
+
+A Go REST service that manages customer entity data backed by PostgreSQL. Provides APIs for case management with pagination and validation, used by other apps in this repository.
+
+| Layer | Technology |
+|-------|------------|
+| Language | Go |
+| Framework | Gin |
+| Database | PostgreSQL 15+ |
+
+See the [Entity Service README](./entity-service/README.md) for full setup and usage documentation.
+
 ### Customer Service Integration (`integrations/customer-service/`)
 
 A Ballerina REST service that aggregates and exposes customer data from multiple backend systems. Provides endpoints for contact lookup, deployment search, and deployed product queries. Includes an in-memory cache layer to reduce upstream load.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-label-assign.yml` — a GitHub Actions workflow that fires on PR `opened`, `reopened`, and `ready_for_review` events
- Automatically assigns the PR author as the PR assignee
- Applies labels based on changed file paths:

| Files changed under… | Label applied |
|---|---|
| `apps/csm-portal/**` | `App/CSM Portal` |
| `apps/customer-portal/**` | `App/Customer Portal` |
| `apps/*/webapp/**` | `Area/Frontend` + `Platform/Web` |
| `apps/*/backend/**` | `Area/Backend` |
| `apps/*/microapp/**` | `Platform/Microapp` |
| `entity-service/**` | `Entity Service` |

## Test plan

- [ ] Open a test PR targeting `v2` with files changed under `apps/csm-portal/webapp/` and verify `App/CSM Portal`, `Area/Frontend`, and `Platform/Web` labels are applied and the author is set as assignee
- [ ] Open a test PR with `entity-service/` changes and verify `Entity Service` label is applied
- [ ] Verify the workflow run appears in the Actions tab with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PRs now automatically receive relevant labels based on changed files.
  * PR authors are now automatically assigned when a pull request is opened or marked ready for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->