### PR TITLE
[Customer Portal MicroApp] feat: show recent chats/cases by activity, allow replying to chats

### DIFF
--- a/apps/customer-portal/microapp/src/components/features/chat/MessageBubble.tsx
+++ b/apps/customer-portal/microapp/src/components/features/chat/MessageBubble.tsx
@@ -14,8 +14,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, Divider, pxToRem, Skeleton, Stack, Typography, type SxProps, type Theme } from "@wso2/oxygen-ui";
-import { Sparkle } from "@wso2/oxygen-ui-icons-react";
+import {
+  alpha,
+  Avatar,
+  Box,
+  Divider,
+  Paper,
+  Skeleton,
+  Stack,
+  Typography,
+  type SxProps,
+  type Theme,
+} from "@wso2/oxygen-ui";
+import { Bot, User } from "@wso2/oxygen-ui-icons-react";
 import { KBCard } from "./KBCard";
 import { ChecklistItem } from "./ChecklistItem";
 import { TypewriterText } from "../../shared";
@@ -34,6 +45,42 @@ export interface ChatMessage {
   onAnimationComplete?: () => void;
 }
 
+const AVATAR_SIZE = 32;
+
+function NoveraAvatar() {
+  return (
+    <Box
+      sx={{
+        width: AVATAR_SIZE,
+        height: AVATAR_SIZE,
+        borderRadius: "50%",
+        background: "linear-gradient(135deg, #EA580C 0%, #F97316 100%)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+      }}
+    >
+      <Bot size={16} color="white" />
+    </Box>
+  );
+}
+
+function UserAvatar() {
+  return (
+    <Avatar
+      sx={{
+        width: AVATAR_SIZE,
+        height: AVATAR_SIZE,
+        bgcolor: (theme) => alpha(theme.palette.primary.light, 0.1),
+        color: (theme) => theme.palette.primary.main,
+      }}
+    >
+      <User size={16} />
+    </Avatar>
+  );
+}
+
 export function MessageBubble({
   author,
   blocks,
@@ -46,102 +93,95 @@ export function MessageBubble({
   const you = author === "you";
 
   return (
-    <Stack direction="row" justifyContent={you ? "end" : "start"}>
-      <Card
-        component={Stack}
-        p={1.5}
-        ml={you ? 10 : undefined}
-        width={you ? "fit-content" : "100%"}
-        sx={{ ...sx, bgcolor: "background.paper" }}
-      >
-        {!you && (
-          <Stack direction="row" justifyContent="space-between" gap={1} mb={0.5}>
-            <Box color="primary.main">
-              <Sparkle size={pxToRem(18)} />
-            </Box>
-            {thinking ? (
-              <Typography
-                noWrap
-                variant="subtitle2"
-                sx={{
-                  fontWeight: "medium",
-                  background: "linear-gradient(90deg, #aaa 25%, #fff 50%, #aaa 75%)",
-                  backgroundSize: "200% 100%",
-                  WebkitBackgroundClip: "text",
-                  WebkitTextFillColor: "transparent",
-                  backgroundClip: "text",
-                  animation: "shimmer 1.5s infinite linear",
-                  "@keyframes shimmer": {
-                    from: { backgroundPosition: "200% center" },
-                    to: { backgroundPosition: "-200% center" },
-                  },
-                  opacity: "80%",
-                  ml: 8,
-                }}
-              >
-                {typeof thinking === "string" ? thinking : "Thinking"}
-              </Typography>
-            ) : (
-              <Typography variant="subtitle2" color="text.disabled">
-                {timestamp}
-              </Typography>
-            )}
-          </Stack>
-        )}
+    <Stack direction="row" gap={1.5} sx={{ flexDirection: you ? "row-reverse" : "row", ...sx }}>
+      {you ? <UserAvatar /> : <NoveraAvatar />}
 
-        <Stack gap={2}>
-          {blocks.map((block, index) => {
-            switch (block.type) {
-              case "text":
-                return (
-                  <Typography
-                    key={index}
-                    variant="body2"
-                    component="span"
-                    sx={{ "& > *": { margin: 0, lineHeight: 1.7 } }}
-                  >
-                    <TypewriterText
-                      tokens={block.value.split("")}
-                      animated={animated}
-                      pending={!!thinking}
-                      onAnimationComplete={onAnimationComplete}
-                    />
-                  </Typography>
-                );
-
-              case "checklist":
-                return (
-                  <Stack key={index} gap={1}>
-                    {block.items.map((item, i) => (
-                      <ChecklistItem key={i}>{item}</ChecklistItem>
-                    ))}
-                  </Stack>
-                );
-
-              case "kb":
-                return (
-                  <Stack key={index} gap={1.5}>
-                    <Divider sx={{ my: 1 }} />
-                    {block.items.map((item, i) => (
-                      <KBCard key={i} id={item.id} title={item.title} />
-                    ))}
-                  </Stack>
-                );
-
-              default:
-                return null;
-            }
-          })}
-        </Stack>
-
-        {you && (
-          <Stack direction="row" justifyContent="end">
-            <Typography variant="subtitle2" color="text.disabled" mt={1}>
+      <Stack gap={0.5} sx={{ flex: you ? "0 1 auto" : 1, maxWidth: you ? "80%" : undefined, minWidth: 0 }}>
+        <Stack direction="row" gap={1} alignItems="center" justifyContent={you ? "flex-end" : "flex-start"}>
+          <Typography variant="body2" fontWeight="medium">
+            {you ? "You" : "Novera"}
+          </Typography>
+          {!you && thinking ? (
+            <Typography
+              noWrap
+              variant="caption"
+              sx={{
+                fontWeight: "medium",
+                background: "linear-gradient(90deg, #aaa 25%, #fff 50%, #aaa 75%)",
+                backgroundSize: "200% 100%",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+                backgroundClip: "text",
+                animation: "shimmer 1.5s infinite linear",
+                "@keyframes shimmer": {
+                  from: { backgroundPosition: "200% center" },
+                  to: { backgroundPosition: "-200% center" },
+                },
+                opacity: "80%",
+              }}
+            >
+              {typeof thinking === "string" ? thinking : "Thinking"}
+            </Typography>
+          ) : (
+            <Typography variant="caption" color="text.secondary">
               {timestamp}
             </Typography>
+          )}
+        </Stack>
+
+        <Box
+          component={you ? Paper : "div"}
+          elevation={0}
+          sx={
+            you ? { bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1), boxShadow: "none", p: 1.25 } : undefined
+          }
+        >
+          <Stack gap={2}>
+            {blocks.map((block, index) => {
+              switch (block.type) {
+                case "text":
+                  return (
+                    <Typography
+                      key={index}
+                      variant="body2"
+                      component="span"
+                      sx={{ "& > *": { margin: 0, lineHeight: 1.7 } }}
+                    >
+                      <TypewriterText
+                        tokens={block.value.split("")}
+                        animated={animated}
+                        pending={!!thinking}
+                        onAnimationComplete={onAnimationComplete}
+                      />
+                    </Typography>
+                  );
+
+                case "checklist":
+                  return (
+                    <Stack key={index} gap={1}>
+                      {block.items.map((item, i) => (
+                        <ChecklistItem key={i}>{item}</ChecklistItem>
+                      ))}
+                    </Stack>
+                  );
+
+                case "kb":
+                  return (
+                    <Stack key={index} gap={1.5}>
+                      <Divider sx={{ my: 1 }} />
+                      {block.items.map((item, i) => (
+                        <KBCard key={i} id={item.id} title={item.title} />
+                      ))}
+                    </Stack>
+                  );
+
+                default:
+                  return null;
+              }
+            })}
           </Stack>
-        )}
-      </Card>
+        </Box>
+      </Stack>
     </Stack>
   );
 }
@@ -155,38 +195,20 @@ export function MessageBubbleSkeleton({ author = "assistant", sx }: MessageBubbl
   const isYou = author === "you";
 
   return (
-    <Stack direction="row" justifyContent={isYou ? "end" : "start"} width="100%">
-      <Card
-        component={Stack}
-        p={1.5}
-        ml={isYou ? 10 : undefined}
-        width={isYou ? "fit-content" : "100%"}
-        sx={{
-          ...sx,
-          bgcolor: "background.paper",
-          borderStyle: "dashed",
-          borderWidth: 1,
-          borderColor: "divider",
-        }}
-      >
-        {!isYou && (
-          <Stack direction="row" justifyContent="start" gap={1} mb={1.5}>
-            <Skeleton variant="circular" width={pxToRem(18)} height={pxToRem(18)} />
-            <Skeleton variant="text" width={60} height={20} />
-          </Stack>
-        )}
+    <Stack direction="row" gap={1.5} width="100%" sx={{ flexDirection: isYou ? "row-reverse" : "row", ...sx }}>
+      <Skeleton variant="circular" width={AVATAR_SIZE} height={AVATAR_SIZE} />
+
+      <Stack gap={0.5} sx={{ flex: isYou ? "0 1 auto" : 1, minWidth: 0 }}>
+        <Stack direction="row" gap={1} justifyContent={isYou ? "flex-end" : "flex-start"}>
+          <Skeleton variant="text" width={50} height={20} />
+          <Skeleton variant="text" width={60} height={20} />
+        </Stack>
 
         <Stack gap={1}>
           <Skeleton variant="text" width={isYou ? 150 : "90%"} height={20} />
           <Skeleton variant="text" width={isYou ? 100 : "75%"} height={20} />
         </Stack>
-
-        {isYou && (
-          <Stack direction="row" justifyContent="end" mt={1}>
-            <Skeleton variant="text" width={50} height={20} />
-          </Stack>
-        )}
-      </Card>
+      </Stack>
     </Stack>
   );
 }

--- a/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
@@ -14,8 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { useState } from "react";
 import { motion, type Variants } from "framer-motion";
-import { Skeleton, Stack, Typography, pxToRem } from "@wso2/oxygen-ui";
+import { IconButton, Skeleton, Stack, Typography, pxToRem } from "@wso2/oxygen-ui";
+import { Check, Copy } from "@wso2/oxygen-ui-icons-react";
 import type { ItemCardProps } from "../support";
 
 import { TYPE_CONFIG } from "../support/config";
@@ -24,14 +26,28 @@ export function OverlineSlot({
   variant = "normal",
   type,
   id,
+  ids,
   title,
 }: {
   variant?: "normal" | "shrunk";
   type: ItemCardProps["type"];
   id?: string;
+  /** One or more copyable identifiers to render instead of `id` (e.g. internal + external case IDs). */
+  ids?: string[];
   title?: string;
 }) {
   const { icon: Icon, color } = TYPE_CONFIG[type];
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard access denied or unavailable — nothing actionable to do here.
+    }
+  };
 
   return (
     <Stack height={40}>
@@ -49,9 +65,25 @@ export function OverlineSlot({
         animate={variant}
       >
         <Icon color={color} size={pxToRem(16)} />
-        <Typography variant="body1" fontWeight="medium" noWrap>
-          {id ?? <Skeleton variant="text" width={120} height={30} />}
-        </Typography>
+        {ids ? (
+          <Stack direction="row" alignItems="center" gap={0.5} minWidth={0}>
+            <Typography variant="body1" fontWeight="medium" noWrap>
+              {ids.join(" | ")}
+            </Typography>
+            <IconButton
+              size="small"
+              color={copied ? "success" : "default"}
+              onClick={() => handleCopy(ids.join(" | "))}
+              aria-label="Copy IDs"
+            >
+              {copied ? <Check size={pxToRem(14)} /> : <Copy size={pxToRem(14)} />}
+            </IconButton>
+          </Stack>
+        ) : (
+          <Typography variant="body1" fontWeight="medium" noWrap>
+            {id ?? <Skeleton variant="text" width={120} height={30} />}
+          </Typography>
+        )}
       </Stack>
 
       {variant === "shrunk" && (

--- a/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from "react";
 import { motion, type Variants } from "framer-motion";
-import { IconButton, Skeleton, Stack, Typography, pxToRem } from "@wso2/oxygen-ui";
+import { IconButton, Skeleton, Stack, Tooltip, Typography, pxToRem } from "@wso2/oxygen-ui";
 import { Check, Copy } from "@wso2/oxygen-ui-icons-react";
 import type { ItemCardProps } from "../support";
 
@@ -70,14 +70,16 @@ export function OverlineSlot({
             <Typography variant="body1" fontWeight="medium" noWrap>
               {ids.join(" | ")}
             </Typography>
-            <IconButton
-              size="small"
-              color={copied ? "success" : "default"}
-              onClick={() => handleCopy(ids.join(" | "))}
-              aria-label="Copy IDs"
-            >
-              {copied ? <Check size={pxToRem(14)} /> : <Copy size={pxToRem(14)} />}
-            </IconButton>
+            <Tooltip title={copied ? "Copied!" : "Copy"}>
+              <IconButton
+                size="small"
+                color={copied ? "success" : "default"}
+                onClick={() => handleCopy(ids.join(" | "))}
+                aria-label="Copy IDs"
+              >
+                {copied ? <Check size={pxToRem(16)} /> : <Copy size={pxToRem(16)} />}
+              </IconButton>
+            </Tooltip>
           </Stack>
         ) : (
           <Typography variant="body1" fontWeight="medium" noWrap>

--- a/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
@@ -40,15 +40,24 @@ export function OverlineSlot({
   const [copied, setCopied] = useState(false);
   const [hovered, setHovered] = useState(false);
 
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
   const handleCopy = async (value: string) => {
     try {
       await navigator.clipboard.writeText(value);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       // Clipboard access denied or unavailable — nothing actionable to do here.
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   return (
     <Stack height={40}>

--- a/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
@@ -38,6 +38,7 @@ export function OverlineSlot({
 }) {
   const { icon: Icon, color } = TYPE_CONFIG[type];
   const [copied, setCopied] = useState(false);
+  const [hovered, setHovered] = useState(false);
 
   const handleCopy = async (value: string) => {
     try {
@@ -70,7 +71,12 @@ export function OverlineSlot({
             <Typography variant="body1" fontWeight="medium" noWrap>
               {ids.join(" | ")}
             </Typography>
-            <Tooltip title={copied ? "Copied!" : "Copy"}>
+            <Tooltip
+              title={copied ? "Copied!" : "Copy"}
+              open={copied || hovered}
+              onOpen={() => setHovered(true)}
+              onClose={() => setHovered(false)}
+            >
               <IconButton
                 size="small"
                 color={copied ? "success" : "default"}

--- a/apps/customer-portal/microapp/src/components/features/detail/StickyCommentBar.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/StickyCommentBar.tsx
@@ -27,6 +27,7 @@ interface StickyCommentBarProps {
   loading?: boolean;
   disabled?: boolean;
   submitOnEnter?: boolean;
+  multiline?: boolean;
 
   onChange: (value: string) => void;
   onSend: () => void;
@@ -40,6 +41,7 @@ export function StickyCommentBar({
   loading = false,
   disabled = false,
   submitOnEnter = true,
+  multiline = false,
   onChange,
   onSend,
 }: StickyCommentBarProps) {
@@ -51,7 +53,7 @@ export function StickyCommentBar({
     onSend();
   };
 
-  const handleKeyDown = (event: KeyboardEvent) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     if (submitOnEnter && event.key === "Enter" && hasContent) {
       event.preventDefault();
       send();
@@ -76,8 +78,10 @@ export function StickyCommentBar({
           size="small"
           value={value}
           placeholder={placeholder}
-          sx={{ alignSelf: "center" }}
-          onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
+          multiline={multiline}
+          maxRows={multiline ? 5 : undefined}
+          sx={{ alignSelf: multiline ? "stretch" : "center" }}
+          onChange={(event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange(event.target.value)}
           onKeyDown={handleKeyDown}
           disabled={loading || disabled}
           fullWidth

--- a/apps/customer-portal/microapp/src/components/shared/TypewriterText.tsx
+++ b/apps/customer-portal/microapp/src/components/shared/TypewriterText.tsx
@@ -62,7 +62,8 @@ export function TypewriterText({ tokens, pending = false, animated = true, onAni
           ),
         }}
       >
-        {animated ? fullText.slice(0, cursor) : fullText}
+        {/* force single newlines into markdown hard breaks so typed line breaks render as typed */}
+        {(animated ? fullText.slice(0, cursor) : fullText).replace(/\n/g, "  \n")}
       </Markdown>
       <Box
         sx={{

--- a/apps/customer-portal/microapp/src/config/constants.tsx
+++ b/apps/customer-portal/microapp/src/config/constants.tsx
@@ -145,12 +145,27 @@ export const CASE_STATE_IDS = {
   REOPENED: 1006,
 } as const;
 
+export const CONVERSATION_STATE_IDS = {
+  OPEN: 1,
+  ACTIVE: 2,
+  RESOLVED: 3,
+  CONVERTED: 4,
+  ABANDONED: 5,
+} as const;
+
 export const ACTION_REQUIRED_CASE_STATUS_IDS = [18, 6];
 export const ACTION_REQUIRED_CHANGE_REQUEST_STATUS_IDS = [1, 5];
 
 export const OUTSTANDING_CASE_STATUS_IDS = [1, 10, 18, 1003, 6, 1006];
 export const OUTSTANDING_CONVERSATIONS_STATUS_IDS = [1, 2];
 export const OUTSTANDING_CHANGE_REQUESTS_STATUS_IDS = [5, -2, -1, 0, 1, 2];
+
+// Chats in these states are read-only — replying is disabled once a conversation
+// has been resolved or converted to a case.
+export const READ_ONLY_CONVERSATION_STATUS_IDS: number[] = [
+  CONVERSATION_STATE_IDS.RESOLVED,
+  CONVERSATION_STATE_IDS.CONVERTED,
+];
 
 export const RESOLVED_CASE_STATUS_IDS = [3];
 export const RESOLVED_CHANGE_REQUEST_STATUS_IDS = [3];

--- a/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -144,7 +144,7 @@ export default function CaseDetailPage() {
       <OverlineSlot
         variant={overlineSlotVariant}
         type="case"
-        id={data?.number ? `${data.internalId} | ${data.number}` : undefined}
+        ids={data?.number ? [data.internalId, data.number] : undefined}
         title={data?.title}
       />,
     );

--- a/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
@@ -176,6 +176,7 @@ export default function ChatDetailPage() {
           value={comment}
           placeholder="Type your message"
           submitOnEnter={false}
+          multiline
           loading={mutation.isPending}
           disabled={!projectId}
           onChange={setComment}

--- a/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
@@ -31,6 +31,7 @@ import { SectionCard } from "@components/shared";
 import { useParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { chats } from "@src/services/chats";
+import { READ_ONLY_CONVERSATION_STATUS_IDS } from "@src/config/constants";
 import { useDateTime } from "../utils/useDateTime";
 
 export default function ChatDetailPage() {
@@ -41,10 +42,12 @@ export default function ChatDetailPage() {
   const [messages, setMessages] = useState<(ChatMessage & { id: string })[]>([]);
   const [comment, setComment] = useState("");
 
-  const { fromNow, format } = useDateTime();
+  const { format } = useDateTime();
   const { id } = useParams();
   const { data } = useQuery(chats.get(id!));
   const { data: comments, isLoading: isCommentsLoading } = useQuery(chats.comments(id!));
+
+  const isReadOnly = data?.statusId !== undefined && READ_ONLY_CONVERSATION_STATUS_IDS.includes(Number(data.statusId));
 
   const mutation = useMutation({
     mutationFn: (body: { message: string; envProducts: Record<string, string[]> }) => {
@@ -65,7 +68,7 @@ export default function ChatDetailPage() {
 
   const handleSend = () => {
     const trimmed = comment.trim();
-    if (!trimmed || !projectId || !id) return;
+    if (!trimmed || !projectId || !id || isReadOnly) return;
     mutation.mutate({ message: trimmed, envProducts: {} });
   };
 
@@ -77,7 +80,7 @@ export default function ChatDetailPage() {
         id: comment.id,
         author: comment.createdBy === "Novera" ? "assistant" : "you",
         blocks: [{ type: "text", value: comment.content || "" }],
-        timestamp: fromNow(comment.createdOn),
+        timestamp: format(comment.createdOn),
       })) || [],
     );
 
@@ -159,13 +162,7 @@ export default function ChatDetailPage() {
                 .slice()
                 .reverse()
                 .map(({ id, ...message }) => (
-                  <MessageBubble
-                    key={id}
-                    {...message}
-                    sx={{ bgcolor: "background.default" }}
-                    thinking={false}
-                    animated={false}
-                  />
+                  <MessageBubble key={id} {...message} thinking={false} animated={false} />
                 ))}
             </Stack>
           )}
@@ -176,10 +173,10 @@ export default function ChatDetailPage() {
 
       <StickyCommentBar
         value={comment}
-        placeholder="Type your message"
+        placeholder={isReadOnly ? "This conversation is no longer active" : "Type your message"}
         submitOnEnter={false}
         loading={mutation.isPending}
-        disabled={!projectId}
+        disabled={!projectId || isReadOnly}
         onChange={setComment}
         onSend={handleSend}
       />

--- a/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
@@ -123,7 +123,7 @@ export default function ChatDetailPage() {
 
   return (
     <>
-      <Stack gap={2} mb={10}>
+      <Stack gap={2} mb={isReadOnly ? 2 : 10}>
         <Typography ref={ref} variant="h5" fontWeight="medium">
           {data?.description}
         </Typography>
@@ -171,15 +171,17 @@ export default function ChatDetailPage() {
       </Stack>
       <div ref={bottomRef} />
 
-      <StickyCommentBar
-        value={comment}
-        placeholder={isReadOnly ? "This conversation is no longer active" : "Type your message"}
-        submitOnEnter={false}
-        loading={mutation.isPending}
-        disabled={!projectId || isReadOnly}
-        onChange={setComment}
-        onSend={handleSend}
-      />
+      {!isReadOnly && (
+        <StickyCommentBar
+          value={comment}
+          placeholder="Type your message"
+          submitOnEnter={false}
+          loading={mutation.isPending}
+          disabled={!projectId}
+          onChange={setComment}
+          onSend={handleSend}
+        />
+      )}
     </>
   );
 }

--- a/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
@@ -17,7 +17,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Grid, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import { StatusChip } from "@components/features/support";
-import { InfoField, OverlineSlot } from "@components/features/detail";
+import { InfoField, OverlineSlot, StickyCommentBar } from "@components/features/detail";
 import {
   ConversationFeedback,
   MessageBubble,
@@ -25,20 +25,40 @@ import {
   type ChatMessage,
 } from "@components/features/chat";
 import { useLayout } from "@context/layout";
+import { useProject } from "@context/project";
+import { useNotify } from "@context/snackbar";
 import { SectionCard } from "@components/shared";
 import { useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { chats } from "@src/services/chats";
 import { useDateTime } from "../utils/useDateTime";
 
 export default function ChatDetailPage() {
   const layout = useLayout();
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+  const { projectId } = useProject();
   const [messages, setMessages] = useState<(ChatMessage & { id: string })[]>([]);
+  const [comment, setComment] = useState("");
 
   const { fromNow, format } = useDateTime();
   const { id } = useParams();
   const { data } = useQuery(chats.get(id!));
   const { data: comments, isLoading: isCommentsLoading } = useQuery(chats.comments(id!));
+
+  const mutation = useMutation({
+    ...chats.send(projectId!, id!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: chats.comments(id!).queryKey });
+      setComment("");
+    },
+    onError: () => notify.error("Failed to send message. Please try again."),
+  });
+
+  const handleSend = () => {
+    if (!comment.trim()) return;
+    mutation.mutate({ message: comment, envProducts: {} });
+  };
 
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -144,6 +164,16 @@ export default function ChatDetailPage() {
         <ConversationFeedback />
       </Stack>
       <div ref={bottomRef} />
+
+      <StickyCommentBar
+        value={comment}
+        placeholder="Type your message"
+        submitOnEnter={false}
+        loading={mutation.isPending}
+        disabled={!projectId}
+        onChange={setComment}
+        onSend={handleSend}
+      />
     </>
   );
 }

--- a/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
@@ -47,7 +47,15 @@ export default function ChatDetailPage() {
   const { data: comments, isLoading: isCommentsLoading } = useQuery(chats.comments(id!));
 
   const mutation = useMutation({
-    ...chats.send(projectId!, id!),
+    mutationFn: (body: { message: string; envProducts: Record<string, string[]> }) => {
+      if (!projectId) {
+        return Promise.reject(new Error("Project ID is not available"));
+      }
+      if (!id) {
+        return Promise.reject(new Error("Conversation ID is not available"));
+      }
+      return chats.send(projectId, id).mutationFn!(body);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: chats.comments(id!).queryKey });
       setComment("");
@@ -56,8 +64,9 @@ export default function ChatDetailPage() {
   });
 
   const handleSend = () => {
-    if (!comment.trim()) return;
-    mutation.mutate({ message: comment, envProducts: {} });
+    const trimmed = comment.trim();
+    if (!trimmed || !projectId || !id) return;
+    mutation.mutate({ message: trimmed, envProducts: {} });
   };
 
   const bottomRef = useRef<HTMLDivElement>(null);

--- a/apps/customer-portal/microapp/src/pages/ChatPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatPage.tsx
@@ -288,6 +288,7 @@ export default function ChatPage() {
         value={comment}
         placeholder="Type your message"
         submitOnEnter={false}
+        multiline
         onChange={setComment}
         onSend={handleSend}
         topSlot={

--- a/apps/customer-portal/microapp/src/pages/ChatPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatPage.tsx
@@ -23,21 +23,19 @@ import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
 import { projects } from "@src/services/projects";
 import { useProject } from "@context/project";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import { Pin } from "@wso2/oxygen-ui-icons-react";
 import { NOVERA_WEBSOCKET_INITIALIZATION_ENDPOINT } from "../config/endpoints";
 import { useMe } from "../context/me";
 import type { FinalNoveraResponse, NoveraResponse } from "../types/novera.dto";
 import { getAccessToken, getIdToken } from "../services/auth";
 import type { Product } from "../types";
-
-dayjs.extend(relativeTime);
+import { useDateTime } from "../utils/useDateTime";
 
 export default function ChatPage() {
   const navigate = useNavigate();
   const { projectId, projectTypeId } = useProject();
   const { id: userId } = useMe();
+  const { format } = useDateTime();
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const [comment, setComment] = useState("");
   const [messages, setMessages] = useState<ChatMessage[]>([
@@ -190,7 +188,7 @@ export default function ChatPage() {
           thinking: false,
           author: "assistant",
           blocks: [{ type: "text", value: (pendingFinalData as FinalNoveraResponse).payload.message }],
-          timestamp: dayjs().fromNow(),
+          timestamp: format(new Date()),
         },
       ]);
       setActiveStreamingMessage(null);
@@ -223,7 +221,7 @@ export default function ChatPage() {
         thinking: false,
         author: "you",
         blocks: [{ type: "text", value: comment }],
-        timestamp: dayjs().fromNow(),
+        timestamp: format(new Date()),
       },
     ]);
 

--- a/apps/customer-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/SupportPage.tsx
@@ -32,7 +32,6 @@ import {
   ITEM_DETAIL_PATHS,
   OUTSTANDING_CASE_STATUS_IDS,
   OUTSTANDING_CHANGE_REQUESTS_STATUS_IDS,
-  OUTSTANDING_CONVERSATIONS_STATUS_IDS,
   TAB_CONFIG,
 } from "../config/constants";
 import { securityReportAnalysis } from "../services/sra";
@@ -155,11 +154,8 @@ function CaseItemListContent() {
   const { projectId } = useProject();
   const { data } = useSuspenseQuery(
     cases.all(projectId!, {
-      filters: {
-        statusIds: OUTSTANDING_CASE_STATUS_IDS,
-      },
       pagination: { limit: 5 },
-      sortBy: { field: "createdOn", order: "desc" },
+      sortBy: { field: "updatedOn", order: "desc" },
     }),
   );
 
@@ -178,11 +174,8 @@ function ChatItemListContent() {
   const { projectId } = useProject();
   const { data } = useSuspenseQuery(
     chats.all(projectId!, {
-      filters: {
-        stateKeys: OUTSTANDING_CONVERSATIONS_STATUS_IDS,
-      },
       pagination: { limit: 5 },
-      sortBy: { field: "createdOn", order: "desc" },
+      sortBy: { field: "updatedOn", order: "desc" },
     }),
   );
 


### PR DESCRIPTION
## Purpose
The Support page's Chats and Cases dashboard preview widgets were hard-filtered to a fixed set of "outstanding" status IDs and sorted by creation date. Items that changed status after creation (e.g. reopened, or just updated) wouldn't surface in the recent list, and "most recent" didn't reflect actual recent activity. Separately, the chat detail view was read-only — no way to reply within an existing conversation once opened from the Support page.

## Goals
- Show chats and cases in the Support page dashboard preview regardless of status, sorted by most-recently-updated instead of most-recently-created.
- Allow users to send a follow-up message from the chat detail page instead of only viewing a read-only transcript.

## Approach
- `SupportPage.tsx` — removed the `stateKeys`/`statusIds` filters from `ChatItemListContent` and `CaseItemListContent`, and changed `sortBy` from `{ field: "createdOn", order: "desc" }` to `{ field: "updatedOn", order: "desc" }` for both. `updatedOn` was already a supported sort field on the backend (`ConversationSortField`/`CaseSortField` enums), just unused by the frontend.
- `ChatDetailPage.tsx` — added a `StickyCommentBar` (the same reusable component used on `CaseDetailPage.tsx`/`ChatPage.tsx`) wired to the existing `chats.send` mutation, which was already implemented in `services/chats.ts` and backed by the existing `POST /projects/{id}/conversations/{conversationId}/messages` endpoint, but previously unused. On send, the mutation invalidates the chat's comments query so the reply and the AI's response (persisted server-side) appear in the transcript. Includes an `onError` toast on send failure and disables the input until `projectId` is resolved (avoids firing the mutation with a null project id on a direct deep-link/hard-refresh).

## Known follow-up
The Cases widget is still labeled "Outstanding Cases" / "Active support tickets" (`TAB_CONFIG.case`) even though it no longer filters by status — left as-is per product decision; worth revisiting the copy in a follow-up if it reads as misleading.

## User stories
As a customer portal user, I want to see my most recently active chats and cases on the Support page dashboard regardless of status, and I want to continue a conversation from an existing chat instead of only being able to start new ones.

## Release note
Support page dashboard now shows recently updated chats and cases of any status, sorted by last activity. Users can send follow-up messages from an existing chat's detail page.

## Documentation
N/A — UI behavior change only, no new user-facing workflow beyond existing chat/case viewing.

## Automation tests
- Unit tests: none added — no existing unit test coverage for these page components to extend.
- Integration tests: verified via `tsc --noEmit` (clean); live UI verification not performed in this environment (no local Asgardeo/backend auth configured) — please verify the reply flow and dashboard sorting against a real project before merging.

## Security checks
- Followed secure coding standards in the WSO2 secure engineering guidelines: yes
- Ran FindSecurityBugs plugin and verified report: not run (frontend-only TypeScript change, no Java/Ballerina touched)
- Confirmed this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Related PRs
N/A — rebased directly on `v2`; no dependency on other open PRs (the "guard against invalid user timezone" fix referenced during development, #1015, is already merged into `v2`).

## Test environment
Node v26.3.0, macOS 26.5.1, verified via `tsc --noEmit` only — live browser verification pending (see Automation tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat details include a sticky message composer (supports multiline) and hide it for read-only conversations.
  * Overline fields can now display and copy multiple identifiers.
* **Bug Fixes**
  * Sending messages now trims input, blocks sending when unavailable/read-only, shows errors on failure, and refreshes the thread after success.
* **UI / Improvements**
  * Chat timestamps now use standard formatted date/time across the conversation view.
  * Message bubbles and their skeletons were refreshed for a cleaner layout.
  * Support tabs for cases/chats now show “most recently updated” results with reduced status filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
