### PR TITLE
[CSM Portal] add create and edit for deployed products

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -833,6 +833,61 @@ export interface BeDeployedProductSearchResponse extends BeSearchResponseBase {
   deployedProducts: BeDeployedProduct[];
 }
 
+/**
+ * Request body for `POST /deployments/{id}/products`. All three ID fields are
+ * required per the OpenAPI spec. Sizing fields are optional.
+ */
+export interface BeDeployedProductCreatePayload {
+  projectId: string;
+  productId: string;
+  versionId: string;
+  cores?: number;
+  tps?: number;
+  description?: string;
+}
+
+export interface BeDeployedProductCreateResponse {
+  message?: string;
+  deployedProduct?: {
+    id: string;
+    createdOn: string;
+    createdBy: string;
+  };
+}
+
+/**
+ * Detail-field update for `PATCH /deployments/{deploymentId}/products/{productId}`.
+ * At least one field required. All fields nullable (clears the value).
+ * `active` is forbidden on this variant -- use `BeDeployedProductDeactivatePayload`.
+ */
+export interface BeDeployedProductDetailUpdatePayload {
+  cores?: number | null;
+  tps?: number | null;
+  description?: string | null;
+  active?: never;
+}
+
+/** Deactivation variant: `active` must be `false`, alone. */
+export interface BeDeployedProductDeactivatePayload {
+  active: false;
+  cores?: never;
+  tps?: never;
+  description?: never;
+}
+
+export type BeDeployedProductUpdatePayload =
+  | BeDeployedProductDetailUpdatePayload
+  | BeDeployedProductDeactivatePayload;
+
+export interface BeDeployedProductUpdateResponse {
+  message?: string;
+  deployedProduct?: {
+    id: string;
+    updatedOn: string;
+    updatedBy: string;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Change requests (managed-cloud; ServiceNow data source only)
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeployedProduct.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeployedProduct.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDeployedProductCreatePayload,
+  BeDeployedProductCreateResponse,
+} from "@api/backend/types";
+
+/**
+ * Create a deployed product under a deployment via
+ * `POST /deployments/{id}/products`. On success, invalidates the
+ * `DEPLOYMENT_PRODUCTS` cache for this deployment so the panel refetches.
+ */
+export function useCreateDeployedProduct(
+  deploymentId: string | undefined,
+): UseMutationResult<BeDeployedProductCreateResponse, Error, BeDeployedProductCreatePayload> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BeDeployedProductCreateResponse, Error, BeDeployedProductCreatePayload>({
+    mutationFn: (payload): Promise<BeDeployedProductCreateResponse> =>
+      api.post<BeDeployedProductCreatePayload, BeDeployedProductCreateResponse>(
+        `/deployments/${encodeURIComponent(deploymentId as string)}/products`,
+        payload,
+      ),
+    onSuccess: () => {
+      // Invalidate both the "records" sub-cache (DeployedProductsPanel) and
+      // the options sub-cache (useDeployedProductOptions in case-create).
+      queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.DEPLOYMENT_PRODUCTS, deploymentId ?? ""],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProductVersions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProductVersions.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeProductVersion,
+  BeProductVersionSearchPayload,
+  BeProductVersionSearchResponse,
+} from "@api/backend/types";
+
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+
+/**
+ * Loads versions for a specific product via
+ * `POST /products/{id}/versions/search`. Disabled until `productId` is
+ * provided so the query is naturally lazy (fires only after a product is
+ * chosen in the create dialog).
+ */
+export function useSearchProductVersions(
+  productId: string | undefined,
+): UseQueryResult<BeProductVersion[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProductVersion[], Error>({
+    queryKey: [ApiQueryKeys.PRODUCT_VERSIONS_SEARCH, productId ?? ""],
+    queryFn: async (): Promise<BeProductVersion[]> => {
+      const all: BeProductVersion[] = [];
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const res = await api.post<BeProductVersionSearchPayload, BeProductVersionSearchResponse>(
+          `/products/${encodeURIComponent(productId as string)}/versions/search`,
+          { pagination: { offset, limit: PAGE_LIMIT } },
+        );
+        const page = res.productVersions ?? [];
+        all.push(...page);
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return all;
+    },
+    enabled: !!productId,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProducts.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProducts.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeProduct, BeProductSearchPayload, BeProductSearchResponse } from "@api/backend/types";
+
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+
+/**
+ * Loads all products via `POST /products/search`. Used as the product picker
+ * in {@link CreateDeployedProductDialog}. The full list is fetched once (paged)
+ * and then filtered locally in the Select component, which is acceptable because
+ * the product catalogue is a bounded, small set.
+ */
+export function useSearchProducts(): UseQueryResult<BeProduct[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProduct[], Error>({
+    queryKey: [ApiQueryKeys.PRODUCTS],
+    queryFn: async (): Promise<BeProduct[]> => {
+      const all: BeProduct[] = [];
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const res = await api.post<BeProductSearchPayload, BeProductSearchResponse>(
+          "/products/search",
+          { pagination: { offset, limit: PAGE_LIMIT } },
+        );
+        const page = res.products ?? [];
+        all.push(...page);
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return all;
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeployedProduct.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeployedProduct.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDeployedProductUpdatePayload,
+  BeDeployedProductUpdateResponse,
+} from "@api/backend/types";
+
+interface UpdateDeployedProductInput {
+  /** UUID of the deployed-product record (`DeployedProduct.id`). */
+  deployedProductId: string;
+  payload: BeDeployedProductUpdatePayload;
+}
+
+/**
+ * Update a deployed product via
+ * `PATCH /deployments/{deploymentId}/products/{productId}`.
+ *
+ * The BE accepts two mutually exclusive shapes per the `oneOf` spec:
+ *  - Detail update: `{ cores?, tps?, description? }` (at least one, no `active`)
+ *  - Deactivate: `{ active: false }` (no other fields)
+ *
+ * The caller is responsible for sending exactly one shape. On success,
+ * invalidates the `DEPLOYMENT_PRODUCTS` cache so the panel refetches.
+ */
+export function useUpdateDeployedProduct(
+  deploymentId: string | undefined,
+): UseMutationResult<BeDeployedProductUpdateResponse, Error, UpdateDeployedProductInput> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BeDeployedProductUpdateResponse, Error, UpdateDeployedProductInput>({
+    mutationFn: ({ deployedProductId, payload }): Promise<BeDeployedProductUpdateResponse> =>
+      api.patch<BeDeployedProductUpdatePayload, BeDeployedProductUpdateResponse>(
+        `/deployments/${encodeURIComponent(deploymentId as string)}/products/${encodeURIComponent(deployedProductId)}`,
+        payload,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.DEPLOYMENT_PRODUCTS, deploymentId ?? ""],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeployedProductDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeployedProductDialog.tsx
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import type { BeDeployedProductCreatePayload } from "@api/backend/types";
+import { useSearchProducts } from "@features/csm-projects/api/useSearchProducts";
+import { useSearchProductVersions } from "@features/csm-projects/api/useSearchProductVersions";
+
+interface CreateDeployedProductDialogProps {
+  /** The project this deployed product belongs to (required by the BE contract). */
+  projectId: string;
+  /** True while the POST is in flight; disables actions. */
+  isSaving: boolean;
+  onClose: () => void;
+  /** Submit the create payload via `POST /deployments/{id}/products`. */
+  onCreate: (payload: BeDeployedProductCreatePayload) => void;
+}
+
+const DESCRIPTION_MAX = 4000;
+
+/**
+ * Create a deployed product under the current deployment. Product and version
+ * are required; cores, tps, and description are optional sizing fields.
+ *
+ * Product list comes from `POST /products/search` (full catalogue, bounded).
+ * Version list is dependent on the selected product and comes from
+ * `POST /products/{id}/versions/search` (lazy-loaded after product pick).
+ *
+ * Mount only while open.
+ */
+export default function CreateDeployedProductDialog({
+  projectId,
+  isSaving,
+  onClose,
+  onCreate,
+}: CreateDeployedProductDialogProps): JSX.Element {
+  const [productId, setProductId] = useState("");
+  const [versionId, setVersionId] = useState("");
+  const [cores, setCores] = useState("");
+  const [tps, setTps] = useState("");
+  const [description, setDescription] = useState("");
+
+  const { data: products, isLoading: productsLoading } = useSearchProducts();
+  const { data: versions, isLoading: versionsLoading } = useSearchProductVersions(
+    productId || undefined,
+  );
+
+  const productError = productId === "";
+  const versionError = versionId === "";
+  // Validate optional numeric fields only when the user has typed something.
+  const coresNum = cores.trim() === "" ? undefined : Number(cores);
+  const tpsNum = tps.trim() === "" ? undefined : Number(tps);
+  const coresError = cores.trim() !== "" && (!Number.isInteger(coresNum) || (coresNum as number) < 0);
+  const tpsError = tps.trim() !== "" && (isNaN(tpsNum as number) || (tpsNum as number) < 0);
+
+  const canSave =
+    !isSaving &&
+    !productError &&
+    !versionError &&
+    !coresError &&
+    !tpsError;
+
+  const handleCreate = (): void => {
+    if (!canSave) return;
+    const payload: BeDeployedProductCreatePayload = {
+      projectId,
+      productId,
+      versionId,
+    };
+    if (coresNum !== undefined) payload.cores = coresNum;
+    if (tpsNum !== undefined) payload.tps = tpsNum;
+    const trimmedDescription = description.trim();
+    if (trimmedDescription) payload.description = trimmedDescription;
+    onCreate(payload);
+  };
+
+  // When the product changes, reset the version so the user must pick again.
+  const handleProductChange = (newProductId: string): void => {
+    setProductId(newProductId);
+    setVersionId("");
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Add deployed product</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          {/* Product picker */}
+          <FormControl size="small" fullWidth required error={productId === "" && tps.length > 0}>
+            <InputLabel id="create-dp-product-label">Product</InputLabel>
+            <Select
+              labelId="create-dp-product-label"
+              label="Product"
+              value={productId}
+              onChange={(e) => handleProductChange(e.target.value as string)}
+              startAdornment={
+                productsLoading ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null
+              }
+            >
+              {(products ?? []).map((p) => (
+                <MenuItem key={p.id} value={p.id}>
+                  {p.name ?? p.id}
+                </MenuItem>
+              ))}
+            </Select>
+            {productId === "" && tps.length > 0 && (
+              <FormHelperText>Product is required.</FormHelperText>
+            )}
+          </FormControl>
+
+          {/* Version picker — disabled until a product is selected */}
+          <FormControl
+            size="small"
+            fullWidth
+            required
+            disabled={!productId}
+            error={productId !== "" && versionId === "" && description.length > 0}
+          >
+            <InputLabel id="create-dp-version-label">Version</InputLabel>
+            <Select
+              labelId="create-dp-version-label"
+              label="Version"
+              value={versionId}
+              onChange={(e) => setVersionId(e.target.value as string)}
+              startAdornment={
+                versionsLoading ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null
+              }
+            >
+              {(versions ?? []).map((v) => (
+                <MenuItem key={v.id} value={v.id}>
+                  {v.version ?? v.id}
+                </MenuItem>
+              ))}
+            </Select>
+            {!productId && (
+              <FormHelperText>Select a product first.</FormHelperText>
+            )}
+            {productId !== "" && versionId === "" && description.length > 0 && (
+              <FormHelperText>Version is required.</FormHelperText>
+            )}
+            {productId !== "" && !versionsLoading && (versions ?? []).length === 0 && (
+              <FormHelperText>
+                <Typography variant="inherit" component="span" color="text.secondary">
+                  No versions available for this product.
+                </Typography>
+              </FormHelperText>
+            )}
+          </FormControl>
+
+          {/* Optional sizing fields */}
+          <TextField
+            label="Cores"
+            value={cores}
+            onChange={(e) => setCores(e.target.value)}
+            size="small"
+            fullWidth
+            type="number"
+            slotProps={{ htmlInput: { min: 0, step: 1 } }}
+            error={coresError}
+            helperText={coresError ? "Must be a non-negative integer." : " "}
+          />
+
+          <TextField
+            label="TPS"
+            value={tps}
+            onChange={(e) => setTps(e.target.value)}
+            size="small"
+            fullWidth
+            type="number"
+            slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
+            error={tpsError}
+            helperText={tpsError ? "Must be a non-negative number." : " "}
+          />
+
+          <TextField
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            size="small"
+            fullWidth
+            multiline
+            minRows={2}
+            slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX } }}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!canSave} onClick={handleCreate}>
+          Add product
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
@@ -17,21 +17,54 @@
 import {
   Alert,
   Box,
+  Button,
   Chip,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Menu,
+  MenuItem,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import { type JSX } from "react";
+import { Ban, MoreVertical, Pencil, Plus } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
 import { useSearchDeployedProducts } from "@features/csm-projects/api/useSearchDeployedProducts";
+import { useCreateDeployedProduct } from "@features/csm-projects/api/useCreateDeployedProduct";
+import { useUpdateDeployedProduct } from "@features/csm-projects/api/useUpdateDeployedProduct";
 import { formatDeploymentDate } from "@features/csm-projects/utils/deployments";
+import type {
+  BeDeployedProduct,
+  BeDeployedProductCreatePayload,
+  BeDeployedProductDetailUpdatePayload,
+} from "@api/backend/types";
+import CreateDeployedProductDialog from "@features/csm-projects/components/CreateDeployedProductDialog";
+import EditDeployedProductDialog from "@features/csm-projects/components/EditDeployedProductDialog";
 
 interface DeployedProductsPanelProps {
   deploymentId: string;
+  /**
+   * The project this deployment belongs to. Required for the create payload
+   * (POST /deployments/{id}/products needs projectId). Derived from
+   * BeDeployment.projectId in the parent dialog. When absent (e.g. opened
+   * from a case context where projectId is not populated), the Add button is
+   * hidden.
+   */
+  projectId?: string;
+}
+
+interface Feedback {
+  message: string;
+  severity: "success" | "error";
 }
 
 /** SN sizing fields arrive as strings; treat null/blank uniformly as "—". */
@@ -40,19 +73,96 @@ function sizingValue(value?: string | null): string {
 }
 
 /**
- * Read-only list of the products deployed in a single deployment
- * (`POST /deployments/{id}/products/search`). Rendered inside an expanded
- * deployment row. Mounting it issues the search, so it loads lazily when the
- * row is expanded.
- *
- * Adding, re-versioning, or removing deployed products is not offered: the
- * backend exposes no write endpoints for deployed products yet.
+ * List of the products deployed in a single deployment with write actions.
+ * Loads via POST /deployments/{id}/products/search when mounted (lazy on
+ * row expand). Engineers can add a new deployed product, edit sizing fields,
+ * or deactivate an existing entry.
  */
 export default function DeployedProductsPanel({
   deploymentId,
+  projectId,
 }: DeployedProductsPanelProps): JSX.Element {
   const { data, isLoading, isError, error } = useSearchDeployedProducts(deploymentId);
+  const createDeployedProduct = useCreateDeployedProduct(deploymentId);
+  const updateDeployedProduct = useUpdateDeployedProduct(deploymentId);
+
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuTarget, setMenuTarget] = useState<BeDeployedProduct | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [editing, setEditing] = useState<BeDeployedProduct | null>(null);
+  const [deactivating, setDeactivating] = useState<BeDeployedProduct | null>(null);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
   const products = data ?? [];
+
+  const openMenu = (e: React.MouseEvent<HTMLElement>, p: BeDeployedProduct): void => {
+    e.stopPropagation();
+    setMenuAnchor(e.currentTarget);
+    setMenuTarget(p);
+  };
+  const closeMenu = (): void => {
+    setMenuAnchor(null);
+    setMenuTarget(null);
+  };
+
+  const handleCreate = (payload: BeDeployedProductCreatePayload): void => {
+    createDeployedProduct.mutate(payload, {
+      onSuccess: () => {
+        setCreating(false);
+        setFeedback({ message: "Deployed product added.", severity: "success" });
+      },
+      onError: (err) => {
+        setCreating(false);
+        setFeedback({
+          message: "Could not add deployed product: " + err.message,
+          severity: "error",
+        });
+      },
+    });
+  };
+
+  const handleSaveEdit = (payload: BeDeployedProductDetailUpdatePayload): void => {
+    if (!editing) return;
+    const productName = editing.product?.name ?? "this product";
+    updateDeployedProduct.mutate(
+      { deployedProductId: editing.id, payload },
+      {
+        onSuccess: () => {
+          setEditing(null);
+          setFeedback({ message: "Updated " + productName + ".", severity: "success" });
+        },
+        onError: (err) => {
+          setEditing(null);
+          setFeedback({
+            message: "Could not update " + productName + ": " + err.message,
+            severity: "error",
+          });
+        },
+      },
+    );
+  };
+
+  const handleDeactivate = (): void => {
+    if (!deactivating) return;
+    const target = deactivating;
+    const productName = target.product?.name ?? "this product";
+    updateDeployedProduct.mutate(
+      { deployedProductId: target.id, payload: { active: false } },
+      {
+        onSuccess: () => {
+          setDeactivating(null);
+          setFeedback({ message: "Deactivated " + productName + ".", severity: "success" });
+        },
+        onError: (err) => {
+          setDeactivating(null);
+          setFeedback({
+            message: "Could not deactivate " + productName + ": " + err.message,
+            severity: "error",
+          });
+        },
+      },
+    );
+  };
 
   if (isLoading) {
     return (
@@ -71,53 +181,165 @@ export default function DeployedProductsPanel({
     );
   }
 
-  if (products.length === 0) {
-    return (
-      <Typography variant="body2" color="text.secondary" sx={{ py: 2, px: 1 }}>
-        No products deployed in this deployment.
-      </Typography>
-    );
-  }
-
   return (
     <Box sx={{ py: 1 }}>
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ textTransform: "uppercase", letterSpacing: 0.4, px: 1 }}
+      {feedback && (
+        <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 1 }}>
+          {feedback.message}
+        </Alert>
+      )}
+
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: 1,
+          mb: 0.5,
+        }}
       >
-        Deployed products
-      </Typography>
-      <Table size="small" sx={{ mt: 0.5 }}>
-        <TableHead>
-          <TableRow>
-            <TableCell>Product</TableCell>
-            <TableCell>Version</TableCell>
-            <TableCell>Support EOL</TableCell>
-            <TableCell align="right">Cores</TableCell>
-            <TableCell align="right">TPS</TableCell>
-            <TableCell>Category</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {products.map((p) => (
-            <TableRow key={p.id}>
-              <TableCell>{p.product?.name || p.product?.id || "—"}</TableCell>
-              <TableCell>
-                {p.version?.name ? (
-                  <Chip size="small" variant="outlined" label={p.version.name} />
-                ) : (
-                  "—"
-                )}
-              </TableCell>
-              <TableCell>{formatDeploymentDate(p.version?.supportEoLDate)}</TableCell>
-              <TableCell align="right">{sizingValue(p.cores)}</TableCell>
-              <TableCell align="right">{sizingValue(p.tps)}</TableCell>
-              <TableCell>{p.category ?? "—"}</TableCell>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+        >
+          Deployed products
+        </Typography>
+        {projectId && (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<Plus size={14} />}
+            onClick={() => setCreating(true)}
+            sx={{ py: 0.25 }}
+          >
+            Add product
+          </Button>
+        )}
+      </Box>
+
+      {products.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 1, px: 1 }}>
+          No products deployed in this deployment.
+        </Typography>
+      ) : (
+        <Table size="small" sx={{ mt: 0.5 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Product</TableCell>
+              <TableCell>Version</TableCell>
+              <TableCell>Support EOL</TableCell>
+              <TableCell align="right">Cores</TableCell>
+              <TableCell align="right">TPS</TableCell>
+              <TableCell>Category</TableCell>
+              <TableCell align="right">Actions</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {products.map((p) => (
+              <TableRow key={p.id}>
+                <TableCell>{p.product?.name || p.product?.id || "—"}</TableCell>
+                <TableCell>
+                  {p.version?.name ? (
+                    <Chip size="small" variant="outlined" label={p.version.name} />
+                  ) : (
+                    "—"
+                  )}
+                </TableCell>
+                <TableCell>{formatDeploymentDate(p.version?.supportEoLDate)}</TableCell>
+                <TableCell align="right">{sizingValue(p.cores)}</TableCell>
+                <TableCell align="right">{sizingValue(p.tps)}</TableCell>
+                <TableCell>{p.category ?? "—"}</TableCell>
+                <TableCell align="right">
+                  <Tooltip title="Product actions">
+                    <IconButton
+                      size="small"
+                      aria-label={"Actions for " + (p.product?.name ?? "deployed product")}
+                      onClick={(e) => openMenu(e, p)}
+                    >
+                      <MoreVertical size={14} />
+                    </IconButton>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
+        <MenuItem
+          onClick={() => {
+            setEditing(menuTarget);
+            closeMenu();
+          }}
+        >
+          <Pencil size={14} style={{ marginRight: 8 }} />
+          Edit details
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setDeactivating(menuTarget);
+            closeMenu();
+          }}
+          sx={{ color: "error.main" }}
+        >
+          <Ban size={14} style={{ marginRight: 8 }} />
+          Deactivate
+        </MenuItem>
+      </Menu>
+
+      {creating && projectId && (
+        <CreateDeployedProductDialog
+          projectId={projectId}
+          isSaving={createDeployedProduct.isPending}
+          onClose={() => setCreating(false)}
+          onCreate={handleCreate}
+        />
+      )}
+
+      {editing && (
+        <EditDeployedProductDialog
+          deployedProduct={editing}
+          isSaving={updateDeployedProduct.isPending}
+          onClose={() => setEditing(null)}
+          onSave={handleSaveEdit}
+        />
+      )}
+
+      <Dialog
+        open={!!deactivating}
+        onClose={() => setDeactivating(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Deactivate deployed product</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Deactivate{" "}
+            <Box component="span" sx={{ fontWeight: 600, color: "text.primary" }}>
+              {deactivating?.product?.name ?? "this product"}
+            </Box>
+            ? This marks it inactive in ServiceNow.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeactivating(null)}
+            disabled={updateDeployedProduct.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={handleDeactivate}
+            disabled={updateDeployedProduct.isPending}
+          >
+            Deactivate
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
@@ -108,7 +108,7 @@ export default function DeploymentDetailsDialog({
             </Box>
           )}
 
-          <DeployedProductsPanel deploymentId={deployment.id} />
+          <DeployedProductsPanel deploymentId={deployment.id} projectId={deployment.projectId} />
         </Box>
       </DialogContent>
       <DialogActions>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.tsx
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type {
+  BeDeployedProduct,
+  BeDeployedProductDetailUpdatePayload,
+} from "@api/backend/types";
+
+interface EditDeployedProductDialogProps {
+  deployedProduct: BeDeployedProduct;
+  /** True while the PATCH is in flight; disables actions. */
+  isSaving: boolean;
+  onClose: () => void;
+  /** Persist the changed detail fields (only changed fields are sent). */
+  onSave: (payload: BeDeployedProductDetailUpdatePayload) => void;
+}
+
+const DESCRIPTION_MAX = 4000;
+
+/**
+ * Edit a deployed product's cores, tps, and description
+ * (`PATCH /deployments/{deploymentId}/products/{productId}` detail variant).
+ *
+ * Only changed fields are sent — the BE requires minProperties 1 for this
+ * variant, so Save is disabled until at least one field differs. Clearing a
+ * field sends `null` to explicitly remove the value.
+ *
+ * Deactivation is a separate concern handled via a confirm dialog in
+ * {@link DeployedProductsPanel}, not here — keeping the two BE shapes distinct
+ * avoids any chance of accidentally mixing `active` with detail fields.
+ *
+ * Mount only while open.
+ */
+export default function EditDeployedProductDialog({
+  deployedProduct,
+  isSaving,
+  onClose,
+  onSave,
+}: EditDeployedProductDialogProps): JSX.Element {
+  // Existing SN cores/tps arrive as strings (or null). Parse to number for the
+  // input; the payload sends numbers per the openapi spec.
+  // `description` is not in the read schema (DeployedProduct in openapi.yaml
+  // does not carry it back) — initialize as empty so we can only set/clear it.
+  const originalCoresStr = deployedProduct.cores?.trim() ?? "";
+  const originalTpsStr = deployedProduct.tps?.trim() ?? "";
+  const originalDescription = "";
+
+  const [cores, setCores] = useState(originalCoresStr);
+  const [tps, setTps] = useState(originalTpsStr);
+  const [description, setDescription] = useState(originalDescription);
+
+  const coresNum = cores.trim() === "" ? null : Number(cores);
+  const tpsNum = tps.trim() === "" ? null : Number(tps);
+  const coresError =
+    cores.trim() !== "" &&
+    (!Number.isInteger(coresNum) || (coresNum as number) < 0);
+  const tpsError =
+    tps.trim() !== "" &&
+    (isNaN(tpsNum as number) || (tpsNum as number) < 0);
+
+  const coresChanged = cores.trim() !== originalCoresStr;
+  const tpsChanged = tps.trim() !== originalTpsStr;
+  const descriptionChanged = description.trim() !== originalDescription;
+
+  const payload = useMemo<BeDeployedProductDetailUpdatePayload>(() => {
+    const next: Record<string, unknown> = {};
+    if (coresChanged) next.cores = coresNum;
+    if (tpsChanged) next.tps = tpsNum;
+    if (descriptionChanged) {
+      next.description = description.trim().length > 0 ? description.trim() : null;
+    }
+    return next as BeDeployedProductDetailUpdatePayload;
+  }, [coresChanged, tpsChanged, descriptionChanged, coresNum, tpsNum, description]);
+
+  const canSave =
+    !isSaving &&
+    !coresError &&
+    !tpsError &&
+    (coresChanged || tpsChanged || descriptionChanged);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Edit deployed product</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          <TextField
+            label="Cores"
+            value={cores}
+            onChange={(e) => setCores(e.target.value)}
+            size="small"
+            fullWidth
+            type="number"
+            autoFocus
+            slotProps={{ htmlInput: { min: 0, step: 1 } }}
+            error={coresError}
+            helperText={coresError ? "Must be a non-negative integer." : " "}
+          />
+
+          <TextField
+            label="TPS"
+            value={tps}
+            onChange={(e) => setTps(e.target.value)}
+            size="small"
+            fullWidth
+            type="number"
+            slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
+            error={tpsError}
+            helperText={tpsError ? "Must be a non-negative number." : " "}
+          />
+
+          <TextField
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            size="small"
+            fullWidth
+            multiline
+            minRows={2}
+            slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX } }}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!canSave} onClick={() => onSave(payload)}>
+          Save changes
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

Adds create / edit / deactivate for **deployed products** within a deployment, using the write endpoints now exposed by the csm-portal backend. FE-only.

- `DeployedProductsPanel` (previously read-only) gains an **Add product** action and a per-row **Edit** / **Deactivate** menu.
- **Create** (`POST /deployments/{id}/products`): product picker + dependent version picker, plus optional cores / TPS / description.
- **Edit** (`PATCH /deployments/{deploymentId}/products/{productId}`): sends only changed cores / TPS / description.
- **Deactivate** uses the same endpoint's deactivate variant (`{ active: false }`), behind a confirm.

### Implementation
- `Be*` payload/response types in `src/api/backend/types.ts`, modelling the PATCH `oneOf` as a union (detail-update vs deactivate) with mutually-exclusive `never` fields.
- Hooks `useCreateDeployedProduct` / `useUpdateDeployedProduct` invalidate the existing `DEPLOYMENT_PRODUCTS` query key so the panel refetches.
- Added `useSearchProducts` (`POST /products/search`) and `useSearchProductVersions` (`POST /products/{id}/versions/search`) — no FE hooks existed for these and the create form needs the pickers.
- `projectId` for the create payload comes from `BeDeployment.projectId` (passed down via `DeploymentDetailsDialog`); the Add action is hidden when `projectId` is unavailable.

### Notes
- The deployed-product read schema (`DeployedProduct`) does not return `description`/`cores`/`tps`, so the edit dialog starts those fields empty (noted in helper text).
- `DeployedProductsPanel.tsx` is ~324 changed lines, just over CodeRabbit's 300-line per-file review window — expect summary-only review on that one file.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (one pre-existing unrelated warning)
- [x] `pnpm test` — 104 passing
- [ ] Manual: add a deployed product, edit its cores/TPS/description, deactivate it