### PR TITLE
[CSM] tighten gosec README guidance

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -94,7 +94,7 @@ go install github.com/securego/gosec/v2/cmd/gosec@latest
 gosec -fmt=text ./...
 ```
 
-The scan should report **0 issues**. Each `// #nosec` annotation documents either a confirmed false positive (with the reason in the comment) or a finding where the vulnerability has been addressed in the same code block. Do not remove an annotation without re-running the scan, reading the cited reason, and verifying the mitigation still holds.
+The scan should report **0 issues**. If a new finding appears, fix the root cause before merging — do not suppress it without a code review.
 
 ## Configuration
 

--- a/entity-service/README.md
+++ b/entity-service/README.md
@@ -123,7 +123,7 @@ go install github.com/securego/gosec/v2/cmd/gosec@latest
 gosec -fmt=text ./...
 ```
 
-The scan should report **0 issues**. Each `// #nosec` annotation documents either a confirmed false positive (with the reason in the comment) or a finding where the vulnerability has been addressed in the same code block. Do not remove an annotation without re-running the scan, reading the cited reason, and verifying the mitigation still holds.
+The scan should report **0 issues**. If a new finding appears, fix the root cause before merging — do not suppress it without a code review.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Remove wording that explained the `#nosec` suppression mechanism from the Security Scanning section in both READMEs
- Replace with a single sentence: the scan should report 0 issues; fix the root cause before merging — do not suppress without a code review

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)