### PR TITLE
[CSM Portal] align attachment and change-request APIs with new backend contract

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/client.ts
+++ b/apps/csm-portal/webapp/src/api/backend/client.ts
@@ -80,6 +80,8 @@ export interface BackendApi {
   post<TRequest, TResponse>(path: string, body: TRequest): Promise<TResponse>;
   patch<TRequest, TResponse>(path: string, body: TRequest): Promise<TResponse>;
   postEmpty<TResponse>(path: string): Promise<TResponse>;
+  /** Authenticated DELETE. Returns the parsed JSON body (`null` on 204). */
+  del<TResponse>(path: string): Promise<TResponse | null>;
   /**
    * Authenticated binary GET. Used for endpoints that stream raw file content
    * (e.g. attachment download) rather than JSON. Unlike {@link BackendApi.get},
@@ -143,6 +145,12 @@ export function useBackendApi(): BackendApi {
           body: "{}",
         });
         if (!response.ok) throw await readError(response);
+        return (await response.json()) as TResponse;
+      },
+      async del<TResponse>(path: string): Promise<TResponse | null> {
+        const response = await authFetch(buildUrl(path), { method: "DELETE" });
+        if (!response.ok) throw await readError(response);
+        if (response.status === 204) return null;
         return (await response.json()) as TResponse;
       },
       async getBlob(path: string): Promise<Blob> {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -512,10 +512,21 @@ export interface BeCaseCommentSearchResponse extends BeSearchResponseBase {
 // Attachments
 // ---------------------------------------------------------------------------
 
-/** A case attachment as returned by `POST /cases/{id}/attachments/search`. */
+/**
+ * Entity an attachment is linked to. Attachments are no longer case-scoped:
+ * the same endpoints serve change requests, deployments, and conversations.
+ */
+export type BeReferenceType =
+  | "case"
+  | "conversation"
+  | "change_request"
+  | "deployment";
+
+/** A attachment as returned by `POST /attachments/search`. */
 export interface BeAttachment {
   id: string;
-  caseId: string;
+  referenceId: string;
+  referenceType: BeReferenceType;
   name: string;
   /** MIME type (e.g. image/png, application/pdf). */
   type: string;
@@ -527,7 +538,13 @@ export interface BeAttachment {
   previewUrl?: string | null;
 }
 
+/**
+ * Search payload for `POST /attachments/search`. `referenceId` + `referenceType`
+ * scope the search to one entity (both required by the BE).
+ */
 export interface BeAttachmentSearchPayload {
+  referenceId: string;
+  referenceType: BeReferenceType;
   pagination?: BePagination;
 }
 
@@ -536,17 +553,20 @@ export interface BeAttachmentSearchResponse extends BeSearchResponseBase {
 }
 
 /**
- * Upload payload for `POST /cases/{id}/attachments`. `file` is a base64 data
- * URI (e.g. `data:image/png;base64,...`); the BE caps the decoded size at 10 MB.
+ * Upload payload for `POST /attachments`. `referenceId` + `referenceType` link
+ * the file to its owning entity; `file` is a base64 data URI (e.g.
+ * `data:image/png;base64,...`); the BE caps the decoded size at 10 MB.
  */
 export interface BeAttachmentCreatePayload {
+  referenceId: string;
+  referenceType: BeReferenceType;
   name: string;
   type: string;
   file: string;
   description?: string | null;
 }
 
-/** Thin ack returned by `POST /cases/{id}/attachments`. */
+/** Thin ack returned by `POST /attachments`. */
 export interface BeAttachmentDetail {
   id: string;
   sizeBytes: number;
@@ -558,6 +578,11 @@ export interface BeAttachmentDetail {
 export interface BeAttachmentCreateResponse {
   message?: string;
   attachment?: BeAttachmentDetail;
+}
+
+/** Ack returned by `DELETE /attachments/{id}`. */
+export interface BeDeleteAttachmentResponse {
+  message?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -885,6 +910,24 @@ export interface BeChangeRequestDetail extends BeChangeRequestSearchView {
   hasCustomerReviewed?: boolean;
   approvedBy?: BeEntityRef | null;
   approvedOn?: string | null;
+}
+
+/**
+ * `PATCH /change-requests/{id}` body (ServiceNow data source only). At least
+ * one field is required by the BE (`minProperties: 1`). `plannedStartOn` is a
+ * `YYYY-MM-DD HH:MM:SS` string.
+ */
+export interface BePatchChangeRequestPayload {
+  plannedStartOn?: string;
+  isCustomerApproved?: boolean;
+  isCustomerReviewed?: boolean;
+}
+
+/** `PATCH /change-requests/{id}` response — the touched identifiers. */
+export interface BePatchChangeRequestResponse {
+  id: string;
+  updatedOn?: string;
+  updatedBy?: string;
 }
 
 export interface BeChangeRequestSearchPayload {

--- a/apps/csm-portal/webapp/src/components/attachments/encodeAttachment.ts
+++ b/apps/csm-portal/webapp/src/components/attachments/encodeAttachment.ts
@@ -23,9 +23,9 @@ export interface EncodedAttachment {
   size: number;
   /**
    * The original File. Used by the post-create upload path
-   * (`POST /cases/{id}/attachments`, which standard cases and service requests
-   * use because the create endpoint only honors create-payload attachments for
-   * security reports).
+   * (`POST /attachments` with `referenceType: "case"`, which standard cases and
+   * service requests use because the create endpoint only honors create-payload
+   * attachments for security reports).
    */
   raw: File;
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
@@ -19,8 +19,8 @@ import type { PostCsmCaseAttachmentInput } from "@features/csm-cases/api/useCsmC
 
 /**
  * Upload create-form attachments to an already-created case via
- * `POST /cases/{id}/attachments`. The case-create endpoint only honors
- * create-payload attachments for security reports, so standard cases and
+ * `POST /attachments` (`referenceType: "case"`). The case-create endpoint only
+ * honors create-payload attachments for security reports, so standard cases and
  * service requests attach their files this way after the case exists.
  *
  * Uploads run concurrently and independently; returns the number that failed

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -29,6 +29,7 @@ import type {
   BeAttachmentCreateResponse,
   BeAttachmentSearchPayload,
   BeAttachmentSearchResponse,
+  BeDeleteAttachmentResponse,
 } from "@api/backend/types";
 import { uiAttachmentFromBe } from "@api/backend/mappers";
 import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
@@ -74,8 +75,8 @@ function saveBlob(blob: Blob, filename: string): void {
 }
 
 /**
- * Load all attachments on a case. In LIVE mode calls
- * `POST /cases/{id}/attachments/search` with a single wide page.
+ * Load all attachments on a case. Calls `POST /attachments/search` scoped to the
+ * case (`referenceType: "case"`) with a single wide page.
  */
 export function useGetCsmCaseAttachments(
   caseId: string | undefined,
@@ -88,15 +89,14 @@ export function useGetCsmCaseAttachments(
       if (!caseId) return [];
 
       const payload: BeAttachmentSearchPayload = {
+        referenceId: caseId,
+        referenceType: "case",
         pagination: { offset: 0, limit: ATTACHMENTS_PAGE_LIMIT },
       };
       const response = await api.post<
         BeAttachmentSearchPayload,
         BeAttachmentSearchResponse
-      >(
-        `/cases/${encodeURIComponent(caseId)}/attachments/search`,
-        payload,
-      );
+      >("/attachments/search", payload);
       return response.attachments.map(uiAttachmentFromBe);
     },
     enabled: !!caseId,
@@ -116,9 +116,10 @@ export interface PostCsmCaseAttachmentInput {
 }
 
 /**
- * Upload a file attachment to a case via `POST /cases/{id}/attachments`. The
- * file is sent as a base64 data URI. The create response is a thin ack, so the
- * list is refetched on success to hydrate the new entry from search.
+ * Upload a file attachment to a case via `POST /attachments` (scoped with
+ * `referenceType: "case"`). The file is sent as a base64 data URI. The create
+ * response is a thin ack, so the list is refetched on success to hydrate the
+ * new entry from search.
  */
 export function usePostCsmCaseAttachment(): UseMutationResult<
   CaseAttachment | null,
@@ -140,13 +141,15 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
 
       const dataUri = await readFileAsDataUrl(input.file);
       const payload: BeAttachmentCreatePayload = {
+        referenceId: input.caseId,
+        referenceType: "case",
         name: input.name?.trim() || input.file.name,
         type: input.file.type || "application/octet-stream",
         file: dataUri,
         description: input.description?.trim() || null,
       };
       await api.post<BeAttachmentCreatePayload, BeAttachmentCreateResponse>(
-        `/cases/${encodeURIComponent(input.caseId)}/attachments`,
+        "/attachments",
         payload,
       );
       // The create response is a thin ack; refetch hydrates the full entry.
@@ -161,25 +164,55 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
 }
 
 /**
- * Returns a function that downloads an attachment's content and saves it. The
- * content endpoint streams raw bytes behind auth, so it is fetched as a blob
- * (a plain `<a href>` would miss the auth headers) and handed to the browser.
+ * Returns a function that downloads an attachment's content and saves it via
+ * `GET /attachments/{id}/content`. The content endpoint streams raw bytes
+ * behind auth, so it is fetched as a blob (a plain `<a href>` would miss the
+ * auth headers) and handed to the browser.
  */
 export function useDownloadCsmCaseAttachment(): (
-  caseId: string,
   attachment: CaseAttachment,
 ) => Promise<void> {
   const api = useBackendApi();
 
   return useCallback(
-    async (caseId: string, attachment: CaseAttachment): Promise<void> => {
+    async (attachment: CaseAttachment): Promise<void> => {
       const blob = await api.getBlob(
-        `/cases/${encodeURIComponent(caseId)}/attachments/${encodeURIComponent(
-          attachment.id,
-        )}/content`,
+        `/attachments/${encodeURIComponent(attachment.id)}/content`,
       );
       saveBlob(blob, attachment.filename);
     },
     [api],
   );
+}
+
+export interface DeleteCsmCaseAttachmentInput {
+  /** Owning case id; used only to invalidate the right attachment list. */
+  caseId: string;
+  attachmentId: string;
+}
+
+/**
+ * Delete an attachment via `DELETE /attachments/{id}` (ServiceNow data source
+ * only). On success the case's attachment list is invalidated so the row drops.
+ */
+export function useDeleteCsmCaseAttachment(): UseMutationResult<
+  void,
+  Error,
+  DeleteCsmCaseAttachmentInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, DeleteCsmCaseAttachmentInput>({
+    mutationFn: async (input): Promise<void> => {
+      await api.del<BeDeleteAttachmentResponse>(
+        `/attachments/${encodeURIComponent(input.attachmentId)}`,
+      );
+    },
+    onSuccess: (_void, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CSM_CASE_ATTACHMENTS, variables.caseId],
+      });
+    },
+  });
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -20,6 +20,8 @@ import {
   Button,
   Card,
   Chip,
+  CircularProgress,
+  IconButton,
   LinearProgress,
   Typography,
 } from "@wso2/oxygen-ui";
@@ -39,6 +41,7 @@ import {
   Plus,
   Server,
   Shield,
+  Trash2,
   TriangleAlert,
   Upload,
   User,
@@ -673,6 +676,8 @@ export function AttachmentsWidget({
   onUpload,
   onDownloadAll,
   onDownload,
+  onDelete,
+  deletingId,
 }: {
   attachments: CaseAttachment[];
   /** List query is loading. */
@@ -687,6 +692,10 @@ export function AttachmentsWidget({
   onUpload?: (file: File) => void;
   onDownloadAll?: () => void;
   onDownload?: (attachment: CaseAttachment) => void;
+  /** Delete an attachment. Omit to hide the per-row delete affordance. */
+  onDelete?: (attachment: CaseAttachment) => void;
+  /** Id of the attachment whose delete is in flight; disables its row actions. */
+  deletingId?: string | null;
 }): JSX.Element {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sorted = [...attachments].sort(
@@ -829,6 +838,22 @@ export function AttachmentsWidget({
               >
                 Download
               </Button>
+              {onDelete && (
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => onDelete(a)}
+                  disabled={deletingId === a.id}
+                  aria-label={`Delete ${a.filename}`}
+                  sx={{ flexShrink: 0 }}
+                >
+                  {deletingId === a.id ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : (
+                    <Trash2 size={16} />
+                  )}
+                </IconButton>
+              )}
             </Box>
           ))}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -62,6 +62,7 @@ import {
   useGetCsmCaseAttachments,
   usePostCsmCaseAttachment,
   useDownloadCsmCaseAttachment,
+  useDeleteCsmCaseAttachment,
 } from "@features/csm-cases/api/useCsmCaseAttachments";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
@@ -260,6 +261,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   } = useGetCsmCaseAttachments(caseId);
   const postAttachment = usePostCsmCaseAttachment();
   const downloadAttachment = useDownloadCsmCaseAttachment();
+  const deleteAttachment = useDeleteCsmCaseAttachment();
   const patchCase = usePatchCsmCase(caseId);
   const patchCaseById = usePatchCsmCaseById();
   const findMyOngoingCases = useFindMyOngoingCases();
@@ -279,6 +281,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [metaCollapsed, setMetaCollapsed] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
+  // Attachment pending delete confirmation (drives the confirm dialog).
+  const [pendingDelete, setPendingDelete] = useState<CaseAttachment | null>(
+    null,
+  );
   // When starting work would leave the engineer with more than one ongoing case,
   // hold the other ongoing case(s) here to drive the confirm dialog.
   const [pauseConflict, setPauseConflict] = useState<MyOngoingCase[] | null>(
@@ -660,27 +666,47 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
   const onDownloadAttachment = useCallback(
     (attachment: CaseAttachment) => {
-      if (!caseId) return;
-      void downloadAttachment(caseId, attachment).catch((err) =>
+      void downloadAttachment(attachment).catch((err) =>
         showError(`Could not download ${attachment.filename}.`, err),
       );
     },
-    [caseId, downloadAttachment, showError],
+    [downloadAttachment, showError],
   );
 
   const onDownloadAllAttachments = useCallback(() => {
-    if (!caseId) return;
     // No bulk endpoint; fetch each sequentially (not a parallel burst) and save.
     void (async () => {
       for (const a of attachmentList) {
         try {
-          await downloadAttachment(caseId, a);
+          await downloadAttachment(a);
         } catch (err) {
           showError(`Could not download ${a.filename}.`, err);
         }
       }
     })();
-  }, [caseId, attachmentList, downloadAttachment, showError]);
+  }, [attachmentList, downloadAttachment, showError]);
+
+  const onConfirmDeleteAttachment = useCallback(() => {
+    if (!caseId || !pendingDelete) return;
+    const target = pendingDelete;
+    deleteAttachment.mutate(
+      { caseId, attachmentId: target.id },
+      {
+        onSuccess: () => {
+          setPendingDelete(null);
+          setFeedback({
+            message: `Deleted ${target.filename}.`,
+            severity: "success",
+            sticky: false,
+          });
+        },
+        onError: (err) => {
+          setPendingDelete(null);
+          showError(`Could not delete ${target.filename}.`, err);
+        },
+      },
+    );
+  }, [caseId, pendingDelete, deleteAttachment, showError]);
 
   if (isLoading) {
     return (
@@ -1200,6 +1226,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
             onUpload={onUploadAttachment}
             onDownloadAll={onDownloadAllAttachments}
             onDownload={onDownloadAttachment}
+            onDelete={setPendingDelete}
+            deletingId={deleteAttachment.isPending ? pendingDelete?.id : null}
           />
         </Box>
       )}
@@ -1222,6 +1250,40 @@ export default function CsmCaseDetailPage(): JSX.Element {
           onAssign={onAssign}
         />
       )}
+
+      <Dialog
+        open={!!pendingDelete}
+        onClose={() => {
+          if (!deleteAttachment.isPending) setPendingDelete(null);
+        }}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Delete attachment?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Permanently delete{" "}
+            <strong>{pendingDelete?.filename}</strong>? This can't be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => setPendingDelete(null)}
+            disabled={deleteAttachment.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={onConfirmDeleteAttachment}
+            disabled={deleteAttachment.isPending}
+          >
+            {deleteAttachment.isPending ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <Dialog
         open={!!pauseConflict}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchChangeRequest.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchChangeRequest.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BePatchChangeRequestPayload,
+  BePatchChangeRequestResponse,
+} from "@api/backend/types";
+
+export interface PatchChangeRequestInput {
+  id: string;
+  patch: BePatchChangeRequestPayload;
+}
+
+/**
+ * Update a change request via `PATCH /change-requests/{id}` (ServiceNow data
+ * source only). The BE requires at least one field in `patch`. On success the
+ * detail and any cached list/search are invalidated so the new values show.
+ */
+export function usePatchChangeRequest(): UseMutationResult<
+  BePatchChangeRequestResponse,
+  Error,
+  PatchChangeRequestInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    BePatchChangeRequestResponse,
+    Error,
+    PatchChangeRequestInput
+  >({
+    mutationFn: (input): Promise<BePatchChangeRequestResponse> =>
+      api.patch<BePatchChangeRequestPayload, BePatchChangeRequestResponse>(
+        `/change-requests/${encodeURIComponent(input.id)}`,
+        input.patch,
+      ),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CHANGE_REQUEST_DETAILS, variables.id],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CHANGE_REQUESTS],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Switch,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type {
+  BeChangeRequestDetail,
+  BePatchChangeRequestPayload,
+} from "@api/backend/types";
+
+interface EditChangeRequestDialogProps {
+  cr: BeChangeRequestDetail;
+  /** True while the PATCH is in flight; disables the actions. */
+  isSaving: boolean;
+  onClose: () => void;
+  /** Submit only the changed fields (`PATCH /change-requests/{id}`). */
+  onSave: (patch: BePatchChangeRequestPayload) => void;
+}
+
+/**
+ * Convert a backend timestamp (`YYYY-MM-DD HH:MM:SS`, or ISO `T`-separated) to
+ * the `YYYY-MM-DDTHH:MM` shape an `<input type="datetime-local">` expects. The
+ * value is treated as plain wall-clock text so no timezone shift is applied.
+ */
+function toDateTimeLocal(raw?: string | null): string {
+  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2})/.exec(raw?.trim() ?? "");
+  return m ? `${m[1]}T${m[2]}` : "";
+}
+
+/** Convert a `datetime-local` value back to the BE's `YYYY-MM-DD HH:MM:SS`. */
+function toBackendDateTime(local: string): string {
+  return `${local.replace("T", " ")}:00`;
+}
+
+/**
+ * Edit the change-request fields the BE allows updating: planned start, and the
+ * customer approved / reviewed flags. Only changed fields are sent, and the BE
+ * requires at least one, so Save is disabled until something differs.
+ */
+export default function EditChangeRequestDialog({
+  cr,
+  isSaving,
+  onClose,
+  onSave,
+}: EditChangeRequestDialogProps): JSX.Element {
+  const initialPlannedStart = useMemo(
+    () => toDateTimeLocal(cr.plannedStartOn),
+    [cr.plannedStartOn],
+  );
+  const [plannedStart, setPlannedStart] = useState(initialPlannedStart);
+  const [approved, setApproved] = useState(!!cr.hasCustomerApproved);
+  const [reviewed, setReviewed] = useState(!!cr.hasCustomerReviewed);
+
+  const patch = useMemo<BePatchChangeRequestPayload>(() => {
+    const next: BePatchChangeRequestPayload = {};
+    if (plannedStart !== initialPlannedStart && plannedStart) {
+      next.plannedStartOn = toBackendDateTime(plannedStart);
+    }
+    if (approved !== !!cr.hasCustomerApproved) next.isCustomerApproved = approved;
+    if (reviewed !== !!cr.hasCustomerReviewed) next.isCustomerReviewed = reviewed;
+    return next;
+  }, [
+    plannedStart,
+    initialPlannedStart,
+    approved,
+    reviewed,
+    cr.hasCustomerApproved,
+    cr.hasCustomerReviewed,
+  ]);
+
+  const hasChanges = Object.keys(patch).length > 0;
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Edit change request</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          <TextField
+            label="Planned start"
+            type="datetime-local"
+            size="small"
+            fullWidth
+            value={plannedStart}
+            onChange={(e) => setPlannedStart(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={approved}
+                onChange={(e) => setApproved(e.target.checked)}
+              />
+            }
+            label="Customer approved"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={reviewed}
+                onChange={(e) => setReviewed(e.target.checked)}
+              />
+            }
+            label="Customer reviewed"
+          />
+          <Typography variant="caption" color="text.secondary">
+            Edits apply to ServiceNow-managed change requests.
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => onSave(patch)}
+          disabled={isSaving || !hasChanges}
+        >
+          {isSaving ? "Saving…" : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -22,12 +22,15 @@ import {
   Skeleton,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft, Check, X } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode } from "react";
+import { ArrowLeft, Check, Pencil, X } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
+import { usePatchChangeRequest } from "@features/csm-operations/api/usePatchChangeRequest";
+import EditChangeRequestDialog from "@features/csm-operations/components/EditChangeRequestDialog";
 import {
   changeRequestImpactColor,
   changeRequestImpactLabel,
@@ -116,6 +119,9 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data, isLoading, isError } = useGetChangeRequest(id);
+  const { showError } = useErrorBanner();
+  const patchCr = usePatchChangeRequest();
+  const [editOpen, setEditOpen] = useState(false);
 
   const back = (): void => {
     navigate(OPERATIONS_CR_PATH);
@@ -189,6 +195,15 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               label={`${changeRequestImpactLabel(cr.impact)} impact`}
             />
           )}
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Pencil size={14} />}
+            onClick={() => setEditOpen(true)}
+            sx={{ ml: "auto", flexShrink: 0 }}
+          >
+            Edit
+          </Button>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
           {cr.number || cr.id}
@@ -280,6 +295,26 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
           <PlanSection title="Rollback plan" html={cr.rollbackPlan} />
           <PlanSection title="Test plan" html={cr.testPlan} />
         </Card>
+      )}
+
+      {editOpen && (
+        <EditChangeRequestDialog
+          cr={cr}
+          isSaving={patchCr.isPending}
+          onClose={() => {
+            if (!patchCr.isPending) setEditOpen(false);
+          }}
+          onSave={(patch) =>
+            patchCr.mutate(
+              { id: cr.id, patch },
+              {
+                onSuccess: () => setEditOpen(false),
+                onError: (err) =>
+                  showError("Could not update the change request.", err),
+              },
+            )
+          }
+        />
       )}
     </Box>
   );


