### PR TITLE
[Customer Portal][Web] feat: cases export and WSO2 case ID in partner global search

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
@@ -483,12 +483,27 @@ export default function PartnerGlobalSearch(): JSX.Element {
                           <Typography noWrap variant="body2">
                             {highlightMatch(c.title ?? "--", debouncedSearchQuery)}
                           </Typography>
-                          <Typography color="text.secondary" noWrap variant="caption">
-                            {formatCasesTableCaseIdentifier(c.number, c.internalId)}
-                          </Typography>
-                          <Typography color="text.secondary" noWrap variant="caption">
-                            {caseTypeLabel}
-                          </Typography>
+                          <Box sx={{ alignItems: "center", display: "flex", gap: 0.75, mt: 0.25 }}>
+                            <Typography color="text.secondary" noWrap variant="caption">
+                              {formatCasesTableCaseIdentifier(c.number, c.internalId)}
+                            </Typography>
+                            <Chip
+                              label={caseTypeLabel}
+                              size="small"
+                              variant="outlined"
+                              sx={(theme) => ({
+                                bgcolor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.05 : 0.1),
+                                borderColor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.18 : 0.3),
+                                color: caseTypeColor,
+                                flexShrink: 0,
+                                fontSize: "0.65rem",
+                                fontWeight: 500,
+                                height: 16,
+                                px: 0,
+                                "& .MuiChip-label": { pl: "5px", pr: "5px" },
+                              })}
+                            />
+                          </Box>
                         </Box>
                       </Box>
                       );

--- a/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
@@ -49,6 +49,11 @@ import {
   downloadProjectListPdf,
   fetchAllProjectsForExport,
 } from "@features/project-hub/utils/projectsExport";
+import {
+  downloadCaseListCsv,
+  downloadCaseListPdf,
+  fetchAllCasesForExport,
+} from "@features/project-hub/utils/casesExport";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import { formatCasesTableCaseIdentifier, getStatusColor } from "@features/dashboard/utils/casesTable";
 import { mapSeverityToDisplay } from "@features/support/utils/support";
