### PR TITLE
[Customer Portal][Web] fix: replace invalid Chip color values in settings role badges

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/utils/settings.ts
+++ b/apps/customer-portal/webapp/src/features/settings/utils/settings.ts
@@ -33,7 +33,7 @@ export function getRoleBadges(contact: ProjectContact): SettingsRoleBadge[] {
   const badges: SettingsRoleBadge[] = [];
 
   if (contact.isCsAdmin) {
-    badges.push({ label: "Admin", Icon: Crown, chipColor: "secondary" });
+    badges.push({ label: "Admin", Icon: Crown, chipColor: "primary" });
   }
 
   if (contact.isLead) {
@@ -41,7 +41,7 @@ export function getRoleBadges(contact: ProjectContact): SettingsRoleBadge[] {
   }
 
   if (contact.isCsIntegrationUser) {
-    badges.push({ label: "System User", Icon: Code, chipColor: "success" });
+    badges.push({ label: "System User", Icon: Code, chipColor: "info" });
   } else {
     if (contact.isPortalUser) {
       badges.push({ label: "Portal User", Icon: Monitor, chipColor: "default" });
@@ -55,7 +55,7 @@ export function getRoleBadges(contact: ProjectContact): SettingsRoleBadge[] {
   }
 
   if (contact.account?.classification === "Partner") {
-    badges.push({ label: "Partner", Icon: Users, chipColor: "secondary" });
+    badges.push({ label: "Partner", Icon: Users, chipColor: "primary" });
   }
 
   return badges;
@@ -75,7 +75,7 @@ export function getRoleChipSx(chipColor: string): object {
     "& .MuiChip-label": { pl: 0.5 },
   };
   switch (chipColor) {
-    case "secondary":
+    case "primary":
       return {
         ...baseStyles,
         color: purple,


### PR DESCRIPTION
## Summary

- Fixes Choreo build failure caused by `"secondary"` and `"success"` being passed to the Oxygen-UI `Chip` `color` prop, which only accepts `"primary" | "info" | "warning" | "error" | "default"`
- `"secondary"` → `"primary"` for Admin and Partner role badges
- `"success"` → `"info"` for System User role badge
- Updated `getRoleChipSx` to case on `"primary"` instead of `"secondary"` so Admin/Partner chips retain their purple sx override

## Test plan

- [ ] Settings page renders role badges without TypeScript errors
- [ ] Admin and Partner chips still display with purple colouring
- [ ] System User chip displays with info (blue) colouring

🤖 Generated with [Claude Code](https://claude.com/claude-code)