### PR DESCRIPTION

**Note:** This PR depends on #964. It targets the new backend contract introduced there (relocated attachment endpoints, the `PATCH /change-requests/{id}` endpoint).

## Summary

Frontend alignment with the reworked attachment endpoints and the new change-request update endpoint. No backend changes.

### Attachments (endpoints moved off the `/cases/{id}` prefix)
Attachments are no longer case-scoped: `referenceId` + `referenceType` now travel in the request body, so the same endpoints serve change requests, deployments, and conversations.
- **types**: add `ReferenceType`; replace `Attachment.caseId` with `referenceId` + `referenceType`; add the new required fields to the create/search payloads; add the delete-attachment response.
- **client**: add a `DELETE` verb.
- **hooks**: repoint search → `POST /attachments/search`, upload → `POST /attachments`, download → `GET /attachments/{id}/content` (case hooks send `referenceType: "case"`); add a delete hook for `DELETE /attachments/{id}`.
- **case detail**: per-attachment delete action with a confirmation dialog.

### Change requests (`PATCH /change-requests/{id}`)
- **types** + `usePatchChangeRequest` hook for `plannedStartOn` / `isCustomerApproved` / `isCustomerReviewed` (sends only changed fields; the backend requires at least one).
- **CR detail page**: an Edit dialog to update the planned start and the customer approved / reviewed flags.

### Not included
- No frontend for the new time-cards search endpoint (out of scope for this PR).
- These actions (attachment delete, change-request patch) are ServiceNow-only on the backend. They are intentionally **not** UI-gated by data source here: as with the existing assignment flow, the backend rejects the call on a non-matching data source and the error surfaces in the UI. Data-source-aware gating will be handled in the FE alongside data-source switching later.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (one pre-existing unrelated warning)
- [x] `pnpm test` — 104 passing
- [ ] Manual: upload / download / delete an attachment on a case detail
- [ ] Manual: edit a change request's planned start and approval flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit change requests, including planned start date and customer approval/review status.
  * Added attachment deletion for case details, with confirmation and progress feedback.
  * Updated attachment handling to support download, upload, search, and delete flows across multiple reference types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->