### PR TITLE
[Customer Portal] feat : add case escalation feature

### DIFF
--- a/apps/customer-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/apiConstants.ts
@@ -71,6 +71,7 @@ export const ApiQueryKeys = {
   DEPLOYMENT_INSTANCE_METRICS: "deployment-instance-metrics",
   DEPLOYED_PRODUCT_INSTANCE_METRICS: "deployed-product-instance-metrics",
   PROJECT_INSTANCE_USAGE_STATS: "project-instance-usage-stats",
+  CASE_ESCALATIONS_SEARCH: "case-escalations-search",
 } as const;
 
 // Constants for API-related mutation keys.

--- a/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
@@ -21,6 +21,7 @@ import {
   KeyRound,
   Monitor,
   Shield,
+  TriangleAlert,
   Type,
   Users,
 } from "@wso2/oxygen-ui-icons-react";
@@ -108,6 +109,15 @@ export const ROLE_CONFIG = [
     permissions: [
       "Can log in to and access the Support Portal",
       "Create and manage support cases within assigned projects",
+    ],
+  },
+  {
+    id: SettingsRoleInfoId.LEAD,
+    label: "Lead",
+    Icon: TriangleAlert,
+    paletteKey: "warning" as const,
+    permissions: [
+      "A portal user who can escalate an issue beyond level 3",
     ],
   },
   {

--- a/apps/customer-portal/webapp/src/features/settings/types/settings.ts
+++ b/apps/customer-portal/webapp/src/features/settings/types/settings.ts
@@ -45,6 +45,7 @@ export enum RegistryTokenDisplayStatus {
 export enum SettingsRoleInfoId {
   ADMIN = "admin",
   PORTAL_USER = "portal_user",
+  LEAD = "lead",
   SYSTEM_USER = "system_user",
   SECURITY_USER = "security_user",
 }

--- a/apps/customer-portal/webapp/src/features/settings/types/users.ts
+++ b/apps/customer-portal/webapp/src/features/settings/types/users.ts
@@ -52,6 +52,7 @@ export type ProjectContact = {
   firstName: string;
   lastName: string;
   isCsAdmin: boolean;
+  isLead?: boolean;
   isCsIntegrationUser: boolean;
   isPortalUser?: boolean;
   isSecurityContact: boolean;

--- a/apps/customer-portal/webapp/src/features/support/api/usePostCaseEscalation.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/usePostCaseEscalation.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import type { CreateEscalationResponse } from "@features/support/types/cases";
+
+export type EscalationApiError = Error & { status: number };
+
+/**
+ * Creates a new escalation for a case.
+ *
+ * @param {string} caseId - The case ID to escalate.
+ * @returns Mutation result for POST /cases/{caseId}/escalations.
+ */
+export function usePostCaseEscalation(caseId: string) {
+  const authFetch = useAuthApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<CreateEscalationResponse, EscalationApiError, { reason: string }>({
+    mutationFn: async ({ reason }) => {
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL ?? "";
+      const response = await authFetch(
+        `${baseUrl}/cases/${caseId}/escalations`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason }),
+        },
+      );
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({})) as { message?: string };
+        const err = new Error(
+          body?.message ?? `Escalation failed: ${response.statusText}`,
+        ) as EscalationApiError;
+        err.status = response.status;
+        throw err;
+      }
+      return response.json() as Promise<CreateEscalationResponse>;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CASE_ESCALATIONS_SEARCH, caseId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CASE_DETAILS],
+      });
+    },
+  });
+}

