### PR TITLE
[Customer Entity] Add workStates and assignedUserIds filters to POST /cases/search

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -768,8 +768,10 @@ type SearchCasesFilters struct {
 	EndCreatedDate     *time.Time `json:"endCreatedDate"`
 	StartUpdatedDate   *time.Time `json:"startUpdatedDate"`
 	EndUpdatedDate     *time.Time `json:"endUpdatedDate"`
-	CreatedBy          []string   `json:"createdBy"`
-	CreatedByMe        bool       `json:"createdByMe"`
+	CreatedBy          []string         `json:"createdBy"`
+	CreatedByMe        bool             `json:"createdByMe"`
+	WorkStates         []CaseWorkState  `json:"workStates"`
+	AssignedUserIDs    []string         `json:"assignedUserIds"`
 }
 
 // SearchCasesRequest is the input for a case search operation.

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -400,6 +400,22 @@ func (r *caseRepo) SearchCases(ctx context.Context, req domain.SearchCasesReques
 		argIdx++
 	}
 
+	if len(req.Filters.WorkStates) > 0 {
+		workStateStrings := make([]string, len(req.Filters.WorkStates))
+		for i, ws := range req.Filters.WorkStates {
+			workStateStrings[i] = string(ws)
+		}
+		where += fmt.Sprintf(" AND c.work_state = ANY($%d::case_work_state_enum[])", argIdx)
+		filterArgs = append(filterArgs, workStateStrings)
+		argIdx++
+	}
+
+	if len(req.Filters.AssignedUserIDs) > 0 {
+		where += fmt.Sprintf(" AND c.assigned_engineer = ANY($%d::uuid[])", argIdx)
+		filterArgs = append(filterArgs, req.Filters.AssignedUserIDs)
+		argIdx++
+	}
+
 	if req.Filters.ClosedStartDate != nil {
 		where += fmt.Sprintf(" AND c.closed_at >= $%d", argIdx)
 		filterArgs = append(filterArgs, req.Filters.ClosedStartDate)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -379,6 +379,14 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "engagementTypes contains invalid value: " + string(et)}
 		}
 	}
+	for _, ws := range req.Filters.WorkStates {
+		if !validCaseWorkState[ws] {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "workStates contains invalid value: " + string(ws)}
+		}
+	}
+	if err := validateUUIDs("assignedUserIds", req.Filters.AssignedUserIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
 
 	if req.Filters.CreatedByMe {
 		token := middleware.UserIDTokenFromContext(ctx)

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -191,6 +191,8 @@ type snCaseFilters struct {
 	EndUpdatedDate      string   `json:"endUpdatedDate,omitempty"`
 	CreatedBy           []string `json:"createdBy,omitempty"`
 	CreatedByMe         bool     `json:"createdByMe,omitempty"`
+	WorkStateKeys       []int    `json:"workStateKeys,omitempty"`
+	AssignedUserIDs     []string `json:"assignedUserIds,omitempty"`
 }
 
 // snStateIDMap maps domain CaseState enums to SN numeric state IDs.
@@ -256,6 +258,16 @@ func domainIssueTypesToSNIDs(issueTypes []domain.CaseIssueType) []int {
 	ids := make([]int, 0, len(issueTypes))
 	for _, it := range issueTypes {
 		if id, ok := snIssueTypeIDMap[it]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func domainWorkStatesToSNIDs(workStates []domain.CaseWorkState) []int {
+	ids := make([]int, 0, len(workStates))
+	for _, ws := range workStates {
+		if id, ok := snWorkStateIDMap[ws]; ok {
 			ids = append(ids, id)
 		}
 	}
@@ -1169,6 +1181,15 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "endUpdatedDate must not be before startUpdatedDate"}
 	}
 
+	for _, ws := range req.Filters.WorkStates {
+		if ws != domain.CaseWorkStateOngoing && ws != domain.CaseWorkStatePaused {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "workStates contains invalid value: " + string(ws)}
+		}
+	}
+	if err := validateUUIDs("assignedUserIds", req.Filters.AssignedUserIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
 		return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
@@ -1213,8 +1234,10 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			EndCreatedDate:     formatSNDate(req.Filters.EndCreatedDate),
 			StartUpdatedDate:   formatSNDate(req.Filters.StartUpdatedDate),
 			EndUpdatedDate:     formatSNDate(req.Filters.EndUpdatedDate),
-			CreatedBy:          req.Filters.CreatedBy,
-			CreatedByMe:        req.Filters.CreatedByMe,
+			CreatedBy:           req.Filters.CreatedBy,
+			CreatedByMe:         req.Filters.CreatedByMe,
+			WorkStateKeys:       domainWorkStatesToSNIDs(req.Filters.WorkStates),
+			AssignedUserIDs:     uuidsToSysids(req.Filters.AssignedUserIDs),
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2349,6 +2349,20 @@ components:
         createdByMe:
           type: boolean
           description: When true, restrict results to cases created by the authenticated user.
+        workStates:
+          type: array
+          items:
+            type: string
+            enum: [ongoing, paused]
+          description: |
+            Filter by work sub-state. Only applicable when state is work_in_progress.
+            For the ServiceNow data source, ongoing maps to key 1 and paused maps to key 2.
+        assignedUserIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Filter by assigned engineer user UUIDs.
 
     SearchCasesRequest:
       type: object


### PR DESCRIPTION
## Summary

- Added `filters.workStates` (`ongoing`, `paused`) and `filters.assignedUserIds` (UUID array) to the `POST /cases/search` request body, supported by both postgres and ServiceNow data sources
- For the ServiceNow data source, `workStates` values are mapped to integer choice-list keys (`ongoing → 1`, `paused → 2`) and `assignedUserIds` UUIDs are converted to sysids before being sent to Choreo
- For the postgres data source, filter clauses are added against `c.work_state` and `c.assigned_engineer` columns with appropriate enum and UUID casts

## Test plan

- [ ] POST /cases/search with `filters.workStates: ["ongoing"]` — verify only work-in-progress cases with workState ongoing are returned (both data sources)
- [ ] POST /cases/search with `filters.workStates: ["paused"]` — verify correct filtering
- [ ] POST /cases/search with `filters.assignedUserIds: ["<uuid>"]` — verify cases are scoped to the assigned engineer
- [ ] POST /cases/search with both filters combined — verify AND logic applies
- [ ] POST /cases/search with an invalid workState value (e.g. `"unknown"`) — verify 400 is returned
- [ ] POST /cases/search with a malformed UUID in `assignedUserIds` — verify 400 is returned
- [ ] Confirm SN payload includes `workStateKeys` as integers and `assignedUserIds` as sysids when data source is ServiceNow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new case search filters for work state and assigned user IDs.
  * Search results can now be narrowed to ongoing/paused cases and to specific assigned engineers/users.

* **Bug Fixes**
  * Improved validation for case search filters to reject invalid work states and malformed UUIDs before running the search.

* **Documentation**
  * Updated the public API schema so the new search options are visible to API consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->