### PR TITLE
[CSM Portal] feat(entity-service): add POST /cases/{id}/github-issues (SN data source)

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1057,6 +1057,52 @@ type SearchCaseCommentsResponse struct {
 	HasMore  bool          `json:"hasMore"`
 }
 
+// CaseGithubIssueReason classifies why a GitHub issue is being filed from a case.
+type CaseGithubIssueReason string
+
+const (
+	CaseGithubIssueReasonDefault   CaseGithubIssueReason = "default"
+	CaseGithubIssueReasonMigration CaseGithubIssueReason = "migration"
+	CaseGithubIssueReasonRDTicket  CaseGithubIssueReason = "rd_ticket"
+)
+
+// CaseGithubIssueRepoOverride explicitly overrides the product-based repo
+// routing lookup for a GitHub issue.
+type CaseGithubIssueRepoOverride struct {
+	Owner string `json:"owner"`
+	Repo  string `json:"repo"`
+}
+
+// CreateCaseGithubIssueRequest is the input for POST /cases/{id}/github-issues.
+// CaseID is populated from the URL path parameter and is not part of the JSON body.
+// Supported by the ServiceNow data source only.
+type CreateCaseGithubIssueRequest struct {
+	CaseID         string                       `json:"-"`
+	Reason         CaseGithubIssueReason        `json:"reason"`
+	Title          string                       `json:"title"`
+	Description    string                       `json:"description"`
+	RepoOverride   *CaseGithubIssueRepoOverride `json:"repoOverride,omitempty"`
+	UpdateLevel    *string                      `json:"updateLevel,omitempty"`
+	PublicIssueURL *string                      `json:"publicIssueUrl,omitempty"`
+	Regression     bool                         `json:"regression,omitempty"`
+	HotFixRequired bool                         `json:"hotFixRequired,omitempty"`
+	IssueTypeLabel *string                      `json:"issueTypeLabel,omitempty"`
+	PriorityLevel  *string                      `json:"priorityLevel,omitempty"`
+}
+
+// CaseGithubIssueDetail holds the result of filing a GitHub issue from a case.
+type CaseGithubIssueDetail struct {
+	URL    string `json:"url"`
+	Number int    `json:"number"`
+	Repo   string `json:"repo"`
+}
+
+// CreateCaseGithubIssueResponse is the response for POST /cases/{id}/github-issues.
+type CreateCaseGithubIssueResponse struct {
+	Message string                `json:"message"`
+	Issue   CaseGithubIssueDetail `json:"issue"`
+}
+
 // Attachment represents a file attachment linked to a reference entity.
 type Attachment struct {
 	ID            string        `json:"id"`

--- a/entity-service/internal/handler/case_github_issue_handler.go
+++ b/entity-service/internal/handler/case_github_issue_handler.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package handler is declared in user_handler.go.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// CaseGithubIssueHandler handles HTTP requests for filing a GitHub issue from a case.
+type CaseGithubIssueHandler struct {
+	svc service.CaseGithubIssueService
+}
+
+// NewCaseGithubIssueHandler constructs a CaseGithubIssueHandler with the given service.
+func NewCaseGithubIssueHandler(svc service.CaseGithubIssueService) *CaseGithubIssueHandler {
+	return &CaseGithubIssueHandler{svc: svc}
+}
+
+// CreateCaseGithubIssue handles POST /cases/{id}/github-issues.
+func (h *CaseGithubIssueHandler) CreateCaseGithubIssue(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		apierror.WriteJSON(w, http.StatusBadRequest, "case ID is required")
+		return
+	}
+
+	var req domain.CreateCaseGithubIssueRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.CaseID = id
+
+	resp, err := h.svc.CreateCaseGithubIssue(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -111,6 +111,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		callRequestHandler = handler.NewCallRequestHandler(service.NewServiceNowCallRequestService(serviceNowIntegrationServiceClient))
 	}
 
+	var caseGithubIssueHandler *handler.CaseGithubIssueHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		caseGithubIssueHandler = handler.NewCaseGithubIssueHandler(service.NewServiceNowCaseGithubIssueService(serviceNowIntegrationServiceClient))
+	}
+
 	var changeRequestHandler *handler.ChangeRequestHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		changeRequestHandler = handler.NewChangeRequestHandler(service.NewServiceNowChangeRequestService(serviceNowIntegrationServiceClient))
