### PR TITLE
ci: add Type/* label from PR title and clarify customer portal coverage

### DIFF
--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -65,12 +65,12 @@ jobs:
             // Strips leading [TAG] prefixes (e.g. "[CSM][Web] fix: ...") before matching.
             const titleBody = pr.title.toLowerCase().trim().replace(/^(\[[^\]]*\]\s*)+/, '');
             const typeRules = [
-              { label: 'Type/Bug',         pattern: /^fix[:(]/ },
-              { label: 'Type/New Feature', pattern: /^feat[:(]/ },
-              { label: 'Type/Improvement', pattern: /^(perf|improve)[:(]/ },
-              { label: 'Type/Docs',        pattern: /^docs?[:(]/ },
-              { label: 'Type/UX',          pattern: /^ux[:(]/ },
-              { label: 'Type/Task',        pattern: /^(chore|ci|refactor|build|test)[:(]/ },
+              { label: 'Type/Bug',         pattern: /^fix[:(!]/ },
+              { label: 'Type/New Feature', pattern: /^feat[:(!]/ },
+              { label: 'Type/Improvement', pattern: /^(perf|improve)[:(!]/ },
+              { label: 'Type/Docs',        pattern: /^docs?[:(!]/ },
+              { label: 'Type/UX',          pattern: /^ux[:(!]/ },
+              { label: 'Type/Task',        pattern: /^(chore|ci|refactor|build|test)[:(!]/ },
             ];
             const typeLabel = typeRules.find(r => r.pattern.test(titleBody))?.label;
             if (typeLabel) labelsToApply.push(typeLabel);

--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -45,20 +45,35 @@ jobs:
             const filenames = files.map(f => f.filename);
             core.info(`Changed files:\n${filenames.join('\n')}`);
 
-            // Label rules — order does not matter, all matching labels are applied
-            const labelRules = [
-              { label: 'App/CSM Portal',       test: f => f.startsWith('apps/csm-portal/') },
-              { label: 'App/Customer Portal',  test: f => f.startsWith('apps/customer-portal/') },
-              { label: 'Area/Frontend',        test: f => /^apps\/[^/]+\/webapp\//.test(f) },
-              { label: 'Area/Backend',         test: f => /^apps\/[^/]+\/backend\//.test(f) },
-              { label: 'Platform/Microapp',    test: f => /^apps\/[^/]+\/microapp\//.test(f) },
-              { label: 'Platform/Web',         test: f => /^apps\/[^/]+\/webapp\//.test(f) },
-              { label: 'Entity Service',       test: f => f.startsWith('entity-service/') },
+            // App labels — applied when any file under the app changes
+            // Area/Platform labels — generic across all apps (covers both CSM Portal and Customer Portal)
+            const fileRules = [
+              { label: 'App/CSM Portal',      test: f => f.startsWith('apps/csm-portal/') },
+              { label: 'App/Customer Portal', test: f => f.startsWith('apps/customer-portal/') },
+              { label: 'Area/Backend',        test: f => /^apps\/[^/]+\/backend\//.test(f) },
+              { label: 'Area/Frontend',       test: f => /^apps\/[^/]+\/webapp\//.test(f) },
+              { label: 'Platform/Microapp',   test: f => /^apps\/[^/]+\/microapp\//.test(f) },
+              { label: 'Platform/Web',        test: f => /^apps\/[^/]+\/webapp\//.test(f) },
+              { label: 'Entity Service',      test: f => f.startsWith('entity-service/') },
             ];
 
-            const labelsToApply = labelRules
+            const labelsToApply = fileRules
               .filter(({ test }) => filenames.some(test))
               .map(({ label }) => label);
+
+            // Type label — inferred from the conventional-commit prefix in the PR title.
+            // Strips leading [TAG] prefixes (e.g. "[CSM][Web] fix: ...") before matching.
+            const titleBody = pr.title.toLowerCase().trim().replace(/^(\[[^\]]*\]\s*)+/, '');
+            const typeRules = [
+              { label: 'Type/Bug',         pattern: /^fix[:(]/ },
+              { label: 'Type/New Feature', pattern: /^feat[:(]/ },
+              { label: 'Type/Improvement', pattern: /^(perf|improve)[:(]/ },
+              { label: 'Type/Docs',        pattern: /^docs?[:(]/ },
+              { label: 'Type/UX',          pattern: /^ux[:(]/ },
+              { label: 'Type/Task',        pattern: /^(chore|ci|refactor|build|test)[:(]/ },
+            ];
+            const typeLabel = typeRules.find(r => r.pattern.test(titleBody))?.label;
+            if (typeLabel) labelsToApply.push(typeLabel);
 
             core.info(`Labels to apply: ${labelsToApply.join(', ') || '(none)'}`);
 


### PR DESCRIPTION
## Summary

- **Type label from PR title** — detects the conventional-commit prefix (strips leading `[TAG]` prefixes like `[CSM][Web]`) and applies the matching `Type/*` label automatically:

  | Title prefix | Label |
  |---|---|
  | `fix:` / `fix(…):` | `Type/Bug` |
  | `feat:` / `feat(…):` | `Type/New Feature` |
  | `perf:` / `improve:` | `Type/Improvement` |
  | `docs:` | `Type/Docs` |
  | `ux:` | `Type/UX` |
  | `chore:` / `ci:` / `refactor:` / `build:` / `test:` | `Type/Task` |

- **Customer Portal coverage** — no new rules needed; `Area/Backend`, `Area/Frontend`, `Platform/Web`, and `Platform/Microapp` are generic and already cover both CSM Portal and Customer Portal. Added a comment to make this explicit.

## Test plan

- [ ] Open a PR with title `[CSM][BE] fix: ...` → `Type/Bug` label applied
- [ ] Open a PR with title `feat: add new endpoint` → `Type/New Feature` label applied
- [ ] Open a PR touching `apps/customer-portal/backend/` → `App/Customer Portal` + `Area/Backend` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic PR labeling to apply both area-based labels from changed files and type labels inferred from the PR title.
  * PRs now more consistently receive relevant labels such as feature, fix, docs, and test categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->