@@ -134,7 +139,7 @@ export default function PartnerGlobalSearch(): JSX.Element {
       isExportingRef.current = true;
       setExportingFormat(format);
       try {
-        const allProjects = await fetchAllProjectsForExport(authFetch);
+        const allProjects = await fetchAllProjectsForExport(authFetch, debouncedSearchQuery);
         if (allProjects.length === 0) {
           showError("No projects to export.");
           return;
@@ -151,10 +156,48 @@ export default function PartnerGlobalSearch(): JSX.Element {
         setExportingFormat(null);
       }
     },
-    [authFetch, showError],
+    [authFetch, debouncedSearchQuery, showError],
   );
 
   const isExporting = exportingFormat !== null;
+
+  const [exportingCasesFormat, setExportingCasesFormat] = useState<ExportFormat | null>(null);
+  const isExportingCasesRef = useRef(false);
+  const [exportCasesAnchorEl, setExportCasesAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleCasesExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingCasesRef.current) setExportCasesAnchorEl(e.currentTarget);
+  };
+  const handleCasesExportClose = () => setExportCasesAnchorEl(null);
+
+  const handleCasesExport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingCasesRef.current) return;
+      handleCasesExportClose();
+      isExportingCasesRef.current = true;
+      setExportingCasesFormat(format);
+      try {
+        const allCases = await fetchAllCasesForExport(authFetch, debouncedSearchQuery);
+        if (allCases.length === 0) {
+          showError("No cases to export.");
+          return;
+        }
+        if (format === "csv") {
+          downloadCaseListCsv(allCases);
+        } else {
+          downloadCaseListPdf(allCases);
+        }
+      } catch {
+        showError("Failed to export cases.");
+      } finally {
+        isExportingCasesRef.current = false;
+        setExportingCasesFormat(null);
+      }
+    },
+    [authFetch, debouncedSearchQuery, showError],
+  );
+
+  const isExportingCases = exportingCasesFormat !== null;
 
   // Table query — filters by the debounced search query when one is active
   const {
@@ -438,14 +481,12 @@ export default function PartnerGlobalSearch(): JSX.Element {
                         </Box>
                         <Box sx={{ flex: 1, minWidth: 0 }}>
                           <Typography noWrap variant="body2">
-                            {highlightMatch(
-                              c.number
-                                ? `${c.number} · ${c.title ?? ""}`
-                                : (c.title ?? ""),
-                              debouncedSearchQuery,
-                            )}
+                            {highlightMatch(c.title ?? "--", debouncedSearchQuery)}
                           </Typography>
-                          <Typography color="text.secondary" variant="caption">
+                          <Typography color="text.secondary" noWrap variant="caption">
+                            {formatCasesTableCaseIdentifier(c.number, c.internalId)}
+                          </Typography>
+                          <Typography color="text.secondary" noWrap variant="caption">
                             {caseTypeLabel}
                           </Typography>
                         </Box>
@@ -638,21 +679,52 @@ export default function PartnerGlobalSearch(): JSX.Element {
 
         {/* Cases section */}
         <Box>
-          <Box sx={{ alignItems: "center", display: "flex", gap: 1, mb: 1.5 }}>
-            <FileText size={20} />
-            <Typography variant="h6">
-              Cases
-              {!isLoadingCases && (
-                <Typography
-                  color="text.secondary"
-                  component="span"
-                  variant="h6"
-                >
-                  {" "}
-                  ({casesTotal})
-                </Typography>
-              )}
-            </Typography>
+          <Box sx={{ alignItems: "center", display: "flex", mb: 1.5 }}>
+            <Box sx={{ alignItems: "center", display: "flex", flex: 1, gap: 1 }}>
+              <FileText size={20} />
+              <Typography variant="h6">
+                Cases
+                {!isLoadingCases && (
+                  <Typography
+                    color="text.secondary"
+                    component="span"
+                    variant="h6"
+                  >
+                    {" "}
+                    ({casesTotal})
+                  </Typography>
+                )}
+              </Typography>
+            </Box>
+            <Button
+              aria-controls="partner-cases-export-menu"
+              aria-expanded={Boolean(exportCasesAnchorEl)}
+              aria-haspopup="menu"
+              disabled={isExportingCases || (!isLoadingCases && casesTotal === 0)}
+              endIcon={<ChevronDown size={16} />}
+              onClick={handleCasesExportOpen}
+              size="small"
+              startIcon={
+                isExportingCases ? (
+                  <CircularProgress color="inherit" size={16} />
+                ) : (
+                  <Download size={16} />
+                )
+              }
+              type="button"
+              variant="outlined"
+            >
+              {isExportingCases ? "Exporting..." : "Export"}
+            </Button>
+            <Menu
+              anchorEl={exportCasesAnchorEl}
+              id="partner-cases-export-menu"
+              onClose={handleCasesExportClose}
+              open={Boolean(exportCasesAnchorEl)}
+            >
+              <MenuItem onClick={() => void handleCasesExport("csv")}>Export to CSV</MenuItem>
+              <MenuItem onClick={() => void handleCasesExport("pdf")}>Export to PDF</MenuItem>
+            </Menu>
           </Box>
 
           <TableContainer component={Paper} sx={{ overflowX: "auto" }}>

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerCasesPage.tsx
@@ -17,10 +17,14 @@
 import {
   alpha,
   Box,
+  Button,
   Chip,
+  CircularProgress,
   IconButton,
   InputAdornment,
   LinearProgress,
+  Menu,
+  MenuItem,
   Paper,
   Skeleton,
   Table,
@@ -33,8 +37,8 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft, FileText, Search, X } from "@wso2/oxygen-ui-icons-react";
-import { type ChangeEvent, type JSX, useEffect, useState } from "react";
+import { ArrowLeft, ChevronDown, Download, FileText, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { type ChangeEvent, type JSX, type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useGetGlobalSearch } from "@api/useGetGlobalSearch";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
@@ -43,6 +47,13 @@ import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import { formatCasesTableCaseIdentifier, getStatusColor } from "@features/dashboard/utils/casesTable";
 import { mapSeverityToDisplay } from "@features/support/utils/support";
 import { getCaseNavigationPath, getCaseTypeChipProps } from "@features/project-hub/utils/globalSearchNavigation";
+import {
+  downloadCaseListCsv,
+  downloadCaseListPdf,
+  fetchAllCasesForExport,
+} from "@features/project-hub/utils/casesExport";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const DEFAULT_ROWS_PER_PAGE = 10;
@@ -55,8 +66,12 @@ const COL_SPAN = 6;
  * Navigated to via "View More" on the partner global search page.
  * Pre-fills the search bar from the `?q=` URL parameter.
  */
+type ExportFormat = "csv" | "pdf";
+
 export default function PartnerCasesPage(): JSX.Element {
   const navigate = useNavigate();
+  const authFetch = useAuthApiClient();
+  const { showError } = useErrorBanner();
   const [searchParams, setSearchParams] = useSearchParams();
   const urlQuery = searchParams.get("q") ?? "";
 
@@ -93,6 +108,44 @@ export default function PartnerCasesPage(): JSX.Element {
 
   const cases = data?.cases ?? [];
   const totalRecords = data?.casesTotal ?? 0;
+
+  const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
+  const isExportingRef = useRef(false);
+  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingRef.current) setExportAnchorEl(e.currentTarget);
+  };
+  const handleExportClose = () => setExportAnchorEl(null);
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingRef.current) return;
+      handleExportClose();
+      isExportingRef.current = true;
+      setExportingFormat(format);
+      try {
+        const allCases = await fetchAllCasesForExport(authFetch, debouncedSearchQuery);
+        if (allCases.length === 0) {
+          showError("No cases to export.");
+          return;
+        }
+        if (format === "csv") {
+          downloadCaseListCsv(allCases);
+        } else {
+          downloadCaseListPdf(allCases);
+        }
+      } catch {
+        showError("Failed to export cases.");
+      } finally {
+        isExportingRef.current = false;
+        setExportingFormat(null);
+      }
+    },
+    [authFetch, debouncedSearchQuery, showError],
+  );
+
+  const isExporting = exportingFormat !== null;
 
   const handleChangePage = (_: unknown, newPage: number) => setPage(newPage);
   const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>) => {
@@ -146,6 +199,35 @@ export default function PartnerCasesPage(): JSX.Element {
             />
           )}
         </Typography>
