### PR TITLE
[Customer Portal Web app] Hide Technical Owner row when email is not set

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/project-overview/contact-info/ContactInfoCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/project-overview/contact-info/ContactInfoCard.tsx
@@ -47,12 +47,14 @@ const ContactInfoCard = ({
     });
   }
 
-  contacts.push({
-    role: "Technical Owner",
-    email: project?.account?.technicalOwnerEmail || null,
-    icon: Shield,
-    bgColor: colors.purple[400],
-  });
+  if (project?.account?.technicalOwnerEmail) {
+    contacts.push({
+      role: "Technical Owner",
+      email: project.account.technicalOwnerEmail,
+      icon: Shield,
+      bgColor: colors.purple[400],
+    });
+  }
 
   const renderContactSkeleton = () => (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>


### PR DESCRIPTION
## Summary

- Technical Owner row in the Contact Information card was always rendered, displaying "Not Available" when technicalOwnerEmail is null
- Now the row is only rendered when technicalOwnerEmail has a value, consistent with how Account Manager is already handled
- If neither contact email is set, the card falls back to "No contact information available"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The project contact section now only shows a Technical Owner entry when an email is available, avoiding empty or placeholder contact details.
  * Improved contact display accuracy on project overview pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->