### PR TITLE
[Customer Portal MicroApp] Submit Novera chat only via send button, not Enter key

### DIFF
--- a/apps/customer-portal/microapp/src/components/features/detail/StickyCommentBar.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/StickyCommentBar.tsx
@@ -26,6 +26,7 @@ interface StickyCommentBarProps {
   bottomSlot?: ReactNode;
   loading?: boolean;
   disabled?: boolean;
+  submitOnEnter?: boolean;
 
   onChange: (value: string) => void;
   onSend: () => void;
@@ -38,6 +39,7 @@ export function StickyCommentBar({
   bottomSlot,
   loading = false,
   disabled = false,
+  submitOnEnter = true,
   onChange,
   onSend,
 }: StickyCommentBarProps) {
@@ -50,7 +52,7 @@ export function StickyCommentBar({
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Enter" && hasContent) {
+    if (submitOnEnter && event.key === "Enter" && hasContent) {
       event.preventDefault();
       send();
     }

--- a/apps/customer-portal/microapp/src/pages/ChatPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatPage.tsx
@@ -289,6 +289,7 @@ export default function ChatPage() {
         loading={!!activeStreamingMessage}
         value={comment}
         placeholder="Type your message"
+        submitOnEnter={false}
         onChange={setComment}
         onSend={handleSend}
         topSlot={


### PR DESCRIPTION
## Summary
- Novera chat (ChatPage) previously submitted on Enter keypress, which was unintentional/unwanted for this flow
- Added an opt-in `submitOnEnter` prop to `StickyCommentBar` (defaults to `true`) so behavior can be scoped per usage without affecting other consumers
- Set `submitOnEnter={false}` on the Novera `ChatPage` usage; all other `StickyCommentBar` consumers (Case, Engagement, Service, Security Report Analysis detail pages) are unaffected

## Test plan
- [ ] Open Novera chat, type a message, press Enter — verify nothing happens (no submit)
- [ ] Tap the send button — verify message submits
- [ ] Spot-check one other `StickyCommentBar` consumer (e.g. Case detail comments) to confirm Enter-to-submit still works there


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether pressing Enter submits a comment in the sticky comment bar.
  * Updated the chat page so Enter no longer sends a message there, while the send button still works as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->