### PR TITLE
[Customer Portal Web App] feat: add escalation levels stepper to case details tab

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -51,6 +51,7 @@ import { DESCRIPTION_PURIFY_CONFIG } from "@utils/common";
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import AssignedEngineerDisplay from "@case-details-details/AssignedEngineerDisplay";
 import CaseDetailsCard from "@case-details-details/CaseDetailsCard";
+import CaseEscalationLevelsCard from "@case-details-details/CaseEscalationLevelsCard";
 import ApiErrorState from "@components/error/ApiErrorState";
 import {
   formatValue,
@@ -479,7 +480,15 @@ export default function CaseDetailsDetailsPanel({
         )
       )}
 
-      {/* Section 2: Product & Environment */}
+      {/* Section 2: Escalation Levels */}
+      {!isEngagement && !isServiceRequest && !isSecurityReportAnalysis && caseId && (
+        <CaseEscalationLevelsCard
+          caseId={caseId}
+          currentLevelId={data?.escalationLevel?.id}
+        />
+      )}
+
+      {/* Section 3: Product & Environment */}
       {!isEngagement && (
         <CaseDetailsCard
           title="Product & Environment"
@@ -522,7 +531,7 @@ export default function CaseDetailsDetailsPanel({
         </CaseDetailsCard>
       )}
 
-      {/* Section 3: Closed Case Details (only when case is closed) */}
+      {/* Section 4: Closed Case Details (only when case is closed) */}
       {statusLabel?.toLowerCase() === "closed" && (
         <CaseDetailsCard
           title={
@@ -562,7 +571,7 @@ export default function CaseDetailsDetailsPanel({
         </CaseDetailsCard>
       )}
 
-      {/* Section 4: Customer Information */}
+      {/* Section 5: Customer Information */}
       <CaseDetailsCard
         title="Customer Information"
         icon={<Building2 size={20} aria-hidden />}
@@ -609,7 +618,7 @@ export default function CaseDetailsDetailsPanel({
         </Box>
       </CaseDetailsCard>
 
-      {/* Section 5: Watch List */}
+      {/* Section 6: Watch List */}
       <CaseDetailsCard
         title="Watch List"
         icon={<Mail size={20} aria-hidden />}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseEscalationLevelsCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseEscalationLevelsCard.tsx
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Fragment, type JSX } from "react";
+import { Box, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
+import { Info, TriangleAlert } from "@wso2/oxygen-ui-icons-react";
+import { usePostCaseEscalationsSearch } from "@features/support/api/usePostCaseEscalationsSearch";
+import type { EscalationRecord } from "@features/support/types/cases";
+import { ESCALATION_NEXT_LEVEL } from "@features/support/constants/supportConstants";
+import CaseDetailsCard from "./CaseDetailsCard";
+
+const TOTAL_LEVELS = 5;
+const LEAD_WARNING_THRESHOLD = 3;
+
+const LEVEL_ROLE: Record<number, string> = Object.fromEntries(
+  Array.from({ length: TOTAL_LEVELS }, (_, i) => [
+    i + 1,
+    ESCALATION_NEXT_LEVEL[String(i) as keyof typeof ESCALATION_NEXT_LEVEL]?.notifiedLabel ?? `EL${i + 1}`,
+  ]),
+);
+
+type StepStatus = "previous" | "active" | "available" | "locked";
+
+function getStepStatus(levelNum: number, currentLevelNum: number): StepStatus {
+  if (levelNum < currentLevelNum) return "previous";
+  if (levelNum === currentLevelNum) return "active";
+  if (levelNum === currentLevelNum + 1) return "available";
+  return "locked";
+}
+
+function TooltipContent({ levelNum, record }: { levelNum: number; record: EscalationRecord | undefined }): JSX.Element {
+  return (
+    <Box sx={{ p: 0.5, maxWidth: 240 }}>
+      <Typography variant="caption" sx={{ fontWeight: 700, display: "block", mb: 0.5 }}>
+        {LEVEL_ROLE[levelNum]} Escalation
+      </Typography>
+      {record?.reason && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.5 }}>
+          {record.reason}
+        </Typography>
+      )}
+      {record?.notificationSentTo && record.notificationSentTo.length > 0 && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.5 }}>
+          Notified: {record.notificationSentTo.map((u) => u.name ?? u.userName).join(", ")}
+        </Typography>
+      )}
+      <Typography variant="caption" sx={{ fontWeight: 500, display: "block" }}>
+        → {LEVEL_ROLE[levelNum]}
+      </Typography>
+    </Box>
+  );
+}
+
+type Props = {
+  caseId: string;
+  currentLevelId?: number | string | null;
+};
+
+export default function CaseEscalationLevelsCard({ caseId, currentLevelId }: Props): JSX.Element {
+  const theme = useTheme();
+  const { data: escalationData } = usePostCaseEscalationsSearch(caseId);
+
+  const currentLevelNum = Math.max(0, Number(currentLevelId ?? 0));
+
+  const recordByLevel = new Map<number, EscalationRecord>();
+  for (const record of escalationData?.escalations ?? []) {
+    const id = Number(record.currentLevel?.id ?? 0);
+    if (id > 0 && !recordByLevel.has(id)) {
+      recordByLevel.set(id, record);
+    }
+  }
+
+  const showLeadWarning = currentLevelNum >= LEAD_WARNING_THRESHOLD;
+
+  const neutralGrayLegend = theme.palette.grey[500];
+  const LEGEND = [
+    { label: "Previous", color: neutralGrayLegend, outlined: false },
+    { label: "Active", color: theme.palette.warning.main, outlined: false },
+    { label: "Available", color: theme.palette.primary.main, outlined: true },
+    { label: "Locked", color: neutralGrayLegend, outlined: true, dim: true },
+  ] as const;
+
+  return (
+    <CaseDetailsCard title="Escalation Levels" icon={<TriangleAlert size={20} aria-hidden />}>
+      {/* Stepper */}
+      <Box sx={{ display: "flex", alignItems: "flex-start", width: "100%", px: 2, pt: 2, pb: 1 }}>
+        {Array.from({ length: TOTAL_LEVELS }, (_, i) => i + 1).map((levelNum, idx) => {
+          const status: StepStatus = getStepStatus(levelNum, currentLevelNum);
+          const record = recordByLevel.get(levelNum);
+          const canShowTooltip = status === "previous" || status === "active";
+
+          // Use a fixed neutral gray for "previous" so it stays gray regardless of theme accent colour
+          const neutralGray = theme.palette.grey[500];
+
+          let circleSx: object;
+          if (status === "active") {
+            circleSx = {
+              bgcolor: theme.palette.warning.main,
+              color: "#fff",
+              border: `2px solid ${theme.palette.warning.main}`,
+              boxShadow: `0 0 0 5px ${alpha(theme.palette.warning.main, 0.22)}`,
+            };
+          } else if (status === "previous") {
+            circleSx = {
+              bgcolor: neutralGray,
+              color: "#fff",
+              border: `2px solid ${neutralGray}`,
+            };
+          } else if (status === "available") {
+            circleSx = {
+              bgcolor: "transparent",
+              color: theme.palette.primary.main,
+              border: `2px solid ${theme.palette.primary.main}`,
+            };
+          } else {
+            // locked — render dimmed via opacity on the wrapper; circleSx is neutral
+            circleSx = {
+              bgcolor: "transparent",
+              color: theme.palette.text.secondary,
+              border: `2px solid ${theme.palette.text.secondary}`,
+            };
+          }
+
+          const labelColor =
+            status === "active"
+              ? "warning.main"
+              : status === "previous"
+                ? neutralGray
+                : status === "locked"
+                  ? theme.palette.text.secondary
+                  : "primary.main";
+
+          const stepNode = (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 0.75,
+                flexShrink: 0,
+                // dim locked steps to make the deactivated state clear
+                opacity: status === "locked" ? 0.55 : 1,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: "50%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontWeight: 700,
+                  fontSize: "0.9rem",
+                  ...circleSx,
+                }}
+              >
+                {levelNum}
+              </Box>
+              <Typography variant="caption" sx={{ fontWeight: 500, color: labelColor }}>
+                EL{levelNum}
+              </Typography>
+            </Box>
+          );
+
+          return (
+            <Fragment key={levelNum}>
+              {idx > 0 && (
+                <Box
+                  sx={{
+                    flex: 1,
+                    height: 2,
+                    bgcolor: levelNum <= currentLevelNum ? "text.secondary" : "divider",
+                    alignSelf: "flex-start",
+                    mt: "19px",
+                    mx: 0.5,
+                  }}
+                />
+              )}
+              {canShowTooltip ? (
+                <Tooltip
+                  title={<TooltipContent levelNum={levelNum} record={record} />}
+                  placement="bottom"
+                  arrow
+                >
+                  <Box>{stepNode}</Box>
+                </Tooltip>
+              ) : (
+                stepNode
+              )}
+            </Fragment>
+          );
+        })}
+      </Box>
+
+      {/* Legend */}
+      <Box sx={{ display: "flex", justifyContent: "center", gap: 3, mb: 2 }}>
+        {LEGEND.map(({ label, color, outlined, ...rest }) => {
+          const dim = "dim" in rest && rest.dim;
+          return (
+          <Box key={label} sx={{ display: "flex", alignItems: "center", gap: 0.5, opacity: dim ? 0.55 : 1 }}>
+            <Box
+              sx={{
+                width: 10,
+                height: 10,
+                borderRadius: "50%",
+                bgcolor: outlined ? "transparent" : color,
+                border: `2px solid ${color}`,
+                flexShrink: 0,
+              }}
+            />
+            <Typography variant="caption" color="text.secondary">
+              {label}
+            </Typography>
+          </Box>
+          );
+        })}
+      </Box>
+
+      {/* Lead-required warning */}
+      {showLeadWarning && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 1,
+            p: 1.5,
+            borderRadius: 1,
+            border: "1px solid",
+            borderColor: alpha(theme.palette.warning.main, 0.3),
+            bgcolor: alpha(theme.palette.warning.main, 0.06),
+          }}
+        >
+          <Info size={16} color={theme.palette.warning.main} style={{ flexShrink: 0, marginTop: 2 }} />
+          <Box>
+            <Typography variant="caption" sx={{ fontWeight: 600, color: "text.primary", display: "block" }}>
+              Need to escalate beyond EL3?
+            </Typography>
+            <Typography variant="caption" sx={{ color: "warning.dark" }}>
+              Contact your lead to escalate to higher levels (EL4-EL5)
+            </Typography>
+          </Box>
+        </Box>
+      )}
+    </CaseDetailsCard>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a new `CaseEscalationLevelsCard` component to the **Details** tab of case details, showing the full EL1–EL5 escalation flow
- Visual states: **Previous** (gray filled), **Active** (orange filled + glow), **Available** (blue outlined), **Locked** (dimmed at 55% opacity)
- Hovering a Previous or Active step shows a tooltip with the escalation record (notified role, reason, notified users)
- Connector lines between steps fill gray for passed levels
- Warning banner shown when case is at EL3+ — prompts contacting a Lead to escalate to EL4–EL5
- Hidden for engagements, service requests, and security report analyses
- React Query deduplicates the escalation fetch (same query key as the Escalation History tab)

## Test plan
- [ ] Open any regular case Details tab — Escalation Levels card appears between Overview and Product & Environment
- [ ] Non-escalated case: EL1 shows as Available (blue outlined), EL2–EL5 as Locked (dimmed)
- [ ] Escalated case at EL2: EL1 = Previous (gray), EL2 = Active (orange), EL3 = Available, EL4–EL5 = Locked
- [ ] Hovering a Previous/Active step shows tooltip with escalation details
- [ ] Warning banner appears for cases at EL3 or above
- [ ] Card is hidden for engagements, service requests, and security report analyses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Escalation Levels” section to case details, showing a 5-step escalation timeline with current, previous, available, and locked states.
  * Expanded the section with helpful details for completed steps, including role, reason, and notified recipients.
  * Added an informational warning when a case reaches higher escalation levels, prompting further escalation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->