### PR TITLE
[CSM Portal] Deployment management + deployed-products view

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -182,6 +182,12 @@ export interface BeCaseView {
   /** Nullable: ServiceNow-sourced cases may have no deployment / product. */
   deployment?: BeEntityRef | null;
   deployedProduct?: BeDeployedProductRef | null;
+  /**
+   * The product itself (distinct from {@link deployedProduct}, the
+   * deployment-scoped instance). Populated even when no specific deployed
+   * product is linked, so it's the reliable fallback for the product name.
+   */
+  product?: BeEntityRef | null;
   /** SR catalog refs (managed-cloud); null for non-catalog cases. */
   catalog?: BeEntityRef | null;
   catalogItem?: BeEntityRef | null;
@@ -669,8 +675,38 @@ export interface BeDeployment {
   type?: BeDeploymentType;
   description?: string;
   createdBy?: string;
-  createdAt?: string;
-  updatedAt?: string;
+  createdOn?: string;
+  updatedOn?: string;
+}
+
+/**
+ * Detail-field update for `PATCH /deployments/{id}`. At least one field must be
+ * present (BE rejects an empty body). `description: null` clears the value.
+ * `typeKey` (the ServiceNow deployment-type integer) is intentionally omitted:
+ * no endpoint exposes the type→key mapping, so type changes are deferred until
+ * the BE either accepts the string `type` enum or exposes a types lookup.
+ */
+export interface BeDeploymentDetailUpdatePayload {
+  name?: string;
+  description?: string | null;
+}
+
+/** Deactivation for `PATCH /deployments/{id}`: `active` must be `false`, alone. */
+export interface BeDeploymentDeactivatePayload {
+  active: false;
+}
+
+export type BeDeploymentUpdatePayload =
+  | BeDeploymentDetailUpdatePayload
+  | BeDeploymentDeactivatePayload;
+
+export interface BeDeploymentUpdateResponse {
+  message: string;
+  deployment: {
+    id: string;
+    updatedOn: string;
+    updatedBy: string;
+  };
 }
 
 export interface BeDeploymentSearchPayload {
@@ -750,8 +786,10 @@ export interface BeDeployedProduct {
   deployment?: BeEntityRef;
   product?: BeEntityRef;
   version?: BeDeployedProductVersion | null;
-  cores?: number | null;
-  tps?: number | null;
+  // SN-only sizing fields; the entity service returns them as strings (and
+  // always null for the Postgres data source).
+  cores?: string | null;
+  tps?: string | null;
   category?: string | null;
   createdOn?: string;
   updatedOn?: string;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -682,18 +682,24 @@ export interface BeDeployment {
 /**
  * Detail-field update for `PATCH /deployments/{id}`. At least one field must be
  * present (BE rejects an empty body). `description: null` clears the value.
- * `typeKey` (the ServiceNow deployment-type integer) is intentionally omitted:
- * no endpoint exposes the type→key mapping, so type changes are deferred until
- * the BE either accepts the string `type` enum or exposes a types lookup.
+ * `active` is forbidden on this variant — use `BeDeploymentDeactivatePayload`.
+ *
+ * Per PR #957: the BE now accepts the string `type` enum directly, so
+ * `typeKey` (the old integer) is gone.
  */
-export interface BeDeploymentDetailUpdatePayload {
+export type BeDeploymentDetailUpdatePayload = {
   name?: string;
+  type?: BeDeploymentType;
   description?: string | null;
-}
+  active?: never;
+} & ({ name: string } | { type: BeDeploymentType } | { description: string | null });
 
 /** Deactivation for `PATCH /deployments/{id}`: `active` must be `false`, alone. */
 export interface BeDeploymentDeactivatePayload {
   active: false;
+  name?: never;
+  type?: never;
+  description?: never;
 }
 
 export type BeDeploymentUpdatePayload =
@@ -706,6 +712,30 @@ export interface BeDeploymentUpdateResponse {
     id: string;
     updatedOn: string;
     updatedBy: string;
+  };
+}
+
+/**
+ * Request body for `POST /deployments`. All four fields are required per the
+ * BE contract (PR #957: `type` is the string enum, `typeKey` integer is gone).
+ */
+export interface BeDeploymentCreatePayload {
+  projectId: string;
+  name: string;
+  type: BeDeploymentType;
+  description: string;
+}
+
+export interface BeDeploymentCreateResponse {
+  message: string;
+  deployment: {
+    id: string;
+    projectId: string;
+    name: string;
+    type: BeDeploymentType;
+    description: string;
+    createdOn: string;
+    createdBy: string;
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -48,7 +48,10 @@ function detailFromBeCase(
     !!assigneeEmail &&
     !!currentUserEmail &&
     assigneeEmail.toLowerCase() === currentUserEmail.toLowerCase();
-  const product = c.deployedProduct?.displayName ?? "—";
+  // Prefer the deployed-product label (carries the version); fall back to the
+  // plain product name, which the CaseView populates even when no specific
+  // deployed product is linked. `||` so an empty displayName also falls through.
+  const product = c.deployedProduct?.displayName || c.product?.name || "—";
   return {
     id: c.id,
     caseNumber: c.number,
@@ -92,6 +95,7 @@ function detailFromBeCase(
       product,
       version: "—",
       deployment: c.deployment?.name ?? "—",
+      deploymentId: c.deployment?.id,
       environment: "prod",
     },
     slaClocks: [],

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -16,11 +16,12 @@
 
 import { Box, Card, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
-import type { JSX, ReactNode } from "react";
+import { useState, type JSX, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
 import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import SemanticChip from "@components/SemanticChip";
+import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
@@ -104,6 +105,48 @@ function LinkText({
   );
 }
 
+// Same link styling as LinkText, but a real <button> for in-page actions
+// (opening a dialog) rather than navigation — so it's keyboard-operable and
+// announced as a button, not a link.
+function LinkButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Typography
+      component="button"
+      type="button"
+      onClick={onClick}
+      variant="body2"
+      noWrap
+      sx={(t) => ({
+        display: "block",
+        cursor: "pointer",
+        textAlign: "left",
+        padding: 0,
+        border: "none",
+        background: "none",
+        font: "inherit",
+        textDecoration: "none",
+        color: t.palette.primary.dark,
+        ...t.applyStyles("dark", { color: t.palette.primary.main }),
+        "&:hover": { textDecoration: "underline" },
+        "&:focus-visible": {
+          outline: "2px solid",
+          outlineColor: "primary.main",
+          outlineOffset: 2,
+          borderRadius: 0.5,
+        },
+      })}
+    >
+      {children}
+    </Typography>
+  );
+}
+
 /**
  * Always-visible facts band shown directly under the case header. Engineers
  * see assignee, project type, deployment/product, who created the case, and
@@ -117,6 +160,7 @@ export default function CaseMetaBand({
 }: CaseMetaBandProps): JSX.Element {
   const product = c.productContext;
   const tier = c.customerContext.tier;
+  const [showDeployment, setShowDeployment] = useState(false);
   // Project type is encoded as the second " - "-delimited segment of the
   // project name (e.g. "Acme - Managed Cloud" → "Managed Cloud"). Temporary
   // until the backend exposes it as a first-class field.
@@ -235,9 +279,15 @@ export default function CaseMetaBand({
             </Typography>
           </Cell>
           <Cell label="Deployment">
-            <Typography variant="body2" noWrap>
-              {product.deployment ?? "—"}
-            </Typography>
+            {product.deploymentId ? (
+              <LinkButton onClick={() => setShowDeployment(true)}>
+                {product.deployment}
+              </LinkButton>
+            ) : (
+              <Typography variant="body2" noWrap>
+                {product.deployment ?? "—"}
+              </Typography>
+            )}
           </Cell>
           <Cell label="Product">
             <Typography variant="body2" noWrap>
@@ -245,6 +295,17 @@ export default function CaseMetaBand({
             </Typography>
           </Cell>
         </Box>
+      )}
+
+      {showDeployment && product.deploymentId && (
+        <DeploymentDetailsDialog
+          deployment={{
+            id: product.deploymentId,
+            name: product.deployment,
+            type: product.deploymentCategory,
+          }}
+          onClose={() => setShowDeployment(false)}
+        />
       )}
     </Card>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -22,6 +22,7 @@ import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import SemanticChip from "@components/SemanticChip";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
+import type { BeDeploymentType } from "@api/backend/types";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
@@ -302,7 +303,9 @@ export default function CaseMetaBand({
           deployment={{
             id: product.deploymentId,
             name: product.deployment,
-            type: product.deploymentCategory,
+            // DeploymentCategory and BeDeploymentType share the same string
+            // literal values. Cast so the dialog receives the right type.
+            type: product.deploymentCategory as BeDeploymentType | undefined,
           }}
           onClose={() => setShowDeployment(false)}
         />

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -573,7 +573,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         sticky: false,
       });
     },
-    [data, showError, patchCase, findMyOngoingCases],
+    [data, showError, patchCase, findMyOngoingCases, detailPath],
   );
 
   // Confirm pausing the engineer's other ongoing case(s) and making this case

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -217,6 +217,8 @@ export interface CaseProductContext {
   updateLevel?: string;
   /** Customer-provided deployment name (set by the customer in the project). */
   deployment: string;
+  /** Deployment UUID, when the case is linked to one — drives the detail link. */
+  deploymentId?: string;
   /** Fixed-list classification of the deployment (e.g. Primary Production). */
   deploymentCategory?: DeploymentCategory;
   environment: "dev" | "qa" | "staging" | "prod";

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -39,6 +39,7 @@ describe("readCasesFiltersFromUrl", () => {
       severities: ["S0", "S2"],
       states: ["open", "closed"],
       caseTypes: ["case", "engagement"],
+      engagementTypes: [],
       assignees: ["alice@example.com", "@me"],
       projects: ["apim"],
     });

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeployment.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeployment.ts
@@ -22,33 +22,27 @@ import {
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
-  BeDeploymentUpdatePayload,
-  BeDeploymentUpdateResponse,
+  BeDeploymentCreatePayload,
+  BeDeploymentCreateResponse,
 } from "@api/backend/types";
 
-interface UpdateDeploymentInput {
-  deploymentId: string;
-  payload: BeDeploymentUpdatePayload;
-}
-
 /**
- * Update a deployment via `PATCH /deployments/{id}` — either detail fields
- * (`name`, `type`, `description`) or deactivation (`active: false`). The
- * backend rejects mixing the two, so callers send one shape per call. On
- * success we invalidate the project's deployment list so the table refetches
- * the authoritative state (a deactivated deployment drops out of the active
- * list). `type` is the string enum per PR #957 (no `typeKey` integer).
+ * Create a deployment via `POST /deployments`. On success we invalidate the
+ * project's deployment list so the table refetches the authoritative state.
+ *
+ * Contract: per PR #957, the BE accepts the string `type` enum directly
+ * (e.g. `"staging"`). The old `typeKey` integer field is gone.
  */
-export function useUpdateDeployment(
+export function useCreateDeployment(
   projectId: string | undefined,
-): UseMutationResult<BeDeploymentUpdateResponse, Error, UpdateDeploymentInput> {
+): UseMutationResult<BeDeploymentCreateResponse, Error, BeDeploymentCreatePayload> {
   const api = useBackendApi();
   const queryClient = useQueryClient();
 
-  return useMutation<BeDeploymentUpdateResponse, Error, UpdateDeploymentInput>({
-    mutationFn: ({ deploymentId, payload }): Promise<BeDeploymentUpdateResponse> =>
-      api.patch<BeDeploymentUpdatePayload, BeDeploymentUpdateResponse>(
-        `/deployments/${encodeURIComponent(deploymentId)}`,
+  return useMutation<BeDeploymentCreateResponse, Error, BeDeploymentCreatePayload>({
+    mutationFn: (payload): Promise<BeDeploymentCreateResponse> =>
+      api.post<BeDeploymentCreatePayload, BeDeploymentCreateResponse>(
+        "/deployments",
         payload,
       ),
     onSuccess: () => {

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchDeployedProducts.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchDeployedProducts.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDeployedProduct,
+  BeDeployedProductSearchPayload,
+  BeDeployedProductSearchResponse,
+} from "@api/backend/types";
+
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+
+/**
+ * Full deployed-product records for a deployment, via
+ * `POST /deployments/{id}/products/search`. Each record embeds the resolved
+ * `product` and `version`, plus the SN-only `cores`/`tps`/`category`, so the
+ * details panel can render them without secondary lookups.
+ *
+ * Distinct from {@link useDeployedProductOptions}, which keys the same endpoint
+ * but returns a label-only shape for the case-create selector — hence the
+ * `"records"` query-key suffix so the two caches don't collide. The query is
+ * disabled until a deployment id is provided (the panel only mounts when its
+ * row is expanded, so the request is naturally lazy).
+ */
+export function useSearchDeployedProducts(
+  deploymentId: string | undefined,
+): UseQueryResult<BeDeployedProduct[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeDeployedProduct[], Error>({
+    queryKey: [ApiQueryKeys.DEPLOYMENT_PRODUCTS, deploymentId ?? "", "records"],
+    queryFn: async (): Promise<BeDeployedProduct[]> => {
+      const all: BeDeployedProduct[] = [];
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const res = await api.post<
+          BeDeployedProductSearchPayload,
+          BeDeployedProductSearchResponse
+        >(
+          `/deployments/${encodeURIComponent(deploymentId as string)}/products/search`,
+          { pagination: { offset, limit: PAGE_LIMIT } },
+        );
+        const page = res.deployedProducts ?? [];
+        all.push(...page);
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return all;
+    },
+    enabled: !!deploymentId,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeployment.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeployment.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDeploymentUpdatePayload,
+  BeDeploymentUpdateResponse,
+} from "@api/backend/types";
+
+interface UpdateDeploymentInput {
+  deploymentId: string;
+  payload: BeDeploymentUpdatePayload;
+}
+
+/**
+ * Update a deployment via `PATCH /deployments/{id}` — either detail fields
+ * (`name` / `description`) or deactivation (`active: false`). The backend
+ * rejects mixing the two, so callers send one shape per call. On success we
+ * invalidate the project's deployment list so the table refetches the
+ * authoritative state (a deactivated deployment drops out of the active list).
+ *
+ * `typeKey` (deployment type) is not handled here — see the note on
+ * {@link BeDeploymentDetailUpdatePayload}.
+ */
+export function useUpdateDeployment(
+  projectId: string | undefined,
+): UseMutationResult<BeDeploymentUpdateResponse, Error, UpdateDeploymentInput> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BeDeploymentUpdateResponse, Error, UpdateDeploymentInput>({
+    mutationFn: ({ deploymentId, payload }): Promise<BeDeploymentUpdateResponse> =>
+      api.patch<BeDeploymentUpdatePayload, BeDeploymentUpdateResponse>(
+        `/deployments/${encodeURIComponent(deploymentId)}`,
+        payload,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.DEPLOYMENTS, projectId ?? ""],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeploymentDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeploymentDialog.test.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import CreateDeploymentDialog from "@features/csm-projects/components/CreateDeploymentDialog";
+
+const PROJECT_ID = "33333333-3333-3333-3333-333333333333";
+
+function renderDialog() {
+  const onCreate = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <CreateDeploymentDialog
+      projectId={PROJECT_ID}
+      isSaving={false}
+      onClose={onClose}
+      onCreate={onCreate}
+    />,
+  );
+  return { onCreate, onClose };
+}
+
+const createButton = (): HTMLElement =>
+  screen.getByRole("button", { name: /^create$/i });
+
+describe("CreateDeploymentDialog", () => {
+  it("disables Create when no fields are filled", () => {
+    renderDialog();
+    expect(createButton()).toBeDisabled();
+  });
+
+  it("disables Create when type is missing", () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "My deployment" },
+    });
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Some description" },
+    });
+    expect(createButton()).toBeDisabled();
+  });
+
+  it("disables Create when name is missing", () => {
+    renderDialog();
+    // Select a type.
+    const typeSelect = screen.getByRole("combobox", { name: /type/i });
+    fireEvent.mouseDown(typeSelect);
+    fireEvent.click(screen.getByRole("option", { name: /staging/i }));
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Some description" },
+    });
+    expect(createButton()).toBeDisabled();
+  });
+
+  it("enables Create and fires onCreate with the correct payload", () => {
+    const { onCreate } = renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "  QA env  " },
+    });
+
+    const typeSelect = screen.getByRole("combobox", { name: /type/i });
+    fireEvent.mouseDown(typeSelect);
+    fireEvent.click(screen.getByRole("option", { name: /^qa$/i }));
+
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "QA environment" },
+    });
+
+    fireEvent.click(createButton());
+    expect(onCreate).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      name: "QA env",
+      type: "qa",
+      description: "QA environment",
+    });
+  });
+
+  it("renders a type selector with all 6 deployment types", () => {
+    renderDialog();
+    const typeSelect = screen.getByRole("combobox", { name: /type/i });
+    fireEvent.mouseDown(typeSelect);
+    expect(screen.getByRole("option", { name: /primary production/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /staging/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /^qa$/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /stress/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /uat/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /development/i })).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const { onClose } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeploymentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeploymentDialog.tsx
@@ -22,26 +22,24 @@ import {
   DialogContent,
   DialogTitle,
   FormControl,
+  FormHelperText,
   InputLabel,
   MenuItem,
   Select,
   TextField,
 } from "@wso2/oxygen-ui";
-import { useMemo, useState, type JSX } from "react";
-import type {
-  BeDeployment,
-  BeDeploymentDetailUpdatePayload,
-  BeDeploymentType,
-} from "@api/backend/types";
+import { useState, type JSX } from "react";
+import type { BeDeploymentCreatePayload, BeDeploymentType } from "@api/backend/types";
 import { deploymentTypeLabel } from "@features/csm-projects/utils/deployments";
 
-interface EditDeploymentDialogProps {
-  deployment: BeDeployment;
-  /** True while the PATCH is in flight; disables the actions. */
+interface CreateDeploymentDialogProps {
+  /** The project this deployment belongs to (pre-populated, read-only). */
+  projectId: string;
+  /** True while the POST is in flight; disables the actions. */
   isSaving: boolean;
   onClose: () => void;
-  /** Persist the changed detail fields via `PATCH /deployments/{id}`. */
-  onSave: (payload: BeDeploymentDetailUpdatePayload) => void;
+  /** Submit the create payload via `POST /deployments`. */
+  onCreate: (payload: BeDeploymentCreatePayload) => void;
 }
 
 const NAME_MAX = 200;
@@ -57,51 +55,44 @@ const DEPLOYMENT_TYPES: BeDeploymentType[] = [
 ];
 
 /**
- * Edit a deployment's name, type, and description (`PATCH /deployments/{id}`
- * detail fields). Type is now a string enum per the BE contract introduced in
- * PR #957 — `typeKey` integer is gone. Mount only while open.
+ * Create a new deployment under the current project. All four fields are
+ * required per `POST /deployments`. The project is locked to the page context;
+ * `type` is the string enum introduced by PR #957 (no `typeKey` integer).
+ * Mount only while open.
  */
-export default function EditDeploymentDialog({
-  deployment,
+export default function CreateDeploymentDialog({
+  projectId,
   isSaving,
   onClose,
-  onSave,
-}: EditDeploymentDialogProps): JSX.Element {
-  const [name, setName] = useState(deployment.name ?? "");
-  const [type, setType] = useState<BeDeploymentType | "">(deployment.type ?? "");
-  const [description, setDescription] = useState(deployment.description ?? "");
+  onCreate,
+}: CreateDeploymentDialogProps): JSX.Element {
+  const [name, setName] = useState("");
+  const [type, setType] = useState<BeDeploymentType | "">("");
+  const [description, setDescription] = useState("");
 
   const trimmedName = name.trim();
   const trimmedDescription = description.trim();
-  const originalName = (deployment.name ?? "").trim();
-  const originalType = deployment.type ?? "";
-  const originalDescription = (deployment.description ?? "").trim();
-
-  const nameChanged = trimmedName !== originalName;
-  const typeChanged = type !== originalType;
-  const descriptionChanged = trimmedDescription !== originalDescription;
   const nameError = trimmedName.length === 0;
+  const typeError = type === "";
+  const descriptionError = trimmedDescription.length === 0;
 
-  // Send only the fields the user actually changed. The backend requires at
-  // least one field, so Save stays disabled until something differs.
-  const payload = useMemo<BeDeploymentDetailUpdatePayload>(() => {
-    const next: Record<string, unknown> = {};
-    if (nameChanged) next.name = trimmedName;
-    if (typeChanged && type) next.type = type;
-    // An emptied description clears the value (null), matching the BE's
-    // nullable detail field.
-    if (descriptionChanged) {
-      next.description = trimmedDescription.length > 0 ? trimmedDescription : null;
-    }
-    return next as BeDeploymentDetailUpdatePayload;
-  }, [nameChanged, typeChanged, descriptionChanged, trimmedName, type, trimmedDescription]);
-
+  // All four fields required by the BE contract.
   const canSave =
-    !isSaving && !nameError && (nameChanged || typeChanged || descriptionChanged);
+    !isSaving && !nameError && !typeError && !descriptionError;
+
+  const handleCreate = (): void => {
+    if (!canSave || !type) return;
+    onCreate({
+      projectId,
+      name: trimmedName,
+      type,
+      description: trimmedDescription,
+    });
+  };
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Edit deployment</DialogTitle>
+      <DialogTitle>Create deployment</DialogTitle>
       <DialogContent dividers>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
           <TextField
@@ -112,15 +103,15 @@ export default function EditDeploymentDialog({
             fullWidth
             required
             autoFocus
-            error={nameError}
-            helperText={nameError ? "Name is required." : " "}
+            error={name.length > 0 && nameError}
+            helperText={name.length > 0 && nameError ? "Name is required." : " "}
             slotProps={{ htmlInput: { maxLength: NAME_MAX } }}
           />
 
-          <FormControl size="small" fullWidth required>
-            <InputLabel id="edit-deployment-type-label">Type</InputLabel>
+          <FormControl size="small" fullWidth required error={type === "" && description.length > 0}>
+            <InputLabel id="create-deployment-type-label">Type</InputLabel>
             <Select
-              labelId="edit-deployment-type-label"
+              labelId="create-deployment-type-label"
               label="Type"
               value={type}
               onChange={(e) => setType(e.target.value as BeDeploymentType)}
@@ -131,6 +122,9 @@ export default function EditDeploymentDialog({
                 </MenuItem>
               ))}
             </Select>
+            {type === "" && description.length > 0 && (
+              <FormHelperText>Type is required.</FormHelperText>
+            )}
           </FormControl>
 
           <TextField
@@ -139,8 +133,15 @@ export default function EditDeploymentDialog({
             onChange={(e) => setDescription(e.target.value)}
             size="small"
             fullWidth
+            required
             multiline
             minRows={3}
+            error={description.length > 0 && descriptionError}
+            helperText={
+              description.length > 0 && descriptionError
+                ? "Description is required."
+                : " "
+            }
             slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX } }}
           />
         </Box>
@@ -149,8 +150,12 @@ export default function EditDeploymentDialog({
         <Button onClick={onClose} disabled={isSaving}>
           Cancel
         </Button>
-        <Button variant="contained" disabled={!canSave} onClick={() => onSave(payload)}>
-          Save changes
+        <Button
+          variant="contained"
+          disabled={!canSave}
+          onClick={handleCreate}
+        >
+          Create
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type JSX } from "react";
+import { useSearchDeployedProducts } from "@features/csm-projects/api/useSearchDeployedProducts";
+import { formatDeploymentDate } from "@features/csm-projects/utils/deployments";
+
+interface DeployedProductsPanelProps {
+  deploymentId: string;
+}
+
+/** SN sizing fields arrive as strings; treat null/blank uniformly as "—". */
+function sizingValue(value?: string | null): string {
+  return value?.trim() ? value : "—";
+}
+
+/**
+ * Read-only list of the products deployed in a single deployment
+ * (`POST /deployments/{id}/products/search`). Rendered inside an expanded
+ * deployment row. Mounting it issues the search, so it loads lazily when the
+ * row is expanded.
+ *
+ * Adding, re-versioning, or removing deployed products is not offered: the
+ * backend exposes no write endpoints for deployed products yet.
+ */
+export default function DeployedProductsPanel({
+  deploymentId,
+}: DeployedProductsPanelProps): JSX.Element {
+  const { data, isLoading, isError, error } = useSearchDeployedProducts(deploymentId);
+  const products = data ?? [];
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert severity="error" sx={{ my: 1 }}>
+        Failed to load deployed products:{" "}
+        {error instanceof Error ? error.message : "unknown error"}
+      </Alert>
+    );
+  }
+
+  if (products.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 2, px: 1 }}>
+        No products deployed in this deployment.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box sx={{ py: 1 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4, px: 1 }}
+      >
+        Deployed products
+      </Typography>
+      <Table size="small" sx={{ mt: 0.5 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Product</TableCell>
+            <TableCell>Version</TableCell>
+            <TableCell>Support EOL</TableCell>
+            <TableCell align="right">Cores</TableCell>
+            <TableCell align="right">TPS</TableCell>
+            <TableCell>Category</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {products.map((p) => (
+            <TableRow key={p.id}>
+              <TableCell>{p.product?.name || p.product?.id || "—"}</TableCell>
+              <TableCell>
+                {p.version?.name ? (
+                  <Chip size="small" variant="outlined" label={p.version.name} />
+                ) : (
+                  "—"
+                )}
+              </TableCell>
+              <TableCell>{formatDeploymentDate(p.version?.supportEoLDate)}</TableCell>
+              <TableCell align="right">{sizingValue(p.cores)}</TableCell>
+              <TableCell align="right">{sizingValue(p.tps)}</TableCell>
+              <TableCell>{p.category ?? "—"}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type JSX, type ReactNode } from "react";
+import type { BeDeployment } from "@api/backend/types";
+import {
+  deploymentTypeLabel,
+  formatDeploymentDate,
+} from "@features/csm-projects/utils/deployments";
+import DeployedProductsPanel from "@features/csm-projects/components/DeployedProductsPanel";
+
+interface DeploymentDetailsDialogProps {
+  deployment: BeDeployment;
+  onClose: () => void;
+}
+
+function MetaCell({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+/**
+ * Read-only details for a single deployment: its metadata plus the products
+ * deployed in it (loaded by {@link DeployedProductsPanel} when this dialog
+ * mounts). Editing the deployment and managing deployed products are separate
+ * concerns handled elsewhere / not yet backed by the API.
+ */
+export default function DeploymentDetailsDialog({
+  deployment,
+  onClose,
+}: DeploymentDetailsDialogProps): JSX.Element {
+  // When opened from a case, only id + name are known (no type/description/
+  // dates), so the type chip and meta grid render only when there's data.
+  const hasMeta = !!(
+    deployment.description ||
+    deployment.createdOn ||
+    deployment.updatedOn
+  );
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <span>{deployment.name || "Deployment"}</span>
+          {deployment.type && (
+            <Chip size="small" variant="outlined" label={deploymentTypeLabel(deployment.type)} />
+          )}
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+          {hasMeta && (
+            <Box
+              sx={{
+                display: "grid",
+                gap: 2,
+                gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
+              }}
+            >
+              {deployment.description && (
+                <MetaCell label="Description">
+                  <Typography variant="body2">{deployment.description}</Typography>
+                </MetaCell>
+              )}
+              {deployment.createdOn && (
+                <MetaCell label="Created">
+                  <Typography variant="body2">{formatDeploymentDate(deployment.createdOn)}</Typography>
+                </MetaCell>
+              )}
+              {deployment.updatedOn && (
+                <MetaCell label="Last updated">
+                  <Typography variant="body2">{formatDeploymentDate(deployment.updatedOn)}</Typography>
+                </MetaCell>
+              )}
+            </Box>
+          )}
+
+          <DeployedProductsPanel deploymentId={deployment.id} />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Menu,
+  MenuItem,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Ban, Eye, MoreVertical, Pencil } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
+import { useUpdateDeployment } from "@features/csm-projects/api/useUpdateDeployment";
+import {
+  deploymentTypeLabel,
+  formatDeploymentDate,
+} from "@features/csm-projects/utils/deployments";
+import type {
+  BeDeployment,
+  BeDeploymentDetailUpdatePayload,
+} from "@api/backend/types";
+import EditDeploymentDialog from "@features/csm-projects/components/EditDeploymentDialog";
+import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
+
+/** Columns rendered per deployment row (5 data + actions). */
+const COLUMN_COUNT = 6;
+
+interface DeploymentsTabProps {
+  projectId: string;
+}
+
+interface Feedback {
+  message: string;
+  severity: "success" | "error";
+}
+
+/**
+ * Lists a project's deployments (`POST /deployments/search`) and lets engineers
+ * edit a deployment's name/description or deactivate it (`PATCH
+ * /deployments/{id}`). Creating deployments and changing a deployment's type are
+ * not offered yet: both need the ServiceNow type→key integer, which no endpoint
+ * exposes.
+ */
+export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.Element {
+  const { data, isLoading, isError, error, isFetching } = useSearchDeployments(projectId);
+  const updateDeployment = useUpdateDeployment(projectId);
+
+  // Row-action menu anchored to the deployment whose "⋮" was clicked.
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuTarget, setMenuTarget] = useState<BeDeployment | null>(null);
+  const [editing, setEditing] = useState<BeDeployment | null>(null);
+  const [deactivating, setDeactivating] = useState<BeDeployment | null>(null);
+  const [viewing, setViewing] = useState<BeDeployment | null>(null);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  const deployments = data ?? [];
+
+  const openMenu = (e: React.MouseEvent<HTMLElement>, d: BeDeployment): void => {
+    setMenuAnchor(e.currentTarget);
+    setMenuTarget(d);
+  };
+  const closeMenu = (): void => {
+    setMenuAnchor(null);
+    setMenuTarget(null);
+  };
+
+  const handleSaveEdit = (payload: BeDeploymentDetailUpdatePayload): void => {
+    if (!editing) return;
+    const name = editing.name ?? "this deployment";
+    updateDeployment.mutate(
+      { deploymentId: editing.id, payload },
+      {
+        onSuccess: () => {
+          setEditing(null);
+          setFeedback({ message: `Updated ${name}.`, severity: "success" });
+        },
+        onError: (err) =>
+          setFeedback({
+            message: `Could not update ${name}: ${err.message}`,
+            severity: "error",
+          }),
+      },
+    );
+  };
+
+  const handleDeactivate = (): void => {
+    if (!deactivating) return;
+    const target = deactivating;
+    const name = target.name ?? "this deployment";
+    updateDeployment.mutate(
+      { deploymentId: target.id, payload: { active: false } },
+      {
+        onSuccess: () => {
+          setDeactivating(null);
+          setFeedback({ message: `Deactivated ${name}.`, severity: "success" });
+        },
+        onError: (err) =>
+          setFeedback({
+            message: `Could not deactivate ${name}: ${err.message}`,
+            severity: "error",
+          }),
+      },
+    );
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {feedback && (
+        <Alert severity={feedback.severity} onClose={() => setFeedback(null)}>
+          {feedback.message}
+        </Alert>
+      )}
+
+      {isError && (
+        <Alert severity="error">
+          Failed to load deployments:{" "}
+          {error instanceof Error ? error.message : "unknown error"}
+        </Alert>
+      )}
+
+      <Paper variant="outlined">
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Type</TableCell>
+                <TableCell>Description</TableCell>
+                <TableCell>Created</TableCell>
+                <TableCell>Updated</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={COLUMN_COUNT} align="center" sx={{ py: 4 }}>
+                    <CircularProgress size={24} />
+                  </TableCell>
+                </TableRow>
+              ) : deployments.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={COLUMN_COUNT} align="center" sx={{ py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No deployments for this project.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                deployments.map((d) => (
+                  <TableRow
+                    key={d.id}
+                    hover
+                    onClick={() => setViewing(d)}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    <TableCell>{d.name || "—"}</TableCell>
+                    <TableCell>
+                      <Chip size="small" variant="outlined" label={deploymentTypeLabel(d.type)} />
+                    </TableCell>
+                    <TableCell sx={{ maxWidth: 320 }}>
+                      <Typography variant="body2" color="text.secondary" noWrap title={d.description}>
+                        {d.description || "—"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{formatDeploymentDate(d.createdOn)}</TableCell>
+                    <TableCell>{formatDeploymentDate(d.updatedOn)}</TableCell>
+                    <TableCell align="right">
+                      <Tooltip title="Deployment actions">
+                        <IconButton
+                          size="small"
+                          aria-label={`Actions for ${d.name || "deployment"}`}
+                          onClick={(e) => {
+                            // Keep the row's open-details click from also firing.
+                            e.stopPropagation();
+                            openMenu(e, d);
+                          }}
+                        >
+                          <MoreVertical size={16} />
+                        </IconButton>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      {isFetching && !isLoading && (
+        <Typography variant="caption" color="text.secondary">
+          Updating…
+        </Typography>
+      )}
+
+      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
+        <MenuItem
+          onClick={() => {
+            setViewing(menuTarget);
+            closeMenu();
+          }}
+        >
+          <Eye size={16} style={{ marginRight: 8 }} />
+          View details
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setEditing(menuTarget);
+            closeMenu();
+          }}
+        >
+          <Pencil size={16} style={{ marginRight: 8 }} />
+          Edit details
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setDeactivating(menuTarget);
+            closeMenu();
+          }}
+          sx={{ color: "error.main" }}
+        >
+          <Ban size={16} style={{ marginRight: 8 }} />
+          Deactivate
+        </MenuItem>
+      </Menu>
+
+      {viewing && (
+        <DeploymentDetailsDialog deployment={viewing} onClose={() => setViewing(null)} />
+      )}
+
+      {editing && (
+        <EditDeploymentDialog
+          deployment={editing}
+          isSaving={updateDeployment.isPending}
+          onClose={() => setEditing(null)}
+          onSave={handleSaveEdit}
+        />
+      )}
+
+      <Dialog
+        open={!!deactivating}
+        onClose={() => setDeactivating(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Deactivate deployment</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Deactivate{" "}
+            <Box component="span" sx={{ fontWeight: 600, color: "text.primary" }}>
+              {deactivating?.name || "this deployment"}
+            </Box>
+            ? This marks the deployment inactive in ServiceNow.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeactivating(null)} disabled={updateDeployment.isPending}>
+            Cancel
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={handleDeactivate}
+            disabled={updateDeployment.isPending}
+          >
+            Deactivate
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
@@ -38,10 +38,11 @@ import {
   Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Ban, Eye, MoreVertical, Pencil } from "@wso2/oxygen-ui-icons-react";
+import { Ban, Eye, MoreVertical, Pencil, Plus } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useUpdateDeployment } from "@features/csm-projects/api/useUpdateDeployment";
+import { useCreateDeployment } from "@features/csm-projects/api/useCreateDeployment";
 import {
   deploymentTypeLabel,
   formatDeploymentDate,
@@ -49,9 +50,11 @@ import {
 import type {
   BeDeployment,
   BeDeploymentDetailUpdatePayload,
+  BeDeploymentCreatePayload,
 } from "@api/backend/types";
 import EditDeploymentDialog from "@features/csm-projects/components/EditDeploymentDialog";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
+import CreateDeploymentDialog from "@features/csm-projects/components/CreateDeploymentDialog";
 
 /** Columns rendered per deployment row (5 data + actions). */
 const COLUMN_COUNT = 6;
@@ -67,14 +70,13 @@ interface Feedback {
 
 /**
  * Lists a project's deployments (`POST /deployments/search`) and lets engineers
- * edit a deployment's name/description or deactivate it (`PATCH
- * /deployments/{id}`). Creating deployments and changing a deployment's type are
- * not offered yet: both need the ServiceNow type→key integer, which no endpoint
- * exposes.
+ * create, edit, or deactivate deployments. Type is editable via a select
+ * (string enum per PR #957; `typeKey` integer is gone).
  */
 export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.Element {
   const { data, isLoading, isError, error, isFetching } = useSearchDeployments(projectId);
   const updateDeployment = useUpdateDeployment(projectId);
+  const createDeployment = useCreateDeployment(projectId);
 
   // Row-action menu anchored to the deployment whose "⋮" was clicked.
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
@@ -82,6 +84,7 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
   const [editing, setEditing] = useState<BeDeployment | null>(null);
   const [deactivating, setDeactivating] = useState<BeDeployment | null>(null);
   const [viewing, setViewing] = useState<BeDeployment | null>(null);
+  const [creating, setCreating] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
 
   const deployments = data ?? [];
@@ -105,11 +108,15 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
           setEditing(null);
           setFeedback({ message: `Updated ${name}.`, severity: "success" });
         },
-        onError: (err) =>
+        onError: (err) => {
+          // Close the dialog first so the page-level alert is not hidden
+          // behind the modal backdrop.
+          setEditing(null);
           setFeedback({
             message: `Could not update ${name}: ${err.message}`,
             severity: "error",
-          }),
+          });
+        },
       },
     );
   };
@@ -125,13 +132,33 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
           setDeactivating(null);
           setFeedback({ message: `Deactivated ${name}.`, severity: "success" });
         },
-        onError: (err) =>
+        onError: (err) => {
+          // Close the dialog first so the page-level alert is not hidden
+          // behind the modal backdrop.
+          setDeactivating(null);
           setFeedback({
             message: `Could not deactivate ${name}: ${err.message}`,
             severity: "error",
-          }),
+          });
+        },
       },
     );
+  };
+
+  const handleCreate = (payload: BeDeploymentCreatePayload): void => {
+    createDeployment.mutate(payload, {
+      onSuccess: () => {
+        setCreating(false);
+        setFeedback({ message: "Deployment created.", severity: "success" });
+      },
+      onError: (err) => {
+        setCreating(false);
+        setFeedback({
+          message: `Could not create deployment: ${err.message}`,
+          severity: "error",
+        });
+      },
+    });
   };
 
   return (
@@ -148,6 +175,17 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
           {error instanceof Error ? error.message : "unknown error"}
         </Alert>
       )}
+
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<Plus size={16} />}
+          onClick={() => setCreating(true)}
+        >
+          Create deployment
+        </Button>
+      </Box>
 
       <Paper variant="outlined">
         <TableContainer>
@@ -266,6 +304,15 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
           isSaving={updateDeployment.isPending}
           onClose={() => setEditing(null)}
           onSave={handleSaveEdit}
+        />
+      )}
+
+      {creating && (
+        <CreateDeploymentDialog
+          projectId={projectId}
+          isSaving={createDeployment.isPending}
+          onClose={() => setCreating(false)}
+          onCreate={handleCreate}
         />
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.test.tsx
@@ -75,8 +75,28 @@ describe("EditDeploymentDialog", () => {
     expect(saveButton()).toBeDisabled();
   });
 
-  it("does not offer type editing", () => {
+  it("renders a type selector with all 6 deployment types", () => {
     renderDialog();
-    expect(screen.getByText(/type changes aren't available yet/i)).toBeInTheDocument();
+    // The Select renders its current value in a combobox.
+    const typeSelect = screen.getByRole("combobox", { name: /type/i });
+    expect(typeSelect).toBeInTheDocument();
+  });
+
+  it("enables Save and sends type when the type is changed", () => {
+    const { onSave } = renderDialog();
+    // Open the Select dropdown and pick "Staging".
+    const typeSelect = screen.getByRole("combobox", { name: /type/i });
+    fireEvent.mouseDown(typeSelect);
+    const stagingOption = screen.getByRole("option", { name: /staging/i });
+    fireEvent.click(stagingOption);
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ type: "staging" });
+  });
+
+  it("does not render 'Type changes aren't available yet'", () => {
+    renderDialog();
+    expect(
+      screen.queryByText(/type changes aren't available yet/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.test.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import EditDeploymentDialog from "@features/csm-projects/components/EditDeploymentDialog";
+import type { BeDeployment } from "@api/backend/types";
+
+const DEPLOYMENT: BeDeployment = {
+  id: "11111111-1111-1111-1111-111111111111",
+  projectId: "22222222-2222-2222-2222-222222222222",
+  name: "Prod",
+  type: "primary_production",
+  description: "Main prod deployment",
+};
+
+function renderDialog(overrides?: Partial<BeDeployment>) {
+  const onSave = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <EditDeploymentDialog
+      deployment={{ ...DEPLOYMENT, ...overrides }}
+      isSaving={false}
+      onClose={onClose}
+      onSave={onSave}
+    />,
+  );
+  return { onSave, onClose };
+}
+
+const saveButton = (): HTMLElement =>
+  screen.getByRole("button", { name: /save changes/i });
+
+describe("EditDeploymentDialog", () => {
+  it("disables Save until a field changes", () => {
+    renderDialog();
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("sends only the changed name", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Production" },
+    });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ name: "Production" });
+  });
+
+  it("sends null when the description is cleared", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "" },
+    });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ description: null });
+  });
+
+  it("keeps Save disabled when the name is emptied", () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "" } });
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("does not offer type editing", () => {
+    renderDialog();
+    expect(screen.getByText(/type changes aren't available yet/i)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.tsx
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type {
+  BeDeployment,
+  BeDeploymentDetailUpdatePayload,
+} from "@api/backend/types";
+import { deploymentTypeLabel } from "@features/csm-projects/utils/deployments";
+
+interface EditDeploymentDialogProps {
+  deployment: BeDeployment;
+  /** True while the PATCH is in flight; disables the actions. */
+  isSaving: boolean;
+  onClose: () => void;
+  /** Persist the changed detail fields via `PATCH /deployments/{id}`. */
+  onSave: (payload: BeDeploymentDetailUpdatePayload) => void;
+}
+
+const NAME_MAX = 200;
+const DESCRIPTION_MAX = 4000;
+
+/**
+ * Edit a deployment's name and description (`PATCH /deployments/{id}` detail
+ * fields). The deployment type is shown read-only: changing it needs the
+ * ServiceNow type→key integer, which no endpoint exposes yet, so type edits are
+ * deferred. Mount only while open.
+ */
+export default function EditDeploymentDialog({
+  deployment,
+  isSaving,
+  onClose,
+  onSave,
+}: EditDeploymentDialogProps): JSX.Element {
+  const [name, setName] = useState(deployment.name ?? "");
+  const [description, setDescription] = useState(deployment.description ?? "");
+
+  const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
+  const originalName = (deployment.name ?? "").trim();
+  const originalDescription = (deployment.description ?? "").trim();
+
+  const nameChanged = trimmedName !== originalName;
+  const descriptionChanged = trimmedDescription !== originalDescription;
+  const nameError = trimmedName.length === 0;
+
+  // Send only the fields the user actually changed. The backend requires at
+  // least one field, so Save stays disabled until something differs.
+  const payload = useMemo<BeDeploymentDetailUpdatePayload>(() => {
+    const next: BeDeploymentDetailUpdatePayload = {};
+    if (nameChanged) next.name = trimmedName;
+    // An emptied description clears the value (null), matching the BE's
+    // nullable detail field.
+    if (descriptionChanged) {
+      next.description = trimmedDescription.length > 0 ? trimmedDescription : null;
+    }
+    return next;
+  }, [nameChanged, descriptionChanged, trimmedName, trimmedDescription]);
+
+  const canSave =
+    !isSaving && !nameError && (nameChanged || descriptionChanged);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Edit deployment</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            size="small"
+            fullWidth
+            required
+            autoFocus
+            error={nameError}
+            helperText={nameError ? "Name is required." : " "}
+            slotProps={{ htmlInput: { maxLength: NAME_MAX } }}
+          />
+
+          <TextField
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            size="small"
+            fullWidth
+            multiline
+            minRows={3}
+            slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX } }}
+          />
+
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+            >
+              Type
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+              <Chip size="small" variant="outlined" label={deploymentTypeLabel(deployment.type)} />
+              <Typography variant="caption" color="text.secondary">
+                Type changes aren't available yet.
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!canSave} onClick={() => onSave(payload)}>
+          Save changes
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -29,8 +29,9 @@ import { useState, type JSX, type ReactNode } from "react";
 import { Link as RouterLink, useNavigate, useParams } from "react-router";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+import DeploymentsTab from "@features/csm-projects/components/DeploymentsTab";
 
-type ProjectTabId = "overview" | "issues";
+type ProjectTabId = "overview" | "issues" | "deployments";
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";
@@ -197,6 +198,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
         <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v as ProjectTabId)}>
           <Tab value="overview" label="Overview" />
           <Tab value="issues" label="Issues" />
