### PR TITLE
[CSM Portal] use skeleton loaders for list pages and engineer search

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -18,8 +18,8 @@ import {
   Alert,
   Box,
   Chip,
-  CircularProgress,
   Paper,
+  Skeleton,
   Table,
   TableBody,
   TableCell,
@@ -114,11 +114,16 @@ export default function CsmAccountsPage(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
-                    <CircularProgress size={24} />
-                  </TableCell>
-                </TableRow>
+                [0, 1, 2, 3, 4, 5].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                  </TableRow>
+                ))
               ) : accounts.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
@@ -18,12 +18,12 @@ import {
   Avatar,
   Box,
   Button,
-  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   InputAdornment,
+  Skeleton,
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
@@ -134,8 +134,16 @@ export default function AssignEngineerDialog({
 
           <Box sx={{ minHeight: 160 }}>
             {isFetching ? (
-              <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-                <CircularProgress size={22} />
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, pt: 0.75 }}>
+                {[0, 1, 2, 3, 4].map((i) => (
+                  <Box key={i} sx={{ display: "flex", alignItems: "center", gap: 1.25, px: 1, py: 0.75 }}>
+                    <Skeleton variant="circular" width={28} height={28} />
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Skeleton variant="text" sx={{ fontSize: "0.875rem", width: "55%" }} />
+                      <Skeleton variant="text" sx={{ fontSize: "0.75rem", width: "75%" }} />
+                    </Box>
+                  </Box>
+                ))}
               </Box>
             ) : isError ? (
               <Typography variant="body2" color="error" sx={{ py: 2 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -18,9 +18,9 @@ import {
   Alert,
   Box,
   Chip,
-  CircularProgress,
   InputAdornment,
   Paper,
+  Skeleton,
   Table,
   TableBody,
   TableCell,
@@ -138,11 +138,17 @@ export default function ChangeRequestsTab(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
-                    <CircularProgress size={24} />
-                  </TableCell>
-                </TableRow>
+                [0, 1, 2, 3, 4, 5].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                  </TableRow>
+                ))
               ) : changeRequests.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -18,8 +18,8 @@ import {
   Alert,
   Box,
   Chip,
-  CircularProgress,
   Paper,
+  Skeleton,
   Table,
   TableBody,
   TableCell,
@@ -117,11 +117,15 @@ export default function CsmProjectsPage(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                    <CircularProgress size={24} />
-                  </TableCell>
-                </TableRow>
+                [0, 1, 2, 3, 4, 5].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                  </TableRow>
+                ))
               ) : projects.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={5} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -18,8 +18,8 @@ import {
   Alert,
   Box,
   Chip,
-  CircularProgress,
   Paper,
+  Skeleton,
   Table,
   TableBody,
   TableCell,
@@ -106,11 +106,15 @@ export default function CsmUsersPage(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                    <CircularProgress size={24} />
-                  </TableCell>
-                </TableRow>
+                [0, 1, 2, 3, 4, 5].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="text" /></TableCell>
+                  </TableRow>
+                ))
               ) : users.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={5} align="center" sx={{ py: 4 }}>


### PR DESCRIPTION
## Summary

Makes loading states consistent. The cases/engagements lists already use skeleton rows, but several list pages and the engineer-search dialog used a centered `CircularProgress` spinner. This switches those to skeletons that match each surface's layout.

- **Accounts / Users / Projects / Change requests** list pages: the initial-load spinner is replaced with ~6 skeleton table rows whose cell count matches each table's columns.
- **Assign engineer dialog**: the results-area spinner is replaced with ~5 skeleton rows shaped like a real engineer row (circular avatar + name + email lines); a stable min-height keeps the dialog from jumping.
- The subtle `isFetching && !isLoading` "updating" footer overlays are intentionally left as-is.

FE-only; no behavior change beyond the loading visual.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (one pre-existing unrelated warning)
- [x] `pnpm test` — 104 passing
- [ ] Manual: trigger initial load on each list and the assign-engineer dialog