### PR TITLE
[CSM] feat: add SNAccount type and ServiceNow account service

### DIFF
--- a/apps/csm-portal/backend/internal/handler/accounts.go
+++ b/apps/csm-portal/backend/internal/handler/accounts.go
@@ -52,8 +52,8 @@ func (h *AccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := r.PathValue("id")
-	if id == "" {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -91,8 +91,6 @@ func (h *AccountHandler) SearchAccounts(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// TODO: Decode into a typed SearchAccountsRequest and validate fields before forwarding.
-
 	result, err := h.entity.SearchAccounts(r.Context(), body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchAccounts failed", "userID", user.UserID, "err", err)
@@ -100,6 +98,5 @@ func (h *AccountHandler) SearchAccounts(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// TODO: Unmarshal result and filter to only the fields required by the frontend.
 	writeJSON(w, http.StatusOK, result)
 }

--- a/apps/csm-portal/backend/internal/handler/accounts_test.go
+++ b/apps/csm-portal/backend/internal/handler/accounts_test.go
@@ -42,36 +42,49 @@ func TestGetAccount(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.GetAccount(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID account ID", func(t *testing.T) {
+		h := NewAccountHandler(&mockEntityAccountClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/accounts/acc-42", nil))
+		r.SetPathValue("id", "acc-42")
+		w := httptest.NewRecorder()
+		h.GetAccount(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
 		assertContentType(t, w, "application/json")
 	})
 
 	t.Run("passes ID to upstream and returns 200 with response", func(t *testing.T) {
+		const accountID = "11111111-1111-1111-1111-111111111111"
 		var capturedID string
 		client := &mockEntityAccountClient{
 			getAccountFn: func(_ context.Context, id string) ([]byte, error) {
 				capturedID = id
-				return []byte(`{"id":"acc-42","name":"WSO2"}`), nil
+				return []byte(`{"id":"` + accountID + `","name":"WSO2"}`), nil
 			},
 		}
 		h := NewAccountHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodGet, "/accounts/acc-42", nil))
-		r.SetPathValue("id", "acc-42")
+		r := withUser(httptest.NewRequest(http.MethodGet, "/accounts/"+accountID, nil))
+		r.SetPathValue("id", accountID)
 		w := httptest.NewRecorder()
 		h.GetAccount(w, r)
 
 		assertStatus(t, w, http.StatusOK)
 		assertContentType(t, w, "application/json")
-		if capturedID != "acc-42" {
-			t.Errorf("upstream received id %q, want %q", capturedID, "acc-42")
+		if capturedID != accountID {
+			t.Errorf("upstream received id %q, want %q", capturedID, accountID)
 		}
 		resp := decodeJSON[map[string]any](t, w)
-		if resp["id"] != "acc-42" {
-			t.Errorf("response id = %v, want acc-42", resp["id"])
+		if resp["id"] != accountID {
+			t.Errorf("response id = %v, want %s", resp["id"], accountID)
 		}
 	})
 
 	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		const accountID = "11111111-1111-1111-1111-111111111111"
 		for _, tc := range upstreamErrors("Failed to retrieve account.") {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
@@ -81,8 +94,8 @@ func TestGetAccount(t *testing.T) {
 					},
 				}
 				h := NewAccountHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodGet, "/accounts/acc-1", nil))
-				r.SetPathValue("id", "acc-1")
+				r := withUser(httptest.NewRequest(http.MethodGet, "/accounts/"+accountID, nil))
+				r.SetPathValue("id", accountID)
 				w := httptest.NewRecorder()
 				h.GetAccount(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -215,6 +215,33 @@ type SearchAccountsResponse struct {
 	HasMore  bool      `json:"hasMore"`
 }
 
+// SNAccount is the account view returned by the ServiceNow data source.
+// Timestamp fields are kept as strings to accommodate empty values from ServiceNow.
+type SNAccount struct {
+	ID                  string  `json:"id"`
+	SfID                string  `json:"sfId"`
+	Name                string  `json:"name"`
+	Tier                string  `json:"tier"`
+	Region              *string `json:"region"`
+	ActivationDate      string  `json:"activationDate"`
+	DeactivationDate    *string `json:"deactivationDate"`
+	OwnerID             string  `json:"ownerId"`
+	TechnicalOwnerID    *string `json:"technicalOwnerId"`
+	AgentEnabled        bool    `json:"agentEnabled"`
+	KbReferencesEnabled bool    `json:"kbReferencesEnabled"`
+	CreatedOn           string  `json:"createdOn"`
+	UpdatedOn           string  `json:"updatedOn"`
+}
+
+// SearchSNAccountsResponse is the paginated result of a ServiceNow account search.
+type SearchSNAccountsResponse struct {
+	Accounts []SNAccount `json:"accounts"`
+	Total    int         `json:"total"`
+	Limit    int         `json:"limit"`
+	Offset   int         `json:"offset"`
+	HasMore  bool        `json:"hasMore"`
+}
+
 // SubscriptionType classifies the subscription type of a project.
 type SubscriptionType string
 

--- a/entity-service/internal/handler/account_handler.go
+++ b/entity-service/internal/handler/account_handler.go
@@ -61,3 +61,40 @@ func (h *AccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(account)
 }
+
+// SNAccountHandler handles HTTP requests for account operations backed by ServiceNow.
+type SNAccountHandler struct {
+	svc service.SNAccountService
+}
+
+// NewSNAccountHandler constructs an SNAccountHandler with the given service.
+func NewSNAccountHandler(svc service.SNAccountService) *SNAccountHandler {
+	return &SNAccountHandler{svc: svc}
+}
+
+// SearchAccounts handles POST /accounts/search for the ServiceNow data source.
+func (h *SNAccountHandler) SearchAccounts(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchAccountsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchAccounts(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetAccount handles GET /accounts/{id} for the ServiceNow data source.
+func (h *SNAccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	account, err := h.svc.GetAccountByID(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(account)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -38,8 +38,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	userHandler := handler.NewUserHandler(userSvc)
 
 	accountRepo := repository.NewAccountRepository(db)
-	accountSvc := service.NewAccountService(accountRepo)
-	accountHandler := handler.NewAccountHandler(accountSvc)
+	accountHandler := handler.NewAccountHandler(service.NewAccountService(accountRepo))
 
 	var serviceNowIntegrationServiceClient *integrationservice.Client
 	if cfg.DataSource == config.DataSourceServiceNow {
@@ -49,6 +48,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 			ClientSecret: cfg.ServiceNowIntegrationServiceClientSecret,
 			Scopes:       cfg.ServiceNowIntegrationServiceScopes,
 		})
+	}
+
+	var snAccountHandler *handler.SNAccountHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		snAccountHandler = handler.NewSNAccountHandler(service.NewServiceNowAccountService(serviceNowIntegrationServiceClient))
 	}
 
 	projectRepo := repository.NewProjectRepository(db)
@@ -142,8 +146,13 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	} else {
 		mux.HandleFunc("POST /users/search", userHandler.SearchUsers)
 	}
-	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)
-	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
+	if snAccountHandler != nil {
+		mux.HandleFunc("GET /accounts/{id}", snAccountHandler.GetAccount)
+		mux.HandleFunc("POST /accounts/search", snAccountHandler.SearchAccounts)
+	} else {
+		mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)
+		mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
+	}
 	mux.HandleFunc("GET /projects/{id}", projectHandler.GetProject)
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	if snProductHandler != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -59,6 +59,16 @@ type AccountService interface {
 	GetAccountByID(ctx context.Context, id string) (domain.Account, error)
 }
 
+// SNAccountService defines the account operations backed by the ServiceNow data source.
+type SNAccountService interface {
+	// SearchAccounts returns a paginated list of ServiceNow accounts matching the
+	// filters in req. An UnauthorizedError is returned when x-user-id-token is absent.
+	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchSNAccountsResponse, error)
+	// GetAccountByID returns the ServiceNow account for the given UUID.
+	// An UnauthorizedError is returned when x-user-id-token is absent.
+	GetAccountByID(ctx context.Context, id string) (domain.SNAccount, error)
+}
+
 // ProjectService defines the operations available on the project entity.
 type ProjectService interface {
 	// SearchProjects returns a paginated list of projects that match the filters

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snAccountsResponse mirrors the Choreo POST /accounts/search response.
+type snAccountsResponse struct {
+	Accounts     []snAccount `json:"accounts"`
+	TotalRecords int         `json:"totalRecords"`
+	Offset       int         `json:"offset"`
+	Limit        int         `json:"limit"`
+}
+
+type snAccount struct {
+	ID               string  `json:"id"`
+	SfID             string  `json:"sfId"`
+	Name             string  `json:"name"`
+	SupportTier      string  `json:"supportTier"`
+	Region           *string `json:"region"`
+	ActivationDate   string  `json:"activationDate"`
+	DeactivationDate *string `json:"deactivationDate"`
+	OwnerID          string  `json:"ownerId"`
+	TechnicalOwnerID *string `json:"technicalOwnerId"`
+	HasAgent         bool    `json:"hasAgent"`
+	HasKbReferences  bool    `json:"hasKbReferences"`
+	CreatedOn        string  `json:"createdOn"`
+	UpdatedOn        string  `json:"updatedOn"`
+}
+
+// snAccountSearchPayload is the Choreo POST /accounts/search request body.
+type snAccountSearchPayload struct {
+	Filters    snAccountFilters    `json:"filters,omitempty"`
+	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snAccountFilters struct {
+	SearchQuery string `json:"searchQuery,omitempty"`
+}
+
+type snAccountService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowAccountService constructs an SNAccountService backed by the Choreo API.
+func NewServiceNowAccountService(client *integrationservice.Client) SNAccountService {
+	return &snAccountService{client: client}
+}
+
+func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchSNAccountsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchSNAccountsResponse{}, err
+	}
+	if err := validateSearchQuery(req.SearchQuery); err != nil {
+		return domain.SearchSNAccountsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchSNAccountsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snAccountSearchPayload{
+		Filters:    snAccountFilters{SearchQuery: req.SearchQuery},
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/accounts/search", token, payload)
+	if err != nil {
+		return domain.SearchSNAccountsResponse{}, err
+	}
+
+	var snResp snAccountsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchSNAccountsResponse{}, fmt.Errorf("sn accounts: parse response: %w", err)
+	}
+
+	accounts := make([]domain.SNAccount, 0, len(snResp.Accounts))
+	for _, a := range snResp.Accounts {
+		accounts = append(accounts, snAccountToDomain(a))
+	}
+
+	return domain.SearchSNAccountsResponse{
+		Accounts: accounts,
+		Total:    snResp.TotalRecords,
+		Limit:    req.Pagination.Limit,
+		Offset:   req.Pagination.Offset,
+		HasMore:  req.Pagination.Offset+len(accounts) < snResp.TotalRecords,
+	}, nil
+}
+
+func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domain.SNAccount, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.SNAccount{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SNAccount{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	raw, err := s.client.Get(ctx, "/accounts/"+uuidToSysid(id), token)
+	if err != nil {
+		return domain.SNAccount{}, err
+	}
+
+	var a snAccount
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return domain.SNAccount{}, fmt.Errorf("sn accounts: parse account response: %w", err)
+	}
+
+	return snAccountToDomain(a), nil
+}
+
+func snAccountToDomain(a snAccount) domain.SNAccount {
+	var deactivationDate *string
+	if a.DeactivationDate != nil && *a.DeactivationDate != "" {
+		deactivationDate = a.DeactivationDate
+	}
+
+	var technicalOwnerID *string
+	if a.TechnicalOwnerID != nil && *a.TechnicalOwnerID != "" {
+		uid := sysidToUUID(*a.TechnicalOwnerID)
+		technicalOwnerID = &uid
+	}
+
+	return domain.SNAccount{
+		ID:                  sysidToUUID(a.ID),
+		SfID:                a.SfID,
+		Name:                a.Name,
+		Tier:                strings.ToLower(a.SupportTier),
+		Region:              a.Region,
+		ActivationDate:      a.ActivationDate,
+		DeactivationDate:    deactivationDate,
+		OwnerID:             sysidToUUID(a.OwnerID),
+		TechnicalOwnerID:    technicalOwnerID,
+		AgentEnabled:        a.HasAgent,
+		KbReferencesEnabled: a.HasKbReferences,
+		CreatedOn:           a.CreatedOn,
+		UpdatedOn:           a.UpdatedOn,
+	}
+}


### PR DESCRIPTION
## Summary

- Introduce `SNAccount` domain type with string date fields to avoid `time.Parse` failures when ServiceNow returns empty strings for timestamp fields
- Add `SNAccountService` interface and `snAccountService` implementation backed by the Choreo API
- Add `SNAccountHandler` and wire it alongside the existing Postgres `AccountHandler` using the same conditional pattern as `snProductHandler`/`snUserHandler`
- Tighten CSM backend `GetAccount` to reject non-UUID path params with a `400` using `uuidRe`; update tests to use real UUIDs throughout

## Test plan

- [x] `POST /accounts/search` returns `SNAccount` list with string dates when `DATA_SOURCE=servicenow`
- [x] `GET /accounts/{id}` resolves sysid → UUID on the way out; rejects non-UUID IDs with 400
- [x] Postgres path unchanged — `AccountHandler` still wired when `DATA_SOURCE` is not `servicenow`
- [x] `go test ./...` passes in both entity service and CSM backend
- [x] CSM backend `GetAccount` returns `400` for empty or non-UUID account ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ServiceNow-backed account search and account detail support.
  * Account endpoints now route to the appropriate backend automatically based on deployment settings.

* **Bug Fixes**
  * Improved account ID validation so invalid UUIDs are rejected with clearer bad-request errors.
  * Updated account lookup behavior to return consistent error handling when upstream requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->