### PR TITLE
[Customer Portal Webapp] Unlock EL4-EL5 escalation steps for lead role users

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -43,6 +43,7 @@ import {
 import { type JSX, useState, useMemo } from "react";
 import { Link, useLocation, useParams } from "react-router";
 import useGetProjectContacts from "@features/settings/api/useGetProjectContacts";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import { usePatchCase } from "@features/support/api/usePatchCase";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
@@ -91,6 +92,11 @@ export default function CaseDetailsDetailsPanel({
   const [savedWatchList, setSavedWatchList] = useState<string[] | null>(null);
 
   const { data: contactsData, isLoading: isContactsLoading, isError: isContactsError } = useGetProjectContacts(projectId);
+  const { data: userDetails } = useGetUserDetails();
+  const isCurrentUserLead =
+    contactsData?.find(
+      (c) => c.email?.toLowerCase() === userDetails?.email?.toLowerCase(),
+    )?.isLead ?? false;
   const contactOptions = useMemo(
     () =>
       (contactsData ?? [])
@@ -485,6 +491,7 @@ export default function CaseDetailsDetailsPanel({
         <CaseEscalationLevelsCard
           caseId={caseId}
           currentLevelId={data?.escalationLevel?.id}
+          isLead={isCurrentUserLead}
         />
       )}
 

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -92,11 +92,13 @@ export default function CaseDetailsDetailsPanel({
   const [savedWatchList, setSavedWatchList] = useState<string[] | null>(null);
 
   const { data: contactsData, isLoading: isContactsLoading, isError: isContactsError } = useGetProjectContacts(projectId);
-  const { data: userDetails } = useGetUserDetails();
+  const { data: userDetails, isLoading: isUserDetailsLoading } = useGetUserDetails();
   const isCurrentUserLead =
-    contactsData?.find(
-      (c) => c.email?.toLowerCase() === userDetails?.email?.toLowerCase(),
-    )?.isLead ?? false;
+    isContactsLoading || isUserDetailsLoading
+      ? undefined
+      : contactsData?.find(
+          (c) => c.email?.toLowerCase() === userDetails?.email?.toLowerCase(),
+        )?.isLead ?? false;
   const contactOptions = useMemo(
     () =>
       (contactsData ?? [])

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseEscalationLevelsCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseEscalationLevelsCard.tsx
@@ -71,7 +71,7 @@ type Props = {
   isLead?: boolean;
 };
 
-export default function CaseEscalationLevelsCard({ caseId, currentLevelId, isLead = false }: Props): JSX.Element {
+export default function CaseEscalationLevelsCard({ caseId, currentLevelId, isLead }: Props): JSX.Element {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const { data: escalationData } = usePostCaseEscalationsSearch(caseId);
@@ -101,7 +101,7 @@ export default function CaseEscalationLevelsCard({ caseId, currentLevelId, isLea
       {/* Stepper */}
       <Box sx={{ display: "flex", alignItems: "flex-start", width: "100%", px: 2, pt: 2, pb: 1 }}>
         {Array.from({ length: TOTAL_LEVELS }, (_, i) => i + 1).map((levelNum, idx) => {
-          const status: StepStatus = getStepStatus(levelNum, currentLevelNum, isLead);
+          const status: StepStatus = getStepStatus(levelNum, currentLevelNum, isLead ?? false);
           const record = recordByLevel.get(levelNum);
           const canShowTooltip = status === "previous" || status === "active";
 

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseEscalationLevelsCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseEscalationLevelsCard.tsx
@@ -24,6 +24,7 @@ import CaseDetailsCard from "./CaseDetailsCard";
 
 const TOTAL_LEVELS = 5;
 const LEAD_WARNING_THRESHOLD = 3;
+const NON_LEAD_AVAILABLE_MAX = 3;
 
 const LEVEL_ROLE: Record<number, string> = Object.fromEntries(
   Array.from({ length: TOTAL_LEVELS }, (_, i) => [
@@ -34,10 +35,10 @@ const LEVEL_ROLE: Record<number, string> = Object.fromEntries(
 
 type StepStatus = "previous" | "active" | "available" | "locked";
 
-function getStepStatus(levelNum: number, currentLevelNum: number): StepStatus {
+function getStepStatus(levelNum: number, currentLevelNum: number, isLead: boolean): StepStatus {
   if (levelNum < currentLevelNum) return "previous";
   if (levelNum === currentLevelNum) return "active";
-  if (levelNum === currentLevelNum + 1) return "available";
+  if (isLead || levelNum <= NON_LEAD_AVAILABLE_MAX) return "available";
   return "locked";
 }
 
@@ -67,9 +68,10 @@ function TooltipContent({ levelNum, record }: { levelNum: number; record: Escala
 type Props = {
   caseId: string;
   currentLevelId?: number | string | null;
+  isLead?: boolean;
 };
 
-export default function CaseEscalationLevelsCard({ caseId, currentLevelId }: Props): JSX.Element {
+export default function CaseEscalationLevelsCard({ caseId, currentLevelId, isLead = false }: Props): JSX.Element {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const { data: escalationData } = usePostCaseEscalationsSearch(caseId);
@@ -99,7 +101,7 @@ export default function CaseEscalationLevelsCard({ caseId, currentLevelId }: Pro
       {/* Stepper */}
       <Box sx={{ display: "flex", alignItems: "flex-start", width: "100%", px: 2, pt: 2, pb: 1 }}>
         {Array.from({ length: TOTAL_LEVELS }, (_, i) => i + 1).map((levelNum, idx) => {
-          const status: StepStatus = getStepStatus(levelNum, currentLevelNum);
+          const status: StepStatus = getStepStatus(levelNum, currentLevelNum, isLead);
           const record = recordByLevel.get(levelNum);
           const canShowTooltip = status === "previous" || status === "active";
 


### PR DESCRIPTION
## Summary

- Escalation levels EL4 and EL5 were always shown as locked even for users with the Lead role
- Root cause: `isLead` was read from `/users/me` (`useGetUserDetails`) which does not include that field — it only exists in the project contacts list (`/projects/{id}/contacts`)
- Fix: derive `isLead` in `CaseDetailsDetailsPanel` by matching the current user's email against `contactsData` (already fetched by the panel), then pass it as a prop to `CaseEscalationLevelsCard`
- Lead users now see all 5 levels as available (orange outline); non-lead users see EL1–EL3 as available and EL4–EL5 as locked

## Test plan

- [ ] Log in as a user with `isLead: true` — verify all 5 escalation circles show the available (orange outline) style
- [ ] Log in as a user with `isLead: false` — verify EL1–EL3 are available and EL4–EL5 are locked (gray outline)
- [ ] Verify the active and previous step styles are unaffected for both user types


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Escalation level visibility now adapts based on whether the current viewer is a lead, giving lead users fuller access to escalation statuses.
  * The case details view now determines the viewer’s lead status automatically and applies it to escalation display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->