### PR TITLE
[CSM][Web] add filter bar to change-requests tab

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  FormControl,
+  Grid,
+  IconButton,
+  InputAdornment,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import type { SelectChangeEvent } from "@wso2/oxygen-ui";
+import {
+  ChevronDown,
+  ChevronUp,
+  ListFilter,
+  Search,
+  X,
+} from "@wso2/oxygen-ui-icons-react";
+import { useMemo, type JSX } from "react";
+import type {
+  BeChangeRequestImpact,
+  BeChangeRequestState,
+} from "@api/backend/types";
+import {
+  CHANGE_REQUEST_IMPACTS,
+  CHANGE_REQUEST_STATES,
+  changeRequestImpactLabel,
+  changeRequestStateLabel,
+} from "@features/csm-operations/utils/changeRequests";
+
+export interface ChangeRequestFilters {
+  search: string;
+  states: BeChangeRequestState[];
+  impacts: BeChangeRequestImpact[];
+  /** YYYY-MM-DD local date string, or empty. */
+  closedStartDate: string;
+  /** YYYY-MM-DD local date string, or empty. */
+  closedEndDate: string;
+}
+
+export const DEFAULT_CR_FILTERS: ChangeRequestFilters = {
+  search: "",
+  states: [],
+  impacts: [],
+  closedStartDate: "",
+  closedEndDate: "",
+};
+
+/** Count non-search active filters (used for the badge on the Filters button). */
+export function countActiveCRFilters(filters: ChangeRequestFilters): number {
+  return (
+    (filters.states.length > 0 ? 1 : 0) +
+    (filters.impacts.length > 0 ? 1 : 0) +
+    (filters.closedStartDate ? 1 : 0) +
+    (filters.closedEndDate ? 1 : 0)
+  );
+}
+
+interface ChangeRequestsFilterBarProps {
+  filters: ChangeRequestFilters;
+  onChange: (next: ChangeRequestFilters) => void;
+  onReset: () => void;
+  isFiltersOpen: boolean;
+  onFiltersToggle: () => void;
+}
+
+interface MultiSelectFieldProps<T extends string> {
+  id: string;
+  label: string;
+  values: T[];
+  options: { value: T; label: string }[];
+  onChange: (next: T[]) => void;
+}
+
+function MultiSelectField<T extends string>({
+  id,
+  label,
+  values,
+  options,
+  onChange,
+}: MultiSelectFieldProps<T>): JSX.Element {
+  const handleChange = (event: SelectChangeEvent<string[]>): void => {
+    const val = event.target.value;
+    onChange((Array.isArray(val) ? val : [val]) as T[]);
+  };
+  return (
+    <FormControl fullWidth size="small">
+      <InputLabel id={`${id}-label`}>{label}</InputLabel>
+      <Select
+        multiple
+        labelId={`${id}-label`}
+        id={id}
+        value={values as unknown as string[]}
+        label={label}
+        onChange={handleChange}
+        renderValue={(selected) => {
+          if (!Array.isArray(selected) || selected.length === 0) return "";
+          const labels = selected.map(
+            (v) => options.find((o) => o.value === v)?.label ?? v,
+          );
+          const text = labels.join(", ");
+          if (labels.length === 1) return text;
+          return (
+            <Tooltip title={text} placement="top">
+              <Box
+                component="span"
+                sx={{
+                  display: "block",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {text}
+              </Box>
+            </Tooltip>
+          );
+        }}
+      >
+        {options.map((opt) => (
+          <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
+            <Checkbox
+              size="small"
+              checked={values.includes(opt.value)}
+              sx={{ mr: 1, p: 0.25 }}
+            />
+            <ListItemText primary={opt.label} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+export default function ChangeRequestsFilterBar({
+  filters,
+  onChange,
+  onReset,
+  isFiltersOpen,
+  onFiltersToggle,
+}: ChangeRequestsFilterBarProps): JSX.Element {
+  const activeCount = countActiveCRFilters(filters);
+  const hasActive = activeCount > 0;
+
+  const stateOptions = useMemo(
+    () =>
+      CHANGE_REQUEST_STATES.map((s) => ({
+        value: s,
+        label: changeRequestStateLabel(s),
+      })),
+    [],
+  );
+  const impactOptions = useMemo(
+    () =>
+      CHANGE_REQUEST_IMPACTS.map((i) => ({
+        value: i,
+        label: changeRequestImpactLabel(i),
+      })),
+    [],
+  );
+
+  return (
+    <Paper sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+      {/* Search bar + filters toggle */}
+      <Box
+        sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}
+      >
+        <Box sx={{ position: "relative", flex: 1, minWidth: 240 }}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Search by number or subject…"
+            value={filters.search}
+            onChange={(e) => onChange({ ...filters, search: e.target.value })}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={16} />
+                  </InputAdornment>
+                ),
+                endAdornment: filters.search ? (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      edge="end"
+                      onClick={() => onChange({ ...filters, search: "" })}
+                      aria-label="Clear search"
+                    >
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+          />
+        </Box>
+
+        <Button
+          variant="outlined"
+          size="small"
+          color="inherit"
+          onClick={hasActive ? onReset : onFiltersToggle}
+          startIcon={hasActive ? <X size={16} /> : <ListFilter size={16} />}
+          endIcon={
+            !hasActive &&
+            (isFiltersOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />)
+          }
+        >
+          {hasActive ? `Clear filters (${activeCount})` : "Filters"}
+        </Button>
+      </Box>
+
+      {/* Collapsible filter grid */}
+      {isFiltersOpen && (
+        <>
+          <Divider />
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <MultiSelectField
+                id="cr-filter-state"
+                label="State"
+                values={filters.states}
+                options={stateOptions}
+                onChange={(next) => onChange({ ...filters, states: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <MultiSelectField
+                id="cr-filter-impact"
+                label="Impact"
+                values={filters.impacts}
+                options={impactOptions}
+                onChange={(next) => onChange({ ...filters, impacts: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Closed from"
+                type="date"
+                value={filters.closedStartDate}
+                onChange={(e) =>
+                  onChange({ ...filters, closedStartDate: e.target.value })
+                }
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Closed to"
+                type="date"
+                value={filters.closedEndDate}
+                onChange={(e) =>
+                  onChange({ ...filters, closedEndDate: e.target.value })
+                }
+                slotProps={{
+                  inputLabel: { shrink: true },
+                  htmlInput: {
+                    min: filters.closedStartDate || undefined,
+                  },
+                }}
+              />
+            </Grid>
+          </Grid>
+          {activeCount > 0 && (
+            <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <Typography variant="caption" color="text.secondary">
+                {activeCount} {activeCount === 1 ? "filter" : "filters"} active
+              </Typography>
+            </Box>
+          )}
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
@@ -224,15 +224,23 @@ export default function ChangeRequestsFilterBar({
           variant="outlined"
           size="small"
           color="inherit"
-          onClick={hasActive ? onReset : onFiltersToggle}
-          startIcon={hasActive ? <X size={16} /> : <ListFilter size={16} />}
-          endIcon={
-            !hasActive &&
-            (isFiltersOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />)
-          }
+          onClick={onFiltersToggle}
+          startIcon={<ListFilter size={16} />}
+          endIcon={isFiltersOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
         >
-          {hasActive ? `Clear filters (${activeCount})` : "Filters"}
+          {hasActive ? `Filters (${activeCount})` : "Filters"}
         </Button>
+        {hasActive && (
+          <Button
+            variant="text"
+            size="small"
+            color="inherit"
+            onClick={onReset}
+            startIcon={<X size={16} />}
+          >
+            Clear filters
+          </Button>
+        )}
       </Box>
 
       {/* Collapsible filter grid */}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -18,7 +18,6 @@ import {
   Alert,
   Box,
   Chip,
-  InputAdornment,
   Paper,
   Skeleton,
   Table,
@@ -28,10 +27,8 @@ import {
   TableHead,
   TablePagination,
   TableRow,
-  TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Search } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useNavigate } from "react-router";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
@@ -43,6 +40,10 @@ import {
   changeRequestStateColor,
   changeRequestStateLabel,
 } from "@features/csm-operations/utils/changeRequests";
+import ChangeRequestsFilterBar, {
+  DEFAULT_CR_FILTERS,
+  type ChangeRequestFilters,
+} from "@features/csm-operations/components/ChangeRequestsFilterBar";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -57,26 +58,45 @@ function formatDate(value?: string | null): string {
   );
 }
 
+/** Convert a YYYY-MM-DD date picker value to an ISO 8601 string at midnight UTC. */
+function toISOStart(date: string): string {
+  return `${date}T00:00:00Z`;
+}
+
+/** Convert a YYYY-MM-DD date picker value to an ISO 8601 string at end-of-day UTC. */
+function toISOEnd(date: string): string {
+  return `${date}T23:59:59Z`;
+}
+
 /**
  * Change-requests listing for the Operations → Change requests tab. Searches
- * `POST /change-requests/search` (subject + number) with server-side
- * pagination; a row opens the change-request detail page.
+ * `POST /change-requests/search` with server-side pagination and filters
+ * (state, impact, closed date range, free-text search).
  */
 export default function ChangeRequestsTab(): JSX.Element {
   const navigate = useNavigate();
-  const [searchInput, setSearchInput] = useState("");
+  const [filters, setFilters] = useState<ChangeRequestFilters>(DEFAULT_CR_FILTERS);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
-  const debouncedSearch = useDebouncedValue(searchInput.trim(), 300);
+  const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
 
   const payload = useMemo(
     () => ({
       filters: {
         ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
+        ...(filters.states.length > 0 && { states: filters.states }),
+        ...(filters.impacts.length > 0 && { impacts: filters.impacts }),
+        ...(filters.closedStartDate && {
+          closedStartDate: toISOStart(filters.closedStartDate),
+        }),
+        ...(filters.closedEndDate && {
+          closedEndDate: toISOEnd(filters.closedEndDate),
+        }),
       },
       pagination: { offset: page * rowsPerPage, limit: rowsPerPage },
     }),
-    [debouncedSearch, page, rowsPerPage],
+    [debouncedSearch, filters.states, filters.impacts, filters.closedStartDate, filters.closedEndDate, page, rowsPerPage],
   );
 
   const { data, isLoading, isError, error, isFetching } =
@@ -85,8 +105,13 @@ export default function ChangeRequestsTab(): JSX.Element {
   const changeRequests = data?.changeRequests ?? [];
   const total = data?.total ?? 0;
 
-  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    setSearchInput(e.target.value);
+  const handleFiltersChange = (next: ChangeRequestFilters): void => {
+    setFilters(next);
+    setPage(0);
+  };
+
+  const handleReset = (): void => {
+    setFilters(DEFAULT_CR_FILTERS);
     setPage(0);
   };
 
@@ -97,22 +122,12 @@ export default function ChangeRequestsTab(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <TextField
-        value={searchInput}
-        onChange={handleSearchChange}
-        placeholder="Search change requests by number or subject…"
-        size="small"
-        sx={{ maxWidth: 480 }}
-        slotProps={{
-          htmlInput: { "aria-label": "Search change requests by number or subject" },
-          input: {
-            startAdornment: (
-              <InputAdornment position="start">
-                <Search size={16} />
-              </InputAdornment>
-            ),
-          },
-        }}
+      <ChangeRequestsFilterBar
+        filters={filters}
+        onChange={handleFiltersChange}
+        onReset={handleReset}
+        isFiltersOpen={isFiltersOpen}
+        onFiltersToggle={() => setIsFiltersOpen((prev: boolean) => !prev)}
       />
 
       {isError && (
@@ -208,7 +223,7 @@ export default function ChangeRequestsTab(): JSX.Element {
           component="div"
           count={total}
           page={page}
-          onPageChange={(_, newPage) => setPage(newPage)}
+          onPageChange={(_: unknown, newPage: number) => setPage(newPage)}
           rowsPerPage={rowsPerPage}
           onRowsPerPageChange={handleChangeRowsPerPage}
           rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -60,6 +60,9 @@ const IMPACT_COLOR: Record<BeChangeRequestImpact, ChipColor> = {
 /** All CR states, for a filter control. */
 export const CHANGE_REQUEST_STATES = Object.keys(STATE_LABEL) as BeChangeRequestState[];
 
+/** All CR impact levels, for a filter control. */
+export const CHANGE_REQUEST_IMPACTS = Object.keys(IMPACT_LABEL) as BeChangeRequestImpact[];
+
 function humanize(value: string): string {
   return value.replace(/_/g, " ");
 }


### PR DESCRIPTION
## Summary

- Add `ChangeRequestsFilterBar` component to the Operations → Change requests tab, replacing the single search field
- Filter bar supports: free-text search (debounced), **State** multi-select, **Impact** multi-select, and **Closed from / Closed to** date range pickers
- Collapsible filter panel with an active-count badge; the button doubles as "Clear filters (N)" when any filter is set
- Export `CHANGE_REQUEST_IMPACTS` from `changeRequests.ts` to complement the existing `CHANGE_REQUEST_STATES`
- All filters wire through to `POST /change-requests/search`; date values are converted from `YYYY-MM-DD` → RFC3339 (`T00:00:00Z` / `T23:59:59Z`) before being sent

## Test plan

- [x] Open Operations → Change requests tab; confirm the filter bar renders in place of the old search box
- [x] Type in the search field; confirm results update (debounced ~300 ms) and page resets to 0
- [x] Open the Filters panel; select one or more States and/or Impacts; confirm the table reflects the filtered results
- [x] Set a Closed from / Closed to date range; confirm the results are scoped correctly
- [x] Confirm the "Filters" button shows the active count badge when filters are set
- [x] Click "Clear filters (N)"; confirm all filters reset and the table reverts to the unfiltered view
- [x] Confirm pagination resets to page 1 on any filter change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer filtering experience for change requests, including search, state, impact, and closed-date filters.
  * Added visual feedback for how many filters are active, plus clear/reset controls.
  * Improved date filtering with proper start/end range behavior.

* **Bug Fixes**
  * Changing filters now resets results back to the first page for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->