### PR TITLE
[CSM Portal] feat: add PATCH /deployments/{id} endpoint via entity service

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -194,6 +194,7 @@ backend/
 
 ### Deployments
 
+- `PATCH /deployments/{id}` — Update a deployment (name, typeKey, description, or deactivate; ServiceNow data source only)
 - `POST /deployments/search` — Search deployments
 - `POST /deployments/{id}/products/search` — Search deployed products
 

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -110,6 +110,7 @@ func main() {
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
+	mux.HandleFunc("PATCH /deployments/{id}", deploymentHandler.PatchDeployment)
 	mux.HandleFunc("POST /deployments/{id}/products/search", deploymentHandler.SearchDeployedProducts)
 	mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
 	mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -101,6 +101,12 @@ func (c *Client) SearchProductVersions(ctx context.Context, productID string, bo
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/products/%s/versions/search", url.PathEscape(productID)), body)
 }
 
+// PatchDeployment calls PATCH /deployments/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) PatchDeployment(ctx context.Context, deploymentID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/deployments/%s", url.PathEscape(deploymentID)), body)
+}
+
 // SearchDeployments calls POST /deployments/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *Client) SearchDeployments(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/deployments.go
+++ b/apps/csm-portal/backend/internal/handler/deployments.go
@@ -80,7 +80,8 @@ func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Reque
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		if _, ok := err.(*http.MaxBytesError); ok {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
 			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
 			return
 		}

