### PR TITLE
[CSM Portal] add SR/SRA creation, shared issue listing, and Customers menu

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { type JSX, lazy } from "react";
-import { Navigate, Route, Routes, useParams } from "react-router";
+import { Navigate, Route, Routes, useLocation, useParams } from "react-router";
 import AuthGuard from "@layouts/AuthGuard";
 import {
   POST_LOGIN_REDIRECT_KEY,
@@ -105,7 +105,11 @@ function RootLanding(): JSX.Element | null {
  */
 function LegacyDetailRedirect({ to }: { to: string }): JSX.Element {
   const { id } = useParams();
-  return <Navigate to={id ? `${to}/${id}` : to} replace />;
+  // Preserve any query/hash so legacy deep links (e.g. /accounts/:id?tab=…#…)
+  // keep their context through the compatibility redirect.
+  const { search, hash } = useLocation();
+  const target = id ? `${to}/${id}` : to;
+  return <Navigate to={`${target}${search}${hash}`} replace />;
 }
 
 export default function App(): JSX.Element {

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { type JSX, lazy } from "react";
-import { Navigate, Route, Routes } from "react-router";
+import { Navigate, Route, Routes, useParams } from "react-router";
 import AuthGuard from "@layouts/AuthGuard";
 import {
   POST_LOGIN_REDIRECT_KEY,
@@ -62,6 +62,9 @@ const CsmAdminLayout = lazy(
 const CsmUsersPage = lazy(
   () => import("@features/csm-users/pages/CsmUsersPage"),
 );
+const CsmCustomersLayout = lazy(
+  () => import("@features/csm-customers/pages/CsmCustomersLayout"),
+);
 const CsmAccountsPage = lazy(
   () => import("@features/csm-accounts/pages/CsmAccountsPage"),
 );
@@ -77,6 +80,12 @@ const CsmProjectDetailPage = lazy(
 const CsmUpdatesPage = lazy(
   () => import("@features/updates/pages/CsmUpdatesPage"),
 );
+const CsmSecurityCenterPage = lazy(
+  () => import("@features/csm-security-center/pages/CsmSecurityCenterPage"),
+);
+const CreateSecurityReportPage = lazy(
+  () => import("@features/csm-security-center/pages/CreateSecurityReportPage"),
+);
 
 /**
  * Landing for `/`. Defers to AuthGuard's post-login deep-link restore when a
@@ -87,6 +96,16 @@ const CsmUpdatesPage = lazy(
 function RootLanding(): JSX.Element | null {
   const pending = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
   return pending ? null : <Navigate to="/dashboard" replace />;
+}
+
+/**
+ * Redirects a legacy detail path (`/accounts/:id`, `/projects/:id`) to its new
+ * home under `/customers`, preserving the id. Exists only so old pinned/deep
+ * links survive the Accounts+Projects → Customers menu merge.
+ */
+function LegacyDetailRedirect({ to }: { to: string }): JSX.Element {
+  const { id } = useParams();
+  return <Navigate to={id ? `${to}/${id}` : to} replace />;
 }
 
 export default function App(): JSX.Element {
@@ -125,11 +144,43 @@ export default function App(): JSX.Element {
               <Route element={<AuthGuard />}>
                 <Route path="/" element={<RootLanding />} />
 
-                {/* BFF-backed pages (entity-service search + by-id endpoints) */}
-                <Route path="accounts" element={<CsmAccountsPage />} />
-                <Route path="accounts/:id" element={<CsmAccountDetailPage />} />
-                <Route path="projects" element={<CsmProjectsPage />} />
-                <Route path="projects/:id" element={<CsmProjectDetailPage />} />
+                {/* Customers — Accounts + Projects under one tabbed section.
+                    BFF-backed pages (entity-service search + by-id endpoints).
+                    Detail pages render full-width (outside the tab layout). */}
+                <Route path="customers" element={<CsmCustomersLayout />}>
+                  <Route
+                    index
+                    element={<Navigate to="/customers/accounts" replace />}
+                  />
+                  <Route path="accounts" element={<CsmAccountsPage />} />
+                  <Route path="projects" element={<CsmProjectsPage />} />
+                </Route>
+                <Route
+                  path="customers/accounts/:id"
+                  element={<CsmAccountDetailPage />}
+                />
+                <Route
+                  path="customers/projects/:id"
+                  element={<CsmProjectDetailPage />}
+                />
+
+                {/* Legacy paths kept alive so pinned/deep links don't 404. */}
+                <Route
+                  path="accounts"
+                  element={<Navigate to="/customers/accounts" replace />}
+                />
+                <Route
+                  path="accounts/:id"
+                  element={<LegacyDetailRedirect to="/customers/accounts" />}
+                />
+                <Route
+                  path="projects"
+                  element={<Navigate to="/customers/projects" replace />}
+                />
+                <Route
+                  path="projects/:id"
+                  element={<LegacyDetailRedirect to="/customers/projects" />}
+                />
 
                 {/* Administration — Users tab is real, others are WIP */}
                 <Route path="admin" element={<CsmAdminLayout />}>
@@ -190,15 +241,10 @@ export default function App(): JSX.Element {
                   }
                 />
                 <Route path="updates" element={<CsmUpdatesPage />} />
+                <Route path="security-center" element={<CsmSecurityCenterPage />} />
                 <Route
-                  path="security-center"
-                  element={
-                    <CsmComingSoonPage
-                      title="Security center"
-                      description="Vulnerability posture across customer deployments."
-                      blockedOn="csm-portal/backend security endpoint"
-                    />
-                  }
+                  path="security-center/reports/new"
+                  element={<CreateSecurityReportPage />}
                 />
                 <Route
                   path="time-cards"

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -194,7 +194,7 @@ export interface BeCaseView {
 }
 
 export interface BeCaseCreatePayload {
-  /** Case type. The portal only creates `case` (standard support) cases. */
+  /** Standard support case. */
   type: "case";
   projectId: string;
   deploymentId: string;
@@ -203,7 +203,68 @@ export interface BeCaseCreatePayload {
   description: string;
   severity: BeCaseSeverity;
   issueType: BeCaseIssueType;
+  /** Optional supporting files (raw base64), like the customer portal. */
+  attachments?: BeCaseAttachmentPayload[];
 }
+
+/** A single answered catalog-item variable in a service-request create. */
+export interface BeCaseVariable {
+  /** Variable (question) id, as returned by the catalog-item variables endpoint. */
+  id: string;
+  /** The engineer's answer for this variable. */
+  value: string;
+}
+
+/**
+ * Catalog-based service request (`type: "service_request"`). ServiceNow-only:
+ * the catalog/catalog-item come from `POST /catalogs/search` (filtered by the
+ * deployed product) and the variables from the catalog-item variables endpoint.
+ */
+export interface BeServiceRequestCreatePayload {
+  type: "service_request";
+  projectId: string;
+  deploymentId: string;
+  deployedProductId: string;
+  catalogId: string;
+  catalogItemId: string;
+  variables: BeCaseVariable[];
+}
+
+/**
+ * An inline attachment in a security-report create. Note `file` is **raw**
+ * base64 (the file's bytes), NOT a `data:` URI — the SRA create path passes it
+ * straight through. (The separate post-case attachment endpoint, by contrast,
+ * requires a data URI.)
+ */
+export interface BeCaseAttachmentPayload {
+  /** File name including extension. */
+  name: string;
+  /** Base64-encoded file content (raw base64, no `data:` prefix). */
+  file: string;
+}
+
+/**
+ * Security report analysis (`type: "security_report_analysis"`). ServiceNow-only;
+ * requires a subject, description, and at least one attachment.
+ */
+export interface BeSecurityReportCreatePayload {
+  type: "security_report_analysis";
+  projectId: string;
+  deploymentId: string;
+  deployedProductId: string;
+  subject: string;
+  description: string;
+  attachments: BeCaseAttachmentPayload[];
+}
+
+/**
+ * Any body accepted by `POST /cases`: a standard support case, a catalog
+ * service request, or a security report analysis.
+ */
+export type BeCaseCreateBody =
+  | BeCaseCreatePayload
+  | BeServiceRequestCreatePayload
+  | BeSecurityReportCreatePayload;
 
 /** The case summary embedded in the `POST /cases` success envelope. */
 export interface BeCreatedCase {
@@ -219,6 +280,55 @@ export interface BeCreatedCase {
 export interface BeCaseCreateResponse {
   message?: string;
   case: BeCreatedCase;
+}
+
+// ---------------------------------------------------------------------------
+// Service catalogs (ServiceNow only) — drive service-request creation
+// ---------------------------------------------------------------------------
+
+/** A catalog item (request form) within a catalog. */
+export interface BeCatalogItemRef {
+  id: string;
+  name?: string;
+}
+
+/** A service catalog and the catalog items it offers. */
+export interface BeCatalogRef {
+  id: string;
+  name?: string;
+  catalogItems?: BeCatalogItemRef[];
+}
+
+/** Request body for `POST /catalogs/search`. */
+export interface BeSearchCatalogsPayload {
+  /** Deployed product to scope catalogs to (required). */
+  deployedProductId: string;
+  pagination?: { offset?: number; limit?: number };
+}
+
+/** `POST /catalogs/search` response. */
+export interface BeSearchCatalogsResponse {
+  catalogs?: BeCatalogRef[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * A catalog-item variable (form field). The contract carries the question
+ * text, display order, and a free-form `type` hint, but no choice/option list
+ * or mandatory flag — so the portal renders every variable as a text field.
+ */
+export interface BeCatalogItemVariable {
+  id: string;
+  questionText?: string;
+  order?: number;
+  type?: string;
+}
+
+/** `GET /catalogs/{catalogId}/items/{catalogItemId}/variables` response. */
+export interface BeGetCatalogItemVariablesResponse {
+  variables?: BeCatalogItemVariable[];
 }
 
 /**

--- a/apps/csm-portal/webapp/src/components/attachments/AttachmentsField.tsx
+++ b/apps/csm-portal/webapp/src/components/attachments/AttachmentsField.tsx
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, IconButton, Typography } from "@wso2/oxygen-ui";
+import { Paperclip, Upload, X } from "@wso2/oxygen-ui-icons-react";
+import { useRef, type ChangeEvent, type JSX } from "react";
+import { formatBytes } from "@utils/formatBytes";
+import { MAX_ATTACHMENT_SIZE_BYTES } from "@features/csm-cases/api/useCsmCaseAttachments";
+import {
+  readFileAsBase64,
+  totalEncodedBytes,
+  type EncodedAttachment,
+} from "@components/attachments/encodeAttachment";
+
+interface AttachmentsFieldProps {
+  attachments: EncodedAttachment[];
+  onChange: (next: EncodedAttachment[]) => void;
+  /** Surface read/size errors (e.g. via the error banner). */
+  onError: (message: string, err?: unknown) => void;
+  /** Combined-encoded-size ceiling; an over-limit list shows an inline error. */
+  maxEncodedBytes: number;
+  /** Adjusts the hint text only ("At least one required" vs "Optional"). */
+  required?: boolean;
+}
+
+/**
+ * A multi-file attachment picker that encodes each file to raw base64 for the
+ * case-create payload. Enforces a per-file size cap and surfaces a combined-size
+ * error; the parent gates submission on `totalEncodedBytes` vs `maxEncodedBytes`.
+ */
+export default function AttachmentsField({
+  attachments,
+  onChange,
+  onError,
+  maxEncodedBytes,
+  required = false,
+}: AttachmentsFieldProps): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const encodedBytes = totalEncodedBytes(attachments);
+  const overLimit = encodedBytes > maxEncodedBytes;
+
+  const onAddFiles = async (e: ChangeEvent<HTMLInputElement>): Promise<void> => {
+    // Snapshot the FileList into a stable array BEFORE clearing the input —
+    // `e.target.files` is live, so resetting `value` first would empty it.
+    const list = Array.from(e.target.files ?? []);
+    // Reset so picking the same file again re-fires change. The File objects in
+    // `list` remain readable after this (only the input's FileList is cleared).
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (list.length === 0) return;
+
+    const tooBig = list.find((f) => f.size > MAX_ATTACHMENT_SIZE_BYTES);
+    if (tooBig) {
+      onError(
+        `"${tooBig.name}" is too large. The maximum attachment size is ${formatBytes(
+          MAX_ATTACHMENT_SIZE_BYTES,
+        )}.`,
+      );
+      return;
+    }
+    try {
+      const encoded = await Promise.all(
+        list.map(async (f) => ({
+          name: f.name,
+          file: await readFileAsBase64(f),
+          size: f.size,
+          raw: f,
+        })),
+      );
+      onChange([...attachments, ...encoded]);
+    } catch (err) {
+      onError("Could not read one of the selected files. Please try again.", err);
+    }
+  };
+
+  const removeAt = (index: number): void => {
+    onChange(attachments.filter((_, i) => i !== index));
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+        <Button
+          component="label"
+          variant="outlined"
+          size="small"
+          startIcon={<Upload size={16} />}
+        >
+          Add attachments
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            hidden
+            onChange={(e) => void onAddFiles(e)}
+          />
+        </Button>
+        <Typography variant="caption" color="text.secondary">
+          {required ? "At least one required" : "Optional"} · up to{" "}
+          {formatBytes(MAX_ATTACHMENT_SIZE_BYTES)} each
+        </Typography>
+      </Box>
+
+      {attachments.map((a, i) => (
+        <Box
+          key={`${a.name}-${i}`}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1,
+            px: 1.5,
+            py: 0.75,
+          }}
+        >
+          <Paperclip size={16} aria-hidden style={{ opacity: 0.7 }} />
+          <Typography variant="body2" sx={{ flexGrow: 1, minWidth: 0 }} noWrap>
+            {a.name}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatBytes(a.size)}
+          </Typography>
+          <IconButton size="small" aria-label={`Remove ${a.name}`} onClick={() => removeAt(i)}>
+            <X size={16} />
+          </IconButton>
+        </Box>
+      ))}
+
+      {overLimit && (
+        <Typography variant="caption" color="error">
+          The attachments are too large together ({formatBytes(encodedBytes)} encoded).
+          Maximum is {formatBytes(maxEncodedBytes)} — remove a file or attach smaller ones.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/components/attachments/encodeAttachment.ts
+++ b/apps/csm-portal/webapp/src/components/attachments/encodeAttachment.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/** A file encoded for a case-create payload: raw base64 + display metadata. */
+export interface EncodedAttachment {
+  name: string;
+  /** Raw base64 (no `data:` prefix) — the shape the SRA create payload wants. */
+  file: string;
+  /** Decoded size in bytes, for display. */
+  size: number;
+  /**
+   * The original File. Used by the post-create upload path
+   * (`POST /cases/{id}/attachments`, which standard cases and service requests
+   * use because the create endpoint only honors create-payload attachments for
+   * security reports).
+   */
+  raw: File;
+}
+
+/** Combined base64 size of all attachments (≈ bytes, base64 is ASCII). */
+export function totalEncodedBytes(attachments: EncodedAttachment[]): number {
+  return attachments.reduce((sum, a) => sum + a.file.length, 0);
+}
+
+/** Read a File as raw base64, stripping the `data:<mime>;base64,` prefix. */
+export function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read the file."));
+    reader.readAsDataURL(file);
+  });
+}

--- a/apps/csm-portal/webapp/src/components/attachments/encodeAttachment.ts
+++ b/apps/csm-portal/webapp/src/components/attachments/encodeAttachment.ts
@@ -30,6 +30,14 @@ export interface EncodedAttachment {
   raw: File;
 }
 
+/**
+ * Aggregate-size ceiling for attachments uploaded after case creation (standard
+ * cases / service requests). Each upload is a separate request capped per-file
+ * at 10 MB, so this is a sanity bound on how much the browser base64-encodes and
+ * holds in memory at once — not a single-request body limit.
+ */
+export const POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES = 100 * 1024 * 1024;
+
 /** Combined base64 size of all attachments (≈ bytes, base64 is ASCII). */
 export function totalEncodedBytes(attachments: EncodedAttachment[]): number {
   return attachments.reduce((sum, a) => sum + a.file.length, 0);

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -31,8 +31,8 @@ interface CsmSideBarProps {
 }
 
 function pickActiveId(pathname: string): string {
-  if (pathname === "/" || pathname === "") return "accounts";
-  return navItemForPath(pathname)?.id ?? "accounts";
+  if (pathname === "/" || pathname === "") return "dashboard";
+  return navItemForPath(pathname)?.id ?? "dashboard";
 }
 
 export default function CsmSideBar({

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -16,11 +16,10 @@
 
 import {
   Briefcase,
-  Building,
+  Building2,
   ChartColumn,
   Clock,
   Cog,
-  FolderOpen,
   Headset,
   RefreshCw,
   Settings,
@@ -43,14 +42,13 @@ export interface CsmNavItem {
  */
 export const CSM_NAV_ITEMS: CsmNavItem[] = [
   { id: "dashboard", label: "Dashboard", path: "/dashboard", icon: ChartColumn },
-  { id: "cases", label: "Cases", path: "/cases", icon: Headset },
+  { id: "support", label: "Support", path: "/cases", icon: Headset },
   { id: "operations", label: "Operations", path: "/operations", icon: Cog },
   { id: "engagements", label: "Engagements", path: "/engagements", icon: Briefcase },
+  { id: "security-center", label: "Security Center", path: "/security-center", icon: Shield },
   { id: "updates", label: "Updates", path: "/updates", icon: RefreshCw },
-  { id: "security-center", label: "Security center", path: "/security-center", icon: Shield },
   { id: "time-cards", label: "Time cards", path: "/time-cards", icon: Clock },
-  { id: "accounts", label: "Accounts", path: "/accounts", icon: Building },
-  { id: "projects", label: "Projects", path: "/projects", icon: FolderOpen },
+  { id: "customers", label: "Customers", path: "/customers", icon: Building2 },
   { id: "admin", label: "Settings", path: "/admin", icon: Settings },
 ];
 

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -93,7 +93,7 @@ export default function CsmAccountDetailPage(): JSX.Element {
   if (isError) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/accounts")} />
+        <BackButton onClick={() => navigate("/customers/accounts")} />
         <Typography variant="body1" color="error">
           Could not load account {id}.
         </Typography>
@@ -104,7 +104,7 @@ export default function CsmAccountDetailPage(): JSX.Element {
   if (!data) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/accounts")} />
+        <BackButton onClick={() => navigate("/customers/accounts")} />
         <Typography variant="h5">Account not found</Typography>
         <Typography variant="body2" color="text.secondary">
           No account with id <code>{id}</code>.
@@ -117,7 +117,7 @@ export default function CsmAccountDetailPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-      <BackButton onClick={() => navigate("/accounts")} />
+      <BackButton onClick={() => navigate("/customers/accounts")} />
 
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -79,12 +79,9 @@ export default function CsmAccountsPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Box>
-        <Typography variant="h5">Accounts</Typography>
-        <Typography variant="body2" color="text.secondary">
-          Search across account name and Salesforce ID (case-insensitive).
-        </Typography>
-      </Box>
+      <Typography variant="body2" color="text.secondary">
+        Search across account name and Salesforce ID (case-insensitive).
+      </Typography>
 
       <TextField
         size="small"
@@ -136,7 +133,7 @@ export default function CsmAccountsPage(): JSX.Element {
                     <TableCell>
                       <Typography
                         component={RouterLink}
-                        to={`/accounts/${a.id}`}
+                        to={`/customers/accounts/${a.id}`}
                         variant="body2"
                         sx={(t) => ({
                           textDecoration: "none",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { EncodedAttachment } from "@components/attachments/encodeAttachment";
+import type { PostCsmCaseAttachmentInput } from "@features/csm-cases/api/useCsmCaseAttachments";
+
+/**
+ * Upload create-form attachments to an already-created case via
+ * `POST /cases/{id}/attachments`. The case-create endpoint only honors
+ * create-payload attachments for security reports, so standard cases and
+ * service requests attach their files this way after the case exists.
+ *
+ * Uploads run concurrently and independently; returns the number that failed
+ * so the caller can warn without blocking navigation to the created case.
+ *
+ * @param upload      the `mutateAsync` of {@link usePostCsmCaseAttachment}
+ * @param uploadedBy  display name of the uploader (signed-in engineer)
+ */
+export async function uploadAttachmentsToCase(
+  upload: (input: PostCsmCaseAttachmentInput) => Promise<unknown>,
+  caseId: string,
+  attachments: EncodedAttachment[],
+  uploadedBy: string,
+): Promise<number> {
+  if (attachments.length === 0) return 0;
+  const results = await Promise.allSettled(
+    attachments.map((a) => upload({ caseId, file: a.raw, name: a.name, uploadedBy })),
+  );
+  return results.filter((r) => r.status === "rejected").length;
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -54,6 +54,7 @@ function detailFromBeCase(
     caseNumber: c.number,
     wso2CaseId: c.internalId,
     subject: c.subject ?? "(no subject)",
+    caseType: c.type ?? undefined,
     customer,
     accountId: account?.id ?? "",
     projectId: c.project?.id ?? "",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/usePostCsmCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/usePostCsmCase.ts
@@ -22,28 +22,29 @@ import {
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
-  BeCaseCreatePayload,
+  BeCaseCreateBody,
   BeCaseCreateResponse,
   BeCreatedCase,
 } from "@api/backend/types";
 
 /**
- * Create a case via `POST /cases`. The backend wraps the result in a
- * `{ message, case }` envelope, so this unwraps and returns the created case
+ * Create a case via `POST /cases`. Accepts any supported create body (standard
+ * support `case` or catalog `service_request`). The backend wraps the result in
+ * a `{ message, case }` envelope, so this unwraps and returns the created case
  * (its `id` drives the post-create redirect). The mutation also invalidates
  * project-scoped case searches so list views refresh.
  */
 export function usePostCsmCase(): UseMutationResult<
   BeCreatedCase,
   Error,
-  BeCaseCreatePayload
+  BeCaseCreateBody
 > {
   const api = useBackendApi();
   const queryClient = useQueryClient();
 
-  return useMutation<BeCreatedCase, Error, BeCaseCreatePayload>({
+  return useMutation<BeCreatedCase, Error, BeCaseCreateBody>({
     mutationFn: async (input): Promise<BeCreatedCase> => {
-      const res = await api.post<BeCaseCreatePayload, BeCaseCreateResponse>(
+      const res = await api.post<BeCaseCreateBody, BeCaseCreateResponse>(
         "/cases",
         input,
       );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
@@ -145,8 +145,8 @@ export default function AsyncProjectSelect({
           label={label}
           required={required}
           placeholder={value ? undefined : "Search projects…"}
-          error={isError && open}
-          helperText={isError && open ? "Project search failed." : undefined}
+          error={isError}
+          helperText={isError ? "Project search failed." : undefined}
         />
       )}
     />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
@@ -16,8 +16,9 @@
 
 import { Autocomplete, TextField } from "@wso2/oxygen-ui";
 import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
-import { useProjectSearch } from "@features/csm-cases/api/useProjectSearch";
+import { useInfiniteProjectSearch } from "@features/csm-cases/api/useProjectSearch";
 
 interface ProjectOption {
   id: string;
@@ -35,10 +36,11 @@ interface AsyncProjectSelectProps {
 }
 
 /**
- * Single-project picker that searches the backend as the user types instead of
- * loading the whole project catalogue up front (see {@link useProjectSearch}).
- * The name of the picked project is remembered so the field keeps its label
- * even after the search term — and its results — move on.
+ * Single-project picker. Mirrors the cases filter's project control
+ * ({@link useInfiniteProjectSearch}): on open it loads the first page of
+ * projects (no typing needed) and pages through the rest on scroll, narrowing
+ * as the user types. The name of the picked project is remembered so the field
+ * keeps its label even after the search term — and its results — move on.
  */
 export default function AsyncProjectSelect({
   id = "case-project",
@@ -48,16 +50,35 @@ export default function AsyncProjectSelect({
   required,
   disabled,
 }: AsyncProjectSelectProps): JSX.Element {
-  // Tracked separately from the displayed input value (which MUI manages and
-  // shows the selected project's name) so the type-ahead query keeps working.
+  // Search term tracked separately from the displayed input value (which MUI
+  // manages and shows the selected project's name) so the type-ahead works.
   const [searchTerm, setSearchTerm] = useState("");
+  const [open, setOpen] = useState(false);
   const debounced = useDebouncedValue(searchTerm, 300);
   const query = debounced.trim();
 
-  const { data, isFetching, isError } = useProjectSearch(
-    query,
-    query.length > 0,
-  );
+  // Enabled while the dropdown is open, so it loads the first page of projects
+  // on open and re-pages as the user types.
+  const {
+    projects,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    isError,
+    fetchNextPage,
+  } = useInfiniteProjectSearch(query, open);
+
+  // Lazy-load the next page when the listbox is scrolled near its end.
+  const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
+    const el = event.currentTarget;
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    ) {
+      fetchNextPage();
+    }
+  };
 
   // Captured at selection time so the field stays labelled once the search
   // results change to a different term.
@@ -66,20 +87,20 @@ export default function AsyncProjectSelect({
   const selectedOption = useMemo<ProjectOption | null>(() => {
     if (!value) return null;
     if (picked && picked.id === value) return picked;
-    const match = (data ?? []).find((p) => p.id === value);
+    const match = projects.find((p) => p.id === value);
     if (match) return { id: match.id, name: match.name || match.id };
     return { id: value, name: value };
-  }, [value, picked, data]);
+  }, [value, picked, projects]);
 
   // Pool = the current selection (so it can render) + the search results,
   // de-duplicated by id.
   const options = useMemo<ProjectOption[]>(() => {
-    const results = (data ?? []).map((p) => ({ id: p.id, name: p.name || p.id }));
+    const results = projects.map((p) => ({ id: p.id, name: p.name || p.id }));
     if (selectedOption && !results.some((o) => o.id === selectedOption.id)) {
       return [selectedOption, ...results];
     }
     return results;
-  }, [data, selectedOption]);
+  }, [projects, selectedOption]);
 
   return (
     <Autocomplete<ProjectOption>
@@ -88,12 +109,21 @@ export default function AsyncProjectSelect({
       id={id}
       options={options}
       value={selectedOption}
+      open={open}
+      onOpen={() => {
+        // Start each open from the default first page rather than a stale term.
+        setSearchTerm("");
+        setOpen(true);
+      }}
+      onClose={() => setOpen(false)}
       disabled={disabled}
-      loading={isFetching}
+      // Spinner only while the first page loads; later pages append on scroll.
+      loading={isFetching && projects.length === 0}
       // The backend already filtered by the typed term; don't re-filter locally.
       filterOptions={(opts) => opts}
       getOptionLabel={(opt) => opt.name}
       isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      slotProps={{ listbox: { onScroll: handleListboxScroll } }}
       onChange={(_event, next) => {
         setPicked(next);
         onChange(next ? next.id : "");
@@ -103,29 +133,22 @@ export default function AsyncProjectSelect({
         else if (reason === "clear") setSearchTerm("");
       }}
       noOptionsText={
-        query.length === 0
-          ? "Type to search projects…"
-          : isError
-            ? "Could not load projects"
-            : isFetching
-              ? "Searching…"
-              : "No projects found"
+        isError
+          ? "Couldn't load projects. Try again."
+          : isFetching
+            ? "Loading projects…"
+            : "No projects found"
       }
-      renderInput={(params) => {
-        const failed = query.length > 0 && isError;
-        return (
-          <TextField
-            {...params}
-            label={label}
-            required={required}
-            placeholder={value ? undefined : "Type a project…"}
-            error={failed}
-            helperText={
-              failed ? "Project search failed. Type to retry." : undefined
-            }
-          />
-        );
-      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          required={required}
+          placeholder={value ? undefined : "Search projects…"}
+          error={isError && open}
+          helperText={isError && open ? "Project search failed." : undefined}
+        />
+      )}
     />
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -209,7 +209,7 @@ export default function CaseMetaBand({
           </Cell>
           <Cell label="Account">
             {c.accountId ? (
-              <LinkText to={`/accounts/${c.accountId}`}>
+              <LinkText to={`/customers/accounts/${c.accountId}`}>
                 {c.customer}
               </LinkText>
             ) : (
@@ -220,7 +220,7 @@ export default function CaseMetaBand({
           </Cell>
           <Cell label="Project">
             {c.projectId ? (
-              <LinkText to={`/projects/${c.projectId}`}>
+              <LinkText to={`/customers/projects/${c.projectId}`}>
                 {c.projectName}
               </LinkText>
             ) : (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -118,6 +118,10 @@ interface CasesFilterBarProps {
   availableAssigneeUsers: AssigneeUser[];
   /** Projects for the (id-based) project filter — value is the id, label the name. */
   availableProjects: { id: string; name: string }[];
+  /** Hide the case-type control when the surrounding view locks the type. */
+  hideTypeFilter?: boolean;
+  /** Hide the project control when the surrounding view is project-scoped. */
+  hideProjectFilter?: boolean;
 }
 
 const ALL_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
@@ -313,6 +317,8 @@ export default function CasesFilterBar({
   onFiltersToggle,
   availableAssigneeUsers,
   availableProjects,
+  hideTypeFilter = false,
+  hideProjectFilter = false,
 }: CasesFilterBarProps): JSX.Element {
   const activeCount = countActiveFilters(filters);
   const hasActive = activeCount > 0;
@@ -604,15 +610,17 @@ export default function CasesFilterBar({
                 onChange={(next) => onChange({ ...filters, states: next })}
               />
             </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              <MultiSelectField
-                id="cases-filter-type"
-                label="Case type"
-                values={filters.caseTypes}
-                options={caseTypeOptions}
-                onChange={(next) => onChange({ ...filters, caseTypes: next })}
-              />
-            </Grid>
+            {!hideTypeFilter && (
+              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+                <MultiSelectField
+                  id="cases-filter-type"
+                  label="Case type"
+                  values={filters.caseTypes}
+                  options={caseTypeOptions}
+                  onChange={(next) => onChange({ ...filters, caseTypes: next })}
+                />
+              </Grid>
+            )}
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
               {/* Disabled until the backend `/cases/search` supports an
                   assigned-engineer filter. The picker is email-backed and ready
@@ -638,13 +646,15 @@ export default function CasesFilterBar({
                 </Box>
               </Tooltip>
             </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              <AsyncProjectMultiSelect
-                values={filters.projects}
-                onChange={(next) => onChange({ ...filters, projects: next })}
-                nameSeed={projectNameSeed}
-              />
-            </Grid>
+            {!hideProjectFilter && (
+              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+                <AsyncProjectMultiSelect
+                  values={filters.projects}
+                  onChange={(next) => onChange({ ...filters, projects: next })}
+                  nameSeed={projectNameSeed}
+                />
+              </Grid>
+            )}
           </Grid>
           {activeCount > 0 && (
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -154,6 +154,11 @@ export default function CsmIssuesView({
 
   const total = data?.total ?? 0;
   const lastPage = total === 0 ? 0 : Math.ceil(total / rowsPerPage) - 1;
+  // Clamp to the last valid page when the loaded set shrinks (filter change, rows
+  // closing). React's documented pattern for adjusting state from changed inputs
+  // is a guarded set during render — not an effect (the lint rule forbids
+  // setState in effects); React re-renders before committing, so it's not a
+  // user-visible extra paint.
   if (data !== undefined && !data.hasMore && page > lastPage) {
     setPage(lastPage);
   }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, TablePagination, Typography } from "@wso2/oxygen-ui";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type JSX,
+  type ReactNode,
+} from "react";
+import { useSearchParams } from "react-router";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import CasesFilterBar, {
+  type CasesFilters,
+} from "@features/csm-cases/components/CasesFilterBar";
+import CasesList from "@features/csm-cases/components/CasesList";
+import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
+import { useDirectoryUsers } from "@api/useDirectoryUsers";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import {
+  DEFAULT_CASES_FILTERS,
+  readCasesFiltersFromUrl,
+  writeCasesFiltersToUrl,
+} from "@features/csm-cases/utils/casesFiltersUrl";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE_OPTIONS = [10, DEFAULT_ROWS_PER_PAGE, BE_MAX_PAGE_LIMIT];
+
+// URL params owned by the filter state; cleared/rewritten on change while any
+// other params (e.g. a `tab` selection) are preserved.
+const FILTER_PARAM_KEYS = [
+  "q",
+  "severities",
+  "states",
+  "types",
+  "assignees",
+  "projects",
+] as const;
+
+interface CsmIssuesViewProps {
+  /** Optional heading shown on the left of the header row. */
+  title?: string;
+  /** Optional right-aligned actions (e.g. a "Create" button). */
+  actions?: ReactNode;
+  /** Plural noun for the count subtitle / empty states. Default "cases". */
+  entityNoun?: string;
+  /** Filter values forced onto every query and hidden from the user (e.g. a
+   *  locked case type or project). Merged over the user's URL filters. */
+  lockedFilters?: Partial<CasesFilters>;
+  /** Hide the case-type filter control (use when `lockedFilters` fixes it). */
+  hideTypeFilter?: boolean;
+  /** Hide the project filter control (use when the view is project-scoped). */
+  hideProjectFilter?: boolean;
+}
+
+/**
+ * Shared issues list: the cases filter bar + list + pagination, backed by
+ * `POST /cases/search`. Reused for the all-cases page, the per-type lists
+ * (service requests, security reports) and the project-scoped issues tab —
+ * each just supplies `lockedFilters` (and hides the now-fixed control) so the
+ * one component covers every "list issues of kind X" surface.
+ */
+export default function CsmIssuesView({
+  title,
+  actions,
+  entityNoun = "cases",
+  lockedFilters,
+  hideTypeFilter,
+  hideProjectFilter,
+}: CsmIssuesViewProps): JSX.Element {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo<CasesFilters>(
+    () => readCasesFiltersFromUrl(searchParams),
+    [searchParams],
+  );
+
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(true);
+
+  const setFilters = useCallback(
+    (next: CasesFilters) => {
+      setPage(0);
+      // Preserve any non-filter params (e.g. the active project-detail tab).
+      const merged = new URLSearchParams(searchParams);
+      FILTER_PARAM_KEYS.forEach((k) => merged.delete(k));
+      writeCasesFiltersToUrl(next).forEach((v, k) => merged.set(k, v));
+      setSearchParams(merged, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const debouncedSearch = useDebouncedValue(filters.search, 300);
+  // User filters (debounced search) with the locked overrides applied last so
+  // the fixed type/project can't be widened by a stale URL value.
+  const queryFilters = useMemo<CasesFilters>(
+    () => ({ ...filters, search: debouncedSearch, ...lockedFilters }),
+    [filters, debouncedSearch, lockedFilters],
+  );
+
+  const { data, isLoading, isError, error } = useGetCsmCases(
+    queryFilters,
+    page,
+    rowsPerPage,
+  );
+
+  const { data: directoryUsers } = useDirectoryUsers();
+  const { showError } = useErrorBanner();
+  const hasShownErrorRef = useRef(false);
+
+  useEffect(() => {
+    if (isError && !hasShownErrorRef.current) {
+      hasShownErrorRef.current = true;
+      showError(`Could not load ${entityNoun}.`, error);
+    }
+    if (!isError) hasShownErrorRef.current = false;
+  }, [isError, error, showError, entityNoun]);
+
+  const cases = data?.cases ?? [];
+
+  const availableAssigneeUsers = useMemo(() => {
+    const list = (directoryUsers ?? [])
+      .filter((u) => u.name)
+      .map((u) => ({ name: u.name, email: u.email }));
+    list.sort((a, b) => a.name.localeCompare(b.name));
+    return list;
+  }, [directoryUsers]);
+
+  const availableProjects = useMemo(() => {
+    const byId = new Map<string, string>();
+    (data?.cases ?? []).forEach((c) => {
+      if (c.projectId) byId.set(c.projectId, c.projectName || c.projectId);
+    });
+    return Array.from(byId, ([id, name]) => ({ id, name }));
+  }, [data?.cases]);
+
+  const total = data?.total ?? 0;
+  const lastPage = total === 0 ? 0 : Math.ceil(total / rowsPerPage) - 1;
+  if (data !== undefined && !data.hasMore && page > lastPage) {
+    setPage(lastPage);
+  }
+  const paginationCount = data === undefined || data.hasMore ? -1 : total;
+
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  const breachedCount = cases.filter(
+    (c) => c.minutesToBreach < 0 && c.state !== "closed",
+  ).length;
+  const myCount = cases.filter(
+    (c) => c.assigneeIsMe && c.state !== "closed",
+  ).length;
+  const rangeStart = total === 0 ? 0 : page * rowsPerPage + 1;
+  const rangeEnd = page * rowsPerPage + cases.length;
+
+  const subtitle = isLoading
+    ? "Loading…"
+    : total === 0
+      ? `No ${entityNoun}`
+      : `Showing ${rangeStart}–${rangeEnd} of ${total}`;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          flexWrap: "wrap",
+        }}
+      >
+        <Box>
+          {title && <Typography variant="h5">{title}</Typography>}
+          <Typography variant="body2" color="text.secondary">
+            {subtitle}
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {breachedCount > 0 && (
+            <Chip size="small" color="error" label={`${breachedCount} breached`} />
+          )}
+          {myCount > 0 && (
+            <Chip
+              size="small"
+              color="primary"
+              variant="outlined"
+              label={`${myCount} mine`}
+            />
+          )}
+          {actions}
+        </Box>
+      </Box>
+
+      <CasesFilterBar
+        filters={filters}
+        onChange={setFilters}
+        onReset={() => setFilters(DEFAULT_CASES_FILTERS)}
+        isFiltersOpen={isFiltersOpen}
+        onFiltersToggle={() => setIsFiltersOpen((v) => !v)}
+        availableAssigneeUsers={availableAssigneeUsers}
+        availableProjects={availableProjects}
+        hideTypeFilter={hideTypeFilter}
+        hideProjectFilter={hideProjectFilter}
+      />
+
+      <CasesList cases={cases} isLoading={isLoading} />
+
+      <TablePagination
+        component="div"
+        count={paginationCount}
+        page={page}
+        onPageChange={(_, newPage) => setPage(newPage)}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+        labelRowsPerPage={`${entityNoun[0].toUpperCase()}${entityNoun.slice(1)} per page`}
+        showFirstButton
+        showLastButton
+      />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -33,12 +33,17 @@ import { useNavigate, useSearchParams } from "react-router";
 import { priorityFromSeverity } from "@api/backend/mappers";
 import { formatBytes } from "@utils/formatBytes";
 import Editor from "@components/rich-text-editor/Editor";
+import AttachmentsField from "@components/attachments/AttachmentsField";
+import { type EncodedAttachment } from "@components/attachments/encodeAttachment";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
+import { usePostCsmCaseAttachment } from "@features/csm-cases/api/useCsmCaseAttachments";
+import { uploadAttachmentsToCase } from "@features/csm-cases/api/uploadAttachmentsToCase";
+import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
 import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
 import type { BeCaseIssueType } from "@api/backend/types";
@@ -89,10 +94,15 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const [issueType, setIssueType] = useState<BeCaseIssueType | "">("");
   const [subject, setSubject] = useState("");
   const [description, setDescription] = useState("");
+  const [attachments, setAttachments] = useState<EncodedAttachment[]>([]);
 
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
+  const postAttachment = usePostCsmCaseAttachment();
+  const uploadedBy = useEngineerDisplayName();
+  // Spans the whole submit (create + post-create attachment uploads).
+  const [submitting, setSubmitting] = useState(false);
 
   // Resolve the locked project's display name so the read-only field shows the
   // name (not the raw id). Only fetched when the form is project-scoped.
@@ -119,6 +129,9 @@ export default function CsmCaseCreatePage(): JSX.Element {
     [description],
   );
   const descriptionOverLimit = descriptionBytes > MAX_DESCRIPTION_CONTENT_BYTES;
+  // Attachments are uploaded after the case is created (separate requests), so
+  // they don't count against the create-body budget — only the per-file cap in
+  // AttachmentsField applies.
   const descriptionError = descriptionOverLimit
     ? `The case description is too large (${formatBytes(
         descriptionBytes,
@@ -137,7 +150,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       subject.trim().length > 0 &&
       !isEmptyHtml(description) &&
       !descriptionOverLimit &&
-      !postCase.isPending,
+      !submitting,
     [
       projectId,
       deploymentId,
@@ -147,7 +160,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       subject,
       description,
       descriptionOverLimit,
-      postCase.isPending,
+      submitting,
     ],
   );
 
@@ -162,10 +175,11 @@ export default function CsmCaseCreatePage(): JSX.Element {
     setDeployedProductId("");
   };
 
-  const handleSubmit = (): void => {
+  const handleSubmit = async (): Promise<void> => {
     if (!canSubmit || !severity || !issueType || descriptionOverLimit) return;
-    postCase.mutate(
-      {
+    setSubmitting(true);
+    try {
+      const created = await postCase.mutateAsync({
         type: "case",
         projectId,
         deploymentId,
@@ -174,13 +188,25 @@ export default function CsmCaseCreatePage(): JSX.Element {
         description,
         severity: priorityFromSeverity(severity),
         issueType: issueType,
-      },
-      {
-        onSuccess: (created) => navigate(`/cases/${created.id}`),
-        onError: (err) =>
-          showError("Could not create the case. Please try again.", err),
-      },
-    );
+      });
+      // The create endpoint doesn't attach files for standard cases, so upload
+      // them to the new case afterwards. A partial failure still lands the case.
+      const failed = await uploadAttachmentsToCase(
+        postAttachment.mutateAsync,
+        created.id,
+        attachments,
+        uploadedBy,
+      );
+      if (failed > 0) {
+        showError(
+          `The case was created, but ${failed} attachment${failed === 1 ? "" : "s"} failed to upload. You can add ${failed === 1 ? "it" : "them"} from the case page.`,
+        );
+      }
+      navigate(`/cases/${created.id}`);
+    } catch (err) {
+      setSubmitting(false);
+      showError("Could not create the case. Please try again.", err);
+    }
   };
 
   return (
@@ -362,7 +388,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
                 minHeight={180}
                 maxHeight={420}
                 toolbarVariant="full"
-                disabled={postCase.isPending}
+                disabled={submitting}
               />
             </Box>
             {descriptionError && (
@@ -375,6 +401,22 @@ export default function CsmCaseCreatePage(): JSX.Element {
               </Typography>
             )}
           </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 0.5 }}
+            >
+              Attachments
+            </Typography>
+            <AttachmentsField
+              attachments={attachments}
+              onChange={setAttachments}
+              onError={showError}
+              maxEncodedBytes={Number.MAX_SAFE_INTEGER}
+            />
+          </Grid>
         </Grid>
 
         <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, mt: 2.5 }}>
@@ -383,10 +425,10 @@ export default function CsmCaseCreatePage(): JSX.Element {
           </Button>
           <Button
             variant="contained"
-            onClick={handleSubmit}
+            onClick={() => void handleSubmit()}
             disabled={!canSubmit}
           >
-            {postCase.isPending ? "Creating…" : "Create case"}
+            {submitting ? "Creating…" : "Create case"}
           </Button>
         </Box>
       </Card>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -34,7 +34,10 @@ import { priorityFromSeverity } from "@api/backend/mappers";
 import { formatBytes } from "@utils/formatBytes";
 import Editor from "@components/rich-text-editor/Editor";
 import AttachmentsField from "@components/attachments/AttachmentsField";
-import { type EncodedAttachment } from "@components/attachments/encodeAttachment";
+import {
+  POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES,
+  type EncodedAttachment,
+} from "@components/attachments/encodeAttachment";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
@@ -414,7 +417,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
               attachments={attachments}
               onChange={setAttachments}
               onError={showError}
-              maxEncodedBytes={Number.MAX_SAFE_INTEGER}
+              maxEncodedBytes={POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES}
             />
           </Grid>
         </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -832,7 +832,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               distinct from the free-form tags by a divider, so the current
               state doesn't get lost among the tag chips. */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-            {c.caseType && (
+            {c.caseType && CASE_TYPE_LABEL[c.caseType] && (
               <Chip
                 size="small"
                 variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -93,6 +93,7 @@ import {
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
 import StateChip from "@components/StateChip";
+import { CASE_TYPE_LABEL } from "@features/csm-cases/utils/caseType";
 import type {
   CaseAttachment,
   CaseLifecycleAction,
@@ -831,6 +832,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
               distinct from the free-form tags by a divider, so the current
               state doesn't get lost among the tag chips. */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            {c.caseType && (
+              <Chip
+                size="small"
+                variant="outlined"
+                label={CASE_TYPE_LABEL[c.caseType]}
+                sx={{ fontWeight: 600 }}
+              />
+            )}
             <SeverityChip severity={c.severity} withLabel />
             <StateChip state={c.state} />
             {c.state === "work_in_progress" && c.workState && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -14,227 +14,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import {
-  Box,
-  Button,
-  Chip,
-  TablePagination,
-  Typography,
-} from "@wso2/oxygen-ui";
+import { Button } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type JSX,
-} from "react";
-import { useNavigate, useSearchParams } from "react-router";
-import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
-import { useDebouncedValue } from "@hooks/useDebouncedValue";
-import CasesFilterBar, {
-  type CasesFilters,
-} from "@features/csm-cases/components/CasesFilterBar";
-import CasesList from "@features/csm-cases/components/CasesList";
-import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
-import { useDirectoryUsers } from "@api/useDirectoryUsers";
-import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
-import {
-  DEFAULT_CASES_FILTERS,
-  readCasesFiltersFromUrl,
-  writeCasesFiltersToUrl,
-} from "@features/csm-cases/utils/casesFiltersUrl";
+import { type JSX } from "react";
+import { useNavigate } from "react-router";
+import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 
-const DEFAULT_ROWS_PER_PAGE = 20;
-// Top option is the backend's max page limit; larger requests are rejected.
-const ROWS_PER_PAGE_OPTIONS = [10, DEFAULT_ROWS_PER_PAGE, BE_MAX_PAGE_LIMIT];
-
+/** All-cases list — the shared issues view across every case type. */
 export default function CsmCasesPage(): JSX.Element {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const filters = useMemo<CasesFilters>(
-    () => readCasesFiltersFromUrl(searchParams),
-    [searchParams],
-  );
-
-  // Pagination is local (not URL) state, matching the projects/accounts pages.
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
-
-  const setFilters = useCallback(
-    (next: CasesFilters) => {
-      // Any filter/search change resets to the first page.
-      setPage(0);
-      setSearchParams(writeCasesFiltersToUrl(next), { replace: true });
-    },
-    [setSearchParams],
-  );
-
-  // Search is now server-side, so debounce it to avoid a request per keystroke.
-  // The filter bar still reflects the raw URL value immediately.
-  const debouncedSearch = useDebouncedValue(filters.search, 300);
-  const queryFilters = useMemo<CasesFilters>(
-    () => ({ ...filters, search: debouncedSearch }),
-    [filters, debouncedSearch],
-  );
-
-  // Load straight away with no filters: the backend sorts by last-updated
-  // descending, so arriving on the page shows the most recently updated cases.
-  // Filters/search narrow that set from there.
-  const { data, isLoading, isError, error } = useGetCsmCases(
-    queryFilters,
-    page,
-    rowsPerPage,
-  );
-
-  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
-    setRowsPerPage(parseInt(e.target.value, 10));
-    setPage(0);
-  };
-  const { data: directoryUsers } = useDirectoryUsers();
-  const { showError } = useErrorBanner();
-  const hasShownErrorRef = useRef(false);
-  const [isFiltersOpen, setIsFiltersOpen] = useState(true);
-
-  useEffect(() => {
-    if (isError && !hasShownErrorRef.current) {
-      hasShownErrorRef.current = true;
-      showError("Could not load cases.", error);
-    }
-    if (!isError) hasShownErrorRef.current = false;
-  }, [isError, error, showError]);
-
-  // The backend already filtered, sorted and paged the rows;
-  // render exactly what came back for the current page.
-  const cases = data?.cases ?? [];
-
-  // Derive option lists for the searchable filters. Assignees come from the
-  // user directory (so typing finds anyone, not only owners present in the
-  // loaded cases). Projects and products are still derived from the case
-  // rows in scope. All sorted and de-duplicated; the lists are small.
-  const availableAssigneeUsers = useMemo(() => {
-    const list = (directoryUsers ?? [])
-      .filter((u) => u.name)
-      .map((u) => ({ name: u.name, email: u.email }));
-    list.sort((a, b) => a.name.localeCompare(b.name));
-    return list;
-  }, [directoryUsers]);
-
-  // The project filter searches the backend as the user types, so we no longer
-  // preload the whole catalogue. These are only the projects on the loaded
-  // cases — used to label an already-selected project id (e.g. from a shared
-  // URL) until a search resolves its name.
-  const availableProjects = useMemo(() => {
-    const byId = new Map<string, string>();
-    (data?.cases ?? []).forEach((c) => {
-      if (c.projectId) byId.set(c.projectId, c.projectName || c.projectId);
-    });
-    return Array.from(byId, ([id, name]) => ({ id, name }));
-  }, [data?.cases]);
-
-  const total = data?.total ?? 0;
-  // Clamp to the last valid page when loaded data shrinks (background refetch,
-  // rows closing). Guard on `data !== undefined` so that during the loading
-  // transition — when data is undefined and total falls to 0 — we don't
-  // immediately reset a page > 0 back to 0, which would break Next navigation.
-  const lastPage = total === 0 ? 0 : Math.ceil(total / rowsPerPage) - 1;
-  if (data !== undefined && !data.hasMore && page > lastPage) {
-    setPage(lastPage);
-  }
-
-  // During loading data is undefined; treat the total as unknown (-1) so the
-  // page index never goes out of range and Next stays enabled mid-transition.
-  // When hasMore is true the backend guarantees more pages exist but total may
-  // only reflect the current page count — also use -1. Only use the exact total
-  // when data has loaded and the backend says there are no more pages.
-  const paginationCount = data === undefined || data.hasMore ? -1 : total;
-
-  // Counts reflect the current page only (the backend exposes no SLA/assignee
-  // breakdown across pages); both are inert in LIVE where that data is absent.
-  const breachedCount = cases.filter(
-    (c) => c.minutesToBreach < 0 && c.state !== "closed",
-  ).length;
-  const myCount = cases.filter(
-    (c) => c.assigneeIsMe && c.state !== "closed",
-  ).length;
-  const rangeStart = total === 0 ? 0 : page * rowsPerPage + 1;
-  const rangeEnd = page * rowsPerPage + cases.length;
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 2,
-          flexWrap: "wrap",
-        }}
-      >
-        <Box>
-          <Typography variant="h5">Cases</Typography>
-          <Typography variant="body2" color="text.secondary">
-            {isLoading
-              ? "Loading…"
-              : total === 0
-                ? "No cases"
-                : `Showing ${rangeStart}–${rangeEnd} of ${total}`}
-          </Typography>
-        </Box>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          {breachedCount > 0 && (
-            <Chip
-              size="small"
-              color="error"
-              label={`${breachedCount} breached`}
-            />
-          )}
-          {myCount > 0 && (
-            <Chip
-              size="small"
-              color="primary"
-              variant="outlined"
-              label={`${myCount} mine`}
-            />
-          )}
-          <Button
-            variant="contained"
-            color="primary"
-            size="small"
-            startIcon={<Plus size={16} />}
-            onClick={() => navigate("/cases/new")}
-          >
-            Create case
-          </Button>
-        </Box>
-      </Box>
-
-      <CasesFilterBar
-        filters={filters}
-        onChange={setFilters}
-        onReset={() => setFilters(DEFAULT_CASES_FILTERS)}
-        isFiltersOpen={isFiltersOpen}
-        onFiltersToggle={() => setIsFiltersOpen((v) => !v)}
-        availableAssigneeUsers={availableAssigneeUsers}
-        availableProjects={availableProjects}
-      />
-
-      <CasesList cases={cases} isLoading={isLoading} />
-
-      <TablePagination
-        component="div"
-        count={paginationCount}
-        page={page}
-        onPageChange={(_, newPage) => setPage(newPage)}
-        rowsPerPage={rowsPerPage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
-        rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
-        labelRowsPerPage="Cases per page"
-        showFirstButton
-        showLastButton
-      />
-    </Box>
+    <CsmIssuesView
+      title="Cases"
+      entityNoun="cases"
+      actions={
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          startIcon={<Plus size={16} />}
+          onClick={() => navigate("/cases/new")}
+        >
+          Create case
+        </Button>
+      }
+    />
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-customers/pages/CsmCustomersLayout.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-customers/pages/CsmCustomersLayout.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { type JSX, Suspense } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router";
+import RouteSuspenseFallback from "@components/route-fallback/RouteSuspenseFallback";
+
+interface CustomersTab {
+  id: string;
+  label: string;
+  path: string;
+}
+
+const CUSTOMERS_TABS: CustomersTab[] = [
+  { id: "accounts", label: "Accounts", path: "/customers/accounts" },
+  { id: "projects", label: "Projects", path: "/customers/projects" },
+];
+
+function pickActiveTab(pathname: string): string {
+  for (const t of CUSTOMERS_TABS) {
+    if (pathname === t.path || pathname.startsWith(`${t.path}/`)) {
+      return t.id;
+    }
+  }
+  return CUSTOMERS_TABS[0].id;
+}
+
+export default function CsmCustomersLayout(): JSX.Element {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const active = pickActiveTab(location.pathname);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Typography variant="h5">Customers</Typography>
+
+      <Tabs
+        value={active}
+        onChange={(_, id) => {
+          const next = CUSTOMERS_TABS.find((t) => t.id === id);
+          if (next) void navigate(next.path);
+        }}
+        variant="scrollable"
+        scrollButtons="auto"
+      >
+        {CUSTOMERS_TABS.map((t) => (
+          <Tab key={t.id} value={t.id} label={t.label} />
+        ))}
+      </Tabs>
+
+      <Suspense fallback={<RouteSuspenseFallback />}>
+        <Outlet />
+      </Suspense>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useCatalogItemVariables.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useCatalogItemVariables.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCatalogItemVariable,
+  BeGetCatalogItemVariablesResponse,
+} from "@api/backend/types";
+
+/**
+ * Variables (form fields) for a catalog item, via
+ * `GET /catalogs/{catalogId}/items/{catalogItemId}/variables`. Returned sorted
+ * by the backend's `order` so the form renders fields in the catalog's intended
+ * sequence. Disabled until both ids are present.
+ */
+export function useCatalogItemVariables(
+  catalogId: string | undefined,
+  catalogItemId: string | undefined,
+): UseQueryResult<BeCatalogItemVariable[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeCatalogItemVariable[], Error>({
+    queryKey: [
+      ApiQueryKeys.CATALOG_ITEM_VARIABLES,
+      catalogId ?? "",
+      catalogItemId ?? "",
+    ],
+    queryFn: async (): Promise<BeCatalogItemVariable[]> => {
+      const res = await api.get<BeGetCatalogItemVariablesResponse>(
+        `/catalogs/${encodeURIComponent(catalogId as string)}/items/${encodeURIComponent(
+          catalogItemId as string,
+        )}/variables`,
+      );
+      const variables = res?.variables ?? [];
+      // Stable sort by display order; variables without an order sink to the end.
+      return [...variables].sort(
+        (a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER),
+      );
+    },
+    enabled: !!catalogId && !!catalogItemId,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCatalogs.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCatalogs.ts
@@ -57,8 +57,12 @@ export function useSearchCatalogs(
         const page = res?.catalogs ?? [];
         all.push(...page);
         offset += page.length;
-        const total = res?.total ?? all.length;
-        if (page.length === 0 || all.length >= total) break;
+        // Stop on an empty page; only trust `total` to end paging when it's
+        // actually present (it's optional — defaulting it to all.length would
+        // stop after the first page and drop later catalogs).
+        const total = res?.total;
+        if (page.length === 0) break;
+        if (total != null && all.length >= total) break;
       }
       return all;
     },

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCatalogs.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCatalogs.ts
@@ -41,7 +41,12 @@ export function useSearchCatalogs(
     queryKey: [ApiQueryKeys.CATALOGS_SEARCH, deployedProductId ?? ""],
     queryFn: async (): Promise<BeCatalogRef[]> => {
       const all: BeCatalogRef[] = [];
-      for (let offset = 0; ; offset += PAGE_LIMIT) {
+      // Advance the offset by the ACTUAL page size, not the requested limit:
+      // the backend may clamp `limit` below PAGE_LIMIT, and incrementing by the
+      // requested value would both skip records and stop early. Terminate on an
+      // empty page or once the reported total is reached.
+      let offset = 0;
+      for (;;) {
         const res = await api.post<
           BeSearchCatalogsPayload,
           BeSearchCatalogsResponse
@@ -49,9 +54,11 @@ export function useSearchCatalogs(
           deployedProductId: deployedProductId as string,
           pagination: { offset, limit: PAGE_LIMIT },
         });
-        const page = res.catalogs ?? [];
+        const page = res?.catalogs ?? [];
         all.push(...page);
-        if (page.length < PAGE_LIMIT) break;
+        offset += page.length;
+        const total = res?.total ?? all.length;
+        if (page.length === 0 || all.length >= total) break;
       }
       return all;
     },

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCatalogs.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCatalogs.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCatalogRef,
+  BeSearchCatalogsPayload,
+  BeSearchCatalogsResponse,
+} from "@api/backend/types";
+
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+
+/**
+ * Service catalogs available for a deployed product, via `POST /catalogs/search`.
+ * Catalogs (and the catalog items they embed) only exist for ServiceNow-sourced
+ * deployed products; managed-cloud products resolve to an empty list. Pages
+ * through so catalogs beyond the first page stay selectable. Disabled until a
+ * deployed-product id is provided.
+ */
+export function useSearchCatalogs(
+  deployedProductId: string | undefined,
+): UseQueryResult<BeCatalogRef[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeCatalogRef[], Error>({
+    queryKey: [ApiQueryKeys.CATALOGS_SEARCH, deployedProductId ?? ""],
+    queryFn: async (): Promise<BeCatalogRef[]> => {
+      const all: BeCatalogRef[] = [];
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const res = await api.post<
+          BeSearchCatalogsPayload,
+          BeSearchCatalogsResponse
+        >("/catalogs/search", {
+          deployedProductId: deployedProductId as string,
+          pagination: { offset, limit: PAGE_LIMIT },
+        });
+        const page = res.catalogs ?? [];
+        all.push(...page);
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return all;
+    },
+    enabled: !!deployedProductId,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type JSX } from "react";
+import Editor from "@components/rich-text-editor/Editor";
+import type { BeCatalogItemVariable } from "@api/backend/types";
+import {
+  isChoiceField,
+  isDateTimeField,
+  isDescriptionField,
+  isFileCopyPathField,
+  isMultiLineField,
+  variableLabel,
+} from "@features/csm-operations/utils/catalogVariables";
+
+interface CatalogVariableFieldsProps {
+  /** Already filtered to user-editable variables (no context/hidden fields). */
+  variables: BeCatalogItemVariable[];
+  values: Record<string, string>;
+  onChange: (id: string, value: string) => void;
+}
+
+/**
+ * Renders a catalog item's user-editable variables, one input per variable,
+ * picking the control from the ServiceNow variable `type`/label: Yes/No select,
+ * multi-line text, datetime picker, rich-text Description, or single-line text.
+ * File Copy Path fields are optional; attachment fields are handled by the
+ * page's shared attachments section and are not rendered here.
+ */
+export default function CatalogVariableFields({
+  variables,
+  values,
+  onChange,
+}: CatalogVariableFieldsProps): JSX.Element {
+  return (
+    <Grid container spacing={2.5}>
+      {variables.map((v) => {
+        const value = values[v.id] ?? "";
+        const label = variableLabel(v);
+
+        if (isChoiceField(v)) {
+          const labelId = `sr-var-${v.id}-label`;
+          return (
+            <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
+              <FormControl fullWidth size="small" required>
+                <InputLabel id={labelId}>{label}</InputLabel>
+                <Select
+                  labelId={labelId}
+                  label={label}
+                  value={value}
+                  onChange={(e) => onChange(v.id, String(e.target.value))}
+                >
+                  <MenuItem value="Yes">Yes</MenuItem>
+                  <MenuItem value="No">No</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+          );
+        }
+
+        if (isDescriptionField(v.questionText ?? "")) {
+          return (
+            <Grid key={v.id} size={{ xs: 12 }}>
+              <Typography
+                component="label"
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mb: 0.5 }}
+              >
+                {label} *
+              </Typography>
+              <Box role="group" aria-label={label}>
+                <Editor
+                  value={value}
+                  onChange={(html) => onChange(v.id, html)}
+                  placeholder=""
+                  minHeight={150}
+                  maxHeight="300px"
+                  toolbarVariant="full"
+                />
+              </Box>
+            </Grid>
+          );
+        }
+
+        if (isMultiLineField(v)) {
+          return (
+            <Grid key={v.id} size={{ xs: 12 }}>
+              <TextField
+                label={label}
+                size="small"
+                fullWidth
+                required
+                multiline
+                minRows={4}
+                value={value}
+                onChange={(e) => onChange(v.id, e.target.value)}
+              />
+            </Grid>
+          );
+        }
+
+        if (isDateTimeField(v)) {
+          return (
+            <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
+              <TextField
+                label={label}
+                size="small"
+                fullWidth
+                required
+                type="datetime-local"
+                value={value}
+                onChange={(e) => onChange(v.id, e.target.value)}
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            </Grid>
+          );
+        }
+
+        // File Copy Path is an optional plain text input.
+        const optional = isFileCopyPathField(v);
+        return (
+          <Grid key={v.id} size={{ xs: 12 }}>
+            <TextField
+              label={label}
+              size="small"
+              fullWidth
+              required={!optional}
+              value={value}
+              onChange={(e) => onChange(v.id, e.target.value)}
+            />
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IssuesListUnavailable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IssuesListUnavailable.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Paper, Typography } from "@wso2/oxygen-ui";
+import { type JSX } from "react";
+
+interface IssuesListUnavailableProps {
+  title: string;
+  description: string;
+}
+
+/**
+ * Placeholder for an issue kind that has no backend search endpoint yet
+ * (change requests, incidents). Keeps the tab structure consistent with the
+ * live, case-typed lists while making clear the listing isn't wired.
+ */
+export default function IssuesListUnavailable({
+  title,
+  description,
+}: IssuesListUnavailableProps): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Typography variant="body2" color="text.secondary">
+          {description}
+        </Typography>
+        <Chip size="small" label="Coming soon" color="warning" variant="outlined" />
+      </Box>
+      <Paper
+        variant="outlined"
+        sx={{
+          p: 5,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 0.5,
+          textAlign: "center",
+        }}
+      >
+        <Typography variant="subtitle2">{title} aren&apos;t available yet</Typography>
+        <Typography variant="body2" color="text.secondary">
+          The list will appear here once the backend search endpoint is available.
+        </Typography>
+      </Paper>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -33,7 +33,10 @@ import { useMemo, useState, type JSX } from "react";
 import { useNavigate } from "react-router";
 import { BackendApiError } from "@api/backend/client";
 import AttachmentsField from "@components/attachments/AttachmentsField";
-import { type EncodedAttachment } from "@components/attachments/encodeAttachment";
+import {
+  POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES,
+  type EncodedAttachment,
+} from "@components/attachments/encodeAttachment";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
@@ -410,7 +413,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 attachments={attachments}
                 onChange={setAttachments}
                 onError={showError}
-                maxEncodedBytes={Number.MAX_SAFE_INTEGER}
+                maxEncodedBytes={POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES}
               />
             </Grid>
           )}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -19,52 +19,199 @@ import {
   Box,
   Button,
   Card,
+  CircularProgress,
   FormControl,
+  FormHelperText,
   Grid,
   InputLabel,
   MenuItem,
   Select,
-  TextField,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import { useNavigate } from "react-router";
+import { BackendApiError } from "@api/backend/client";
+import AttachmentsField from "@components/attachments/AttachmentsField";
+import { type EncodedAttachment } from "@components/attachments/encodeAttachment";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
-import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
-import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
-
-const SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
-
-// Submission is disabled until the backend exposes a service-request create
-// endpoint. SR is currently only a case *type* (`service_request`) in the
-// contract; there is no SR entity/endpoint and `POST /cases` accepts only
-// `type: "support"`. The form is built and validated so it can be wired the
-// moment the BE adds the endpoint (and its catalog/category model) — flip this
-// flag and add the mutation in `handleSubmit`.
-const SR_CREATE_ENABLED = false;
+import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
+import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
+import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
+import { usePostCsmCaseAttachment } from "@features/csm-cases/api/useCsmCaseAttachments";
+import { uploadAttachmentsToCase } from "@features/csm-cases/api/uploadAttachmentsToCase";
+import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
+import { useSearchCatalogs } from "@features/csm-operations/api/useSearchCatalogs";
+import { useCatalogItemVariables } from "@features/csm-operations/api/useCatalogItemVariables";
+import CatalogVariableFields from "@features/csm-operations/components/CatalogVariableFields";
+import {
+  encodeVariableValue,
+  getFirstEmptyRequiredField,
+  getUserEditableVariables,
+  isAttachmentField,
+} from "@features/csm-operations/utils/catalogVariables";
 
 export default function CreateServiceRequestPage(): JSX.Element {
   const navigate = useNavigate();
+  const { showError } = useErrorBanner();
 
   const [projectId, setProjectId] = useState("");
-  const [priority, setPriority] = useState<Severity | "">("");
-  const [subject, setSubject] = useState("");
-  const [description, setDescription] = useState("");
+  const [deploymentId, setDeploymentId] = useState("");
+  const [deployedProductId, setDeployedProductId] = useState("");
+  const [catalogId, setCatalogId] = useState("");
+  const [catalogItemId, setCatalogItemId] = useState("");
+  // Variable answers, keyed by variable id.
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [attachments, setAttachments] = useState<EncodedAttachment[]>([]);
 
-  const isValid = useMemo(
-    () =>
-      !!projectId &&
-      !!priority &&
-      subject.trim().length > 0 &&
-      description.trim().length > 0,
-    [projectId, priority, subject, description],
+  const deployments = useSearchDeployments(projectId || undefined);
+  const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
+  const catalogs = useSearchCatalogs(deployedProductId || undefined);
+  const variables = useCatalogItemVariables(
+    catalogId || undefined,
+    catalogItemId || undefined,
+  );
+  const postCase = usePostCsmCase();
+  const postAttachment = usePostCsmCaseAttachment();
+  const uploadedBy = useEngineerDisplayName();
+  // Spans the whole submit (create + post-create attachment uploads).
+  const [submitting, setSubmitting] = useState(false);
+
+  const catalogItems = useMemo(
+    () => catalogs.data?.find((c) => c.id === catalogId)?.catalogItems ?? [],
+    [catalogs.data, catalogId],
   );
 
-  // Wire the real mutation here when SR_CREATE_ENABLED flips on.
-  const handleSubmit = (): void => {
-    if (!SR_CREATE_ENABLED || !isValid) return;
+  // ServiceNow returns context/hidden fields mixed in; only user-editable
+  // (non-attachment) variables get a rendered input. Attachments go to the
+  // shared attachments section below.
+  const allVariables = useMemo(() => variables.data ?? [], [variables.data]);
+  const renderableVars = useMemo(
+    () => getUserEditableVariables(allVariables).filter((v) => !isAttachmentField(v)),
+    [allVariables],
+  );
+  const firstEmptyRequired = useMemo(
+    () => getFirstEmptyRequiredField(allVariables, answers),
+    [allVariables, answers],
+  );
+
+
+  // A deployed product with no catalogs is the common non-ServiceNow case;
+  // tell the engineer rather than leaving an empty dropdown.
+  const noCatalogs =
+    !!deployedProductId &&
+    catalogs.isSuccess &&
+    (catalogs.data?.length ?? 0) === 0;
+
+  // Cascade resets: a parent change invalidates every dependent field below it.
+  const onProjectChange = (next: string): void => {
+    setProjectId(next);
+    setDeploymentId("");
+    setDeployedProductId("");
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const onDeploymentChange = (next: string): void => {
+    setDeploymentId(next);
+    setDeployedProductId("");
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const onDeployedProductChange = (next: string): void => {
+    setDeployedProductId(next);
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const onCatalogChange = (next: string): void => {
+    setCatalogId(next);
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const onCatalogItemChange = (next: string): void => {
+    setCatalogItemId(next);
+    setAnswers({});
+  };
+
+  const hasOptionsError =
+    deployments.isError || deployedProducts.isError || catalogs.isError;
+  const retryOptions = (): void => {
+    if (deployments.isError) void deployments.refetch();
+    if (deployedProducts.isError) void deployedProducts.refetch();
+    if (catalogs.isError) void catalogs.refetch();
+  };
+
+  const canSubmit = useMemo(
+    () =>
+      !!projectId &&
+      !!deploymentId &&
+      !!deployedProductId &&
+      !!catalogId &&
+      !!catalogItemId &&
+      !variables.isLoading &&
+      !variables.isError &&
+      // Hot fix (mirrors the customer portal): all typable variables required.
+      firstEmptyRequired === null &&
+      !submitting,
+    [
+      projectId,
+      deploymentId,
+      deployedProductId,
+      catalogId,
+      catalogItemId,
+      variables.isLoading,
+      variables.isError,
+      firstEmptyRequired,
+      submitting,
+    ],
+  );
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!canSubmit) return;
+    // Send user-editable, non-attachment variables, encoded by type, omitting
+    // empties. Context/hidden fields are excluded by getUserEditableVariables.
+    const variablePayload = getUserEditableVariables(allVariables)
+      .filter((v) => !isAttachmentField(v))
+      .map((v) => ({ id: v.id, value: encodeVariableValue(v, answers[v.id] ?? "") }))
+      .filter((v) => v.value !== "");
+
+    setSubmitting(true);
+    try {
+      const created = await postCase.mutateAsync({
+        type: "service_request",
+        projectId,
+        deploymentId,
+        deployedProductId,
+        catalogId,
+        catalogItemId,
+        variables: variablePayload,
+      });
+      // The create endpoint doesn't attach files for service requests, so upload
+      // them to the new case afterwards. A partial failure still lands the case.
+      const failed = await uploadAttachmentsToCase(
+        postAttachment.mutateAsync,
+        created.id,
+        attachments,
+        uploadedBy,
+      );
+      if (failed > 0) {
+        showError(
+          `The service request was created, but ${failed} attachment${failed === 1 ? "" : "s"} failed to upload. You can add ${failed === 1 ? "it" : "them"} from the case page.`,
+        );
+      }
+      navigate(`/cases/${created.id}`);
+    } catch (err) {
+      setSubmitting(false);
+      // The backend surfaces real validation messages on 4xx; show them.
+      const msg =
+        err instanceof BackendApiError && err.status < 500 && err.message
+          ? err.message
+          : "Could not create the service request. Please try again.";
+      showError(msg, err);
+    }
   };
 
   return (
@@ -82,89 +229,217 @@ export default function CreateServiceRequestPage(): JSX.Element {
       </Typography>
 
       <Card variant="outlined" sx={{ p: 3 }}>
-        <Alert severity="info" sx={{ mb: 2.5 }}>
-          Service request creation isn&apos;t available yet — the backend
-          endpoint (and the request catalog) are still to come. You can review
-          the form below; submitting is disabled for now.
-        </Alert>
+        {hasOptionsError && (
+          <Box
+            sx={{
+              mb: 2,
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              flexWrap: "wrap",
+            }}
+          >
+            <Typography variant="body2" color="error.main">
+              Some dropdown options failed to load.
+            </Typography>
+            <Button size="small" variant="outlined" onClick={retryOptions}>
+              Retry
+            </Button>
+          </Box>
+        )}
 
         <Grid container spacing={2.5}>
-          <Grid size={{ xs: 12, md: 8 }}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <AsyncProjectSelect
               value={projectId}
-              onChange={setProjectId}
+              onChange={onProjectChange}
               required
             />
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="sr-priority-label">Priority</InputLabel>
+              <InputLabel id="sr-deployment-label">Deployment</InputLabel>
               <Select
-                labelId="sr-priority-label"
-                label="Priority"
-                value={priority}
-                onChange={(e) => setPriority(e.target.value as Severity)}
+                labelId="sr-deployment-label"
+                label="Deployment"
+                value={deploymentId}
+                onChange={(e) => onDeploymentChange(String(e.target.value))}
+                disabled={!projectId || deployments.isLoading}
               >
-                {SEVERITIES.map((s) => (
-                  <MenuItem key={s} value={s}>
-                    {s} · {SEVERITY_LABEL[s]}
+                {(deployments.data ?? []).map((d) => (
+                  <MenuItem key={d.id} value={d.id}>
+                    {d.name ?? d.id}
                   </MenuItem>
                 ))}
               </Select>
+              {!projectId ? (
+                <FormHelperText>Select a project first</FormHelperText>
+              ) : deployments.isLoading ? (
+                <FormHelperText>Loading deployments…</FormHelperText>
+              ) : null}
             </FormControl>
           </Grid>
 
-          <Grid size={{ xs: 12 }}>
-            <TextField
-              label="Subject"
-              size="small"
-              fullWidth
-              required
-              value={subject}
-              onChange={(e) => setSubject(e.target.value.slice(0, 200))}
-              helperText={
-                subject.length >= 160 ? `${subject.length}/200` : undefined
-              }
-            />
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="sr-product-label">Deployed product</InputLabel>
+              <Select
+                labelId="sr-product-label"
+                label="Deployed product"
+                value={deployedProductId}
+                onChange={(e) => onDeployedProductChange(String(e.target.value))}
+                disabled={!deploymentId || deployedProducts.isLoading}
+              >
+                {(deployedProducts.data ?? []).map((dp) => (
+                  <MenuItem key={dp.id} value={dp.id}>
+                    {dp.label}
+                  </MenuItem>
+                ))}
+              </Select>
+              {!deploymentId ? (
+                <FormHelperText>Select a deployment first</FormHelperText>
+              ) : deployedProducts.isLoading ? (
+                <FormHelperText>Loading products…</FormHelperText>
+              ) : null}
+            </FormControl>
           </Grid>
 
-          <Grid size={{ xs: 12 }}>
-            <TextField
-              label="Description"
-              size="small"
-              fullWidth
-              required
-              multiline
-              minRows={5}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Describe what the customer is requesting…"
-            />
+          <Grid size={{ xs: 12, md: 6 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="sr-catalog-label">Catalog</InputLabel>
+              <Select
+                labelId="sr-catalog-label"
+                label="Catalog"
+                value={catalogId}
+                onChange={(e) => onCatalogChange(String(e.target.value))}
+                disabled={!deployedProductId || catalogs.isLoading || noCatalogs}
+              >
+                {(catalogs.data ?? []).map((c) => (
+                  <MenuItem key={c.id} value={c.id}>
+                    {c.name ?? c.id}
+                  </MenuItem>
+                ))}
+              </Select>
+              {!deployedProductId ? (
+                <FormHelperText>Select a deployed product first</FormHelperText>
+              ) : catalogs.isLoading ? (
+                <FormHelperText>Loading catalogs…</FormHelperText>
+              ) : noCatalogs ? (
+                <FormHelperText>
+                  No service catalogs are available for this product.
+                </FormHelperText>
+              ) : null}
+            </FormControl>
           </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="sr-catalog-item-label">Catalog item</InputLabel>
+              <Select
+                labelId="sr-catalog-item-label"
+                label="Catalog item"
+                value={catalogItemId}
+                onChange={(e) => onCatalogItemChange(String(e.target.value))}
+                disabled={!catalogId}
+              >
+                {catalogItems.map((ci) => (
+                  <MenuItem key={ci.id} value={ci.id}>
+                    {ci.name ?? ci.id}
+                  </MenuItem>
+                ))}
+              </Select>
+              {!catalogId ? (
+                <FormHelperText>Select a catalog first</FormHelperText>
+              ) : null}
+            </FormControl>
+          </Grid>
+
+          {/* Dynamic variable form for the chosen catalog item. */}
+          {catalogItemId && (
+            <Grid size={{ xs: 12 }}>
+              {variables.isLoading ? (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, py: 1 }}>
+                  <CircularProgress size={18} />
+                  <Typography variant="body2" color="text.secondary">
+                    Loading request form…
+                  </Typography>
+                </Box>
+              ) : variables.isError ? (
+                <Alert
+                  severity="error"
+                  action={
+                    <Button
+                      color="inherit"
+                      size="small"
+                      onClick={() => void variables.refetch()}
+                    >
+                      Retry
+                    </Button>
+                  }
+                >
+                  Could not load the request form for this catalog item.
+                </Alert>
+              ) : renderableVars.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  This catalog item has no additional fields.
+                </Typography>
+              ) : (
+                <CatalogVariableFields
+                  variables={renderableVars}
+                  values={answers}
+                  onChange={(id, value) =>
+                    setAnswers((prev) => ({ ...prev, [id]: value }))
+                  }
+                />
+              )}
+            </Grid>
+          )}
+
+          {/* Optional supporting attachments. */}
+          {catalogItemId && !variables.isLoading && !variables.isError && (
+            <Grid size={{ xs: 12 }}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mb: 0.5 }}
+              >
+                Attachments
+              </Typography>
+              <AttachmentsField
+                attachments={attachments}
+                onChange={setAttachments}
+                onError={showError}
+                maxEncodedBytes={Number.MAX_SAFE_INTEGER}
+              />
+            </Grid>
+          )}
         </Grid>
 
-        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, mt: 2.5 }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "flex-end",
+            alignItems: "center",
+            gap: 1.5,
+            mt: 2.5,
+          }}
+        >
+          {firstEmptyRequired && !variables.isLoading && (
+            <Typography variant="caption" color="text.secondary" sx={{ mr: "auto" }}>
+              Required field: {firstEmptyRequired}
+            </Typography>
+          )}
           <Button variant="outlined" onClick={() => navigate("/operations")}>
             Cancel
           </Button>
-          <Tooltip
-            title={
-              SR_CREATE_ENABLED
-                ? ""
-                : "Service request creation will be enabled once the backend supports it."
-            }
+          <Button
+            variant="contained"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
           >
-            <Box component="span">
-              <Button
-                variant="contained"
-                onClick={handleSubmit}
-                disabled={!SR_CREATE_ENABLED || !isValid}
-              >
-                Create service request
-              </Button>
-            </Box>
-          </Tooltip>
+            {submitting ? "Creating…" : "Create service request"}
+          </Button>
         </Box>
       </Card>
     </Box>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -14,19 +14,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Chip, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { useState, type JSX, type ReactNode } from "react";
+import { useState, type JSX } from "react";
 import { useNavigate } from "react-router";
+import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+import IssuesListUnavailable from "@features/csm-operations/components/IssuesListUnavailable";
 
 type OperationsTabId = "service_requests" | "change_requests" | "incidents";
 
 /**
  * Operations landing — the home for the managed-cloud operational entities,
- * split into Service Requests / Change Requests / Incidents tabs. Only the
- * Service Request create entry point is live; the list views and the
- * CR/Incident tabs are awaiting their backend endpoints, so they render
- * "coming soon" placeholders. Replaces the previous blanket coming-soon page.
+ * split into Service Requests / Change Requests / Incidents tabs. Service
+ * requests are case-typed, so they list through the shared issues view; CR and
+ * Incidents have no backend search endpoint yet and render an unavailable
+ * placeholder.
  */
 export default function OperationsPage(): JSX.Element {
   const navigate = useNavigate();
@@ -53,9 +55,11 @@ export default function OperationsPage(): JSX.Element {
       </Box>
 
       {activeTab === "service_requests" && (
-        <TabPanel
-          description="Catalog-driven requests raised on behalf of a customer (e.g. configuration, access, infrastructure changes)."
-          action={
+        <CsmIssuesView
+          entityNoun="service requests"
+          lockedFilters={{ caseTypes: ["service_request"] }}
+          hideTypeFilter
+          actions={
             <Button
               variant="contained"
               color="primary"
@@ -66,71 +70,22 @@ export default function OperationsPage(): JSX.Element {
               Create service request
             </Button>
           }
-        >
-          <Typography variant="body2" color="text.secondary">
-            The service request list will appear here once the backend search
-            endpoint is available.
-          </Typography>
-        </TabPanel>
+        />
       )}
 
       {activeTab === "change_requests" && (
-        <TabPanel
+        <IssuesListUnavailable
+          title="Change requests"
           description="Controlled changes, linked to service requests, with peer / CAB approval."
-          comingSoon
         />
       )}
 
       {activeTab === "incidents" && (
-        <TabPanel
+        <IssuesListUnavailable
+          title="Incidents"
           description="SaaS incidents raised by CRE or automation; may link to a case."
-          comingSoon
         />
       )}
-    </Box>
-  );
-}
-
-interface TabPanelProps {
-  description: string;
-  action?: ReactNode;
-  comingSoon?: boolean;
-  children?: ReactNode;
-}
-
-function TabPanel({
-  description,
-  action,
-  comingSoon,
-  children,
-}: TabPanelProps): JSX.Element {
-  return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 1.5,
-          flexWrap: "wrap",
-        }}
-      >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <Typography variant="body2" color="text.secondary">
-            {description}
-          </Typography>
-          {comingSoon && (
-            <Chip
-              size="small"
-              label="Coming soon"
-              color="warning"
-              variant="outlined"
-            />
-          )}
-        </Box>
-        {action}
-      </Box>
-      {children}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
@@ -105,6 +105,10 @@ function isAttachmentFieldByQuestionText(questionText: string): boolean {
 /** Attachment/file-upload field (by type or questionText). Optional + collected
  *  in the shared attachments section, so these are not rendered as text inputs. */
 export function isAttachmentField(variable: BeCatalogItemVariable): boolean {
+  // A File Copy Path field is a plain (optional) text input, not an upload —
+  // exclude it explicitly since its type/label can contain "file" and would
+  // otherwise be swallowed by isAttachmentType and dropped from the form.
+  if (isFileCopyPathField(variable)) return false;
   return (
     isAttachmentType(variable.type ?? "") ||
     isAttachmentFieldByQuestionText(variable.questionText ?? "")

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Service-catalog variable classification + value encoding for the service
+// request form. ServiceNow returns the full raw variable set for a catalog
+// item — including auto-populated "context" fields (project/deployment/product)
+// and hidden system fields (case type, priority, ...) — so the portal must
+// classify them client-side, exactly as the customer portal does. The shape
+// (`id`/`questionText`/`order`/`type`) and these heuristics mirror the
+// customer-portal reference (operations/utils/serviceRequestValidation.ts).
+
+import { htmlToPlainText } from "@components/rich-text-editor/richTextEditor";
+import type { BeCatalogItemVariable } from "@api/backend/types";
+
+// Variable `type` strings ServiceNow emits (matched case-insensitively).
+export const VARIABLE_TYPE_SINGLE_LINE = "Single Line Text";
+export const VARIABLE_TYPE_MULTI_LINE = "Multi Line Text";
+export const VARIABLE_TYPE_SELECT = "Select Box";
+export const VARIABLE_TYPE_CHECKBOX = "Checkbox";
+export const VARIABLE_TYPE_RADIO = "Radio Buttons";
+
+/** Boolean-ish field that renders a Yes/No dropdown (no choice list in the API). */
+export function isChoiceField(variable: BeCatalogItemVariable): boolean {
+  const t = (variable.type ?? "").trim();
+  return (
+    t === VARIABLE_TYPE_SELECT ||
+    t === VARIABLE_TYPE_RADIO ||
+    t === VARIABLE_TYPE_CHECKBOX
+  );
+}
+
+/** Multi-line free text (but not the Description field, which is rich text). */
+export function isMultiLineField(variable: BeCatalogItemVariable): boolean {
+  const t = (variable.type ?? "").trim().toLowerCase();
+  return (
+    (t === VARIABLE_TYPE_MULTI_LINE.toLowerCase() || t.includes("multi")) &&
+    !isDescriptionField(variable.questionText ?? "")
+  );
+}
+
+/** The Description field — rendered with the rich-text editor; value sent as HTML. */
+export function isDescriptionField(questionText: string): boolean {
+  const normalized = (questionText ?? "")
+    .replace(/^\s*\*?\s*/, "")
+    .trim()
+    .toLowerCase();
+  return normalized === "description";
+}
+
+/** File Copy Path field — a plain (optional) text input, not an upload. */
+export function isFileCopyPathField(variable: BeCatalogItemVariable): boolean {
+  const q = (variable.questionText ?? "").trim();
+  const t = (variable.type ?? "").trim();
+  return /file\s*copy\s*path/i.test(q) || /file\s*copy\s*path/i.test(t);
+}
+
+function isAttachmentType(type: string): boolean {
+  const t = (type ?? "").trim().toLowerCase();
+  return (
+    t === "attachment" ||
+    t === "file" ||
+    t === "file upload" ||
+    t.includes("attachment") ||
+    t.includes("file upload") ||
+    (t.includes("file") && !t.includes("configuration")) ||
+    t.includes("attach") ||
+    t.includes("document") ||
+    t.includes("upload")
+  );
+}
+
+function isAttachmentFieldByQuestionText(questionText: string): boolean {
+  const q = (questionText ?? "").trim().toLowerCase();
+  if (!q) return false;
+  const patterns = [
+    /attachment/i,
+    /attach\s/i,
+    /attach$/i,
+    /file\s*upload/i,
+    /upload\s*file/i,
+    /vulnerability\s*scan\s*report/i,
+    /scan\s*report/i,
+    /upload\s*document/i,
+    /document\s*upload/i,
+    /attach\s*report/i,
+    /attach\s*document/i,
+  ];
+  return patterns.some((p) => p.test(q));
+}
+
+/** Attachment/file-upload field (by type or questionText). Optional + collected
+ *  in the shared attachments section, so these are not rendered as text inputs. */
+export function isAttachmentField(variable: BeCatalogItemVariable): boolean {
+  return (
+    isAttachmentType(variable.type ?? "") ||
+    isAttachmentFieldByQuestionText(variable.questionText ?? "")
+  );
+}
+
+const CONTEXT_FIELD_PATTERNS = [
+  /^project$/i,
+  /^deployments?$/i,
+  /^product$/i,
+  /^wso2\s*product$/i,
+  /^environment$/i,
+];
+
+const HIDDEN_FIELD_PATTERNS = [
+  /^case\s*type$/i,
+  /^service\s*request\s*category$/i,
+  /^classification$/i,
+  /^class\s*fication$/i,
+  /^srns$/i,
+  /^state$/i,
+  /^assignment\s*group$/i,
+  /^assigned\s*to$/i,
+  /^priority$/i,
+  /^impact$/i,
+];
+
+/** Auto-populated from the project/deployment/product cascade — not shown. */
+export function isContextField(questionText: string): boolean {
+  const normalized = questionText?.trim().toLowerCase() ?? "";
+  return CONTEXT_FIELD_PATTERNS.some((p) => p.test(normalized));
+}
+
+/** System field ServiceNow defaults — sent by the backend, not shown. */
+export function isHiddenField(questionText: string): boolean {
+  const normalized = questionText?.trim().toLowerCase() ?? "";
+  return HIDDEN_FIELD_PATTERNS.some((p) => p.test(normalized));
+}
+
+const DATE_TIME_FIELD_PATTERNS: RegExp[] = [
+  /start\s*(date|time)/i,
+  /end\s*(date|time)/i,
+  /scheduled\s*(date|time|start|end)/i,
+  /implementation\s*(date|time|start|end)/i,
+  /planned\s*(start|end|date|time)/i,
+  /actual\s*(start|end|date|time)/i,
+  /date\s*(and\s*)?\/?\s*time/i,
+  /time\s*(and\s*)?\/?\s*date/i,
+];
+
+/** Renders a datetime-local picker (by type or questionText). */
+export function isDateTimeField(variable: BeCatalogItemVariable): boolean {
+  const t = (variable.type ?? "").trim();
+  if (/date.*time|datetime/i.test(t) || /^date$/i.test(t)) return true;
+  const q = (variable.questionText ?? "").trim();
+  return DATE_TIME_FIELD_PATTERNS.some((p) => p.test(q));
+}
+
+/** Strip the leading `*`/whitespace ServiceNow prefixes onto required labels. */
+export function variableLabel(variable: BeCatalogItemVariable): string {
+  return (variable.questionText ?? "").replace(/^\s*\*?\s*/, "").trim() || variable.id;
+}
+
+/**
+ * User-editable variables — excludes context and hidden fields, sorted by the
+ * backend's display order. This is the set the form renders and validates.
+ */
+export function getUserEditableVariables(
+  variables: BeCatalogItemVariable[],
+): BeCatalogItemVariable[] {
+  return variables
+    .filter(
+      (v) =>
+        !isContextField(v.questionText ?? "") &&
+        !isHiddenField(v.questionText ?? ""),
+    )
+    .sort(
+      (a, b) =>
+        (a.order ?? Number.MAX_SAFE_INTEGER) -
+        (b.order ?? Number.MAX_SAFE_INTEGER),
+    );
+}
+
+/**
+ * First empty required field label, or null if all are filled. Hot fix
+ * (mirrors the customer portal): every typable field is mandatory; attachment
+ * and File Copy Path fields are optional and skipped.
+ */
+export function getFirstEmptyRequiredField(
+  variables: BeCatalogItemVariable[],
+  values: Record<string, string>,
+): string | null {
+  for (const v of getUserEditableVariables(variables)) {
+    if (isAttachmentField(v) || isFileCopyPathField(v)) continue;
+    const raw = (values[v.id] ?? "").trim();
+    const textContent = raw.replace(/<[^>]+>/g, "").trim();
+    if (!textContent) return variableLabel(v);
+  }
+  return null;
+}
+
+/**
+ * Encode a variable's raw input into the value the payload carries:
+ * description stays HTML, datetime becomes an ISO-UTC string, everything else
+ * is reduced to trimmed plain text.
+ */
+export function encodeVariableValue(
+  variable: BeCatalogItemVariable,
+  raw: string,
+): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return "";
+  if (isDescriptionField(variable.questionText ?? "")) return trimmed;
+  if (isDateTimeField(variable)) {
+    const ms = Date.parse(trimmed);
+    return Number.isNaN(ms) ? trimmed : new Date(ms).toISOString();
+  }
+  return htmlToPlainText(trimmed).trim();
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
@@ -34,11 +34,12 @@ export const VARIABLE_TYPE_RADIO = "Radio Buttons";
 
 /** Boolean-ish field that renders a Yes/No dropdown (no choice list in the API). */
 export function isChoiceField(variable: BeCatalogItemVariable): boolean {
-  const t = (variable.type ?? "").trim();
+  // Case-insensitive, matching the documented contract and the other classifiers.
+  const t = (variable.type ?? "").trim().toLowerCase();
   return (
-    t === VARIABLE_TYPE_SELECT ||
-    t === VARIABLE_TYPE_RADIO ||
-    t === VARIABLE_TYPE_CHECKBOX
+    t === VARIABLE_TYPE_SELECT.toLowerCase() ||
+    t === VARIABLE_TYPE_RADIO.toLowerCase() ||
+    t === VARIABLE_TYPE_CHECKBOX.toLowerCase()
   );
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -20,12 +20,17 @@ import {
   Card,
   Chip,
   Skeleton,
+  Tab,
+  Tabs,
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode } from "react";
+import { useState, type JSX, type ReactNode } from "react";
 import { Link as RouterLink, useNavigate, useParams } from "react-router";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
+import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+
+type ProjectTabId = "overview" | "issues";
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";
@@ -114,6 +119,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data, isLoading, isError } = useGetProject(id);
+  const [activeTab, setActiveTab] = useState<ProjectTabId>("overview");
 
   if (isLoading) {
     return (
@@ -127,7 +133,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
   if (isError) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/projects")} />
+        <BackButton onClick={() => navigate("/customers/projects")} />
         <Typography variant="body1" color="error">
           Could not load project {id}.
         </Typography>
@@ -138,7 +144,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
   if (!data) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/projects")} />
+        <BackButton onClick={() => navigate("/customers/projects")} />
         <Typography variant="h5">Project not found</Typography>
         <Typography variant="body2" color="text.secondary">
           No project with id <code>{id}</code>.
@@ -151,7 +157,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-      <BackButton onClick={() => navigate("/projects")} />
+      <BackButton onClick={() => navigate("/customers/projects")} />
 
       <Box
         sx={{
@@ -187,57 +193,74 @@ export default function CsmProjectDetailPage(): JSX.Element {
         </Button>
       </Box>
 
-      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-        <Typography variant="subtitle2">Overview</Typography>
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: {
-              xs: "1fr",
-              sm: "repeat(2, minmax(0, 1fr))",
-              md: "repeat(3, minmax(0, 1fr))",
-            },
-          }}
-        >
-          <MetaCell label="Project key">
-            <Mono>{p.key}</Mono>
-          </MetaCell>
-          <MetaCell label="Subscription">
-            <Typography variant="body2">{formatSubscriptionType(p.subscriptionType)}</Typography>
-          </MetaCell>
-          <MetaCell label="Account">
-            {p.account?.id ? (
-              <LinkText to={`/accounts/${p.account.id}`}>
-                {p.account.name || p.account.id}
-              </LinkText>
-            ) : (
-              <Typography variant="body2">—</Typography>
-            )}
-          </MetaCell>
-          <MetaCell label="Account tier">
-            <Typography variant="body2">{p.account?.tier || "—"}</Typography>
-          </MetaCell>
-          <MetaCell label="Start date">
-            <Typography variant="body2">{formatDate(p.startDate)}</Typography>
-          </MetaCell>
-          <MetaCell label="End date">
-            <Typography variant="body2">{formatDate(p.endDate)}</Typography>
-          </MetaCell>
-          <MetaCell label="Salesforce ID">
-            <Mono>{p.sfId || "—"}</Mono>
-          </MetaCell>
-          <MetaCell label="Created">
-            <Typography variant="body2">{formatDate(p.createdOn)}</Typography>
-          </MetaCell>
-          <MetaCell label="Last updated">
-            <Typography variant="body2">{formatDate(p.updatedOn)}</Typography>
-          </MetaCell>
-          <MetaCell label="Project ID">
-            <Mono>{p.id}</Mono>
-          </MetaCell>
-        </Box>
-      </Card>
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v as ProjectTabId)}>
+          <Tab value="overview" label="Overview" />
+          <Tab value="issues" label="Issues" />
+        </Tabs>
+      </Box>
+
+      {activeTab === "overview" && (
+        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+          <Typography variant="subtitle2">Overview</Typography>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: {
+                xs: "1fr",
+                sm: "repeat(2, minmax(0, 1fr))",
+                md: "repeat(3, minmax(0, 1fr))",
+              },
+            }}
+          >
+            <MetaCell label="Project key">
+              <Mono>{p.key}</Mono>
+            </MetaCell>
+            <MetaCell label="Subscription">
+              <Typography variant="body2">{formatSubscriptionType(p.subscriptionType)}</Typography>
+            </MetaCell>
+            <MetaCell label="Account">
+              {p.account?.id ? (
+                <LinkText to={`/customers/accounts/${p.account.id}`}>
+                  {p.account.name || p.account.id}
+                </LinkText>
+              ) : (
+                <Typography variant="body2">—</Typography>
+              )}
+            </MetaCell>
+            <MetaCell label="Account tier">
+              <Typography variant="body2">{p.account?.tier || "—"}</Typography>
+            </MetaCell>
+            <MetaCell label="Start date">
+              <Typography variant="body2">{formatDate(p.startDate)}</Typography>
+            </MetaCell>
+            <MetaCell label="End date">
+              <Typography variant="body2">{formatDate(p.endDate)}</Typography>
+            </MetaCell>
+            <MetaCell label="Salesforce ID">
+              <Mono>{p.sfId || "—"}</Mono>
+            </MetaCell>
+            <MetaCell label="Created">
+              <Typography variant="body2">{formatDate(p.createdOn)}</Typography>
+            </MetaCell>
+            <MetaCell label="Last updated">
+              <Typography variant="body2">{formatDate(p.updatedOn)}</Typography>
+            </MetaCell>
+            <MetaCell label="Project ID">
+              <Mono>{p.id}</Mono>
+            </MetaCell>
+          </Box>
+        </Card>
+      )}
+
+      {activeTab === "issues" && (
+        <CsmIssuesView
+          entityNoun="issues"
+          lockedFilters={{ projects: [p.id] }}
+          hideProjectFilter
+        />
+      )}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -83,12 +83,9 @@ export default function CsmProjectsPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Box>
-        <Typography variant="h5">Projects</Typography>
-        <Typography variant="body2" color="text.secondary">
-          Search across project name, project key, and subscription type.
-        </Typography>
-      </Box>
+      <Typography variant="body2" color="text.secondary">
+        Search across project name, project key, and subscription type.
+      </Typography>
 
       <TextField
         size="small"
@@ -139,7 +136,7 @@ export default function CsmProjectsPage(): JSX.Element {
                     <TableCell>
                       <Typography
                         component={RouterLink}
-                        to={`/projects/${p.id}`}
+                        to={`/customers/projects/${p.id}`}
                         variant="body2"
                         sx={(t) => ({
                           textDecoration: "none",

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -69,6 +69,9 @@ export default function CreateSecurityReportPage(): JSX.Element {
   const [deploymentId, setDeploymentId] = useState("");
   const [deployedProductId, setDeployedProductId] = useState("");
   const [subject, setSubject] = useState("");
+  // Once the engineer edits the subject we stop auto-regenerating it, so a later
+  // product reselect doesn't clobber their text.
+  const [subjectEdited, setSubjectEdited] = useState(false);
   const [description, setDescription] = useState("");
   const [attachments, setAttachments] = useState<EncodedAttachment[]>([]);
 
@@ -90,6 +93,7 @@ export default function CreateSecurityReportPage(): JSX.Element {
   // the product is chosen (both names are loaded by then), matching the customer
   // portal. Event-driven so it stays editable and avoids a setState effect.
   const regenerateSubject = (depId: string, prodId: string): void => {
+    if (subjectEdited) return;
     const depName = deployments.data?.find((d) => d.id === depId)?.name;
     const prodLabel = deployedProducts.data?.find((dp) => dp.id === prodId)?.label;
     if (depName && prodLabel) {
@@ -264,7 +268,10 @@ export default function CreateSecurityReportPage(): JSX.Element {
               fullWidth
               required
               value={subject}
-              onChange={(e) => setSubject(e.target.value.slice(0, 200))}
+              onChange={(e) => {
+                setSubjectEdited(true);
+                setSubject(e.target.value.slice(0, 200));
+              }}
               helperText={
                 subject.length >= 160
                   ? `${subject.length}/200`

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -44,10 +44,9 @@ import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedPr
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
 
 // POST /cases caps the whole body at 10 MiB (BE maxCaseBodyBytes). Attachments
-// dominate that, so cap the combined base64 size with headroom for the subject,
-// description, and JSON envelope.
+// dominate that, but the subject + (rich-text, unbounded) description share the
+// same body, so the attachment budget is whatever those leave under the cap.
 const MAX_BODY_BYTES = 10 * 1024 * 1024;
-const MAX_ATTACHMENTS_ENCODED_BYTES = MAX_BODY_BYTES - 64 * 1024;
 
 /** The rich-text editor emits `<p></p>` when empty; check the stripped text. */
 function isEmptyHtml(html: string): boolean {
@@ -77,7 +76,15 @@ export default function CreateSecurityReportPage(): JSX.Element {
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
 
-  const overLimit = totalEncodedBytes(attachments) > MAX_ATTACHMENTS_ENCODED_BYTES;
+  // The create body carries subject + description (HTML) + base64 attachments;
+  // give attachments only the room the text leaves so the whole body stays under
+  // the backend's maxCaseBodyBytes once serialized.
+  const nonAttachmentBytes = useMemo(
+    () => new TextEncoder().encode(subject + description).length,
+    [subject, description],
+  );
+  const attachmentsBudget = Math.max(0, MAX_BODY_BYTES - nonAttachmentBytes - 4 * 1024);
+  const overLimit = totalEncodedBytes(attachments) > attachmentsBudget;
 
   // Auto-generate the report title as "{Deployment} - {Product} - {date}" when
   // the product is chosen (both names are loaded by then), matching the customer
@@ -302,7 +309,7 @@ export default function CreateSecurityReportPage(): JSX.Element {
               attachments={attachments}
               onChange={setAttachments}
               onError={showError}
-              maxEncodedBytes={MAX_ATTACHMENTS_ENCODED_BYTES}
+              maxEncodedBytes={attachmentsBudget}
               required
             />
           </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -1,0 +1,326 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  FormControl,
+  FormHelperText,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type JSX } from "react";
+import { useNavigate } from "react-router";
+import { BackendApiError } from "@api/backend/client";
+import Editor from "@components/rich-text-editor/Editor";
+import AttachmentsField from "@components/attachments/AttachmentsField";
+import {
+  totalEncodedBytes,
+  type EncodedAttachment,
+} from "@components/attachments/encodeAttachment";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
+import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
+import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
+import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
+
+// POST /cases caps the whole body at 10 MiB (BE maxCaseBodyBytes). Attachments
+// dominate that, so cap the combined base64 size with headroom for the subject,
+// description, and JSON envelope.
+const MAX_BODY_BYTES = 10 * 1024 * 1024;
+const MAX_ATTACHMENTS_ENCODED_BYTES = MAX_BODY_BYTES - 64 * 1024;
+
+/** The rich-text editor emits `<p></p>` when empty; check the stripped text. */
+function isEmptyHtml(html: string): boolean {
+  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
+}
+
+/** Today as YYYY-MM-DD, for the auto-generated report title. */
+function todayStamp(): string {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+export default function CreateSecurityReportPage(): JSX.Element {
+  const navigate = useNavigate();
+  const { showError } = useErrorBanner();
+
+  const [projectId, setProjectId] = useState("");
+  const [deploymentId, setDeploymentId] = useState("");
+  const [deployedProductId, setDeployedProductId] = useState("");
+  const [subject, setSubject] = useState("");
+  const [description, setDescription] = useState("");
+  const [attachments, setAttachments] = useState<EncodedAttachment[]>([]);
+
+  const deployments = useSearchDeployments(projectId || undefined);
+  const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
+  const postCase = usePostCsmCase();
+
+  const overLimit = totalEncodedBytes(attachments) > MAX_ATTACHMENTS_ENCODED_BYTES;
+
+  // Auto-generate the report title as "{Deployment} - {Product} - {date}" when
+  // the product is chosen (both names are loaded by then), matching the customer
+  // portal. Event-driven so it stays editable and avoids a setState effect.
+  const regenerateSubject = (depId: string, prodId: string): void => {
+    const depName = deployments.data?.find((d) => d.id === depId)?.name;
+    const prodLabel = deployedProducts.data?.find((dp) => dp.id === prodId)?.label;
+    if (depName && prodLabel) {
+      setSubject(`${depName} - ${prodLabel} - ${todayStamp()}`.slice(0, 200));
+    }
+  };
+
+  // Cascade resets: a parent change invalidates its children.
+  const onProjectChange = (next: string): void => {
+    setProjectId(next);
+    setDeploymentId("");
+    setDeployedProductId("");
+  };
+  const onDeploymentChange = (next: string): void => {
+    setDeploymentId(next);
+    setDeployedProductId("");
+  };
+  const onDeployedProductChange = (next: string): void => {
+    setDeployedProductId(next);
+    regenerateSubject(deploymentId, next);
+  };
+
+  const hasOptionsError = deployments.isError || deployedProducts.isError;
+  const retryOptions = (): void => {
+    if (deployments.isError) void deployments.refetch();
+    if (deployedProducts.isError) void deployedProducts.refetch();
+  };
+
+  const canSubmit = useMemo(
+    () =>
+      !!projectId &&
+      !!deploymentId &&
+      !!deployedProductId &&
+      subject.trim().length > 0 &&
+      !isEmptyHtml(description) &&
+      attachments.length > 0 &&
+      !overLimit &&
+      !postCase.isPending,
+    [
+      projectId,
+      deploymentId,
+      deployedProductId,
+      subject,
+      description,
+      attachments.length,
+      overLimit,
+      postCase.isPending,
+    ],
+  );
+
+  const handleSubmit = (): void => {
+    if (!canSubmit) return;
+    postCase.mutate(
+      {
+        type: "security_report_analysis",
+        projectId,
+        deploymentId,
+        deployedProductId,
+        subject: subject.trim(),
+        description,
+        attachments: attachments.map((a) => ({ name: a.name, file: a.file })),
+      },
+      {
+        onSuccess: (created) => navigate(`/cases/${created.id}`),
+        onError: (err) => {
+          // The backend surfaces real validation messages on 4xx; show them.
+          const msg =
+            err instanceof BackendApiError && err.status < 500 && err.message
+              ? err.message
+              : "Could not create the security report. Please try again.";
+          showError(msg, err);
+        },
+      },
+    );
+  };
+
+  return (
+    <Box sx={{ width: "100%", px: 3, py: 3 }}>
+      <Button
+        variant="text"
+        startIcon={<ArrowLeft size={16} />}
+        onClick={() => navigate("/security-center")}
+        sx={{ mb: 1 }}
+      >
+        Back to Security Center
+      </Button>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        New security report
+      </Typography>
+
+      <Card variant="outlined" sx={{ p: 3 }}>
+        {hasOptionsError && (
+          <Box
+            sx={{
+              mb: 2,
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              flexWrap: "wrap",
+            }}
+          >
+            <Typography variant="body2" color="error.main">
+              Some dropdown options failed to load.
+            </Typography>
+            <Button size="small" variant="outlined" onClick={retryOptions}>
+              Retry
+            </Button>
+          </Box>
+        )}
+
+        <Grid container spacing={2.5}>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <AsyncProjectSelect
+              value={projectId}
+              onChange={onProjectChange}
+              required
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="sra-deployment-label">Deployment</InputLabel>
+              <Select
+                labelId="sra-deployment-label"
+                label="Deployment"
+                value={deploymentId}
+                onChange={(e) => onDeploymentChange(String(e.target.value))}
+                disabled={!projectId || deployments.isLoading}
+              >
+                {(deployments.data ?? []).map((d) => (
+                  <MenuItem key={d.id} value={d.id}>
+                    {d.name ?? d.id}
+                  </MenuItem>
+                ))}
+              </Select>
+              {!projectId ? (
+                <FormHelperText>Select a project first</FormHelperText>
+              ) : deployments.isLoading ? (
+                <FormHelperText>Loading deployments…</FormHelperText>
+              ) : null}
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="sra-product-label">Deployed product</InputLabel>
+              <Select
+                labelId="sra-product-label"
+                label="Deployed product"
+                value={deployedProductId}
+                onChange={(e) => onDeployedProductChange(String(e.target.value))}
+                disabled={!deploymentId || deployedProducts.isLoading}
+              >
+                {(deployedProducts.data ?? []).map((dp) => (
+                  <MenuItem key={dp.id} value={dp.id}>
+                    {dp.label}
+                  </MenuItem>
+                ))}
+              </Select>
+              {!deploymentId ? (
+                <FormHelperText>Select a deployment first</FormHelperText>
+              ) : deployedProducts.isLoading ? (
+                <FormHelperText>Loading products…</FormHelperText>
+              ) : null}
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <TextField
+              label="Subject"
+              size="small"
+              fullWidth
+              required
+              value={subject}
+              onChange={(e) => setSubject(e.target.value.slice(0, 200))}
+              helperText={
+                subject.length >= 160
+                  ? `${subject.length}/200`
+                  : "Auto-generated from deployment and product; edit if needed."
+              }
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <Typography
+              id="sra-description-label"
+              component="label"
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 0.5 }}
+            >
+              Description *
+            </Typography>
+            <Box role="group" aria-labelledby="sra-description-label">
+              <Editor
+                value={description}
+                onChange={setDescription}
+                placeholder="Describe the security report and what needs analysis…"
+                minHeight={150}
+                maxHeight="300px"
+                toolbarVariant="full"
+                disabled={postCase.isPending}
+              />
+            </Box>
+          </Grid>
+
+          {/* At least one attachment is required for a security report. */}
+          <Grid size={{ xs: 12 }}>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 0.5 }}
+            >
+              Attachments *
+            </Typography>
+            <AttachmentsField
+              attachments={attachments}
+              onChange={setAttachments}
+              onError={showError}
+              maxEncodedBytes={MAX_ATTACHMENTS_ENCODED_BYTES}
+              required
+            />
+          </Grid>
+        </Grid>
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, mt: 2.5 }}>
+          <Button variant="outlined" onClick={() => navigate("/security-center")}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {postCase.isPending ? "Creating…" : "Create security report"}
+          </Button>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Chip, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { Plus } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX, type ReactNode } from "react";
+import { useNavigate } from "react-router";
+import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+
+type SecurityCenterTabId = "security_reports" | "vulnerabilities";
+
+/**
+ * Security Center landing — the home for the customer-security entities, split
+ * into Security Reports (SRA) / Vulnerabilities tabs. Only the security-report
+ * create entry point is live; the report list and the Vulnerabilities tab are
+ * awaiting their backend endpoints, so they render "coming soon" placeholders.
+ * Replaces the previous blanket coming-soon page.
+ */
+export default function CsmSecurityCenterPage(): JSX.Element {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] =
+    useState<SecurityCenterTabId>("security_reports");
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box>
+        <Typography variant="h5">Security Center</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Security reports and vulnerability posture across customer deployments.
+        </Typography>
+      </Box>
+
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, v) => setActiveTab(v as SecurityCenterTabId)}
+        >
+          <Tab value="security_reports" label="Security reports" />
+          <Tab value="vulnerabilities" label="Vulnerabilities" />
+        </Tabs>
+      </Box>
+
+      {activeTab === "security_reports" && (
+        <CsmIssuesView
+          entityNoun="security reports"
+          lockedFilters={{ caseTypes: ["security_report_analysis"] }}
+          hideTypeFilter
+          actions={
+            <Button
+              variant="contained"
+              color="primary"
+              size="small"
+              startIcon={<Plus size={16} />}
+              onClick={() => navigate("/security-center/reports/new")}
+            >
+              New security report
+            </Button>
+          }
+        />
+      )}
+
+      {activeTab === "vulnerabilities" && (
+        <TabPanel
+          description="Vulnerability posture across customer deployments, with response-time tracking."
+          comingSoon
+        />
+      )}
+    </Box>
+  );
+}
+
+interface TabPanelProps {
+  description: string;
+  action?: ReactNode;
+  comingSoon?: boolean;
+  children?: ReactNode;
+}
+
+function TabPanel({
+  description,
+  action,
+  comingSoon,
+  children,
+}: TabPanelProps): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1.5,
+          flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            {description}
+          </Typography>
+          {comingSoon && (
+            <Chip
+              size="small"
+              label="Coming soon"
+              color="warning"
+              variant="outlined"
+            />
+          )}
+        </Box>
+        {action}
+      </Box>
+      {children}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/hooks/useEngineerDisplayName.ts
+++ b/apps/csm-portal/webapp/src/hooks/useEngineerDisplayName.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+
+/**
+ * Display name for the signed-in engineer, resolved from the ID token: full
+ * name, else given + family name, else the email local part, else a generic
+ * fallback. Used to attribute session-authored comments and attachments before
+ * the backend resolves its own author.
+ */
+export function useEngineerDisplayName(): string {
+  const claims = useIdTokenClaims();
+  return (
+    claims?.name ||
+    [claims?.given_name, claims?.family_name].filter(Boolean).join(" ").trim() ||
+    claims?.email?.split("@")[0] ||
+    "Unknown engineer"
+  );
+}


### PR DESCRIPTION
## Summary

Adds catalog-driven Service Request and Security Report (SRA) creation, a shared issue list+filter reused across types, and a Customers menu consolidation — building on the new catalog/`service_request`/`security_report_analysis` backend capabilities.

### Navigation
- **Customers menu**: Accounts + Projects merged into one `Customers` item with Accounts/Projects tabs; routes moved under `/customers` (legacy `/accounts`, `/projects` redirect so existing links/pins survive).
- Renamed the `Cases` menu item to **Support**; moved **Security Center** above Updates and capitalised it.

### Service Requests (catalog-driven)
- Rebuilt the SR create flow as a cascade: project → deployment → deployed product → catalog → catalog item → dynamic variable form (consumes catalog search + catalog-item variables endpoints).
- Classifies ServiceNow variables client-side: hides auto-populated context fields (project/deployment/product/environment) and hidden system fields; renders by type (Yes/No select, multi-line, datetime, rich-text description); enforces required typable fields. (Mirrors the customer portal's handling of the same data.)

### Security Reports (SRA)
- Security Center is now a tabbed page (Security reports + Vulnerabilities).
- New security-report create page: subject, rich-text description, required attachments, submitting `type: security_report_analysis`.

### Shared issue listing + filtering
- Extracted `CsmIssuesView` (filter bar + list + pagination) from the cases page and reused it — via locked filters + hidden controls — for: the all-cases page, Operations → Service requests, Security Center → Security reports, and a **new Issues tab on the project detail page**.
- Change-request and incident tabs render an "unavailable" placeholder (no backend search endpoint yet).

### Case creation
- Optional attachments via a shared `AttachmentsField`. Standard cases and service requests upload attachments **after** creation via the per-case attachment endpoint (the create endpoint only attaches files for security reports); SRA sends them in the create payload.

### Other
- Project pickers on all create forms now load a default project set on open and page on scroll (matching the cases filter), via the shared `AsyncProjectSelect`.
- Case detail: case **type** shown as a chip, positioned before the severity chip.

## Notes
- FE-only. No backend/entity changes; builds against existing endpoints.
- Catalog/SR/SRA flows depend on the ServiceNow data source, so the create round-trips need a ServiceNow-backed environment to exercise end to end.

## Test plan
- [x] Customers menu shows Accounts/Projects tabs; old `/accounts` and `/projects` links redirect.
- [x] Create a service request: catalog + item load, variable form renders by type, required fields enforced, case created.
- [ ] Create a security report: required attachments enforced; case created with attachments.
- [ ] Create a standard case with attachments: case created and attachments appear on the case.
- [ ] Service-request and security-report lists render under their tabs; project detail Issues tab lists that project's issues.
- [x] Project picker on create forms shows a default set on open and searches/pages.
- [x] Case detail shows the type chip before the severity chip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Customers and Security Center areas with tabbed navigation, detail pages, and create flows (including new service request and security report creation with dynamic variable fields and attachment uploads).
  * Introduced an issues list view with URL-synced filtering, search, and pagination for multiple entities.
* **Bug Fixes**
  * Redirected legacy account/project URLs to the new customer-scoped routes to prevent 404s.
* **UI Updates**
  * Updated customer-scoped navigation links and “active” sidebar behavior; refined key labels and case details (including case type chips).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->