### PR TITLE
[CSM Portal] add product vulnerabilities list and detail view

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -89,6 +89,9 @@ const CsmSecurityCenterPage = lazy(
 const CreateSecurityReportPage = lazy(
   () => import("@features/csm-security-center/pages/CreateSecurityReportPage"),
 );
+const ProductVulnerabilityDetailPage = lazy(
+  () => import("@features/csm-security-center/pages/ProductVulnerabilityDetailPage"),
+);
 const CsmEngagementsPage = lazy(
   () => import("@features/csm-engagements/pages/CsmEngagementsPage"),
 );
@@ -250,6 +253,10 @@ export default function App(): JSX.Element {
                 <Route
                   path="security-center/reports/new"
                   element={<CreateSecurityReportPage />}
+                />
+                <Route
+                  path="security-center/vulnerabilities/:id"
+                  element={<ProductVulnerabilityDetailPage />}
                 />
                 <Route
                   path="time-cards"

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1062,3 +1062,58 @@ export interface BeChangeRequestSearchResponse {
   limit: number;
   offset: number;
 }
+
+// ---------------------------------------------------------------------------
+// Product vulnerabilities (managed-cloud; ServiceNow data source only)
+// ---------------------------------------------------------------------------
+
+/** Priority enum for product vulnerabilities. */
+export type BeVulnerabilityPriority =
+  | "info"
+  | "low"
+  | "medium"
+  | "high"
+  | "critical"
+  | "unknown";
+
+/**
+ * Single product vulnerability as returned by both the search list and the
+ * `GET /products/vulnerabilities/{id}` detail endpoint.
+ */
+export interface BeProductVulnerabilityView {
+  id: string;
+  cveId?: string;
+  vulnerabilityId?: string;
+  /** Priority label from the upstream (e.g. "High", "Critical"). */
+  priority?: string;
+  productName?: string | null;
+  productVersion?: string | null;
+  componentName?: string;
+  version?: string;
+  type?: string;
+  componentType?: string | null;
+  updateLevel?: string | null;
+  useCase?: string | null;
+  justification?: string | null;
+  resolution?: string | null;
+}
+
+export interface BeSearchProductVulnerabilitiesFilters {
+  searchQuery?: string;
+  priority?: BeVulnerabilityPriority;
+  productName?: string;
+  productVersion?: string;
+}
+
+export interface BeSearchProductVulnerabilitiesPayload {
+  filters?: BeSearchProductVulnerabilitiesFilters;
+  pagination?: BePagination;
+}
+
+/** Note: the vulnerabilities search response carries no `hasMore`. */
+export interface BeSearchProductVulnerabilitiesResponse {
+  productVulnerabilities: BeProductVulnerabilityView[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/api/useGetProductVulnerability.ts
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/api/useGetProductVulnerability.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeProductVulnerabilityView } from "@api/backend/types";
+
+/**
+ * Look up a single product vulnerability by id via
+ * `GET /products/vulnerabilities/{id}` (ServiceNow data source only). Returns
+ * `null` when the id is unknown so the detail page can render a not-found state
+ * rather than an error.
+ */
+export function useGetProductVulnerability(
+  id: string | undefined,
+): UseQueryResult<BeProductVulnerabilityView | null, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProductVulnerabilityView | null, Error>({
+    queryKey: [ApiQueryKeys.PRODUCT_VULNERABILITY, id ?? ""],
+    queryFn: (): Promise<BeProductVulnerabilityView | null> =>
+      api.get<BeProductVulnerabilityView>(
+        `/products/vulnerabilities/${encodeURIComponent(id as string)}`,
+      ),
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/api/useSearchProductVulnerabilities.ts
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/api/useSearchProductVulnerabilities.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeSearchProductVulnerabilitiesPayload,
+  BeSearchProductVulnerabilitiesResponse,
+} from "@api/backend/types";
+
+/**
+ * Search product vulnerabilities via `POST /products/vulnerabilities/search`
+ * (ServiceNow data source only). Returns the raw paged response so the listing
+ * can drive server-side pagination from `total`. `keepPreviousData` keeps the
+ * table populated while the next page/filter loads.
+ */
+export function useSearchProductVulnerabilities(
+  payload: BeSearchProductVulnerabilitiesPayload,
+): UseQueryResult<BeSearchProductVulnerabilitiesResponse, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeSearchProductVulnerabilitiesResponse, Error>({
+    queryKey: [ApiQueryKeys.PRODUCT_VULNERABILITIES_SEARCH, payload],
+    queryFn: (): Promise<BeSearchProductVulnerabilitiesResponse> =>
+      api.post<BeSearchProductVulnerabilitiesPayload, BeSearchProductVulnerabilitiesResponse>(
+        "/products/vulnerabilities/search",
+        payload,
+      ),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  InputAdornment,
+  MenuItem,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Search } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useNavigate } from "react-router";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useSearchProductVulnerabilities } from "@features/csm-security-center/api/useSearchProductVulnerabilities";
+import {
+  VULNERABILITY_PRIORITIES,
+  vulnerabilityPriorityColor,
+  vulnerabilityPriorityLabel,
+} from "@features/csm-security-center/utils/vulnerabilities";
+import type { BeVulnerabilityPriority } from "@api/backend/types";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+
+/**
+ * Product vulnerabilities listing for the Security Center → Vulnerabilities tab.
+ * Searches `POST /products/vulnerabilities/search` with server-side pagination;
+ * a row opens the vulnerability detail page.
+ */
+export default function ProductVulnerabilitiesTab(): JSX.Element {
+  const navigate = useNavigate();
+  const [searchInput, setSearchInput] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState<BeVulnerabilityPriority | "">("");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const debouncedSearch = useDebouncedValue(searchInput.trim(), 300);
+
+  const payload = useMemo(
+    () => ({
+      filters: {
+        ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
+        ...(priorityFilter !== "" && { priority: priorityFilter }),
+      },
+      pagination: { offset: page * rowsPerPage, limit: rowsPerPage },
+    }),
+    [debouncedSearch, priorityFilter, page, rowsPerPage],
+  );
+
+  const { data, isLoading, isError, error, isFetching } =
+    useSearchProductVulnerabilities(payload);
+
+  const vulnerabilities = data?.productVulnerabilities ?? [];
+  const total = data?.total ?? 0;
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setSearchInput(e.target.value);
+    setPage(0);
+  };
+
+  const handlePriorityChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setPriorityFilter(e.target.value as BeVulnerabilityPriority | "");
+    setPage(0);
+  };
+
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        <TextField
+          value={searchInput}
+          onChange={handleSearchChange}
+          placeholder="Search vulnerabilities…"
+          size="small"
+          sx={{ maxWidth: 400 }}
+          slotProps={{
+            htmlInput: { "aria-label": "Search vulnerabilities" },
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={16} />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+        <TextField
+          select
+          value={priorityFilter}
+          onChange={handlePriorityChange}
+          size="small"
+          label="Priority"
+          sx={{ minWidth: 140 }}
+          slotProps={{
+            htmlInput: { "aria-label": "Filter by priority" },
+          }}
+        >
+          <MenuItem value="">All priorities</MenuItem>
+          {VULNERABILITY_PRIORITIES.map((p) => (
+            <MenuItem key={p} value={p}>
+              {vulnerabilityPriorityLabel(p)}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Box>
+
+      {isError && (
+        <Alert severity="error">
+          Failed to load vulnerabilities:{" "}
+          {error instanceof Error ? error.message : "unknown error"}
+        </Alert>
+      )}
+
+      <Paper variant="outlined">
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>CVE / Vulnerability ID</TableCell>
+                <TableCell>Component</TableCell>
+                <TableCell>Product</TableCell>
+                <TableCell>Priority</TableCell>
+                <TableCell>Type</TableCell>
+                <TableCell>Update level</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                    <CircularProgress size={24} />
+                  </TableCell>
+                </TableRow>
+              ) : isError ? (
+                // The error Alert above carries the detail; don't fall through
+                // to the empty state (which would read as "0 results").
+                null
+              ) : vulnerabilities.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No vulnerabilities found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                vulnerabilities.map((vuln) => {
+                  // Encode the id for the client route; ids are arbitrary
+                  // strings and the detail hook encodes its backend path too.
+                  const detailPath = `/security-center/vulnerabilities/${encodeURIComponent(
+                    vuln.id,
+                  )}`;
+                  return (
+                  <TableRow
+                    key={vuln.id}
+                    hover
+                    onClick={() => navigate(detailPath)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        navigate(detailPath);
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`View vulnerability ${
+                      vuln.cveId || vuln.vulnerabilityId || vuln.id
+                    }`}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                        {vuln.cveId || vuln.vulnerabilityId || "—"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" noWrap title={vuln.componentName}>
+                        {vuln.componentName || "—"}
+                        {vuln.version ? (
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ ml: 0.5 }}
+                          >
+                            {vuln.version}
+                          </Typography>
+                        ) : null}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" noWrap>
+                        {vuln.productName || "—"}
+                        {vuln.productVersion ? (
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ ml: 0.5 }}
+                          >
+                            {vuln.productVersion}
+                          </Typography>
+                        ) : null}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      {vuln.priority ? (
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          color={vulnerabilityPriorityColor(vuln.priority)}
+                          label={vuln.priority}
+                        />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell>{vuln.type || "—"}</TableCell>
+                    <TableCell>{vuln.updateLevel || "—"}</TableCell>
+                  </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(_, newPage) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+          showFirstButton
+          showLastButton
+        />
+      </Paper>
+
+      {isFetching && !isLoading && (
+        <Typography variant="caption" color="text.secondary">
+          Updating…
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -14,25 +14,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Chip, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { useState, type JSX, type ReactNode } from "react";
-import { useNavigate } from "react-router";
+import { type JSX } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+import ProductVulnerabilitiesTab from "@features/csm-security-center/components/ProductVulnerabilitiesTab";
 
 type SecurityCenterTabId = "security_reports" | "vulnerabilities";
 
+const TAB_IDS: SecurityCenterTabId[] = ["security_reports", "vulnerabilities"];
+
 /**
  * Security Center landing — the home for the customer-security entities, split
- * into Security Reports (SRA) / Vulnerabilities tabs. Only the security-report
- * create entry point is live; the report list and the Vulnerabilities tab are
- * awaiting their backend endpoints, so they render "coming soon" placeholders.
- * Replaces the previous blanket coming-soon page.
+ * into Security Reports (SRA) / Vulnerabilities tabs. The active tab lives in
+ * the URL (`?tab=`) so the vulnerability detail page can link back to the right
+ * tab, and the selection survives a refresh or share.
  */
 export default function CsmSecurityCenterPage(): JSX.Element {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] =
-    useState<SecurityCenterTabId>("security_reports");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab") as SecurityCenterTabId | null;
+  const activeTab: SecurityCenterTabId =
+    tabParam && TAB_IDS.includes(tabParam) ? tabParam : "security_reports";
+
+  const handleTabChange = (_: unknown, next: SecurityCenterTabId): void => {
+    setSearchParams((prev) => {
+      prev.set("tab", next);
+      return prev;
+    });
+  };
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -46,7 +57,7 @@ export default function CsmSecurityCenterPage(): JSX.Element {
       <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
         <Tabs
           value={activeTab}
-          onChange={(_, v) => setActiveTab(v as SecurityCenterTabId)}
+          onChange={handleTabChange}
         >
           <Tab value="security_reports" label="Security reports" />
           <Tab value="vulnerabilities" label="Vulnerabilities" />
@@ -72,56 +83,7 @@ export default function CsmSecurityCenterPage(): JSX.Element {
         />
       )}
 
-      {activeTab === "vulnerabilities" && (
-        <TabPanel
-          description="Vulnerability posture across customer deployments, with response-time tracking."
-          comingSoon
-        />
-      )}
-    </Box>
-  );
-}
-
-interface TabPanelProps {
-  description: string;
-  action?: ReactNode;
-  comingSoon?: boolean;
-  children?: ReactNode;
-}
-
-function TabPanel({
-  description,
-  action,
-  comingSoon,
-  children,
-}: TabPanelProps): JSX.Element {
-  return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 1.5,
-          flexWrap: "wrap",
-        }}
-      >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <Typography variant="body2" color="text.secondary">
-            {description}
-          </Typography>
-          {comingSoon && (
-            <Chip
-              size="small"
-              label="Coming soon"
-              color="warning"
-              variant="outlined"
-            />
-          )}
-        </Box>
-        {action}
-      </Box>
-      {children}
+      {activeTab === "vulnerabilities" && <ProductVulnerabilitiesTab />}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode } from "react";
+import { useNavigate, useParams } from "react-router";
+import { useGetProductVulnerability } from "@features/csm-security-center/api/useGetProductVulnerability";
+import {
+  vulnerabilityPriorityColor,
+} from "@features/csm-security-center/utils/vulnerabilities";
+
+const SECURITY_CENTER_VULN_PATH = "/security-center?tab=vulnerabilities";
+
+function MetaCell({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+/**
+ * A plain-text section for long-form vulnerability fields (useCase, justification,
+ * resolution). These fields come from ServiceNow as plain text rather than rich
+ * HTML — rendered as preformatted text to preserve line breaks. Renders nothing
+ * when the field is absent or blank.
+ */
+function TextSection({ title, text }: { title: string; text?: string | null }): JSX.Element | null {
+  if (!text || text.trim().length === 0) return null;
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+      >
+        {text}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * Read-only detail for a single product vulnerability
+ * (`GET /products/vulnerabilities/{id}`): scalar metadata fields and optional
+ * long-form text sections for use case, justification, and resolution.
+ */
+export default function ProductVulnerabilityDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useGetProductVulnerability(id);
+
+  const back = (): void => {
+    navigate(SECURITY_CENTER_VULN_PATH);
+  };
+
+  const BackButton = (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={back}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back to vulnerabilities
+    </Button>
+  );
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rectangular" height={32} width={240} />
+        <Skeleton variant="rectangular" height={260} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {BackButton}
+        <Typography variant="body1" color="error">
+          Could not load vulnerability {id}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {BackButton}
+        <Typography variant="h5">Vulnerability not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No vulnerability with id <code>{id}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const vuln = data;
+  const heading = vuln.cveId || vuln.vulnerabilityId || "Vulnerability";
+
+  const hasLongFormContent =
+    (vuln.useCase && vuln.useCase.trim().length > 0) ||
+    (vuln.justification && vuln.justification.trim().length > 0) ||
+    (vuln.resolution && vuln.resolution.trim().length > 0);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      {BackButton}
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="h5" sx={{ fontFamily: "monospace" }}>
+            {heading}
+          </Typography>
+          {vuln.priority && (
+            <Chip
+              size="small"
+              color={vulnerabilityPriorityColor(vuln.priority)}
+              label={vuln.priority}
+            />
+          )}
+        </Box>
+        {vuln.cveId && vuln.vulnerabilityId && vuln.cveId !== vuln.vulnerabilityId && (
+          <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+            {vuln.vulnerabilityId}
+          </Typography>
+        )}
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="CVE ID">
+            <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+              {vuln.cveId || "—"}
+            </Typography>
+          </MetaCell>
+          <MetaCell label="Vulnerability ID">
+            <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+              {vuln.vulnerabilityId || "—"}
+            </Typography>
+          </MetaCell>
+          <MetaCell label="Priority">
+            <Typography variant="body2">{vuln.priority || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Component">
+            <Typography variant="body2">{vuln.componentName || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Component version">
+            <Typography variant="body2">{vuln.version || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Component type">
+            <Typography variant="body2">{vuln.componentType || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Product">
+            <Typography variant="body2">{vuln.productName || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Product version">
+            <Typography variant="body2">{vuln.productVersion || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Type">
+            <Typography variant="body2">{vuln.type || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Update level">
+            <Typography variant="body2">{vuln.updateLevel || "—"}</Typography>
+          </MetaCell>
+        </Box>
+      </Card>
+
+      {hasLongFormContent && (
+        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
+          <Typography variant="subtitle2">Details</Typography>
+          <TextSection title="Use case" text={vuln.useCase} />
+          <TextSection title="Justification" text={vuln.justification} />
+          <TextSection title="Resolution" text={vuln.resolution} />
+        </Card>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/utils/vulnerabilities.ts
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/utils/vulnerabilities.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeVulnerabilityPriority } from "@api/backend/types";
+
+type ChipColor = "default" | "info" | "warning" | "success" | "error";
+
+/**
+ * Human-readable label for a `VulnerabilityPriority` enum value (used in the
+ * filter select). The `priority` field on `ProductVulnerabilityView` is already
+ * a label string from the upstream (e.g. "High"), so use it directly for display.
+ */
+const PRIORITY_LABEL: Record<BeVulnerabilityPriority, string> = {
+  info: "Info",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  critical: "Critical",
+  unknown: "Unknown",
+};
+
+/**
+ * MUI/Oxygen chip colour keyed on the *lowercase* priority string. Works with
+ * both the enum values (filter select) and the label strings from
+ * `ProductVulnerabilityView.priority` (e.g. "High" → lower-cased to "high").
+ */
+const PRIORITY_COLOR: Record<string, ChipColor> = {
+  critical: "error",
+  high: "error",
+  medium: "warning",
+  low: "info",
+  info: "default",
+  unknown: "default",
+};
+
+/** All vulnerability priorities in display order (highest to lowest). */
+export const VULNERABILITY_PRIORITIES = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+  "unknown",
+] as BeVulnerabilityPriority[];
+
+export function vulnerabilityPriorityLabel(priority: BeVulnerabilityPriority): string {
+  return PRIORITY_LABEL[priority] ?? priority;
+}
+
+/**
+ * Returns the MUI chip colour for a priority value. Accepts both enum values
+ * ("high") and label strings from the view ("High") by normalising to lowercase.
+ */
+export function vulnerabilityPriorityColor(priority?: string | null): ChipColor {
+  if (!priority) return "default";
+  return PRIORITY_COLOR[priority.toLowerCase()] ?? "default";
+}


### PR DESCRIPTION
## Summary

Builds out the Security Center **Vulnerabilities** tab (previously a "coming soon" placeholder) against the now-available product-vulnerabilities endpoints. FE-only.

- Replaces the placeholder with a searchable, paginated vulnerabilities list (`POST /products/vulnerabilities/search`): debounced text search, priority filter, and columns for CVE / vulnerability id, component, product, priority, type, and update level.
- Row click opens a detail view (`GET /products/vulnerabilities/{id}`) at `security-center/vulnerabilities/:id` showing the scalar fields plus use case / justification / resolution when present.

### Implementation
- `Be*` vulnerability types in `src/api/backend/types.ts`; reuses the existing `PRODUCT_VULNERABILITIES_SEARCH` / `PRODUCT_VULNERABILITY` query keys.
- Search + detail hooks mirror the change-requests hook conventions (`keepPreviousData`, null-on-missing).
- Priority chip colour mapping in a small `utils/vulnerabilities.ts`; the `priority` field is an upstream label, so the colour lookup is case-insensitive.
- The Security Center page now drives tab selection from the URL (`?tab=vulnerabilities`) so the detail page's back button lands on the right tab.

### Notes
- `useCase` / `justification` / `resolution` are rendered as plain (pre-wrapped) text since the spec types them as plain strings; if they turn out to carry ServiceNow rich-text HTML, that's a small follow-up to sanitize + render as HTML.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (one pre-existing unrelated warning)
- [x] `pnpm test` — 104 passing
- [ ] Manual: search/filter vulnerabilities, open a detail view, use the back button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Vulnerabilities tab in Security Center with searchable, paginated results.
  * Added a vulnerability detail page with back navigation, loading, error, and empty states.
  * Enabled direct navigation to vulnerability details from the list.
  * Updated tab switching to use the URL, making the active tab shareable and persistent.

* **Bug Fixes**
  * Added priority labels and color handling so vulnerability severity is displayed more clearly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->