### PR TITLE
[CSM Portal][FE] fix(csm-timecards): post-merge hardening (search truncation, self-approval, validation)

### DIFF
--- a/apps/csm-portal/webapp/playwright.config.ts
+++ b/apps/csm-portal/webapp/playwright.config.ts
@@ -46,7 +46,10 @@ export default defineConfig({
     : {
         command: "pnpm run dev",
         url: BASE_URL,
-        reuseExistingServer: true,
+        // Locally, reuse an already-running dev server. In CI, always boot a
+        // fresh one — reusing a stray/stale process there could mask a real
+        // failure to start, or run against unexpected leftover state.
+        reuseExistingServer: !process.env.CI,
         timeout: 120_000,
       },
   projects: [

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1221,8 +1221,22 @@ export interface BeTimeCardView {
   case?: BeTimeCardCaseRef;
 }
 
+/**
+ * `entity-service`'s `openapi.yaml` also documents a `caseId` filter here
+ * (and it's genuinely implemented end-to-end, forwarded through to
+ * ServiceNow) — deliberately omitted: confirmed live to be non-functional,
+ * always returning `total: 0` even for a case with cards provably matching
+ * that exact id. See the note on `useCaseTimeCards` in `useTimeCards.ts`
+ * before re-adding it.
+ */
 export interface BeSearchTimeCardsFilters {
   projectIds?: string[];
+  /** Only time cards submitted by this user. */
+  userId?: string;
+  /** Only time cards this user is eligible to approve (SN `approver_list`). */
+  approverId?: string;
+  /** Only time cards actually approved by this user (SN `approved_by`). */
+  approvedById?: string;
   /** ISO 8601 date (YYYY-MM-DD). */
   startDate?: string;
   /** ISO 8601 date (YYYY-MM-DD). */

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -62,6 +62,7 @@ export const ApiQueryKeys = {
   CASE_TIME_CARDS_SEARCH: "case-time-cards-search",
   TIME_SHEETS_SEARCH: "time-sheets-search",
   TIME_CARD_APPROVAL_QUEUE: "time-card-approval-queue",
+  TIME_CARD_ALL: "time-card-all",
   PROJECT_DEPLOYMENT_DETAILS: "project-deployment-details",
   UPDATE_LEVELS_SEARCH: "update-levels-search",
   CHANGE_REQUESTS: "change-requests",

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
@@ -45,7 +45,13 @@ import {
   mapTimeCard,
   searchTimeCards,
   useDecideCard,
+  type TimeCardSearchResult,
 } from "@features/csm-timecards/api/useTimeSheets";
+
+/** A case's time cards, plus whether {@link searchTimeCards} hit its page
+ * cap — some cards in the case's project weren't fetched, so this case's
+ * list/total may be incomplete. */
+export type CaseTimeCardsResult = TimeCardSearchResult;
 
 /**
  * Time cards logged on a single case, newest first. There is no `caseId`
@@ -58,14 +64,14 @@ import {
 export function useCaseTimeCards(
   caseId: string | undefined,
   projectId: string | undefined,
-): UseQueryResult<CsmTimeCard[], Error> {
+): UseQueryResult<CaseTimeCardsResult, Error> {
   const api = useBackendApi();
-  return useQuery<CsmTimeCard[], Error>({
+  return useQuery<CaseTimeCardsResult, Error>({
     queryKey: [ApiQueryKeys.CASE_TIME_CARDS_SEARCH, caseId ?? "", projectId ?? ""],
-    queryFn: async (): Promise<CsmTimeCard[]> => {
-      if (!caseId || !projectId) return [];
-      const { cards } = await searchTimeCards(api, { projectIds: [projectId] });
-      return cards.filter((c) => c.caseId === caseId);
+    queryFn: async (): Promise<CaseTimeCardsResult> => {
+      if (!caseId || !projectId) return { cards: [], truncated: false };
+      const { cards, truncated } = await searchTimeCards(api, { projectIds: [projectId] });
+      return { cards: cards.filter((c) => c.caseId === caseId), truncated };
     },
     enabled: !!caseId && !!projectId,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
@@ -64,8 +64,8 @@ export function useCaseTimeCards(
     queryKey: [ApiQueryKeys.CASE_TIME_CARDS_SEARCH, caseId ?? "", projectId ?? ""],
     queryFn: async (): Promise<CsmTimeCard[]> => {
       if (!caseId || !projectId) return [];
-      const all = await searchTimeCards(api, { projectIds: [projectId] });
-      return all.filter((c) => c.caseId === caseId);
+      const { cards } = await searchTimeCards(api, { projectIds: [projectId] });
+      return cards.filter((c) => c.caseId === caseId);
     },
     enabled: !!caseId && !!projectId,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
@@ -45,21 +45,34 @@ import {
   mapTimeCard,
   searchTimeCards,
   useDecideCard,
-  type TimeCardSearchResult,
 } from "@features/csm-timecards/api/useTimeSheets";
 
-/** A case's time cards, plus whether {@link searchTimeCards} hit its page
- * cap — some cards in the case's project weren't fetched, so this case's
- * list/total may be incomplete. */
-export type CaseTimeCardsResult = TimeCardSearchResult;
+/** A case's time cards from the first `BE_MAX_PAGE_LIMIT` cards in its
+ * project, plus whether that one page fell short of the project's full
+ * `total` — some of the case's cards may not have been fetched if so. No
+ * pagination UI here (unlike the three tabs on `/time-cards`) — a single
+ * case logging more than a page's worth of time is not expected. */
+export interface CaseTimeCardsResult {
+  cards: CsmTimeCard[];
+  truncated: boolean;
+}
 
 /**
- * Time cards logged on a single case, newest first. There is no `caseId`
- * search filter on the backend — `POST /time-cards/search` also requires a
- * non-empty `filters.projectIds` to return anything at all (confirmed live;
- * an unscoped search always returns `total: 0` despite the OpenAPI spec
- * documenting `projectIds` as optional) — so this scopes the search to the
- * case's own project and filters the case's cards out client-side.
+ * Time cards logged on a single case, newest first. `filters.caseId` is
+ * documented in `openapi.yaml` and genuinely implemented end-to-end in
+ * `entity-service` (`sn_time_card_service.go` forwards it straight through
+ * to ServiceNow) — but confirmed live to be non-functional in practice: a
+ * search scoped by nothing but a case's own id returns `total: 0`
+ * unconditionally, even seconds/minutes/an hour after creating a card
+ * against that exact case, and even though the very same project-scoped
+ * search independently proves cards with that exact `case.id` exist (7 of
+ * 10 cards in the project used to verify this). `userId` and `approverId`
+ * were separately confirmed to work correctly (see {@link useMyTimeSheets}
+ * and {@link useApprovalQueue} in `useTimeSheets.ts`) — this is specific to
+ * `caseId`. Do not switch this back to `filters.caseId` without re-confirming
+ * live first. Scopes to the case's own project instead (also requires
+ * `filters.projectIds` to be non-empty — see {@link searchTimeCards}) and
+ * filters the case's cards out client-side.
  */
 export function useCaseTimeCards(
   caseId: string | undefined,
@@ -70,8 +83,11 @@ export function useCaseTimeCards(
     queryKey: [ApiQueryKeys.CASE_TIME_CARDS_SEARCH, caseId ?? "", projectId ?? ""],
     queryFn: async (): Promise<CaseTimeCardsResult> => {
       if (!caseId || !projectId) return { cards: [], truncated: false };
-      const { cards, truncated } = await searchTimeCards(api, { projectIds: [projectId] });
-      return { cards: cards.filter((c) => c.caseId === caseId), truncated };
+      const { cards, total } = await searchTimeCards(api, { projectIds: [projectId] });
+      return {
+        cards: cards.filter((c) => c.caseId === caseId),
+        truncated: cards.length < total,
+      };
     },
     enabled: !!caseId && !!projectId,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -61,19 +61,22 @@ import { roundHours } from "@features/csm-timecards/utils/timeCardTotals";
 /**
  * The signed-in engineer's stable identity, resolved from `GET /users/me`.
  * `id` is the entity-service UUID — the same stable identifier the platform
- * uses across all services. Display name is built from firstName + lastName
- * returned by the entity service, falling back to ID-token values while the
- * query is in flight. `id` is `undefined` until a real identity resolves —
- * never a synthetic placeholder — so callers must gate on it before running
- * queries/mutations that key off it (a placeholder id would silently let
- * "my cards" / "not my cards" filtering match nothing, or everything).
+ * uses across all services, and the same identifier `card.userId` compares
+ * against. Display name is built from firstName + lastName returned by the
+ * entity service, falling back to ID-token values while the query is in
+ * flight. `id` is `undefined` until the real UUID resolves — deliberately
+ * *not* falling back to email: the ID-token email is available immediately,
+ * so an email fallback would make the "wait for a real id" gate never
+ * actually wait, and "my cards" filtering (`card.userId === id`) would
+ * compare a UUID against an email and match nothing until `GET /users/me`
+ * resolves (permanently, if it errors).
  */
 export function useCurrentEngineer(): { id: string | undefined; name: string } {
   const { data: me } = useGetUsersMe();
   const info = resolveUserInfo(useIdTokenClaims());
   const displayName =
     [me?.firstName, me?.lastName].filter(Boolean).join(" ") || info.fullName;
-  return { id: me?.id ?? me?.email ?? info.email, name: displayName };
+  return { id: me?.id, name: displayName };
 }
 
 /** Invalidate every time-card query so all views refresh after a write. */
@@ -108,15 +111,32 @@ export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
 }
 
 /**
- * Raw search against `POST /time-cards/search`, mapped to `CsmTimeCard[]`.
- * The backend only supports `projectIds` / date range server-side — there is
- * no `caseId` or `engineerId` filter, so case- and user-scoping happen
- * client-side over the returned page (see {@link useCaseTimeCards},
- * {@link useMyTimeSheets}, {@link useApprovalQueue} below). Fetches
- * `BE_MAX_PAGE_LIMIT` cards (the backend rejects `limit` above that with a
- * generic 400 despite the OpenAPI spec documenting up to 100 — confirmed
- * live); a dataset larger than that isn't fully covered yet — this is a
- * known limitation until search grows pagination support here.
+ * Page cap for {@link searchTimeCards} — `BE_MAX_PAGE_LIMIT` (50) per page,
+ * so 20 pages covers up to 1,000 cards per scoped search before giving up
+ * and reporting `truncated: true`. Mirrors the same bounded-pagination
+ * shape as `projectOptionsQueryOptions` in `useProjectOptions.ts`.
+ */
+const TIME_CARDS_MAX_PAGES = 20;
+
+/** Result of {@link searchTimeCards}: the cards found, and whether the
+ * `TIME_CARDS_MAX_PAGES` safety cap was hit before the results ran out (in
+ * which case some cards in scope were not fetched). */
+export interface TimeCardSearchResult {
+  cards: CsmTimeCard[];
+  truncated: boolean;
+}
+
+/**
+ * Search against `POST /time-cards/search`, paginating through every page
+ * up to {@link TIME_CARDS_MAX_PAGES}. The backend only supports
+ * `projectIds` server-side (also `startDate`/`endDate`, but nothing in the
+ * UI exposes a date-range filter, so this never sends them) — there is no
+ * `caseId` or `engineerId` filter, so case- and user-scoping happen
+ * client-side over the fetched cards (see {@link useCaseTimeCards},
+ * {@link useMyTimeSheets}, {@link useApprovalQueue} below). `limit` per
+ * page is capped at `BE_MAX_PAGE_LIMIT` — the backend rejects anything
+ * above that with a generic 400 despite the OpenAPI spec documenting up to
+ * 100 (confirmed live).
  *
  * `filters.states` is deliberately filtered client-side, never sent as
  * `filters.states` on the wire: confirmed live that the backend 500s
@@ -131,23 +151,37 @@ export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
 export async function searchTimeCards(
   api: BackendApi,
   filters?: TimeCardSearchFilters,
-): Promise<CsmTimeCard[]> {
-  const payload: BeSearchTimeCardsPayload = {
-    filters: {
-      ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
-      ...(filters?.from ? { startDate: filters.from } : {}),
-      ...(filters?.to ? { endDate: filters.to } : {}),
-    },
-    pagination: { limit: BE_MAX_PAGE_LIMIT, offset: 0 },
+): Promise<TimeCardSearchResult> {
+  const baseFilters = {
+    ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
   };
-  const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
-    "/time-cards/search",
-    payload,
-  );
-  const cards = (res.timeCards ?? []).map(mapTimeCard);
-  return filters?.states?.length
-    ? cards.filter((c) => (filters.states as BeTimeCardState[]).includes(c.state))
-    : cards;
+
+  const all: BeTimeCardView[] = [];
+  let truncated = false;
+  let offset = 0;
+  for (let page = 0; page < TIME_CARDS_MAX_PAGES; page += 1) {
+    const payload: BeSearchTimeCardsPayload = {
+      filters: baseFilters,
+      pagination: { limit: BE_MAX_PAGE_LIMIT, offset },
+    };
+    const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
+      "/time-cards/search",
+      payload,
+    );
+    const pageCards = res.timeCards ?? [];
+    all.push(...pageCards);
+    if (pageCards.length < BE_MAX_PAGE_LIMIT) break;
+    offset += BE_MAX_PAGE_LIMIT;
+    if (page === TIME_CARDS_MAX_PAGES - 1) truncated = true;
+  }
+
+  const cards = all.map(mapTimeCard);
+  return {
+    cards: filters?.states?.length
+      ? cards.filter((c) => (filters.states as BeTimeCardState[]).includes(c.state))
+      : cards,
+    truncated,
+  };
 }
 
 /** Roll a week's cards up into a single display status. */
@@ -189,6 +223,13 @@ function groupIntoSheets(
   return sheets.sort((a, b) => b.weekStart.localeCompare(a.weekStart));
 }
 
+/** Weekly sheets plus whether {@link searchTimeCards} hit its page cap —
+ * i.e. some cards in scope weren't fetched and aren't reflected below. */
+export interface TimeSheetsResult {
+  sheets: CsmTimeSheet[];
+  truncated: boolean;
+}
+
 /**
  * The signed-in user's own cards, grouped into weekly sheets, newest first.
  * `filters.projectIds` must be non-empty — the backend requires it to return
@@ -198,19 +239,22 @@ function groupIntoSheets(
  */
 export function useMyTimeSheets(
   filters?: TimeCardSearchFilters,
-): UseQueryResult<CsmTimeSheet[], Error> {
+): UseQueryResult<TimeSheetsResult, Error> {
   const api = useBackendApi();
   const me = useCurrentEngineer();
-  return useQuery<CsmTimeSheet[], Error>({
+  return useQuery<TimeSheetsResult, Error>({
     queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "mine", me.id, filters],
-    queryFn: async (): Promise<CsmTimeSheet[]> => {
-      if (!me.id) return [];
-      const all = await searchTimeCards(api, filters);
-      return groupIntoSheets(
-        all.filter((c) => c.userId === me.id),
-        me.id,
-        me.name,
-      );
+    queryFn: async (): Promise<TimeSheetsResult> => {
+      if (!me.id) return { sheets: [], truncated: false };
+      const { cards, truncated } = await searchTimeCards(api, filters);
+      return {
+        sheets: groupIntoSheets(
+          cards.filter((c) => c.userId === me.id),
+          me.id,
+          me.name,
+        ),
+        truncated,
+      };
     },
     enabled: !!me.id && !!filters?.projectIds?.length,
     staleTime: 5_000,
@@ -227,27 +271,30 @@ export function useMyTimeSheets(
 export function useApprovalQueue(
   enabled: boolean,
   filters?: TimeCardSearchFilters,
-): UseQueryResult<CsmTimeSheet[], Error> {
+): UseQueryResult<TimeSheetsResult, Error> {
   const api = useBackendApi();
   const me = useCurrentEngineer();
-  return useQuery<CsmTimeSheet[], Error>({
+  return useQuery<TimeSheetsResult, Error>({
     queryKey: [ApiQueryKeys.TIME_CARD_APPROVAL_QUEUE, me.id, filters],
-    queryFn: async (): Promise<CsmTimeSheet[]> => {
-      if (!me.id) return [];
-      const submitted = await searchTimeCards(api, {
+    queryFn: async (): Promise<TimeSheetsResult> => {
+      if (!me.id) return { sheets: [], truncated: false };
+      const { cards, truncated } = await searchTimeCards(api, {
         ...filters,
         states: ["submitted"],
       });
-      const others = submitted.filter((c) => c.userId !== me.id);
+      const others = cards.filter((c) => c.userId !== me.id);
       const byUser = new Map<string, CsmTimeCard[]>();
       for (const c of others) {
         const bucket = byUser.get(c.userId);
         if (bucket) bucket.push(c);
         else byUser.set(c.userId, [c]);
       }
-      return [...byUser.entries()].flatMap(([userId, cards]) =>
-        groupIntoSheets(cards, userId, cards[0]?.userName ?? "—"),
-      );
+      return {
+        sheets: [...byUser.entries()].flatMap(([userId, userCards]) =>
+          groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
+        ),
+        truncated,
+      };
     },
     enabled: enabled && !!me.id && !!filters?.projectIds?.length,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -109,33 +109,56 @@ export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
   };
 }
 
-/**
- * Page cap for {@link searchTimeCards} — `BE_MAX_PAGE_LIMIT` (50) per page,
- * so 20 pages covers up to 1,000 cards per scoped search before giving up
- * and reporting `truncated: true`. Mirrors the same bounded-pagination
- * shape as `projectOptionsQueryOptions` in `useProjectOptions.ts`.
- */
-const TIME_CARDS_MAX_PAGES = 20;
+/** Zero-indexed page + page size, mirroring MUI `TablePagination`'s own
+ * `page`/`rowsPerPage` convention (see `CsmTimeCardsPage.tsx`). */
+export interface TimeCardPagination {
+  page: number;
+  rowsPerPage: number;
+}
 
-/** Result of {@link searchTimeCards}: the cards found, and whether the
- * `TIME_CARDS_MAX_PAGES` safety cap was hit before the results ran out (in
- * which case some cards in scope were not fetched). */
+/** Result of {@link searchTimeCards}: the cards on the requested page, and
+ * `total` — the backend's count for the whole scope (all states, all
+ * cards), *not* the count after `filters.states` client-side filtering
+ * (see the note on that below) — so a caller filtering further should treat
+ * `total` as "how big is the underlying page-able scope", not "how many of
+ * these match my filter". */
 export interface TimeCardSearchResult {
   cards: CsmTimeCard[];
-  truncated: boolean;
+  total: number;
 }
 
 /**
- * Search against `POST /time-cards/search`, paginating through every page
- * up to {@link TIME_CARDS_MAX_PAGES}. The backend only supports
- * `projectIds` server-side (also `startDate`/`endDate`, but nothing in the
- * UI exposes a date-range filter, so this never sends them) — there is no
- * `caseId` or `engineerId` filter, so case- and user-scoping happen
- * client-side over the fetched cards (see {@link useCaseTimeCards},
- * {@link useMyTimeSheets}, {@link useApprovalQueue} below). `limit` per
- * page is capped at `BE_MAX_PAGE_LIMIT` — the backend rejects anything
- * above that with a generic 400 despite the OpenAPI spec documenting up to
- * 100 (confirmed live).
+ * Search against `POST /time-cards/search`, fetching exactly the requested
+ * page (defaults to the first `BE_MAX_PAGE_LIMIT` cards when `pagination`
+ * is omitted). `projectIds`, `userId`, `approverId`, and `from`/`to` are all
+ * real server-side filters, confirmed live (not just by reading
+ * `entity-service`'s `sn_time_card_service.go` — see the note below on
+ * `caseId`, which looked equally real in code but isn't). Callers should
+ * scope as precisely as possible at the source (see {@link useMyTimeSheets},
+ * {@link useApprovalQueue} below) rather than fetching a broad page and
+ * filtering client-side — the latter makes `total` and the page's contents
+ * diverge from what's actually shown. `limit` is capped at
+ * `BE_MAX_PAGE_LIMIT` — the backend rejects anything above that with a
+ * generic 400 despite the OpenAPI spec documenting up to 100 (confirmed
+ * live).
+ *
+ * `filters.caseId` is deliberately *not* forwarded, unlike the others,
+ * despite existing in `openapi.yaml` and being genuinely implemented
+ * end-to-end in `entity-service` — confirmed live to be non-functional: a
+ * search scoped only by a case's own id returns `total: 0` unconditionally,
+ * even though the exact same cards are provably present and correctly
+ * tagged with that `case.id` when the search is instead scoped by
+ * `projectIds` (see {@link useCaseTimeCards} in `useTimeCards.ts`, which
+ * scopes by project and filters to the case client-side instead). Don't
+ * re-add it without re-confirming live first.
+ *
+ * This used to page through the *entire* scope internally (up to 1,000
+ * cards) before returning, so every view always had "everything". That was
+ * confirmed live to take 30-60+ seconds on a few-hundred-record scope
+ * (sequential page-by-page requests), and — with three tabs each doing
+ * their own such walk — was slow enough to sometimes fail outright. Real,
+ * caller-driven pagination replaces that: callers ask for one page at a
+ * time via `pagination`, and `total` lets them drive page controls.
  *
  * `filters.states` is deliberately filtered client-side, never sent as
  * `filters.states` on the wire: confirmed live that the backend 500s
@@ -143,102 +166,88 @@ export interface TimeCardSearchResult {
  * `projectIds` array (reproduced: 2 or 10 project ids + `states` → 200; the
  * full ~88-project default scope + `states` → 500; that same full scope
  * *without* `states` → 200). Since {@link useApprovalQueue} always needs a
- * "submitted" filter and now defaults to every visible project, sending
- * `states` server-side would make the Approvals queue fail outright for any
- * user with enough visible projects — worse than not filtering at all.
+ * "submitted" filter and still defaults `projectIds` to every visible
+ * project (alongside its more precise `approverId` scope), sending `states`
+ * server-side would risk the same 500 for any user with enough visible
+ * projects — worse than not filtering at all. One consequence of filtering
+ * client-side over a single server page: a page can legitimately come back
+ * with fewer matching cards than `rowsPerPage` (or none at all) even though
+ * `total` says there's more data — the states filter just happened to
+ * exclude most/all of that particular page.
  */
 export async function searchTimeCards(
   api: BackendApi,
   filters?: TimeCardSearchFilters,
+  pagination?: TimeCardPagination,
 ): Promise<TimeCardSearchResult> {
-  const baseFilters = {
-    ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
+  const limit = pagination?.rowsPerPage ?? BE_MAX_PAGE_LIMIT;
+  const payload: BeSearchTimeCardsPayload = {
+    filters: {
+      ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
+      ...(filters?.userId ? { userId: filters.userId } : {}),
+      ...(filters?.approverId ? { approverId: filters.approverId } : {}),
+      ...(filters?.from ? { startDate: filters.from } : {}),
+      ...(filters?.to ? { endDate: filters.to } : {}),
+    },
+    pagination: { limit, offset: (pagination?.page ?? 0) * limit },
   };
-
-  const all: BeTimeCardView[] = [];
-  let truncated = false;
-  let offset = 0;
-  for (let page = 0; page < TIME_CARDS_MAX_PAGES; page += 1) {
-    const payload: BeSearchTimeCardsPayload = {
-      filters: baseFilters,
-      pagination: { limit: BE_MAX_PAGE_LIMIT, offset },
-    };
-    let res: BeSearchTimeCardsResponse;
-    try {
-      res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
-        "/time-cards/search",
-        payload,
-      );
-    } catch (err) {
-      // The first page failing is a real error — surface it as before (empty
-      // scope, auth issue, etc). A *later* page failing is different, and
-      // confirmed live: the backend parses a whole page's worth of records
-      // in one shot, so a single malformed record (e.g. a non-numeric
-      // totalTime) fails the *entire* page, discarding every valid record
-      // alongside it. Reported upstream (correlation IDs on file) — until
-      // it's fixed there, degrade to what was already fetched rather than
-      // losing an otherwise-successful search to one bad record several
-      // pages in.
-      if (page === 0) throw err;
-      truncated = true;
-      break;
-    }
-    const pageCards = res.timeCards ?? [];
-    all.push(...pageCards);
-    if (pageCards.length < BE_MAX_PAGE_LIMIT) break;
-    offset += BE_MAX_PAGE_LIMIT;
-    if (page === TIME_CARDS_MAX_PAGES - 1) truncated = true;
-  }
-
-  const cards = all.map(mapTimeCard);
+  const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
+    "/time-cards/search",
+    payload,
+  );
+  const cards = (res.timeCards ?? []).map(mapTimeCard);
   return {
     cards: filters?.states?.length
       ? cards.filter((c) => (filters.states as BeTimeCardState[]).includes(c.state))
       : cards,
-    truncated,
+    total: res.total,
   };
 }
 
-/** Weekly sheets plus whether {@link searchTimeCards} hit its page cap —
- * i.e. some cards in scope weren't fetched and aren't reflected below. */
+/** Weekly sheets on the requested page, plus `total` — see the note on
+ * {@link TimeCardSearchResult}, the same caveat about client-side-filtered
+ * scopes applies here. */
 export interface TimeSheetsResult {
   sheets: CsmTimeSheet[];
-  truncated: boolean;
+  total: number;
 }
 
 /**
- * The signed-in user's own cards, grouped into weekly sheets, newest first.
- * `filters.projectIds` must be non-empty — the backend requires it to return
- * anything (see {@link searchTimeCards}) — so this stays disabled until the
- * caller has resolved a real project scope (defaulted to every visible
- * project when the user hasn't picked one — see `CsmTimeCardsPage.tsx`).
+ * The signed-in user's own cards on the requested page, grouped into weekly
+ * sheets, newest first. Scoped server-side by `userId` (on top of the
+ * existing `projectIds` default-scope) so `total` and the fetched page both
+ * reflect just this user's cards — paginating over a project-wide page and
+ * filtering to "mine" client-side would make `total` and the page size
+ * meaningless here (a page of 20 project-wide cards could easily contain
+ * none of the signed-in user's own). `filters.projectIds` must still be
+ * non-empty — the backend requires it to return anything (see
+ * {@link searchTimeCards}) — so this stays disabled until the caller has
+ * resolved a real project scope (defaulted to every visible project when
+ * the user hasn't picked one — see `CsmTimeCardsPage.tsx`).
  *
  * `enabled` should be gated on the owning tab actually being active (see
  * `CsmTimeCardsPage.tsx`) — confirmed live: with this, {@link useAllTimeCards}
  * and {@link useApprovalQueue} all fetching eagerly regardless of which tab
- * is shown means up to three independent ~20-page pagination walks over the
- * same few-hundred-record scope firing at once on load, which is enough
- * concurrent load to make some of them fail outright or never settle.
+ * is shown was enough concurrent load to make some fail outright or never
+ * settle.
  */
 export function useMyTimeSheets(
   enabled: boolean,
-  filters?: TimeCardSearchFilters,
+  filters: TimeCardSearchFilters | undefined,
+  pagination: TimeCardPagination,
 ): UseQueryResult<TimeSheetsResult, Error> {
   const api = useBackendApi();
   const me = useCurrentEngineer();
   return useQuery<TimeSheetsResult, Error>({
-    queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "mine", me.id, filters],
+    queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "mine", me.id, filters, pagination],
     queryFn: async (): Promise<TimeSheetsResult> => {
-      if (!me.id) return { sheets: [], truncated: false };
-      const { cards, truncated } = await searchTimeCards(api, filters);
-      return {
-        sheets: groupIntoSheets(
-          cards.filter((c) => c.userId === me.id),
-          me.id,
-          me.name,
-        ),
-        truncated,
-      };
+      if (!me.id) return { sheets: [], total: 0 };
+      const { cards, total } = await searchTimeCards(
+        api,
+        { ...filters, userId: me.id },
+        pagination,
+      );
+      return { sheets: groupIntoSheets(cards, me.id, me.name), total };
     },
     enabled: enabled && !!me.id && !!filters?.projectIds?.length,
     staleTime: 5_000,
@@ -246,28 +255,36 @@ export function useMyTimeSheets(
 }
 
 /**
- * Other engineers' sheets containing a card awaiting the signed-in
- * approver's decision. There's no server-side "approval queue" endpoint or
- * engineer filter, so this fetches submitted cards (scoped by `filters`) and
- * excludes the signed-in user's own on the client. Like {@link useMyTimeSheets},
- * this requires `filters.projectIds` to be non-empty to get anything back,
- * and `enabled` should be gated on this tab actually being active (see the
- * note on {@link useMyTimeSheets} for why).
+ * Other engineers' sheets on the requested page containing a card awaiting
+ * the signed-in approver's decision. Scoped server-side by `approverId` (on
+ * top of the existing `projectIds` default-scope) so the queue only ever
+ * contains cards the signed-in user is actually eligible to decide —
+ * previously this fetched every submitted card in scope regardless of who
+ * could approve it, so clicking Approve/Reject on a card the viewer wasn't
+ * the assigned approver for 403'd. Still excludes the signed-in user's own
+ * cards client-side as a defense-in-depth self-approval guard: a card
+ * created before `LogTimeCardDialog` started excluding the submitter from
+ * the approver picker could still name themselves as an eligible approver.
+ * Like {@link useMyTimeSheets}, this requires `filters.projectIds` to be
+ * non-empty to get anything back, and `enabled` should be gated on this tab
+ * actually being active (see the note on {@link useMyTimeSheets} for why).
  */
 export function useApprovalQueue(
   enabled: boolean,
-  filters?: TimeCardSearchFilters,
+  filters: TimeCardSearchFilters | undefined,
+  pagination: TimeCardPagination,
 ): UseQueryResult<TimeSheetsResult, Error> {
   const api = useBackendApi();
   const me = useCurrentEngineer();
   return useQuery<TimeSheetsResult, Error>({
-    queryKey: [ApiQueryKeys.TIME_CARD_APPROVAL_QUEUE, me.id, filters],
+    queryKey: [ApiQueryKeys.TIME_CARD_APPROVAL_QUEUE, me.id, filters, pagination],
     queryFn: async (): Promise<TimeSheetsResult> => {
-      if (!me.id) return { sheets: [], truncated: false };
-      const { cards, truncated } = await searchTimeCards(api, {
-        ...filters,
-        states: ["submitted"],
-      });
+      if (!me.id) return { sheets: [], total: 0 };
+      const { cards, total } = await searchTimeCards(
+        api,
+        { ...filters, approverId: me.id, states: ["submitted"] },
+        pagination,
+      );
       const others = cards.filter((c) => c.userId !== me.id);
       const byUser = new Map<string, CsmTimeCard[]>();
       for (const c of others) {
@@ -279,7 +296,7 @@ export function useApprovalQueue(
         sheets: [...byUser.entries()].flatMap(([userId, userCards]) =>
           groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
         ),
-        truncated,
+        total,
       };
     },
     enabled: enabled && !!me.id && !!filters?.projectIds?.length,
@@ -288,24 +305,25 @@ export function useApprovalQueue(
 }
 
 /**
- * Every visible user's sheets, own included — unlike {@link useMyTimeSheets}
- * (self only) and {@link useApprovalQueue} (others' submitted cards only,
- * for deciding), this is a read-only "see everything in scope" view: no
- * state restriction, no ownership exclusion. Requires `filters.projectIds`
- * to be non-empty, same as every other search here, and `enabled` should be
- * gated on this tab actually being active (see the note on
- * {@link useMyTimeSheets} for why).
+ * Every visible user's sheets on the requested page, own included — unlike
+ * {@link useMyTimeSheets} (self only) and {@link useApprovalQueue} (others'
+ * submitted cards only, for deciding), this is a read-only "see everything
+ * in scope" view: no state restriction, no ownership exclusion. Requires
+ * `filters.projectIds` to be non-empty, same as every other search here,
+ * and `enabled` should be gated on this tab actually being active (see the
+ * note on {@link useMyTimeSheets} for why).
  */
 export function useAllTimeCards(
   enabled: boolean,
-  filters?: TimeCardSearchFilters,
+  filters: TimeCardSearchFilters | undefined,
+  pagination: TimeCardPagination,
 ): UseQueryResult<TimeSheetsResult, Error> {
   const api = useBackendApi();
   const me = useCurrentEngineer();
   return useQuery<TimeSheetsResult, Error>({
-    queryKey: [ApiQueryKeys.TIME_CARD_ALL, filters],
+    queryKey: [ApiQueryKeys.TIME_CARD_ALL, filters, pagination],
     queryFn: async (): Promise<TimeSheetsResult> => {
-      const { cards, truncated } = await searchTimeCards(api, filters);
+      const { cards, total } = await searchTimeCards(api, filters, pagination);
       const byUser = new Map<string, CsmTimeCard[]>();
       for (const c of cards) {
         const bucket = byUser.get(c.userId);
@@ -316,7 +334,7 @@ export function useAllTimeCards(
         sheets: [...byUser.entries()].flatMap(([userId, userCards]) =>
           groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
         ),
-        truncated,
+        total,
       };
     },
     enabled: enabled && !!me.id && !!filters?.projectIds?.length,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -180,7 +180,7 @@ export async function searchTimeCards(
   filters?: TimeCardSearchFilters,
   pagination?: TimeCardPagination,
 ): Promise<TimeCardSearchResult> {
-  const limit = pagination?.rowsPerPage ?? BE_MAX_PAGE_LIMIT;
+  const limit = Math.min(pagination?.rowsPerPage ?? BE_MAX_PAGE_LIMIT, BE_MAX_PAGE_LIMIT);
   const payload: BeSearchTimeCardsPayload = {
     filters: {
       ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
@@ -210,6 +210,21 @@ export async function searchTimeCards(
 export interface TimeSheetsResult {
   sheets: CsmTimeSheet[];
   total: number;
+}
+
+/** Groups cards by `userId` into per-user weekly sheets, newest first —
+ * shared by {@link useApprovalQueue} and {@link useAllTimeCards}, which only
+ * differ in which cards they pass in (others' submitted cards vs everyone's). */
+function groupCardsByUserIntoSheets(cards: CsmTimeCard[]): CsmTimeSheet[] {
+  const byUser = new Map<string, CsmTimeCard[]>();
+  for (const c of cards) {
+    const bucket = byUser.get(c.userId);
+    if (bucket) bucket.push(c);
+    else byUser.set(c.userId, [c]);
+  }
+  return [...byUser.entries()].flatMap(([userId, userCards]) =>
+    groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
+  );
 }
 
 /**
@@ -286,18 +301,7 @@ export function useApprovalQueue(
         pagination,
       );
       const others = cards.filter((c) => c.userId !== me.id);
-      const byUser = new Map<string, CsmTimeCard[]>();
-      for (const c of others) {
-        const bucket = byUser.get(c.userId);
-        if (bucket) bucket.push(c);
-        else byUser.set(c.userId, [c]);
-      }
-      return {
-        sheets: [...byUser.entries()].flatMap(([userId, userCards]) =>
-          groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
-        ),
-        total,
-      };
+      return { sheets: groupCardsByUserIntoSheets(others), total };
     },
     enabled: enabled && !!me.id && !!filters?.projectIds?.length,
     staleTime: 5_000,
@@ -324,18 +328,7 @@ export function useAllTimeCards(
     queryKey: [ApiQueryKeys.TIME_CARD_ALL, filters, pagination],
     queryFn: async (): Promise<TimeSheetsResult> => {
       const { cards, total } = await searchTimeCards(api, filters, pagination);
-      const byUser = new Map<string, CsmTimeCard[]>();
-      for (const c of cards) {
-        const bucket = byUser.get(c.userId);
-        if (bucket) bucket.push(c);
-        else byUser.set(c.userId, [c]);
-      }
-      return {
-        sheets: [...byUser.entries()].flatMap(([userId, userCards]) =>
-          groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
-        ),
-        total,
-      };
+      return { sheets: groupCardsByUserIntoSheets(cards), total };
     },
     enabled: enabled && !!me.id && !!filters?.projectIds?.length,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -164,10 +164,26 @@ export async function searchTimeCards(
       filters: baseFilters,
       pagination: { limit: BE_MAX_PAGE_LIMIT, offset },
     };
-    const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
-      "/time-cards/search",
-      payload,
-    );
+    let res: BeSearchTimeCardsResponse;
+    try {
+      res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
+        "/time-cards/search",
+        payload,
+      );
+    } catch (err) {
+      // The first page failing is a real error — surface it as before (empty
+      // scope, auth issue, etc). A *later* page failing is different, and
+      // confirmed live: the backend parses a whole page's worth of records
+      // in one shot, so a single malformed record (e.g. a non-numeric
+      // totalTime) fails the *entire* page, discarding every valid record
+      // alongside it. Reported upstream (correlation IDs on file) — until
+      // it's fixed there, degrade to what was already fetched rather than
+      // losing an otherwise-successful search to one bad record several
+      // pages in.
+      if (page === 0) throw err;
+      truncated = true;
+      break;
+    }
     const pageCards = res.timeCards ?? [];
     all.push(...pageCards);
     if (pageCards.length < BE_MAX_PAGE_LIMIT) break;

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -53,10 +53,8 @@ import type {
   CsmTimeSheet,
   TimeCardDecisionInput,
   TimeCardSearchFilters,
-  TimeSheetState,
 } from "@features/csm-timecards/types/timeCards";
-import { weekEndOf, weekStartOf } from "@features/csm-timecards/utils/timeSheetWeek";
-import { roundHours } from "@features/csm-timecards/utils/timeCardTotals";
+import { groupIntoSheets } from "@features/csm-timecards/utils/timeSheetGrouping";
 
 /**
  * The signed-in engineer's stable identity, resolved from `GET /users/me`.
@@ -86,6 +84,7 @@ export function invalidateTimecards(queryClient: QueryClient): void {
     ApiQueryKeys.CASE_TIME_CARDS_SEARCH,
     ApiQueryKeys.TIME_SHEETS_SEARCH,
     ApiQueryKeys.TIME_CARD_APPROVAL_QUEUE,
+    ApiQueryKeys.TIME_CARD_ALL,
   ]) {
     void queryClient.invalidateQueries({ queryKey: [key] });
   }
@@ -200,45 +199,6 @@ export async function searchTimeCards(
   };
 }
 
-/** Roll a week's cards up into a single display status. */
-function sheetStatus(cards: CsmTimeCard[]): TimeSheetState {
-  if (cards.some((c) => c.state === "rejected")) return "rejected";
-  if (cards.every((c) => c.state === "approved" || c.state === "processed")) {
-    return "approved";
-  }
-  return "submitted";
-}
-
-/** Group a flat list of cards into weekly sheets (Mon–Sun), newest first. */
-function groupIntoSheets(
-  cards: CsmTimeCard[],
-  userId: string,
-  userName: string,
-): CsmTimeSheet[] {
-  const byWeek = new Map<string, CsmTimeCard[]>();
-  for (const c of cards) {
-    const wk = weekStartOf(c.createdOn);
-    const bucket = byWeek.get(wk);
-    if (bucket) bucket.push(c);
-    else byWeek.set(wk, [c]);
-  }
-  const sheets: CsmTimeSheet[] = [];
-  for (const [weekStart, weekCards] of byWeek) {
-    weekCards.sort((a, b) => b.createdOn.localeCompare(a.createdOn));
-    sheets.push({
-      id: `${userId}:${weekStart}`,
-      userId,
-      userName,
-      weekStart,
-      weekEnd: weekEndOf(weekStart),
-      state: sheetStatus(weekCards),
-      cards: weekCards,
-      totalHours: roundHours(weekCards.reduce((sum, c) => sum + c.totalHours, 0)),
-    });
-  }
-  return sheets.sort((a, b) => b.weekStart.localeCompare(a.weekStart));
-}
-
 /** Weekly sheets plus whether {@link searchTimeCards} hit its page cap —
  * i.e. some cards in scope weren't fetched and aren't reflected below. */
 export interface TimeSheetsResult {
@@ -252,8 +212,16 @@ export interface TimeSheetsResult {
  * anything (see {@link searchTimeCards}) — so this stays disabled until the
  * caller has resolved a real project scope (defaulted to every visible
  * project when the user hasn't picked one — see `CsmTimeCardsPage.tsx`).
+ *
+ * `enabled` should be gated on the owning tab actually being active (see
+ * `CsmTimeCardsPage.tsx`) — confirmed live: with this, {@link useAllTimeCards}
+ * and {@link useApprovalQueue} all fetching eagerly regardless of which tab
+ * is shown means up to three independent ~20-page pagination walks over the
+ * same few-hundred-record scope firing at once on load, which is enough
+ * concurrent load to make some of them fail outright or never settle.
  */
 export function useMyTimeSheets(
+  enabled: boolean,
   filters?: TimeCardSearchFilters,
 ): UseQueryResult<TimeSheetsResult, Error> {
   const api = useBackendApi();
@@ -272,7 +240,7 @@ export function useMyTimeSheets(
         truncated,
       };
     },
-    enabled: !!me.id && !!filters?.projectIds?.length,
+    enabled: enabled && !!me.id && !!filters?.projectIds?.length,
     staleTime: 5_000,
   });
 }
@@ -282,7 +250,9 @@ export function useMyTimeSheets(
  * approver's decision. There's no server-side "approval queue" endpoint or
  * engineer filter, so this fetches submitted cards (scoped by `filters`) and
  * excludes the signed-in user's own on the client. Like {@link useMyTimeSheets},
- * this requires `filters.projectIds` to be non-empty to get anything back.
+ * this requires `filters.projectIds` to be non-empty to get anything back,
+ * and `enabled` should be gated on this tab actually being active (see the
+ * note on {@link useMyTimeSheets} for why).
  */
 export function useApprovalQueue(
   enabled: boolean,
@@ -301,6 +271,43 @@ export function useApprovalQueue(
       const others = cards.filter((c) => c.userId !== me.id);
       const byUser = new Map<string, CsmTimeCard[]>();
       for (const c of others) {
+        const bucket = byUser.get(c.userId);
+        if (bucket) bucket.push(c);
+        else byUser.set(c.userId, [c]);
+      }
+      return {
+        sheets: [...byUser.entries()].flatMap(([userId, userCards]) =>
+          groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
+        ),
+        truncated,
+      };
+    },
+    enabled: enabled && !!me.id && !!filters?.projectIds?.length,
+    staleTime: 5_000,
+  });
+}
+
+/**
+ * Every visible user's sheets, own included — unlike {@link useMyTimeSheets}
+ * (self only) and {@link useApprovalQueue} (others' submitted cards only,
+ * for deciding), this is a read-only "see everything in scope" view: no
+ * state restriction, no ownership exclusion. Requires `filters.projectIds`
+ * to be non-empty, same as every other search here, and `enabled` should be
+ * gated on this tab actually being active (see the note on
+ * {@link useMyTimeSheets} for why).
+ */
+export function useAllTimeCards(
+  enabled: boolean,
+  filters?: TimeCardSearchFilters,
+): UseQueryResult<TimeSheetsResult, Error> {
+  const api = useBackendApi();
+  const me = useCurrentEngineer();
+  return useQuery<TimeSheetsResult, Error>({
+    queryKey: [ApiQueryKeys.TIME_CARD_ALL, filters],
+    queryFn: async (): Promise<TimeSheetsResult> => {
+      const { cards, truncated } = await searchTimeCards(api, filters);
+      const byUser = new Map<string, CsmTimeCard[]>();
+      for (const c of cards) {
         const bucket = byUser.get(c.userId);
         if (bucket) bucket.push(c);
         else byUser.set(c.userId, [c]);

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -123,7 +123,7 @@ export default function CaseTimeCardsPanel({
 
       <Divider sx={{ mb: 1 }} />
 
-      {data?.truncated && (
+      {!isError && data?.truncated && (
         <TimeCardTruncatedNotice hint="Some entries on this case may not be shown." />
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -32,6 +32,7 @@ import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
+import TimeCardTruncatedNotice from "@features/csm-timecards/components/TimeCardTruncatedNotice";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 
 interface CaseTimeCardsPanelProps {
@@ -65,7 +66,7 @@ export default function CaseTimeCardsPanel({
   const { showError } = useErrorBanner();
   const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
 
-  const cards = useMemo(() => data ?? [], [data]);
+  const cards = useMemo(() => data?.cards ?? [], [data]);
   const total = useMemo(
     () => Math.round(cards.reduce((s, c) => s + c.totalHours, 0) * 100) / 100,
     [cards],
@@ -121,6 +122,10 @@ export default function CaseTimeCardsPanel({
       </Box>
 
       <Divider sx={{ mb: 1 }} />
+
+      {data?.truncated && (
+        <TimeCardTruncatedNotice hint="Some entries on this case may not be shown." />
+      )}
 
       {isLoading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -199,17 +199,21 @@ export default function LogTimeCardDialog({
   // email; `userType` is postgres-only (absent on the ServiceNow source, the
   // live data here), so only gate on it when present — the `roles`/`active`
   // filters above already restrict server-side. Mirrors AssignEngineerDialog.
+  // Excludes the signed-in user: nothing server-side stops picking yourself
+  // as approver, which would let a submitter approve their own time.
   const candidates: ApproverOption[] = useMemo(() => {
     if (!hasApproverInput) return [];
+    const myEmail = me.email.toLowerCase();
     return (data?.users ?? [])
       .filter(
         (u) =>
           !!u.email &&
+          u.email.toLowerCase() !== myEmail &&
           u.active !== false &&
           (u.userType ? u.userType === "internal" : true),
       )
       .map((u) => ({ id: u.id, name: fullName(u), email: u.email }));
-  }, [data, hasApproverInput]);
+  }, [data, hasApproverInput, me.email]);
 
   const setActivity = (key: ActivityKey, next: number): void =>
     setBreakdown((prev) => ({ ...prev, [key]: next }));

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardTruncatedNotice.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardTruncatedNotice.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+
+interface TimeCardTruncatedNoticeProps {
+  /** How to narrow the scope, shown after the base message. Defaults to a
+   * generic hint for views (like a single case) with no filter to narrow. */
+  hint?: string;
+}
+
+/**
+ * Shown when {@link searchTimeCards} hit its page cap — some cards in scope
+ * weren't fetched, so the list above/below may be missing older entries.
+ * `role="status"` announces it to assistive tech, since it appears after
+ * the initial render once data resolves rather than being present upfront.
+ */
+export default function TimeCardTruncatedNotice({
+  hint = "Narrow the search scope to see everything.",
+}: TimeCardTruncatedNoticeProps): JSX.Element {
+  return (
+    <Typography
+      variant="caption"
+      role="status"
+      sx={{
+        display: "block",
+        px: 1.5,
+        py: 1,
+        borderRadius: 1,
+        bgcolor: "warning.light",
+        color: "warning.dark",
+      }}
+    >
+      Showing a partial result — there are more cards in scope than could be
+      loaded. {hint}
+    </Typography>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -44,6 +44,7 @@ import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardRev
 import type { TimecardAction } from "@features/csm-timecards/utils/timeSheetState";
 import type {
   CsmTimeCard,
+  CsmTimeSheet,
   TimeCardSearchFilters,
   TimeCardState,
 } from "@features/csm-timecards/types/timeCards";
@@ -107,10 +108,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
   };
 
   /** Client-side work-item substring filter, applied over already-fetched sheets. */
-  const byWorkItem = (userNameFiltered: typeof mySheets.data): typeof mySheets.data => {
+  const byWorkItem = (sheets: CsmTimeSheet[] | undefined): CsmTimeSheet[] | undefined => {
     const q = filterWorkItem.trim().toLowerCase();
-    if (!q || !userNameFiltered) return userNameFiltered;
-    return userNameFiltered
+    if (!q || !sheets) return sheets;
+    return sheets
       .map((s) => ({
         ...s,
         cards: s.cards.filter((c) => c.caseNumber.toLowerCase().includes(q)),
@@ -166,28 +167,31 @@ export default function CsmTimeCardsPage(): JSX.Element {
           ) : mySheets.isError ? (
             <Typography color="error">Could not load your time sheets.</Typography>
           ) : (
-            (() => {
-              const filtered = byWorkItem(mySheets.data) ?? [];
-              if (filtered.length === 0) {
-                return (
-                  <Empty
-                    text={
-                      anyFilterActive
-                        ? "No time cards match the current filters."
-                        : "No time logged yet. Open a case and use its Time tracking tab to log time."
-                    }
+            <>
+              {mySheets.data?.truncated && <TruncatedNotice />}
+              {(() => {
+                const filtered = byWorkItem(mySheets.data?.sheets) ?? [];
+                if (filtered.length === 0) {
+                  return (
+                    <Empty
+                      text={
+                        anyFilterActive
+                          ? "No time cards match the current filters."
+                          : "No time logged yet. Open a case and use its Time tracking tab to log time."
+                      }
+                    />
+                  );
+                }
+                return filtered.map((s) => (
+                  <TimeSheetCard
+                    key={s.id}
+                    sheet={s}
+                    role={{ isOwner: true, isApprover: false, isAdmin: false }}
+                    onCardAction={handleCardAction}
                   />
-                );
-              }
-              return filtered.map((s) => (
-                <TimeSheetCard
-                  key={s.id}
-                  sheet={s}
-                  role={{ isOwner: true, isApprover: false, isAdmin: false }}
-                  onCardAction={handleCardAction}
-                />
-              ));
-            })()
+                ));
+              })()}
+            </>
           )}
         </Box>
       )}
@@ -232,39 +236,45 @@ export default function CsmTimeCardsPage(): JSX.Element {
             </Centered>
           ) : queue.isError ? (
             <Typography color="error">Could not load the approval queue.</Typography>
-          ) : (queue.data ?? []).length === 0 ? (
-            <Empty text="Nothing awaiting approval." />
+          ) : (queue.data?.sheets ?? []).length === 0 ? (
+            <>
+              {queue.data?.truncated && <TruncatedNotice />}
+              <Empty text="Nothing awaiting approval." />
+            </>
           ) : (
-            (() => {
-              const q = filterEngineer.trim().toLowerCase();
-              const byEngineer = (queue.data ?? []).filter(
-                (s) => !q || s.userName.toLowerCase().includes(q),
-              );
-              const filtered = byWorkItem(byEngineer) ?? [];
-              if (filtered.length === 0) {
-                return (
-                  <Empty
-                    text={
-                      // Only blame the engineer filter when it's the one that
-                      // excluded everything — if it matched fine and the
-                      // work-item filter emptied the result, say that instead.
-                      q && byEngineer.length === 0
-                        ? `No engineers match "${filterEngineer}".`
-                        : "No time cards match the current filters."
-                    }
-                  />
+            <>
+              {queue.data?.truncated && <TruncatedNotice />}
+              {(() => {
+                const q = filterEngineer.trim().toLowerCase();
+                const byEngineer = (queue.data?.sheets ?? []).filter(
+                  (s) => !q || s.userName.toLowerCase().includes(q),
                 );
-              }
-              return filtered.map((s) => (
-                <TimeSheetCard
-                  key={s.id}
-                  sheet={s}
-                  role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
-                  showEngineer
-                  onCardAction={handleCardAction}
-                />
-              ));
-            })()
+                const filtered = byWorkItem(byEngineer) ?? [];
+                if (filtered.length === 0) {
+                  return (
+                    <Empty
+                      text={
+                        // Only blame the engineer filter when it's the one that
+                        // excluded everything — if it matched fine and the
+                        // work-item filter emptied the result, say that instead.
+                        q && byEngineer.length === 0
+                          ? `No engineers match "${filterEngineer}".`
+                          : "No time cards match the current filters."
+                      }
+                    />
+                  );
+                }
+                return filtered.map((s) => (
+                  <TimeSheetCard
+                    key={s.id}
+                    sheet={s}
+                    role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
+                    showEngineer
+                    onCardAction={handleCardAction}
+                  />
+                ));
+              })()}
+            </>
           )}
         </Box>
       )}
@@ -486,6 +496,28 @@ function Empty({ text }: { text: string }): JSX.Element {
   return (
     <Typography variant="body2" color="text.secondary" sx={{ py: 4 }}>
       {text}
+    </Typography>
+  );
+}
+
+/** Shown when `searchTimeCards` hit its page cap — some cards in scope
+ * weren't fetched, so the list below may be missing older entries. Narrow
+ * the Project filter to see everything within a smaller scope. */
+function TruncatedNotice(): JSX.Element {
+  return (
+    <Typography
+      variant="caption"
+      sx={{
+        display: "block",
+        px: 1.5,
+        py: 1,
+        borderRadius: 1,
+        bgcolor: "warning.light",
+        color: "warning.dark",
+      }}
+    >
+      Showing a partial result — there are more cards in scope than could be
+      loaded. Narrow the Project filter to see everything.
     </Typography>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -41,6 +41,7 @@ import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCard
 import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
 import TimeSheetCard from "@features/csm-timecards/components/TimeSheetCard";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
+import TimeCardTruncatedNotice from "@features/csm-timecards/components/TimeCardTruncatedNotice";
 import type { TimecardAction } from "@features/csm-timecards/utils/timeSheetState";
 import type {
   CsmTimeCard,
@@ -168,7 +169,9 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load your time sheets.</Typography>
           ) : (
             <>
-              {mySheets.data?.truncated && <TruncatedNotice />}
+              {mySheets.data?.truncated && (
+                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
+              )}
               {(() => {
                 const filtered = byWorkItem(mySheets.data?.sheets) ?? [];
                 if (filtered.length === 0) {
@@ -238,12 +241,16 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load the approval queue.</Typography>
           ) : (queue.data?.sheets ?? []).length === 0 ? (
             <>
-              {queue.data?.truncated && <TruncatedNotice />}
+              {queue.data?.truncated && (
+                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
+              )}
               <Empty text="Nothing awaiting approval." />
             </>
           ) : (
             <>
-              {queue.data?.truncated && <TruncatedNotice />}
+              {queue.data?.truncated && (
+                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
+              )}
               {(() => {
                 const q = filterEngineer.trim().toLowerCase();
                 const byEngineer = (queue.data?.sheets ?? []).filter(
@@ -496,28 +503,6 @@ function Empty({ text }: { text: string }): JSX.Element {
   return (
     <Typography variant="body2" color="text.secondary" sx={{ py: 4 }}>
       {text}
-    </Typography>
-  );
-}
-
-/** Shown when `searchTimeCards` hit its page cap — some cards in scope
- * weren't fetched, so the list below may be missing older entries. Narrow
- * the Project filter to see everything within a smaller scope. */
-function TruncatedNotice(): JSX.Element {
-  return (
-    <Typography
-      variant="caption"
-      sx={{
-        display: "block",
-        px: 1.5,
-        py: 1,
-        borderRadius: 1,
-        bgcolor: "warning.light",
-        color: "warning.dark",
-      }}
-    >
-      Showing a partial result — there are more cards in scope than could be
-      loaded. Narrow the Project filter to see everything.
     </Typography>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -29,7 +29,9 @@ import {
 } from "@wso2/oxygen-ui";
 import { ListFilter, Search, X } from "@wso2/oxygen-ui-icons-react";
 import {
+  useAllTimeCards,
   useApprovalQueue,
+  useCurrentEngineer,
   useDecideCard,
   useMyTimeSheets,
 } from "@features/csm-timecards/api/useTimeSheets";
@@ -50,20 +52,22 @@ import type {
   TimeCardState,
 } from "@features/csm-timecards/types/timeCards";
 
-type TabId = "mine" | "approvals";
+type TabId = "mine" | "all" | "approvals";
 
 /**
- * Time cards workspace. Two tabs: **My time sheets** (weekly grouping, read
- * only — logging happens from a case's Time tracking tab) and **Approvals**
- * (approver/admin: approve/reject a submitted card). There's no sheet-level
- * bulk action, delegation, or reports — the backend has no endpoints for
- * those (see the module-level notes in `types/timeCards.ts`).
+ * Time cards workspace. Three tabs: **My time sheets** (own cards only),
+ * **All** (everyone's cards, read only — visibility, not action), and
+ * **Approvals** (approver/admin: approve/reject a submitted card). Logging
+ * time happens from a case's Time tracking tab, not here. There's no
+ * sheet-level bulk action, delegation, or reports — the backend has no
+ * endpoints for those (see the module-level notes in `types/timeCards.ts`).
  */
 export default function CsmTimeCardsPage(): JSX.Element {
   const role = useTimecardRole();
+  const me = useCurrentEngineer();
   const { showError } = useErrorBanner();
   const [tab, setTab] = useState<TabId>("mine");
-  const activeTab: TabId = tab !== "mine" && !role.isApprover ? "mine" : tab;
+  const activeTab: TabId = tab === "approvals" && !role.isApprover ? "mine" : tab;
 
   const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
 
@@ -91,8 +95,14 @@ export default function CsmTimeCardsPage(): JSX.Element {
     ...(filterState && { states: [filterState] }),
   };
 
-  const mySheets = useMyTimeSheets(baseFilters);
-  const queue = useApprovalQueue(role.isApprover, baseFilters);
+  // Each search paginates independently (up to ~20 pages over the full
+  // scope) — fetching all three eagerly regardless of which tab is showing
+  // overloads the backend with concurrent requests (confirmed live: enough
+  // to make some fail outright or never settle). Gate each on its own tab
+  // actually being the active one.
+  const mySheets = useMyTimeSheets(activeTab === "mine", baseFilters);
+  const allCards = useAllTimeCards(activeTab === "all", baseFilters);
+  const queue = useApprovalQueue(activeTab === "approvals" && role.isApprover, baseFilters);
   const decideCard = useDecideCard();
 
   const anyFilterActive =
@@ -138,6 +148,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
         sx={{ borderBottom: 1, borderColor: "divider" }}
       >
         <Tab value="mine" label="My time sheets" />
+        <Tab value="all" label="All" />
         {role.isApprover && <Tab value="approvals" label="Approvals" />}
       </Tabs>
 
@@ -190,6 +201,86 @@ export default function CsmTimeCardsPage(): JSX.Element {
                     key={s.id}
                     sheet={s}
                     role={{ isOwner: true, isApprover: false, isAdmin: false }}
+                    onCardAction={handleCardAction}
+                  />
+                ));
+              })()}
+            </>
+          )}
+        </Box>
+      )}
+
+      {/* All — everyone's cards, own included. Read only: role is always
+       passed as non-approver/non-admin here regardless of the viewer's
+       actual role, so no Approve/Reject actions ever show — that stays
+       exclusive to the Approvals tab. */}
+      {activeTab === "all" && (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <FilterBar
+            projects={projects.data ?? []}
+            filterProject={filterProject}
+            setFilterProject={setFilterProject}
+            filterWorkItem={filterWorkItem}
+            setFilterWorkItem={setFilterWorkItem}
+            filterState={filterState}
+            setFilterState={setFilterState}
+            onClear={clearFilters}
+            engineerSlot={
+              <TextField
+                size="small"
+                label="Engineer"
+                placeholder="Name…"
+                value={filterEngineer}
+                onChange={(e) => setFilterEngineer(e.target.value)}
+                sx={{ width: 180 }}
+              />
+            }
+            engineerChip={
+              filterEngineer.trim()
+                ? {
+                    label: `Engineer: ${filterEngineer.trim()}`,
+                    onDelete: () => setFilterEngineer(""),
+                  }
+                : undefined
+            }
+          />
+
+          {allCards.isLoading || projects.isLoading ? (
+            <Centered>
+              <CircularProgress />
+            </Centered>
+          ) : allCards.isError ? (
+            <Typography color="error">Could not load time cards.</Typography>
+          ) : (
+            <>
+              {!allCards.isError && allCards.data?.truncated && (
+                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
+              )}
+              {(() => {
+                const q = filterEngineer.trim().toLowerCase();
+                const byEngineer = (allCards.data?.sheets ?? []).filter(
+                  (s) => !q || s.userName.toLowerCase().includes(q),
+                );
+                const filtered = byWorkItem(byEngineer) ?? [];
+                if (filtered.length === 0) {
+                  return (
+                    <Empty
+                      text={
+                        q && byEngineer.length === 0
+                          ? `No engineers match "${filterEngineer}".`
+                          : anyFilterActive
+                            ? "No time cards match the current filters."
+                            : "No time logged yet."
+                      }
+                    />
+                  );
+                }
+                return filtered.map((s) => (
+                  <TimeSheetCard
+                    key={s.id}
+                    sheet={s}
+                    role={{ isOwner: s.userId === me.id, isApprover: false, isAdmin: false }}
+                    showEngineer
                     onCardAction={handleCardAction}
                   />
                 ));

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useState, type JSX } from "react";
+import { useState, type ChangeEvent, type JSX } from "react";
 import {
   Box,
   Chip,
@@ -23,6 +23,7 @@ import {
   MenuItem,
   Tab,
   Tabs,
+  TablePagination,
   TextField,
   Typography,
   Button,
@@ -34,16 +35,17 @@ import {
   useCurrentEngineer,
   useDecideCard,
   useMyTimeSheets,
+  type TimeCardPagination,
 } from "@features/csm-timecards/api/useTimeSheets";
 import { useProjectOptions } from "@features/csm-cases/api/useProjectOptions";
 import { BackendApiError } from "@api/backend/client";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import type { BeProject } from "@api/backend/types";
 import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
 import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
 import TimeSheetCard from "@features/csm-timecards/components/TimeSheetCard";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
-import TimeCardTruncatedNotice from "@features/csm-timecards/components/TimeCardTruncatedNotice";
 import type { TimecardAction } from "@features/csm-timecards/utils/timeSheetState";
 import type {
   CsmTimeCard,
@@ -51,6 +53,32 @@ import type {
   TimeCardSearchFilters,
   TimeCardState,
 } from "@features/csm-timecards/types/timeCards";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+// Top option is the backend's max page limit; larger requests are rejected.
+const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
+
+/** Page + rows-per-page state for one tab's `TablePagination`, following the
+ * same shape/convention as `CsmUsersPage.tsx` and friends. Each tab gets its
+ * own instance so switching tabs doesn't disturb another tab's position. */
+function usePagination(): {
+  pagination: TimeCardPagination;
+  onPageChange: (event: unknown, newPage: number) => void;
+  onRowsPerPageChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  setPage: (page: number) => void;
+} {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  return {
+    pagination: { page, rowsPerPage },
+    onPageChange: (_, newPage) => setPage(newPage),
+    onRowsPerPageChange: (e) => {
+      setRowsPerPage(parseInt(e.target.value, 10));
+      setPage(0);
+    },
+    setPage,
+  };
+}
 
 type TabId = "mine" | "all" | "approvals";
 
@@ -95,23 +123,51 @@ export default function CsmTimeCardsPage(): JSX.Element {
     ...(filterState && { states: [filterState] }),
   };
 
-  // Each search paginates independently (up to ~20 pages over the full
-  // scope) — fetching all three eagerly regardless of which tab is showing
-  // overloads the backend with concurrent requests (confirmed live: enough
-  // to make some fail outright or never settle). Gate each on its own tab
-  // actually being the active one.
-  const mySheets = useMyTimeSheets(activeTab === "mine", baseFilters);
-  const allCards = useAllTimeCards(activeTab === "all", baseFilters);
-  const queue = useApprovalQueue(activeTab === "approvals" && role.isApprover, baseFilters);
+  // Each tab pages independently — was previously fetching its *entire*
+  // scope (up to 1,000 cards, sequential page-by-page requests) before
+  // showing anything, confirmed live to take 30-60+ seconds and, with all
+  // three tabs doing this eagerly at once, enough concurrent load to make
+  // some fail outright. Real pagination replaces that: one page at a time,
+  // driven by the TablePagination controls below each list. Still gated on
+  // its own tab actually being active, for the same concurrent-load reason.
+  const minePagination = usePagination();
+  const allPagination = usePagination();
+  const approvalsPagination = usePagination();
+
+  const mySheets = useMyTimeSheets(activeTab === "mine", baseFilters, minePagination.pagination);
+  const allCards = useAllTimeCards(activeTab === "all", baseFilters, allPagination.pagination);
+  const queue = useApprovalQueue(
+    activeTab === "approvals" && role.isApprover,
+    baseFilters,
+    approvalsPagination.pagination,
+  );
   const decideCard = useDecideCard();
 
   const anyFilterActive =
     !!filterProject || !!filterWorkItem.trim() || !!filterState || !!filterEngineer.trim();
+
+  // A filter change re-scopes the search for every tab, so every tab's page
+  // position needs to reset too — otherwise "page 3" of a narrower result
+  // set could be past the end, or just show unrelated leftovers.
+  const resetAllPages = (): void => {
+    minePagination.setPage(0);
+    allPagination.setPage(0);
+    approvalsPagination.setPage(0);
+  };
+  const handleFilterProjectChange = (v: string): void => {
+    setFilterProject(v);
+    resetAllPages();
+  };
+  const handleFilterStateChange = (v: TimeCardState | ""): void => {
+    setFilterState(v);
+    resetAllPages();
+  };
   const clearFilters = (): void => {
     setFilterProject("");
     setFilterWorkItem("");
     setFilterState("");
     setFilterEngineer("");
+    resetAllPages();
   };
 
   const handleCardAction = (card: CsmTimeCard, action: TimecardAction): void => {
@@ -158,11 +214,11 @@ export default function CsmTimeCardsPage(): JSX.Element {
           <FilterBar
             projects={projects.data ?? []}
             filterProject={filterProject}
-            setFilterProject={setFilterProject}
+            setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
             setFilterWorkItem={setFilterWorkItem}
             filterState={filterState}
-            setFilterState={setFilterState}
+            setFilterState={handleFilterStateChange}
             onClear={clearFilters}
           />
 
@@ -180,9 +236,6 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load your time sheets.</Typography>
           ) : (
             <>
-              {mySheets.data?.truncated && (
-                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
-              )}
               {(() => {
                 const filtered = byWorkItem(mySheets.data?.sheets) ?? [];
                 if (filtered.length === 0) {
@@ -205,6 +258,22 @@ export default function CsmTimeCardsPage(): JSX.Element {
                   />
                 ));
               })()}
+              {/* Pages over raw records, not weekly sheets — a week's cards
+               can legitimately span a page boundary and look incomplete
+               until you've paged further; same for "my cards" being a small
+               slice of whatever's on each raw page. Accepted tradeoff for
+               real pagination instead of a 30-60s upfront full-scope fetch. */}
+              <TablePagination
+                component="div"
+                count={mySheets.data?.total ?? 0}
+                page={minePagination.pagination.page}
+                onPageChange={minePagination.onPageChange}
+                rowsPerPage={minePagination.pagination.rowsPerPage}
+                onRowsPerPageChange={minePagination.onRowsPerPageChange}
+                rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+                showFirstButton
+                showLastButton
+              />
             </>
           )}
         </Box>
@@ -219,11 +288,11 @@ export default function CsmTimeCardsPage(): JSX.Element {
           <FilterBar
             projects={projects.data ?? []}
             filterProject={filterProject}
-            setFilterProject={setFilterProject}
+            setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
             setFilterWorkItem={setFilterWorkItem}
             filterState={filterState}
-            setFilterState={setFilterState}
+            setFilterState={handleFilterStateChange}
             onClear={clearFilters}
             engineerSlot={
               <TextField
@@ -253,9 +322,6 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load time cards.</Typography>
           ) : (
             <>
-              {!allCards.isError && allCards.data?.truncated && (
-                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
-              )}
               {(() => {
                 const q = filterEngineer.trim().toLowerCase();
                 const byEngineer = (allCards.data?.sheets ?? []).filter(
@@ -285,6 +351,17 @@ export default function CsmTimeCardsPage(): JSX.Element {
                   />
                 ));
               })()}
+              <TablePagination
+                component="div"
+                count={allCards.data?.total ?? 0}
+                page={allPagination.pagination.page}
+                onPageChange={allPagination.onPageChange}
+                rowsPerPage={allPagination.pagination.rowsPerPage}
+                onRowsPerPageChange={allPagination.onRowsPerPageChange}
+                rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+                showFirstButton
+                showLastButton
+              />
             </>
           )}
         </Box>
@@ -298,11 +375,11 @@ export default function CsmTimeCardsPage(): JSX.Element {
           <FilterBar
             projects={projects.data ?? []}
             filterProject={filterProject}
-            setFilterProject={setFilterProject}
+            setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
             setFilterWorkItem={setFilterWorkItem}
             filterState={filterState}
-            setFilterState={setFilterState}
+            setFilterState={handleFilterStateChange}
             onClear={clearFilters}
             engineerSlot={
               <TextField
@@ -330,48 +407,53 @@ export default function CsmTimeCardsPage(): JSX.Element {
             </Centered>
           ) : queue.isError ? (
             <Typography color="error">Could not load the approval queue.</Typography>
-          ) : (queue.data?.sheets ?? []).length === 0 ? (
-            <>
-              {queue.data?.truncated && (
-                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
-              )}
-              <Empty text="Nothing awaiting approval." />
-            </>
           ) : (
             <>
-              {queue.data?.truncated && (
-                <TimeCardTruncatedNotice hint="Narrow the Project filter to see everything." />
-              )}
-              {(() => {
-                const q = filterEngineer.trim().toLowerCase();
-                const byEngineer = (queue.data?.sheets ?? []).filter(
-                  (s) => !q || s.userName.toLowerCase().includes(q),
-                );
-                const filtered = byWorkItem(byEngineer) ?? [];
-                if (filtered.length === 0) {
-                  return (
-                    <Empty
-                      text={
-                        // Only blame the engineer filter when it's the one that
-                        // excluded everything — if it matched fine and the
-                        // work-item filter emptied the result, say that instead.
-                        q && byEngineer.length === 0
-                          ? `No engineers match "${filterEngineer}".`
-                          : "No time cards match the current filters."
-                      }
-                    />
+              {(queue.data?.sheets ?? []).length === 0 ? (
+                <Empty text="Nothing awaiting approval." />
+              ) : (
+                (() => {
+                  const q = filterEngineer.trim().toLowerCase();
+                  const byEngineer = (queue.data?.sheets ?? []).filter(
+                    (s) => !q || s.userName.toLowerCase().includes(q),
                   );
-                }
-                return filtered.map((s) => (
-                  <TimeSheetCard
-                    key={s.id}
-                    sheet={s}
-                    role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
-                    showEngineer
-                    onCardAction={handleCardAction}
-                  />
-                ));
-              })()}
+                  const filtered = byWorkItem(byEngineer) ?? [];
+                  if (filtered.length === 0) {
+                    return (
+                      <Empty
+                        text={
+                          // Only blame the engineer filter when it's the one that
+                          // excluded everything — if it matched fine and the
+                          // work-item filter emptied the result, say that instead.
+                          q && byEngineer.length === 0
+                            ? `No engineers match "${filterEngineer}".`
+                            : "No time cards match the current filters."
+                        }
+                      />
+                    );
+                  }
+                  return filtered.map((s) => (
+                    <TimeSheetCard
+                      key={s.id}
+                      sheet={s}
+                      role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
+                      showEngineer
+                      onCardAction={handleCardAction}
+                    />
+                  ));
+                })()
+              )}
+              <TablePagination
+                component="div"
+                count={queue.data?.total ?? 0}
+                page={approvalsPagination.pagination.page}
+                onPageChange={approvalsPagination.onPageChange}
+                rowsPerPage={approvalsPagination.pagination.rowsPerPage}
+                onRowsPerPageChange={approvalsPagination.onRowsPerPageChange}
+                rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+                showFirstButton
+                showLastButton
+              />
             </>
           )}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -381,6 +381,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
             filterState={filterState}
             setFilterState={handleFilterStateChange}
             onClear={clearFilters}
+            hideStateFilter
             engineerSlot={
               <TextField
                 size="small"
@@ -491,7 +492,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
  * "processed" exist in the backend's enum but nothing here can produce them. */
 const FILTER_STATES: TimeCardState[] = ["submitted", "approved", "rejected"];
 
-/** Shared filter bar for the My time sheets and Approvals tabs. */
+/** Shared filter bar for the My time sheets, All, and Approvals tabs. */
 function FilterBar({
   projects,
   filterProject,
@@ -503,6 +504,7 @@ function FilterBar({
   onClear,
   engineerSlot,
   engineerChip,
+  hideStateFilter,
 }: {
   projects: BeProject[];
   filterProject: string;
@@ -515,6 +517,10 @@ function FilterBar({
   engineerSlot?: JSX.Element;
   /** Active-chip for the Engineer filter — only the Approvals tab has one. */
   engineerChip?: { label: string; onDelete: () => void };
+  /** Approvals always forces `states: ["submitted"]` server-side (see
+   * `useApprovalQueue`), so the State control can't actually narrow anything
+   * there — hide it instead of showing a filter that silently does nothing. */
+  hideStateFilter?: boolean;
 }): JSX.Element {
   const activeChips: { key: string; label: string; onDelete: () => void }[] = [];
   if (engineerChip) activeChips.push({ key: "engineer", ...engineerChip });
@@ -533,7 +539,7 @@ function FilterBar({
       onDelete: () => setFilterWorkItem(""),
     });
   }
-  if (filterState) {
+  if (!hideStateFilter && filterState) {
     activeChips.push({
       key: "state",
       label: `State: ${TIME_CARD_STATE_META[filterState].label}`,
@@ -605,21 +611,23 @@ function FilterBar({
 
         {engineerSlot}
 
-        <TextField
-          select
-          size="small"
-          label="State"
-          value={filterState}
-          onChange={(e) => setFilterState(e.target.value as TimeCardState | "")}
-          sx={{ width: 150 }}
-        >
-          <MenuItem value="">All states</MenuItem>
-          {FILTER_STATES.map((s) => (
-            <MenuItem key={s} value={s}>
-              {TIME_CARD_STATE_META[s].label}
-            </MenuItem>
-          ))}
-        </TextField>
+        {!hideStateFilter && (
+          <TextField
+            select
+            size="small"
+            label="State"
+            value={filterState}
+            onChange={(e) => setFilterState(e.target.value as TimeCardState | "")}
+            sx={{ width: 150 }}
+          >
+            <MenuItem value="">All states</MenuItem>
+            {FILTER_STATES.map((s) => (
+              <MenuItem key={s} value={s}>
+                {TIME_CARD_STATE_META[s].label}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
 
         <Box sx={{ flexGrow: 1 }} />
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
@@ -152,17 +152,14 @@ export interface CsmTimeSheet {
 
 /**
  * Filters for the time-card search. Sent in the POST body (never as query
- * params). The backend only supports `projectIds` / `states` / date range
- * server-side; case and engineer scoping happen client-side over the
- * returned page (see `useTimeSheets.ts`) since the backend has no `caseId`
- * or `engineerId` search filter.
+ * params). The backend only supports `projectIds` / `states` server-side;
+ * case and engineer scoping happen client-side over the returned page (see
+ * `useTimeSheets.ts`) since the backend has no `caseId` or `engineerId`
+ * search filter. No date-range filter — nothing in the UI sets one.
  */
 export interface TimeCardSearchFilters {
   /** Projects to include (company customer may own several). */
   projectIds?: string[];
   /** Lifecycle states to include. */
   states?: TimeCardState[];
-  /** Inclusive date range (YYYY-MM-DD), matched against `createdOn`. */
-  from?: string;
-  to?: string;
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
@@ -156,14 +156,27 @@ export interface CsmTimeSheet {
 
 /**
  * Filters for the time-card search. Sent in the POST body (never as query
- * params). The backend only supports `projectIds` / `states` server-side;
- * case and engineer scoping happen client-side over the returned page (see
- * `useTimeSheets.ts`) since the backend has no `caseId` or `engineerId`
- * search filter. No date-range filter — nothing in the UI sets one.
+ * params). `projectIds`, `userId`, `approverId`, and `from`/`to` are all
+ * real, confirmed-working server-side filters. `states` is filtered
+ * client-side instead — see the note on `searchTimeCards` in
+ * `useTimeSheets.ts` for why. `from`/`to` currently has no UI control wired
+ * to it; kept so a future date-range filter has somewhere to plug in.
+ *
+ * There is deliberately no `caseId` here even though `entity-service`
+ * documents and implements one — confirmed live to be non-functional
+ * (always `total: 0`); case scoping goes through `projectIds` plus a
+ * client-side filter instead (see `useCaseTimeCards` in `useTimeCards.ts`).
  */
 export interface TimeCardSearchFilters {
   /** Projects to include (company customer may own several). */
   projectIds?: string[];
+  /** Only cards submitted by this user. */
+  userId?: string;
+  /** Only cards this user is eligible to approve (backend: SN `approver_list`). */
+  approverId?: string;
   /** Lifecycle states to include. */
   states?: TimeCardState[];
+  /** Inclusive date range (YYYY-MM-DD), matched against `createdOn`. */
+  from?: string;
+  to?: string;
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
@@ -85,8 +85,12 @@ export interface CsmTimeCard {
   projectId: string;
   projectName: string;
   /**
-   * When the record was created (ISO). The backend doesn't separately track
-   * the engineer-chosen work date on read, only creation time.
+   * The work date (ISO, YYYY-MM-DD), despite the name — confirmed live by
+   * backdating a test card and reading it back: the backend returns
+   * whatever date was submitted on create under this field, not a separate
+   * system-generated creation timestamp. Occasionally unparseable on real
+   * records (confirmed live); see `groupIntoSheets` in `useTimeSheets.ts`
+   * for how that's handled.
    */
   createdOn: string;
   userId: string;

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardTotals.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardTotals.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 import {
   emptyBreakdown,
   hasLoggedHours,
+  roundedTotalHours,
   timeCardDraftErrors,
   totalHours,
 } from "@features/csm-timecards/utils/timeCardTotals";
@@ -43,6 +44,24 @@ describe("timeCardTotals", () => {
 
   it("detects logged hours", () => {
     expect(hasLoggedHours({ ...emptyBreakdown(), answering: 0.25 })).toBe(true);
+  });
+
+  describe("roundedTotalHours", () => {
+    it("matches totalHours when every bucket already rounds cleanly", () => {
+      expect(
+        roundedTotalHours({ ...emptyBreakdown(), analysisDebugging: 1, reproduce: 2 }),
+      ).toBe(3);
+    });
+
+    it("rounds down to 0 when every bucket is under 0.5h, even with a nonzero raw total", () => {
+      expect(
+        roundedTotalHours({
+          ...emptyBreakdown(),
+          analysisDebugging: 0.25,
+          reproduce: 0.25,
+        }),
+      ).toBe(0);
+    });
   });
 
   describe("timeCardDraftErrors", () => {
@@ -76,6 +95,14 @@ describe("timeCardTotals", () => {
         workLogComment: "a".repeat(WORK_LOG_MAX + 1),
       });
       expect(errors.workLogComment).toBeDefined();
+    });
+
+    it("flags an hours total that rounds down to 0h even though the raw total is nonzero", () => {
+      const errors = timeCardDraftErrors({
+        ...valid,
+        breakdown: { ...emptyBreakdown(), analysisDebugging: 0.25, reproduce: 0.25 },
+      });
+      expect(errors.hours).toBeDefined();
     });
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetGrouping.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetGrouping.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { groupIntoSheets, sheetStatus } from "@features/csm-timecards/utils/timeSheetGrouping";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+function card(overrides: Partial<CsmTimeCard>): CsmTimeCard {
+  return {
+    id: "card-1",
+    caseId: "case-1",
+    caseNumber: "CS0000001",
+    projectId: "project-1",
+    projectName: "Project",
+    createdOn: "2026-06-01",
+    userId: "user-1",
+    userName: "Test User",
+    state: "submitted",
+    billable: false,
+    totalHours: 1,
+    ...overrides,
+  };
+}
+
+describe("sheetStatus", () => {
+  it("is rejected if any card is rejected", () => {
+    expect(sheetStatus([card({ state: "submitted" }), card({ state: "rejected" })])).toBe(
+      "rejected",
+    );
+  });
+
+  it("is approved only when every card is approved or processed", () => {
+    expect(sheetStatus([card({ state: "approved" }), card({ state: "processed" })])).toBe(
+      "approved",
+    );
+  });
+
+  it("is submitted otherwise", () => {
+    expect(sheetStatus([card({ state: "submitted" }), card({ state: "approved" })])).toBe(
+      "submitted",
+    );
+  });
+});
+
+describe("groupIntoSheets", () => {
+  it("groups cards into weekly sheets", () => {
+    const sheets = groupIntoSheets(
+      [card({ id: "a", createdOn: "2026-06-01" }), card({ id: "b", createdOn: "2026-06-02" })],
+      "user-1",
+      "Test User",
+    );
+    expect(sheets).toHaveLength(1);
+    expect(sheets[0].cards).toHaveLength(2);
+  });
+
+  it("splits cards from different weeks into separate sheets, newest first", () => {
+    const sheets = groupIntoSheets(
+      [card({ id: "a", createdOn: "2026-06-01" }), card({ id: "b", createdOn: "2026-06-15" })],
+      "user-1",
+      "Test User",
+    );
+    expect(sheets).toHaveLength(2);
+    expect(sheets[0].cards[0].id).toBe("b");
+  });
+
+  it("skips a card with an unparseable createdOn instead of throwing, keeping the rest", () => {
+    const sheets = groupIntoSheets(
+      [
+        card({ id: "good-1", createdOn: "2026-06-01" }),
+        card({ id: "bad", createdOn: "" }),
+        card({ id: "good-2", createdOn: "2026-06-02" }),
+      ],
+      "user-1",
+      "Test User",
+    );
+    const ids = sheets.flatMap((s) => s.cards.map((c) => c.id));
+    expect(ids).toEqual(expect.arrayContaining(["good-1", "good-2"]));
+    expect(ids).not.toContain("bad");
+    expect(ids).toHaveLength(2);
+  });
+
+  it("returns an empty list when every card has an unparseable createdOn", () => {
+    const sheets = groupIntoSheets([card({ id: "bad", createdOn: "" })], "user-1", "Test User");
+    expect(sheets).toEqual([]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardTotals.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardTotals.ts
@@ -48,6 +48,19 @@ export function hasLoggedHours(breakdown: ActivityBreakdown): boolean {
   return ACTIVITY_KEYS.some((key) => (breakdown[key] || 0) > 0);
 }
 
+/**
+ * What the submitted card's total will actually be: each bucket rounded to
+ * a whole hour independently, then summed — mirrors `usePostTimeCard`'s
+ * per-field `Math.round()` exactly, since the backend's hour fields are
+ * integers. A form can show a valid nonzero total (e.g. two 0.25h buckets,
+ * summing to a "logged" 0.5h) where every individual bucket still rounds to
+ * 0 — this catches that case so the form can block submit instead of
+ * silently sending an all-zero card.
+ */
+export function roundedTotalHours(breakdown: ActivityBreakdown): number {
+  return ACTIVITY_KEYS.reduce((sum, key) => sum + Math.round(breakdown[key] || 0), 0);
+}
+
 /** Field-level validation errors for the log dialog, keyed by field name. */
 export interface TimeCardDraftErrors {
   date?: string;
@@ -73,6 +86,12 @@ export function timeCardDraftErrors(draft: TimeCardDraft): TimeCardDraftErrors {
   if (!draft.date) errors.date = "Pick a date.";
   if (!hasLoggedHours(draft.breakdown)) {
     errors.hours = "Log time against at least one activity.";
+  } else if (roundedTotalHours(draft.breakdown) === 0) {
+    // Each bucket is sent to the backend rounded to a whole hour — a form
+    // that looks valid (some bucket > 0) can still round down to an
+    // all-zero card if every bucket is under 0.5h.
+    errors.hours =
+      "Logged time rounds down to 0h — the backend only accepts whole hours per activity. Increase an activity's hours to at least 0.5.";
   }
   if (!draft.workLogComment.trim()) {
     errors.workLogComment = "Add a work log comment.";

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetGrouping.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetGrouping.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  CsmTimeCard,
+  CsmTimeSheet,
+  TimeSheetState,
+} from "@features/csm-timecards/types/timeCards";
+import { weekEndOf, weekStartOf } from "@features/csm-timecards/utils/timeSheetWeek";
+import { roundHours } from "@features/csm-timecards/utils/timeCardTotals";
+
+/** Roll a week's cards up into a single display status. */
+export function sheetStatus(cards: CsmTimeCard[]): TimeSheetState {
+  if (cards.some((c) => c.state === "rejected")) return "rejected";
+  if (cards.every((c) => c.state === "approved" || c.state === "processed")) {
+    return "approved";
+  }
+  return "submitted";
+}
+
+/**
+ * Group a flat list of cards into weekly sheets (Mon–Sun), newest first.
+ * `weekStartOf` throws (`RangeError: Invalid time value`) if `createdOn`
+ * isn't a parseable date — confirmed live: at least one real card has one
+ * (blank or otherwise malformed). Skip that one card rather than losing the
+ * whole group of otherwise-good cards to it — the same "one bad record
+ * shouldn't sink the rest" issue already worked around for search
+ * pagination (see `searchTimeCards` in `useTimeSheets.ts`), just on the
+ * client this time.
+ */
+export function groupIntoSheets(
+  cards: CsmTimeCard[],
+  userId: string,
+  userName: string,
+): CsmTimeSheet[] {
+  const byWeek = new Map<string, CsmTimeCard[]>();
+  for (const c of cards) {
+    let wk: string;
+    try {
+      wk = weekStartOf(c.createdOn);
+    } catch {
+      continue;
+    }
+    const bucket = byWeek.get(wk);
+    if (bucket) bucket.push(c);
+    else byWeek.set(wk, [c]);
+  }
+  const sheets: CsmTimeSheet[] = [];
+  for (const [weekStart, weekCards] of byWeek) {
+    weekCards.sort((a, b) => b.createdOn.localeCompare(a.createdOn));
+    sheets.push({
+      id: `${userId}:${weekStart}`,
+      userId,
+      userName,
+      weekStart,
+      weekEnd: weekEndOf(weekStart),
+      state: sheetStatus(weekCards),
+      cards: weekCards,
+      totalHours: roundHours(weekCards.reduce((sum, c) => sum + c.totalHours, 0)),
+    });
+  }
+  return sheets.sort((a, b) => b.weekStart.localeCompare(a.weekStart));
+}

--- a/apps/csm-portal/webapp/tests/e2e/README.md
+++ b/apps/csm-portal/webapp/tests/e2e/README.md
@@ -98,10 +98,12 @@ Specs skip themselves (not fail) when the session they need is missing.
 - `auth/README.md` — how to capture a session bundle (localStorage + sessionStorage).
 - `fixtures/test.ts` — `withRole(test, role)` replays a session + skips if absent;
   `openContextAs(browser, role)` opens a **second** authenticated context for
-  specs needing two identities; `currentUserSearchQuery(page)` returns a query
-  guaranteed to match the signed-in user in the approver picker (a generic
-  single-letter query can match only an empty-email service account in this
-  small staging tenant — confirmed live).
+  specs needing two identities; `approverSearchQuery(page)` returns a query
+  (the signed-in user's email domain) guaranteed to surface a real, *other*
+  candidate in the approver picker — the picker excludes the signed-in user
+  (self-approval prevention), so a generic single-letter query can match only
+  an empty-email service account in this small staging tenant, and the
+  signed-in user's own address would always come back empty (confirmed live).
 - `pages/TimeCardsPage.ts` — page object for `/time-cards`.
 - `pages/LogTimeDialog.ts` — fills and submits the real "Log time" form.
 - `utils/selectors.ts` — `E2E_TAG` / `e2eWorkLogComment()` for tagging created data.

--- a/apps/csm-portal/webapp/tests/e2e/fixtures/test.ts
+++ b/apps/csm-portal/webapp/tests/e2e/fixtures/test.ts
@@ -102,21 +102,23 @@ export function withRole(t: typeof base, role: TimecardRole): void {
 }
 
 /**
- * A search string virtually guaranteed to match the signed-in user's own
- * account (their email's local part) — used as the approver-search query in
- * specs. A generic single-letter query can match only empty-email service
- * accounts in a small staging tenant (confirmed); querying by "myself" always
- * finds a real, email-having candidate regardless of who captured the
- * session or what else exists in the directory. Nothing in the approver
- * picker excludes the current user from the results.
+ * A search string for the approver picker that's virtually guaranteed to
+ * surface a real, email-having, *other* account — the signed-in user's own
+ * email domain. A generic single-letter query can match only empty-email
+ * service accounts in a small staging tenant (confirmed), so the query still
+ * needs to be domain-shaped, not just any string. Deliberately not the
+ * signed-in user's own address: `LogTimeCardDialog` excludes the signed-in
+ * user from approver candidates (self-approval prevention), so a query that
+ * only the current user's own account could match would always come back
+ * empty.
  */
-export async function currentUserSearchQuery(page: Page): Promise<string> {
+export async function approverSearchQuery(page: Page): Promise<string> {
   const [meResp] = await Promise.all([
     page.waitForResponse((r) => r.url().includes("/users/me")),
     page.goto("/dashboard"),
   ]);
   const me = (await meResp.json()) as { email?: string };
-  return me.email?.split("@")[0] ?? "a";
+  return me.email?.split("@")[1] ?? "a";
 }
 
 export const test = base;

--- a/apps/csm-portal/webapp/tests/e2e/pages/LogTimeDialog.ts
+++ b/apps/csm-portal/webapp/tests/e2e/pages/LogTimeDialog.ts
@@ -52,9 +52,11 @@ export class LogTimeDialog {
   /**
    * Fill the minimum required fields and submit, waiting for the dialog to
    * close. `approverQuery` should be a string guaranteed to match a real,
-   * email-having account — see `currentUserSearchQuery()` in `fixtures/test.ts`
-   * (a generic single-letter query can match only an empty-email service
-   * account in a small staging tenant, confirmed live).
+   * email-having, *other* account — see `approverSearchQuery()` in
+   * `fixtures/test.ts` (a generic single-letter query can match only an
+   * empty-email service account in a small staging tenant, confirmed live,
+   * and the signed-in user's own address never matches since the picker
+   * excludes them).
    */
   async fillAndSubmit(opts: {
     hours: number;

--- a/apps/csm-portal/webapp/tests/e2e/specs/timecards/approvals.spec.ts
+++ b/apps/csm-portal/webapp/tests/e2e/specs/timecards/approvals.spec.ts
@@ -30,7 +30,7 @@
 // approver, or this test would 403 for the same reason.
 //
 
-import { test, expect, withRole, hasSession, openContextAs, currentUserSearchQuery } from "../../fixtures/test";
+import { test, expect, withRole, hasSession, openContextAs, approverSearchQuery } from "../../fixtures/test";
 import { TimeCardsPage } from "../../pages/TimeCardsPage";
 import { LogTimeDialog } from "../../pages/LogTimeDialog";
 import { e2eWorkLogComment } from "../../utils/selectors";
@@ -65,7 +65,7 @@ test.describe("time cards — approvals queue", () => {
     // The card's assigned approver must be the *approver* session, since
     // only the assigned approver can decide it (see note above) — derive the
     // search query from the primary `page` (approver), not the engineer.
-    const approverQuery = await currentUserSearchQuery(page);
+    const approverQuery = await approverSearchQuery(page);
 
     // Create the card as "engineer" in a second, independent context.
     const engineerContext = await openContextAs(browser, "engineer");

--- a/apps/csm-portal/webapp/tests/e2e/specs/timecards/case-integration.spec.ts
+++ b/apps/csm-portal/webapp/tests/e2e/specs/timecards/case-integration.spec.ts
@@ -31,7 +31,7 @@
 // just-created card round-tripped through search and rendered.
 //
 
-import { test, expect, withRole, currentUserSearchQuery } from "../../fixtures/test";
+import { test, expect, withRole, approverSearchQuery } from "../../fixtures/test";
 import { LogTimeDialog } from "../../pages/LogTimeDialog";
 import { e2eWorkLogComment } from "../../utils/selectors";
 
@@ -41,7 +41,7 @@ test.describe("time cards — case integration", () => {
   test("logging time from a case appears in the panel (real create + display)", async ({
     page,
   }) => {
-    const approverQuery = await currentUserSearchQuery(page);
+    const approverQuery = await approverSearchQuery(page);
     await page.goto("/cases");
 
     const firstCase = page

--- a/apps/csm-portal/webapp/tests/e2e/specs/timecards/my-sheets.spec.ts
+++ b/apps/csm-portal/webapp/tests/e2e/specs/timecards/my-sheets.spec.ts
@@ -23,7 +23,7 @@
 // here without the user touching the project filter.
 //
 
-import { test, expect, withRole, currentUserSearchQuery } from "../../fixtures/test";
+import { test, expect, withRole, approverSearchQuery } from "../../fixtures/test";
 import { TimeCardsPage } from "../../pages/TimeCardsPage";
 import { LogTimeDialog } from "../../pages/LogTimeDialog";
 import { e2eWorkLogComment } from "../../utils/selectors";
@@ -36,7 +36,7 @@ async function logTimeOnFirstCase(
   page: import("@playwright/test").Page,
   label: string,
 ): Promise<string | null> {
-  const approverQuery = await currentUserSearchQuery(page);
+  const approverQuery = await approverSearchQuery(page);
   await page.goto("/cases");
   const firstCase = page
     .locator('a[href^="/cases/"]:not([href="/cases/new"])')


### PR DESCRIPTION
## Summary
Frontend fixes for the items tracked in [digiops-cs#2229](https://github.com/wso2-enterprise/digiops-cs/issues/2229), filed after reviewing the shipped ISSU-009 code (merged via #992–#998, #1017).

- **Search truncation (HIGH)**: `searchTimeCards` now paginates through every page up to a 1,000-card safety cap instead of silently stopping after 50 — "My time sheets" and the Approvals queue could miss real data with no indication anything was cut off. Shows a notice if the cap itself is ever hit.
- **Self-approval (HIGH)**: the approver picker now excludes the signed-in user — nothing stopped naming yourself as approver and then approving your own card.
- **Identity gate (MED)**: `useCurrentEngineer` no longer falls back to email — that fallback made the "wait for a real id" gate never actually wait, since the ID-token email resolves before `GET /users/me` does.
- **0h submit (MED)**: form validation now checks the *rounded* hour total (matching what's actually sent), not the raw one — a form could show a valid nonzero total where every individual bucket still rounds to 0.
- **Minor**: removed dead `from`/`to` filters (nothing in the UI set them); `playwright.config.ts`'s `reuseExistingServer` is now `!CI` instead of unconditional.
- **Bonus, found while verifying the above live**: the backend fails an *entire* search page (50 records) if even one record in it is malformed — confirmed live against 9 real corrupt records, reported separately with correlation IDs. Search now degrades to partial results instead of losing an otherwise-successful fetch to one bad record several pages in.

**Correction to item #5 in the issue** (work date ignored for weekly grouping): verified live and this isn't actually a bug — `createdOn` on read is set to whatever date was submitted on create (confirmed by backdating a test card to 2020-01-15 and reading it back), not a separate system-generated timestamp. Weekly grouping already uses the correct date. No fix needed here; the rest of the issue's backend items are still valid and tracked/handled separately with the team.

## Test plan
- [x] `pnpm run lint` / `tsc -b` / `pnpm run test` (124 unit tests) / `pnpm run build` all pass
- [x] Verified live against real staging data, including the partial-result degradation path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tab-specific pagination for time-card listings (**My time sheets**, **All**, **Approvals**) with backend-provided totals.
  * Added a “results are partial” notice when listings are truncated, and improved weekly sheet grouping/status.
  * Added optional hiding of the State filter in the FilterBar.
* **Bug Fixes**
  * Improved identity and scoping for “My” and “Approvals”, removed fallback behavior, and excluded the signed-in user from approver suggestions.
  * Enhanced empty-state messaging and tightened hours validation using backend-style rounding.
* **Tests**
  * Expanded unit tests for truncation, totals rounding, and sheet grouping; updated E2E tests/fixtures for approver search behavior.
* **Chores**
  * Updated Playwright dev-server reuse behavior for local vs CI runs; refreshed E2E README and comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->