--- a/apps/customer-portal/webapp/src/features/support/api/usePostCaseEscalationsSearch.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/usePostCaseEscalationsSearch.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery } from "@tanstack/react-query";
+import { useAsgardeo } from "@asgardeo/react";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import type { EscalationSearchResponse } from "@features/support/types/cases";
+
+/**
+ * Fetches escalation history for a specific case.
+ * Uses POST /cases/{caseId}/escalations/search; caseId is auto-injected by the backend.
+ *
+ * @param {string} caseId - The ID of the case.
+ * @param {boolean} [enabled] - Whether the query should run.
+ * @returns Query result containing escalation records sorted newest-first.
+ */
+export function usePostCaseEscalationsSearch(caseId: string, enabled = true) {
+  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
+  const authFetch = useAuthApiClient();
+
+  return useQuery<EscalationSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.CASE_ESCALATIONS_SEARCH, caseId],
+    queryFn: async (): Promise<EscalationSearchResponse> => {
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL ?? "";
+      const response = await authFetch(
+        `${baseUrl}/cases/${caseId}/escalations/search`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sortBy: { field: "createdOn", order: "desc" },
+            pagination: { limit: 20, offset: 0 },
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to fetch escalation history: ${response.statusText}`);
+      }
+      return response.json() as Promise<EscalationSearchResponse>;
+    },
+    enabled: !!caseId && !isAuthLoading && isSignedIn && enabled,
+    staleTime: 0,
+  });
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -28,6 +28,7 @@ import useGetProjectFilters from "@api/useGetProjectFilters";
 import useGetAIChatHistory from "@features/support/api/useGetAIChatHistory";
 import { useConversationRecommendationsSearch } from "@features/support/api/useConversationRecommendationsSearch";
 import { buildRecommendationRequestFromCase } from "@features/support/utils/recommendations";
+import { usePostCaseEscalationsSearch } from "@features/support/api/usePostCaseEscalationsSearch";
 import {
   getStatusColor,
   resolveColorFromTheme,
@@ -155,6 +156,7 @@ export default function CaseDetailsContent({
     isSecurityReportAnalysis || isEngagementRoute || isServiceRequest;
   const hideRelatedChangeRequestsTab =
     !isServiceRequest || !data?.changeRequests?.length;
+  const hideEscalationTab = isEngagementRoute || isServiceRequest || isSecurityReportAnalysis;
 
   // Eagerly fetch KB recommendations so the tab count is available on page load.
   // React Query deduplicates the network call when the KB tab component mounts later.
@@ -182,6 +184,15 @@ export default function CaseDetailsContent({
     !hideKnowledgeBaseTab &&
     (isKbCommentsLoading || (!!kbPayload && isKbRecLoading && !kbRecData));
 
+  // Eagerly fetch escalation history so count is available on page load.
+  const { data: escalationData, refetch: refetchEscalations } =
+    usePostCaseEscalationsSearch(caseId, !hideEscalationTab);
+  const escalationCount = hideEscalationTab
+    ? undefined
+    : (escalationData?.totalRecords ?? escalationData?.escalations?.length);
+  const isEscalated = data?.isEscalated ?? false;
+  const escalationLevelId = String(data?.escalationLevel?.id ?? "0");
+
   const visibleTabs = useMemo(
     () => [
       0,
@@ -190,8 +201,9 @@ export default function CaseDetailsContent({
       ...(hideCallsTab ? [] : [3]),
       ...(hideKnowledgeBaseTab ? [] : [4]),
       ...(hideRelatedChangeRequestsTab ? [] : [5]),
+      ...(hideEscalationTab ? [] : [6]),
     ],
-    [hideCallsTab, hideKnowledgeBaseTab, hideRelatedChangeRequestsTab],
+    [hideCallsTab, hideKnowledgeBaseTab, hideRelatedChangeRequestsTab, hideEscalationTab],
   );
   const clampedActiveTab = Math.min(
     activeTab,
@@ -327,6 +339,12 @@ export default function CaseDetailsContent({
                     }
                     showStatusChip={headerVariant !== "engagement"}
                     variant={headerVariant}
+                    isEscalated={!hideEscalationTab && isEscalated}
+                    escalationLevelLabel={
+                      !hideEscalationTab && isEscalated
+                        ? (data?.escalationLevel?.label ?? null)
+                        : null
+                    }
                   />
                 </Box>
 
@@ -341,6 +359,8 @@ export default function CaseDetailsContent({
                     caseId={caseId}
                     isLoading={isLoading}
                     hideAssignedEngineer={hideAssignedEngineer}
+                    escalationLevelId={hideEscalationTab ? null : escalationLevelId}
+                    onEscalateSuccess={() => void refetchEscalations()}
                   />
                 )}
               </Box>
@@ -360,6 +380,9 @@ export default function CaseDetailsContent({
           knowledgeBaseCount={knowledgeBaseCount}
           knowledgeBaseCountLoading={knowledgeBaseCountLoading}
           hideRelatedChangeRequestsTab={hideRelatedChangeRequestsTab}
+          hideEscalationTab={hideEscalationTab}
+          escalationCount={escalationCount}
+          isEscalated={isEscalated}
         />
       </Paper>
 

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -29,6 +29,8 @@ import useGetAIChatHistory from "@features/support/api/useGetAIChatHistory";
 import { useConversationRecommendationsSearch } from "@features/support/api/useConversationRecommendationsSearch";
 import { buildRecommendationRequestFromCase } from "@features/support/utils/recommendations";
 import { usePostCaseEscalationsSearch } from "@features/support/api/usePostCaseEscalationsSearch";
+import useGetProjectContacts from "@features/settings/api/useGetProjectContacts";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import {
   getStatusColor,
   resolveColorFromTheme,
@@ -192,6 +194,15 @@ export default function CaseDetailsContent({
     : (escalationData?.totalRecords ?? escalationData?.escalations?.length);
   const isEscalated = data?.isEscalated ?? false;
   const escalationLevelId = String(data?.escalationLevel?.id ?? "0");
+
+  // Determine if the logged-in user is a Lead (required for EL3+ escalations).
+  const { data: userDetails } = useGetUserDetails();
+  const { data: projectContacts } = useGetProjectContacts(
+    hideEscalationTab ? "" : resolvedProjectId,
+  );
+  const isCurrentUserLead = !!projectContacts?.find(
+    (c) => c.email.toLowerCase() === (userDetails?.email ?? "").toLowerCase(),
+  )?.isLead;
 
   const visibleTabs = useMemo(
     () => [
@@ -361,6 +372,7 @@ export default function CaseDetailsContent({
                     hideAssignedEngineer={hideAssignedEngineer}
                     escalationLevelId={hideEscalationTab ? null : escalationLevelId}
                     onEscalateSuccess={() => void refetchEscalations()}
+                    isCurrentUserLead={isCurrentUserLead}
                   />
                 )}
               </Box>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -196,13 +196,18 @@ export default function CaseDetailsContent({
   const escalationLevelId = String(data?.escalationLevel?.id ?? "0");
 
   // Determine if the logged-in user is a Lead (required for EL3+ escalations).
-  const { data: userDetails } = useGetUserDetails();
+  // Keep undefined while userDetails is still loading to avoid a false-negative
+  // that would cause the Escalate button to flicker into view for Lead users.
+  const { data: userDetails, isLoading: isUserDetailsLoading } = useGetUserDetails();
   const { data: projectContacts } = useGetProjectContacts(
     hideEscalationTab ? "" : resolvedProjectId,
   );
-  const isCurrentUserLead = !!projectContacts?.find(
-    (c) => c.email.toLowerCase() === (userDetails?.email ?? "").toLowerCase(),
-  )?.isLead;
+  const isCurrentUserLead: boolean | undefined =
+    !isUserDetailsLoading && !!userDetails?.email
+      ? !!projectContacts?.find(
+          (c) => c.email.toLowerCase() === userDetails.email!.toLowerCase(),
+        )?.isLead
+      : undefined;
 
   const visibleTabs = useMemo(
     () => [

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/CaseEscalationHistoryPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/CaseEscalationHistoryPanel.tsx
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  Typography,
+  alpha,
+  useTheme,
+} from "@wso2/oxygen-ui";
+import { ArrowRight, Flag, TriangleAlert } from "@wso2/oxygen-ui-icons-react";
+import { type JSX } from "react";
+import { usePostCaseEscalationsSearch } from "@features/support/api/usePostCaseEscalationsSearch";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
+import type { EscalationRecord } from "@features/support/types/cases";
+
+type Props = {
+  caseId: string;
+  caseCreatedOn?: string | null;
+};
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function EscalationTimelineItem({
+  record,
+  currentUserEmail,
+  isLast,
+}: {
+  record: EscalationRecord;
+  currentUserEmail: string;
+  isLast: boolean;
+}): JSX.Element {
+  const theme = useTheme();
+  const amberColor = theme.palette.warning.main;
+  const amberLight = theme.palette.warning.light;
+
+  const isCurrentUser =
+    !!currentUserEmail &&
+    record.createdBy.toLowerCase() === currentUserEmail.toLowerCase();
+  const actor = isCurrentUser ? "You" : record.createdBy;
+
+  return (
+    <Box sx={{ display: "flex", gap: 2 }}>
+      {/* Left: icon + line */}
+      <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: 32, flexShrink: 0 }}>
+        <Box
+          sx={{
+            width: 32,
+            height: 32,
+            borderRadius: "50%",
+            bgcolor: alpha(amberLight, 0.2),
+            border: `2px solid ${alpha(amberColor, 0.4)}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          <TriangleAlert size={15} color={amberColor} />
+        </Box>
+        {!isLast && (
+          <Box
+            sx={{
+              width: 2,
+              flex: 1,
+              mt: 0.5,
+              bgcolor: "divider",
+              minHeight: 24,
+            }}
+          />
+        )}
+      </Box>
+
+      {/* Right: content */}
+      <Box sx={{ flex: 1, pb: isLast ? 0 : 3 }}>
+        {/* Level row */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap", mb: 0.75 }}>
+          <Chip
+            label={record.previousLevel?.label ?? "—"}
+            size="small"
+            variant="outlined"
+            sx={{ fontWeight: 600, fontSize: "0.7rem", height: 20 }}
+          />
+          <ArrowRight size={14} color={theme.palette.text.secondary} />
+          <Chip
+            label={record.currentLevel?.label ?? "—"}
+            size="small"
+            variant="outlined"
+            sx={{
+              fontWeight: 600,
+              fontSize: "0.7rem",
+              height: 20,
+              color: amberColor,
+              borderColor: alpha(amberColor, 0.5),
+              bgcolor: alpha(amberLight, 0.12),
+            }}
+          />
+          <Typography variant="caption" color="text.secondary">
+            by{" "}
+            <Box component="span" fontWeight={500} color="text.primary">
+              {actor}
+            </Box>
+          </Typography>
+        </Box>
+
+        {/* Timestamp */}
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.75 }}>
+          {formatDate(record.createdOn)}
+        </Typography>
+
+        {/* Notified */}
+        {record.notificationSentTo && record.notificationSentTo.length > 0 && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.75 }}>
+            Notified: {record.notificationSentTo.map((u) => u.name ?? u.userName).join(", ")}
+          </Typography>
+        )}
+
+        {/* Reason */}
+        {record.reason && (
+          <Box
+            sx={{
+              bgcolor: "action.hover",
+              borderRadius: 1,
+              px: 1.5,
+              py: 1,
+              mt: 0.5,
+            }}
+          >
+            <Typography variant="caption" color="text.secondary">
+              {record.reason}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Escalation history timeline panel for a case.
+ * Shows all escalation records newest-first, with the initial EL0 state pinned at the bottom.
+ *
+ * @param {Props} props - caseId and caseCreatedOn.
+ * @returns {JSX.Element} The escalation history panel.
+ */
+export default function CaseEscalationHistoryPanel({ caseId, caseCreatedOn }: Props): JSX.Element {
+  const theme = useTheme();
+  const { data: userDetails } = useGetUserDetails();
+  const currentUserEmail = userDetails?.email?.toLowerCase() ?? "";
+
+  const { data, isLoading, isError } = usePostCaseEscalationsSearch(caseId);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+        <CircularProgress size={28} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Typography variant="body2" color="error" sx={{ py: 4, textAlign: "center" }}>
+        Failed to load escalation history.
+      </Typography>
+    );
+  }
+
+  const records = data?.escalations ?? [];
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+        <TriangleAlert size={16} color={theme.palette.warning.main} />
+        <Typography variant="subtitle2" fontWeight={600}>
+          Escalation History
+        </Typography>
+        {records.length > 0 && (
+          <Chip
+            label={records.length}
+            size="small"
+            sx={{
+              height: 18,
+              fontSize: "0.7rem",
+              bgcolor: alpha(theme.palette.warning.light, 0.2),
+              color: theme.palette.warning.dark,
+            }}
+          />
+        )}
+      </Stack>
+
+      {records.length === 0 ? (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            py: 6,
+            gap: 1,
+          }}
+        >
+          <Flag size={32} color={theme.palette.text.disabled} />
+          <Typography variant="body2" color="text.secondary">
+            No escalations recorded for this case.
+          </Typography>
+        </Box>
+      ) : (
+        <Box>
+          {records.map((record, idx) => (
+            <EscalationTimelineItem
+              key={record.id}
+              record={record}
+              currentUserEmail={currentUserEmail}
+              isLast={idx === records.length - 1 && !caseCreatedOn}
+            />
+          ))}
+
+          {/* Initial state anchor */}
+          <Box sx={{ display: "flex", gap: 2 }}>
+            <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: 32, flexShrink: 0 }}>
+              <Box
+                sx={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: "50%",
+                  bgcolor: "action.hover",
+                  border: `2px solid`,
+                  borderColor: "divider",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                }}
+              >
+                <Flag size={14} color={theme.palette.text.secondary} />
+              </Box>
+            </Box>
+            <Box sx={{ flex: 1, pb: 0 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5, mt: 0.5 }}>
+                <Chip
+                  label="EL0"
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontWeight: 600, fontSize: "0.7rem", height: 20 }}
+                />
+                <Typography variant="caption" color="text.secondary">
+                  Case created
+                </Typography>
+              </Box>
+              {caseCreatedOn && (
+                <Typography variant="caption" color="text.secondary">
+                  {formatDate(caseCreatedOn)}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+
+          <Divider sx={{ mt: 2 }} />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/CaseEscalationHistoryPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/CaseEscalationHistoryPanel.tsx
@@ -236,7 +236,7 @@ export default function CaseEscalationHistoryPanel({ caseId, caseCreatedOn }: Pr
               key={record.id}
               record={record}
               currentUserEmail={currentUserEmail}
-              isLast={idx === records.length - 1 && !caseCreatedOn}
+              isLast={false}
             />
           ))}
 

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/EscalateCaseModal.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/EscalateCaseModal.tsx
@@ -1,0 +1,292 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { EscalateCaseModalProps } from "@features/support/types/supportComponents";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  TextField,
+  Typography,
+  alpha,
+  useTheme,
+} from "@wso2/oxygen-ui";
+import { AlertCircle, TriangleAlert, X } from "@wso2/oxygen-ui-icons-react";
+import { useCallback, useState, type ChangeEvent, type JSX } from "react";
+import { usePostCaseEscalation } from "@features/support/api/usePostCaseEscalation";
+import { ESCALATION_NEXT_LEVEL } from "@features/support/constants/supportConstants";
+
+const INLINE_ERROR_STATUSES = new Set([400, 403, 404, 409]);
+
+/**
+ * Modal for escalating a case to the next escalation level.
+ * Shows current/next level, who will be notified, and a mandatory reason textarea.
+ * HTTP 4xx errors are shown inline; 500+ errors are forwarded via onError.
+ *
+ * @param {EscalateCaseModalProps} props - Modal control props.
+ * @returns {JSX.Element} The escalate case modal.
+ */
+export default function EscalateCaseModal({
+  open,
+  caseId,
+  escalationLevelId,
+  escalationLevelLabel,
+  onClose,
+  onSuccess,
+  onError,
+}: EscalateCaseModalProps): JSX.Element {
+  const theme = useTheme();
+  const [reason, setReason] = useState("");
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  const { mutate, isPending } = usePostCaseEscalation(caseId);
+  const nextLevel = ESCALATION_NEXT_LEVEL[escalationLevelId];
+
+  const resetAndClose = useCallback(() => {
+    setReason("");
+    setInlineError(null);
+    onClose();
+  }, [onClose]);
+
+  const handleClose = useCallback(() => {
+    if (isPending) return;
+    resetAndClose();
+  }, [isPending, resetAndClose]);
+
+  const handleReasonChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setReason(e.target.value);
+      if (inlineError) setInlineError(null);
+    },
+    [inlineError],
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (!reason.trim() || isPending || !nextLevel) return;
+    setInlineError(null);
+    mutate(
+      { reason: reason.trim() },
+      {
+        onSuccess: () => {
+          resetAndClose();
+          onSuccess?.();
+        },
+        onError: (err) => {
+          if (INLINE_ERROR_STATUSES.has(err.status)) {
+            setInlineError(err.message);
+          } else {
+            const msg = err.message ?? "Failed to escalate case. Please try again.";
+            onError?.(msg);
+            resetAndClose();
+          }
+        },
+      },
+    );
+  }, [reason, isPending, nextLevel, mutate, resetAndClose, onSuccess, onError]);
+
+  const canConfirm = reason.trim() !== "" && !!nextLevel && !isPending;
+
+  const amberColor = theme.palette.warning.main;
+  const amberLight = theme.palette.warning.light;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="escalate-case-modal-title"
+    >
+      <IconButton
+        aria-label="Close"
+        size="small"
+        onClick={handleClose}
+        disabled={isPending}
+        sx={{ position: "absolute", right: 12, top: 12, zIndex: 1 }}
+      >
+        <X size={18} />
+      </IconButton>
+
+      <DialogTitle
+        id="escalate-case-modal-title"
+        sx={{ pr: 6, pb: 0.5 }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <TriangleAlert size={22} color={amberColor} />
+          <Typography variant="h6" component="span" fontWeight={700}>
+            Escalate to {nextLevel?.notifiedLabel ?? "Next Level"} Escalation
+          </Typography>
+        </Box>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mt: 0.5, fontWeight: "normal" }}
+        >
+          This will escalate your case for higher-level attention and faster resolution.
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1.5 }}>
+        {inlineError && (
+          <Alert severity="error" onClose={() => setInlineError(null)} sx={{ mb: 2 }}>
+            {inlineError}
+          </Alert>
+        )}
+
+        {/* Escalation level info card */}
+        <Box
+          sx={{
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 2,
+            p: 2,
+            mb: 2.5,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              mb: 1,
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              Current Level:
+            </Typography>
+            <Chip
+              label={escalationLevelLabel}
+              size="small"
+              variant="outlined"
+              sx={{ fontWeight: 600, fontSize: "0.75rem", height: 24 }}
+            />
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              Next Level:
+            </Typography>
+            <Chip
+              label={nextLevel?.nextLabel ?? "—"}
+              size="small"
+              variant="outlined"
+              sx={{
+                fontWeight: 600,
+                fontSize: "0.75rem",
+                height: 24,
+                color: amberColor,
+                borderColor: alpha(amberColor, 0.5),
+                bgcolor: alpha(amberLight, 0.12),
+              }}
+            />
+          </Box>
+
+          <Divider sx={{ my: 1.5 }} />
+
+          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.75 }}>
+            Who will be notified:
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            • {nextLevel?.nextLabel} – {nextLevel?.notifiedLabel}
+          </Typography>
+        </Box>
+
+        {/* Reason field */}
+        <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+          Reason for Escalation{" "}
+          <Box component="span" sx={{ color: "error.main" }}>
+            *
+          </Box>
+        </Typography>
+        <TextField
+          id="escalation-reason"
+          placeholder="Please provide detailed context about why this case needs escalation. Include any business impact, urgency, or specific issues that require higher-level attention..."
+          value={reason}
+          onChange={handleReasonChange}
+          fullWidth
+          multiline
+          rows={5}
+          disabled={isPending}
+          inputProps={{ "aria-label": "Reason for escalation" }}
+          sx={{ mb: 2 }}
+        />
+
+        {/* What happens next info box */}
+        <Box
+          sx={{
+            bgcolor: alpha(amberLight, 0.18),
+            border: 1,
+            borderColor: alpha(amberColor, 0.3),
+            borderRadius: 2,
+            p: 1.5,
+            display: "flex",
+            gap: 1.25,
+            alignItems: "flex-start",
+          }}
+        >
+          <AlertCircle size={18} color={amberColor} style={{ flexShrink: 0, marginTop: 2 }} />
+          <Box>
+            <Typography variant="body2" fontWeight={700} color="warning.dark" sx={{ mb: 0.5 }}>
+              What happens next?
+            </Typography>
+            <Typography variant="body2" color="warning.dark">
+              • {nextLevel?.notifiedLabel} will be notified immediately
+            </Typography>
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2.5, gap: 1 }}>
+        <Button variant="outlined" onClick={handleClose} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleConfirm}
+          disabled={!canConfirm}
+          startIcon={
+            isPending ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <TriangleAlert size={16} />
+            )
+          }
+          sx={{
+            bgcolor: amberColor,
+            color: theme.palette.warning.contrastText,
+            "&:hover": { bgcolor: theme.palette.warning.dark },
+            "&:disabled": { bgcolor: alpha(amberColor, 0.4) },
+          }}
+        >
+          {isPending ? "Escalating..." : "Confirm Escalation"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -28,6 +28,7 @@ import EscalateCaseModal from "../escalation/EscalateCaseModal";
 import { type JSX, useState } from "react";
 import {
   CASE_STATUS_ACTIONS,
+  ESCALATION_LEAD_REQUIRED_FROM_LEVEL,
   ESCALATION_MAX_LEVEL_ID,
   ESCALATION_NEXT_LEVEL,
   type CaseStatusPaletteIntent,
@@ -94,6 +95,7 @@ export default function CaseDetailsActionRow({
   isLoading = false,
   escalationLevelId,
   onEscalateSuccess,
+  isCurrentUserLead = false,
 }: CaseDetailsActionRowProps): JSX.Element {
   void assignedEngineer;
   void engineerInitials;
@@ -115,10 +117,12 @@ export default function CaseDetailsActionRow({
 
   const resolvedEscalationLevelId = String(escalationLevelId ?? "0");
   const escalationLevelInfo = ESCALATION_NEXT_LEVEL[resolvedEscalationLevelId];
+  const needsLead = ESCALATION_LEAD_REQUIRED_FROM_LEVEL.has(resolvedEscalationLevelId);
   const showEscalateButton =
     statusLabel !== "Closed" &&
     resolvedEscalationLevelId !== ESCALATION_MAX_LEVEL_ID &&
-    !!escalationLevelInfo;
+    !!escalationLevelInfo &&
+    (!needsLead || isCurrentUserLead);
 
   const availableActions = getAvailableCaseActions(statusLabel).filter(
     (label) => {

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -24,9 +24,12 @@ import {
   type Theme,
 } from "@wso2/oxygen-ui";
 import CaseStateConfirmDialog from "@features/support/components/case-details/dialogs/CaseStateConfirmDialog";
+import EscalateCaseModal from "../escalation/EscalateCaseModal";
 import { type JSX, useState } from "react";
 import {
   CASE_STATUS_ACTIONS,
+  ESCALATION_MAX_LEVEL_ID,
+  ESCALATION_NEXT_LEVEL,
   type CaseStatusPaletteIntent,
 } from "@features/support/constants/supportConstants";
 import useGetProjectFilters from "@api/useGetProjectFilters";
@@ -40,6 +43,7 @@ import {
   toPresentContinuousActionLabel,
   toPresentTenseActionLabel,
 } from "@features/support/utils/support";
+import { TriangleAlert } from "@wso2/oxygen-ui-icons-react";
 
 const ACTION_BUTTON_ICON_SIZE = 12;
 
@@ -88,6 +92,8 @@ export default function CaseDetailsActionRow({
   projectId = "",
   caseId = "",
   isLoading = false,
+  escalationLevelId,
+  onEscalateSuccess,
 }: CaseDetailsActionRowProps): JSX.Element {
   void assignedEngineer;
   void engineerInitials;
@@ -105,6 +111,14 @@ export default function CaseDetailsActionRow({
     label: string;
     stateKey: number;
   } | null>(null);
+  const [escalateModalOpen, setEscalateModalOpen] = useState(false);
+
+  const resolvedEscalationLevelId = String(escalationLevelId ?? "0");
+  const escalationLevelInfo = ESCALATION_NEXT_LEVEL[resolvedEscalationLevelId];
+  const showEscalateButton =
+    statusLabel !== "Closed" &&
+    resolvedEscalationLevelId !== ESCALATION_MAX_LEVEL_ID &&
+    !!escalationLevelInfo;
 
   const availableActions = getAvailableCaseActions(statusLabel).filter(
     (label) => {
@@ -167,6 +181,30 @@ export default function CaseDetailsActionRow({
           </Button>
         );
       })}
+      {showEscalateButton && (
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<TriangleAlert size={ACTION_BUTTON_ICON_SIZE} />}
+          onClick={() => setEscalateModalOpen(true)}
+          sx={{
+            borderColor: theme.palette.warning.light,
+            bgcolor: alpha(theme.palette.warning.light, 0.1),
+            color: theme.palette.warning.light,
+            fontSize: "0.7rem",
+            minHeight: 0,
+            py: 0.5,
+            px: 1,
+            "&:hover": {
+              borderColor: theme.palette.warning.main,
+              bgcolor: alpha(theme.palette.warning.light, 0.2),
+            },
+            textTransform: "none",
+          }}
+        >
+          Escalate Case
+        </Button>
+      )}
       <CaseStateConfirmDialog
         open={!!confirmAction}
         actionLabel={confirmAction ? toPresentTenseActionLabel(confirmAction.label) : ""}
@@ -195,6 +233,20 @@ export default function CaseDetailsActionRow({
           );
         }}
       />
+      {showEscalateButton && (
+        <EscalateCaseModal
+          open={escalateModalOpen}
+          caseId={caseId}
+          escalationLevelId={resolvedEscalationLevelId}
+          escalationLevelLabel={`EL${resolvedEscalationLevelId}`}
+          onClose={() => setEscalateModalOpen(false)}
+          onSuccess={() => {
+            showSuccess("Case escalated successfully.");
+            onEscalateSuccess?.();
+          }}
+          onError={(msg) => showError(msg)}
+        />
+      )}
     </Stack>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -95,7 +95,7 @@ export default function CaseDetailsActionRow({
   isLoading = false,
   escalationLevelId,
   onEscalateSuccess,
-  isCurrentUserLead = false,
+  isCurrentUserLead,
 }: CaseDetailsActionRowProps): JSX.Element {
   void assignedEngineer;
   void engineerInitials;
@@ -122,7 +122,7 @@ export default function CaseDetailsActionRow({
     statusLabel !== "Closed" &&
     resolvedEscalationLevelId !== ESCALATION_MAX_LEVEL_ID &&
     !!escalationLevelInfo &&
-    (!needsLead || isCurrentUserLead);
+    (!needsLead || isCurrentUserLead === true);
 
   const availableActions = getAvailableCaseActions(statusLabel).filter(
     (label) => {

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsHeader.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsHeader.tsx
@@ -23,7 +23,9 @@ import {
   Tooltip,
   Typography,
   alpha,
+  useTheme,
 } from "@wso2/oxygen-ui";
+import { TriangleAlert } from "@wso2/oxygen-ui-icons-react";
 import { useEffect, useRef, useState, type JSX } from "react";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import {
@@ -52,7 +54,10 @@ export default function CaseDetailsHeader({
   showSeverityChip = true,
   showStatusChip = true,
   variant = "default",
+  isEscalated = false,
+  escalationLevelLabel,
 }: CaseDetailsHeaderProps): JSX.Element {
+  const theme = useTheme();
   const titleRef = useRef<HTMLDivElement | null>(null);
   const [showTitleTooltip, setShowTitleTooltip] = useState(false);
 
@@ -144,6 +149,24 @@ export default function CaseDetailsHeader({
                 pl: "6px",
                 pr: "6px",
               },
+            }}
+          />
+        )}
+        {isEscalated && escalationLevelLabel && (
+          <Chip
+            icon={<TriangleAlert size={11} />}
+            label={`Escalated to ${escalationLevelLabel}`}
+            size="small"
+            variant="outlined"
+            sx={{
+              color: theme.palette.warning.dark,
+              borderColor: alpha(theme.palette.warning.main, 0.5),
+              bgcolor: alpha(theme.palette.warning.light, 0.12),
+              fontWeight: 500,
+              height: 20,
+              fontSize: "0.7rem",
+              "& .MuiChip-icon": { color: theme.palette.warning.main, ml: "4px" },
+              "& .MuiChip-label": { pl: "4px", pr: "8px" },
             }}
           />
         )}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsTabPanels.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsTabPanels.tsx
@@ -24,6 +24,7 @@ import CaseDetailsAttachmentsPanel from "@case-details-attachments/CaseDetailsAt
 import CaseDetailsDetailsPanel from "@case-details-details/CaseDetailsDetailsPanel";
 import CallsPanel from "@case-details-calls/CallsPanel";
 import CaseKnowledgeBaseRecommendations from "@features/support/components/knowledge-base/CaseKnowledgeBaseRecommendations";
+import CaseEscalationHistoryPanel from "../escalation/CaseEscalationHistoryPanel";
 
 /**
  * Renders the active tab panel for case details (Activity, Details, Attachments, Calls,
@@ -195,6 +196,13 @@ export default function CaseDetailsTabPanels({
         </Stack>
       );
     }
+    case 6:
+      return (
+        <CaseEscalationHistoryPanel
+          caseId={caseId}
+          caseCreatedOn={data?.createdOn}
+        />
+      );
     default:
       return null;
   }

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsTabs.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsTabs.tsx
@@ -16,7 +16,7 @@
 
 import type { CaseDetailsTabsProps } from "@features/support/types/supportComponents";
 import { CASE_DETAILS_TABS } from "@features/support/constants/supportConstants";
-import { Box, Button, Skeleton, Tab, Tabs } from "@wso2/oxygen-ui";
+import { Box, Button, Skeleton, Tab, Tabs, useTheme } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode } from "react";
 
@@ -38,7 +38,11 @@ export default function CaseDetailsTabs({
   knowledgeBaseCount,
   knowledgeBaseCountLoading = false,
   hideRelatedChangeRequestsTab = true,
+  hideEscalationTab = true,
+  escalationCount,
+  isEscalated = false,
 }: CaseDetailsTabsProps): JSX.Element {
+  const theme = useTheme();
   const tabs = CASE_DETAILS_TABS.filter((t) => {
     if (hideCallsTab && t.label.startsWith("Calls")) {
       return false;
@@ -47,6 +51,9 @@ export default function CaseDetailsTabs({
       return false;
     }
     if (hideRelatedChangeRequestsTab && t.label === "Related Change Requests") {
+      return false;
+    }
+    if (hideEscalationTab && t.label === "Escalation") {
       return false;
     }
     return true;
@@ -84,8 +91,11 @@ export default function CaseDetailsTabs({
           const isAttachmentsTab = label.startsWith("Attachments");
           const isCallsTab = label.startsWith("Calls");
           const isKnowledgeBaseTab = label.startsWith("Knowledge Base");
+          const isEscalationTab = label === "Escalation";
 
           let tabLabel: ReactNode = label;
+          let tabIcon: ReactNode = <Icon size={14} />;
+
           if (isAttachmentsTab && attachmentCount !== undefined) {
             tabLabel = `Attachments (${attachmentCount})`;
           } else if (isCallsTab && callCount !== undefined) {
@@ -106,12 +116,19 @@ export default function CaseDetailsTabs({
             } else if (knowledgeBaseCount !== undefined) {
               tabLabel = `Knowledge Base (${knowledgeBaseCount})`;
             }
+          } else if (isEscalationTab) {
+            if (escalationCount !== undefined) {
+              tabLabel = `Escalation (${escalationCount})`;
+            }
+            if (isEscalated) {
+              tabIcon = <Icon size={14} color={theme.palette.warning.main} />;
+            }
           }
 
           return (
             <Tab
               key={label}
-              icon={<Icon size={14} />}
+              icon={tabIcon}
               iconPosition="start"
               label={tabLabel}
             />

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -328,7 +328,21 @@ export const CASE_DETAILS_TABS: CaseDetailsTabConfig[] = [
   { label: "Calls (0)", Icon: Phone },
   { label: "Knowledge Base (0)", Icon: BookOpen },
   { label: "Related Change Requests", Icon: GitBranch },
+  { label: "Escalation", Icon: TriangleAlert },
 ];
+
+export const ESCALATION_MAX_LEVEL_ID = "5";
+
+export const ESCALATION_NEXT_LEVEL: Record<
+  string,
+  { nextId: string; nextLabel: string; notifiedLabel: string }
+> = {
+  "0": { nextId: "1", nextLabel: "EL1", notifiedLabel: "Team Lead" },
+  "1": { nextId: "2", nextLabel: "EL2", notifiedLabel: "Technology Unit Head" },
+  "2": { nextId: "3", nextLabel: "EL3", notifiedLabel: "CRE Head" },
+  "3": { nextId: "4", nextLabel: "EL4", notifiedLabel: "CCO / CRO" },
+  "4": { nextId: "5", nextLabel: "EL5", notifiedLabel: "CEO" },
+};
 
 // Case status actions shown in the case details action row. Close button last.
 export const CASE_STATUS_ACTIONS: CaseStatusAction[] = [

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -333,6 +333,9 @@ export const CASE_DETAILS_TABS: CaseDetailsTabConfig[] = [
 
 export const ESCALATION_MAX_LEVEL_ID = "5";
 
+// Escalation levels that require the user to have isLead: true (EL3→EL4 and EL4→EL5).
+export const ESCALATION_LEAD_REQUIRED_FROM_LEVEL = new Set(["3", "4"]);
+
 export const ESCALATION_NEXT_LEVEL: Record<
   string,
   { nextId: string; nextLabel: string; notifiedLabel: string }

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -202,6 +202,65 @@ export type CaseVariable = {
   value: string;
 };
 
+// Item type for an escalation level.
+export type EscalationLevel = {
+  id: number | string;
+  label: string;
+};
+
+// Item type for a user notified about an escalation.
+export type EscalationNotifiedUser = {
+  id: string;
+  userName: string;
+  name?: string | null;
+  email?: string | null;
+};
+
+// Item type for a single escalation record.
+export type EscalationRecord = {
+  id: string;
+  case: { id: string; name: string };
+  currentLevel: EscalationLevel | null;
+  previousLevel: EscalationLevel | null;
+  createdBy: string;
+  createdOn: string;
+  updatedOn?: string;
+  reason: string;
+  notificationSentTo?: EscalationNotifiedUser[] | null;
+};
+
+// Request type for creating an escalation.
+export type CreateEscalationRequest = {
+  reason: string;
+};
+
+// Response type for creating an escalation.
+export type CreateEscalationResponse = {
+  message: string;
+  escalation: EscalationRecord;
+};
+
+// Request type for searching escalations.
+// Note: filters.caseIds is injected by cs-tools backend; frontend sends only sortBy/pagination.
+export type EscalationSearchRequest = {
+  sortBy?: {
+    field: "createdOn" | "updatedOn";
+    order: "asc" | "desc";
+  };
+  pagination?: {
+    limit: number;
+    offset: number;
+  };
+};
+
+// Response type for escalation search.
+export type EscalationSearchResponse = {
+  escalations: EscalationRecord[];
+  totalRecords: number;
+  offset: number;
+  limit: number;
+};
+
 // Response type for detailed case information.
 export type CaseDetails = AuditMetadata & {
   id: string;
@@ -240,6 +299,8 @@ export type CaseDetails = AuditMetadata & {
   findingsResolved: number | null;
   findingsTotal: number | null;
   watchList?: Array<{ id?: string; userName?: string; name?: string; email?: string }> | null;
+  escalationLevel?: EscalationLevel | null;
+  isEscalated?: boolean | null;
 };
 
 // Item type for a single case comment.

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -56,6 +56,8 @@ export type CaseDetailsHeaderProps = {
   showSeverityChip?: boolean;
   showStatusChip?: boolean;
   variant?: CaseDetailsHeaderVariant;
+  isEscalated?: boolean;
+  escalationLevelLabel?: string | null;
 };
 
 export type OutstandingCasesListProps = {
@@ -405,6 +407,9 @@ export type CaseDetailsTabsProps = {
   knowledgeBaseCount?: number;
   knowledgeBaseCountLoading?: boolean;
   hideRelatedChangeRequestsTab?: boolean;
+  hideEscalationTab?: boolean;
+  escalationCount?: number;
+  isEscalated?: boolean;
 };
 
 export type CaseDetailsTabPanelsProps = {
@@ -441,6 +446,18 @@ export type CaseDetailsActionRowProps = {
   isLoading?: boolean;
   hideAssignedEngineer?: boolean;
   restrictToCloseOnly?: boolean;
+  escalationLevelId?: string | null;
+  onEscalateSuccess?: () => void;
+};
+
+export type EscalateCaseModalProps = {
+  open: boolean;
+  caseId: string;
+  escalationLevelId: string;
+  escalationLevelLabel: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+  onError?: (message: string) => void;
 };
 
 export type CasesOverviewStatCardProps = {

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -448,6 +448,7 @@ export type CaseDetailsActionRowProps = {
   restrictToCloseOnly?: boolean;
   escalationLevelId?: string | null;
   onEscalateSuccess?: () => void;
+  isCurrentUserLead?: boolean;
 };
 
 export type EscalateCaseModalProps = {

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -448,7 +448,7 @@ export type CaseDetailsActionRowProps = {
   restrictToCloseOnly?: boolean;
   escalationLevelId?: string | null;
   onEscalateSuccess?: () => void;
-  isCurrentUserLead?: boolean;
+  isCurrentUserLead?: boolean | undefined;
 };
 
 export type EscalateCaseModalProps = {


### PR DESCRIPTION
## Summary

- Add `EscalateCaseModal` matching Figma design — current/next level chips, reason textarea, notification info, amber warning box, and Confirm Escalation button
- Add `CaseEscalationHistoryPanel` with newest-first timeline showing level transitions, creator, timestamp, and notified users
- Add **Escalation** tab (index 6) to case details with count badge and amber icon when escalated; hidden for engagements, service requests, and security reports
- Show **"Escalated to \<level\>"** amber chip in case header when the case is escalated
- Add **Escalate Case** button in the action row — hidden for Closed cases and when max level (EL5) is reached
- Restrict EL3→EL4 and EL4→EL5 escalations to users with `isLead: true` in project contacts; EL0→EL3 available to all users
- Wire up `POST /cases/{caseId}/escalations` (create) and `POST /cases/{caseId}/escalations/search` (history) — backend injects `caseIds` filter, frontend sends only `sortBy` and `pagination`
- Eagerly fetch escalation count on page load for the tab badge

## API notes

The escalation search and create endpoints are functional on the cs-tools and entity-service Choreo deployments. The ServiceNow scripted REST API (`/api/x_wso2_customer_0/escalations`) has a known bug where `notificationSentTo` is returned as a string instead of a user object array — this causes a 500 on both search and create. A fix is required on the ServiceNow side; no frontend or backend changes are needed once that is resolved.

## Test plan

- [ ] Open a case detail page — verify Escalation tab appears with correct count
- [ ] Click Escalate Case — verify modal shows current level chip, next level chip, notified role, reason textarea, and amber warning box
- [ ] Confirm escalation — verify success banner and history panel updates
- [ ] Verify Escalate button is hidden for Closed cases
- [ ] Verify Escalate button is hidden when case is at EL5
- [ ] Verify EL3/EL4 Escalate button is hidden for non-Lead users and visible for Lead users
- [ ] Verify Escalation tab is hidden on engagement, service request, and security report pages
- [ ] Verify escalated case shows amber "Escalated to \<level\>" chip in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added case escalation capabilities to case details, including a new Escalation tab, history timeline, and an “Escalate Case” dialog with reason submission.
  * Display “Escalated” status/level, escalation counts, and “You” attribution in the timeline.
  * Added a new “Lead” role to support lead-based escalation actions.
* **Bug Fixes**
  * Improved escalation UI states with loading, empty, and error handling; refreshed case data after successful escalation.
* **Style**
  * Introduced warning-themed visual cues for escalated cases and escalation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->