### PR TITLE
[CSM Portal][FE] feat(csm-timecards): UI components (5/6)

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/DelegateApprovalsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/DelegateApprovalsDialog.tsx
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState, type JSX } from "react";
+import {
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { initialsOf } from "@utils/userClaims";
+import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import { MOCK_APPROVERS } from "@features/csm-timecards/constants/timeCardConstants";
+import type { ApproverDelegation } from "@features/csm-timecards/types/timeCards";
+
+interface DelegateInput {
+  delegateId: string;
+  delegateName: string;
+  from: string;
+  to: string;
+}
+
+interface DelegateApprovalsDialogProps {
+  current: ApproverDelegation | null;
+  isSaving: boolean;
+  onClose: () => void;
+  /** Save a delegation, or pass `null` to clear it. */
+  onSave: (input: DelegateInput | null) => void;
+}
+
+function isoToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+function isoInDays(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Lets an approver delegate their approvals to another approver for a date
+ * range (no per-resource delegation, no re-delegation — per the spec). While a
+ * delegation is active, the approver's own accept/reject actions are suspended.
+ */
+export default function DelegateApprovalsDialog({
+  current,
+  isSaving,
+  onClose,
+  onSave,
+}: DelegateApprovalsDialogProps): JSX.Element {
+  const [delegate, setDelegate] = useState<{ id: string; name: string } | null>(
+    current ? { id: current.delegateId, name: current.delegateName } : null,
+  );
+  const [input, setInput] = useState("");
+  const [from, setFrom] = useState(current?.from ?? isoToday());
+  const [to, setTo] = useState(current?.to ?? isoInDays(14));
+
+  const search = useDebouncedValue(input.trim(), 300);
+  const { data } = useSearchUsers({
+    ...(search.length > 0 && { searchQuery: search }),
+    pagination: { limit: 6, offset: 0 },
+  });
+  const candidates = useMemo(() => {
+    const live = (data?.users ?? [])
+      .filter((u) => u.userType === "internal" && !!u.email)
+      .map((u) => ({
+        id: u.id,
+        name: u.name.trim() || u.userName,
+      }));
+    if (live.length > 0) return live;
+    const q = input.trim().toLowerCase();
+    return MOCK_APPROVERS.filter((a) => !q || a.name.toLowerCase().includes(q));
+  }, [data, input]);
+
+  const canSave = !!delegate && !!from && !!to && from <= to;
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Delegate approvals</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Hand your time-card approvals to another approver while you're away.
+            Your own accept/reject is paused for the period.
+          </Typography>
+
+          {delegate ? (
+            <Chip
+              label={delegate.name}
+              onDelete={() => setDelegate(null)}
+              deleteIcon={<X size={14} />}
+              sx={{ alignSelf: "flex-start" }}
+            />
+          ) : (
+            <>
+              <TextField
+                size="small"
+                label="Delegate to"
+                placeholder="Search approvers…"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+              />
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  border: 1,
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  maxHeight: 160,
+                  overflowY: "auto",
+                }}
+              >
+                {candidates.length === 0 ? (
+                  <Typography variant="caption" color="text.secondary" sx={{ p: 1 }}>
+                    No matching approvers.
+                  </Typography>
+                ) : (
+                  candidates.map((u) => (
+                    <Button
+                      key={u.id}
+                      variant="text"
+                      color="inherit"
+                      onClick={() => {
+                        setDelegate(u);
+                        setInput("");
+                      }}
+                      sx={{
+                        justifyContent: "flex-start",
+                        textTransform: "none",
+                        px: 1,
+                        py: 0.5,
+                        gap: 1,
+                      }}
+                    >
+                      <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
+                        {initialsOf(u.name)}
+                      </Avatar>
+                      <Typography variant="body2">{u.name}</Typography>
+                    </Button>
+                  ))
+                )}
+              </Box>
+            </>
+          )}
+
+          <Box sx={{ display: "flex", gap: 1.5 }}>
+            <TextField
+              type="date"
+              label="From"
+              size="small"
+              fullWidth
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+            <TextField
+              type="date"
+              label="To"
+              size="small"
+              fullWidth
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ justifyContent: "space-between" }}>
+        <Button
+          color="error"
+          disabled={!current || isSaving}
+          onClick={() => onSave(null)}
+        >
+          Remove delegation
+        </Button>
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <Button color="inherit" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            disabled={!canSave || isSaving}
+            onClick={() =>
+              delegate &&
+              onSave({
+                delegateId: delegate.id,
+                delegateName: delegate.name,
+                from,
+                to,
+              })
+            }
+          >
+            Delegate
+          </Button>
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -1,0 +1,613 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState, type JSX, type KeyboardEvent } from "react";
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  InputAdornment,
+  LinearProgress,
+  MenuItem,
+  Switch,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Clock, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import { initialsOf, resolveUserInfo } from "@utils/userClaims";
+import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import type { NormalizedUser } from "@features/csm-users/types/csmUsers";
+import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
+import {
+  ACTIVITY_BUCKETS,
+  DEFAULT_BILLABLE,
+  DEFAULT_ISSUE_COMPLEXITY,
+  DEFAULT_TIME_CARD_CATEGORY,
+  ISSUE_COMPLEXITY_OPTIONS,
+  MOCK_APPROVERS,
+  TASK_TYPE_LABEL,
+  TASK_TYPES,
+  TIME_CARD_CATEGORIES,
+  WORK_LOG_MAX,
+} from "@features/csm-timecards/constants/timeCardConstants";
+import type {
+  ActivityBreakdown,
+  ActivityKey,
+  CreateTimeCardInput,
+  CsmTimeCard,
+  IssueComplexity,
+  TaskType,
+  TimeCardApprover,
+  TimeCardCategory,
+} from "@features/csm-timecards/types/timeCards";
+import {
+  emptyBreakdown,
+  timeCardDraftErrors,
+  totalHours,
+} from "@features/csm-timecards/utils/timeCardTotals";
+import { localTodayIso } from "@features/csm-timecards/utils/timeSheetWeek";
+
+interface LogTimeCardDialogProps {
+  /** Preset task id; omitted when logging from the standalone page. */
+  caseId?: string;
+  /** Preset task reference; when omitted the user types one (free text). */
+  caseNumber?: string;
+  /** Project of the parent case (passed from case detail; carried onto the card). */
+  projectId?: string;
+  projectName?: string;
+  /** Preset task type (case tab → "case", grid → the row's type). */
+  taskType?: TaskType;
+  /** Lock the date to a specific day (grid cell create). */
+  presetDate?: string;
+  /** When set, the dialog edits this card (prefilled) instead of creating one. */
+  editing?: CsmTimeCard;
+  /** Existing cards used to warn about a duplicate entry (same case + day). */
+  existingCards?: CsmTimeCard[];
+  /** True while the create/update mutation is in flight. */
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (input: CreateTimeCardInput) => void;
+}
+
+interface ApproverOption {
+  id: string;
+  name: string;
+  email?: string;
+}
+
+function fullName(u: NormalizedUser): string {
+  return u.name.trim() || u.userName;
+}
+
+/** One activity row: a labelled hours input plus a proportion bar (relative to
+ * the current logged total so each bar shows share-of-work, not share-of-day). */
+function ActivityRow({
+  label,
+  value,
+  total,
+  onChange,
+  onBlur,
+}: {
+  label: string;
+  value: number;
+  /** Running total across all buckets — used to size the proportion bar. */
+  total: number;
+  onChange: (next: number) => void;
+  onBlur?: () => void;
+}): JSX.Element {
+  const pct = total > 0 ? Math.min(100, (value / total) * 100) : 0;
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: "1fr 96px",
+        alignItems: "center",
+        columnGap: 1.5,
+        rowGap: 0.5,
+      }}
+    >
+      <Typography variant="body2">{label}</Typography>
+      <TextField
+        type="number"
+        size="small"
+        value={Number.isFinite(value) ? value : 0}
+        onChange={(e) => onChange(Math.max(0, Number(e.target.value) || 0))}
+        slotProps={{ htmlInput: { min: 0, step: 0.25, "aria-label": label } }}
+        onBlur={onBlur}
+        sx={{ width: 96 }}
+      />
+      <Box sx={{ gridColumn: "1 / -1", mt: -0.25 }}>
+        <LinearProgress
+          variant="determinate"
+          value={pct}
+          sx={{ height: 4, borderRadius: 2 }}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Improved "Create Time Card" form. Mirrors the ServiceNow fields (date,
+ * category, the five activity buckets, work-log comment, issue complexity,
+ * approver) but adds a live running total, per-activity proportion bars, an
+ * auto-filled engineer + Pending status, and inline validation. The task is
+ * preset when opened from a case; on the standalone page the user types it.
+ */
+export default function LogTimeCardDialog({
+  caseId,
+  caseNumber,
+  projectId,
+  projectName,
+  taskType: taskTypeProp,
+  presetDate,
+  editing,
+  existingCards,
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: LogTimeCardDialogProps): JSX.Element {
+  const me = resolveUserInfo(useIdTokenClaims());
+  const effectiveCaseNumber = caseNumber ?? editing?.caseNumber;
+  const effectiveCaseId = caseId ?? editing?.caseId;
+  const effectiveProjectId = projectId ?? editing?.projectId ?? "";
+  const effectiveProjectName = projectName ?? editing?.projectName ?? "";
+  const presetCase = !!effectiveCaseNumber;
+
+  const [taskType, setTaskType] = useState<TaskType>(
+    taskTypeProp ?? editing?.taskType ?? "case",
+  );
+  const [caseInput, setCaseInput] = useState(effectiveCaseNumber ?? "");
+  const [date, setDate] = useState(presetDate ?? editing?.date ?? localTodayIso());
+  const [category, setCategory] = useState<TimeCardCategory>(
+    editing?.category ?? DEFAULT_TIME_CARD_CATEGORY,
+  );
+  const [issueComplexity, setIssueComplexity] = useState<IssueComplexity>(
+    editing?.issueComplexity ?? DEFAULT_ISSUE_COMPLEXITY,
+  );
+  const [billable, setBillable] = useState<boolean>(
+    editing?.billable ?? DEFAULT_BILLABLE,
+  );
+  const [breakdown, setBreakdown] = useState<ActivityBreakdown>(
+    editing ? { ...editing.breakdown } : emptyBreakdown(),
+  );
+  const [workLogComment, setWorkLogComment] = useState(
+    editing?.workLogComment ?? "",
+  );
+  const [approver, setApprover] = useState<TimeCardApprover | null>(
+    editing?.approvers[0] ?? null,
+  );
+  const [approverInput, setApproverInput] = useState("");
+  const [touched, setTouched] = useState<Set<string>>(new Set());
+  const touch = (field: string): void =>
+    setTouched((prev) => new Set(prev).add(field));
+  const isTouched = (field: string): boolean => touched.has(field);
+
+  const total = totalHours(breakdown);
+  const errors = timeCardDraftErrors({
+    date,
+    breakdown,
+    workLogComment,
+    approverId: approver?.id,
+  });
+  const caseError =
+    !presetCase && !caseInput.trim() ? "Enter a case number." : undefined;
+  const isValid = Object.keys(errors).length === 0 && !caseError;
+
+  // Soft warning (not a blocker): an entry already exists for this case on this
+  // day — the engineer probably means to edit it rather than create a second one.
+  const resolvedCaseNumber = (effectiveCaseNumber ?? caseInput).trim();
+  const duplicateCard =
+    resolvedCaseNumber && date
+      ? (existingCards ?? []).find(
+          (c) =>
+            c.id !== editing?.id &&
+            c.caseNumber === resolvedCaseNumber &&
+            c.date === date,
+        )
+      : undefined;
+
+  const search = useDebouncedValue(approverInput.trim(), 300);
+  const { data } = useSearchUsers({
+    ...(search.length > 0 && { searchQuery: search }),
+    pagination: { limit: 6, offset: 0 },
+  });
+  // Live results when the backend answers; otherwise a static mock list so the
+  // approver can still be chosen offline (FE-first).
+  const hasApproverInput = approverInput.trim().length > 0;
+  const candidates: ApproverOption[] = useMemo(() => {
+    if (!hasApproverInput) return [];
+    const live = (data?.users ?? [])
+      .filter((u) => u.userType === "internal" && !!u.email)
+      .map((u) => ({ id: u.id, name: fullName(u), email: u.email }));
+    if (live.length > 0) return live;
+    const q = approverInput.trim().toLowerCase();
+    return MOCK_APPROVERS.filter((a) => a.name.toLowerCase().includes(q));
+  }, [data, approverInput, hasApproverInput]);
+
+  const setActivity = (key: ActivityKey, next: number): void =>
+    setBreakdown((prev) => ({ ...prev, [key]: next }));
+
+  const ALL_FIELDS = ["case", "date", "hours", "workLogComment", "approver"];
+  const handleSubmit = (): void => {
+    if (!isValid || !approver) {
+      setTouched(new Set(ALL_FIELDS));
+      return;
+    }
+    const resolvedNumber = (effectiveCaseNumber ?? caseInput).trim();
+    onSubmit({
+      taskType,
+      caseId: effectiveCaseId ?? resolvedNumber,
+      caseNumber: resolvedNumber,
+      projectId: effectiveProjectId,
+      projectName: effectiveProjectName,
+      date,
+      category,
+      breakdown,
+      billable,
+      workLogComment: workLogComment.trim(),
+      issueComplexity,
+      approver,
+    });
+  };
+
+  /** Submit on Enter, except inside the multiline work-log (where Enter = newline). */
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    if (
+      e.key === "Enter" &&
+      !e.shiftKey &&
+      (e.target as HTMLElement).tagName !== "TEXTAREA"
+    ) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {editing ? "Edit time card" : "Log time"}
+        {effectiveCaseNumber ? ` · ${effectiveCaseNumber}` : ""}
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box
+          onKeyDown={handleKeyDown}
+          sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+        >
+          {/* Engineer + status (auto, read-only) */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 1,
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Avatar
+                src={me.avatarUrl}
+                sx={{ width: 28, height: 28, fontSize: "0.75rem" }}
+              >
+                {initialsOf(me.fullName)}
+              </Avatar>
+              <Typography variant="body2">{me.fullName}</Typography>
+            </Box>
+            <TimeCardStatusChip state="pending" />
+          </Box>
+
+          {/* Task (preset → read-only; standalone → type + reference) */}
+          {presetCase ? (
+            <Typography variant="body2" color="text.secondary">
+              Task: {TASK_TYPE_LABEL[taskType]} · {effectiveCaseNumber}
+              {effectiveProjectName ? ` · ${effectiveProjectName}` : ""}
+            </Typography>
+          ) : (
+            <Box
+              sx={{
+                display: "grid",
+                gap: 1.5,
+                gridTemplateColumns: { xs: "1fr", sm: "180px 1fr" },
+              }}
+            >
+              <TextField
+                select
+                label="Task type"
+                size="small"
+                value={taskType}
+                onChange={(e) => setTaskType(e.target.value as TaskType)}
+              >
+                {TASK_TYPES.map((t) => (
+                  <MenuItem key={t.key} value={t.key}>
+                    {t.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                label="Task reference"
+                size="small"
+                required
+                placeholder="e.g. CS0352584"
+                value={caseInput}
+                onChange={(e) => setCaseInput(e.target.value)}
+                onBlur={() => touch("case")}
+                error={isTouched("case") && !!caseError}
+                helperText={isTouched("case") ? caseError : undefined}
+              />
+            </Box>
+          )}
+
+          {/* Date + category */}
+          <Box
+            sx={{
+              display: "grid",
+              gap: 1.5,
+              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+            }}
+          >
+            <TextField
+              type="date"
+              label="Date"
+              size="small"
+              required
+              disabled={!!presetDate}
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              onBlur={() => touch("date")}
+              error={isTouched("date") && !!errors.date}
+              helperText={isTouched("date") ? errors.date : undefined}
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+            <TextField
+              select
+              label="Category"
+              size="small"
+              value={category}
+              onChange={(e) => setCategory(e.target.value as TimeCardCategory)}
+            >
+              {TIME_CARD_CATEGORIES.map((c) => (
+                <MenuItem key={c} value={c}>
+                  {c}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Box>
+
+          {duplicateCard && (
+            <Alert severity="warning" sx={{ py: 0 }}>
+              You already logged {duplicateCard.totalHours.toFixed(2)}h on{" "}
+              {resolvedCaseNumber} for this day. Consider editing that entry instead of
+              creating a duplicate.
+            </Alert>
+          )}
+
+          <Divider />
+
+          {/* Time breakdown */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+            }}
+          >
+            <Typography variant="subtitle2">Time breakdown (hours)</Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+              <Clock size={14} />
+              <Typography variant="subtitle2" color="primary">
+                {total.toFixed(2)}h total
+              </Typography>
+            </Box>
+          </Box>
+          {isTouched("hours") && errors.hours && (
+            <Typography variant="caption" color="error">
+              {errors.hours}
+            </Typography>
+          )}
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+            {ACTIVITY_BUCKETS.map((b) => (
+              <ActivityRow
+                key={b.key}
+                label={b.label}
+                value={breakdown[b.key]}
+                total={total}
+                onChange={(next) => setActivity(b.key, next)}
+                onBlur={() => touch("hours")}
+              />
+            ))}
+          </Box>
+
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              flexWrap: "wrap",
+              gap: 1,
+            }}
+          >
+            <TextField
+              select
+              label="Issue complexity"
+              size="small"
+              value={issueComplexity}
+              onChange={(e) => setIssueComplexity(e.target.value as IssueComplexity)}
+              sx={{ maxWidth: { sm: 220 }, minWidth: 160 }}
+            >
+              {ISSUE_COMPLEXITY_OPTIONS.map((o) => (
+                <MenuItem key={o} value={o}>
+                  {o}
+                </MenuItem>
+              ))}
+            </TextField>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={billable}
+                  onChange={(e) => setBillable(e.target.checked)}
+                />
+              }
+              label={billable ? "Billable" : "Non-billable"}
+              labelPlacement="start"
+              sx={{ ml: 0 }}
+            />
+          </Box>
+
+          {/* Work log */}
+          <TextField
+            label="Work log comment"
+            required
+            multiline
+            minRows={3}
+            value={workLogComment}
+            onChange={(e) =>
+              setWorkLogComment(e.target.value.slice(0, WORK_LOG_MAX))
+            }
+            onBlur={() => touch("workLogComment")}
+            error={isTouched("workLogComment") && !!errors.workLogComment}
+            helperText={
+              isTouched("workLogComment") && errors.workLogComment
+                ? errors.workLogComment
+                : `${WORK_LOG_MAX - workLogComment.length} characters left`
+            }
+          />
+
+          {/* Approver */}
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+            <Typography variant="subtitle2">Approver (team lead)</Typography>
+            {approver ? (
+              <Chip
+                label={approver.name}
+                onDelete={() => setApprover(null)}
+                deleteIcon={<X size={14} />}
+                sx={{ alignSelf: "flex-start" }}
+              />
+            ) : (
+              <>
+                <TextField
+                  size="small"
+                  placeholder="Search engineers by name or email…"
+                  value={approverInput}
+                  onChange={(e) => setApproverInput(e.target.value)}
+                  onBlur={() => touch("approver")}
+                  error={isTouched("approver") && !!errors.approver}
+                  helperText={isTouched("approver") ? errors.approver : undefined}
+                  slotProps={{
+                    input: {
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <Search size={16} />
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
+                />
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    border: 1,
+                    borderColor: "divider",
+                    borderRadius: 1,
+                    maxHeight: 180,
+                    overflowY: "auto",
+                  }}
+                >
+                  {!hasApproverInput ? (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ p: 1 }}
+                    >
+                      Start typing to search for an approver.
+                    </Typography>
+                  ) : candidates.length === 0 ? (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ p: 1 }}
+                    >
+                      No matching engineers.
+                    </Typography>
+                  ) : (
+                    candidates.map((u) => (
+                      <Button
+                        key={u.id}
+                        variant="text"
+                        color="inherit"
+                        onClick={() => {
+                          setApprover({ id: u.id, name: u.name });
+                          setApproverInput("");
+                        }}
+                        sx={{
+                          justifyContent: "flex-start",
+                          textTransform: "none",
+                          px: 1,
+                          py: 0.5,
+                          gap: 1,
+                        }}
+                      >
+                        <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
+                          {initialsOf(u.name)}
+                        </Avatar>
+                        <Box sx={{ minWidth: 0, textAlign: "left" }}>
+                          <Typography variant="body2" noWrap>
+                            {u.name}
+                          </Typography>
+                          {u.email && (
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              noWrap
+                              sx={{ display: "block" }}
+                            >
+                              {u.email}
+                            </Typography>
+                          )}
+                        </Box>
+                      </Button>
+                    ))
+                  )}
+                </Box>
+              </>
+            )}
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={isSubmitting || (touched.size > 0 && !isValid)}
+        >
+          {editing ? "Save changes" : "Submit for review"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState, type JSX } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Check, X } from "@wso2/oxygen-ui-icons-react";
+import RelativeTime from "@components/RelativeTime";
+import {
+  billableLabel,
+  breakdownSummary,
+  LEAD_COMMENT_MAX,
+  TIME_CARD_ACTIVITY_LABEL,
+} from "@features/csm-timecards/constants/timeCardConstants";
+import type {
+  CsmTimeCard,
+  TimeCardDecisionInput,
+} from "@features/csm-timecards/types/timeCards";
+
+interface TimeCardReviewDialogProps {
+  card: CsmTimeCard;
+  /** True while the decision mutation is in flight. */
+  isDeciding: boolean;
+  onClose: () => void;
+  onDecide: (decision: TimeCardDecisionInput) => void;
+}
+
+function Field({ label, value }: { label: string; value: string }): JSX.Element {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2">{value}</Typography>
+    </Box>
+  );
+}
+
+/**
+ * Team-lead review of a pending time card. Shows the engineer, the case, the
+ * activity breakdown and the work log, and captures an optional Lead's comment
+ * before accepting or rejecting. Reject requires nothing extra but a reason is
+ * encouraged — the comment is sent with either decision.
+ */
+export default function TimeCardReviewDialog({
+  card,
+  isDeciding,
+  onClose,
+  onDecide,
+}: TimeCardReviewDialogProps): JSX.Element {
+  const [leadComment, setLeadComment] = useState("");
+
+  const decide = (state: "approved" | "rejected"): void =>
+    onDecide({ cardId: card.id, state, leadComment });
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Review time card · {card.caseNumber} · {card.totalHours.toFixed(2)}h
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 1.5,
+            }}
+          >
+            <Field label="Engineer" value={card.userName} />
+            <Field label="Date" value={card.date} />
+            <Field label="Category" value={card.category} />
+            <Field label="Issue complexity" value={card.issueComplexity} />
+            <Field label="Billable" value={billableLabel(card.billable)} />
+          </Box>
+
+          <Field label="Time breakdown" value={breakdownSummary(card.breakdown)} />
+
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Work log
+            </Typography>
+            <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+              {card.workLogComment}
+            </Typography>
+          </Box>
+
+          {card.activity.length > 0 && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Activity
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, mt: 0.25 }}>
+                {card.activity.map((a, i) => (
+                  <Typography key={i} variant="caption" color="text.secondary">
+                    <Box component="span" sx={{ fontWeight: 600, color: "text.primary" }}>
+                      {TIME_CARD_ACTIVITY_LABEL[a.action]}
+                    </Box>{" "}
+                    by {a.by} · <RelativeTime iso={a.at} />
+                    {a.note ? ` — ${a.note}` : ""}
+                  </Typography>
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          <TextField
+            label="Lead's comment (optional)"
+            multiline
+            minRows={2}
+            value={leadComment}
+            onChange={(e) =>
+              setLeadComment(e.target.value.slice(0, LEAD_COMMENT_MAX))
+            }
+            helperText={`${LEAD_COMMENT_MAX - leadComment.length} characters left`}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isDeciding}>
+          Cancel
+        </Button>
+        <Button
+          color="error"
+          variant="outlined"
+          startIcon={<X size={16} />}
+          onClick={() => decide("rejected")}
+          disabled={isDeciding}
+        >
+          Reject
+        </Button>
+        <Button
+          color="success"
+          variant="contained"
+          startIcon={<Check size={16} />}
+          onClick={() => decide("approved")}
+          disabled={isDeciding}
+        >
+          Accept
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardStatusChip.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardStatusChip.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import SemanticChip from "@components/SemanticChip";
+import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
+import type { TimeCardState } from "@features/csm-timecards/types/timeCards";
+
+/** Status pill for a time card's approval state. Single source of truth for its
+ * label + colour (see {@link TIME_CARD_STATE_META}). */
+export default function TimeCardStatusChip({
+  state,
+  size = "small",
+}: {
+  state: TimeCardState;
+  size?: "small" | "medium";
+}): JSX.Element {
+  const meta = TIME_CARD_STATE_META[state];
+  return <SemanticChip role={meta.role} label={meta.label} size={size} />;
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeSheetCard.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeSheetCard.tsx
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Divider,
+  LinearProgress,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Check, Trash2, X } from "@wso2/oxygen-ui-icons-react";
+import SemanticChip from "@components/SemanticChip";
+import RelativeTime from "@components/RelativeTime";
+import {
+  breakdownSummary,
+  TIME_SHEET_STATE_META,
+} from "@features/csm-timecards/constants/timeCardConstants";
+import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
+import {
+  cardActions,
+  sheetActions,
+  type SheetAction,
+  type TimecardAction,
+  type TimecardRoleCtx,
+} from "@features/csm-timecards/utils/timeSheetState";
+import { weekLabel } from "@features/csm-timecards/utils/timeSheetWeek";
+import type {
+  CsmTimeCard,
+  CsmTimeSheet,
+} from "@features/csm-timecards/types/timeCards";
+
+interface TimeSheetCardProps {
+  sheet: CsmTimeSheet;
+  role: TimecardRoleCtx;
+  /** Show the engineer's name (approvals view); omit on the user's own sheets. */
+  showEngineer?: boolean;
+  /** Approver actions disabled (e.g. approvals delegated away). */
+  approverDisabled?: boolean;
+  onSheetAction: (sheet: CsmTimeSheet, action: SheetAction) => void;
+  onCardAction: (card: CsmTimeCard, action: TimecardAction) => void;
+}
+
+const CARD_BUTTONS: Record<
+  TimecardAction,
+  {
+    label: string;
+    color: "success" | "error" | "warning" | "inherit";
+    variant: "contained" | "outlined" | "text";
+    icon?: JSX.Element;
+    approverAction: boolean;
+  }
+> = {
+  edit: { label: "Edit", color: "inherit", variant: "text", approverAction: false },
+  submit: { label: "Submit", color: "inherit", variant: "outlined", approverAction: false },
+  resubmit: { label: "Resubmit", color: "inherit", variant: "outlined", approverAction: false },
+  delete: {
+    label: "Delete",
+    color: "error",
+    variant: "text",
+    icon: <Trash2 size={14} />,
+    approverAction: false,
+  },
+  approve: {
+    label: "Approve",
+    color: "success",
+    variant: "contained",
+    icon: <Check size={14} />,
+    approverAction: true,
+  },
+  reject: {
+    label: "Reject",
+    color: "error",
+    variant: "outlined",
+    icon: <X size={14} />,
+    approverAction: true,
+  },
+  recall: { label: "Recall", color: "warning", variant: "outlined", approverAction: true },
+  process: { label: "Process", color: "inherit", variant: "outlined", approverAction: true },
+};
+
+const SHEET_BUTTONS: Record<
+  SheetAction,
+  {
+    label: string;
+    color: "primary" | "success" | "error" | "warning";
+    variant: "contained" | "outlined";
+    icon?: JSX.Element;
+    approverAction: boolean;
+  }
+> = {
+  approve: {
+    label: "Approve remaining",
+    color: "success",
+    variant: "contained",
+    icon: <Check size={14} />,
+    approverAction: true,
+  },
+  reject: {
+    label: "Reject remaining",
+    color: "error",
+    variant: "outlined",
+    icon: <X size={14} />,
+    approverAction: true,
+  },
+  recall: { label: "Recall week", color: "warning", variant: "outlined", approverAction: true },
+  submit: { label: "Submit week", color: "primary", variant: "contained", approverAction: false },
+};
+
+/** A weekly time sheet: header (week, total, status), sheet-level actions, and
+ * each card with its status and role/state-appropriate actions. Used in both
+ * "My time sheets" (owner) and "Approvals" (approver/admin). */
+export default function TimeSheetCard({
+  sheet,
+  role,
+  showEngineer = false,
+  approverDisabled = false,
+  onSheetAction,
+  onCardAction,
+}: TimeSheetCardProps): JSX.Element {
+  const meta = TIME_SHEET_STATE_META[sheet.state];
+  const sActions = sheetActions(sheet, role);
+
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 1,
+          mb: 1,
+        }}
+      >
+        <Box>
+          {showEngineer && (
+            <Typography variant="subtitle2" sx={{ lineHeight: 1.2 }}>
+              {sheet.userName}
+            </Typography>
+          )}
+          <Typography variant="body2" color="text.secondary">
+            {weekLabel(sheet.weekStart)}
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <SemanticChip role={meta.role} label={meta.label} />
+          <Typography variant="h6" sx={{ lineHeight: 1 }}>
+            {sheet.totalHours.toFixed(2)}h
+          </Typography>
+        </Box>
+      </Box>
+
+      <LinearProgress
+        variant="determinate"
+        value={Math.min(100, (sheet.totalHours / 40) * 100)}
+        sx={{ height: 6, borderRadius: 3, mb: 1.5 }}
+      />
+
+      <Divider sx={{ mb: 1 }} />
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+        {sheet.cards.map((c) => {
+          const actions = cardActions(c.state, role);
+          return (
+            <Box
+              key={c.id}
+              data-testid={`timecard-row-${c.caseNumber}`}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 1,
+                py: 0.5,
+                flexWrap: "wrap",
+              }}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, flexWrap: "wrap" }}>
+                  <Typography variant="body2" noWrap>
+                    {c.caseNumber} · {c.category} · {c.totalHours.toFixed(2)}h
+                  </Typography>
+                  <Chip
+                    label={c.billable ? "Billable" : "Non-billable"}
+                    size="small"
+                    sx={{
+                      height: 18,
+                      fontSize: "0.65rem",
+                      fontWeight: 600,
+                      bgcolor: c.billable ? "success.light" : "action.hover",
+                      color: c.billable ? "success.dark" : "text.secondary",
+                    }}
+                  />
+                </Box>
+                <Typography variant="caption" color="text.secondary">
+                  {breakdownSummary(c.breakdown)} · <RelativeTime iso={c.submittedAt} />
+                </Typography>
+                {c.leadComment && (
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: "block" }}
+                  >
+                    Lead: {c.leadComment}
+                  </Typography>
+                )}
+              </Box>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                <TimeCardStatusChip state={c.state} />
+                {actions.map((a) => {
+                  const b = CARD_BUTTONS[a];
+                  return (
+                    <Button
+                      key={a}
+                      size="small"
+                      color={b.color}
+                      variant={b.variant}
+                      startIcon={b.icon}
+                      disabled={b.approverAction && approverDisabled}
+                      onClick={() => onCardAction(c, a)}
+                    >
+                      {b.label}
+                    </Button>
+                  );
+                })}
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {sActions.length > 0 && (
+        <>
+          <Divider sx={{ my: 1 }} />
+          <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+            {sActions.map((a) => {
+              const b = SHEET_BUTTONS[a];
+              return (
+                <Button
+                  key={a}
+                  size="small"
+                  variant={b.variant}
+                  color={b.color}
+                  startIcon={b.icon}
+                  disabled={b.approverAction && approverDisabled}
+                  onClick={() => onSheetAction(sheet, a)}
+                >
+                  {b.label}
+                </Button>
+              );
+            })}
+          </Box>
+        </>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Purpose
Adds the five reusable UI components consumed by the time-cards page and case-detail panel. **Requires PR 4/6 (#996) to be merged first.**

## Goals
- `TimeCardStatusChip.tsx` — semantic status chip for card and sheet states
- `TimeSheetCard.tsx` — weekly sheet card with per-card actions and sheet-level approve/reject/submit buttons
- `LogTimeCardDialog.tsx` — dialog for logging or editing a time card (date, activity breakdown, billable flag, approver picker)
- `TimeCardReviewDialog.tsx` — approver accept/reject dialog with lead comment
- `DelegateApprovalsDialog.tsx` — dialog for team leads to delegate approvals for a date range

## Approach
All components use Oxygen UI primitives and compose the hooks/utils from PRs 2–4. No inline styles — MUI `sx` only.

## User stories
**ISSU-009 — Time Management** (Epic: Issue Management, Priority: Must have)
> As a CS Engineer, I want to log time spent on an issue so that effort is tracked for operational reporting and billing purposes.

Acceptance criteria addressed here:
- Log entries with date, hours, activity type, description and billable flag ✓ (`LogTimeCardDialog`)
- Team Leads approve/reject submissions ✓ (`TimeCardReviewDialog`)
- Delegation of approvals ✓ (`DelegateApprovalsDialog`)

## Release note
Reusable time-card UI components. No user-visible route changes in this PR — wiring lands in PR 6/6.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests: covered by PR 2–4 util tests; component-level tests to follow post-BFF wiring

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
**6-PR series for ISSU-009 — merge into `v2` in order:**
1. #992 — Foundation
2. #994 — Core utility functions and tests
3. #995 — API data layer
4. #996 — Notification util, role hooks and remaining tests
5. **This PR** — UI components
6. PR 6/6 — Page and case-detail integration ← merge last

## Migrations
N/A

## Test environment
macOS 14, Node 20, Chrome 126

## Learning
N/A