### PR TITLE
[Customer Portal Web App] fix: classify WSO2 Integrator as MI product type in usage metrics

### DIFF
--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
@@ -80,6 +80,12 @@ function parseMajorVersion(label: string): number {
   return m ? parseInt(m[1], 10) : 0;
 }
 
+const PRODUCT_TYPE_PATTERNS: [WsoProductType, RegExp][] = [
+  [WsoProductType.APIM, /api[\s-]?manager|\bapim\b/i],
+  [WsoProductType.IS, /identity[\s-]server/i],
+  [WsoProductType.MI, /micro[\s-]integrator|\bintegrator\b/i],
+];
+
 /**
  * Classifies a product label into a WSO2 product type and extracts major version.
  *
@@ -90,16 +96,11 @@ export function classifyProductLabel(label: string): {
   type: WsoProductType;
   majorVersion: number;
 } {
-  const lower = label.toLowerCase();
   const majorVersion = parseMajorVersion(label);
-  if (lower.includes("api manager") || lower.includes("apim")) {
-    return { type: WsoProductType.APIM, majorVersion };
-  }
-  if (lower.includes("identity server")) {
-    return { type: WsoProductType.IS, majorVersion };
-  }
-  if (lower.includes("micro integrator")) {
-    return { type: WsoProductType.MI, majorVersion };
+  for (const [type, pattern] of PRODUCT_TYPE_PATTERNS) {
+    if (pattern.test(label)) {
+      return { type, majorVersion };
+    }
   }
   return { type: WsoProductType.UNKNOWN, majorVersion };
 }


### PR DESCRIPTION
## Summary

- **Bug**: "WSO2 Integrator: MI x.x.x" product labels were not matching the `micro integrator` string check, so they fell through to `UNKNOWN` and displayed all metric columns (Transactions, API Count, Total Users, Root Organizations) instead of just `TRANSACTION_COUNT`.
- **Fix**: Replaced the ad-hoc `includes()` string checks in `classifyProductLabel` with a prioritised `PRODUCT_TYPE_PATTERNS` regex table. The MI pattern `/micro[\s-]integrator|\bintegrator\b/i` covers both legacy ("Micro Integrator") and current ("WSO2 Integrator: MI") naming conventions.

## Test plan

- [ ] Open a deployment with a "WSO2 Integrator: MI x.x.x" product — verify only the Transactions column is shown (no API Count / Total Users / Root Organizations)
- [ ] Verify APIM products still show Transactions + API Count (+ MCP API Count for v7+)
- [ ] Verify IS products still show Root Organizations + Total Users (+ B2B Orgs for v7+)
- [ ] Verify unknown products still fall back to showing all common metric columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product detection in usage metrics so labels are classified more accurately, including better handling of spacing, punctuation, and version formats.
  * Reduced misclassification of product types, which should make metric views and filtering more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->