### PR TITLE
[CSM][BE] feat: update POST /users/search with filters, sortBy, and SNUser response

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -180,7 +180,7 @@ backend/
 
 - `GET /users/me` — Get current user profile
 - `PATCH /users/me` — Update current user profile (phone number)
-- `POST /users/search` — Search users
+- `POST /users/search` — Search users; optional `filters` (`searchQuery`, `roles`, `userNames`, `emails`, `active`) and `sortBy` (`field`, `order`); response shape depends on data source (`User` for postgres, `SNUser` for ServiceNow)
 
 ### Accounts
 

--- a/apps/csm-portal/backend/internal/handler/users.go
+++ b/apps/csm-portal/backend/internal/handler/users.go
@@ -182,8 +182,6 @@ func (h *UsersHandler) SearchUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Decode into a typed SearchUsersRequest and validate fields before forwarding.
-
 	result, err := h.entity.SearchUsers(r.Context(), body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchUsers failed", "userID", user.UserID, "err", err)
@@ -191,6 +189,5 @@ func (h *UsersHandler) SearchUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Unmarshal result and filter to only the fields required by the frontend.
 	writeJSON(w, http.StatusOK, result)
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -612,7 +612,11 @@ paths:
 
   /users/search:
     post:
-      summary: Search users.
+      summary: Search users with optional filters, sort, and pagination.
+      description: >
+        Returns a paginated list of users. When the entity-service data source is
+        ServiceNow the response uses SNUser (name, timeZone, active, roles); for
+        the postgres data source it uses User (firstName, lastName, userType).
       operationId: postUsersSearch
       requestBody:
         description: User search payload
@@ -623,19 +627,27 @@ paths:
         required: true
       responses:
         "200":
-          description: Ok
+          description: Users matching the supplied filters.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserSearchResponse'
+                oneOf:
+                  - $ref: '#/components/schemas/UserSearchResponse'
+                  - $ref: '#/components/schemas/SNUserSearchResponse'
         "400":
-          description: BadRequest
+          description: Bad request — invalid filter value, sort field, or pagination limit.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
           content:
             application/json:
               schema:
@@ -2768,18 +2780,72 @@ components:
       type: object
       properties:
         pagination:
-          allOf:
-            - $ref: '#/components/schemas/Pagination'
-            - properties:
-                limit:
-                  default: 20
-                  maximum: 100
+          $ref: '#/components/schemas/UserPagination'
+        filters:
+          $ref: '#/components/schemas/UserSearchFilters'
+        sortBy:
+          $ref: '#/components/schemas/UserSortBy'
+
+    UserPagination:
+      type: object
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 10
+          description: Number of results per page. Defaults to 10, capped at 50.
+        offset:
+          type: integer
+          minimum: 0
+          default: 0
+
+    UserSearchFilters:
+      type: object
+      properties:
         searchQuery:
           type: string
-          description: Searches across userName and email (case-insensitive); max 200 characters
+          maxLength: 200
+          description: Case-insensitive match against username and email.
+        roles:
+          type: array
+          maxItems: 20
+          items:
+            type: string
+            enum: [internal, agent, admin, commenter, external, customer, customer_admin, partner, partner_admin]
+          description: Filter by one or more ServiceNow roles. ServiceNow data source only.
+        userNames:
+          type: array
+          maxItems: 50
+          items:
+            type: string
+          description: Filter to specific usernames (exact match).
+        emails:
+          type: array
+          maxItems: 50
+          items:
+            type: string
+          description: Filter to specific email addresses (exact match).
+        active:
+          type: boolean
+          nullable: true
+          description: When set, restricts results to active or inactive users. ServiceNow data source only.
+
+    UserSortBy:
+      type: object
+      properties:
+        field:
+          type: string
+          enum: [name, createdOn, updatedOn]
+          description: Column to sort by. ServiceNow data source only.
+        order:
+          type: string
+          enum: [asc, desc]
+          description: Sort direction. Defaults to asc when field is set.
 
     UserSearchResponse:
       type: object
+      description: Paginated user list from the postgres data source.
       properties:
         users:
           type: array
@@ -2794,6 +2860,48 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    SNUser:
+      type: object
+      description: User as returned by the ServiceNow data source.
+      properties:
+        id:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+        timeZone:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+
+    SNUserSearchResponse:
+      type: object
+      description: Paginated user list from the ServiceNow data source.
+      properties:
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/SNUser'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
 
     User:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2846,6 +2846,7 @@ components:
     UserSearchResponse:
       type: object
       description: Paginated user list from the postgres data source.
+      required: [users, total, limit, offset, hasMore]
       properties:
         users:
           type: array
@@ -2891,6 +2892,7 @@ components:
     SNUserSearchResponse:
       type: object
       description: Paginated user list from the ServiceNow data source.
+      required: [users, total, limit, offset]
       properties:
         users:
           type: array


### PR DESCRIPTION
## Summary

Implements the CSM portal backend side of entity-service PR #973.

- **`UserSearchPayload`** restructured: flat `searchQuery` moved into a nested `filters` object; new `sortBy` added; pagination now uses `UserPagination` (default 10, max 50 instead of 20/100)
- **`UserSearchFilters`**: `searchQuery`, `roles` (SN-only, enum), `userNames`, `emails`, `active` (SN-only)
- **`UserSortBy`**: `field` (`name`/`createdOn`/`updatedOn`) + `order` (`asc`/`desc`); ServiceNow data source only
- **`SNUser`** + **`SNUserSearchResponse`** schemas added for the ServiceNow data source response shape
- **`/users/search` 200 response** updated to `oneOf` (`UserSearchResponse` | `SNUserSearchResponse`)
- Added missing `403` response to `/users/search`
- Stale TODO comments removed from `SearchUsers` handler (all validation is handled in the entity service)
- `README.md` updated

The handler itself remains a passthrough — request body is forwarded to the entity service unchanged and the raw response is returned.

## Entity service PR
wso2-open-operations/cs-tools#973

## Test plan

- [x] `POST /users/search` with `{}` body forwards to entity service and returns response
- [x] `POST /users/search` with `{ "filters": { "searchQuery": "alice" } }` forwards correctly
- [x] Build passes, all existing handler tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the user search API documentation with supported filters, sorting options, and clearer response details.
  * Clarified that search results may return different user shapes depending on the data source.
* **New Features**
  * Updated the API contract to support source-specific search responses, including ServiceNow user results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->