### PR TITLE
[CSM Portal] Render change-request rich-text fields as sanitized HTML

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -15,11 +15,11 @@
 // under the License.
 
 import { alpha, Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
-import DOMPurify from "dompurify";
 import type { JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
 import SemanticChip from "@components/SemanticChip";
 import { pickAccessibleText } from "@utils/contrastText";
+import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { initialsOf } from "@utils/userClaims";
 import type {
   CsmCaseComment,
@@ -45,37 +45,11 @@ const ROLE_COLOR: Record<
   system: "warning",
 };
 
-const PURIFY_CONFIG = {
-  ALLOWED_TAGS: [
-    "p",
-    "br",
-    "strong",
-    "b",
-    "em",
-    "i",
-    "u",
-    "s",
-    "code",
-    "pre",
-    "ul",
-    "ol",
-    "li",
-    "a",
-    "blockquote",
-    "h1",
-    "h2",
-    "h3",
-    "img",
-    "span",
-  ],
-  ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
-};
-
 export default function CsmCaseCommentBubble({
   comment,
 }: CsmCaseCommentBubbleProps): JSX.Element {
   const theme = useTheme();
-  const safeHtml = DOMPurify.sanitize(comment.bodyHtml, PURIFY_CONFIG);
+  const safeHtml = sanitizeRichTextHtml(comment.bodyHtml);
   const isSystem = comment.authorRole === "system";
 
   if (isSystem) {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -23,10 +23,10 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, Check, X } from "@wso2/oxygen-ui-icons-react";
-import DOMPurify from "dompurify";
 import { type JSX, type ReactNode } from "react";
 import { useNavigate, useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
 import {
   changeRequestImpactColor,
@@ -37,23 +37,6 @@ import {
 import type { BeEntityRef } from "@api/backend/types";
 
 const OPERATIONS_CR_PATH = "/operations?tab=change_requests";
-
-// CR long-text fields (description, justification, plans) come back as
-// ServiceNow rich-text HTML, so they're sanitized before rendering. Allow-list
-// mirrors the case comment renderer (CsmCaseCommentBubble).
-const PURIFY_CONFIG = {
-  ALLOWED_TAGS: [
-    "p", "br", "strong", "b", "em", "i", "u", "s", "code", "pre",
-    "ul", "ol", "li", "a", "blockquote", "h1", "h2", "h3", "img", "span", "table",
-    "thead", "tbody", "tr", "th", "td",
-  ],
-  ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
-};
-
-/** True when an HTML string has no visible content (e.g. `<p></p>`, `&nbsp;`). */
-function isBlankHtml(html: string): boolean {
-  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
-}
 
 function formatDateTime(value?: string | null): string {
   return (
@@ -99,7 +82,7 @@ function YesNo({ value }: { value?: boolean }): JSX.Element {
  */
 function PlanSection({ title, html }: { title: string; html?: string | null }): JSX.Element | null {
   if (!html || isBlankHtml(html)) return null;
-  const safeHtml = DOMPurify.sanitize(html, PURIFY_CONFIG);
+  const safeHtml = sanitizeRichTextHtml(html);
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
       <Typography variant="subtitle2">{title}</Typography>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -23,6 +23,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, Check, X } from "@wso2/oxygen-ui-icons-react";
+import DOMPurify from "dompurify";
 import { type JSX, type ReactNode } from "react";
 import { useNavigate, useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
@@ -36,6 +37,23 @@ import {
 import type { BeEntityRef } from "@api/backend/types";
 
 const OPERATIONS_CR_PATH = "/operations?tab=change_requests";
+
+// CR long-text fields (description, justification, plans) come back as
+// ServiceNow rich-text HTML, so they're sanitized before rendering. Allow-list
+// mirrors the case comment renderer (CsmCaseCommentBubble).
+const PURIFY_CONFIG = {
+  ALLOWED_TAGS: [
+    "p", "br", "strong", "b", "em", "i", "u", "s", "code", "pre",
+    "ul", "ol", "li", "a", "blockquote", "h1", "h2", "h3", "img", "span", "table",
+    "thead", "tbody", "tr", "th", "td",
+  ],
+  ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
+};
+
+/** True when an HTML string has no visible content (e.g. `<p></p>`, `&nbsp;`). */
+function isBlankHtml(html: string): boolean {
+  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
+}
 
 function formatDateTime(value?: string | null): string {
   return (
@@ -74,15 +92,34 @@ function YesNo({ value }: { value?: boolean }): JSX.Element {
   );
 }
 
-/** A long-form plan section; renders only when the field has content. */
-function PlanSection({ title, text }: { title: string; text?: string | null }): JSX.Element | null {
-  if (!text) return null;
+/**
+ * A long-form plan section. The value is ServiceNow rich-text HTML, so it's
+ * sanitized and rendered as HTML. Renders nothing when the field is empty or
+ * has no visible content.
+ */
+function PlanSection({ title, html }: { title: string; html?: string | null }): JSX.Element | null {
+  if (!html || isBlankHtml(html)) return null;
+  const safeHtml = DOMPurify.sanitize(html, PURIFY_CONFIG);
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
       <Typography variant="subtitle2">{title}</Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "pre-wrap" }}>
-        {text}
-      </Typography>
+      <Box
+        sx={{
+          color: "text.secondary",
+          fontSize: "0.875rem",
+          lineHeight: 1.5,
+          wordBreak: "break-word",
+          "& p": { my: 0.5 },
+          "& p:first-of-type": { mt: 0 },
+          "& p:last-child": { mb: 0 },
+          "& ul, & ol": { my: 0.5, pl: 3 },
+          "& a": { color: "primary.main" },
+          "& img": { maxWidth: "100%", height: "auto" },
+          "& table": { borderCollapse: "collapse", width: "100%" },
+          "& th, & td": { border: 1, borderColor: "divider", px: 1, py: 0.5, textAlign: "left" },
+        }}
+        dangerouslySetInnerHTML={{ __html: safeHtml }}
+      />
     </Box>
   );
 }
@@ -241,22 +278,24 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
         </Box>
       </Card>
 
-      {(cr.description ||
-        cr.justification ||
-        cr.impactDescription ||
-        cr.serviceOutage ||
-        cr.communicationPlan ||
-        cr.rollbackPlan ||
-        cr.testPlan) && (
+      {[
+        cr.description,
+        cr.justification,
+        cr.impactDescription,
+        cr.serviceOutage,
+        cr.communicationPlan,
+        cr.rollbackPlan,
+        cr.testPlan,
+      ].some((v) => v && !isBlankHtml(v)) && (
         <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
           <Typography variant="subtitle2">Details &amp; plans</Typography>
-          <PlanSection title="Description" text={cr.description} />
-          <PlanSection title="Justification" text={cr.justification} />
-          <PlanSection title="Impact description" text={cr.impactDescription} />
-          <PlanSection title="Service outage" text={cr.serviceOutage} />
-          <PlanSection title="Communication plan" text={cr.communicationPlan} />
-          <PlanSection title="Rollback plan" text={cr.rollbackPlan} />
-          <PlanSection title="Test plan" text={cr.testPlan} />
+          <PlanSection title="Description" html={cr.description} />
+          <PlanSection title="Justification" html={cr.justification} />
+          <PlanSection title="Impact description" html={cr.impactDescription} />
+          <PlanSection title="Service outage" html={cr.serviceOutage} />
+          <PlanSection title="Communication plan" html={cr.communicationPlan} />
+          <PlanSection title="Rollback plan" html={cr.rollbackPlan} />
+          <PlanSection title="Test plan" html={cr.testPlan} />
         </Card>
       )}
     </Box>

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import DOMPurify from "dompurify";
+
+/**
+ * Sanitize backend rich-text HTML (ServiceNow case comments, change-request
+ * descriptions/plans, …) for safe rendering via dangerouslySetInnerHTML.
+ *
+ * Uses DOMPurify's default policy — no custom tag/attribute allow-list — to
+ * stay aligned with the customer portal, which renders the same ServiceNow HTML
+ * with bare `DOMPurify.sanitize(html)` (its `INLINE_COMMENT_HTML_PURIFY` is `{}`).
+ * The defaults already strip scripts, event handlers, and `javascript:` URLs; a
+ * stricter allow-list here silently dropped legitimate content (tables,
+ * headings) the portal keeps.
+ */
+export function sanitizeRichTextHtml(html: string): string {
+  return DOMPurify.sanitize(html);
+}
+
+/** True when an HTML string has no visible content (e.g. `<p></p>`, `&nbsp;`). */
+export function isBlankHtml(html: string): boolean {
+  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
+}


### PR DESCRIPTION
## What

Two related fixes for how the CSM portal renders ServiceNow rich-text HTML.

### 1. Render change-request rich-text as HTML
The change-request `description`, `justification`, and plan fields (impact description, service outage, communication / rollback / test plans) come from ServiceNow as **rich-text HTML**. The CR detail page (added in #959) rendered them as plain `pre-wrap` text, so raw `<p>`/`<ul>`/… markup showed instead of formatted content.

- Render each field as sanitized HTML via `dangerouslySetInnerHTML`.
- Style the output (paragraphs, lists, links, images capped to container width, bordered tables).
- Skip any section whose HTML has no visible content (e.g. `<p></p>`, `&nbsp;`), and omit the "Details & plans" card entirely when every field is blank.

### 2. One shared sanitizer, aligned with the customer portal
The deployment/CR work and the existing case comment bubble each carried their own duplicated DOMPurify allow-list. Extracted a single `@utils/sanitizeHtml` (`sanitizeRichTextHtml` + `isBlankHtml`) and pointed both the CR detail page and `CsmCaseCommentBubble` at it.

The shared sanitizer uses **DOMPurify defaults (no custom allow-list)**, matching the customer portal, which renders the same ServiceNow HTML with bare `DOMPurify.sanitize(html)` (its `INLINE_COMMENT_HTML_PURIFY` is `{}`). The defaults still strip scripts, event handlers, and `javascript:` URLs. The previous CSM allow-list was stricter and silently dropped legitimate content (tables, headings).

> Note: this loosens the case comment bubble from its old strict allow-list to the portal-aligned defaults, so comments can now render a few more tags (e.g. tables). Intentional alignment; flag if you'd rather keep comments strict and align CR only.

Follow-up to #959 (already merged before this landed).

## Testing
`pnpm lint` (0 errors), `pnpm build`, `pnpm test` (104 passing) — all green.
