### PR TITLE
[CSM][BE] feat: add workStates and assignedUserIds filters to POST /cases/search

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -165,7 +165,7 @@ backend/
 - `POST /cases` — Create a case (`type`: `case`; `service_request` and `security_report_analysis` are ServiceNow data source only)
 - `GET /cases/{id}` — Get case by ID
 - `PATCH /cases/{id}` — Update a case (state, severity, workState, watchList, or assigneeEmail)
-- `POST /cases/search` — Search cases
+- `POST /cases/search` — Search cases; filters include `types`, `states`, `severities`, `workStates` (`ongoing`/`paused`), `assignedUserIds`, `engagementTypes`, `issueTypes`, date ranges, `createdBy`, `createdByMe`
 - `POST /cases/{id}/comments` — Create a comment on a case
 - `POST /cases/{id}/comments/search` — Search comments on a case
 - `POST /attachments` — Upload an attachment (`referenceId`, `referenceType`, `name`, `type`, `file` in body)

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -165,7 +165,7 @@ backend/
 - `POST /cases` — Create a case (`type`: `case`; `service_request` and `security_report_analysis` are ServiceNow data source only)
 - `GET /cases/{id}` — Get case by ID
 - `PATCH /cases/{id}` — Update a case (state, severity, workState, watchList, or assigneeEmail)
-- `POST /cases/search` — Search cases; filters include `types`, `states`, `severities`, `workStates` (`ongoing`/`paused`), `assignedUserIds`, `engagementTypes`, `issueTypes`, date ranges, `createdBy`, `createdByMe`
+- `POST /cases/search` — Search cases; filters include `searchQuery`, `types`, `states`, `severities`, `workStates` (`ongoing`/`paused`), `assignedUserIds`, `projectIds`, `deploymentIds`, `engagementTypes`, `issueTypes`, date ranges, `createdBy`, `createdByMe`
 - `POST /cases/{id}/comments` — Create a comment on a case
 - `POST /cases/{id}/comments/search` — Search comments on a case
 - `POST /attachments` — Upload an attachment (`referenceId`, `referenceType`, `name`, `type`, `file` in body)

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2373,6 +2373,22 @@ components:
         createdByMe:
           type: boolean
           description: When true, the caller's email (from JWT) is appended to createdBy (optional)
+        workStates:
+          type: array
+          items:
+            type: string
+            enum:
+              - ongoing
+              - paused
+          description: >
+            Filter by work sub-state (optional). Only applicable when state is work_in_progress.
+            For the ServiceNow data source, ongoing maps to key 1 and paused maps to key 2.
+        assignedUserIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Filter by assigned engineer user UUIDs (optional)
 
     CaseSearchPayload:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2381,7 +2381,7 @@ components:
               - ongoing
               - paused
           description: >
-            Filter by work sub-state (optional). Only applicable when state is work_in_progress.
+            Filter by work sub-state (optional). Only meaningful when `states` includes `work_in_progress`.
             For the ServiceNow data source, ongoing maps to key 1 and paused maps to key 2.
         assignedUserIds:
           type: array


### PR DESCRIPTION
## Summary

Implements the CSM portal backend side of entity-service PR #976.

- **`CaseSearchFilters`**: added `workStates` (array of `ongoing`/`paused`) and `assignedUserIds` (array of UUIDs)
- `workStates` note: only meaningful when `state` is `work_in_progress`; for the ServiceNow data source, `ongoing → 1` and `paused → 2` (mapping handled in entity service)
- `assignedUserIds` note: UUID array validated in entity service; for ServiceNow, UUIDs are converted to sysids before the Choreo call
- `README.md` updated to document all case search filters

The handler is a passthrough — the new filter fields are forwarded to the entity service unchanged.

## Entity service PR
wso2-open-operations/cs-tools#976

## Test plan

- [x] Build passes, all tests pass
- [ ] `POST /cases/search` with `filters.workStates: ["ongoing"]` returns only ongoing cases
- [ ] `POST /cases/search` with `filters.assignedUserIds: ["<uuid>"]` scopes to the assigned engineer
- [ ] Invalid `workState` value returns 400 from entity service
- [ ] Malformed UUID in `assignedUserIds` returns 400 from entity service

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded case search options with additional filters for work state and assigned users.
  * Updated API documentation to list the full set of supported case search filters, including type, state, severity, date range, and creator-related criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->