### PR TITLE
[CSM][BE] add POST /cases/{id}/github-issues endpoint

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -189,6 +189,7 @@ backend/
 - `POST /cases/{id}/call-requests` — Create a call request for a case (ServiceNow only)
 - `POST /cases/{id}/call-requests/search` — Search call requests for a case (ServiceNow only)
 - `PATCH /cases/{id}/call-requests/{callRequestId}` — Update a call request (ServiceNow only)
+- `POST /cases/{id}/github-issues` — Create a GitHub issue from a case; `reason` selects target repo (`default`/`migration`/`rd_ticket`; ServiceNow only)
 
 ### Users
 

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -107,6 +107,7 @@ func main() {
 	mux.HandleFunc("POST /cases/{id}/call-requests", caseHandler.CreateCallRequest)
 	mux.HandleFunc("POST /cases/{id}/call-requests/search", caseHandler.SearchCallRequests)
 	mux.HandleFunc("PATCH /cases/{caseId}/call-requests/{callRequestId}", caseHandler.PatchCallRequest)
+	mux.HandleFunc("POST /cases/{id}/github-issues", caseHandler.CreateCaseGithubIssue)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -281,3 +281,9 @@ func (c *Client) SearchGroups(ctx context.Context, body []byte) ([]byte, error) 
 func (c *Client) SearchConfigurationItems(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/configuration-items/search", body)
 }
+
+// CreateCaseGithubIssue calls POST /cases/{id}/github-issues on the entity service.
+// Response is returned as raw JSON.
+func (c *Client) CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/github-issues", url.PathEscape(caseID)), body)
+}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -57,6 +57,7 @@ type entityCaseClient interface {
 	CreateCallRequest(ctx context.Context, body []byte) ([]byte, error)
 	SearchCallRequests(ctx context.Context, body []byte) ([]byte, error)
 	PatchCallRequest(ctx context.Context, callRequestID string, body []byte) ([]byte, error)
+	CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error)
 }
 
 // CaseHandler handles HTTP requests for case operations, delegating to the
