### PR TITLE
ci: add auto-label-assign workflow to main so pull_request_target fires

### DIFF
--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Auto Label and Assign PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  auto-label-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Apply labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const prNumber = pr.number;
+
+            // Fetch all changed files (handles PRs with >30 files via pagination)
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: prNumber, per_page: 100 }
+            );
+            const filenames = files.map(f => f.filename);
+            core.info(`Changed files:\n${filenames.join('\n')}`);
+
+            // Label rules — order does not matter, all matching labels are applied
+            const labelRules = [
+              { label: 'App/CSM Portal',       test: f => f.startsWith('apps/csm-portal/') },
+              { label: 'App/Customer Portal',  test: f => f.startsWith('apps/customer-portal/') },
+              { label: 'Area/Frontend',        test: f => /^apps\/[^/]+\/webapp\//.test(f) },
+              { label: 'Area/Backend',         test: f => /^apps\/[^/]+\/backend\//.test(f) },
+              { label: 'Platform/Microapp',    test: f => /^apps\/[^/]+\/microapp\//.test(f) },
+              { label: 'Platform/Web',         test: f => /^apps\/[^/]+\/webapp\//.test(f) },
+              { label: 'Entity Service',       test: f => f.startsWith('entity-service/') },
+            ];
+
+            const labelsToApply = labelRules
+              .filter(({ test }) => filenames.some(test))
+              .map(({ label }) => label);
+
+            core.info(`Labels to apply: ${labelsToApply.join(', ') || '(none)'}`);
+
+            if (labelsToApply.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: labelsToApply,
+              });
+            }
+
+      - name: Assign PR author
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: pr.number,
+              assignees: [pr.user.login],
+            });
+            core.info(`Assigned: ${pr.user.login}`);


### PR DESCRIPTION
## Summary

The `pull_request_target` event requires the workflow file to exist on the repository's **default branch** (`main`) to trigger on PRs opened from forks. The workflow was previously only on `v2`, which is why it was never firing.

This PR adds the exact same `auto-label-assign.yml` from `v2` to `main` with no changes.

## Test plan

- [ ] Open a new PR from a fork targeting `v2` — the Auto Label and Assign PR workflow should now appear under Checks and apply labels automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)