### PR TITLE
[Customer Portal MicroApp] fix: unreadable RichText content in dark mode

### DIFF
--- a/apps/customer-portal/microapp/src/components/shared/RichText.tsx
+++ b/apps/customer-portal/microapp/src/components/shared/RichText.tsx
@@ -52,6 +52,14 @@ export const RichTextBase = styled(Box)(({ theme }) => ({
     fontFamily: "inherit !important",
     lineHeight: "inherit !important",
   },
+
+  ...theme.applyStyles("dark", {
+    color: "#000",
+    filter: "invert(0.88) hue-rotate(180deg)",
+    "& *": { backgroundColor: "transparent !important" },
+    "& pre": { backgroundColor: "#ececec !important", color: "#000 !important" },
+    "& img": { filter: "invert(1) hue-rotate(180deg)" },
+  }),
 }));
 
 export const RichText = (props: React.ComponentProps<typeof RichTextBase>) => {

--- a/apps/customer-portal/microapp/src/components/shared/RichText.tsx
+++ b/apps/customer-portal/microapp/src/components/shared/RichText.tsx
@@ -55,10 +55,10 @@ export const RichTextBase = styled(Box)(({ theme }) => ({
 
   ...theme.applyStyles("dark", {
     color: "#000",
-    filter: "invert(0.88) hue-rotate(180deg)",
+    filter: "invert(1) hue-rotate(180deg) brightness(0.88)",
     "& *": { backgroundColor: "transparent !important" },
     "& pre": { backgroundColor: "#ececec !important", color: "#000 !important" },
-    "& img": { filter: "invert(1) hue-rotate(180deg)" },
+    "& img": { filter: "invert(1) hue-rotate(180deg) brightness(1.136)" }
   }),
 }));
 


### PR DESCRIPTION
## Problem

Case Activity Timeline comments (and other server-rendered HTML) were
invisible in dark mode - only spans with their own bright inline colors
(e.g. green code formatting) remained visible.

Root cause: comment bodies come from ServiceNow as HTML with inline
colors authored for a light background (e.g. `color: #000000`). In dark
mode the card background turns dark but the hardcoded dark text colors
remain, producing dark-on-dark text. `RichText` already normalized
inline font sizes but never handled colors.

## Fix

`components/shared/RichText.tsx`, dark mode only (via
`theme.applyStyles("dark", ...)` - required with CSS-vars theming,
where `theme.palette.mode` is always "light" inside styled callbacks):

- Render the content as light-authored (`color: #000`) and apply
  `filter: invert(0.88) hue-rotate(180deg)`, which flips lightness
  while preserving hue - black text becomes near-white, and author
  colors (green code spans, links) stay recognizable instead of being
  flattened to a single theme color.
- Inline background colors are neutralized; `pre` blocks get a light
  background that inverts into a dark code-block background.
- Images are counter-inverted so screenshots/photos render normally.

Light mode is untouched. Since `RichText` is shared, this also fixes
the same issue on service, engagement, security report analysis, and
announcement detail pages.

## Testing

- Dark mode (iOS simulator via the Developer micro-app): timeline text
  is readable; green code spans remain green; code blocks show a dark
  background; light mode rendering is unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rich text rendering in dark mode for better readability.
  * Adjusted text, code block, background, and image styling so nested content displays more consistently with dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->