### PR TITLE
[CSM Portal] fix(entity-service): lowercase workState in SN case search

### DIFF
--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1259,7 +1259,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		description := c.Description
 		severityLabel := snSeverityLabelStr(c.Severity)
 		issueTypeLabel := snIssueTypeLabelStr(c.IssueType)
-		workStateLabel := snLabelStr(c.WorkState)
+		workStateLabel := snWorkStateLabelStr(c.WorkState)
 		engagementTypeLabel := snLabelStr(c.EngagementType)
 
 		stateLabel := ""
@@ -1358,6 +1358,21 @@ func snLabelStr(l *snCaseLabel) *string {
 		return nil
 	}
 	return &l.Label
+}
+
+// snWorkStateLabelStr normalizes an SN work-state label to the lowercased
+// domain enum value ("ongoing"/"paused") as a string, or nil when absent or
+// unrecognised. The search view carries workState as a plain string, but it
+// must match the enum the detail endpoint returns (GET /cases/{id} maps via
+// snWorkStateLabelToEnum) so both paths agree on casing. Returning the raw SN
+// label here (e.g. "Ongoing") breaks clients that gate on the lowercased value.
+func snWorkStateLabelStr(ws *snCaseLabel) *string {
+	e := snWorkStateLabelToEnum(ws)
+	if e == nil {
+		return nil
+	}
+	s := string(*e)
+	return &s
 }
 
 // snCaseStateMap maps SN state labels (lowercased) to domain CaseState enums.


### PR DESCRIPTION
## Problem

The ServiceNow case mapping returns `workState` in two different casings:

- **Detail** (`GET /cases/{id}`): `snWorkStateLabelToEnum` lowercases the SN label → `"ongoing"` / `"paused"` (the documented domain enum).
- **Search** (`POST /cases/search`): `snLabelStr` returned the **raw** SN label verbatim → `"Ongoing"` / `"Paused"`.

Any client that gates on the lowercased enum value (e.g. the CSM portal's single-active-case check, which looks for the engineer's other `ongoing` cases via search) never matched a search result, because `"Ongoing" !== "ongoing"`. The search response also violated its own documented `workState` enum.

## Fix

Map the search view's `workState` through the same enum logic as the detail path, via a new `snWorkStateLabelStr` helper (returns nil for absent or unrecognised labels). Both paths now agree on casing.

## Scope

CSM Go entity-service only. This is the CSM-owned data source; no change to the shared ServiceNow scripted APIs or the Ballerina entity-service, so there is no customer-portal impact. The change is additive/normalizing on an existing field — the wire value simply becomes the already-documented lowercase enum.

## Testing

`go build ./...` and `go vet ./internal/service/` pass.