@@ -697,4 +698,45 @@ func (h *CaseHandler) PatchCallRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, result)
+}
+
+// CreateCaseGithubIssue handles POST /cases/{id}/github-issues.
+func (h *CaseHandler) CreateCaseGithubIssue(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("id")
+	if caseID == "" || !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateCaseGithubIssue(r.Context(), caseID, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCaseGithubIssue failed", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamError(w, err, "Failed to create GitHub issue.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
 }

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1200,3 +1200,109 @@ func TestGetCaseAttachmentContent(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateCaseGithubIssue(t *testing.T) {
+	const caseID = "11111111-1111-1111-1111-111111111111"
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/github-issues", strings.NewReader(`{"title":"crash"}`))
+		r.SetPathValue("id", caseID)
+		w := httptest.NewRecorder()
+		h.CreateCaseGithubIssue(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty case ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases//github-issues", strings.NewReader(`{"title":"crash"}`)))
+		w := httptest.NewRecorder()
+		h.CreateCaseGithubIssue(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID case ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/not-a-uuid/github-issues", strings.NewReader(`{"title":"crash"}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.CreateCaseGithubIssue(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/github-issues", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", caseID)
+		w := httptest.NewRecorder()
+		h.CreateCaseGithubIssue(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/github-issues", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", caseID)
+		w := httptest.NewRecorder()
+		h.CreateCaseGithubIssue(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards case ID and body to upstream and returns 201", func(t *testing.T) {
+		const reqPayload = `{"reason":"default","title":"crash on startup","description":"details"}`
+		var capturedCaseID string
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			createCaseGithubIssueFn: func(_ context.Context, id string, body []byte) ([]byte, error) {
+				capturedCaseID = id
+				capturedBody = body
+				return []byte(`{"issueUrl":"https://github.com/org/repo/issues/1","issueNumber":1,"repository":"org/repo"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/github-issues", strings.NewReader(reqPayload)))
+		r.SetPathValue("id", caseID)
+		w := httptest.NewRecorder()
+		h.CreateCaseGithubIssue(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+		assertContentType(t, w, "application/json")
+		if capturedCaseID != caseID {
+			t.Errorf("upstream received caseID %q, want %q", capturedCaseID, caseID)
+		}
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to create GitHub issue.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					createCaseGithubIssueFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/github-issues", strings.NewReader(`{"title":"crash"}`)))
+				r.SetPathValue("id", caseID)
+				w := httptest.NewRecorder()
+				h.CreateCaseGithubIssue(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -98,6 +98,7 @@ type mockEntityCaseClient struct {
 	createCallRequestFn        func(ctx context.Context, body []byte) ([]byte, error)
 	searchCallRequestsFn       func(ctx context.Context, body []byte) ([]byte, error)
 	patchCallRequestFn         func(ctx context.Context, callRequestID string, body []byte) ([]byte, error)
+	createCaseGithubIssueFn    func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
@@ -187,6 +188,13 @@ func (m *mockEntityCaseClient) SearchCallRequests(ctx context.Context, body []by
 func (m *mockEntityCaseClient) PatchCallRequest(ctx context.Context, callRequestID string, body []byte) ([]byte, error) {
 	if m.patchCallRequestFn != nil {
 		return m.patchCallRequestFn(ctx, callRequestID, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	if m.createCaseGithubIssueFn != nil {
+		return m.createCaseGithubIssueFn(ctx, caseID, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1547,6 +1547,70 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /cases/{id}/github-issues:
+    post:
+      summary: Create a GitHub issue from a case (ServiceNow data source only).
+      operationId: createCaseGithubIssue
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID of the case.
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCaseGithubIssuePayload'
+      responses:
+        "201":
+          description: GitHub issue created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateCaseGithubIssueResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: Request entity too large.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /change-requests/{id}:
     patch:
       summary: Update a change request (ServiceNow data source only).
@@ -4857,3 +4921,53 @@ components:
               type: string
             updatedBy:
               type: string
+
+    CreateCaseGithubIssuePayload:
+      type: object
+      required: [reason, title, description]
+      additionalProperties: false
+      properties:
+        reason:
+          type: string
+          enum: [default, migration, rd_ticket]
+          description: Reason code that selects the GitHub repo target.
+        title:
+          type: string
+          description: Title of the GitHub issue.
+        description:
+          type: string
+          description: Body/description of the GitHub issue.
+        repoOverride:
+          type: string
+          description: Optional repository override (e.g. org/repo).
+        updateLevel:
+          type: string
+          description: Affected product update level.
+        publicIssueUrl:
+          type: string
+          description: URL of a related public issue.
+        regression:
+          type: boolean
+          description: Whether the issue is a regression.
+        hotFixRequired:
+          type: boolean
+          description: Whether a hot fix is required.
+        issueTypeLabel:
+          type: string
+          description: GitHub label for the issue type.
+        priorityLevel:
+          type: string
+          description: Priority level for the issue.
+
+    CreateCaseGithubIssueResponse:
+      type: object
+      properties:
+        issueUrl:
+          type: string
+          description: URL of the created GitHub issue.
+        issueNumber:
+          type: integer
+          description: Number of the created GitHub issue.
+        repository:
+          type: string
+          description: Repository where the issue was created (org/repo).


### PR DESCRIPTION
## Summary

- Adds `POST /cases/{id}/github-issues` to the CSM portal backend as a BFF passthrough to the entity service
- Validates the case UUID before forwarding; returns 400 on empty/non-UUID ID
- Caps body at 1 MiB, validates JSON structure before upstream call; returns 201 on success
- Updates `openapi.yaml` with the new path, `CreateCaseGithubIssuePayload` and `CreateCaseGithubIssueResponse` schemas
- Updates `README.md` to document the new endpoint

Corresponds to entity-service changes in #1006.

## Test plan

- [ ] All existing tests pass (`make test`)
- [ ] Unauthenticated requests return 401
- [ ] Empty or non-UUID case ID returns 400
- [ ] Bodies > 1 MiB return 413
- [ ] Invalid JSON body returns 400
- [ ] Valid request forwards body and case ID to entity service and returns 201 with response

🤖 Generated with [Claude Code](https://claude.com/claude-code)