@@ -182,6 +187,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)
 		mux.HandleFunc("POST /call-requests/search", callRequestHandler.SearchCallRequests)
 		mux.HandleFunc("PATCH /call-requests/{id}", callRequestHandler.PatchCallRequest)
+	}
+
+	if caseGithubIssueHandler != nil {
+		mux.HandleFunc("POST /cases/{id}/github-issues", caseGithubIssueHandler.CreateCaseGithubIssue)
 	}
 
 	if changeRequestHandler != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -171,6 +171,15 @@ type CaseService interface {
 	DeleteCaseAttachment(ctx context.Context, req domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error)
 }
 
+// CaseGithubIssueService defines the operation for filing a GitHub issue from a case.
+// All methods require the ServiceNow data source; there is no Postgres fallback.
+type CaseGithubIssueService interface {
+	// CreateCaseGithubIssue files a new GitHub issue on the internal repo mapped to the
+	// case's product, and appends a work note on the case with the resulting issue URL.
+	// A ValidationError is returned for invalid input; a NotFoundError if no case matches.
+	CreateCaseGithubIssue(ctx context.Context, req domain.CreateCaseGithubIssueRequest) (domain.CreateCaseGithubIssueResponse, error)
+}
+
 // CatalogService defines the operations available on service catalogs.
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type CatalogService interface {

--- a/entity-service/internal/service/sn_case_github_issue_service.go
+++ b/entity-service/internal/service/sn_case_github_issue_service.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// validCaseGithubIssueReasons is the set of accepted CaseGithubIssueReason values.
+var validCaseGithubIssueReasons = map[domain.CaseGithubIssueReason]struct{}{
+	domain.CaseGithubIssueReasonDefault:   {},
+	domain.CaseGithubIssueReasonMigration: {},
+	domain.CaseGithubIssueReasonRDTicket:  {},
+}
+
+// snCaseGithubIssueRepoOverride mirrors CaseGithubIssueRepoOverride in the SN integration service payload.
+type snCaseGithubIssueRepoOverride struct {
+	Owner string `json:"owner"`
+	Repo  string `json:"repo"`
+}
+
+// snCaseGithubIssueCreatePayload mirrors POST /cases/{id}/github-issues in the SN integration service.
+type snCaseGithubIssueCreatePayload struct {
+	Reason         domain.CaseGithubIssueReason   `json:"reason"`
+	Title          string                         `json:"title"`
+	Description    string                         `json:"description"`
+	RepoOverride   *snCaseGithubIssueRepoOverride `json:"repoOverride,omitempty"`
+	UpdateLevel    *string                        `json:"updateLevel,omitempty"`
+	PublicIssueURL *string                        `json:"publicIssueUrl,omitempty"`
+	Regression     bool                           `json:"regression,omitempty"`
+	HotFixRequired bool                           `json:"hotFixRequired,omitempty"`
+	IssueTypeLabel *string                        `json:"issueTypeLabel,omitempty"`
+	PriorityLevel  *string                        `json:"priorityLevel,omitempty"`
+}
+
+// snCaseGithubIssueCreateResponse mirrors the SN integration service POST /cases/{id}/github-issues response.
+type snCaseGithubIssueCreateResponse struct {
+	Message string `json:"message"`
+	Issue   struct {
+		URL    string `json:"url"`
+		Number int    `json:"number"`
+		Repo   string `json:"repo"`
+	} `json:"issue"`
+}
+
+type snCaseGithubIssueService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowCaseGithubIssueService constructs a CaseGithubIssueService backed by the SN integration service.
+func NewServiceNowCaseGithubIssueService(client *integrationservice.Client) CaseGithubIssueService {
+	return &snCaseGithubIssueService{client: client}
+}
+
+// CreateCaseGithubIssue implements CaseGithubIssueService.
+func (s *snCaseGithubIssueService) CreateCaseGithubIssue(ctx context.Context, req domain.CreateCaseGithubIssueRequest) (domain.CreateCaseGithubIssueResponse, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.CreateCaseGithubIssueResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	if req.CaseID == "" {
+		return domain.CreateCaseGithubIssueResponse{}, &apierror.ValidationError{Msg: "case ID is required"}
+	}
+	if err := validateUUIDs("caseId", []string{req.CaseID}); err != nil {
+		return domain.CreateCaseGithubIssueResponse{}, err
+	}
+	if _, ok := validCaseGithubIssueReasons[req.Reason]; !ok {
+		return domain.CreateCaseGithubIssueResponse{}, &apierror.ValidationError{Msg: "reason contains invalid value: " + string(req.Reason)}
+	}
+	if req.Title == "" {
+		return domain.CreateCaseGithubIssueResponse{}, &apierror.ValidationError{Msg: "title is required"}
+	}
+	if req.Description == "" {
+		return domain.CreateCaseGithubIssueResponse{}, &apierror.ValidationError{Msg: "description is required"}
+	}
+	if req.RepoOverride != nil && (req.RepoOverride.Owner == "" || req.RepoOverride.Repo == "") {
+		return domain.CreateCaseGithubIssueResponse{}, &apierror.ValidationError{Msg: "repoOverride requires both owner and repo"}
+	}
+
+	payload := snCaseGithubIssueCreatePayload{
+		Reason:         req.Reason,
+		Title:          req.Title,
+		Description:    req.Description,
+		UpdateLevel:    req.UpdateLevel,
+		PublicIssueURL: req.PublicIssueURL,
+		Regression:     req.Regression,
+		HotFixRequired: req.HotFixRequired,
+		IssueTypeLabel: req.IssueTypeLabel,
+		PriorityLevel:  req.PriorityLevel,
+	}
+	if req.RepoOverride != nil {
+		payload.RepoOverride = &snCaseGithubIssueRepoOverride{
+			Owner: req.RepoOverride.Owner,
+			Repo:  req.RepoOverride.Repo,
+		}
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/"+uuidToSysid(req.CaseID)+"/github-issues", token, payload)
+	if err != nil {
+		return domain.CreateCaseGithubIssueResponse{}, err
+	}
+
+	var snResp snCaseGithubIssueCreateResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CreateCaseGithubIssueResponse{}, fmt.Errorf("sn create case github issue: parse response: %w", err)
+	}
+
+	return domain.CreateCaseGithubIssueResponse{
+		Message: snResp.Message,
+		Issue: domain.CaseGithubIssueDetail{
+			URL:    snResp.Issue.URL,
+			Number: snResp.Issue.Number,
+			Repo:   snResp.Issue.Repo,
+		},
+	}, nil
+}

--- a/entity-service/internal/service/sn_case_github_issue_service_test.go
+++ b/entity-service/internal/service/sn_case_github_issue_service_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+)
+
+// contextWithUserIDToken builds a context carrying the given x-user-id-token,
+// going through the real middleware so the private context key stays
+// encapsulated in the middleware package.
+func contextWithUserIDToken(token string) context.Context {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	if token != "" {
+		req.Header.Set("x-user-id-token", token)
+	}
+	var captured context.Context
+	middleware.UserIDToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Context()
+	})).ServeHTTP(httptest.NewRecorder(), req)
+	return captured
+}
+
+func TestSNCaseGithubIssueService_CreateCaseGithubIssue_Validation(t *testing.T) {
+	validCaseID := "11111111-1111-1111-1111-111111111111"
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		req     domain.CreateCaseGithubIssueRequest
+		wantErr any // pointer type to assert via errors.As-style type switch below
+	}{
+		{
+			name: "missing token",
+			ctx:  context.Background(),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      validCaseID,
+				Reason:      domain.CaseGithubIssueReasonDefault,
+				Title:       "t",
+				Description: "d",
+			},
+			wantErr: &apierror.UnauthorizedError{},
+		},
+		{
+			name: "empty case ID",
+			ctx:  contextWithUserIDToken("token"),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      "",
+				Reason:      domain.CaseGithubIssueReasonDefault,
+				Title:       "t",
+				Description: "d",
+			},
+			wantErr: &apierror.ValidationError{},
+		},
+		{
+			name: "invalid case ID format",
+			ctx:  contextWithUserIDToken("token"),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      "not-a-uuid",
+				Reason:      domain.CaseGithubIssueReasonDefault,
+				Title:       "t",
+				Description: "d",
+			},
+			wantErr: &apierror.ValidationError{},
+		},
+		{
+			name: "invalid reason",
+			ctx:  contextWithUserIDToken("token"),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      validCaseID,
+				Reason:      "not_a_reason",
+				Title:       "t",
+				Description: "d",
+			},
+			wantErr: &apierror.ValidationError{},
+		},
+		{
+			name: "missing title",
+			ctx:  contextWithUserIDToken("token"),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      validCaseID,
+				Reason:      domain.CaseGithubIssueReasonDefault,
+				Title:       "",
+				Description: "d",
+			},
+			wantErr: &apierror.ValidationError{},
+		},
+		{
+			name: "missing description",
+			ctx:  contextWithUserIDToken("token"),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      validCaseID,
+				Reason:      domain.CaseGithubIssueReasonDefault,
+				Title:       "t",
+				Description: "",
+			},
+			wantErr: &apierror.ValidationError{},
+		},
+		{
+			name: "repoOverride missing repo",
+			ctx:  contextWithUserIDToken("token"),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      validCaseID,
+				Reason:      domain.CaseGithubIssueReasonDefault,
+				Title:       "t",
+				Description: "d",
+				RepoOverride: &domain.CaseGithubIssueRepoOverride{
+					Owner: "wso2-enterprise",
+					Repo:  "",
+				},
+			},
+			wantErr: &apierror.ValidationError{},
+		},
+		{
+			name: "repoOverride missing owner",
+			ctx:  contextWithUserIDToken("token"),
+			req: domain.CreateCaseGithubIssueRequest{
+				CaseID:      validCaseID,
+				Reason:      domain.CaseGithubIssueReasonDefault,
+				Title:       "t",
+				Description: "d",
+				RepoOverride: &domain.CaseGithubIssueRepoOverride{
+					Owner: "",
+					Repo:  "wso2-apim-internal",
+				},
+			},
+			wantErr: &apierror.ValidationError{},
+		},
+	}
+
+	// client is intentionally nil: every case above must fail validation
+	// before the service ever touches s.client.Post.
+	svc := NewServiceNowCaseGithubIssueService(nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.CreateCaseGithubIssue(tt.ctx, tt.req)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			switch tt.wantErr.(type) {
+			case *apierror.UnauthorizedError:
+				if _, ok := err.(*apierror.UnauthorizedError); !ok {
+					t.Fatalf("expected *apierror.UnauthorizedError, got %T: %v", err, err)
+				}
+			case *apierror.ValidationError:
+				if _, ok := err.(*apierror.ValidationError); !ok {
+					t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+				}
+			}
+		})
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -663,6 +663,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/{id}/github-issues:
+    post:
+      summary: File a GitHub issue against a product's internal repo from a support case (ServiceNow data source only).
+      operationId: createCaseGithubIssue
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCaseGithubIssueRequest'
+      responses:
+        "201":
+          description: GitHub issue created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateCaseGithubIssueResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /attachments:
     post:
       summary: Upload a file attachment to a support case.
