### PR TITLE
feat(customer-portal): add case escalation feature

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/CaseEscalationHistoryPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/CaseEscalationHistoryPanel.tsx
@@ -231,7 +231,7 @@ export default function CaseEscalationHistoryPanel({ caseId, caseCreatedOn }: Pr
         </Box>
       ) : (
         <Box>
-          {records.map((record, idx) => (
+          {records.map((record) => (
             <EscalationTimelineItem
               key={record.id}
               record={record}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsTabs.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsTabs.tsx
@@ -121,7 +121,7 @@ export default function CaseDetailsTabs({
               tabLabel = `Escalation (${escalationCount})`;
             }
             if (isEscalated) {
-              tabIcon = <Icon size={14} color={theme.palette.warning.main} />;
+              tabIcon = <Box component="span" sx={{ color: theme.palette.warning.main, display: "flex" }}><Icon size={14} /></Box>;
             }
           }
 


### PR DESCRIPTION
## Summary

- Add `EscalateCaseModal`, `CaseEscalationHistoryPanel`, Escalation tab, header chip, and Escalate Case button to case details
- Restrict EL3→EL4 and EL4→EL5 escalations to Lead users (`isLead: true` in project contacts)
- Add Lead role card to the Role Permissions info panel in Settings
- Wire up `POST /cases/{caseId}/escalations` and `POST /cases/{caseId}/escalations/search`

## Fixes

- Guard lead lookup with `isLoading` from `useGetUserDetails` to prevent button flicker for Lead users at EL3/EL4
- Always show connector from last escalation record to EL0 anchor (was incorrectly hidden when `caseCreatedOn` was absent)
- Remove unused `idx` from `records.map` after `isLast={false}` fix
- Wrap `TriangleAlert` in `Box` with `sx` color instead of unsupported `color` prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Escalation tab’s warning icon display so it renders consistently with the intended warning color and alignment.
  * Cleaned up the escalation history display without changing the information shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->