### PR TITLE
[CSM Portal][BE] fix: split auto-label-assign into two steps to handle assignee 403

### DIFF
--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -28,7 +28,7 @@ jobs:
       issues: write
       contents: read
     steps:
-      - name: Apply labels and assignee
+      - name: Apply labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -71,15 +71,18 @@ jobs:
               });
             }
 
-            // Assign the PR author
-            try {
-              await github.rest.issues.addAssignees({
-                owner,
-                repo,
-                issue_number: prNumber,
-                assignees: [pr.user.login],
-              });
-              core.info(`Assigned: ${pr.user.login}`);
-            } catch (error) {
-              core.warning(`Could not assign ${pr.user.login}: ${error.message}`);
-            }
+      - name: Assign PR author
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: pr.number,
+              assignees: [pr.user.login],
+            });
+            core.info(`Assigned: ${pr.user.login}`);


### PR DESCRIPTION
## Summary
- Splits the single `Apply labels and assignee` step into two separate steps: `Apply labels` and `Assign PR author`
- Adds `continue-on-error: true` to the assign step so a 403 (common when org-level workflow token permissions are read-only) does not block labeling

## Root cause
`GITHUB_TOKEN` in org repos is capped at whatever the org's "Workflow permissions" setting allows. If that's read-only, the `issues: write` permission declared in the workflow has no effect, causing a 403 on the assignees endpoint. Separating the steps ensures labeling still succeeds.

## Test plan
- [ ] Open a PR targeting `v2` and verify labels are applied correctly
- [ ] Verify the assign step shows `continue-on-error` when GITHUB_TOKEN lacks assignee write access
- [ ] If org admin sets workflow permissions to read+write, verify both steps succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request automation so label application and author assignment run independently.
  * Made author assignment more resilient, reducing the chance that a failure stops the rest of the workflow.
  * Preserved assignment logging while keeping the process more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->