### PR TITLE
[Customer Portal Web App] Add Lead role to Edit User Roles modal and table view

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/api/usePatchProjectContact.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/usePatchProjectContact.ts
@@ -50,9 +50,7 @@ export function usePatchProjectContact(
 
   return useMutation<void, Error, PatchProjectContactVariables>({
     mutationFn: async ({ email, isCsAdmin, isLead, isPortalUser, isSecurityContact }): Promise<void> => {
-      logger.debug(
-        `[usePatchProjectContact] Patching ${email} isCsAdmin=${isCsAdmin} isLead=${isLead} isPortalUser=${isPortalUser} isSecurityContact=${isSecurityContact}`,
-      );
+      logger.debug("[usePatchProjectContact] Updating project contact membership roles");
 
       try {
         if (!isSignedIn || isAuthLoading) {

--- a/apps/customer-portal/webapp/src/features/settings/api/usePatchProjectContact.ts
+++ b/apps/customer-portal/webapp/src/features/settings/api/usePatchProjectContact.ts
@@ -28,6 +28,7 @@ import { parseApiResponseMessage } from "@utils/ApiError";
 export interface PatchProjectContactVariables {
   email: string;
   isCsAdmin: boolean;
+  isLead: boolean;
   isPortalUser: boolean;
   isSecurityContact: boolean;
 }
@@ -48,9 +49,9 @@ export function usePatchProjectContact(
   const authFetch = useAuthApiClient();
 
   return useMutation<void, Error, PatchProjectContactVariables>({
-    mutationFn: async ({ email, isCsAdmin, isPortalUser, isSecurityContact }): Promise<void> => {
+    mutationFn: async ({ email, isCsAdmin, isLead, isPortalUser, isSecurityContact }): Promise<void> => {
       logger.debug(
-        `[usePatchProjectContact] Patching ${email} isCsAdmin=${isCsAdmin} isPortalUser=${isPortalUser} isSecurityContact=${isSecurityContact}`,
+        `[usePatchProjectContact] Patching ${email} isCsAdmin=${isCsAdmin} isLead=${isLead} isPortalUser=${isPortalUser} isSecurityContact=${isSecurityContact}`,
       );
 
       try {
@@ -66,7 +67,7 @@ export function usePatchProjectContact(
         const requestUrl = `${baseUrl}/projects/${projectId}/contacts/${encodeURIComponent(email)}`;
         const response = await authFetch(requestUrl, {
           method: "PATCH",
-          body: JSON.stringify({ isCsAdmin, isPortalUser, isSecurityContact }),
+          body: JSON.stringify({ isCsAdmin, isLead, isPortalUser, isSecurityContact }),
         });
 
         if (!response.ok) {

--- a/apps/customer-portal/webapp/src/features/settings/components/EditUserModal.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/EditUserModal.tsx
@@ -115,18 +115,23 @@ export default function EditUserModal({
       const next = new Set(prev);
       if (next.has(roleId)) {
         next.delete(roleId);
+        // Removing Portal User also removes Lead (Lead requires portal access)
+        if (roleId === "portal") next.delete("lead");
       } else {
         next.add(roleId);
+        // Adding Lead implicitly requires Portal User
+        if (roleId === "lead") next.add("portal");
       }
       return next;
     });
   };
 
   const handleSave = useCallback(() => {
+    const isLead = selectedRoles.has("lead");
     onSubmit({
       isCsAdmin: selectedRoles.has("admin"),
-      isLead: selectedRoles.has("lead"),
-      isPortalUser: selectedRoles.has("portal"),
+      isLead,
+      isPortalUser: selectedRoles.has("portal") || isLead,
       isSecurityContact: selectedRoles.has("security"),
     });
   }, [selectedRoles, onSubmit]);

--- a/apps/customer-portal/webapp/src/features/settings/components/EditUserModal.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/EditUserModal.tsx
@@ -32,7 +32,7 @@ import {
   colors,
   useTheme,
 } from "@wso2/oxygen-ui";
-import { Crown, Monitor, Settings, Shield, X } from "@wso2/oxygen-ui-icons-react";
+import { Crown, Monitor, Settings, Shield, TriangleAlert, X } from "@wso2/oxygen-ui-icons-react";
 import { NULL_PLACEHOLDER } from "@features/settings/constants/settingsConstants";
 import { getAvatarColor, getInitials } from "@features/settings/utils/settings";
 import type { EditUserModalProps } from "@features/settings/types/settings";
@@ -44,6 +44,13 @@ const EDITABLE_ROLES = [
     description: "Full administrative privileges and user management",
     Icon: Crown,
     color: "secondary" as const,
+  },
+  {
+    id: "lead" as const,
+    label: "Lead",
+    description: "A portal user who can escalate an issue beyond level 3",
+    Icon: TriangleAlert,
+    color: "warning" as const,
   },
   {
     id: "portal" as const,
@@ -84,6 +91,7 @@ export default function EditUserModal({
     if (!contact) return new Set<EditableRoleId>();
     const initial = new Set<EditableRoleId>();
     if (contact.isCsAdmin) initial.add("admin");
+    if (contact.isLead) initial.add("lead");
     // isPortalUser is the explicit flag; fall back to !isCsIntegrationUser if absent
     const portalUser = contact.isPortalUser ?? !contact.isCsIntegrationUser;
     if (portalUser) initial.add("portal");
@@ -117,6 +125,7 @@ export default function EditUserModal({
   const handleSave = useCallback(() => {
     onSubmit({
       isCsAdmin: selectedRoles.has("admin"),
+      isLead: selectedRoles.has("lead"),
       isPortalUser: selectedRoles.has("portal"),
       isSecurityContact: selectedRoles.has("security"),
     });
@@ -125,6 +134,7 @@ export default function EditUserModal({
   const initialRoles = getInitialRoles();
   const isDirty =
     selectedRoles.has("admin") !== initialRoles.has("admin") ||
+    selectedRoles.has("lead") !== initialRoles.has("lead") ||
     selectedRoles.has("portal") !== initialRoles.has("portal") ||
     selectedRoles.has("security") !== initialRoles.has("security");
 

--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
@@ -158,12 +158,13 @@ export default function SettingsUserManagement({
   }, [removeTarget, deleteContact, showSuccess, showError]);
 
   const handleEditUser = useCallback(
-    (next: { isCsAdmin: boolean; isPortalUser: boolean; isSecurityContact: boolean }) => {
+    (next: { isCsAdmin: boolean; isLead: boolean; isPortalUser: boolean; isSecurityContact: boolean }) => {
       if (!editTarget?.email) return;
       patchContact.mutate(
         {
           email: editTarget.email,
           isCsAdmin: next.isCsAdmin,
+          isLead: next.isLead,
           isPortalUser: next.isPortalUser,
           isSecurityContact: next.isSecurityContact,
         },

--- a/apps/customer-portal/webapp/src/features/settings/types/settings.ts
+++ b/apps/customer-portal/webapp/src/features/settings/types/settings.ts
@@ -105,7 +105,7 @@ export type EditUserModalProps = {
   contact: ProjectContact | null;
   isSubmitting?: boolean;
   onClose: () => void;
-  onSubmit: (next: { isCsAdmin: boolean; isPortalUser: boolean; isSecurityContact: boolean }) => void;
+  onSubmit: (next: { isCsAdmin: boolean; isLead: boolean; isPortalUser: boolean; isSecurityContact: boolean }) => void;
 };
 
 export type RemoveUserModalProps = {

--- a/apps/customer-portal/webapp/src/features/settings/utils/settings.ts
+++ b/apps/customer-portal/webapp/src/features/settings/utils/settings.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { colors } from "@wso2/oxygen-ui";
-import { Code, Crown, Monitor, Shield, Users } from "@wso2/oxygen-ui-icons-react";
+import { Code, Crown, Monitor, Shield, TriangleAlert, Users } from "@wso2/oxygen-ui-icons-react";
 import {
   NULL_PLACEHOLDER,
   SETTINGS_AVATAR_BACKGROUND_COLORS,
@@ -34,6 +34,10 @@ export function getRoleBadges(contact: ProjectContact): SettingsRoleBadge[] {
 
   if (contact.isCsAdmin) {
     badges.push({ label: "Admin", Icon: Crown, chipColor: "primary" });
+  }
+
+  if (contact.isLead) {
+    badges.push({ label: "Lead", Icon: TriangleAlert, chipColor: "warning" });
   }
 
   if (contact.isCsIntegrationUser) {


### PR DESCRIPTION
## Summary
- Add **Lead** role checkbox to the Edit User Roles modal (between Admin and Portal User), using `TriangleAlert` + warning color consistent with the Role Permissions info panel
- Show **Lead** badge in the Role column of the user management table for contacts with `isLead: true`
- Thread `isLead` through `usePatchProjectContact`, `EditUserModalProps`, and `handleEditUser` so it is sent in the PATCH request body

Follows the backend changes from PR #975 which added `isLead` to `MembershipRolePayload`, `ContactOnboardPayload`, and the `Membership` response type.

## Test plan
- [ ] Open Edit User Roles modal — Lead role appears between Admin and Portal User
- [ ] Toggle Lead on/off and save — PATCH request body includes `isLead: true/false`
- [ ] Contact with `isLead: true` shows Lead badge in the table Role column
- [ ] Other roles (Admin, Portal User, Security Contact) are unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new **Lead** role in user management.
  * Users marked as Lead now show a dedicated badge and icon in the settings UI.
  * The edit user flow now includes Lead as a selectable role and preserves it when editing existing users.

* **Bug Fixes**
  * Updated role changes to save and refresh the new Lead state consistently across the settings experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->