### PR TITLE
[CSM Portal][FE] feat(csm-timecards): notification util, role hooks and remaining tests (4/6)

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useIsTeamLead.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useIsTeamLead.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
+
+/**
+ * True when the signed-in user may approve time cards. Thin alias over
+ * {@link useTimecardRole}'s `isApprover` (admins included), kept for the case
+ * "Time tracking" tab. Prefer `useTimecardRole` for new code.
+ */
+export function useIsTeamLead(): boolean {
+  return useTimecardRole().isApprover;
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useTimecardRole.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useTimecardRole.ts
@@ -17,8 +17,8 @@
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { resolveUserInfo } from "@utils/userClaims";
 import {
-  teamLeadGroup,
-  timecardAdminGroup,
+  TIMECARD_ADMIN_GROUP,
+  TIMECARD_APPROVER_GROUP,
 } from "@features/csm-timecards/constants/timeCardConstants";
 
 export interface TimecardRole {
@@ -29,14 +29,16 @@ export interface TimecardRole {
 }
 
 /**
- * The signed-in user's time-card role, from the OIDC `groups` claim. Admins are
- * a superset of approvers. Client-side affordance only — the backend must
- * enforce the same gates (Phase 2).
+ * The signed-in user's time-card role, derived from the Asgardeo `groups` claim.
+ * Phase 1 / FE-first interim: role flags should come from `GET /users/me` once
+ * the backend exposes `isTimecardApprover` / `isTimecardAdmin` (ISSU-009 Phase 2).
+ * Admins are a superset of approvers. Client-side affordance only — the backend
+ * must enforce the same gates.
  */
 export function useTimecardRole(): TimecardRole {
   const { groups } = resolveUserInfo(useIdTokenClaims());
   const lower = groups.map((g) => g.toLowerCase());
-  const isAdmin = lower.includes(timecardAdminGroup().toLowerCase());
-  const isApprover = isAdmin || lower.includes(teamLeadGroup().toLowerCase());
+  const isAdmin = lower.includes(TIMECARD_ADMIN_GROUP.toLowerCase());
+  const isApprover = isAdmin || lower.includes(TIMECARD_APPROVER_GROUP.toLowerCase());
   return { isApprover, isAdmin };
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useTimecardRole.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useTimecardRole.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import { resolveUserInfo } from "@utils/userClaims";
+import {
+  teamLeadGroup,
+  timecardAdminGroup,
+} from "@features/csm-timecards/constants/timeCardConstants";
+
+export interface TimecardRole {
+  /** May approve/reject/recall time cards (approver group, or admin). */
+  isApprover: boolean;
+  /** Time-card admin: edit any user's editable cards, approve by exception. */
+  isAdmin: boolean;
+}
+
+/**
+ * The signed-in user's time-card role, from the OIDC `groups` claim. Admins are
+ * a superset of approvers. Client-side affordance only — the backend must
+ * enforce the same gates (Phase 2).
+ */
+export function useTimecardRole(): TimecardRole {
+  const { groups } = resolveUserInfo(useIdTokenClaims());
+  const lower = groups.map((g) => g.toLowerCase());
+  const isAdmin = lower.includes(timecardAdminGroup().toLowerCase());
+  const isApprover = isAdmin || lower.includes(teamLeadGroup().toLowerCase());
+  return { isApprover, isAdmin };
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useTimecardRole.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/hooks/useTimecardRole.ts
@@ -14,8 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
-import { resolveUserInfo } from "@utils/userClaims";
+import { useGetUsersMe } from "@features/settings/api/useGetUsersMe";
 import {
   TIMECARD_ADMIN_GROUP,
   TIMECARD_APPROVER_GROUP,
@@ -29,16 +28,14 @@ export interface TimecardRole {
 }
 
 /**
- * The signed-in user's time-card role, derived from the Asgardeo `groups` claim.
- * Phase 1 / FE-first interim: role flags should come from `GET /users/me` once
- * the backend exposes `isTimecardApprover` / `isTimecardAdmin` (ISSU-009 Phase 2).
- * Admins are a superset of approvers. Client-side affordance only — the backend
- * must enforce the same gates.
+ * The signed-in user's time-card role, resolved from `GET /users/me` roles
+ * (platform-owned data from the entity service). Admins are a superset of
+ * approvers. Client-side affordance only — the backend must enforce the same gates.
  */
 export function useTimecardRole(): TimecardRole {
-  const { groups } = resolveUserInfo(useIdTokenClaims());
-  const lower = groups.map((g) => g.toLowerCase());
-  const isAdmin = lower.includes(TIMECARD_ADMIN_GROUP.toLowerCase());
-  const isApprover = isAdmin || lower.includes(TIMECARD_APPROVER_GROUP.toLowerCase());
+  const { data: me } = useGetUsersMe();
+  const roles = (me?.roles ?? []).map((r) => r.toLowerCase());
+  const isAdmin = roles.includes(TIMECARD_ADMIN_GROUP.toLowerCase());
+  const isApprover = isAdmin || roles.includes(TIMECARD_APPROVER_GROUP.toLowerCase());
   return { isApprover, isAdmin };
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardNotifications.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardNotifications.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { timeCardNotices } from "@features/csm-timecards/utils/timeCardNotifications";
+import { emptyBreakdown } from "@features/csm-timecards/utils/timeCardTotals";
+import type {
+  CsmTimeCard,
+  CsmTimeSheet,
+  TimeCardState,
+} from "@features/csm-timecards/types/timeCards";
+
+function card(
+  id: string,
+  state: TimeCardState,
+  extra: Partial<CsmTimeCard> = {},
+): CsmTimeCard {
+  return {
+    id,
+    taskType: "case",
+    caseId: id,
+    caseNumber: `CS-${id}`,
+    projectId: "proj-1",
+    projectName: "Test Project",
+    date: "2026-06-24",
+    userId: "u1",
+    userName: "Alex Engineer",
+    state,
+    category: "Task work",
+    billable: true,
+    breakdown: emptyBreakdown(),
+    totalHours: 0,
+    workLogComment: "",
+    issueComplexity: "N/A",
+    approvers: [],
+    submittedAt: "2026-06-24T09:00:00Z",
+    activity: [],
+    ...extra,
+  };
+}
+
+function sheet(cards: CsmTimeCard[]): CsmTimeSheet {
+  return {
+    id: "u1:2026-06-22",
+    userId: "u1",
+    userName: "Alex Engineer",
+    weekStart: "2026-06-22",
+    weekEnd: "2026-06-28",
+    state: "rejected",
+    cards,
+    totalHours: 0,
+  };
+}
+
+describe("timeCardNotices", () => {
+  it("raises a notice for rejected and recalled cards only", () => {
+    const notices = timeCardNotices([
+      sheet([
+        card("1", "rejected", { leadComment: "Fix the hours." }),
+        card("2", "approved"),
+        card("3", "recalled", { decidedBy: "Lead" }),
+        card("4", "pending"),
+      ]),
+    ]);
+    expect(notices.map((n) => n.cardId).sort()).toEqual(["1", "3"]);
+  });
+
+  it("includes the lead's comment in a rejection notice", () => {
+    const [notice] = timeCardNotices([
+      sheet([
+        card("1", "rejected", {
+          leadComment: "Fix the hours.",
+          decidedAt: "2026-06-25T09:00:00Z",
+        }),
+      ]),
+    ]);
+    expect(notice.severity).toBe("error");
+    expect(notice.message).toContain("Fix the hours.");
+  });
+
+  it("returns nothing when no cards need rework", () => {
+    expect(timeCardNotices([sheet([card("1", "approved")])])).toEqual([]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetState.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  cardActions,
+  sheetActions,
+  sheetStatus,
+} from "@features/csm-timecards/utils/timeSheetState";
+import type {
+  CsmTimeCard,
+  CsmTimeSheet,
+  TimeCardState,
+} from "@features/csm-timecards/types/timeCards";
+
+const OWNER = { isOwner: true, isApprover: false, isAdmin: false };
+const APPROVER = { isOwner: false, isApprover: true, isAdmin: false };
+const ADMIN = { isOwner: false, isApprover: false, isAdmin: true };
+
+function card(state: TimeCardState): CsmTimeCard {
+  return {
+    id: state,
+    taskType: "case",
+    activity: [],
+    caseId: "c",
+    caseNumber: "CS1",
+    projectId: "proj-1",
+    projectName: "Test Project",
+    date: "2026-06-24",
+    userId: "u",
+    userName: "U",
+    state,
+    category: "Task work",
+    billable: true,
+    breakdown: {
+      analysisDebugging: 0,
+      reproduce: 0,
+      settingUp: 0,
+      providingSolution: 0,
+      answering: 0,
+    },
+    totalHours: 0,
+    workLogComment: "",
+    issueComplexity: "N/A",
+    approvers: [],
+    submittedAt: "2026-06-24T09:00:00Z",
+  };
+}
+
+describe("cardActions", () => {
+  it("owner can edit + delete + submit a pending card", () => {
+    expect(cardActions("pending", OWNER)).toEqual(["edit", "delete", "submit"]);
+  });
+  it("owner cannot act on a submitted card", () => {
+    expect(cardActions("submitted", OWNER)).toEqual([]);
+  });
+  it("approver approves/rejects a submitted card", () => {
+    expect(cardActions("submitted", APPROVER)).toEqual(["approve", "reject"]);
+  });
+  it("approver can recall an approved card; admin can also process", () => {
+    expect(cardActions("approved", APPROVER)).toEqual(["recall"]);
+    expect(cardActions("approved", ADMIN)).toEqual(["recall", "process"]);
+  });
+  it("owner can edit + delete + resubmit a rejected or recalled card", () => {
+    expect(cardActions("rejected", OWNER)).toEqual(["edit", "delete", "resubmit"]);
+    expect(cardActions("recalled", OWNER)).toEqual(["edit", "delete", "resubmit"]);
+  });
+  it("processed is terminal", () => {
+    expect(cardActions("processed", ADMIN)).toEqual([]);
+  });
+});
+
+describe("sheetStatus", () => {
+  it("rolls up by priority: rejected > recalled > submitted > approved > open", () => {
+    expect(sheetStatus([])).toBe("open");
+    expect(sheetStatus([card("pending")])).toBe("open");
+    expect(sheetStatus([card("submitted")])).toBe("submitted");
+    expect(sheetStatus([card("approved"), card("processed")])).toBe("approved");
+    expect(sheetStatus([card("recalled"), card("submitted")])).toBe("recalled");
+    expect(sheetStatus([card("rejected"), card("approved")])).toBe("rejected");
+  });
+});
+
+describe("sheetActions", () => {
+  const sheet = (cards: CsmTimeCard[]): CsmTimeSheet => ({
+    id: "u:2026-06-22",
+    userId: "u",
+    userName: "U",
+    weekStart: "2026-06-22",
+    weekEnd: "2026-06-28",
+    state: sheetStatus(cards),
+    cards,
+    totalHours: 0,
+  });
+
+  it("owner can submit a week with editable cards", () => {
+    expect(sheetActions(sheet([card("pending")]), OWNER)).toEqual(["submit"]);
+  });
+  it("approver can approve-remaining, reject and recall", () => {
+    expect(
+      sheetActions(sheet([card("submitted"), card("approved")]), APPROVER),
+    ).toEqual(["approve", "reject", "recall"]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardNotifications.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardNotifications.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Lifecycle notifications for the time reporter (ISSU-009: "Automated
+// notifications must be sent to the time reporter regarding lifecycle status
+// changes, e.g. when a time log is rejected"). FE-first: there is no push
+// channel yet, so we derive in-app notices from the engineer's own cards and
+// surface them as a banner. The backend phase replaces this with real
+// notifications, keyed off the same lifecycle events.
+//
+
+import type { CsmTimeCard, CsmTimeSheet } from "@features/csm-timecards/types/timeCards";
+
+/** Severity drives the banner colour; "error" for rejections, "warning" for recalls. */
+export type TimeCardNoticeSeverity = "error" | "warning" | "success";
+
+export interface TimeCardNotice {
+  cardId: string;
+  severity: TimeCardNoticeSeverity;
+  caseNumber: string;
+  /** Human-readable line, e.g. "CS0352584 was rejected — Please fix the hours." */
+  message: string;
+  /** When the deciding event happened (ISO), newest first when sorted. */
+  at: string;
+}
+
+/**
+ * Build the reporter's lifecycle notices from their weekly sheets: a card the
+ * reporter must act on (rejected or recalled) yields a notice. Newest first.
+ */
+export function timeCardNotices(sheets: CsmTimeSheet[]): TimeCardNotice[] {
+  const cards: CsmTimeCard[] = sheets.flatMap((s) => s.cards);
+  const notices: TimeCardNotice[] = [];
+  for (const c of cards) {
+    if (c.state === "rejected") {
+      notices.push({
+        cardId: c.id,
+        severity: "error",
+        caseNumber: c.caseNumber,
+        message: `${c.caseNumber} was rejected${
+          c.leadComment ? ` — ${c.leadComment}` : ""
+        }. Edit and resubmit.`,
+        at: c.decidedAt ?? c.submittedAt,
+      });
+    } else if (c.state === "recalled") {
+      notices.push({
+        cardId: c.id,
+        severity: "warning",
+        caseNumber: c.caseNumber,
+        message: `${c.caseNumber} was recalled for adjustment${
+          c.decidedBy ? ` by ${c.decidedBy}` : ""
+        }. Edit and resubmit.`,
+        at: c.decidedAt ?? c.submittedAt,
+      });
+    }
+  }
+  return notices.sort((a, b) => b.at.localeCompare(a.at));
+}


### PR DESCRIPTION
## Purpose
Adds the notification utility, RBAC role hooks and the remaining test files. **Requires PR 3/6 (#995) to be merged first.**

## Goals
- `timeCardNotifications.ts` — derives actionable notice banners from a user's open sheets (overdue, rejected, nearing deadline)
- `useIsTeamLead.ts` — checks signed-in user's OIDC groups against `CSM_PORTAL_TEAM_LEAD_GROUP`
- `useTimecardRole.ts` — composes `isOwner`, `isApprover`, `isAdmin` context for a given card/sheet
- `timeCardNotifications.test.ts`, `timeSheetState.test.ts` — remaining util test coverage

## Approach
Role resolution reads from the OIDC `groups` claim at runtime so no hardcoded group names exist in source. Defaults are configurable via `window.config`.

## User stories
**ISSU-009 — Time Management** (Epic: Issue Management, Priority: Must have)
> As a CS Engineer, I want to log time spent on an issue so that effort is tracked for operational reporting and billing purposes.

Acceptance criteria addressed here:
- Proper notifications sent to the time reporter on lifecycle status changes ✓
- Team Leads gate-checked via RBAC hooks ✓

## Release note
Internal role hooks and notification logic for time-cards. No user-visible change in this PR.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests: `timeCardNotifications.test.ts`, `timeSheetState.test.ts`

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
**6-PR series for ISSU-009 — merge into `v2` in order:**
1. #992 — Foundation
2. #994 — Core utility functions and tests
3. #995 — API data layer
4. **This PR** — Notification util, role hooks and remaining tests
5. PR 5/6 — UI components
6. PR 6/6 — Page and case-detail integration ← merge last

## Migrations
N/A

## Test environment
macOS 14, Node 20, Chrome 126

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full timecard experience for creating, submitting, approving, rejecting, recalling, deleting, and updating time entries.
  * Introduced weekly timesheet views, approval queues, delegation handling, and summary reports.
  * Added clearer timecard labels, activity summaries, week calculations, and role-based actions for owners, approvers, and admins.

* **Bug Fixes**
  * Improved notice handling for rejected and recalled timecards, including clearer messages and sorting by latest activity.
  * Tightened validation so incomplete drafts are flagged before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->