### PR TITLE
[Customer Portal Webapp] Hide Escalate Case button for service requests and engagements

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -115,10 +115,11 @@ export default function CaseDetailsActionRow({
   } | null>(null);
   const [escalateModalOpen, setEscalateModalOpen] = useState(false);
 
-  const resolvedEscalationLevelId = String(escalationLevelId ?? "0");
-  const escalationLevelInfo = ESCALATION_NEXT_LEVEL[resolvedEscalationLevelId];
-  const needsLead = ESCALATION_LEAD_REQUIRED_FROM_LEVEL.has(resolvedEscalationLevelId);
+  const resolvedEscalationLevelId = escalationLevelId != null ? String(escalationLevelId) : null;
+  const escalationLevelInfo = resolvedEscalationLevelId != null ? ESCALATION_NEXT_LEVEL[resolvedEscalationLevelId ?? "0"] : null;
+  const needsLead = resolvedEscalationLevelId != null && ESCALATION_LEAD_REQUIRED_FROM_LEVEL.has(resolvedEscalationLevelId);
   const showEscalateButton =
+    resolvedEscalationLevelId != null &&
     statusLabel !== "Closed" &&
     resolvedEscalationLevelId !== ESCALATION_MAX_LEVEL_ID &&
     !!escalationLevelInfo &&


### PR DESCRIPTION
## Summary
- `String(null ?? "0")` was resolving to `"0"`, which has a valid entry in `ESCALATION_NEXT_LEVEL`, causing the Escalate Case button to appear on service request and engagement detail pages even though escalation
  doesn't apply there
- Fixed by treating a `null` `escalationLevelId` (the signal set by`hideEscalationTab`) as "no escalation context", short-circuiting `showEscalateButton` to `false`
- Escalate Case button now only appears on default support case detail pages

## Test plan
- [ ] Open a regular support case — Escalate Case button should appear as before
- [ ] Open a service request detail page — Escalate Case button should not appear
- [ ] Open an engagement detail page — Escalate Case button should not appear
- [ ] Verify closed cases still do not show the button


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case escalation handling so cases without an escalation level no longer show escalation actions incorrectly.
  * The “Escalate Case” option now appears only when an escalation level is available, helping prevent invalid escalation attempts.
  * Escalation details are now carried through more reliably when opening the escalation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->