+        <Button
+          aria-controls="cases-page-export-menu"
+          aria-expanded={Boolean(exportAnchorEl)}
+          aria-haspopup="menu"
+          disabled={isExporting || (!isLoading && totalRecords === 0)}
+          endIcon={<ChevronDown size={16} />}
+          onClick={handleExportOpen}
+          size="small"
+          startIcon={
+            isExporting ? (
+              <CircularProgress color="inherit" size={16} />
+            ) : (
+              <Download size={16} />
+            )
+          }
+          type="button"
+          variant="outlined"
+        >
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+        <Menu
+          anchorEl={exportAnchorEl}
+          id="cases-page-export-menu"
+          onClose={handleExportClose}
+          open={Boolean(exportAnchorEl)}
+        >
+          <MenuItem onClick={() => void handleExport("csv")}>Export to CSV</MenuItem>
+          <MenuItem onClick={() => void handleExport("pdf")}>Export to PDF</MenuItem>
+        </Menu>
       </Box>
 
       {/* Filtered-results hint */}

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/casesExport.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/casesExport.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { buildCsvContent, downloadCsvFile } from "@utils/csv";
+import { downloadPdfFile, type PdfColumnStyle } from "@utils/pdf";
+import type { GlobalSearchCase, GlobalSearchResponse } from "@features/project-hub/types/globalSearch";
+import type { AuthFetchFn } from "@features/project-hub/utils/projectsExport";
+import { getCaseTypeChipProps } from "@features/project-hub/utils/globalSearchNavigation";
+
+const EXPORT_ALL_PAGE_SIZE = 50;
+
+const EXPORT_HEADERS = [
+  "Title",
+  "Case ID",
+  "Case Type",
+  "Severity",
+  "Status",
+  "Created by",
+  "Created on",
+  "Project",
+];
+
+// A4 landscape usable width ~269mm, 8 columns.
+const PDF_COLUMN_STYLES: Record<number, PdfColumnStyle> = {
+  0: { cellWidth: 70 },                       // Title
+  1: { cellWidth: 35 },                       // Case ID
+  2: { cellWidth: 30 },                       // Case Type
+  3: { cellWidth: 20, halign: "center" },     // Severity
+  4: { cellWidth: 24, halign: "center" },     // Status
+  5: { cellWidth: 30 },                       // Created by
+  6: { cellWidth: 24, halign: "center" },     // Created on
+  7: { cellWidth: 36 },                       // Project
+};
+
+const DATE_LOCALE = "en-US";
+const DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "--";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? "--" : d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT);
+}
+
+function formatCaseId(number?: string | null, internalId?: string | null): string {
+  const n = number?.trim() ?? "";
+  const id = internalId?.trim() ?? "";
+  if (n && id) return `${n} | ${id}`;
+  return n || id || "--";
+}
+
+function buildFilename(ext: "csv" | "pdf"): string {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `cases-${yyyy}-${mm}-${dd}.${ext}`;
+}
+
+function mapCasesToRows(cases: GlobalSearchCase[]): string[][] {
+  return cases.map((c) => {
+    const { displayLabel: caseTypeLabel } = getCaseTypeChipProps(c.caseType?.label);
+    return [
+      c.title?.trim() ?? "--",
+      formatCaseId(c.number, c.internalId),
+      caseTypeLabel,
+      c.severity?.label ?? "--",
+      c.state?.label ?? "--",
+      c.createdBy?.trim() ?? "--",
+      formatDate(c.createdOn),
+      c.project?.label ?? "--",
+    ];
+  });
+}
+
+/**
+ * Fetches every page of cases matching an optional search query via POST /search.
+ * Use this to collect the full dataset before exporting.
+ */
+export async function fetchAllCasesForExport(
+  authFetch: AuthFetchFn,
+  searchQuery?: string,
+): Promise<GlobalSearchCase[]> {
+  const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
+  if (!baseUrl) throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
+
+  const allCases: GlobalSearchCase[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const body = {
+      filters: {
+        types: ["cases"],
+        ...(searchQuery?.trim() ? { searchQuery: searchQuery.trim() } : {}),
+      },
+      casesPagination: { offset, limit: EXPORT_ALL_PAGE_SIZE },
+    };
+
+    const response = await authFetch(`${baseUrl}/search`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error fetching cases for export: ${response.statusText}`);
+    }
+
+    const data: GlobalSearchResponse = await response.json();
+    const page = data.cases ?? [];
+    allCases.push(...page);
+
+    const total = data.casesTotal ?? 0;
+    const nextOffset = offset + EXPORT_ALL_PAGE_SIZE;
+    if (page.length === 0 || allCases.length >= total || nextOffset <= offset) {
+      break;
+    }
+    offset = nextOffset;
+  }
+
+  return allCases;
+}
+
+export function downloadCaseListCsv(cases: GlobalSearchCase[]): void {
+  const rows = mapCasesToRows(cases);
+  const content = buildCsvContent(EXPORT_HEADERS, rows);
+  downloadCsvFile(buildFilename("csv"), content);
+}
+
+export function downloadCaseListPdf(cases: GlobalSearchCase[]): void {
+  const rows = mapCasesToRows(cases);
+  downloadPdfFile(
+    buildFilename("pdf"),
+    "Cases",
+    EXPORT_HEADERS,
+    rows,
+    PDF_COLUMN_STYLES,
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/casesExport.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/casesExport.ts
@@ -52,12 +52,14 @@ const DATE_FORMAT: Intl.DateTimeFormatOptions = {
   year: "numeric",
 };
 
+/** Formats an ISO date string for display in exported files. */
 function formatDate(value: string | null | undefined): string {
   if (!value) return "--";
   const d = new Date(value);
   return isNaN(d.getTime()) ? "--" : d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT);
 }
 
+/** Combines the portal case number and WSO2 internal ID into a single display string. */
 function formatCaseId(number?: string | null, internalId?: string | null): string {
   const n = number?.trim() ?? "";
   const id = internalId?.trim() ?? "";
@@ -65,6 +67,7 @@ function formatCaseId(number?: string | null, internalId?: string | null): strin
   return n || id || "--";
 }
 
+/** Builds a timestamped filename for the exported file. */
 function buildFilename(ext: "csv" | "pdf"): string {
   const now = new Date();
   const yyyy = now.getFullYear();
@@ -73,6 +76,7 @@ function buildFilename(ext: "csv" | "pdf"): string {
   return `cases-${yyyy}-${mm}-${dd}.${ext}`;
 }
 
+/** Maps a list of GlobalSearchCase objects to string rows for CSV/PDF output. */
 function mapCasesToRows(cases: GlobalSearchCase[]): string[][] {
   return cases.map((c) => {
     const { displayLabel: caseTypeLabel } = getCaseTypeChipProps(c.caseType?.label);
@@ -136,12 +140,14 @@ export async function fetchAllCasesForExport(
   return allCases;
 }
 
+/** Triggers a CSV file download containing the provided cases. */
 export function downloadCaseListCsv(cases: GlobalSearchCase[]): void {
   const rows = mapCasesToRows(cases);
   const content = buildCsvContent(EXPORT_HEADERS, rows);
   downloadCsvFile(buildFilename("csv"), content);
 }
 
+/** Triggers a PDF file download containing the provided cases. */
 export function downloadCaseListPdf(cases: GlobalSearchCase[]): void {
   const rows = mapCasesToRows(cases);
   downloadPdfFile(


### PR DESCRIPTION
## Purpose

Extends the partner global search with cases export (CSV/PDF) and improves the live search dropdown by surfacing the WSO2 case ID alongside a coloured case type chip for each case result.

## Goals

- Allow partner users to export their full case list (filtered by search query) to CSV or PDF without leaving the portal
- Make case type immediately identifiable in the dropdown alongside the case reference ID

## Approach

- New `casesExport.ts` utility mirrors the existing `projectsExport.ts` pattern: paginated `fetchAllCasesForExport` via `POST /search` with `types: ["cases"]`, plus `downloadCaseListCsv` / `downloadCaseListPdf`
- Export buttons added to the cases section header in `PartnerGlobalSearch` and to the `PartnerCasesPage` header; both pass the active debounced search query to the fetch so exported data matches what the user sees
- Dropdown case items updated to show `formatCasesTableCaseIdentifier` (the WSO2 case ID) as a secondary caption and the case type as a small coloured chip inline

## Release note

Partner users can now export their cases list (CSV/PDF) from the global search page and the cases view-more page. The live search dropdown now shows the WSO2 case reference ID and a coloured case type chip for each case result.

## Documentation

No public-facing documentation changes required.

## Security checks

- Export fetches data via the authenticated `authFetch` client; no credentials or tokens are included in exported files
- No new endpoints introduced; reuses the existing `POST /search` API

## Test plan

- [ ] Open partner global search — cases section has an Export button
- [ ] Export to CSV with no filter: all cases are included, columns are Title / Case ID / Case Type / Severity / Status / Created by / Created on / Project
- [ ] Export to PDF with an active search query: only matching cases are exported
- [ ] Open `/partner/cases` — Export button appears in the page header, respects `?q=` filter
- [ ] Type in the search dropdown and verify each case result shows `ID: CS-xxxx | INT-xxxx` with a coloured case type chip inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)