### PR TITLE
[Customer Portal Web App] fix: usage metrics product count, MI classifier, and Java version display

### DIFF
--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -381,7 +381,7 @@ function EnvironmentBreakdownAccordion({
   );
 
   const { productCount, instanceCount, totalCores, transactionsLabel } = useMemo(() => {
-    if (!depInstancesData) {
+    if (!depInstancesData || !depUsagesData) {
       return {
         productCount: row.productCount,
         instanceCount: row.instanceCount,
@@ -390,7 +390,7 @@ function EnvironmentBreakdownAccordion({
       };
     }
     const instances = depInstancesData.instances ?? [];
-    const usages = depUsagesData?.usages ?? [];
+    const usages = depUsagesData.usages ?? [];
     const productIds = new Set([
       ...instances.map((i) => i.deployedProduct?.id ?? i.product?.id).filter(Boolean),
       ...usages.map((u) => u.deployedProduct?.id ?? u.product?.id).filter(Boolean),

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsEnvironmentProducts.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsEnvironmentProducts.ts
@@ -232,10 +232,11 @@ export function deriveUsageEnvironmentProducts(
           },
         ];
 
-        const javaVer =
+        const javaVer = (
           instMetric?.dataPoints.at(-1)?.jdkVersion ??
           instMetric?.dataPoints.at(-1)?.deploymentMetadata?.jdkVersion ??
-          USAGE_METRICS_VALUE_EM_DASH;
+          USAGE_METRICS_VALUE_EM_DASH
+        ).replace(/^"|"$/g, "");
         const u2Level =
           instMetric?.dataPoints.at(-1)?.deploymentMetadata?.updateLevel ??
           USAGE_METRICS_VALUE_EM_DASH;

--- a/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/utils/usageMetricsProductClassifier.ts
@@ -83,7 +83,7 @@ function parseMajorVersion(label: string): number {
 const PRODUCT_TYPE_PATTERNS: [WsoProductType, RegExp][] = [
   [WsoProductType.APIM, /api[\s-]?manager|\bapim\b/i],
   [WsoProductType.IS, /identity[\s-]server/i],
-  [WsoProductType.MI, /micro[\s-]integrator|\bintegrator\b/i],
+  [WsoProductType.MI, /micro[\s-]integrator|wso2\s+integrator/i],
 ];
 
 /**


### PR DESCRIPTION
## Summary

- **Product count consistency**: Environment row header was fluctuating between 3 and 4 products depending on whether usage data had loaded. Fixed by waiting for both deployment-scoped instance and usage queries before recomputing, and counting unique products from both sources (instances + usages) so the header always matches the expanded product cards.
- **MI product classifier**: Narrowed the `\bintegrator\b` regex to `wso2\s+integrator` so only genuine MI product labels ("WSO2 Integrator: MI x.x.x") are matched, preventing accidental classification of unrelated integrator labels.
- **Java Version display**: Strip surrounding quotes from `jdkVersion` values returned by the API (e.g. `"21.0.10"` → `21.0.10`).

## Test plan

- [ ] Open a deployment with mixed products (some with instances only, some with transactions only) — verify product count in collapsed header matches the number of product cards when expanded
- [ ] Verify count does not flicker when expanding the accordion
- [ ] Open a deployment with "WSO2 Integrator: MI x.x.x" product — verify only Transactions column is shown
- [ ] Verify Java Version shows without surrounding quotes in the instance row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage metrics calculations when environment data is incomplete, so charts and totals now fall back more reliably to available values.
  * Cleaned up Java version display by removing extra quotation marks from shown values.
  * Refined product detection for Micro Integrator so related usage metrics are classified more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->