### PR TITLE
[Entity-Service] skip DB connection when DATA_SOURCE=servicenow

### DIFF
--- a/entity-service/cmd/api/main.go
+++ b/entity-service/cmd/api/main.go
@@ -46,7 +46,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("connect to database: %v", err)
 	}
-	defer pool.Close()
+	if pool != nil {
+		defer pool.Close()
+	}
 
 	addr := ":" + cfg.ServerPort
 	srv := server.New(addr, pool, cfg)

--- a/entity-service/internal/db/postgres.go
+++ b/entity-service/internal/db/postgres.go
@@ -60,10 +60,13 @@ func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	return pool, nil
 }
 
-// NewPoolIfNeeded creates a Postgres connection pool. A pool is always required
-// because only ProjectService is SN-backed; all other entities (users, accounts,
-// products, deployments, cases) continue to use Postgres regardless of DATA_SOURCE.
+// NewPoolIfNeeded creates a Postgres connection pool when one is needed.
+// When DATA_SOURCE=servicenow all entity reads/writes go through the SN
+// integration service, so no pool is opened and (nil, nil) is returned.
 func NewPoolIfNeeded(cfg *config.Config) (*pgxpool.Pool, error) {
+	if cfg.DataSource == config.DataSourceServiceNow {
+		return nil, nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return NewPool(ctx, cfg.DSN())

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -74,9 +74,12 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		snProductHandler = handler.NewSNProductHandler(service.NewServiceNowProductService(serviceNowIntegrationServiceClient))
 	}
 
-	productVersionRepo := repository.NewProductVersionRepository(db)
-	productVersionSvc := service.NewProductVersionService(productVersionRepo)
-	productVersionHandler := handler.NewProductVersionHandler(productVersionSvc)
+	var productVersionHandler *handler.ProductVersionHandler
+	if db != nil {
+		productVersionRepo := repository.NewProductVersionRepository(db)
+		productVersionSvc := service.NewProductVersionService(productVersionRepo)
+		productVersionHandler = handler.NewProductVersionHandler(productVersionSvc)
+	}
 
 	deploymentRepo := repository.NewDeploymentRepository(db)
 	var activeDeploymentSvc service.DeploymentService
@@ -185,7 +188,9 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	} else {
 		mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	}
-	mux.HandleFunc("POST /products/{id}/versions/search", productVersionHandler.SearchProductVersions)
+	if productVersionHandler != nil {
+		mux.HandleFunc("POST /products/{id}/versions/search", productVersionHandler.SearchProductVersions)
+	}
 	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	mux.HandleFunc("PATCH /deployments/{id}", deploymentHandler.PatchDeployment)


### PR DESCRIPTION
## Summary

- `NewPoolIfNeeded` now returns `nil, nil` immediately when `DATA_SOURCE=servicenow` — no DB credentials or live database required to start the service
- `main.go` guards `pool.Close()` so it only runs when a pool was actually opened
- `productVersionHandler` in `routes.go` is now conditional on `db != nil` — it was the only endpoint always registered regardless of data source (product version data lives only in postgres)

All other postgres repos in `routes.go` are safe with a `nil` pool: they're constructed but never queried because their route registrations are in `else` branches that only execute when `DATA_SOURCE=postgres`.

## Test plan

- [x] Start with `DATA_SOURCE=servicenow` and no `DB_*` env vars → service starts cleanly
- [x] `POST /products/{id}/versions/search` returns 404 when `DATA_SOURCE=servicenow` (route not registered)
- [x] All existing postgres-backed behaviour unchanged when `DATA_SOURCE=postgres`

🤖 Generated with [Claude Code](https://claude.com/claude-code)