### PR TITLE
[CSM][BE] Add isLead role support to project contacts endpoints

### DIFF
--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1102,6 +1102,8 @@ public type ContactOnboardPayload record {|
     boolean isCsIntegrationUser;
     # Whether the contact is a customer admin or not
     boolean isCsAdmin = false;
+    # Whether the contact is a lead or not
+    boolean isLead = false;
     # Whether the contact is a portal user or not
     boolean isPortalUser = false;
     # Whether the contact is Security Contact or not
@@ -1112,6 +1114,8 @@ public type ContactOnboardPayload record {|
 public type MembershipRolePayload record {|
     # Whether the contact is a customer admin or not
     boolean isCsAdmin = false;
+    # Whether the contact is a lead or not
+    boolean isLead = false;
     # Whether the contact is a portal user or not
     boolean isPortalUser = false;
     # Whether the contact is a security contact or not

--- a/apps/customer-portal/backend/modules/user_management/types.bal
+++ b/apps/customer-portal/backend/modules/user_management/types.bal
@@ -87,6 +87,8 @@ public type OnBoardContactPayload record {|
     boolean isCsIntegrationUser;
     # Whether the contact is a customer admin or not
     boolean isCsAdmin = false;
+    # Whether the contact is a lead or not
+    boolean isLead = false;
     # Whether the contact is a portal user or not
     boolean isPortalUser = false;
     # Whether the contact is Security Contact or not
@@ -117,6 +119,8 @@ public type Membership record {|
     string state;
     # Whether the contact is a customer admin or not
     boolean? isCsAdmin;
+    # Whether the contact is a lead or not
+    boolean? isLead;
     # Whether the contact is a portal user or not
     boolean? isPortalUser;
     # Whether the contact is a Security contact or not
@@ -154,6 +158,8 @@ public type MembershipRolePayload record {|
     string adminEmail;
     # Whether the contact is a customer admin or not
     boolean isCsAdmin = false;
+    # Whether the contact is a lead or not
+    boolean isLead = false;
     # Whether the contact is a portal user or not
     boolean isPortalUser = false;
     # Whether the contact is a security contact or not

--- a/apps/customer-portal/backend/modules/user_management/user_management.bal
+++ b/apps/customer-portal/backend/modules/user_management/user_management.bal
@@ -49,7 +49,7 @@ public isolated function createProjectContact(string projectId, OnBoardContactPa
         contactFirstName: payload.contactFirstName,
         contactLastName: payload.contactLastName,
         isCsIntegrationUser: payload.isCsIntegrationUser,
-        role: getRoles(payload.isCsAdmin, payload.isPortalUser, payload.isSecurityContact)
+        role: getRoles(payload.isCsAdmin, payload.isLead, payload.isPortalUser, payload.isSecurityContact)
     };
 
     http:Response userCreateResponse = check userManagementClient->/projects/[projectId]/contact.post(userManagementPayload);
@@ -103,7 +103,7 @@ public isolated function updateMembershipRole(string projectId, string contactEm
 
     UserManagementMembershipRolePayload userManagementPayload = {
         adminEmail: payload.adminEmail,
-        role: getRoles(payload.isCsAdmin, payload.isPortalUser, payload.isSecurityContact)
+        role: getRoles(payload.isCsAdmin, payload.isLead, payload.isPortalUser, payload.isSecurityContact)
     };
 
     http:Response userUpdateResponse =
@@ -156,10 +156,22 @@ public isolated function validateProjectContact(ValidationPayload payload) retur
     return error(check errBody.message);
 }
 
-isolated function getRoles(boolean isCsAdmin, boolean isPortalUser, boolean isSecurityContact) returns string[] {
+# Get the roles for a contact based on the provided boolean flags.
+# 
+# + isCsAdmin - Whether the contact is a customer admin or not
+# + isLead - Whether the contact is a lead or not
+# + isPortalUser - Whether the contact is a portal user or not
+# + isSecurityContact - Whether the contact is a security contact or not
+# + return - Array of roles for the contact
+isolated function getRoles(boolean isCsAdmin, boolean isLead, boolean isPortalUser, boolean isSecurityContact)
+    returns string[] {
+
     string[] roles = [];
     if isCsAdmin {
         roles.push(ADMIN_ROLE);
+    }
+    if isLead {
+        roles.push(LEAD);
     }
     if isPortalUser {
         roles.push(PORTAL_USER_ROLE);
@@ -191,6 +203,7 @@ isolated function toMembership(UserManagementMembership membership) returns Memb
         id: membership.id,
         state: membership.state,
         isCsAdmin: hasRole(membership["role"], ADMIN_ROLE),
+        isLead: hasRole(membership["role"], LEAD),
         isPortalUser: hasRole(membership["role"], PORTAL_USER_ROLE),
         isSecurityContact: hasRole(membership["role"], SECURITY_CONTACT_ROLE),
         contact: membership["contact"]

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -4388,6 +4388,10 @@ components:
           type: boolean
           description: Whether the contact is a customer admin or not
           default: false
+        isLead:
+          type: boolean
+          description: Whether the contact is a lead or not
+          default: false
         isPortalUser:
           type: boolean
           description: Whether the contact is a portal user or not
@@ -5019,6 +5023,7 @@ components:
       required:
       - id
       - isCsAdmin
+      - isLead
       - isPortalUser
       - isSecurityContact
       - state
@@ -5033,6 +5038,10 @@ components:
         isCsAdmin:
           type: boolean
           description: Whether the contact is a customer admin or not
+          nullable: true
+        isLead:
+          type: boolean
+          description: Whether the contact is a lead or not
           nullable: true
         isPortalUser:
           type: boolean
@@ -5051,6 +5060,10 @@ components:
         isCsAdmin:
           type: boolean
           description: Whether the contact is a customer admin or not
+          default: false
+        isLead:
+          type: boolean
+          description: Whether the contact is a lead or not
           default: false
         isPortalUser:
           type: boolean

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -3481,9 +3481,9 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                     contactLastName: payload.contactLastName,
                     isCsIntegrationUser: payload.isCsIntegrationUser,
                     isCsAdmin: payload.isCsAdmin,
+                    isLead: payload.isLead,
                     isPortalUser: payload.isPortalUser,
                     isSecurityContact: payload.isSecurityContact
-
                 });
         if response is error {
             if getStatusCode(response) == http:STATUS_FORBIDDEN {
@@ -3632,6 +3632,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                 {
                     adminEmail: userInfo.email,
                     isCsAdmin: payload.isCsAdmin,
+                    isLead: payload.isLead,
                     isPortalUser: payload.isPortalUser,
                     isSecurityContact: payload.isSecurityContact
                 });


### PR DESCRIPTION
## Summary
- Add `isLead` field to `ContactOnboardPayload` in `types/types.bal` and `user_management/types.bal` so the Lead role can be passed when creating a project contact
- Add `isLead` field to `MembershipRolePayload` in both type files so it can be updated via the PATCH endpoint
- Add `isLead` to the `Membership` response type so the current lead status is returned
- Update `getRoles()` in `user_management.bal` to include the `"Lead"` role string when `isLead` is true
- Update `toMembership()` to read back the Lead role from the membership role string
- Pass `isLead` through in the `POST /projects/{id}/contacts` and `PATCH /projects/{id}/contacts/{email}` handlers in `service.bal`
- Update `openapi.yaml` schemas for `ContactOnboardPayload`, `MembershipRolePayload`, and `Membership`

## Test plan
- [ ] `POST /projects/{id}/contacts` with `isLead: true` creates membership with Lead role
- [ ] `PATCH /projects/{id}/contacts/{email}` with `isLead: true` updates membership to include Lead role
- [ ] `PATCH /projects/{id}/contacts/{email}` with `isLead: false` removes Lead role from membership
- [ ] Response `Membership` object reflects `isLead` correctly
- [ ] Other roles (`isCsAdmin`, `isPortalUser`, `isSecurityContact`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)