### PR TITLE
[Entity-Service] add SN-backed POST /products/{id}/versions/search

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -401,6 +401,28 @@ const (
 	SupportStatusDiscontinued SupportStatus = "discontinued"
 )
 
+// SNProductVersion is the ServiceNow-backed product version type.
+// Date fields are strings (e.g. "2024-01-15") rather than time.Time to avoid
+// parse errors when SN returns empty strings for optional date fields.
+type SNProductVersion struct {
+	ID                             string  `json:"id"`
+	ProductID                      string  `json:"productId"`
+	Version                        string  `json:"version"`
+	CurrentSupportStatus           string  `json:"currentSupportStatus"`
+	ReleaseDate                    string  `json:"releaseDate"`
+	SupportEOLDate                 *string `json:"supportEolDate"`
+	EarliestPossibleSupportEOLDate *string `json:"earliestPossibleSupportEolDate"`
+}
+
+// SearchSNProductVersionsResponse is the paginated SN product version search result.
+type SearchSNProductVersionsResponse struct {
+	ProductVersions []SNProductVersion `json:"productVersions"`
+	Total           int                `json:"total"`
+	Limit           int                `json:"limit"`
+	Offset          int                `json:"offset"`
+	HasMore         bool               `json:"hasMore"`
+}
+
 // ProductVersion represents a versioned release of a software product.
 // SupportEOLDate and EarliestPossibleSupportEOLDate are optional.
 type ProductVersion struct {

--- a/entity-service/internal/handler/product_version_handler.go
+++ b/entity-service/internal/handler/product_version_handler.go
@@ -50,3 +50,29 @@ func (h *ProductVersionHandler) SearchProductVersions(w http.ResponseWriter, r *
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// SNProductVersionHandler handles POST /products/{id}/versions/search via ServiceNow.
+type SNProductVersionHandler struct {
+	svc service.SNProductVersionService
+}
+
+// NewSNProductVersionHandler constructs an SNProductVersionHandler with the given service.
+func NewSNProductVersionHandler(svc service.SNProductVersionService) *SNProductVersionHandler {
+	return &SNProductVersionHandler{svc: svc}
+}
+
+// SearchProductVersions handles POST /products/{id}/versions/search for the SN data source.
+func (h *SNProductVersionHandler) SearchProductVersions(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchProductVersionsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.ProductID = r.PathValue("id")
+	resp, err := h.svc.SearchProductVersions(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -75,7 +75,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	}
 
 	var productVersionHandler *handler.ProductVersionHandler
-	if db != nil {
+	var snProductVersionHandler *handler.SNProductVersionHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		snProductVersionHandler = handler.NewSNProductVersionHandler(service.NewServiceNowProductVersionService(serviceNowIntegrationServiceClient))
+	} else if db != nil {
 		productVersionRepo := repository.NewProductVersionRepository(db)
 		productVersionSvc := service.NewProductVersionService(productVersionRepo)
 		productVersionHandler = handler.NewProductVersionHandler(productVersionSvc)
@@ -188,7 +191,9 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	} else {
 		mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	}
-	if productVersionHandler != nil {
+	if snProductVersionHandler != nil {
+		mux.HandleFunc("POST /products/{id}/versions/search", snProductVersionHandler.SearchProductVersions)
+	} else if productVersionHandler != nil {
 		mux.HandleFunc("POST /products/{id}/versions/search", productVersionHandler.SearchProductVersions)
 	}
 	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -103,6 +103,13 @@ type ProductVersionService interface {
 	SearchProductVersions(ctx context.Context, req domain.SearchProductVersionsRequest) (domain.SearchProductVersionsResponse, error)
 }
 
+// SNProductVersionService is the ServiceNow-backed variant of ProductVersionService.
+// It returns SNProductVersion items with string date fields to avoid time.Parse errors
+// on empty SN date strings.
+type SNProductVersionService interface {
+	SearchProductVersions(ctx context.Context, req domain.SearchProductVersionsRequest) (domain.SearchSNProductVersionsResponse, error)
+}
+
 // DeploymentService defines the operations available on the deployment entity.
 type DeploymentService interface {
 	// SearchDeployments returns a paginated list of deployments filtered by optional

--- a/entity-service/internal/service/sn_product_version_service.go
+++ b/entity-service/internal/service/sn_product_version_service.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snProductVersionsResponse mirrors the Choreo POST /products/{id}/versions/search response.
+type snProductVersionsResponse struct {
+	Versions     []snProductVersion `json:"versions"`
+	TotalRecords int                `json:"totalRecords"`
+	Offset       int                `json:"offset"`
+	Limit        int                `json:"limit"`
+}
+
+type snProductVersion struct {
+	ID                             string  `json:"id"`
+	Version                        string  `json:"version"`
+	CurrentSupportStatus           string  `json:"currentSupportStatus"`
+	ReleaseDate                    string  `json:"releaseDate"`
+	SupportEolDate                 *string `json:"supportEolDate"`
+	EarliestPossibleSupportEolDate *string `json:"earliestPossibleSupportEolDate"`
+}
+
+// snProductVersionSearchPayload is the Choreo POST /products/{id}/versions/search request body.
+type snProductVersionSearchPayload struct {
+	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snProductVersionService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowProductVersionService constructs an SNProductVersionService backed by the Choreo API.
+func NewServiceNowProductVersionService(client *integrationservice.Client) SNProductVersionService {
+	return &snProductVersionService{client: client}
+}
+
+func (s *snProductVersionService) SearchProductVersions(ctx context.Context, req domain.SearchProductVersionsRequest) (domain.SearchSNProductVersionsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchSNProductVersionsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchSNProductVersionsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	productSysid := uuidToSysid(req.ProductID)
+	path := fmt.Sprintf("/products/%s/versions/search", productSysid)
+
+	payload := snProductVersionSearchPayload{
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, path, token, payload)
+	if err != nil {
+		return domain.SearchSNProductVersionsResponse{}, err
+	}
+
+	var snResp snProductVersionsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchSNProductVersionsResponse{}, fmt.Errorf("sn product versions: parse response: %w", err)
+	}
+
+	versions := make([]domain.SNProductVersion, 0, len(snResp.Versions))
+	for _, v := range snResp.Versions {
+		pv := domain.SNProductVersion{
+			ID:                   sysidToUUID(v.ID),
+			ProductID:            req.ProductID,
+			Version:              v.Version,
+			CurrentSupportStatus: v.CurrentSupportStatus,
+			ReleaseDate:          v.ReleaseDate,
+		}
+		if v.SupportEolDate != nil && *v.SupportEolDate != "" {
+			pv.SupportEOLDate = v.SupportEolDate
+		}
+		if v.EarliestPossibleSupportEolDate != nil && *v.EarliestPossibleSupportEolDate != "" {
+			pv.EarliestPossibleSupportEOLDate = v.EarliestPossibleSupportEolDate
+		}
+		versions = append(versions, pv)
+	}
+
+	total := snResp.TotalRecords
+	return domain.SearchSNProductVersionsResponse{
+		ProductVersions: versions,
+		Total:           total,
+		Limit:           req.Pagination.Limit,
+		Offset:          req.Pagination.Offset,
+		HasMore:         req.Pagination.Offset+len(versions) < total,
+	}, nil
+}

--- a/entity-service/internal/service/sn_product_version_service.go
+++ b/entity-service/internal/service/sn_product_version_service.go
@@ -46,7 +46,12 @@ type snProductVersion struct {
 
 // snProductVersionSearchPayload is the Choreo POST /products/{id}/versions/search request body.
 type snProductVersionSearchPayload struct {
-	Pagination snProjectPagination `json:"pagination"`
+	Filters    snProductVersionFilters `json:"filters,omitempty"`
+	Pagination snProjectPagination     `json:"pagination"`
+}
+
+type snProductVersionFilters struct {
+	SearchQuery string `json:"searchQuery,omitempty"`
 }
 
 type snProductVersionService struct {
@@ -62,6 +67,9 @@ func (s *snProductVersionService) SearchProductVersions(ctx context.Context, req
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchSNProductVersionsResponse{}, err
 	}
+	if err := validateSearchQuery(req.SearchQuery); err != nil {
+		return domain.SearchSNProductVersionsResponse{}, err
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
@@ -72,6 +80,7 @@ func (s *snProductVersionService) SearchProductVersions(ctx context.Context, req
 	path := fmt.Sprintf("/products/%s/versions/search", productSysid)
 
 	payload := snProductVersionSearchPayload{
+		Filters:    snProductVersionFilters{SearchQuery: req.SearchQuery},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 


### PR DESCRIPTION
## Summary

- Adds `SNProductVersion` domain type with string date fields (avoids `time.Parse` errors on empty SN date strings — same pattern as `SNProduct`/`SNAccount`)
- Adds `SNProductVersionService` interface and `sn_product_version_service.go` implementation — calls `POST /products/{sysid}/versions/search` on the Choreo API, converts product UUID → sysid on the way out and version sysids → UUIDs on the way back
- Adds `SNProductVersionHandler` alongside the existing postgres-backed `ProductVersionHandler`
- Routes `POST /products/{id}/versions/search` to the SN handler when `DATA_SOURCE=servicenow`, otherwise to the postgres handler (unchanged behaviour)

## Test plan

- [ ] `POST /products/{id}/versions/search` returns version list from SN when `DATA_SOURCE=servicenow`
- [ ] Version IDs are returned as UUIDs (not raw SN sysids)
- [ ] Optional date fields (`supportEolDate`, `earliestPossibleSupportEolDate`) are omitted from response when empty
- [ ] Existing postgres behaviour unchanged when `DATA_SOURCE=postgres`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ServiceNow support for product version search.
  * Introduced a ServiceNow-specific response shape with string-based date fields for safer display.
  * Enabled the API to route product version search requests to the appropriate backend based on data source.

* **Bug Fixes**
  * Improved handling of empty or nullable support/end-of-life dates.
  * Added pagination and result-mapping updates to return more reliable search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->