+          <Tab value="deployments" label="Deployments" />
         </Tabs>
       </Box>
 
@@ -261,6 +263,8 @@ export default function CsmProjectDetailPage(): JSX.Element {
           hideProjectFilter
         />
       )}
+
+      {activeTab === "deployments" && <DeploymentsTab projectId={p.id} />}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/utils/deployments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/utils/deployments.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeDeploymentType } from "@api/backend/types";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+
+/**
+ * Format a backend timestamp as a date for the deployment views. Uses the
+ * shared timezone-aware formatter (honours the user's preferred timezone and
+ * the backend's space-separated timestamp format) and falls back to "—" for
+ * missing/unparseable values. Shared by the deployments table, the details
+ * dialog, and the deployed-products panel so the format stays consistent.
+ */
+export function formatDeploymentDate(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+    }) ?? "—"
+  );
+}
+
+/** Human label for each deployment-type enum value returned by the backend. */
+const DEPLOYMENT_TYPE_LABEL: Record<BeDeploymentType, string> = {
+  primary_production: "Primary Production",
+  staging: "Staging",
+  qa: "QA",
+  stress: "Stress",
+  uat: "UAT",
+  development: "Development",
+};
+
+/**
+ * Display label for a deployment type. Falls back to the raw value (with
+ * underscores spaced out) for any type the backend adds before this map does.
+ */
+export function deploymentTypeLabel(type?: BeDeploymentType | string): string {
+  if (!type) return "—";
+  return (
+    DEPLOYMENT_TYPE_LABEL[type as BeDeploymentType] ?? type.replace(/_/g, " ")
+  );
+}


