### PR TITLE
[CSM Portal] Adopt nested /users/search contract; add role/status filters & sort

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -417,9 +417,9 @@ export interface BeCaseSearchFilters {
    * Filter by assigned-engineer user UUIDs. The cases-list assignee picker is
    * email/`@me`-based; `useGetCsmCases` resolves the selection to UUIDs (named
    * engineers via `/users/search`, `@me` via the app-wide current-user context
-   * / `/users/me`). `@me` resolution depends on `/users/me` returning an `id` —
-   * a BFF TODO; until it lands, an `@me`-only selection resolves to nothing and
-   * the filter is omitted.
+   * backed by `/users/me`). `@me` needs the caller's `id`, which `/users/me`
+   * omits only when the entity service is unavailable — in that case an
+   * `@me`-only selection resolves to nothing and the filter is omitted.
    */
   assignedUserIds?: string[];
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -414,13 +414,11 @@ export interface BeCaseSearchFilters {
    */
   workStates?: BeCaseWorkState[];
   /**
-   * Filter by assigned-engineer user UUIDs. NOTE: the cases-list assignee
-   * control stays disabled for now. The picker is email/`@me`-based, but this
-   * filter is UUID-based with no `assignedToMe` equivalent, and `GET /users/me`
-   * does not yet return the caller's UUID (BE TODO) — so `@me` cannot be
-   * resolved. Enable once `/users/me` returns an `id` (or the BE adds
-   * `assignedToMe`); named-engineer UUIDs are already available via
-   * `/users/search`.
+   * Filter by assigned-engineer user UUIDs. The cases-list assignee picker is
+   * email/`@me`-based; `useGetCsmCases` resolves the selection to UUIDs (named
+   * engineers via `/users/search`, `@me` via `/users/me`). `@me` resolution
+   * depends on `/users/me` returning an `id` — a BFF TODO; until it lands, an
+   * `@me`-only selection resolves to nothing and the filter is omitted.
    */
   assignedUserIds?: string[];
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -416,9 +416,10 @@ export interface BeCaseSearchFilters {
   /**
    * Filter by assigned-engineer user UUIDs. The cases-list assignee picker is
    * email/`@me`-based; `useGetCsmCases` resolves the selection to UUIDs (named
-   * engineers via `/users/search`, `@me` via `/users/me`). `@me` resolution
-   * depends on `/users/me` returning an `id` — a BFF TODO; until it lands, an
-   * `@me`-only selection resolves to nothing and the filter is omitted.
+   * engineers via `/users/search`, `@me` via the app-wide current-user context
+   * / `/users/me`). `@me` resolution depends on `/users/me` returning an `id` —
+   * a BFF TODO; until it lands, an `@me`-only selection resolves to nothing and
+   * the filter is omitted.
    */
   assignedUserIds?: string[];
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -408,9 +408,21 @@ export interface BeCaseSearchFilters {
   createdBy?: string[];
   /** When true, the caller's email (from the JWT) is appended to `createdBy`. */
   createdByMe?: boolean;
-  // NOTE: there is no assigned-engineer filter here yet. The cases-list
-  // assignee control is disabled until the entity/BFF add one (e.g.
-  // `assignedTo`/`assignedToMe`, mirroring `createdBy`/`createdByMe`).
+  /**
+   * Work sub-state filter (ServiceNow: `ongoing` → 1, `paused` → 2). Only
+   * meaningful when `states` includes `work_in_progress`.
+   */
+  workStates?: BeCaseWorkState[];
+  /**
+   * Filter by assigned-engineer user UUIDs. NOTE: the cases-list assignee
+   * control stays disabled for now. The picker is email/`@me`-based, but this
+   * filter is UUID-based with no `assignedToMe` equivalent, and `GET /users/me`
+   * does not yet return the caller's UUID (BE TODO) — so `@me` cannot be
+   * resolved. Enable once `/users/me` returns an `id` (or the BE adds
+   * `assignedToMe`); named-engineer UUIDs are already available via
+   * `/users/search`.
+   */
+  assignedUserIds?: string[];
 }
 
 export interface BeCaseSearchPayload {

--- a/apps/csm-portal/webapp/src/api/useDirectoryUsers.ts
+++ b/apps/csm-portal/webapp/src/api/useDirectoryUsers.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { ApiQueryKeys } from "@constants/apiConstants";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 
 /**
@@ -54,9 +54,10 @@ export function useDirectoryUsers(): UseQueryResult<DirectoryUser[], Error> {
   return useQuery<DirectoryUser[], Error>({
     queryKey: [ApiQueryKeys.CSM_ADMIN_USERS, "directory"],
     queryFn: async (): Promise<DirectoryUser[]> => {
-      const res = await api.post<Record<string, never>, unknown>(
+      // No filters: fetch the broadest page the BE allows (default is only 10).
+      const res = await api.post<{ pagination: { limit: number } }, unknown>(
         "/users/search",
-        {},
+        { pagination: { limit: BE_MAX_PAGE_LIMIT } },
       );
       const rows: RawDirectoryUser[] = Array.isArray(res)
         ? (res as RawDirectoryUser[])

--- a/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
+++ b/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
@@ -41,17 +41,6 @@ const E164 = /^\+[1-9]\d{7,14}$/;
 // Show at most this many group chips inline before collapsing with "+N more".
 const GROUPS_PREVIEW_LIMIT = 4;
 
-function formatLastPasswordUpdate(epochMs: string | undefined): string {
-  if (!epochMs) return "Not available";
-  const ms = parseInt(epochMs, 10);
-  if (Number.isNaN(ms)) return "Not available";
-  return new Date(ms).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-  });
-}
-
 export interface UserProfileModalProps {
   open: boolean;
   onClose: () => void;
@@ -239,19 +228,6 @@ export default function UserProfileModal({
                 </IconButton>
               </Box>
             )}
-          </Box>
-
-          <Box>
-            <Typography variant="caption" color="text.secondary">
-              Last password update
-            </Typography>
-            <Typography variant="body2" sx={{ mt: 0.5 }}>
-              {isLoading ? (
-                <Skeleton width={160} />
-              ) : (
-                formatLastPasswordUpdate(userMe?.lastPasswordUpdateTime)
-              )}
-            </Typography>
           </Box>
         </Box>
 

--- a/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
+++ b/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
@@ -113,7 +113,9 @@ export default function UserProfileModal({
       return;
     }
 
-    if (tzChanged && nextTz && !normalizeUserTimeZone(nextTz)) {
+    // Time zone has no "unset" on the backend; clearing the picker (empty
+    // draft) must not PATCH `timeZone: ""`. Require a valid zone when changed.
+    if (tzChanged && (!nextTz || !normalizeUserTimeZone(nextTz))) {
       showError("Select a valid time zone.");
       return;
     }

--- a/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
+++ b/apps/csm-portal/webapp/src/components/header/UserProfileModal.tsx
@@ -15,6 +15,7 @@
 // under the License.
 
 import {
+  Autocomplete,
   Avatar,
   Box,
   Button,
@@ -27,13 +28,20 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { PencilLine, X } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, useCallback, useEffect, useState } from "react";
+import { type JSX, useCallback, useEffect, useMemo, useState } from "react";
 import { useGetUsersMe } from "@features/settings/api/useGetUsersMe";
-import { usePatchUsersMe } from "@features/settings/api/usePatchUsersMe";
+import {
+  usePatchUsersMe,
+  type UpdateUserPayload,
+} from "@features/settings/api/usePatchUsersMe";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { initialsOf, resolveUserInfo } from "@utils/userClaims";
+import {
+  listSupportedTimeZones,
+  normalizeUserTimeZone,
+} from "@utils/dateTime";
 
 // E.164 phone validator: leading + required, then country code digit + 7-14 more digits.
 const E164 = /^\+[1-9]\d{7,14}$/;
@@ -58,56 +66,81 @@ export default function UserProfileModal({
 
   const [phoneDraft, setPhoneDraft] = useState("");
   const [isPhoneEditing, setIsPhoneEditing] = useState(false);
+  const [tzDraft, setTzDraft] = useState<string | null>(null);
+  const [isTzEditing, setIsTzEditing] = useState(false);
 
   const info = resolveUserInfo(claims);
   const email = userMe?.email || info.email || "—";
   const initials = initialsOf(info.fullName);
+  const timeZoneOptions = useMemo(() => listSupportedTimeZones(), []);
 
   useEffect(() => {
     if (open && userMe) {
-      // Seed the editable draft from the latest server value each time the
+      // Seed the editable drafts from the latest server values each time the
       // dialog opens (the accepted "reset form state on open" pattern).
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- form reset on dialog open
+      /* eslint-disable react-hooks/set-state-in-effect -- form reset on dialog open */
       setPhoneDraft(userMe.phoneNumber ?? "");
+      setTzDraft(normalizeUserTimeZone(userMe.timeZone));
       setIsPhoneEditing(false);
+      setIsTzEditing(false);
+      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [open, userMe]);
 
-  const handlePhoneEditCancel = useCallback(() => {
+  const handleEditCancel = useCallback(() => {
     setPhoneDraft(userMe?.phoneNumber ?? "");
+    setTzDraft(normalizeUserTimeZone(userMe?.timeZone));
     setIsPhoneEditing(false);
-  }, [userMe?.phoneNumber]);
+    setIsTzEditing(false);
+  }, [userMe?.phoneNumber, userMe?.timeZone]);
 
   const handleSave = useCallback(() => {
-    const current = userMe?.phoneNumber ?? "";
-    const next = phoneDraft.trim();
+    const currentPhone = userMe?.phoneNumber ?? "";
+    const nextPhone = phoneDraft.trim();
+    const phoneChanged = nextPhone !== currentPhone;
 
-    if (next === current) {
+    const currentTz = normalizeUserTimeZone(userMe?.timeZone) ?? "";
+    const nextTz = tzDraft ?? "";
+    const tzChanged = nextTz !== currentTz;
+
+    if (!phoneChanged && !tzChanged) {
       onClose();
       return;
     }
 
-    if (next && !E164.test(next)) {
+    if (phoneChanged && nextPhone && !E164.test(nextPhone)) {
       showError("Phone number must be in E.164 format, e.g. +14155552671.");
       return;
     }
 
-    patchUserMe.mutate(
-      { phoneNumber: next },
-      {
-        onSuccess: () => {
-          showSuccess("Profile updated.");
-          setIsPhoneEditing(false);
-          onClose();
-        },
-        onError: () => {
-          showError("Could not update phone number. Please try again.");
-        },
+    if (tzChanged && nextTz && !normalizeUserTimeZone(nextTz)) {
+      showError("Select a valid time zone.");
+      return;
+    }
+
+    const payload: UpdateUserPayload = {
+      ...(phoneChanged && { phoneNumber: nextPhone }),
+      ...(tzChanged && { timeZone: nextTz }),
+    };
+
+    patchUserMe.mutate(payload, {
+      onSuccess: () => {
+        // The mutation invalidates `users-me`; CurrentUserProvider re-seeds the
+        // preferred-timezone store from the refetched profile.
+        showSuccess("Profile updated.");
+        setIsPhoneEditing(false);
+        setIsTzEditing(false);
+        onClose();
       },
-    );
+      onError: () => {
+        showError("Could not update profile. Please try again.");
+      },
+    });
   }, [
     phoneDraft,
+    tzDraft,
     userMe?.phoneNumber,
+    userMe?.timeZone,
     patchUserMe,
     showError,
     showSuccess,
@@ -229,11 +262,59 @@ export default function UserProfileModal({
               </Box>
             )}
           </Box>
+
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Time zone
+            </Typography>
+            {isTzEditing ? (
+              <Box sx={{ display: "flex", gap: 1, alignItems: "center", mt: 0.5 }}>
+                <Autocomplete
+                  size="small"
+                  fullWidth
+                  options={timeZoneOptions}
+                  value={tzDraft}
+                  onChange={(_, next) => setTzDraft(next)}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      placeholder="Select a time zone"
+                      helperText="Used to display dates and times in your zone"
+                    />
+                  )}
+                />
+              </Box>
+            ) : (
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  mt: 0.5,
+                }}
+              >
+                <Typography variant="body2">
+                  {isLoading ? (
+                    <Skeleton width={160} />
+                  ) : (
+                    normalizeUserTimeZone(userMe?.timeZone) || "Not set"
+                  )}
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={() => setIsTzEditing(true)}
+                  aria-label="Edit time zone"
+                >
+                  <PencilLine size={16} />
+                </IconButton>
+              </Box>
+            )}
+          </Box>
         </Box>
 
         <Stack direction="row" justifyContent="flex-end" spacing={1}>
-          {isPhoneEditing && (
-            <Button variant="text" onClick={handlePhoneEditCancel}>
+          {(isPhoneEditing || isTzEditing) && (
+            <Button variant="text" onClick={handleEditCancel}>
               Cancel
             </Button>
           )}
@@ -242,7 +323,7 @@ export default function UserProfileModal({
             onClick={handleSave}
             disabled={patchUserMe.isPending}
           >
-            {isPhoneEditing ? "Save" : "Close"}
+            {isPhoneEditing || isTzEditing ? "Save" : "Close"}
           </Button>
         </Stack>
       </Box>

--- a/apps/csm-portal/webapp/src/context/current-user/CurrentUserContext.tsx
+++ b/apps/csm-portal/webapp/src/context/current-user/CurrentUserContext.tsx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/* eslint-disable react-refresh/only-export-components -- Provider component and its useXxx hook are colocated per the repo's context idiom (fast-refresh DX only) */
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type JSX,
+  type ReactNode,
+} from "react";
+import {
+  useGetUsersMe,
+  type UsersMeResponse,
+} from "@features/settings/api/useGetUsersMe";
+
+interface CurrentUserContextType {
+  /** The signed-in user's platform profile (`GET /users/me`), once loaded. */
+  user: UsersMeResponse | undefined;
+  /** True while the initial `/users/me` fetch is in flight. */
+  isLoading: boolean;
+  /** True if the `/users/me` fetch failed. */
+  isError: boolean;
+}
+
+const CurrentUserContext = createContext<CurrentUserContextType | undefined>(
+  undefined,
+);
+
+interface CurrentUserProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Fetches the signed-in user's platform profile (`GET /users/me`) **once** and
+ * makes it available app-wide via {@link useCurrentUser}. Mounted inside the
+ * auth boundary (AuthGuard), so the call fires a single time per session after
+ * sign-in — the IdP-issued claims (email, name) come from the ID token via
+ * `useIdTokenClaims`; this is the platform-owned counterpart (UUID, phone, …).
+ *
+ * Components must read the current user through `useCurrentUser()` rather than
+ * calling `useGetUsersMe()` ad hoc, so `/users/me` is not re-issued per feature.
+ */
+export function CurrentUserProvider({
+  children,
+}: CurrentUserProviderProps): JSX.Element {
+  const { data, isLoading, isError } = useGetUsersMe();
+
+  const value = useMemo<CurrentUserContextType>(
+    () => ({ user: data, isLoading, isError }),
+    [data, isLoading, isError],
+  );
+
+  return (
+    <CurrentUserContext.Provider value={value}>
+      {children}
+    </CurrentUserContext.Provider>
+  );
+}
+
+/**
+ * Access the signed-in user's platform profile. Must be used within a
+ * {@link CurrentUserProvider} (mounted by AuthGuard).
+ */
+export function useCurrentUser(): CurrentUserContextType {
+  const ctx = useContext(CurrentUserContext);
+  if (ctx === undefined) {
+    throw new Error("useCurrentUser must be used within a CurrentUserProvider");
+  }
+  return ctx;
+}

--- a/apps/csm-portal/webapp/src/context/current-user/CurrentUserContext.tsx
+++ b/apps/csm-portal/webapp/src/context/current-user/CurrentUserContext.tsx
@@ -19,6 +19,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useMemo,
   type JSX,
   type ReactNode,
@@ -27,6 +28,7 @@ import {
   useGetUsersMe,
   type UsersMeResponse,
 } from "@features/settings/api/useGetUsersMe";
+import { setUserPreferredTimeZone } from "@utils/dateTime";
 
 interface CurrentUserContextType {
   /** The signed-in user's platform profile (`GET /users/me`), once loaded. */
@@ -59,6 +61,12 @@ export function CurrentUserProvider({
   children,
 }: CurrentUserProviderProps): JSX.Element {
   const { data, isLoading, isError } = useGetUsersMe();
+
+  // Seed the app-wide preferred-timezone store (used for view-only date
+  // formatting) from the profile, so dates render in the user's own zone.
+  useEffect(() => {
+    setUserPreferredTimeZone(data?.timeZone);
+  }, [data?.timeZone]);
 
   const value = useMemo<CurrentUserContextType>(
     () => ({ user: data, isLoading, isError }),

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -155,8 +155,9 @@ export function useGetCsmCases(
       // the directory, so this resolves them all); `@me` → the caller's id,
       // taken from the app-wide CurrentUserProvider (no per-query `/users/me`).
       // Runs only when the assignee filter is active. A user whose id can't be
-      // resolved (e.g. `@me` before the BFF populates `id`, or an email with no
-      // match) is dropped; if nothing resolves, the filter is omitted rather
+      // resolved (e.g. `@me` when `/users/me` omits `id` — entity service down
+      // — or an email with no match) is dropped; if nothing resolves, the
+      // filter is omitted rather
       // than sent empty. A transport failure of the lookup is NOT swallowed —
       // it throws so the query errors (the list shows an error) instead of
       // silently broadening an active assignee filter to all cases.

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -30,12 +30,15 @@ import {
   uiStateFromBe,
 } from "@api/backend/mappers";
 import { projectOptionsQueryOptions } from "@features/csm-cases/api/useProjectOptions";
+import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/components/CasesFilterBar";
+import type { UsersMeResponse } from "@features/settings/api/useGetUsersMe";
 import type {
   BeAccount,
   BeAccountSearchPayload,
   BeAccountSearchResponse,
   BeCaseSearchPayload,
   BeCaseSearchResponse,
+  BeUserSearchResponse,
 } from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import type {
@@ -122,8 +125,10 @@ export function useGetCsmCases(
 
   return useQuery<CsmCasesListResponse, Error>({
     // Sort the array filters so selection order doesn't fragment the cache
-    // (["S1","S2"] and ["S2","S1"] are the same query). `assignees` is omitted:
-    // the assignee filter is disabled and not sent, so it never changes results.
+    // (["S1","S2"] and ["S2","S1"] are the same query). `assignees` holds
+    // engineer emails (+ the `@me` sentinel); it's resolved to UUIDs in the
+    // queryFn, but keying on the raw selection is enough since resolution is
+    // deterministic. `currentUserEmail` is already in the key, covering `@me`.
     queryKey: [
       ApiQueryKeys.CSM_CASES,
       search,
@@ -131,6 +136,7 @@ export function useGetCsmCases(
       [...filters.states].sort(),
       [...filters.caseTypes].sort(),
       [...filters.workStates].sort(),
+      [...filters.assignees].sort(),
       [...filters.projects].sort(),
       [...filters.engagementTypes].sort(),
       currentUserEmail ?? "",
@@ -138,6 +144,53 @@ export function useGetCsmCases(
       pageSize,
     ],
     queryFn: async (): Promise<CsmCasesListResponse> => {
+      // Resolve the assignee filter (engineer emails + the `@me` sentinel) to
+      // the UUIDs `/cases/search` expects. Named engineers → ids from a
+      // targeted `/users/search` by email (selectable emails always come from
+      // the directory, so this resolves them all); `@me` → the caller's id from
+      // `/users/me`. Runs only when the assignee filter is active. A user whose
+      // id can't be resolved (e.g. `@me` before the BFF populates `id`) is
+      // dropped; if nothing resolves, the filter is omitted rather than sent
+      // empty.
+      let assignedUserIds: string[] | undefined;
+      if (filters.assignees.length > 0) {
+        const wantsMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
+        const emails = filters.assignees.filter((a) => a !== ASSIGNEE_ME_TOKEN);
+        const [byEmail, me] = await Promise.all([
+          emails.length > 0
+            ? api
+                .post<
+                  { filters: { emails: string[] }; pagination: { limit: number } },
+                  BeUserSearchResponse
+                >("/users/search", {
+                  filters: { emails },
+                  pagination: { limit: BE_MAX_PAGE_LIMIT },
+                })
+                .catch((err) => {
+                  logger.warn(
+                    `[useGetCsmCases] assignee lookup failed: ${(err as Error).message}`,
+                  );
+                  return null;
+                })
+            : Promise.resolve(null),
+          wantsMe
+            ? queryClient
+                .fetchQuery({
+                  queryKey: ["users-me"],
+                  queryFn: () => api.get<UsersMeResponse>("/users/me"),
+                  staleTime: 60_000,
+                })
+                .catch(() => null)
+            : Promise.resolve(null),
+        ]);
+        const ids = new Set<string>();
+        (byEmail?.users ?? []).forEach((u) => {
+          if (u.id) ids.add(u.id);
+        });
+        if (wantsMe && me?.id) ids.add(me.id);
+        if (ids.size > 0) assignedUserIds = [...ids];
+      }
+
       // One cross-project case search, plus project/account lookups for the
       // customer column (cases embed the project, but not its account). The
       // lookups go through `fetchQuery` with their own stable keys, so they
@@ -172,10 +225,10 @@ export function useGetCsmCases(
             ...(filters.projects.length > 0 && {
               projectIds: filters.projects,
             }),
-            // No assignee filter: `/cases/search` has `assignedUserIds`, but
-            // it is UUID-based and `@me` has no current-user UUID to resolve to
-            // yet (see BeCaseSearchFilters), so the disabled control sends
-            // nothing.
+            // Assignee filter, resolved to engineer UUIDs above.
+            ...(assignedUserIds && assignedUserIds.length > 0 && {
+              assignedUserIds,
+            }),
           },
         }),
         queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -155,29 +155,32 @@ export function useGetCsmCases(
       // the directory, so this resolves them all); `@me` → the caller's id,
       // taken from the app-wide CurrentUserProvider (no per-query `/users/me`).
       // Runs only when the assignee filter is active. A user whose id can't be
-      // resolved (e.g. `@me` before the BFF populates `id`) is dropped; if
-      // nothing resolves, the filter is omitted rather than sent empty.
+      // resolved (e.g. `@me` before the BFF populates `id`, or an email with no
+      // match) is dropped; if nothing resolves, the filter is omitted rather
+      // than sent empty. A transport failure of the lookup is NOT swallowed —
+      // it throws so the query errors (the list shows an error) instead of
+      // silently broadening an active assignee filter to all cases.
       let assignedUserIds: string[] | undefined;
       if (filters.assignees.length > 0) {
         const wantsMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
         const emails = filters.assignees.filter((a) => a !== ASSIGNEE_ME_TOKEN);
-        const byEmail =
-          emails.length > 0
-            ? await api
-                .post<
-                  { filters: { emails: string[] }; pagination: { limit: number } },
-                  BeUserSearchResponse
-                >("/users/search", {
-                  filters: { emails },
-                  pagination: { limit: BE_MAX_PAGE_LIMIT },
-                })
-                .catch((err) => {
-                  logger.warn(
-                    `[useGetCsmCases] assignee lookup failed: ${(err as Error).message}`,
-                  );
-                  return null;
-                })
-            : null;
+        let byEmail: BeUserSearchResponse | null = null;
+        if (emails.length > 0) {
+          try {
+            byEmail = await api.post<
+              { filters: { emails: string[] }; pagination: { limit: number } },
+              BeUserSearchResponse
+            >("/users/search", {
+              filters: { emails },
+              pagination: { limit: BE_MAX_PAGE_LIMIT },
+            });
+          } catch (err) {
+            logger.warn(
+              `[useGetCsmCases] assignee lookup failed: ${(err as Error).message}`,
+            );
+            throw new Error("Failed to resolve the assignee filter");
+          }
+        }
         const ids = new Set<string>();
         (byEmail?.users ?? []).forEach((u) => {
           if (u.id) ids.add(u.id);

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -156,11 +156,13 @@ export function useGetCsmCases(
       // taken from the app-wide CurrentUserProvider (no per-query `/users/me`).
       // Runs only when the assignee filter is active. A user whose id can't be
       // resolved (e.g. `@me` when `/users/me` omits `id` — entity service down
-      // — or an email with no match) is dropped; if nothing resolves, the
-      // filter is omitted rather
-      // than sent empty. A transport failure of the lookup is NOT swallowed —
-      // it throws so the query errors (the list shows an error) instead of
-      // silently broadening an active assignee filter to all cases.
+      // — or an email with no match) is dropped. If an active assignee filter
+      // resolves to NO ids, the result is definitionally empty (cases assigned
+      // to engineers we couldn't identify), so we return an empty list rather
+      // than omitting the filter — omitting it would broaden the search to ALL
+      // cases, the opposite of what the user asked for. A transport failure of
+      // the lookup is NOT swallowed — it throws so the query errors (the list
+      // shows an error) instead of silently broadening to all cases.
       let assignedUserIds: string[] | undefined;
       if (filters.assignees.length > 0) {
         const wantsMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
@@ -188,6 +190,12 @@ export function useGetCsmCases(
         });
         if (wantsMe && currentUserId) ids.add(currentUserId);
         if (ids.size > 0) assignedUserIds = [...ids];
+      }
+
+      // Active assignee filter that resolved to nothing → empty result, not a
+      // broadened (filter-less) search. See the resolution note above.
+      if (filters.assignees.length > 0 && !assignedUserIds) {
+        return { cases: [], total: 0, limit: pageSize, offset, hasMore: false };
       }
 
       // One cross-project case search, plus project/account lookups for the

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -130,6 +130,7 @@ export function useGetCsmCases(
       [...filters.severities].sort(),
       [...filters.states].sort(),
       [...filters.caseTypes].sort(),
+      [...filters.workStates].sort(),
       [...filters.projects].sort(),
       [...filters.engagementTypes].sort(),
       currentUserEmail ?? "",
@@ -158,6 +159,12 @@ export function useGetCsmCases(
             ...(filters.caseTypes.length > 0 && {
               types: filters.caseTypes,
             }),
+            // Work sub-state filter (ongoing/paused); only meaningful when
+            // `states` includes `work_in_progress`, but the BE accepts it
+            // independently so we forward it as-is.
+            ...(filters.workStates.length > 0 && {
+              workStates: filters.workStates,
+            }),
             ...(filters.engagementTypes.length > 0 && {
               engagementTypes: filters.engagementTypes,
             }),
@@ -165,8 +172,10 @@ export function useGetCsmCases(
             ...(filters.projects.length > 0 && {
               projectIds: filters.projects,
             }),
-            // No assignee filter: `/cases/search` has no assigned-engineer
-            // filter yet, so the (disabled) assignee control sends nothing.
+            // No assignee filter: `/cases/search` has `assignedUserIds`, but
+            // it is UUID-based and `@me` has no current-user UUID to resolve to
+            // yet (see BeCaseSearchFilters), so the disabled control sends
+            // nothing.
           },
         }),
         queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -31,7 +31,7 @@ import {
 } from "@api/backend/mappers";
 import { projectOptionsQueryOptions } from "@features/csm-cases/api/useProjectOptions";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/components/CasesFilterBar";
-import type { UsersMeResponse } from "@features/settings/api/useGetUsersMe";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import type {
   BeAccount,
   BeAccountSearchPayload,
@@ -119,6 +119,10 @@ export function useGetCsmCases(
   // Signed-in email, to resolve `assigneeIsMe` per row against the assigned
   // engineer's email. In the key so a late-arriving claim recomputes.
   const currentUserEmail = useIdTokenClaims()?.email;
+  // The caller's platform UUID, fetched once app-wide (CurrentUserProvider) and
+  // used to resolve the `@me` assignee filter. In the key so a late-arriving id
+  // re-resolves an `@me` selection.
+  const currentUserId = useCurrentUser().user?.id;
 
   const offset = page * pageSize;
   const search = filters.search.trim();
@@ -140,6 +144,7 @@ export function useGetCsmCases(
       [...filters.projects].sort(),
       [...filters.engagementTypes].sort(),
       currentUserEmail ?? "",
+      currentUserId ?? "",
       page,
       pageSize,
     ],
@@ -147,18 +152,18 @@ export function useGetCsmCases(
       // Resolve the assignee filter (engineer emails + the `@me` sentinel) to
       // the UUIDs `/cases/search` expects. Named engineers → ids from a
       // targeted `/users/search` by email (selectable emails always come from
-      // the directory, so this resolves them all); `@me` → the caller's id from
-      // `/users/me`. Runs only when the assignee filter is active. A user whose
-      // id can't be resolved (e.g. `@me` before the BFF populates `id`) is
-      // dropped; if nothing resolves, the filter is omitted rather than sent
-      // empty.
+      // the directory, so this resolves them all); `@me` → the caller's id,
+      // taken from the app-wide CurrentUserProvider (no per-query `/users/me`).
+      // Runs only when the assignee filter is active. A user whose id can't be
+      // resolved (e.g. `@me` before the BFF populates `id`) is dropped; if
+      // nothing resolves, the filter is omitted rather than sent empty.
       let assignedUserIds: string[] | undefined;
       if (filters.assignees.length > 0) {
         const wantsMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
         const emails = filters.assignees.filter((a) => a !== ASSIGNEE_ME_TOKEN);
-        const [byEmail, me] = await Promise.all([
+        const byEmail =
           emails.length > 0
-            ? api
+            ? await api
                 .post<
                   { filters: { emails: string[] }; pagination: { limit: number } },
                   BeUserSearchResponse
@@ -172,22 +177,12 @@ export function useGetCsmCases(
                   );
                   return null;
                 })
-            : Promise.resolve(null),
-          wantsMe
-            ? queryClient
-                .fetchQuery({
-                  queryKey: ["users-me"],
-                  queryFn: () => api.get<UsersMeResponse>("/users/me"),
-                  staleTime: 60_000,
-                })
-                .catch(() => null)
-            : Promise.resolve(null),
-        ]);
+            : null;
         const ids = new Set<string>();
         (byEmail?.users ?? []).forEach((u) => {
           if (u.id) ids.add(u.id);
         });
-        if (wantsMe && me?.id) ids.add(me.id);
+        if (wantsMe && currentUserId) ids.add(currentUserId);
         if (ids.size > 0) assignedUserIds = [...ids];
       }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
@@ -31,7 +31,10 @@ import { Search, UserCheck } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
-import type { User } from "@features/csm-users/types/csmUsers";
+import {
+  INTERNAL_USER_ROLES,
+  type NormalizedUser,
+} from "@features/csm-users/types/csmUsers";
 
 interface AssignEngineerDialogProps {
   /** Current assignee display name, or "Unassigned". */
@@ -54,8 +57,8 @@ function initialsOf(name: string): string {
     .join("");
 }
 
-function fullName(u: User): string {
-  return [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.userName;
+function fullName(u: NormalizedUser): string {
+  return u.name.trim() || u.userName;
 }
 
 /**
@@ -76,16 +79,22 @@ export default function AssignEngineerDialog({
   const [input, setInput] = useState("");
   const search = useDebouncedValue(input.trim(), 300);
   const { data, isFetching, isError } = useSearchUsers({
-    ...(search.length > 0 && { searchQuery: search }),
+    filters: {
+      ...(search.length > 0 && { searchQuery: search }),
+      // Internal-facing roles only (ServiceNow source); the BE applies the
+      // filter, so we no longer client-gate on `userType` (absent on SnUser).
+      roles: INTERNAL_USER_ROLES,
+    },
     pagination: { limit: 8, offset: 0 },
   });
 
-  // Only internal engineers are assignable, and only ones that carry an email
-  // (the assign call is email-based).
+  // Assignment is email-based, so an assignee must carry an email. The role
+  // filter above already restricts to internal staff; we keep a userType guard
+  // only for the postgres source (where roles are absent).
   const engineers = useMemo(
     () =>
       (data?.users ?? []).filter(
-        (u) => u.userType === "internal" && !!u.email,
+        (u) => !!u.email && (u.userType ? u.userType === "internal" : true),
       ),
     [data],
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
@@ -84,17 +84,23 @@ export default function AssignEngineerDialog({
       // Internal-facing roles only (ServiceNow source); the BE applies the
       // filter, so we no longer client-gate on `userType` (absent on SnUser).
       roles: INTERNAL_USER_ROLES,
+      // Don't offer inactive accounts as assignment targets.
+      active: true,
     },
     pagination: { limit: 8, offset: 0 },
   });
 
-  // Assignment is email-based, so an assignee must carry an email. The role
-  // filter above already restricts to internal staff; we keep a userType guard
-  // only for the postgres source (where roles are absent).
+  // Assignment is email-based, so an assignee must carry an email. The role +
+  // active filters above already restrict server-side; we keep a defensive
+  // `active !== false` check and a userType guard for the postgres source
+  // (where `roles`/`active` are absent).
   const engineers = useMemo(
     () =>
       (data?.users ?? []).filter(
-        (u) => !!u.email && (u.userType ? u.userType === "internal" : true),
+        (u) =>
+          !!u.email &&
+          u.active !== false &&
+          (u.userType ? u.userType === "internal" : true),
       ),
     [data],
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -172,6 +172,7 @@ interface MultiSelectFieldProps<T extends string> {
   values: T[];
   options: { value: T; label: string }[];
   onChange: (next: T[]) => void;
+  disabled?: boolean;
 }
 
 function MultiSelectField<T extends string>({
@@ -180,13 +181,14 @@ function MultiSelectField<T extends string>({
   values,
   options,
   onChange,
+  disabled,
 }: MultiSelectFieldProps<T>): JSX.Element {
   const handleChange = (event: SelectChangeEvent<string[]>): void => {
     const val = event.target.value;
     onChange((Array.isArray(val) ? val : [val]) as T[]);
   };
   return (
-    <FormControl fullWidth size="small">
+    <FormControl fullWidth size="small" disabled={disabled}>
       <InputLabel id={`${id}-label`}>{label}</InputLabel>
       <Select
         multiple
@@ -648,16 +650,32 @@ export default function CasesFilterBar({
                 label="State"
                 values={filters.states}
                 options={stateOptions}
-                onChange={(next) => onChange({ ...filters, states: next })}
+                // Work sub-state only applies to `work_in_progress` cases, so
+                // drop any selected work states when that state leaves the
+                // filter — keeps shared URLs / saved views from carrying an
+                // inert work-state selection.
+                onChange={(next) =>
+                  onChange({
+                    ...filters,
+                    states: next,
+                    workStates: next.includes("work_in_progress")
+                      ? filters.workStates
+                      : [],
+                  })
+                }
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              {/* Only meaningful for `work_in_progress` cases (ongoing/paused
+                  are sub-states of it); disabled until that state is filtered
+                  in, so the control can't add an inert filter. */}
               <MultiSelectField
                 id="cases-filter-work-state"
                 label="Work state"
                 values={filters.workStates}
                 options={workStateOptions}
                 onChange={(next) => onChange({ ...filters, workStates: next })}
+                disabled={!filters.states.includes("work_in_progress")}
               />
             </Grid>
             {showEngagementTypeFilter && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -88,9 +88,9 @@ export const ASSIGNEE_ME_TOKEN = "@me";
  * Filter state for the CSM cases list. `severities` / `states` / `caseTypes`
  * are multi-select arrays driven by fixed enums; `projects` is an id-based
  * type-to-search multi-select. `assignees` holds engineer **emails** plus the
- * sentinel `@me`; the control is disabled for now (the BE filter is UUID-based
- * and `@me` has no current-user UUID to resolve to yet). The rest are pushed
- * into the `/cases/search` payload server-side.
+ * sentinel `@me`; `useGetCsmCases` resolves these to the engineer UUIDs that
+ * `/cases/search` filters on. All are pushed into the `/cases/search` payload
+ * server-side.
  */
 export interface CasesFilters {
   search: string;
@@ -683,29 +683,20 @@ export default function CasesFilterBar({
               </Grid>
             )}
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Still disabled. `/cases/search` now has `assignedUserIds`,
-                  but it is UUID-based while this picker is email/`@me`-based,
-                  and `GET /users/me` does not return the caller's UUID yet, so
-                  `@me` cannot be resolved. The hook sends no assignee field
-                  meanwhile, so the search is never broken. */}
-              <Tooltip title="Assignee filtering is coming soon.">
-                <Box>
-                  <SearchableMultiSelect
-                    id="cases-filter-assignee"
-                    label="Assignee"
-                    placeholder="Search engineers…"
-                    values={filters.assignees}
-                    options={assigneeOptions}
-                    formatOption={formatAssignee}
-                    getOptionSecondary={assigneeSecondary}
-                    getOptionSearchText={assigneeSearchText}
-                    onChange={(next) =>
-                      onChange({ ...filters, assignees: next })
-                    }
-                    disabled
-                  />
-                </Box>
-              </Tooltip>
+              {/* Email/`@me`-based picker; `useGetCsmCases` resolves the
+                  selection to the UUIDs `/cases/search` expects (`@me` via
+                  `/users/me`, named engineers via `/users/search`). */}
+              <SearchableMultiSelect
+                id="cases-filter-assignee"
+                label="Assignee"
+                placeholder="Search engineers…"
+                values={filters.assignees}
+                options={assigneeOptions}
+                formatOption={formatAssignee}
+                getOptionSecondary={assigneeSecondary}
+                getOptionSearchText={assigneeSearchText}
+                onChange={(next) => onChange({ ...filters, assignees: next })}
+              />
             </Grid>
             {!hideProjectFilter && (
               <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -70,7 +70,11 @@ import {
   SUGGESTED_FILTER_VIEWS,
   useSavedFilterViews,
 } from "@features/csm-cases/utils/savedFilterViews";
-import type { BeCaseType, BeEngagementType } from "@api/backend/types";
+import type {
+  BeCaseType,
+  BeCaseWorkState,
+  BeEngagementType,
+} from "@api/backend/types";
 import {
   ALL_CASE_TYPES,
   CASE_TYPE_LABEL,
@@ -83,10 +87,10 @@ export const ASSIGNEE_ME_TOKEN = "@me";
 /**
  * Filter state for the CSM cases list. `severities` / `states` / `caseTypes`
  * are multi-select arrays driven by fixed enums; `projects` is an id-based
- * type-to-search multi-select. `assignees` holds engineer **emails** (the
- * stable identity the backend filters on) plus the sentinel `@me` (resolves to
- * the caller via `assignedToMe`). All are pushed into the `/cases/search`
- * payload server-side.
+ * type-to-search multi-select. `assignees` holds engineer **emails** plus the
+ * sentinel `@me`; the control is disabled for now (the BE filter is UUID-based
+ * and `@me` has no current-user UUID to resolve to yet). The rest are pushed
+ * into the `/cases/search` payload server-side.
  */
 export interface CasesFilters {
   search: string;
@@ -96,6 +100,8 @@ export interface CasesFilters {
   caseTypes: BeCaseType[];
   /** Engineer emails (+ the `@me` sentinel) to filter by assigned engineer. */
   assignees: string[];
+  /** Work sub-state filter; only meaningful when `states` includes `work_in_progress`. */
+  workStates: BeCaseWorkState[];
   projects: string[];
   /** Engagement sub-type filter; only meaningful when `caseTypes` is locked to `engagement`. */
   engagementTypes: BeEngagementType[];
@@ -142,6 +148,12 @@ const ENGAGEMENT_TYPE_LABEL: Record<BeEngagementType, string> = {
   new_feature_improvement: "New feature / improvement",
   follow_up: "Follow-up",
   onboarding: "Onboarding",
+};
+
+const ALL_WORK_STATES: BeCaseWorkState[] = ["ongoing", "paused"];
+const WORK_STATE_LABEL: Record<BeCaseWorkState, string> = {
+  ongoing: "Ongoing",
+  paused: "Paused",
 };
 
 const ALL_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
@@ -383,6 +395,10 @@ export default function CasesFilterBar({
   );
   const stateOptions = useMemo(
     () => PRIMARY_STATES.map((s) => ({ value: s, label: STATE_LABEL[s] })),
+    [],
+  );
+  const workStateOptions = useMemo(
+    () => ALL_WORK_STATES.map((s) => ({ value: s, label: WORK_STATE_LABEL[s] })),
     [],
   );
   const caseTypeOptions = useMemo(
@@ -635,6 +651,15 @@ export default function CasesFilterBar({
                 onChange={(next) => onChange({ ...filters, states: next })}
               />
             </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <MultiSelectField
+                id="cases-filter-work-state"
+                label="Work state"
+                values={filters.workStates}
+                options={workStateOptions}
+                onChange={(next) => onChange({ ...filters, workStates: next })}
+              />
+            </Grid>
             {showEngagementTypeFilter && (
               <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
                 <MultiSelectField
@@ -658,11 +683,11 @@ export default function CasesFilterBar({
               </Grid>
             )}
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Disabled until the backend `/cases/search` supports an
-                  assigned-engineer filter. The picker is email-backed and ready
-                  to enable (options labelled by name, `@me` sentinel); the hook
-                  does NOT send any assignee field meanwhile, so the search is
-                  never broken. */}
+              {/* Still disabled. `/cases/search` now has `assignedUserIds`,
+                  but it is UUID-based while this picker is email/`@me`-based,
+                  and `GET /users/me` does not return the caller's UUID yet, so
+                  `@me` cannot be resolved. The hook sends no assignee field
+                  meanwhile, so the search is never broken. */}
               <Tooltip title="Assignee filtering is coming soon.">
                 <Box>
                   <SearchableMultiSelect

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -684,8 +684,9 @@ export default function CasesFilterBar({
             )}
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
               {/* Email/`@me`-based picker; `useGetCsmCases` resolves the
-                  selection to the UUIDs `/cases/search` expects (`@me` via
-                  `/users/me`, named engineers via `/users/search`). */}
+                  selection to the UUIDs `/cases/search` expects (`@me` via the
+                  app-wide current-user context, named engineers via
+                  `/users/search`). */}
               <SearchableMultiSelect
                 id="cases-filter-assignee"
                 label="Assignee"

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -32,12 +32,12 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "q=timeout&severities=S0,S2&states=open,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim",
+      "q=timeout&severities=S0,S2&states=open,work_in_progress,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim",
     );
     expect(readCasesFiltersFromUrl(params)).toEqual({
       search: "timeout",
       severities: ["S0", "S2"],
-      states: ["open", "closed"],
+      states: ["open", "work_in_progress", "closed"],
       caseTypes: ["case", "engagement"],
       engagementTypes: [],
       assignees: ["alice@example.com", "@me"],
@@ -57,8 +57,15 @@ describe("readCasesFiltersFromUrl", () => {
   });
 
   it("drops work-state values outside the allowed enum", () => {
-    const params = new URLSearchParams("workStates=ongoing,bogus,2");
+    const params = new URLSearchParams(
+      "states=work_in_progress&workStates=ongoing,bogus,2",
+    );
     expect(readCasesFiltersFromUrl(params).workStates).toEqual(["ongoing"]);
+  });
+
+  it("drops work states when `work_in_progress` is not in the state filter", () => {
+    const params = new URLSearchParams("states=open&workStates=ongoing,paused");
+    expect(readCasesFiltersFromUrl(params).workStates).toEqual([]);
   });
 
   it("strips empties and over-long free-form entries", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -32,7 +32,7 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "q=timeout&severities=S0,S2&states=open,closed&types=case,engagement&assignees=alice@example.com,@me&projects=apim",
+      "q=timeout&severities=S0,S2&states=open,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim",
     );
     expect(readCasesFiltersFromUrl(params)).toEqual({
       search: "timeout",
@@ -41,6 +41,7 @@ describe("readCasesFiltersFromUrl", () => {
       caseTypes: ["case", "engagement"],
       engagementTypes: [],
       assignees: ["alice@example.com", "@me"],
+      workStates: ["ongoing", "paused"],
       projects: ["apim"],
     });
   });
@@ -53,6 +54,11 @@ describe("readCasesFiltersFromUrl", () => {
     expect(f.severities).toEqual(["S0"]);
     expect(f.states).toEqual(["open"]);
     expect(f.caseTypes).toEqual(["case"]);
+  });
+
+  it("drops work-state values outside the allowed enum", () => {
+    const params = new URLSearchParams("workStates=ongoing,bogus,2");
+    expect(readCasesFiltersFromUrl(params).workStates).toEqual(["ongoing"]);
   });
 
   it("strips empties and over-long free-form entries", () => {
@@ -75,6 +81,7 @@ describe("writeCasesFiltersToUrl", () => {
       states: ["work_in_progress"],
       caseTypes: ["service_request"],
       assignees: ["carol@example.com"],
+      workStates: ["paused"],
       projects: ["streaming"],
       engagementTypes: [],
     };

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -18,7 +18,11 @@ import type {
   CaseState,
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
-import type { BeCaseType, BeEngagementType } from "@api/backend/types";
+import type {
+  BeCaseType,
+  BeCaseWorkState,
+  BeEngagementType,
+} from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
 
@@ -28,6 +32,7 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   states: [],
   caseTypes: [],
   assignees: [],
+  workStates: [],
   projects: [],
   engagementTypes: [],
 };
@@ -42,6 +47,7 @@ const VALID_STATES: CaseState[] = [
   "closed",
 ];
 const VALID_CASE_TYPES: BeCaseType[] = ALL_CASE_TYPES;
+const VALID_WORK_STATES: BeCaseWorkState[] = ["ongoing", "paused"];
 const VALID_ENGAGEMENT_TYPES: BeEngagementType[] = [
   "migration",
   "consultancy",
@@ -80,6 +86,7 @@ export function readCasesFiltersFromUrl(
     states: parseCsv(params.get("states"), VALID_STATES),
     caseTypes: parseCsv(params.get("types"), VALID_CASE_TYPES),
     assignees: parseFreeFormCsv(params.get("assignees")),
+    workStates: parseCsv(params.get("workStates"), VALID_WORK_STATES),
     projects: parseFreeFormCsv(params.get("projects")),
     engagementTypes: parseCsv(params.get("engagementTypes"), VALID_ENGAGEMENT_TYPES),
   };
@@ -96,6 +103,7 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   if (f.states.length) out.set("states", f.states.join(","));
   if (f.caseTypes.length) out.set("types", f.caseTypes.join(","));
   if (f.assignees.length) out.set("assignees", f.assignees.join(","));
+  if (f.workStates.length) out.set("workStates", f.workStates.join(","));
   if (f.projects.length) out.set("projects", f.projects.join(","));
   if (f.engagementTypes.length) out.set("engagementTypes", f.engagementTypes.join(","));
   return out;
@@ -114,6 +122,7 @@ export function countActiveFilters(f: CasesFilters): number {
   if (f.states.length) n += 1;
   if (f.caseTypes.length) n += 1;
   if (f.assignees.length) n += 1;
+  if (f.workStates.length) n += 1;
   if (f.projects.length) n += 1;
   if (f.engagementTypes.length) n += 1;
   return n;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -80,13 +80,21 @@ function parseFreeFormCsv(raw: string | null, maxEntryLen = 120): string[] {
 export function readCasesFiltersFromUrl(
   params: URLSearchParams,
 ): CasesFilters {
+  const states = parseCsv(params.get("states"), VALID_STATES);
+  // Work sub-states only apply to `work_in_progress` cases. Mirror the
+  // filter-bar invariant (the State control clears work states when that state
+  // leaves the selection) so a hand-edited / stale URL can't load an active but
+  // un-clearable work-state filter behind the disabled control.
+  const workStates = states.includes("work_in_progress")
+    ? parseCsv(params.get("workStates"), VALID_WORK_STATES)
+    : [];
   return {
     search: params.get("q") ?? "",
     severities: parseCsv(params.get("severities"), VALID_SEVERITIES),
-    states: parseCsv(params.get("states"), VALID_STATES),
+    states,
     caseTypes: parseCsv(params.get("types"), VALID_CASE_TYPES),
     assignees: parseFreeFormCsv(params.get("assignees")),
-    workStates: parseCsv(params.get("workStates"), VALID_WORK_STATES),
+    workStates,
     projects: parseFreeFormCsv(params.get("projects")),
     engagementTypes: parseCsv(params.get("engagementTypes"), VALID_ENGAGEMENT_TYPES),
   };

--- a/apps/csm-portal/webapp/src/features/csm-users/api/useSearchUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/api/useSearchUsers.ts
@@ -18,15 +18,23 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import { apiConfig } from "@config/apiConfig";
 import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
-import type {
-  SearchUsersRequest,
-  SearchUsersResponse,
+import {
+  normalizeUserSearchResponse,
+  type NormalizedUserSearchResult,
+  type SearchUsersRequest,
+  type SearchUsersResponse,
 } from "@features/csm-users/types/csmUsers";
 
+/**
+ * Searches users via `POST /users/search`. The endpoint returns a `oneOf`
+ * (postgres `User` vs ServiceNow `SnUser`); the result is normalized into a
+ * source-agnostic {@link NormalizedUserSearchResult} so callers don't branch
+ * on the live data source.
+ */
 export function useSearchUsers(request: SearchUsersRequest) {
   const authFetch = useAuthApiClient();
 
-  return useQuery<SearchUsersResponse, Error>({
+  return useQuery<SearchUsersResponse, Error, NormalizedUserSearchResult>({
     queryKey: ["csm-users-search", request],
     queryFn: async () => {
       const res = await authFetch(`${apiConfig.backendUrl}/users/search`, {
@@ -43,6 +51,7 @@ export function useSearchUsers(request: SearchUsersRequest) {
       }
       return (await res.json()) as SearchUsersResponse;
     },
+    select: normalizeUserSearchResponse,
     placeholderData: keepPreviousData,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -17,9 +17,17 @@
 import {
   Alert,
   Box,
+  Checkbox,
   Chip,
+  FormControl,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  OutlinedInput,
   Paper,
+  Select,
   Skeleton,
+  Stack,
   Table,
   TableBody,
   TableCell,
@@ -27,32 +35,61 @@ import {
   TableHead,
   TablePagination,
   TableRow,
+  TableSortLabel,
   TextField,
   Typography,
+  type SelectChangeEvent,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
-import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
+import {
+  INTERNAL_USER_ROLES,
+  type SearchUsersRequest,
+  type SnUserRole,
+  type UserSortField,
+  type UserSortOrder,
+} from "@features/csm-users/types/csmUsers";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
+const ALL_ROLES: SnUserRole[] = [
+  ...INTERNAL_USER_ROLES,
+  "commenter",
+  "external",
+  "customer",
+  "customer_admin",
+  "partner",
+  "partner_admin",
+];
+
+type ActiveFilter = "all" | "active" | "inactive";
+
 export default function CsmUsersPage(): JSX.Element {
   const [searchInput, setSearchInput] = useState("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [roleFilter, setRoleFilter] = useState<SnUserRole[]>([]);
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>("all");
+  const [sortField, setSortField] = useState<UserSortField>("name");
+  const [sortOrder, setSortOrder] = useState<UserSortOrder>("asc");
 
   const debouncedSearch = useDebouncedValue(searchInput, 300);
 
   const request = useMemo<SearchUsersRequest>(
     () => ({
       pagination: { limit: rowsPerPage, offset: page * rowsPerPage },
-      searchQuery: debouncedSearch.trim() || undefined,
+      filters: {
+        ...(debouncedSearch.trim() && { searchQuery: debouncedSearch.trim() }),
+        ...(roleFilter.length > 0 && { roles: roleFilter }),
+        ...(activeFilter !== "all" && { active: activeFilter === "active" }),
+      },
+      sortBy: { field: sortField, order: sortOrder },
     }),
-    [debouncedSearch, page, rowsPerPage],
+    [debouncedSearch, page, rowsPerPage, roleFilter, activeFilter, sortField, sortOrder],
   );
 
   const { data, isLoading, isFetching, isError, error } = useSearchUsers(request);
@@ -67,24 +104,80 @@ export default function CsmUsersPage(): JSX.Element {
     setPage(0);
   };
 
+  const handleRoleChange = (e: SelectChangeEvent<SnUserRole[]>) => {
+    const value = e.target.value;
+    setRoleFilter(typeof value === "string" ? (value.split(",") as SnUserRole[]) : value);
+    setPage(0);
+  };
+
+  const handleActiveChange = (e: SelectChangeEvent) => {
+    setActiveFilter(e.target.value as ActiveFilter);
+    setPage(0);
+  };
+
+  const handleSort = (field: UserSortField) => {
+    if (sortField === field) {
+      setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
+    } else {
+      setSortField(field);
+      setSortOrder("asc");
+    }
+    setPage(0);
+  };
+
   const users = data?.users ?? [];
   const total = data?.total ?? 0;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
       <Typography variant="body2" color="text.secondary">
-        Search across username and email (case-insensitive).
+        Search across username and email (case-insensitive). Filter by role and status.
       </Typography>
 
-      <TextField
-        size="small"
-        label="Search users"
-        placeholder="Search users by username or email"
-        value={searchInput}
-        onChange={handleSearchChange}
-        slotProps={{ htmlInput: { "aria-label": "Search users by username or email" } }}
-        sx={{ maxWidth: 480 }}
-      />
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2} sx={{ flexWrap: "wrap" }}>
+        <TextField
+          size="small"
+          label="Search users"
+          placeholder="Search users by username or email"
+          value={searchInput}
+          onChange={handleSearchChange}
+          slotProps={{ htmlInput: { "aria-label": "Search users by username or email" } }}
+          sx={{ minWidth: 280, flex: 1 }}
+        />
+
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <InputLabel id="user-roles-label">Roles</InputLabel>
+          <Select
+            labelId="user-roles-label"
+            multiple
+            value={roleFilter}
+            onChange={handleRoleChange}
+            input={<OutlinedInput label="Roles" />}
+            renderValue={(selected) => (selected as SnUserRole[]).join(", ")}
+          >
+            {ALL_ROLES.map((role) => (
+              <MenuItem key={role} value={role}>
+                <Checkbox checked={roleFilter.includes(role)} />
+                <ListItemText primary={role} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 140 }}>
+          <InputLabel id="user-active-label">Status</InputLabel>
+          <Select
+            labelId="user-active-label"
+            value={activeFilter}
+            onChange={handleActiveChange}
+            input={<OutlinedInput label="Status" />}
+          >
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="active">Active</MenuItem>
+            <MenuItem value="inactive">Inactive</MenuItem>
+          </Select>
+        </FormControl>
+      </Stack>
 
       {isError && (
         <Alert severity="error">
@@ -98,9 +191,18 @@ export default function CsmUsersPage(): JSX.Element {
             <TableHead>
               <TableRow>
                 <TableCell>Username</TableCell>
-                <TableCell>Name</TableCell>
+                <TableCell sortDirection={sortField === "name" ? sortOrder : false}>
+                  <TableSortLabel
+                    active={sortField === "name"}
+                    direction={sortField === "name" ? sortOrder : "asc"}
+                    onClick={() => handleSort("name")}
+                  >
+                    Name
+                  </TableSortLabel>
+                </TableCell>
                 <TableCell>Email</TableCell>
-                <TableCell>Type</TableCell>
+                <TableCell>Roles</TableCell>
+                <TableCell>Status</TableCell>
                 <TableCell>Timezone</TableCell>
               </TableRow>
             </TableHead>
@@ -108,41 +210,64 @@ export default function CsmUsersPage(): JSX.Element {
               {isLoading ? (
                 [0, 1, 2, 3, 4, 5].map((i) => (
                   <TableRow key={i}>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
+                    {[0, 1, 2, 3, 4, 5].map((c) => (
+                      <TableCell key={c}>
+                        <Skeleton variant="text" />
+                      </TableCell>
+                    ))}
                   </TableRow>
                 ))
               ) : users.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       No users found.
                     </Typography>
                   </TableCell>
                 </TableRow>
               ) : (
-                users.map((u) => {
-                  const fullName = `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim() || "—";
-                  return (
-                    <TableRow key={u.id} hover>
-                      <TableCell>{u.userName}</TableCell>
-                      <TableCell>{fullName}</TableCell>
-                      <TableCell>{u.email}</TableCell>
-                      <TableCell>
+                users.map((u) => (
+                  <TableRow key={u.id} hover>
+                    <TableCell>{u.userName}</TableCell>
+                    <TableCell>{u.name || "—"}</TableCell>
+                    <TableCell>{u.email}</TableCell>
+                    <TableCell>
+                      <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+                        {u.roles && u.roles.length > 0
+                          ? u.roles.map((r) => (
+                              <Chip
+                                key={r}
+                                size="small"
+                                label={r}
+                                color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
+                                variant="outlined"
+                              />
+                            ))
+                          : u.userType
+                            ? <Chip
+                                size="small"
+                                label={u.userType}
+                                color={u.userType === "internal" ? "primary" : "default"}
+                                variant="outlined"
+                              />
+                            : "—"}
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      {u.active === undefined ? (
+                        "—"
+                      ) : (
                         <Chip
                           size="small"
-                          label={u.userType}
-                          color={u.userType === "internal" ? "primary" : "default"}
+                          label={u.active ? "Active" : "Inactive"}
+                          color={u.active ? "success" : "default"}
                           variant="outlined"
                         />
-                      </TableCell>
-                      <TableCell>{u.timezone ?? "—"}</TableCell>
-                    </TableRow>
-                  );
-                })
+                      )}
+                    </TableCell>
+                    <TableCell>{u.timezone ?? "—"}</TableCell>
+                  </TableRow>
+                ))
               )}
             </TableBody>
           </Table>

--- a/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
@@ -16,6 +16,28 @@
 
 export type UserType = "internal" | "customer";
 
+/**
+ * Roles as modelled by the ServiceNow data source. `internal`/`agent`/`admin`
+ * are WSO2-internal staff; the rest are external (customer/partner) contacts.
+ */
+export type SnUserRole =
+  | "internal"
+  | "agent"
+  | "admin"
+  | "commenter"
+  | "external"
+  | "customer"
+  | "customer_admin"
+  | "partner"
+  | "partner_admin";
+
+/** Internal-facing roles: the translation of the old `userType === "internal"`. */
+export const INTERNAL_USER_ROLES: SnUserRole[] = ["internal", "agent", "admin"];
+
+export type UserSortField = "name" | "createdOn" | "updatedOn";
+export type UserSortOrder = "asc" | "desc";
+
+/** User shape returned by the postgres data source. */
 export interface User {
   id: string;
   userName: string;
@@ -29,18 +51,128 @@ export interface User {
   updatedAt: string;
 }
 
+/**
+ * User shape returned by the ServiceNow data source. No `firstName`/`lastName`
+ * (use `name`), no `userType` (use `roles`), no `hasMore` on the envelope.
+ */
+export interface SnUser {
+  id: string;
+  userName: string;
+  name: string;
+  email: string;
+  timeZone?: string | null;
+  active: boolean;
+  createdOn: string;
+  updatedOn: string;
+  roles: string[];
+}
+
+export interface UserSearchFilters {
+  searchQuery?: string;
+  /** ServiceNow data source only. */
+  roles?: SnUserRole[];
+  userNames?: string[];
+  emails?: string[];
+  /** ServiceNow data source only. */
+  active?: boolean | null;
+}
+
+export interface UserSortBy {
+  /** ServiceNow data source only. */
+  field: UserSortField;
+  order?: UserSortOrder;
+}
+
 export interface SearchUsersRequest {
   pagination?: {
     limit?: number;
     offset?: number;
   };
-  searchQuery?: string;
+  filters?: UserSearchFilters;
+  sortBy?: UserSortBy;
 }
 
-export interface SearchUsersResponse {
+/** Postgres-data-source response envelope. */
+export interface UserSearchResponse {
   users: User[];
   total: number;
   limit: number;
   offset: number;
   hasMore: boolean;
+}
+
+/** ServiceNow-data-source response envelope (no `hasMore`). */
+export interface SnUserSearchResponse {
+  users: SnUser[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/** Either data source's raw envelope; `/users/search` returns a `oneOf`. */
+export type SearchUsersResponse = UserSearchResponse | SnUserSearchResponse;
+
+/**
+ * Source-agnostic row the UI renders. Both `User` and `SnUser` normalize into
+ * this so screens don't branch on the live data source.
+ */
+export interface NormalizedUser {
+  id: string;
+  userName: string;
+  name: string;
+  email: string;
+  timezone: string | null;
+  /** Present only from the postgres source. */
+  userType?: UserType;
+  /** Present only from the ServiceNow source. */
+  active?: boolean;
+  /** Present only from the ServiceNow source. */
+  roles?: string[];
+}
+
+export interface NormalizedUserSearchResult {
+  users: NormalizedUser[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+function isSnUser(u: User | SnUser): u is SnUser {
+  return "name" in u || "active" in u || "roles" in u;
+}
+
+/** Maps either source's user shape into {@link NormalizedUser}. */
+export function normalizeUser(u: User | SnUser): NormalizedUser {
+  if (isSnUser(u)) {
+    return {
+      id: u.id,
+      userName: u.userName,
+      name: u.name?.trim() || "",
+      email: u.email,
+      timezone: u.timeZone ?? null,
+      active: u.active,
+      roles: u.roles,
+    };
+  }
+  return {
+    id: u.id,
+    userName: u.userName,
+    name: `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim(),
+    email: u.email,
+    timezone: u.timezone ?? null,
+    userType: u.userType,
+  };
+}
+
+/** Normalizes either response envelope; derives `hasMore` when absent. */
+export function normalizeUserSearchResponse(
+  res: SearchUsersResponse,
+): NormalizedUserSearchResult {
+  const users = (res.users ?? []).map((u) => normalizeUser(u));
+  const hasMore =
+    "hasMore" in res
+      ? res.hasMore
+      : res.offset + users.length < res.total;
+  return { users, total: res.total, limit: res.limit, offset: res.offset, hasMore };
 }

--- a/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
+++ b/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
@@ -19,16 +19,20 @@ import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import { apiConfig } from "@config/apiConfig";
 import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
 
-// Matches csm-portal-backend openapi UserResponse. `id` is the caller's
-// platform UUID, consumed by the cases assignee filter to resolve the `@me`
-// sentinel. The BFF is expected to populate it shortly (currently a TODO,
-// blocked on entity wiring, alongside firstName/lastName/timeZone/roles); it
-// stays optional so `@me` degrades gracefully until the field lands.
+// Matches csm-portal-backend openapi UserResponse. Identity fields
+// (id/firstName/lastName/timeZone/roles) come from the entity service; `id` is
+// the caller's platform UUID, consumed by the cases assignee filter to resolve
+// the `@me` sentinel. `id` is optional because the contract omits it when the
+// entity service is unavailable (the assignee `@me` path degrades gracefully in
+// that case). `phoneNumber` is sourced from SCIM.
 export interface UsersMeResponse {
   id?: string;
   email?: string;
+  firstName?: string;
+  lastName?: string;
+  timeZone?: string;
+  roles?: string[];
   phoneNumber?: string;
-  lastPasswordUpdateTime?: string;
 }
 
 export function useGetUsersMe() {

--- a/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
+++ b/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
@@ -19,10 +19,13 @@ import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import { apiConfig } from "@config/apiConfig";
 import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
 
-// Matches csm-portal-backend openapi UserResponse; id/firstName/lastName/
-// timeZone/roles are intentionally absent — TODO on the BFF side, blocked on
-// entity wiring.
+// Matches csm-portal-backend openapi UserResponse. `id` is the caller's
+// platform UUID, consumed by the cases assignee filter to resolve the `@me`
+// sentinel. The BFF is expected to populate it shortly (currently a TODO,
+// blocked on entity wiring, alongside firstName/lastName/timeZone/roles); it
+// stays optional so `@me` degrades gracefully until the field lands.
 export interface UsersMeResponse {
+  id?: string;
   email?: string;
   phoneNumber?: string;
   lastPasswordUpdateTime?: string;

--- a/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
+++ b/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
@@ -48,5 +48,9 @@ export function useGetUsersMe() {
       }
       return (await res.json()) as UsersMeResponse;
     },
+    // The signed-in user's profile is effectively static for a session; this is
+    // fetched once app-wide via CurrentUserProvider, so keep it fresh to avoid
+    // refetches on incidental remounts.
+    staleTime: 5 * 60_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/settings/api/usePatchUsersMe.ts
+++ b/apps/csm-portal/webapp/src/features/settings/api/usePatchUsersMe.ts
@@ -19,14 +19,18 @@ import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import { apiConfig } from "@config/apiConfig";
 import { ApiError, parseApiResponseMessage } from "@utils/ApiError";
 
-// BFF currently accepts only phoneNumber (E.164). timeZone is TODO per BFF
-// openapi.
+// PATCH /users/me accepts phoneNumber (E.164, via SCIM) and timeZone (via the
+// entity service); at least one is required. The response echoes only the
+// field(s) that were updated. No timeZone-editing UI exists yet — the field is
+// here for contract parity and a future profile editor.
 export interface UpdateUserPayload {
   phoneNumber?: string;
+  timeZone?: string;
 }
 
 export interface UpdatedUserResponse {
   phoneNumber?: string;
+  timeZone?: string;
 }
 
 export function usePatchUsersMe() {

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -20,6 +20,7 @@ import { ProtectedRoute } from "@asgardeo/react-router";
 import { useLocation, useNavigate } from "react-router";
 import AppLayout from "@layouts/AppLayout";
 import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
+import { CurrentUserProvider } from "@context/current-user/CurrentUserContext";
 
 /**
  * AuthGuard renders AppLayout (header/footer) so loading state is visible
@@ -73,7 +74,9 @@ export default function AuthGuard(): JSX.Element {
         defaultSignIn(signInOptions);
       }}
     >
-      <AppLayout />
+      <CurrentUserProvider>
+        <AppLayout />
+      </CurrentUserProvider>
     </ProtectedRoute>
   );
 }

--- a/apps/csm-portal/webapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.ts
@@ -51,6 +51,29 @@ export function normalizeUserTimeZone(
 }
 
 /**
+ * Lists the IANA time zones the runtime supports, for the profile time-zone
+ * picker. Uses `Intl.supportedValuesOf` where available; falls back to the
+ * browser's own zone on older runtimes so the picker is never empty.
+ *
+ * @returns {string[]} Sorted IANA time-zone identifiers.
+ */
+export function listSupportedTimeZones(): string[] {
+  try {
+    const fn = (Intl as { supportedValuesOf?: (key: string) => string[] })
+      .supportedValuesOf;
+    if (typeof fn === "function") return fn("timeZone");
+  } catch {
+    /* older runtime without Intl.supportedValuesOf */
+  }
+  try {
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return zone ? [zone] : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Stores user timezone globally for view-only date formatting.
  *
  * @param timeZone - Timezone from users/me response.


### PR DESCRIPTION
## Summary

Adopts the backend contract changes that landed on `v2` and addresses review feedback.

### 1. `POST /users/search` rework (entity PRs #973/#974)
The request now takes **nested filters** (`filters.searchQuery`, `roles`, `userNames`, `emails`, `active`), an optional `sortBy`, and the response is a `oneOf` of two user shapes depending on the live data source. The webapp still sent the old flat `{ searchQuery }` (silently dropped → unfiltered results), and the ServiceNow user shape has no `userType` (broke the engineer-assignment list).

- **types**: nest `filters` + `sortBy`; add the ServiceNow user shape and a normalizer mapping **both** response shapes to one source-agnostic row (deriving `hasMore` when the envelope omits it).
- **useSearchUsers**: normalize via react-query `select` so callers don't branch on the data source.
- **AssignEngineerDialog**: filter assignable engineers by internal-facing roles server-side; only offer **active** accounts (`active: true` + defensive client check).
- **CsmUsersPage**: role + active-status filters and a sortable name column; roles/status columns.
- **useDirectoryUsers**: request the max page size (default dropped to 10) so the assignee directory isn't truncated.

### 2. `POST /cases/search` new filters (entity #976 / BE #979)
- Adds `workStates` and `assignedUserIds` to the FE filter types.
- **Work state** (ongoing/paused) multi-select, wired end-to-end (state, URL, active-filter count, query key, payload). Gated behind the `work_in_progress` state so it can't add an inert filter, and cleared from URLs/saved views when that state leaves the filter.
- **Assignee filter** enabled (was disabled). Picker stays email/`@me`-based; `useGetCsmCases` resolves the selection to engineer UUIDs — named engineers via a targeted `POST /users/search` by email, `@me` via the caller's `id`. A lookup transport failure fails the query (shows an error) rather than silently broadening to all cases.

### 3. `GET/PATCH /users/me` rework (entity/BE #985)
`GET /users/me` now returns `id`, `firstName`, `lastName`, `timeZone`, `roles` (+ `phoneNumber` from SCIM) and drops `lastPasswordUpdateTime`; `PATCH` now accepts `timeZone`.

- **`/users/me` fetched once app-wide** via a new `CurrentUserProvider` (mounted in `AuthGuard`), exposed through `useCurrentUser()` — the platform-owned counterpart to the IdP claims in `useIdTokenClaims`. The cases `@me` filter reads the caller's `id` from this context (no per-query `/users/me`).
- **UsersMeResponse**: add `firstName`/`lastName`/`timeZone`/`roles`; remove `lastPasswordUpdateTime`.
- **UserProfileModal**: drop the now-dead "Last password update" row.
- **usePatchUsersMe**: add `timeZone` to the request/response types.
- **Profile modal**: add an editable **Time zone** picker (Autocomplete over `Intl.supportedValuesOf`); save sends only the changed field(s). `CurrentUserProvider` now seeds the app-wide preferred-timezone store from the profile (it was never populated), so view-only dates render in the user's zone.

## Notes
- Role/status/sort, `workStates`, and the `emails`/`roles` user filters are honoured by the ServiceNow data source; the postgres source rejects the SN-only fields. When FE data-source switching arrives, these controls should be capability-gated.
- `@me` resolution depends on `/users/me` returning `id`; the contract omits `id` only when the entity service is unavailable, in which case an `@me`-only selection resolves to nothing and the filter is omitted.
- "Assignable engineer" maps to the internal-facing roles (`internal`, `agent`, `admin`); adjust if it should be narrower.

## Test plan
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm build` (type-checks clean)
- [x] `pnpm test` (105/105 pass)
- [ ] Manual: Users page search / role / status filters and name sort
- [ ] Manual: assign-engineer dialog lists active internal users; assigns by email
- [ ] Manual: cases Work state filter (enabled only with the Work-in-progress state)
- [ ] Manual: cases assignee filter by named engineer and `@me`
- [ ] Manual: profile modal renders without the removed password row; time-zone picker saves and updates date formatting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * **Users:** added role/status filters plus sortable **Name**; user list now shows **Roles**, **Status**, and **Timezone**.
  * **Cases:** added **Work state** multi-select with URL persistence; assignee filtering now supports resolving **`@me`**.
* **Bug Fixes**
  * User directory search now defaults to paginated results and displays consistently normalized user data.
  * Case results now refresh when work state or assignee filters change.
* **Chores**
  * Added app-wide current-user context for **`@me`** resolution; user profile now supports updating **Time zone** and no longer shows **Last password update**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
