### PR TITLE
[CSM Portal] add call requests to case detail

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -834,6 +834,115 @@ export interface BeDeployedProductSearchResponse extends BeSearchResponseBase {
 }
 
 // ---------------------------------------------------------------------------
+// Call requests
+// ---------------------------------------------------------------------------
+
+/**
+ * State of a call request. `id` may be an integer or string (per the OpenAPI
+ * spec -- treat it as opaque and use `label` for display). `label` is the
+ * human-readable state name.
+ */
+export interface BeCallRequestState {
+  id: number | string;
+  label?: string;
+}
+
+/**
+ * The 8 state keys that `SearchCallRequestsPayload.filters.states` and
+ * `UpdateCallRequestPayload.state` accept as plain string enums.
+ */
+export type BeCallRequestStateKey =
+  | "pending_on_customer"
+  | "pending_on_wso2"
+  | "scheduled"
+  | "customer_rejected"
+  | "wso2_rejected"
+  | "canceled"
+  | "notes_pending"
+  | "concluded";
+
+/** A call request list/detail item returned by `POST /cases/{id}/call-requests/search`. */
+export interface BeCallRequestView {
+  id: string;
+  number?: string;
+  case?: {
+    id: string;
+    name?: string;
+    number?: string;
+  };
+  reason?: string;
+  preferredTimes?: string[];
+  durationMin?: number;
+  scheduleTime?: string;
+  meetingLink?: string;
+  createdOn?: string;
+  updatedOn?: string;
+  state?: BeCallRequestState;
+  cancellationReason?: string;
+}
+
+/** `POST /cases/{id}/call-requests` request body. */
+export interface BeCreateCallRequestPayload {
+  reason: string;
+  /** One or more preferred UTC datetimes (ISO strings). */
+  utcTimes: string[];
+  /** Duration of the call in minutes (min 1). */
+  durationInMinutes: number;
+}
+
+/** `POST /cases/{id}/call-requests` response. */
+export interface BeCreateCallRequestResponse {
+  message?: string;
+  callRequest?: {
+    id: string;
+    createdOn?: string;
+    createdBy?: string;
+    state?: BeCallRequestState;
+  };
+}
+
+/** `POST /cases/{id}/call-requests/search` request body. */
+export interface BeSearchCallRequestsPayload {
+  filters?: {
+    states?: BeCallRequestStateKey[];
+  };
+  pagination?: {
+    offset?: number;
+    /** Default 20, max 100. */
+    limit?: number;
+  };
+}
+
+/** `POST /cases/{id}/call-requests/search` response. */
+export interface BeSearchCallRequestsResponse {
+  callRequests: BeCallRequestView[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+/** `PATCH /cases/{caseId}/call-requests/{callRequestId}` request body. */
+export interface BeUpdateCallRequestPayload {
+  state: BeCallRequestStateKey;
+  /** Required when `state` is `"canceled"`. */
+  cancellationReason?: string;
+  /** Updated preferred UTC datetimes. */
+  utcTimes?: string[];
+  /** Updated duration in minutes (min 1). */
+  durationInMinutes?: number;
+}
+
+/** `PATCH /cases/{caseId}/call-requests/{callRequestId}` response. */
+export interface BeUpdateCallRequestResponse {
+  message?: string;
+  callRequest?: {
+    id: string;
+    updatedOn?: string;
+    updatedBy?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Change requests (managed-cloud; ServiceNow data source only)
 // ---------------------------------------------------------------------------
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseCallRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseCallRequests.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCallRequestView,
+  BeCreateCallRequestPayload,
+  BeCreateCallRequestResponse,
+  BeSearchCallRequestsPayload,
+  BeSearchCallRequestsResponse,
+  BeUpdateCallRequestPayload,
+  BeUpdateCallRequestResponse,
+} from "@api/backend/types";
+
+/** Page size for the call-requests list; well within the BE max of 100. */
+const CALL_REQUESTS_PAGE_LIMIT = 20;
+
+/**
+ * Load call requests for a case via `POST /cases/{id}/call-requests/search`.
+ * A single wide page is used; the number of call requests per case is expected
+ * to be small enough that pagination is not needed in the detail view.
+ */
+export function useGetCsmCaseCallRequests(
+  caseId: string | undefined,
+): UseQueryResult<BeCallRequestView[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeCallRequestView[], Error>({
+    queryKey: [ApiQueryKeys.CASE_CALL_REQUESTS, caseId ?? ""],
+    queryFn: async (): Promise<BeCallRequestView[]> => {
+      if (!caseId) return [];
+
+      const payload: BeSearchCallRequestsPayload = {
+        pagination: { offset: 0, limit: CALL_REQUESTS_PAGE_LIMIT },
+      };
+      const response = await api.post<
+        BeSearchCallRequestsPayload,
+        BeSearchCallRequestsResponse
+      >(
+        `/cases/${encodeURIComponent(caseId)}/call-requests/search`,
+        payload,
+      );
+      return response.callRequests ?? [];
+    },
+    enabled: !!caseId,
+    staleTime: 10_000,
+  });
+}
+
+export interface PostCsmCaseCallRequestInput {
+  caseId: string;
+  reason: string;
+  /** ISO datetime strings (UTC preferred times). */
+  utcTimes: string[];
+  durationInMinutes: number;
+}
+
+/**
+ * Create a call request on a case via `POST /cases/{id}/call-requests`.
+ * Invalidates the call-requests list on success.
+ */
+export function usePostCsmCaseCallRequest(): UseMutationResult<
+  BeCreateCallRequestResponse,
+  Error,
+  PostCsmCaseCallRequestInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BeCreateCallRequestResponse, Error, PostCsmCaseCallRequestInput>({
+    mutationFn: async (input): Promise<BeCreateCallRequestResponse> => {
+      const payload: BeCreateCallRequestPayload = {
+        reason: input.reason,
+        utcTimes: input.utcTimes,
+        durationInMinutes: input.durationInMinutes,
+      };
+      return api.post<BeCreateCallRequestPayload, BeCreateCallRequestResponse>(
+        `/cases/${encodeURIComponent(input.caseId)}/call-requests`,
+        payload,
+      );
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CASE_CALL_REQUESTS, variables.caseId],
+      });
+    },
+  });
+}
+
+export interface PatchCsmCaseCallRequestInput {
+  caseId: string;
+  callRequestId: string;
+  patch: BeUpdateCallRequestPayload;
+}
+
+/**
+ * Update a call request state via `PATCH /cases/{caseId}/call-requests/{callRequestId}`.
+ * Invalidates the call-requests list on success.
+ */
+export function usePatchCsmCaseCallRequest(): UseMutationResult<
+  BeUpdateCallRequestResponse,
+  Error,
+  PatchCsmCaseCallRequestInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BeUpdateCallRequestResponse, Error, PatchCsmCaseCallRequestInput>({
+    mutationFn: async (input): Promise<BeUpdateCallRequestResponse> => {
+      return api.patch<BeUpdateCallRequestPayload, BeUpdateCallRequestResponse>(
+        `/cases/${encodeURIComponent(input.caseId)}/call-requests/${encodeURIComponent(input.callRequestId)}`,
+        input.patch,
+      );
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CASE_CALL_REQUESTS, variables.caseId],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestRow.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestRow.tsx
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type JSX } from "react";
+import type { BeCallRequestView, BeCallRequestStateKey } from "@api/backend/types";
+import {
+  CALL_REQUEST_TRANSITIONS,
+  callRequestStateColor,
+  callRequestStateLabel,
+} from "@features/csm-cases/utils/callRequestState";
+import RelativeTime from "@components/RelativeTime";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function formatPreferredTimes(times: string[] | undefined): string {
+  if (!times || times.length === 0) return "—";
+  return times
+    .map((t) => {
+      try {
+        return new Intl.DateTimeFormat(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+          timeZone: "UTC",
+        }).format(new Date(t)) + " UTC";
+      } catch {
+        return t;
+      }
+    })
+    .join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CallRequestRowProps {
+  cr: BeCallRequestView;
+  onUpdateState: (cr: BeCallRequestView) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CallRequestRow({ cr, onUpdateState }: CallRequestRowProps): JSX.Element {
+  const stateKey = cr.state
+    ? (String(cr.state.id) as BeCallRequestStateKey)
+    : null;
+  const hasTransitions = stateKey
+    ? CALL_REQUEST_TRANSITIONS[stateKey].length > 0
+    : false;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 0.5,
+        py: 1.25,
+        borderTop: 1,
+        borderColor: "divider",
+        "&:first-of-type": { borderTop: 0, pt: 0 },
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 1,
+          flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+          {cr.number && (
+            <Typography
+              variant="caption"
+              sx={{ fontFamily: "monospace", color: "text.secondary" }}
+            >
+              {cr.number}
+            </Typography>
+          )}
+          <Chip
+            size="small"
+            label={callRequestStateLabel(cr.state)}
+            color={callRequestStateColor(cr.state)}
+          />
+        </Box>
+        {hasTransitions && (
+          <Button
+            size="small"
+            variant="outlined"
+            color="inherit"
+            onClick={() => onUpdateState(cr)}
+            sx={{ textTransform: "none", flexShrink: 0 }}
+          >
+            Change state
+          </Button>
+        )}
+      </Box>
+
+      {cr.reason && (
+        <Typography variant="body2">{cr.reason}</Typography>
+      )}
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+          gap: 0.75,
+          mt: 0.5,
+        }}
+      >
+        <Box>
+          <Typography variant="caption" color="text.secondary" display="block">
+            Duration
+          </Typography>
+          <Typography variant="body2">
+            {cr.durationMin ? `${cr.durationMin} min` : "—"}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="caption" color="text.secondary" display="block">
+            Preferred times
+          </Typography>
+          <Typography variant="body2" sx={{ whiteSpace: "pre-line" }}>
+            {formatPreferredTimes(cr.preferredTimes)}
+          </Typography>
+        </Box>
+        {cr.scheduleTime && (
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">
+              Scheduled time
+            </Typography>
+            <Typography variant="body2">
+              {formatPreferredTimes([cr.scheduleTime])}
+            </Typography>
+          </Box>
+        )}
+        {cr.meetingLink && (
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">
+              Meeting link
+            </Typography>
+            <Typography
+              variant="body2"
+              component="a"
+              href={cr.meetingLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ color: "primary.main", wordBreak: "break-all" }}
+            >
+              Join meeting
+            </Typography>
+          </Box>
+        )}
+        {cr.cancellationReason && (
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">
+              Cancellation reason
+            </Typography>
+            <Typography variant="body2">{cr.cancellationReason}</Typography>
+          </Box>
+        )}
+        {cr.createdOn && (
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">
+              Created
+            </Typography>
+            <Typography variant="body2">
+              <RelativeTime iso={cr.createdOn} />
+            </Typography>
+          </Box>
+        )}
+        {cr.updatedOn && (
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">
+              Last updated
+            </Typography>
+            <Typography variant="body2">
+              <RelativeTime iso={cr.updatedOn} />
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Divider,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Phone, Plus, RefreshCw } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import type { BeCallRequestView, BeCallRequestStateKey } from "@api/backend/types";
+import {
+  useGetCsmCaseCallRequests,
+  usePostCsmCaseCallRequest,
+  usePatchCsmCaseCallRequest,
+} from "@features/csm-cases/api/useCsmCaseCallRequests";
+import {
+  ALL_CALL_REQUEST_STATES,
+  CALL_REQUEST_STATE_LABEL,
+} from "@features/csm-cases/utils/callRequestState";
+import { CreateCallRequestDialog } from "./CreateCallRequestDialog";
+import { UpdateCallRequestDialog } from "./UpdateCallRequestDialog";
+import { CallRequestRow } from "./CallRequestRow";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CallRequestsWidgetProps {
+  caseId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CallRequestsWidget({ caseId }: CallRequestsWidgetProps): JSX.Element {
+  const { data, isLoading, isError, refetch } = useGetCsmCaseCallRequests(caseId);
+  const postCallRequest = usePostCsmCaseCallRequest();
+  const patchCallRequest = usePatchCsmCaseCallRequest();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const [updateTarget, setUpdateTarget] = useState<BeCallRequestView | null>(null);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+
+  // State filter — empty string means "all".
+  const [stateFilter, setStateFilter] = useState<BeCallRequestStateKey | "">("");
+
+  const filteredRequests = stateFilter
+    ? (data ?? []).filter(
+        (cr) => String(cr.state?.id) === stateFilter,
+      )
+    : (data ?? []);
+
+  const handleCreate = async (
+    reason: string,
+    utcTimes: string[],
+    durationInMinutes: number,
+  ) => {
+    setCreateError(null);
+    try {
+      await postCallRequest.mutateAsync({ caseId, reason, utcTimes, durationInMinutes });
+      setCreateOpen(false);
+    } catch (err) {
+      setCreateError(
+        err instanceof Error ? err.message : "Could not submit the call request.",
+      );
+    }
+  };
+
+  const handleUpdateState = async (
+    newState: BeCallRequestStateKey,
+    cancellationReason?: string,
+  ) => {
+    if (!updateTarget) return;
+    setUpdateError(null);
+    try {
+      await patchCallRequest.mutateAsync({
+        caseId,
+        callRequestId: updateTarget.id,
+        patch: {
+          state: newState,
+          ...(cancellationReason ? { cancellationReason } : {}),
+        },
+      });
+      setUpdateTarget(null);
+    } catch (err) {
+      setUpdateError(
+        err instanceof Error ? err.message : "Could not update the call request.",
+      );
+    }
+  };
+
+  return (
+    <>
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        {/* Header */}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 1,
+            flexWrap: "wrap",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+            <Phone size={16} />
+            <Typography variant="subtitle2">Call requests</Typography>
+            {!isLoading && !isError && (
+              <Chip
+                size="small"
+                variant="outlined"
+                label={`${data?.length ?? 0} total`}
+              />
+            )}
+          </Box>
+          <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+            {/* State filter */}
+            <FormControl size="small" sx={{ minWidth: 180 }}>
+              <InputLabel id="cr-filter-label">Filter by state</InputLabel>
+              <Select
+                labelId="cr-filter-label"
+                value={stateFilter}
+                label="Filter by state"
+                onChange={(e) =>
+                  setStateFilter(e.target.value as BeCallRequestStateKey | "")
+                }
+              >
+                <MenuItem value="">All states</MenuItem>
+                <Divider />
+                {ALL_CALL_REQUEST_STATES.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {CALL_REQUEST_STATE_LABEL[s]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<Plus size={14} />}
+              onClick={() => setCreateOpen(true)}
+              sx={{ textTransform: "none" }}
+            >
+              Request a call
+            </Button>
+          </Box>
+        </Box>
+
+        {/* Content */}
+        {isLoading && (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} variant="rectangular" height={64} />
+            ))}
+          </Box>
+        )}
+
+        {isError && (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 1,
+              py: 3,
+            }}
+          >
+            <Typography variant="body2" color="error">
+              Could not load call requests.
+            </Typography>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<RefreshCw size={14} />}
+              onClick={() => void refetch()}
+              sx={{ textTransform: "none" }}
+            >
+              Retry
+            </Button>
+          </Box>
+        )}
+
+        {!isLoading && !isError && filteredRequests.length === 0 && (
+          <Box sx={{ py: 3, textAlign: "center" }}>
+            <Typography variant="body2" color="text.secondary">
+              {stateFilter
+                ? `No call requests in state "${CALL_REQUEST_STATE_LABEL[stateFilter]}".`
+                : "No call requests yet. Use the button above to request a call."}
+            </Typography>
+          </Box>
+        )}
+
+        {!isLoading && !isError && filteredRequests.length > 0 && (
+          <Box sx={{ display: "flex", flexDirection: "column" }}>
+            {filteredRequests.map((cr) => (
+              <CallRequestRow
+                key={cr.id}
+                cr={cr}
+                onUpdateState={setUpdateTarget}
+              />
+            ))}
+          </Box>
+        )}
+      </Card>
+
+      <CreateCallRequestDialog
+        open={createOpen}
+        submitting={postCallRequest.isPending}
+        error={createError}
+        onClose={() => {
+          setCreateOpen(false);
+          setCreateError(null);
+        }}
+        onSubmit={(reason, utcTimes, durationInMinutes) =>
+          void handleCreate(reason, utcTimes, durationInMinutes)
+        }
+      />
+
+      <UpdateCallRequestDialog
+        callRequest={updateTarget}
+        submitting={patchCallRequest.isPending}
+        error={updateError}
+        onClose={() => {
+          setUpdateTarget(null);
+          setUpdateError(null);
+        }}
+        onSubmit={(newState, cancellationReason) =>
+          void handleUpdateState(newState, cancellationReason)
+        }
+      />
+    </>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Plus } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/** Parse an ISO datetime local-value from an <input type="datetime-local"> back to UTC ISO. */
+function localInputToUtcIso(localValue: string): string {
+  // datetime-local gives "YYYY-MM-DDTHH:mm" which is treated as local time by Date.
+  const d = new Date(localValue);
+  return d.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CreateDialogProps {
+  open: boolean;
+  submitting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (reason: string, utcTimes: string[], durationInMinutes: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CreateCallRequestDialog({
+  open,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: CreateDialogProps): JSX.Element {
+  const [reason, setReason] = useState("");
+  const [duration, setDuration] = useState("30");
+  // Each entry is a datetime-local string from the input.
+  const [timeslots, setTimeslots] = useState<string[]>([""]);
+
+  const handleClose = () => {
+    setReason("");
+    setDuration("30");
+    setTimeslots([""]);
+    onClose();
+  };
+
+  const addTimeslot = () => setTimeslots((prev) => [...prev, ""]);
+  const removeTimeslot = (i: number) =>
+    setTimeslots((prev) => prev.filter((_, idx) => idx !== i));
+  const updateTimeslot = (i: number, val: string) =>
+    setTimeslots((prev) => prev.map((v, idx) => (idx === i ? val : v)));
+
+  const filledSlots = timeslots.filter(Boolean);
+  const durationNum = parseInt(duration, 10);
+  const canSubmit =
+    reason.trim().length > 0 &&
+    filledSlots.length > 0 &&
+    !isNaN(durationNum) &&
+    durationNum >= 1;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit(
+      reason.trim(),
+      filledSlots.map(localInputToUtcIso),
+      durationNum,
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Request a call</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          {error && (
+            <Typography variant="body2" color="error">
+              {error}
+            </Typography>
+          )}
+          <TextField
+            label="Reason for the call"
+            multiline
+            minRows={3}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            fullWidth
+            required
+            disabled={submitting}
+            placeholder="Describe why a call is needed..."
+          />
+          <TextField
+            label="Duration (minutes)"
+            type="number"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            fullWidth
+            required
+            disabled={submitting}
+            inputProps={{ min: 1 }}
+          />
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              Preferred times (UTC) — add one or more options
+            </Typography>
+            {timeslots.map((slot, i) => (
+              <Box key={i} sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+                <TextField
+                  type="datetime-local"
+                  value={slot}
+                  onChange={(e) => updateTimeslot(i, e.target.value)}
+                  fullWidth
+                  disabled={submitting}
+                  size="small"
+                />
+                {timeslots.length > 1 && (
+                  <Button
+                    size="small"
+                    color="inherit"
+                    onClick={() => removeTimeslot(i)}
+                    disabled={submitting}
+                    sx={{ minWidth: 0, px: 1 }}
+                  >
+                    Remove
+                  </Button>
+                )}
+              </Box>
+            ))}
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Plus size={14} />}
+              onClick={addTimeslot}
+              disabled={submitting}
+              sx={{ alignSelf: "flex-start", textTransform: "none" }}
+            >
+              Add another time slot
+            </Button>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={handleClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!canSubmit || submitting}
+          loading={submitting}
+        >
+          Submit request
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/UpdateCallRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/UpdateCallRequestDialog.tsx
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import type { BeCallRequestView, BeCallRequestStateKey } from "@api/backend/types";
+import {
+  CALL_REQUEST_STATE_LABEL,
+  CALL_REQUEST_TRANSITIONS,
+  callRequestStateLabel,
+  requiresCancellationReason,
+} from "@features/csm-cases/utils/callRequestState";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UpdateDialogProps {
+  callRequest: BeCallRequestView | null;
+  submitting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (newState: BeCallRequestStateKey, cancellationReason?: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function UpdateCallRequestDialog({
+  callRequest,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: UpdateDialogProps): JSX.Element {
+  const currentStateKey = callRequest?.state
+    ? (String(callRequest.state.id) as BeCallRequestStateKey)
+    : null;
+  const transitions = currentStateKey ? CALL_REQUEST_TRANSITIONS[currentStateKey] : [];
+
+  // Use `string` here to avoid TS union-narrowing false-positive on the "" guard.
+  const [selectedState, setSelectedState] = useState<string>("");
+  const [cancelReason, setCancelReason] = useState("");
+
+  const handleClose = () => {
+    setSelectedState("");
+    setCancelReason("");
+    onClose();
+  };
+
+  const needsCancelReason =
+    selectedState !== "" && requiresCancellationReason(selectedState as BeCallRequestStateKey);
+  const canSubmit =
+    selectedState !== "" &&
+    (!needsCancelReason || cancelReason.trim().length > 0);
+
+  const handleSubmit = () => {
+    if (!canSubmit || selectedState === "") return;
+    onSubmit(selectedState as BeCallRequestStateKey, needsCancelReason ? cancelReason.trim() : undefined);
+  };
+
+  return (
+    <Dialog
+      open={!!callRequest}
+      onClose={handleClose}
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle>Update call request state</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          {error && (
+            <Typography variant="body2" color="error">
+              {error}
+            </Typography>
+          )}
+          {callRequest && (
+            <Typography variant="body2" color="text.secondary">
+              Current state:{" "}
+              <strong>{callRequestStateLabel(callRequest.state)}</strong>
+            </Typography>
+          )}
+          {transitions.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No transitions available from this state.
+            </Typography>
+          ) : (
+            <FormControl fullWidth size="small" disabled={submitting}>
+              <InputLabel id="cr-state-select-label">New state</InputLabel>
+              <Select
+                labelId="cr-state-select-label"
+                value={selectedState}
+                label="New state"
+                onChange={(e) =>
+                  setSelectedState(e.target.value)
+                }
+              >
+                {transitions.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {CALL_REQUEST_STATE_LABEL[s]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {needsCancelReason && (
+            <TextField
+              label="Cancellation reason"
+              multiline
+              minRows={2}
+              value={cancelReason}
+              onChange={(e) => setCancelReason(e.target.value)}
+              fullWidth
+              required
+              disabled={submitting}
+            />
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={handleClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!canSubmit || transitions.length === 0 || submitting}
+          loading={submitting}
+        >
+          Update
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -38,6 +38,7 @@ import {
   ListChecks,
   MessageSquarePlus,
   Paperclip,
+  Phone,
   TriangleAlert,
   X,
 } from "@wso2/oxygen-ui-icons-react";
@@ -78,6 +79,7 @@ import {
   TimeLogsWidget,
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
+import { CallRequestsWidget } from "@features/csm-cases/components/CallRequestsWidget";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import {
   publicCommentGateReason,
@@ -200,7 +202,8 @@ type CaseTabId =
   | "details"
   | "sla"
   | "attachments"
-  | "time";
+  | "time"
+  | "call-requests";
 
 /**
  * Walk the parent chain to find the nearest vertically-scrollable element.
@@ -235,6 +238,7 @@ const TAB_DEFS: Array<{
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
   // Time tracking is parked until its backend flow lands; disabled for now.
   { id: "time", label: "Time tracking", icon: <Layers size={16} />, disabled: true },
+  { id: "call-requests", label: "Call requests", icon: <Phone size={16} /> },
 ];
 
 export default function CsmCaseDetailPage(): JSX.Element {
@@ -1210,6 +1214,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
             logs={c.timeLogs}
             onAdd={() => onAction({ secondary: "log_time" })}
           />
+        </Box>
+      )}
+
+      {activeTab === "call-requests" && caseId && (
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
+          <CallRequestsWidget caseId={caseId} />
         </Box>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/callRequestState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/callRequestState.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeCallRequestStateKey } from "@api/backend/types";
+
+/** Human-readable label for each call request state key. */
+export const CALL_REQUEST_STATE_LABEL: Record<BeCallRequestStateKey, string> = {
+  pending_on_customer: "Pending on customer",
+  pending_on_wso2: "Pending on WSO2",
+  scheduled: "Scheduled",
+  customer_rejected: "Rejected by customer",
+  wso2_rejected: "Rejected by WSO2",
+  canceled: "Canceled",
+  notes_pending: "Notes pending",
+  concluded: "Concluded",
+};
+
+/**
+ * MUI Chip `color` for each state. Maps to the Oxygen UI palette.
+ * Terminal states (rejected, canceled, concluded) use muted colours;
+ * active/pending states use the action palette.
+ */
+export const CALL_REQUEST_STATE_COLOR: Record<
+  BeCallRequestStateKey,
+  "default" | "primary" | "secondary" | "error" | "info" | "success" | "warning"
+> = {
+  pending_on_customer: "warning",
+  pending_on_wso2: "info",
+  scheduled: "primary",
+  customer_rejected: "error",
+  wso2_rejected: "error",
+  canceled: "default",
+  notes_pending: "warning",
+  concluded: "success",
+};
+
+/**
+ * Resolve the display label for a call request state returned by the backend.
+ * The backend may return `state.label` directly; fall back to our own label map
+ * using the id cast to a string key when `label` is absent or when the id is a
+ * known enum key.
+ */
+export function callRequestStateLabel(state: {
+  id: number | string;
+  label?: string;
+} | undefined): string {
+  if (!state) return "Unknown";
+  if (state.label) return state.label;
+  // id may be the string key or an opaque integer — map what we can.
+  const key = String(state.id) as BeCallRequestStateKey;
+  return CALL_REQUEST_STATE_LABEL[key] ?? String(state.id);
+}
+
+/**
+ * Resolve the MUI chip color for a call request state returned by the backend.
+ * Same resolution logic as `callRequestStateLabel`.
+ */
+export function callRequestStateColor(
+  state: { id: number | string; label?: string } | undefined,
+): "default" | "primary" | "secondary" | "error" | "info" | "success" | "warning" {
+  if (!state) return "default";
+  const key = String(state.id) as BeCallRequestStateKey;
+  return CALL_REQUEST_STATE_COLOR[key] ?? "default";
+}
+
+/** All 8 state keys, used to drive filter dropdowns. */
+export const ALL_CALL_REQUEST_STATES: BeCallRequestStateKey[] = [
+  "pending_on_customer",
+  "pending_on_wso2",
+  "scheduled",
+  "customer_rejected",
+  "wso2_rejected",
+  "canceled",
+  "notes_pending",
+  "concluded",
+];
+
+/**
+ * State transitions available to a CS engineer from a given current state.
+ * This is deliberately conservative: only transitions that make operational
+ * sense are exposed; the full graph is owned by the backend and may accept more.
+ *
+ * From pending states: can schedule, reject (wso2), or cancel.
+ * From scheduled: can conclude, move to notes_pending, or cancel.
+ * From notes_pending: can conclude or cancel.
+ * Terminal states (customer_rejected, wso2_rejected, canceled, concluded): no transitions.
+ */
+export const CALL_REQUEST_TRANSITIONS: Record<
+  BeCallRequestStateKey,
+  BeCallRequestStateKey[]
+> = {
+  pending_on_customer: ["pending_on_wso2", "scheduled", "wso2_rejected", "canceled"],
+  pending_on_wso2: ["pending_on_customer", "scheduled", "wso2_rejected", "canceled"],
+  scheduled: ["notes_pending", "concluded", "canceled"],
+  customer_rejected: [],
+  wso2_rejected: [],
+  canceled: [],
+  notes_pending: ["concluded", "canceled"],
+  concluded: [],
+};
+
+/** Returns true for states where a cancellation reason is required. */
+export function requiresCancellationReason(state: BeCallRequestStateKey): boolean {
+  return state === "canceled";
+}


### PR DESCRIPTION
## Summary

Adds a **Call requests** tab to the case detail page, consuming the call-request endpoints now exposed by the csm-portal backend. FE-only.

- New tab on the case detail page listing a case's call requests (reason, state, preferred times, duration, schedule time + meeting link when scheduled, cancellation reason when present).
- **Create** a call request (`POST /cases/{id}/call-requests`): reason, one or more preferred UTC times, duration in minutes.
- **Update state** (`PATCH /cases/{caseId}/call-requests/{callRequestId}`): operationally sensible transitions per current state; cancelling requires a cancellation reason. Terminal states expose no transitions.
- Optional state filter on the list.

### Implementation
- `Be*` call-request types in `src/api/backend/types.ts`; reuses the existing `CASE_CALL_REQUESTS` query key.
- Hooks: `useGetCsmCaseCallRequests` (search), `usePostCsmCaseCallRequest` (create), `usePatchCsmCaseCallRequest` (update), mirroring the case-comments hook conventions.
- UI split across `CallRequestsWidget` + `CallRequestRow` + `CreateCallRequestDialog` + `UpdateCallRequestDialog` (each kept small for reviewability).
- The call-request `state.id` can be int or string per the spec; the state util normalises via `String(id)` and prefers the backend `label` for display.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (one pre-existing unrelated warning)
- [x] `pnpm test` — 104 passing
- [ ] Manual: create a call request on a case, then move it through states / cancel