### PR TITLE
[Customer Portal][BE] Add warn log on registry token creation failure

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -4662,6 +4662,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         );
         if response is error {
             if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                log:printWarn(string `Invalid request parameters for creating registry token by user: ${
+                    userInfo.userId}`, response);
                 return <http:BadRequest>{
                     body: {
                         message: "Invalid request parameters for creating registry token."


### PR DESCRIPTION
## Description
- Add warn log on registry token creation failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning logging for failed registry token requests, including the requester’s user ID and additional response details for easier troubleshooting.
  * No changes were made to response content or status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->