### PR DESCRIPTION
## What

Adds deployment management and a deployed-products view to the CSM portal, and links the case overview's deployment field to it.

### Deployments tab (Customers → Projects → project)
- **List** a project's deployments (`POST /deployments/search`): name, type, description, created/updated.
- **Edit** name/description and **deactivate** a deployment via the new `PATCH /deployments/{id}` (`active:false`).
- **Details modal**: clicking a row (or its "View details" action) opens a read-only modal listing the deployment's **deployed products** (`POST /deployments/{id}/products/search`): product, version, support EOL, cores, TPS, category.

### Case overview
- The **Deployment** field in `CaseMetaBand` is now a button that opens the same deployment-details modal when the case carries a `deploymentId`.
- **Bug fix:** the case overview's **Product** cell was empty when a case had no linked deployed-product but did have a `product` ref. The detail mapper now falls back to the `CaseView.product` name.

## Deliberately deferred (no BE endpoints yet)
- **Create deployment** and **change a deployment's type** — both require the ServiceNow deployment-type integer (`typeKey`), which no endpoint exposes (search only returns the string label). Unlike case create/update, the deployment endpoints pass the raw SN integer through.
- **Managing deployed products** (add / re-version / remove) — deployed products are search-only on both the backend and entity service.

## Also includes
A small first commit fixing **pre-existing breakage on `v2`** left by the engagements-UI merge (so this branch's CI is green):
- a `casesFiltersUrl` unit test not updated for the new `engagementTypes` field, and
- a blocking `react-hooks` lint error in `CsmCaseDetailPage` (`detailPath` missing from an `onAction` dependency array).

## Testing
`pnpm lint` (0 errors), `pnpm build`, and `pnpm test` (96 passing, incl. new `EditDeploymentDialog` tests) all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Deployments** tab on project pages to view deployment details and related deployed products.
  * Users can now open an in-page deployment details dialog from case and project views.
  * Deployment details can be edited directly, including name and description, and deployments can be deactivated from the UI.

* **Bug Fixes**
  * Improved case product display by falling back to a linked product name when the primary deployment label is missing.
  * Fixed filter parsing so empty engagement types are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->