### PR TITLE
[CSM Portal] make dashboard composition charts clickable to filter cases

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
@@ -16,6 +16,8 @@
 
 import { Box, Typography } from "@wso2/oxygen-ui";
 import { useMemo, type JSX } from "react";
+import { useNavigate } from "react-router";
+import { casesHref } from "@features/csm-cases/utils/casesFiltersUrl";
 import {
   COMPOSITION_STATES,
   useCaseComposition,
@@ -60,6 +62,7 @@ const STATE_SLICE_COLOR: Record<CaseState, string> = {
  */
 export default function CaseCompositionCharts(): JSX.Element {
   const { data, isLoading, isError } = useCaseComposition();
+  const navigate = useNavigate();
 
   const severitySlices = useMemo<CompositionSlice[]>(
     () =>
@@ -101,6 +104,9 @@ export default function CaseCompositionCharts(): JSX.Element {
           total={data?.severityTotal ?? 0}
           isLoading={isLoading}
           isError={isError}
+          onSliceClick={(id) =>
+            navigate(casesHref({ severities: [id as Severity] }))
+          }
         />
         <CompositionDonut
           title="Cases by state"
@@ -109,6 +115,9 @@ export default function CaseCompositionCharts(): JSX.Element {
           total={data?.stateTotal ?? 0}
           isLoading={isLoading}
           isError={isError}
+          onSliceClick={(id) =>
+            navigate(casesHref({ states: [id as CaseState] }))
+          }
         />
       </Box>
       {/* Reconciles the pies with the matrix above: both show active cases only,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CompositionDonut.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CompositionDonut.tsx
@@ -38,6 +38,12 @@ interface CompositionDonutProps {
   isError: boolean;
   /** Noun for the empty state, e.g. "cases". */
   emptyNoun?: string;
+  /**
+   * When provided, slices and legend rows become clickable and call this with
+   * the slice `id` (e.g. to navigate to a filtered list). Omit for a static
+   * chart.
+   */
+  onSliceClick?: (id: string) => void;
 }
 
 /**
@@ -53,6 +59,7 @@ export default function CompositionDonut({
   isLoading,
   isError,
   emptyNoun = "cases",
+  onSliceClick,
 }: CompositionDonutProps): JSX.Element {
   const pieData = slices.filter((s) => s.value > 0);
   const isEmpty = !isLoading && !isError && total === 0;
@@ -103,6 +110,9 @@ export default function CompositionDonut({
               width: DONUT_SIZE,
               height: DONUT_SIZE,
               flexShrink: 0,
+              ...(onSliceClick && {
+                "& .recharts-pie-sector": { cursor: "pointer" },
+              }),
             }}
           >
             <PieChart
@@ -123,6 +133,12 @@ export default function CompositionDonut({
                   endAngle: -270,
                   label: false,
                   labelLine: false,
+                  ...(onSliceClick && {
+                    onClick: (_data: unknown, index: number) => {
+                      const slice = pieData[index];
+                      if (slice) onSliceClick(slice.id);
+                    },
+                  }),
                 },
               ]}
             />
@@ -150,11 +166,13 @@ export default function CompositionDonut({
               return (
                 <Box
                   key={s.id}
+                  onClick={onSliceClick ? () => onSliceClick(s.id) : undefined}
                   sx={{
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "space-between",
                     gap: 1,
+                    cursor: onSliceClick ? "pointer" : "default",
                   }}
                 >
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 0 }}>


### PR DESCRIPTION
## Summary

The dashboard's 'Cases by severity' and 'Cases by state' donut charts are now interactive: clicking a **pie slice or its legend row** navigates to the cases list pre-filtered by that severity/state (e.g. clicking the *Open* slice opens `/cases?states=open`).

This mirrors the **customer portal's** existing clickable dashboard charts (`ActiveCasesChart` / `ChartLegend`) — same approach, kept intentionally minimal.

### Implementation
- `CompositionDonut` gains an optional `onSliceClick(id)` prop. When set, the pie's `onClick` and each legend row call it with the slice id, and the cursor becomes a pointer (matching the customer portal: `onClick` + `cursor: pointer`, no extra scaffolding). Omitting the prop leaves the chart static.
- `CaseCompositionCharts` wires it via the existing `casesHref({ severities | states })` helper + `navigate`, so filter encoding stays in one place.

FE-only; no new dependencies.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (one pre-existing unrelated warning)
- [x] `pnpm test` — 104 passing
- [ ] Manual: click a slice and a legend row in each donut; confirm the cases list opens filtered to that severity/state