### PR TITLE
[Customer Portal Webapp] Prevent Add Product dropdown from capping at 20 items on scroll

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/AddProductModal.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/AddProductModal.tsx
@@ -90,10 +90,18 @@ export default function AddProductModal({
   const accumulatedProductsLengthRef = useRef(0);
   const accumulatedVersionsLengthRef = useRef(0);
 
+  const productsRef = useRef<ProductItem[]>([]);
+  const versionsRef = useRef<ProductVersionItem[]>([]);
+
   useLayoutEffect(() => {
+    productsRef.current = products;
     accumulatedProductsLengthRef.current = products.length;
+  }, [products]);
+
+  useLayoutEffect(() => {
+    versionsRef.current = versions;
     accumulatedVersionsLengthRef.current = versions.length;
-  }, [products, versions]);
+  }, [versions]);
 
   const resetModalState = useCallback(() => {
     setForm({ ...ADD_PRODUCT_MODAL_INITIAL_FORM });
@@ -173,7 +181,7 @@ export default function AddProductModal({
       return;
     }
 
-    const prevProducts = products;
+    const prevProducts = productsRef.current;
     const prevProductIds = new Set(
       prevProducts.map((p) => p.id).filter((id): id is string => Boolean(id)),
     );
@@ -196,7 +204,7 @@ export default function AddProductModal({
       applyServerProductsTotal();
     }
     setProducts([...prevProducts, ...newProductItems]);
-  }, [productsPage, products]);
+  }, [productsPage]);
 
   const productsTotalRecords = Number.isFinite(cachedProductsTotalRecords)
     ? (cachedProductsTotalRecords as number)
@@ -283,7 +291,7 @@ export default function AddProductModal({
       return;
     }
 
-    const prevVersions = versions;
+    const prevVersions = versionsRef.current;
     const prevVersionIds = new Set(
       prevVersions.map((v) => v.id).filter((id): id is string => Boolean(id)),
     );
@@ -306,7 +314,7 @@ export default function AddProductModal({
       applyServerVersionsTotal();
     }
     setVersions([...prevVersions, ...newVersionItems]);
-  }, [form.productId, versionsPage, versions]);
+  }, [form.productId, versionsPage]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const versionsTotalRecords = Number.isFinite(cachedVersionsTotalRecords)


### PR DESCRIPTION
## Summary

- The Product Name and Version dropdowns in the Add WSO2 Product modal stopped loading items beyond the second page (offset=10, ~20 items)
- Root cause: including `products`/`versions` state in the accumulation `useEffect` dependency array caused a re-run after each merge; the duplicate-ID guard found no new items and incorrectly set `totalRecords` to the current list length, blocking further scroll-triggered loads
- Fix: track the accumulated list via refs (`productsRef`, `versionsRef`) so the effect only fires when new API data arrives, not when state is updated

## Test plan

- [ ] Open the Add WSO2 Product modal on a deployment with >20 products
- [ ] Open the Product Name dropdown and scroll to the bottom — verify items beyond 20 load continuously until all 48 are shown
- [ ] Verify the Version dropdown has the same behaviour when a product with many versions is selected
- [ ] Confirm selecting a product and version still submits correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the add-product flow so paginated product and version lists load more reliably without duplicate recomputation or stale results.
  * Reduced unnecessary updates while merging additional pages, helping keep the modal more responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->