### PR TITLE
[Customer Portal Web App] fix: add missing isLead field to patch contact test fixture

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/api/__tests__/settingsApiHooks.test.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/api/__tests__/settingsApiHooks.test.tsx
@@ -138,6 +138,7 @@ describe("settings API hooks", () => {
     await result.current.mutateAsync({
       email: "abc+1@test.dev",
       isCsAdmin: true,
+      isLead: false,
       isPortalUser: true,
       isSecurityContact: false,
     });


### PR DESCRIPTION
## Summary
- Add missing `isLead: false` to the `PatchProjectContactVariables` fixture in `settingsApiHooks.test.tsx`

`isLead` was made a required field in `PatchProjectContactVariables` as part of PR #978, but the existing test fixture was not updated, causing a `TS2345` build failure in CI.

## Test plan
- [ ] `pnpm build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for patching an existing project contact to include an additional contact field in the request payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->