### PR TITLE
[CSM Portal] Change-request listing & detail; scope Cases list to cases

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -56,6 +56,9 @@ const OperationsPage = lazy(
 const CreateServiceRequestPage = lazy(
   () => import("@features/csm-operations/pages/CreateServiceRequestPage"),
 );
+const CsmChangeRequestDetailPage = lazy(
+  () => import("@features/csm-operations/pages/CsmChangeRequestDetailPage"),
+);
 const CsmAdminLayout = lazy(
   () => import("@features/csm-admin/pages/CsmAdminLayout"),
 );
@@ -234,6 +237,10 @@ export default function App(): JSX.Element {
                 <Route
                   path="operations/service-requests/new"
                   element={<CreateServiceRequestPage />}
+                />
+                <Route
+                  path="operations/change-requests/:id"
+                  element={<CsmChangeRequestDetailPage />}
                 />
 
                 <Route path="engagements" element={<CsmEngagementsPage />} />

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -764,3 +764,81 @@ export interface BeDeployedProductSearchPayload {
 export interface BeDeployedProductSearchResponse extends BeSearchResponseBase {
   deployedProducts: BeDeployedProduct[];
 }
+
+// ---------------------------------------------------------------------------
+// Change requests (managed-cloud; ServiceNow data source only)
+// ---------------------------------------------------------------------------
+
+export type BeChangeRequestState =
+  | "customer_approval"
+  | "scheduled"
+  | "implement"
+  | "review"
+  | "customer_review"
+  | "rollback"
+  | "closed"
+  | "canceled";
+
+export type BeChangeRequestImpact = "high" | "medium" | "low";
+
+/** List-item / shared shape for a change request (`POST /change-requests/search`). */
+export interface BeChangeRequestSearchView {
+  id: string;
+  number?: string;
+  subject?: string | null;
+  description?: string | null;
+  project?: BeEntityRef;
+  case?: BeEntityRef | null;
+  deployment?: BeEntityRef | null;
+  deployedProduct?: BeEntityRef | null;
+  product?: BeEntityRef | null;
+  assignedEngineer?: BeEntityRef | null;
+  assignedTeam?: BeEntityRef | null;
+  plannedStartOn?: string | null;
+  plannedEndOn?: string | null;
+  duration?: string | null;
+  impact?: string | null;
+  state?: string | null;
+  type?: string | null;
+  createdOn?: string;
+  updatedOn?: string;
+}
+
+/** `GET /change-requests/{id}` — the search view plus the heavy plan fields. */
+export interface BeChangeRequestDetail extends BeChangeRequestSearchView {
+  createdBy?: string;
+  justification?: string | null;
+  impactDescription?: string | null;
+  serviceOutage?: string | null;
+  communicationPlan?: string | null;
+  rollbackPlan?: string | null;
+  testPlan?: string | null;
+  hasCustomerApproved?: boolean;
+  hasCustomerReviewed?: boolean;
+  approvedBy?: BeEntityRef | null;
+  approvedOn?: string | null;
+}
+
+export interface BeChangeRequestSearchPayload {
+  filters?: {
+    projectIds?: string[];
+    searchQuery?: string;
+    states?: BeChangeRequestState[];
+    impacts?: BeChangeRequestImpact[];
+    closedStartDate?: string;
+    closedEndDate?: string;
+  };
+  sortBy?: {
+    field?: "createdOn" | "updatedOn";
+    order?: "asc" | "desc";
+  };
+  pagination?: BePagination;
+}
+
+/** Note: the CR search response carries no `hasMore` (unlike the other searches). */
+export interface BeChangeRequestSearchResponse {
+  changeRequests: BeChangeRequestSearchView[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -573,7 +573,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         sticky: false,
       });
     },
-    [data, showError, patchCase, findMyOngoingCases],
+    [data, showError, patchCase, findMyOngoingCases, detailPath],
   );
 
   // Confirm pausing the engineer's other ongoing case(s) and making this case

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -28,6 +28,12 @@ export default function CsmCasesPage(): JSX.Element {
     <CsmIssuesView
       title="Cases"
       entityNoun="cases"
+      // Cases list is support cases only. The other issue types have dedicated
+      // homes — service requests under Operations, engagements under
+      // Engagements, security reports under Security Center — so they're locked
+      // out here (and the type filter is hidden since it's fixed to `case`).
+      lockedFilters={{ caseTypes: ["case"] }}
+      hideTypeFilter
       actions={
         <Button
           variant="contained"

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -39,6 +39,7 @@ describe("readCasesFiltersFromUrl", () => {
       severities: ["S0", "S2"],
       states: ["open", "closed"],
       caseTypes: ["case", "engagement"],
+      engagementTypes: [],
       assignees: ["alice@example.com", "@me"],
       projects: ["apim"],
     });

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useGetChangeRequest.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useGetChangeRequest.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeChangeRequestDetail } from "@api/backend/types";
+
+/**
+ * Look up a single change request by id via `GET /change-requests/{id}`
+ * (ServiceNow data source only). Returns `null` when the id is unknown so the
+ * detail page can render a not-found state rather than an error.
+ */
+export function useGetChangeRequest(
+  id: string | undefined,
+): UseQueryResult<BeChangeRequestDetail | null, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeChangeRequestDetail | null, Error>({
+    queryKey: [ApiQueryKeys.CHANGE_REQUEST_DETAILS, id ?? ""],
+    queryFn: (): Promise<BeChangeRequestDetail | null> =>
+      api.get<BeChangeRequestDetail>(
+        `/change-requests/${encodeURIComponent(id as string)}`,
+      ),
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchChangeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchChangeRequests.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeChangeRequestSearchPayload,
+  BeChangeRequestSearchResponse,
+} from "@api/backend/types";
+
+/**
+ * Search change requests via `POST /change-requests/search` (ServiceNow data
+ * source only). Returns the raw paged response so the listing can drive
+ * server-side pagination from `total`. `keepPreviousData` keeps the table
+ * populated while the next page/filter loads.
+ */
+export function useSearchChangeRequests(
+  payload: BeChangeRequestSearchPayload,
+): UseQueryResult<BeChangeRequestSearchResponse, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeChangeRequestSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.CHANGE_REQUESTS, payload],
+    queryFn: (): Promise<BeChangeRequestSearchResponse> =>
+      api.post<BeChangeRequestSearchPayload, BeChangeRequestSearchResponse>(
+        "/change-requests/search",
+        payload,
+      ),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  InputAdornment,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Search } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useNavigate } from "react-router";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { useSearchChangeRequests } from "@features/csm-operations/api/useSearchChangeRequests";
+import {
+  changeRequestImpactColor,
+  changeRequestImpactLabel,
+  changeRequestStateColor,
+  changeRequestStateLabel,
+} from "@features/csm-operations/utils/changeRequests";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+
+function formatDate(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+    }) ?? "—"
+  );
+}
+
+/**
+ * Change-requests listing for the Operations → Change requests tab. Searches
+ * `POST /change-requests/search` (subject + number) with server-side
+ * pagination; a row opens the change-request detail page.
+ */
+export default function ChangeRequestsTab(): JSX.Element {
+  const navigate = useNavigate();
+  const [searchInput, setSearchInput] = useState("");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const debouncedSearch = useDebouncedValue(searchInput.trim(), 300);
+
+  const payload = useMemo(
+    () => ({
+      filters: {
+        ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
+      },
+      pagination: { offset: page * rowsPerPage, limit: rowsPerPage },
+    }),
+    [debouncedSearch, page, rowsPerPage],
+  );
+
+  const { data, isLoading, isError, error, isFetching } =
+    useSearchChangeRequests(payload);
+
+  const changeRequests = data?.changeRequests ?? [];
+  const total = data?.total ?? 0;
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setSearchInput(e.target.value);
+    setPage(0);
+  };
+
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <TextField
+        value={searchInput}
+        onChange={handleSearchChange}
+        placeholder="Search change requests by number or subject…"
+        size="small"
+        sx={{ maxWidth: 480 }}
+        slotProps={{
+          htmlInput: { "aria-label": "Search change requests by number or subject" },
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <Search size={16} />
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+
+      {isError && (
+        <Alert severity="error">
+          Failed to load change requests:{" "}
+          {error instanceof Error ? error.message : "unknown error"}
+        </Alert>
+      )}
+
+      <Paper variant="outlined">
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Number</TableCell>
+                <TableCell>Subject</TableCell>
+                <TableCell>Project</TableCell>
+                <TableCell>State</TableCell>
+                <TableCell>Impact</TableCell>
+                <TableCell>Planned start</TableCell>
+                <TableCell>Updated</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
+                    <CircularProgress size={24} />
+                  </TableCell>
+                </TableRow>
+              ) : changeRequests.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No change requests found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                changeRequests.map((cr) => (
+                  <TableRow
+                    key={cr.id}
+                    hover
+                    onClick={() => navigate(`/operations/change-requests/${cr.id}`)}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    <TableCell>{cr.number || "—"}</TableCell>
+                    <TableCell sx={{ maxWidth: 360 }}>
+                      <Typography variant="body2" noWrap title={cr.subject ?? undefined}>
+                        {cr.subject || "—"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{cr.project?.name || "—"}</TableCell>
+                    <TableCell>
+                      {cr.state ? (
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          color={changeRequestStateColor(cr.state)}
+                          label={changeRequestStateLabel(cr.state)}
+                        />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {cr.impact ? (
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          color={changeRequestImpactColor(cr.impact)}
+                          label={changeRequestImpactLabel(cr.impact)}
+                        />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell>{formatDate(cr.plannedStartOn)}</TableCell>
+                    <TableCell>{formatDate(cr.updatedOn)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(_, newPage) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+          showFirstButton
+          showLastButton
+        />
+      </Paper>
+
+      {isFetching && !isLoading && (
+        <Typography variant="caption" color="text.secondary">
+          Updating…
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, Check, X } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode } from "react";
+import { useNavigate, useParams } from "react-router";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
+import {
+  changeRequestImpactColor,
+  changeRequestImpactLabel,
+  changeRequestStateColor,
+  changeRequestStateLabel,
+} from "@features/csm-operations/utils/changeRequests";
+import type { BeEntityRef } from "@api/backend/types";
+
+const OPERATIONS_CR_PATH = "/operations?tab=change_requests";
+
+function formatDateTime(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }) ?? "—"
+  );
+}
+
+function MetaCell({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function RefText({ value }: { value?: BeEntityRef | null }): JSX.Element {
+  return <Typography variant="body2">{value?.name || "—"}</Typography>;
+}
+
+function YesNo({ value }: { value?: boolean }): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+      {value ? <Check size={14} /> : <X size={14} />}
+      <Typography variant="body2">{value ? "Yes" : "No"}</Typography>
+    </Box>
+  );
+}
+
+/** A long-form plan section; renders only when the field has content. */
+function PlanSection({ title, text }: { title: string; text?: string | null }): JSX.Element | null {
+  if (!text) return null;
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "pre-wrap" }}>
+        {text}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * Read-only detail for a single change request (`GET /change-requests/{id}`):
+ * its references, the change window, approval state, and the implementation /
+ * rollback / test / communication plans.
+ */
+export default function CsmChangeRequestDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useGetChangeRequest(id);
+
+  const back = (): void => {
+    navigate(OPERATIONS_CR_PATH);
+  };
+
+  const BackButton = (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={back}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back to change requests
+    </Button>
+  );
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rectangular" height={32} width={240} />
+        <Skeleton variant="rectangular" height={260} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {BackButton}
+        <Typography variant="body1" color="error">
+          Could not load change request {id}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {BackButton}
+        <Typography variant="h5">Change request not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No change request with id <code>{id}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const cr = data;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      {BackButton}
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="h5">{cr.subject || cr.number || "Change request"}</Typography>
+          {cr.state && (
+            <Chip
+              size="small"
+              color={changeRequestStateColor(cr.state)}
+              label={changeRequestStateLabel(cr.state)}
+            />
+          )}
+          {cr.impact && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color={changeRequestImpactColor(cr.impact)}
+              label={`${changeRequestImpactLabel(cr.impact)} impact`}
+            />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+          {cr.number || cr.id}
+        </Typography>
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Project"><RefText value={cr.project} /></MetaCell>
+          <MetaCell label="Type">
+            <Typography variant="body2">{cr.type || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Linked case"><RefText value={cr.case} /></MetaCell>
+          <MetaCell label="Deployment"><RefText value={cr.deployment} /></MetaCell>
+          <MetaCell label="Deployed product"><RefText value={cr.deployedProduct} /></MetaCell>
+          <MetaCell label="Product"><RefText value={cr.product} /></MetaCell>
+          <MetaCell label="Assigned engineer"><RefText value={cr.assignedEngineer} /></MetaCell>
+          <MetaCell label="Assigned team"><RefText value={cr.assignedTeam} /></MetaCell>
+          <MetaCell label="Duration">
+            <Typography variant="body2">{cr.duration || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Planned start">
+            <Typography variant="body2">{formatDateTime(cr.plannedStartOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Planned end">
+            <Typography variant="body2">{formatDateTime(cr.plannedEndOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Created">
+            <Typography variant="body2">{formatDateTime(cr.createdOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Last updated">
+            <Typography variant="body2">{formatDateTime(cr.updatedOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Created by">
+            <Typography variant="body2">{cr.createdBy || "—"}</Typography>
+          </MetaCell>
+        </Box>
+      </Card>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Approval</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Customer approved"><YesNo value={cr.hasCustomerApproved} /></MetaCell>
+          <MetaCell label="Customer reviewed"><YesNo value={cr.hasCustomerReviewed} /></MetaCell>
+          <MetaCell label="Approved by"><RefText value={cr.approvedBy} /></MetaCell>
+          <MetaCell label="Approved on">
+            <Typography variant="body2">{formatDateTime(cr.approvedOn)}</Typography>
+          </MetaCell>
+        </Box>
+      </Card>
+
+      {(cr.description ||
+        cr.justification ||
+        cr.impactDescription ||
+        cr.serviceOutage ||
+        cr.communicationPlan ||
+        cr.rollbackPlan ||
+        cr.testPlan) && (
+        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
+          <Typography variant="subtitle2">Details &amp; plans</Typography>
+          <PlanSection title="Description" text={cr.description} />
+          <PlanSection title="Justification" text={cr.justification} />
+          <PlanSection title="Impact description" text={cr.impactDescription} />
+          <PlanSection title="Service outage" text={cr.serviceOutage} />
+          <PlanSection title="Communication plan" text={cr.communicationPlan} />
+          <PlanSection title="Rollback plan" text={cr.rollbackPlan} />
+          <PlanSection title="Test plan" text={cr.testPlan} />
+        </Card>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -16,23 +16,40 @@
 
 import { Box, Button, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { useState, type JSX } from "react";
-import { useNavigate } from "react-router";
+import { type JSX } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import IssuesListUnavailable from "@features/csm-operations/components/IssuesListUnavailable";
+import ChangeRequestsTab from "@features/csm-operations/components/ChangeRequestsTab";
 
 type OperationsTabId = "service_requests" | "change_requests" | "incidents";
+
+const TAB_IDS: readonly OperationsTabId[] = [
+  "service_requests",
+  "change_requests",
+  "incidents",
+];
 
 /**
  * Operations landing — the home for the managed-cloud operational entities,
  * split into Service Requests / Change Requests / Incidents tabs. Service
- * requests are case-typed, so they list through the shared issues view; CR and
- * Incidents have no backend search endpoint yet and render an unavailable
- * placeholder.
+ * requests are case-typed, so they list through the shared issues view; change
+ * requests have their own search endpoint and listing; Incidents has no backend
+ * yet and renders an unavailable placeholder.
  */
 export default function OperationsPage(): JSX.Element {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
+  // Active tab lives in the URL (`?tab=`) so the change-request detail page can
+  // link back to the right tab, and the tab survives a refresh / share.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab") as OperationsTabId | null;
+  const activeTab: OperationsTabId =
+    tabParam && TAB_IDS.includes(tabParam) ? tabParam : "service_requests";
+  const setActiveTab = (next: OperationsTabId): void =>
+    setSearchParams((prev) => {
+      prev.set("tab", next);
+      return prev;
+    });
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -73,12 +90,7 @@ export default function OperationsPage(): JSX.Element {
         />
       )}
 
-      {activeTab === "change_requests" && (
-        <IssuesListUnavailable
-          title="Change requests"
-          description="Controlled changes, linked to service requests, with peer / CAB approval."
-        />
-      )}
+      {activeTab === "change_requests" && <ChangeRequestsTab />}
 
       {activeTab === "incidents" && (
         <IssuesListUnavailable

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  BeChangeRequestImpact,
+  BeChangeRequestState,
+} from "@api/backend/types";
+
+type ChipColor = "default" | "info" | "warning" | "success" | "error";
+
+const STATE_LABEL: Record<BeChangeRequestState, string> = {
+  customer_approval: "Customer Approval",
+  scheduled: "Scheduled",
+  implement: "Implement",
+  review: "Review",
+  customer_review: "Customer Review",
+  rollback: "Rollback",
+  closed: "Closed",
+  canceled: "Canceled",
+};
+
+// State chip colour: approvals/reviews are in-flight (info), implement is active
+// (warning), rollback/cancel are problem states (error), closed is terminal-good.
+const STATE_COLOR: Record<BeChangeRequestState, ChipColor> = {
+  customer_approval: "info",
+  scheduled: "info",
+  implement: "warning",
+  review: "info",
+  customer_review: "info",
+  rollback: "error",
+  closed: "success",
+  canceled: "error",
+};
+
+const IMPACT_LABEL: Record<BeChangeRequestImpact, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+const IMPACT_COLOR: Record<BeChangeRequestImpact, ChipColor> = {
+  high: "error",
+  medium: "warning",
+  low: "default",
+};
+
+/** All CR states, for a filter control. */
+export const CHANGE_REQUEST_STATES = Object.keys(STATE_LABEL) as BeChangeRequestState[];
+
+function humanize(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+export function changeRequestStateLabel(state?: string | null): string {
+  if (!state) return "—";
+  return STATE_LABEL[state as BeChangeRequestState] ?? humanize(state);
+}
+
+export function changeRequestStateColor(state?: string | null): ChipColor {
+  return STATE_COLOR[state as BeChangeRequestState] ?? "default";
+}
+
+export function changeRequestImpactLabel(impact?: string | null): string {
+  if (!impact) return "—";
+  return IMPACT_LABEL[impact as BeChangeRequestImpact] ?? humanize(impact);
+}
+
+export function changeRequestImpactColor(impact?: string | null): ChipColor {
+  return IMPACT_COLOR[impact as BeChangeRequestImpact] ?? "default";
+}


### PR DESCRIPTION
## What

Adds change-request **listing** and a **detail view** to the Operations area, and scopes the Cases list to support cases only.

### Operations → Change requests
- Replaces the "unavailable" placeholder with a real listing backed by `POST /change-requests/search`: search (number + subject) with server-side pagination, columns for number, subject, project, state, impact, planned start, updated. State/impact render as colour-coded chips.
- A row opens the new **change-request detail page** (`/operations/change-requests/:id`, `GET /change-requests/{id}`): references (project, linked case, deployment, deployed product, product, assigned engineer/team), the change window (planned start/end, duration), approval state (customer approved/reviewed, approved by/on), and the implementation / rollback / test / communication plans.
- The Operations active tab is now kept in the URL (`?tab=`) so the detail page links back to the Change requests tab and the tab survives refresh/share.

### Cases list scoped to support cases
The Cases page listed every issue type. Service requests (Operations), engagements (Engagements), and security reports (Security Center) have their own homes, so the Cases list is now locked to `caseTypes: ['case']` and the type filter is hidden.

## Notes
- Change-request endpoints are **ServiceNow-source only**, so this can't be exercised against the local Postgres preview stack.
- Includes the same small first commit fixing pre-existing `v2` lint/test breakage from the engagements merge (dedupes on merge with #958).

## Testing
`pnpm lint` (0 errors), `pnpm build`, `pnpm test` (91 passing) all green.
