### PR TITLE
[Customer Portal Web App] feat: grant partner admin role access to partner UI

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -40,7 +40,7 @@ import ProjectCard from "@features/project-hub/components/ProjectCard";
 import ProjectCardSkeleton from "@features/project-hub/components/project-card/ProjectCardSkeleton";
 import PartnerGlobalSearch from "@features/project-hub/components/PartnerGlobalSearch";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
-import { SETTINGS_PARTNER_ROLE } from "@features/settings/constants/settingsConstants";
+import { hasPartnerAccess } from "@features/settings/constants/settingsConstants";
 import { clearLastSelectedProject } from "@features/settings/utils/settingsStorage";
 import { ChevronUp, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useAsgardeo } from "@asgardeo/react";
@@ -176,7 +176,7 @@ export default function ProjectHub(): JSX.Element {
 
   const isPartner =
     !isLoadingUserDetails &&
-    (userDetails?.roles ?? []).includes(SETTINGS_PARTNER_ROLE);
+    hasPartnerAccess(userDetails?.roles ?? []);
 
   const isCheckingAllSuspended =
     !isLoading &&

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -238,11 +238,6 @@ export default function ProjectHub(): JSX.Element {
     clearLastSelectedProject();
   }, []);
 
-  // Partner users always see the global search page (projects + cases).
-  if (isPartner && !isAuthLoading && !isLoadingUserDetails) {
-    return <PartnerGlobalSearch />;
-  }
-
   const hasSearchQuery = Boolean(searchQuery.trim());
 
   const contentView = useMemo(
@@ -264,6 +259,11 @@ export default function ProjectHub(): JSX.Element {
       projects.length,
     ],
   );
+
+  // Partner users always see the global search page (projects + cases).
+  if (isPartner && !isAuthLoading && !isLoadingUserDetails) {
+    return <PartnerGlobalSearch />;
+  }
 
   const showSearchBar = shouldShowProjectHubSearchBar(
     titleTotalRecords,

--- a/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/settings/constants/settingsConstants.ts
@@ -46,6 +46,14 @@ export const SETTINGS_CUSTOMER_ADMIN_ROLE = "sn_customerservice.customer_admin";
 /** ServiceNow partner role — triggers list view in ProjectHub when >4 projects. */
 export const SETTINGS_PARTNER_ROLE = "sn_customerservice.partner";
 
+/** ServiceNow partner admin role — same partner UI access as SETTINGS_PARTNER_ROLE. */
+export const SETTINGS_PARTNER_ADMIN_ROLE = "sn_customerservice.partner_admin";
+
+/** Returns true if the given role list grants partner-level UI access. */
+export function hasPartnerAccess(roles: string[]): boolean {
+  return roles.includes(SETTINGS_PARTNER_ROLE) || roles.includes(SETTINGS_PARTNER_ADMIN_ROLE);
+}
+
 export const SETTINGS_PAGE_TABS = [
   {
     id: SettingsPageTabId.USERS,

--- a/apps/customer-portal/webapp/src/layouts/PartnerGuard.tsx
+++ b/apps/customer-portal/webapp/src/layouts/PartnerGuard.tsx
@@ -18,7 +18,7 @@ import { type JSX } from "react";
 import { Navigate, Outlet } from "react-router";
 import { Box, LinearProgress, Typography } from "@wso2/oxygen-ui";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
-import { SETTINGS_PARTNER_ROLE } from "@features/settings/constants/settingsConstants";
+import { hasPartnerAccess } from "@features/settings/constants/settingsConstants";
 
 /**
  * Guards all /partner/* routes so only users with the partner role can access them.
@@ -46,7 +46,7 @@ export default function PartnerGuard(): JSX.Element {
     );
   }
 
-  const isPartner = (userDetails?.roles ?? []).includes(SETTINGS_PARTNER_ROLE);
+  const isPartner = hasPartnerAccess(userDetails?.roles ?? []);
 
   if (!isPartner) {
     return <Navigate replace to="/" />;


### PR DESCRIPTION
## Summary
- Add `sn_customerservice.partner_admin` role as a valid partner UI access role
- Introduce `hasPartnerAccess()` helper in settings constants to centralise the role check for both partner roles
- Update `PartnerGuard` and `ProjectHub` to use the new helper

## Test plan
- [ ] User with `sn_customerservice.partner` role sees the partner UI (no regression)
- [ ] User with `sn_customerservice.partner_admin` role sees the partner UI
- [ ] User with neither role is redirected to home page from `/partner/*` routes
- [ ] Partner list view threshold and project/case search behave correctly for both roles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Partner access now includes an additional partner admin role, allowing more eligible users to enter partner-specific areas.
* **Bug Fixes**
  * Updated partner access checks so partner users are routed correctly to partner search and partner pages.
  * Non-partner users continue to be redirected away from partner-only sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->