### PR TITLE
[Customer Portal Web App] Prevent Contact Information card content from being clipped by height constraints

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/project-overview/contact-info/ContactInfoCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/project-overview/contact-info/ContactInfoCard.tsx
@@ -67,7 +67,7 @@ const ContactInfoCard = ({
   );
 
   return (
-    <Card sx={{ height: "100%" }}>
+    <Card>
       <CardContent sx={{ p: 3, overflow: "auto" }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           <Users size={20} />

--- a/apps/customer-portal/webapp/src/features/project-details/components/project-overview/service-hours-allocations/ServiceHoursAllocationsCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/project-overview/service-hours-allocations/ServiceHoursAllocationsCard.tsx
@@ -62,11 +62,10 @@ export default function ServiceHoursAllocationsCard({
   const hideOnboardingSection = shouldHideOnboardingData(project?.onboardingStatus);
 
   return (
-    <Card sx={{ height: "100%" }}>
+    <Card>
       <CardContent
         sx={{
           p: 3,
-          height: "100%",
           display: "flex",
           flexDirection: "column",
           gap: 3,

--- a/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
@@ -169,7 +169,7 @@ export default function ProjectDetails(): JSX.Element {
                 />
               </Grid>
               <Grid size={{ xs: 12, md: 6 }}>
-                <Box sx={{ display: "flex", flexDirection: "column", gap: 3, height: "100%" }}>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
                   <ContactInfoCard
                     project={project}
                     isLoading={(isDetailsLoading || !project) && !projectError}


### PR DESCRIPTION
### Summary

- The right column `Box` in `ProjectDetails` had `height: "100%"` which forced both stacked cards (`ContactInfoCard` and `ServiceHoursAllocationsCard`) to compete for a fixed height matching the left column
- Both cards also had `height: "100%"` on their Card and CardContent, causing ContactInfoCard to clip its bottom content — the Technical Owner avatar and email row were hidden when the card ran out of allocated height
- Removed height: "100%" from the right column Box, `ContactInfoCard's` `Card`, and `ServiceHoursAllocationsCard's` `Card/CardContent` so each card sizes naturally to its content