### PR TITLE
[CSM Portal][BE] feat: add POST /deployments endpoint via entity service

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -194,6 +194,7 @@ backend/
 
 ### Deployments
 
+- `POST /deployments` — Create a deployment (ServiceNow data source only)
 - `PATCH /deployments/{id}` — Update a deployment (name, typeKey, description, or deactivate; ServiceNow data source only)
 - `POST /deployments/search` — Search deployments
 - `POST /deployments/{id}/products/search` — Search deployed products

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -109,6 +109,7 @@ func main() {
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
+	mux.HandleFunc("POST /deployments", deploymentHandler.PostDeployment)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("PATCH /deployments/{id}", deploymentHandler.PatchDeployment)
 	mux.HandleFunc("POST /deployments/{id}/products/search", deploymentHandler.SearchDeployedProducts)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -101,6 +101,12 @@ func (c *Client) SearchProductVersions(ctx context.Context, productID string, bo
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/products/%s/versions/search", url.PathEscape(productID)), body)
 }
 
+// PostDeployment calls POST /deployments on the entity service to create a new deployment.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/deployments", body)
+}
+
 // PatchDeployment calls PATCH /deployments/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) PatchDeployment(ctx context.Context, deploymentID string, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/deployments.go
+++ b/apps/csm-portal/backend/internal/handler/deployments.go
@@ -46,6 +46,7 @@ func injectDeploymentID(body []byte, deploymentID string) ([]byte, error) {
 
 // entityDeploymentClient abstracts the entity service deployment operations used by DeploymentHandler.
 type entityDeploymentClient interface {
+	PostDeployment(ctx context.Context, body []byte) ([]byte, error)
 	SearchDeployments(ctx context.Context, body []byte) ([]byte, error)
 	SearchDeployedProducts(ctx context.Context, body []byte) ([]byte, error)
 	PatchDeployment(ctx context.Context, deploymentID string, body []byte) ([]byte, error)
@@ -60,6 +61,42 @@ type DeploymentHandler struct {
 // NewDeploymentHandler creates a DeploymentHandler backed by the given entity client.
 func NewDeploymentHandler(entity entityDeploymentClient) *DeploymentHandler {
 	return &DeploymentHandler{entity: entity}
+}
+
+// PostDeployment handles POST /deployments.
+// Forwards the request body directly to the entity service and returns 201 on success.
+func (h *DeploymentHandler) PostDeployment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.PostDeployment(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity PostDeployment failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to create deployment.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
 }
 
 // PatchDeployment handles PATCH /deployments/{id}.

--- a/apps/csm-portal/backend/internal/handler/deployments_test.go
+++ b/apps/csm-portal/backend/internal/handler/deployments_test.go
@@ -25,6 +25,84 @@ import (
 	"testing"
 )
 
+func TestPostDeployment(t *testing.T) {
+	const validBody = `{"projectId":"11111111-1111-1111-1111-111111111111","name":"Prod","typeKey":1,"description":"Main prod deployment"}`
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := httptest.NewRequest(http.MethodPost, "/deployments", strings.NewReader(validBody))
+		w := httptest.NewRecorder()
+		h.PostDeployment(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.PostDeployment(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewDeploymentHandler(&mockEntityDeploymentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.PostDeployment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 201", func(t *testing.T) {
+		var capturedBody []byte
+		client := &mockEntityDeploymentClient{
+			postDeploymentFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"message":"Deployment created successfully","deployment":{"id":"11111111-1111-1111-1111-111111111111","createdOn":"2026-06-26T00:00:00Z","createdBy":"user@wso2.com"}}`), nil
+			},
+		}
+		h := NewDeploymentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/deployments", strings.NewReader(validBody)))
+		w := httptest.NewRecorder()
+		h.PostDeployment(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != validBody {
+			t.Errorf("upstream received body %q, want %q", capturedBody, validBody)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["message"] != "Deployment created successfully" {
+			t.Errorf("message = %v, want %q", resp["message"], "Deployment created successfully")
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to create deployment.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityDeploymentClient{
+					postDeploymentFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewDeploymentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/deployments", strings.NewReader(validBody)))
+				w := httptest.NewRecorder()
+				h.PostDeployment(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestSearchDeployments(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewDeploymentHandler(&mockEntityDeploymentClient{})

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -301,9 +301,17 @@ func (m *mockEntityChangeRequestClient) GetChangeRequest(ctx context.Context, id
 // ----- mock entity deployment client -----
 
 type mockEntityDeploymentClient struct {
+	postDeploymentFn         func(ctx context.Context, body []byte) ([]byte, error)
 	searchDeploymentsFn      func(ctx context.Context, body []byte) ([]byte, error)
 	searchDeployedProductsFn func(ctx context.Context, body []byte) ([]byte, error)
 	patchDeploymentFn        func(ctx context.Context, deploymentID string, body []byte) ([]byte, error)
+}
+
+func (m *mockEntityDeploymentClient) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {
+	if m.postDeploymentFn != nil {
+		return m.postDeploymentFn(ctx, body)
+	}
+	return []byte(`{}`), nil
 }
 
 func (m *mockEntityDeploymentClient) SearchDeployments(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -865,6 +865,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /deployments:
+    post:
+      summary: Create a new deployment.
+      operationId: postDeployment
+      requestBody:
+        description: Deployment creation payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeploymentCreatePayload'
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /deployments/{id}:
     patch:
       summary: Update a deployment's name, type, description, or deactivate it.
@@ -2247,6 +2296,41 @@ components:
         updatedOn:
           type: string
           format: date-time
+
+    DeploymentCreatePayload:
+      type: object
+      required: [projectId, name, typeKey, description]
+      properties:
+        projectId:
+          type: string
+          format: uuid
+          description: UUID of the project this deployment belongs to.
+        name:
+          type: string
+          description: Display name of the deployment.
+        typeKey:
+          type: integer
+          description: ServiceNow deployment type integer key.
+        description:
+          type: string
+          description: Description of the deployment.
+
+    DeploymentCreateResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        deployment:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            createdOn:
+              type: string
+              format: date-time
+            createdBy:
+              type: string
 
     DeploymentUpdatePayload:
       oneOf:

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -350,6 +350,28 @@ type SearchDeploymentsResponse struct {
 	HasMore     bool             `json:"hasMore"`
 }
 
+// CreateDeploymentRequest is the input for POST /deployments.
+// All four fields are required.
+type CreateDeploymentRequest struct {
+	ProjectID   string `json:"projectId"`
+	Name        string `json:"name"`
+	TypeKey     int    `json:"typeKey"`
+	Description string `json:"description"`
+}
+
+// CreateDeploymentResponse is the response for POST /deployments.
+type CreateDeploymentResponse struct {
+	Message    string            `json:"message"`
+	Deployment CreatedDeployment `json:"deployment"`
+}
+
+// CreatedDeployment carries the key fields of a newly created deployment.
+type CreatedDeployment struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
+}
+
 // UpdateDeploymentRequest is the input for PATCH /deployments/{id}.
 // Either detail fields (Name, TypeKey, Description) or Active (to deactivate) must be provided,
 // but not both groups in the same request. Active can only be set to false.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -351,11 +351,12 @@ type SearchDeploymentsResponse struct {
 }
 
 // CreateDeploymentRequest is the input for POST /deployments.
-// All four fields are required.
+// All four fields are required. TypeKey uses a pointer to distinguish an omitted
+// field from an explicit value (including 0).
 type CreateDeploymentRequest struct {
 	ProjectID   string `json:"projectId"`
 	Name        string `json:"name"`
-	TypeKey     int    `json:"typeKey"`
+	TypeKey     *int   `json:"typeKey"`
 	Description string `json:"description"`
 }
 

--- a/entity-service/internal/handler/deployment_handler.go
+++ b/entity-service/internal/handler/deployment_handler.go
@@ -35,6 +35,22 @@ func NewDeploymentHandler(svc service.DeploymentService) *DeploymentHandler {
 	return &DeploymentHandler{svc: svc}
 }
 
+// CreateDeployment handles POST /deployments.
+func (h *DeploymentHandler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
+	var req domain.CreateDeploymentRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.CreateDeployment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // PatchDeployment handles PATCH /deployments/{id}.
 // Accepts name, typeKey, description (detail fields) or active=false (deactivation), but not both groups.
 func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Request) {

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -117,6 +117,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productVersionHandler.SearchProductVersions)
+	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("PATCH /deployments/{id}", deploymentHandler.PatchDeployment)
 	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)

--- a/entity-service/internal/service/deployment_service.go
+++ b/entity-service/internal/service/deployment_service.go
@@ -34,6 +34,11 @@ func NewDeploymentService(repo repository.DeploymentRepository) DeploymentServic
 	return &deploymentService{repo: repo}
 }
 
+// CreateDeployment implements DeploymentService. Not supported for the PostgreSQL data source.
+func (s *deploymentService) CreateDeployment(_ context.Context, _ domain.CreateDeploymentRequest) (domain.CreateDeploymentResponse, error) {
+	return domain.CreateDeploymentResponse{}, &apierror.ValidationError{Msg: "CreateDeployment is not supported for the PostgreSQL data source"}
+}
+
 // UpdateDeployment implements DeploymentService. Not supported for the PostgreSQL data source.
 func (s *deploymentService) UpdateDeployment(_ context.Context, _ domain.UpdateDeploymentRequest) (domain.UpdateDeploymentResponse, error) {
 	return domain.UpdateDeploymentResponse{}, &apierror.ValidationError{Msg: "UpdateDeployment is not supported for the PostgreSQL data source"}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -78,6 +78,9 @@ type DeploymentService interface {
 	// project IDs, deployment type keys, and name search query. A ValidationError is
 	// returned for invalid input; any other error indicates an infrastructure failure.
 	SearchDeployments(ctx context.Context, req domain.SearchDeploymentsRequest) (domain.SearchDeploymentsResponse, error)
+	// CreateDeployment creates a new deployment in ServiceNow.
+	// Supported by the ServiceNow data source only.
+	CreateDeployment(ctx context.Context, req domain.CreateDeploymentRequest) (domain.CreateDeploymentResponse, error)
 	// UpdateDeployment updates a deployment's name, type, description, or deactivates it.
 	// Either detail fields or Active=false must be provided, but not both.
 	// Supported by the ServiceNow data source only.

--- a/entity-service/internal/service/sn_deployment_service.go
+++ b/entity-service/internal/service/sn_deployment_service.go
@@ -149,7 +149,7 @@ func (s *snDeploymentService) SearchDeployments(ctx context.Context, req domain.
 type snCreateDeploymentPayload struct {
 	ProjectID   string `json:"projectId"`
 	Name        string `json:"name"`
-	TypeKey     int    `json:"typeKey"`
+	TypeKey     int    `json:"typeKey"` // always set after nil-check in CreateDeployment
 	Description string `json:"description"`
 }
 
@@ -170,7 +170,7 @@ func (s *snDeploymentService) CreateDeployment(ctx context.Context, req domain.C
 	if req.Name == "" {
 		return domain.CreateDeploymentResponse{}, &apierror.ValidationError{Msg: "name is required"}
 	}
-	if req.TypeKey == 0 {
+	if req.TypeKey == nil {
 		return domain.CreateDeploymentResponse{}, &apierror.ValidationError{Msg: "typeKey is required"}
 	}
 	if req.Description == "" {
@@ -185,7 +185,7 @@ func (s *snDeploymentService) CreateDeployment(ctx context.Context, req domain.C
 	payload := snCreateDeploymentPayload{
 		ProjectID:   uuidToSysid(req.ProjectID),
 		Name:        req.Name,
-		TypeKey:     req.TypeKey,
+		TypeKey:     *req.TypeKey,
 		Description: req.Description,
 	}
 

--- a/entity-service/internal/service/sn_deployment_service.go
+++ b/entity-service/internal/service/sn_deployment_service.go
@@ -145,6 +145,75 @@ func (s *snDeploymentService) SearchDeployments(ctx context.Context, req domain.
 	}, nil
 }
 
+// snCreateDeploymentPayload is the Choreo POST /deployments request body.
+type snCreateDeploymentPayload struct {
+	ProjectID   string `json:"projectId"`
+	Name        string `json:"name"`
+	TypeKey     int    `json:"typeKey"`
+	Description string `json:"description"`
+}
+
+type snCreateDeploymentResponse struct {
+	Message    string `json:"message"`
+	Deployment struct {
+		ID        string `json:"id"`
+		CreatedOn string `json:"createdOn"`
+		CreatedBy string `json:"createdBy"`
+	} `json:"deployment"`
+}
+
+// CreateDeployment implements DeploymentService for the ServiceNow data source.
+func (s *snDeploymentService) CreateDeployment(ctx context.Context, req domain.CreateDeploymentRequest) (domain.CreateDeploymentResponse, error) {
+	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
+		return domain.CreateDeploymentResponse{}, err
+	}
+	if req.Name == "" {
+		return domain.CreateDeploymentResponse{}, &apierror.ValidationError{Msg: "name is required"}
+	}
+	if req.TypeKey == 0 {
+		return domain.CreateDeploymentResponse{}, &apierror.ValidationError{Msg: "typeKey is required"}
+	}
+	if req.Description == "" {
+		return domain.CreateDeploymentResponse{}, &apierror.ValidationError{Msg: "description is required"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.CreateDeploymentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snCreateDeploymentPayload{
+		ProjectID:   uuidToSysid(req.ProjectID),
+		Name:        req.Name,
+		TypeKey:     req.TypeKey,
+		Description: req.Description,
+	}
+
+	raw, err := s.client.Post(ctx, "/deployments", token, payload)
+	if err != nil {
+		return domain.CreateDeploymentResponse{}, err
+	}
+
+	var snResp snCreateDeploymentResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CreateDeploymentResponse{}, fmt.Errorf("sn create deployment: parse response: %w", err)
+	}
+
+	createdOn, err := time.Parse(snCreatedOnLayout, snResp.Deployment.CreatedOn)
+	if err != nil {
+		return domain.CreateDeploymentResponse{}, fmt.Errorf("sn create deployment: parse createdOn %q: %w", snResp.Deployment.CreatedOn, err)
+	}
+
+	return domain.CreateDeploymentResponse{
+		Message: snResp.Message,
+		Deployment: domain.CreatedDeployment{
+			ID:        sysidToUUID(snResp.Deployment.ID),
+			CreatedOn: createdOn,
+			CreatedBy: snResp.Deployment.CreatedBy,
+		},
+	}, nil
+}
+
 // snUpdateDeploymentPayload is the Choreo PATCH /deployments/{id} request body.
 // Description is json.RawMessage so an explicit null ("description":null) can be
 // distinguished from an omitted field — omitempty drops nil RawMessage entirely.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -249,6 +249,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /deployments:
+    post:
+      summary: Create a new deployment.
+      operationId: createDeployment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeploymentRequest'
+      responses:
+        "201":
+          description: Deployment created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateDeploymentResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized — x-user-id-token header is missing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /deployments/{id}:
     patch:
       summary: Update a deployment's name, type, description, or deactivate it.
@@ -1275,6 +1311,44 @@ components:
         updatedOn:
           type: string
           format: date-time
+
+    CreateDeploymentRequest:
+      type: object
+      required: [projectId, name, typeKey, description]
+      properties:
+        projectId:
+          type: string
+          format: uuid
+          description: UUID of the project this deployment belongs to.
+        name:
+          type: string
+          description: Display name of the deployment.
+        typeKey:
+          type: integer
+          description: ServiceNow deployment type integer key.
+        description:
+          type: string
+          description: Description of the deployment.
+
+    CreateDeploymentResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        deployment:
+          $ref: '#/components/schemas/CreatedDeployment'
+
+    CreatedDeployment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
 
     UpdateDeploymentRequest:
       oneOf:


### PR DESCRIPTION
## Summary

- **entity-service**: Add `CreateDeployment` to `DeploymentService` interface; ServiceNow implementation validates `projectId` UUID and required `name`/`typeKey`/`description` fields, converts `projectId` to sysid outbound and deployment `id` back to UUID inbound; Postgres stub returns 400
- **csm-portal backend**: Add `PostDeployment` to `entityDeploymentClient` interface and handler with auth check, 1 MiB body cap, JSON validation, upstream error mapping; returns 201 on success
- **openapi.yaml** (both services): `CreateDeploymentRequest`/`CreateDeploymentResponse` schemas; `POST /deployments` path with 201/400/401/403/413/500 responses
- **README**: Document `POST /deployments` in the Deployments section

## Test plan

- [ ] `POST /deployments` with valid body returns 201 and deployment details
- [ ] Missing/empty required fields (`projectId`, `name`, `typeKey`, `description`) return 400
- [ ] Non-UUID `projectId` returns 400
- [ ] Request without auth token returns 401
- [ ] Body exceeding 1 MiB returns 413
- [ ] Invalid JSON body returns 400
- [ ] Upstream errors (404, 500) are mapped correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating deployments through a new `POST /deployments` endpoint.
  * The API now accepts deployment details and returns the created deployment information on success.

* **Bug Fixes**
  * Requests are now validated for JSON format, required fields, and maximum size, with clear error responses for unauthorized or invalid submissions.

* **Documentation**
  * Updated API documentation to include the new deployment creation endpoint and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->