@@ -3735,6 +3784,74 @@ components:
               type: string
             state:
               $ref: '#/components/schemas/CallRequestState'
+
+    CaseGithubIssueRepoOverride:
+      type: object
+      required: [owner, repo]
+      additionalProperties: false
+      properties:
+        owner:
+          type: string
+          description: GitHub org/owner, overriding the product-based routing lookup.
+        repo:
+          type: string
+          description: GitHub repo, overriding the product-based routing lookup.
+
+    CreateCaseGithubIssueRequest:
+      type: object
+      required: [reason, title, description]
+      additionalProperties: false
+      properties:
+        reason:
+          type: string
+          enum: [default, migration, rd_ticket]
+          description: Why the issue is being filed; selects labels applied on the GitHub issue.
+        title:
+          type: string
+          description: GitHub issue title.
+        description:
+          type: string
+          description: GitHub issue body. Case number, product, and reporter are appended server-side.
+        repoOverride:
+          $ref: '#/components/schemas/CaseGithubIssueRepoOverride'
+        updateLevel:
+          type: string
+          description: Product update level, appended to the issue body.
+        publicIssueUrl:
+          type: string
+          description: Link to a related public-facing GitHub issue, appended to the issue body.
+        regression:
+          type: boolean
+          default: false
+          description: Whether this is a regression; adds a "regression" label and tags the case.
+        hotFixRequired:
+          type: boolean
+          default: false
+          description: Whether a hotfix is required; appended to the issue body.
+        issueTypeLabel:
+          type: string
+          description: Issue-type label to apply on GitHub (e.g. "Type/Patch", "Type/Incident").
+        priorityLevel:
+          type: string
+          description: Priority label to apply when issueTypeLabel is "Type/Incident".
+
+    CaseGithubIssueDetail:
+      type: object
+      properties:
+        url:
+          type: string
+        number:
+          type: integer
+        repo:
+          type: string
+
+    CreateCaseGithubIssueResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        issue:
+          $ref: '#/components/schemas/CaseGithubIssueDetail'
 
     SearchCallRequestsRequest:
       type: object


