### PR TITLE
[Customer Portal MicroApp] fix: guard against invalid user timezone

### DIFF
--- a/apps/customer-portal/microapp/src/context/me/MeProvider.tsx
+++ b/apps/customer-portal/microapp/src/context/me/MeProvider.tsx
@@ -70,7 +70,8 @@ export default function MeProvider({ children }: { children: React.ReactNode }) 
         id: meData.id,
         roles: meData.roles,
         isAdmin: meData.roles.includes(ADMIN_USER_ROLE),
-        timezone: meData.timezone,
+        // ServiceNow returns "--None--" for unset choice fields; treat it as absent.
+        timezone: meData.timezone && meData.timezone !== "--None--" ? meData.timezone : undefined,
       }}
     >
       {children}

--- a/apps/customer-portal/microapp/src/utils/useDateTime.ts
+++ b/apps/customer-portal/microapp/src/utils/useDateTime.ts
@@ -8,9 +8,25 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(relativeTime);
 
+/**
+ * Returns the given timezone if it is a valid IANA identifier, otherwise
+ * falls back to the device timezone. Guards against placeholder values
+ * (e.g. ServiceNow's "--None--") that would make Intl/dayjs throw.
+ */
+const resolveTimezone = (timezone?: string): string => {
+  const fallback = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (!timezone) return fallback;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return timezone;
+  } catch {
+    return fallback;
+  }
+};
+
 export function useDateTime() {
   const { timezone } = useMe();
-  const tz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const tz = resolveTimezone(timezone);
 
   const toUtc = (date: Date | string) => {
     if (date instanceof Date) {

--- a/apps/customer-portal/microapp/src/utils/useDateTime.ts
+++ b/apps/customer-portal/microapp/src/utils/useDateTime.ts
@@ -13,12 +13,12 @@ dayjs.extend(relativeTime);
  * falls back to the device timezone. Guards against placeholder values
  * (e.g. ServiceNow's "--None--") that would make Intl/dayjs throw.
  */
-const resolveTimezone = (timezone?: string): string => {
+const resolveTimezone = (tz?: string): string => {
   const fallback = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  if (!timezone) return fallback;
+  if (!tz) return fallback;
   try {
-    Intl.DateTimeFormat(undefined, { timeZone: timezone });
-    return timezone;
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return tz;
   } catch {
     return fallback;
   }


### PR DESCRIPTION
The /me endpoint returns the ServiceNow placeholder "--None--" when a
user has no timezone set. This string passed the nullish check in
useDateTime and crashed dayjs.tz() with RangeError: invalid time zone,
causing every ItemCard on the Support page to hit the error boundary.

useDateTime: validate the timezone via Intl and fall back to the
device timezone when missing or invalid
MeProvider: normalize "--None--" to undefined at the data boundary