--- a/apps/csm-portal/backend/internal/handler/deployments.go
+++ b/apps/csm-portal/backend/internal/handler/deployments.go
@@ -48,6 +48,7 @@ func injectDeploymentID(body []byte, deploymentID string) ([]byte, error) {
 type entityDeploymentClient interface {
 	SearchDeployments(ctx context.Context, body []byte) ([]byte, error)
 	SearchDeployedProducts(ctx context.Context, body []byte) ([]byte, error)
+	PatchDeployment(ctx context.Context, deploymentID string, body []byte) ([]byte, error)
 }
 
 // DeploymentHandler handles HTTP requests for deployment operations, delegating to the
@@ -59,6 +60,47 @@ type DeploymentHandler struct {
 // NewDeploymentHandler creates a DeploymentHandler backed by the given entity client.
 func NewDeploymentHandler(entity entityDeploymentClient) *DeploymentHandler {
 	return &DeploymentHandler{entity: entity}
+}
+
+// PatchDeployment handles PATCH /deployments/{id}.
+// Accepts name, typeKey, description (detail fields) or active=false (deactivation) and forwards to the entity service.
+func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	deploymentID := r.PathValue("id")
+	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.PatchDeployment(r.Context(), deploymentID, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity PatchDeployment failed", "userID", user.UserID, "deploymentID", deploymentID, "err", err)
+		mapUpstreamError(w, err, "Failed to update deployment.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // SearchDeployments handles POST /deployments/search.

--- a/apps/csm-portal/backend/internal/handler/deployments_test.go
+++ b/apps/csm-portal/backend/internal/handler/deployments_test.go
@@ -102,6 +102,106 @@ func TestSearchDeployments(t *testing.T) {
 	})
 }
 
+func TestPatchDeployment(t *testing.T) {
+	const validID = "11111111-1111-1111-1111-111111111111"
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := httptest.NewRequest(http.MethodPatch, "/deployments/"+validID, strings.NewReader(`{"name":"prod"}`))
+		r.SetPathValue("id", validID)
+		w := httptest.NewRecorder()
+		h.PatchDeployment(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID deployment id", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/deployments/not-a-uuid", strings.NewReader(`{"name":"prod"}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.PatchDeployment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/deployments/"+validID, strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", validID)
+		w := httptest.NewRecorder()
+		h.PatchDeployment(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/deployments/"+validID, strings.NewReader(`not-json`)))
+		r.SetPathValue("id", validID)
+		w := httptest.NewRecorder()
+		h.PatchDeployment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body and deployment id to upstream and returns 200", func(t *testing.T) {
+		const reqPayload = `{"name":"new-name"}`
+		var capturedID string
+		var capturedBody []byte
+		client := &mockEntityDeploymentClient{
+			patchDeploymentFn: func(_ context.Context, deploymentID string, body []byte) ([]byte, error) {
+				capturedID = deploymentID
+				capturedBody = body
+				return []byte(`{"message":"Deployment updated successfully","deployment":{"id":"` + validID + `","updatedOn":"2026-06-26T00:00:00Z","updatedBy":"user@wso2.com"}}`), nil
+			},
+		}
+		h := NewDeploymentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/deployments/"+validID, strings.NewReader(reqPayload)))
+		r.SetPathValue("id", validID)
+		w := httptest.NewRecorder()
+		h.PatchDeployment(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != validID {
+			t.Errorf("upstream received id %q, want %q", capturedID, validID)
+		}
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["message"] != "Deployment updated successfully" {
+			t.Errorf("message = %v, want %q", resp["message"], "Deployment updated successfully")
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to update deployment.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityDeploymentClient{
+					patchDeploymentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewDeploymentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/deployments/"+validID, strings.NewReader(`{"name":"x"}`)))
+				r.SetPathValue("id", validID)
+				w := httptest.NewRecorder()
+				h.PatchDeployment(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestSearchDeployedProducts(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -301,8 +301,9 @@ func (m *mockEntityChangeRequestClient) GetChangeRequest(ctx context.Context, id
 // ----- mock entity deployment client -----
 
 type mockEntityDeploymentClient struct {
-	searchDeploymentsFn        func(ctx context.Context, body []byte) ([]byte, error)
-	searchDeployedProductsFn   func(ctx context.Context, body []byte) ([]byte, error)
+	searchDeploymentsFn      func(ctx context.Context, body []byte) ([]byte, error)
+	searchDeployedProductsFn func(ctx context.Context, body []byte) ([]byte, error)
+	patchDeploymentFn        func(ctx context.Context, deploymentID string, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityDeploymentClient) SearchDeployments(ctx context.Context, body []byte) ([]byte, error) {
@@ -315,6 +316,13 @@ func (m *mockEntityDeploymentClient) SearchDeployments(ctx context.Context, body
 func (m *mockEntityDeploymentClient) SearchDeployedProducts(ctx context.Context, body []byte) ([]byte, error) {
 	if m.searchDeployedProductsFn != nil {
 		return m.searchDeployedProductsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityDeploymentClient) PatchDeployment(ctx context.Context, deploymentID string, body []byte) ([]byte, error) {
+	if m.patchDeploymentFn != nil {
+		return m.patchDeploymentFn(ctx, deploymentID, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2249,19 +2249,26 @@ components:
           format: date-time
 
     DeploymentUpdatePayload:
-      type: object
-      properties:
-        name:
-          type: string
-        typeKey:
-          type: integer
-          description: ServiceNow deployment type integer key.
-        description:
-          type: string
-          nullable: true
-        active:
-          type: boolean
-          description: Can only be set to false to deactivate the deployment.
+      oneOf:
+        - description: Update deployment detail fields. At least one of name, typeKey, or description must be provided.
+          type: object
+          minProperties: 1
+          properties:
+            name:
+              type: string
+            typeKey:
+              type: integer
+              description: ServiceNow deployment type integer key.
+            description:
+              type: string
+              nullable: true
+        - description: Deactivate the deployment. active must be false; no other fields may be present.
+          type: object
+          required: [active]
+          properties:
+            active:
+              type: boolean
+              enum: [false]
 
     DeploymentUpdateResponse:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -865,6 +865,69 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /deployments/{id}:
+    patch:
+      summary: Update a deployment's name, type, description, or deactivate it.
+      operationId: patchDeployment
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the deployment to update.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Deployment update payload. Provide either detail fields (name, typeKey, description) or active=false, but not both.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeploymentUpdatePayload'
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentUpdateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /deployments/search:
     post:
       summary: Search deployments.
@@ -2184,6 +2247,40 @@ components:
         updatedOn:
           type: string
           format: date-time
+
+    DeploymentUpdatePayload:
+      type: object
+      properties:
+        name:
+          type: string
+        typeKey:
+          type: integer
+          description: ServiceNow deployment type integer key.
+        description:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+          description: Can only be set to false to deactivate the deployment.
+
+    DeploymentUpdateResponse:
+      type: object
+      required: [message, deployment]
+      properties:
+        message:
+          type: string
+        deployment:
+          type: object
+          required: [id, updatedOn, updatedBy]
+          properties:
+            id:
+              type: string
+              format: uuid
+            updatedOn:
+              type: string
+              format: date-time
+            updatedBy:
+              type: string
 
     DeploymentSearchPayload:
       type: object

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -353,12 +353,16 @@ type SearchDeploymentsResponse struct {
 // UpdateDeploymentRequest is the input for PATCH /deployments/{id}.
 // Either detail fields (Name, TypeKey, Description) or Active (to deactivate) must be provided,
 // but not both groups in the same request. Active can only be set to false.
+// Description uses a pointer-to-pointer to distinguish three states:
+//   - nil outer pointer: field omitted — leave description unchanged
+//   - non-nil outer, nil inner (*Description == nil): explicit null — clear the description
+//   - non-nil outer, non-nil inner: set description to the given value
 type UpdateDeploymentRequest struct {
-	ID          string  `json:"-"`
-	Name        *string `json:"name"`
-	TypeKey     *int    `json:"typeKey"`
-	Description *string `json:"description"`
-	Active      *bool   `json:"active"`
+	ID          string   `json:"-"`
+	Name        *string  `json:"name"`
+	TypeKey     *int     `json:"typeKey"`
+	Description **string `json:"description"`
+	Active      *bool    `json:"active"`
 }
 
 // UpdateDeploymentResponse is the response for PATCH /deployments/{id}.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -350,6 +350,30 @@ type SearchDeploymentsResponse struct {
 	HasMore     bool             `json:"hasMore"`
 }
 
+// UpdateDeploymentRequest is the input for PATCH /deployments/{id}.
+// Either detail fields (Name, TypeKey, Description) or Active (to deactivate) must be provided,
+// but not both groups in the same request. Active can only be set to false.
+type UpdateDeploymentRequest struct {
+	ID          string  `json:"-"`
+	Name        *string `json:"name"`
+	TypeKey     *int    `json:"typeKey"`
+	Description *string `json:"description"`
+	Active      *bool   `json:"active"`
+}
+
+// UpdateDeploymentResponse is the response for PATCH /deployments/{id}.
+type UpdateDeploymentResponse struct {
+	Message    string            `json:"message"`
+	Deployment UpdatedDeployment `json:"deployment"`
+}
+
+// UpdatedDeployment carries the fields of a deployment that may change after an update.
+type UpdatedDeployment struct {
+	ID        string    `json:"id"`
+	UpdatedOn time.Time `json:"updatedOn"`
+	UpdatedBy string    `json:"updatedBy"`
+}
+
 // DeployedProduct represents a product (and optional version) associated with a deployment.
 type DeployedProduct struct {
 	ID               string    `json:"id"`

--- a/entity-service/internal/handler/deployment_handler.go
+++ b/entity-service/internal/handler/deployment_handler.go
@@ -35,6 +35,23 @@ func NewDeploymentHandler(svc service.DeploymentService) *DeploymentHandler {
 	return &DeploymentHandler{svc: svc}
 }
 
+// PatchDeployment handles PATCH /deployments/{id}.
+// Accepts name, typeKey, description (detail fields) or active=false (deactivation), but not both groups.
+func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Request) {
+	var req domain.UpdateDeploymentRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.ID = r.PathValue("id")
+	resp, err := h.svc.UpdateDeployment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // SearchDeployments handles POST /deployments/search.
 func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchDeploymentsRequest

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -118,6 +118,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productVersionHandler.SearchProductVersions)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
+	mux.HandleFunc("PATCH /deployments/{id}", deploymentHandler.PatchDeployment)
 	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)

--- a/entity-service/internal/service/deployment_service.go
+++ b/entity-service/internal/service/deployment_service.go
@@ -20,6 +20,7 @@ package service
 import (
 	"context"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/repository"
 )
@@ -31,6 +32,11 @@ type deploymentService struct {
 // NewDeploymentService constructs a DeploymentService backed by the given repository.
 func NewDeploymentService(repo repository.DeploymentRepository) DeploymentService {
 	return &deploymentService{repo: repo}
+}
+
+// UpdateDeployment implements DeploymentService. Not supported for the PostgreSQL data source.
+func (s *deploymentService) UpdateDeployment(_ context.Context, _ domain.UpdateDeploymentRequest) (domain.UpdateDeploymentResponse, error) {
+	return domain.UpdateDeploymentResponse{}, &apierror.ValidationError{Msg: "UpdateDeployment is not supported for the PostgreSQL data source"}
 }
 
 // SearchDeployments implements DeploymentService.

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -78,6 +78,10 @@ type DeploymentService interface {
 	// project IDs, deployment type keys, and name search query. A ValidationError is
 	// returned for invalid input; any other error indicates an infrastructure failure.
 	SearchDeployments(ctx context.Context, req domain.SearchDeploymentsRequest) (domain.SearchDeploymentsResponse, error)
+	// UpdateDeployment updates a deployment's name, type, description, or deactivates it.
+	// Either detail fields or Active=false must be provided, but not both.
+	// Supported by the ServiceNow data source only.
+	UpdateDeployment(ctx context.Context, req domain.UpdateDeploymentRequest) (domain.UpdateDeploymentResponse, error)
 }
 
 // DeployedProductService defines the operations available on the deployed_products entity.

--- a/entity-service/internal/service/sn_deployment_service.go
+++ b/entity-service/internal/service/sn_deployment_service.go
@@ -146,11 +146,13 @@ func (s *snDeploymentService) SearchDeployments(ctx context.Context, req domain.
 }
 
 // snUpdateDeploymentPayload is the Choreo PATCH /deployments/{id} request body.
+// Description is json.RawMessage so an explicit null ("description":null) can be
+// distinguished from an omitted field — omitempty drops nil RawMessage entirely.
 type snUpdateDeploymentPayload struct {
-	Name        *string `json:"name,omitempty"`
-	TypeKey     *int    `json:"typeKey,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Active      *bool   `json:"active,omitempty"`
+	Name        *string         `json:"name,omitempty"`
+	TypeKey     *int            `json:"typeKey,omitempty"`
+	Description json.RawMessage `json:"description,omitempty"`
+	Active      *bool           `json:"active,omitempty"`
 }
 
 type snUpdateDeploymentResponse struct {
@@ -185,10 +187,20 @@ func (s *snDeploymentService) UpdateDeployment(ctx context.Context, req domain.U
 	}
 
 	payload := snUpdateDeploymentPayload{
-		Name:        req.Name,
-		TypeKey:     req.TypeKey,
-		Description: req.Description,
-		Active:      req.Active,
+		Name:    req.Name,
+		TypeKey: req.TypeKey,
+		Active:  req.Active,
+	}
+	if req.Description != nil {
+		if *req.Description == nil {
+			payload.Description = json.RawMessage("null")
+		} else {
+			b, err := json.Marshal(**req.Description)
+			if err != nil {
+				return domain.UpdateDeploymentResponse{}, fmt.Errorf("sn update deployment: marshal description: %w", err)
+			}
+			payload.Description = b
+		}
 	}
 
 	raw, err := s.client.Patch(ctx, "/deployments/"+uuidToSysid(req.ID), token, payload)

--- a/entity-service/internal/service/sn_deployment_service.go
+++ b/entity-service/internal/service/sn_deployment_service.go
@@ -145,6 +145,77 @@ func (s *snDeploymentService) SearchDeployments(ctx context.Context, req domain.
 	}, nil
 }
 
+// snUpdateDeploymentPayload is the Choreo PATCH /deployments/{id} request body.
+type snUpdateDeploymentPayload struct {
+	Name        *string `json:"name,omitempty"`
+	TypeKey     *int    `json:"typeKey,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Active      *bool   `json:"active,omitempty"`
+}
+
+type snUpdateDeploymentResponse struct {
+	Message    string `json:"message"`
+	Deployment struct {
+		ID        string `json:"id"`
+		UpdatedOn string `json:"updatedOn"`
+		UpdatedBy string `json:"updatedBy"`
+	} `json:"deployment"`
+}
+
+// UpdateDeployment implements DeploymentService for the ServiceNow data source.
+func (s *snDeploymentService) UpdateDeployment(ctx context.Context, req domain.UpdateDeploymentRequest) (domain.UpdateDeploymentResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.UpdateDeploymentResponse{}, err
+	}
+
+	hasDetailFields := req.Name != nil || req.TypeKey != nil || req.Description != nil
+	if !hasDetailFields && req.Active == nil {
+		return domain.UpdateDeploymentResponse{}, &apierror.ValidationError{Msg: "at least one of name, typeKey, description, or active must be provided"}
+	}
+	if hasDetailFields && req.Active != nil {
+		return domain.UpdateDeploymentResponse{}, &apierror.ValidationError{Msg: "active must not be provided when updating deployment details"}
+	}
+	if req.Active != nil && *req.Active {
+		return domain.UpdateDeploymentResponse{}, &apierror.ValidationError{Msg: "active can only be set to false"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.UpdateDeploymentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snUpdateDeploymentPayload{
+		Name:        req.Name,
+		TypeKey:     req.TypeKey,
+		Description: req.Description,
+		Active:      req.Active,
+	}
+
+	raw, err := s.client.Patch(ctx, "/deployments/"+uuidToSysid(req.ID), token, payload)
+	if err != nil {
+		return domain.UpdateDeploymentResponse{}, err
+	}
+
+	var snResp snUpdateDeploymentResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateDeploymentResponse{}, fmt.Errorf("sn update deployment: parse response: %w", err)
+	}
+
+	updatedOn, err := time.Parse(snCreatedOnLayout, snResp.Deployment.UpdatedOn)
+	if err != nil {
+		return domain.UpdateDeploymentResponse{}, fmt.Errorf("sn update deployment: parse updatedOn %q: %w", snResp.Deployment.UpdatedOn, err)
+	}
+
+	return domain.UpdateDeploymentResponse{
+		Message: snResp.Message,
+		Deployment: domain.UpdatedDeployment{
+			ID:        sysidToUUID(snResp.Deployment.ID),
+			UpdatedOn: updatedOn,
+			UpdatedBy: snResp.Deployment.UpdatedBy,
+		},
+	}, nil
+}
+
 // validDeploymentTypes is the set of known DeploymentType enum values.
 var validDeploymentTypes = map[domain.DeploymentType]struct{}{
 	domain.DeploymentTypePrimaryProduction: {},

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -279,6 +279,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized (missing x-user-id-token header).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Deployment not found.
           content:
@@ -1271,19 +1277,26 @@ components:
           format: date-time
 
     UpdateDeploymentRequest:
-      type: object
-      properties:
-        name:
-          type: string
-        typeKey:
-          type: integer
-          description: ServiceNow deployment type integer key.
-        description:
-          type: string
-          nullable: true
-        active:
-          type: boolean
-          description: Can only be set to false to deactivate the deployment.
+      oneOf:
+        - description: Update deployment detail fields. At least one of name, typeKey, or description must be provided.
+          type: object
+          minProperties: 1
+          properties:
+            name:
+              type: string
+            typeKey:
+              type: integer
+              description: ServiceNow deployment type integer key.
+            description:
+              type: string
+              nullable: true
+        - description: Deactivate the deployment. active must be false; no other fields may be present.
+          type: object
+          required: [active]
+          properties:
+            active:
+              type: boolean
+              enum: [false]
 
     UpdateDeploymentResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -249,6 +249,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /deployments/{id}:
+    patch:
+      summary: Update a deployment's name, type, description, or deactivate it.
+      operationId: patchDeployment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDeploymentRequest'
+      responses:
+        "200":
+          description: Deployment updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateDeploymentResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Deployment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /deployments/search:
     post:
       summary: Search deployments by name, project IDs, or deployment type.
@@ -1226,6 +1269,43 @@ components:
         updatedOn:
           type: string
           format: date-time
+
+    UpdateDeploymentRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        typeKey:
+          type: integer
+          description: ServiceNow deployment type integer key.
+        description:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+          description: Can only be set to false to deactivate the deployment.
+
+    UpdateDeploymentResponse:
+      type: object
+      required: [message, deployment]
+      properties:
+        message:
+          type: string
+        deployment:
+          $ref: '#/components/schemas/UpdatedDeployment'
+
+    UpdatedDeployment:
+      type: object
+      required: [id, updatedOn, updatedBy]
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
 
     SearchDeploymentsResponse:
       type: object


### PR DESCRIPTION
## Summary

- **New `PATCH /deployments/{id}` endpoint** in entity-service (ServiceNow data source only), mirroring the Ballerina reference implementation in `digiops-cs/entity-service`
- **New `PATCH /deployments/{id}` endpoint** in csm-portal backend BFF, forwarding to entity-service
- Accepts either deployment detail fields (`name`, `typeKey`, `description`) **or** `active: false` to deactivate — mutually exclusive groups enforced in the service layer
- UUID→sysid conversion on the outbound path; sysid→UUID on the response

## Changes

### entity-service
- `internal/domain/entity.go` — `UpdateDeploymentRequest`, `UpdateDeploymentResponse`, `UpdatedDeployment` types
- `internal/service/interfaces.go` — `UpdateDeployment` added to `DeploymentService` interface
- `internal/service/deployment_service.go` — stub returning `ValidationError` (PostgreSQL data source not supported)
- `internal/service/sn_deployment_service.go` — full ServiceNow implementation with validation, UUID↔sysid conversion, and response mapping
- `internal/handler/deployment_handler.go` — `PatchDeployment` handler
- `internal/server/routes.go` — `PATCH /deployments/{id}` registered
- `openapi.yaml` — new path + `UpdateDeploymentRequest`, `UpdateDeploymentResponse`, `UpdatedDeployment` schemas

### csm-portal backend
- `internal/entity/entity.go` — `PatchDeployment` client method
- `internal/handler/deployments.go` — `PatchDeployment` added to interface and handler (auth → UUID guard → body cap → forward → error map)
- `internal/handler/helpers_test.go` — `patchDeploymentFn` field + `PatchDeployment` method added to mock
- `internal/handler/deployments_test.go` — `TestPatchDeployment` covering auth, UUID validation, body size/JSON, happy path, upstream error mapping
- `cmd/server/main.go` — `PATCH /deployments/{id}` registered
- `openapi.yaml` — new path + `DeploymentUpdatePayload`, `DeploymentUpdateResponse` schemas
- `README.md` — endpoint list updated

## Test plan

- [x] `PATCH /deployments/{id}` with `{"name":"new-name"}` updates deployment name
- [x] `PATCH /deployments/{id}` with `{"active":false}` deactivates deployment
- [x] Mixing detail fields and `active` returns 400
- [x] `{"active":true}` returns 400
- [x] Empty body `{}` returns 400
- [x] Non-UUID deployment ID returns 400
- [x] Missing auth returns 401
- [x] All handler unit tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating deployments via `PATCH /deployments/{id}`.
  * Deployment updates can now change key details such as name, type, description, or deactivate a deployment.
  * The API now returns updated deployment information, including who made the change and when.
  * Request validation and error handling were added for invalid IDs, malformed requests, and oversized payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->