### PR DESCRIPTION
## Summary
- Adds `POST /cases/{id}/github-issues` to the entity-service, letting a CS agent file a GitHub issue against a product's internal repo directly from a case.
- ServiceNow data source only — new `CaseGithubIssueService` interface (mirrors `CallRequestService`/`CatalogService`: no Postgres fallback, since there's no Postgres equivalent and no GitHub-repo routing data on Postgres cases).
- Calls a new SN Scripted REST operation on the existing `x_wso2_customer_0` `Cases` API, which consolidates 3 of 5 duplicated legacy Agent Workspace UI Actions ("Open Git Issue", "Open Migration Git Issue", "Open R&D ticket") into one parameterized endpoint. No new external dependency — same Choreo-fronted SN base URL every other case action already uses.
- Request supports `reason` (`default`/`migration`/`rd_ticket`), `title`, `description`, `repoOverride`, and the fields the legacy flows collected but a first pass of this change initially dropped: `updateLevel`, `publicIssueUrl`, `regression`, `hotFixRequired`, `issueTypeLabel`, `priorityLevel`.
- `openapi.yaml` documents the new path and schemas.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] SN-side operation verified directly (bypassing entity-service): auth/role gate, field validation, case-access check, case-state gate, and product-routing resolution all confirmed via test calls against the dev tenant
- [ ] End-to-end through this entity-service function against the live SN dev tenant (not yet run — the SN-side outbound GitHub call is currently blocked by an expired PAT on `InternalGitHubIssues`'s Basic-auth profile, a pre-existing credential issue unrelated to this change, affecting all five legacy flows too)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to create a GitHub issue from a support case.
  * Support now includes issue details such as title, description, labels, priority, regression/hotfix flags, and optional repository overrides.
  * Responses now return the created issue’s link, number, and repository.

* **Bug Fixes**
  * Improved validation and error handling for missing case IDs, invalid input, unauthorized access, and not-found cases.

* **Documentation**
  * Updated the API specification with the new request and response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->