### PR TITLE
[CSM Portal][FE] feat: implement engagements search and detail navigation

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -75,6 +75,7 @@ describe("writeCasesFiltersToUrl", () => {
       caseTypes: ["service_request"],
       assignees: ["carol@example.com"],
       projects: ["streaming"],
+      engagementTypes: [],
     };
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
     expect(round).toEqual(filters);


### PR DESCRIPTION
## Summary

- Replaces the coming-soon placeholder at `/engagements` with a fully working engagements list backed by `POST /cases/search` (type: engagement)
- Extends `CasesFilters` with `engagementTypes`; adds engagement-type multi-select to `CasesFilterBar` behind `showEngagementTypeFilter` prop
- Persists `engagementTypes` in URL via `casesFiltersUrl` read/write/count
- Threads `detailBasePath` down to `CasesList` row links; `CsmCaseDetailPage` derives back label/path from `location.pathname`
- New `CsmEngagementsPage` using `CsmIssuesView` with locked engagement type
- Fixes TS2741 Choreo build error: adds missing `engagementTypes` field to `casesFiltersUrl` round-trip test

## Test plan

- [ ] Navigate to `/engagements` — list loads correctly with engagement type filter visible
- [ ] Apply engagement type filter, confirm URL updates and results filter
- [ ] Click a row — navigates to `/engagements/:id` with "Back to engagements" label
- [ ] Navigate to `/cases/:id` — "Back to cases" label still shown
- [ ] Choreo build passes (TS2741 error resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)