### PR TITLE
[CSM Portal] feat(webapp): raise internal GitHub issue from a case + cases-list work-state chip

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -992,6 +992,60 @@ export interface BeCreateCallRequestResponse {
   };
 }
 
+// ---------------------------------------------------------------------------
+// GitHub issue creation from a case — `POST /cases/{id}/github-issues`
+// (ServiceNow data source only; the BFF forwards the body opaquely to the
+// entity service, which validates and routes it to the SN scoped app).
+// ---------------------------------------------------------------------------
+
+/**
+ * Why the issue is being filed. Selects the label set applied on the GitHub
+ * issue and collapses the three legacy "open git issue" flows into one:
+ * `default` (Open Git Issue), `migration` (Open Migration Git Issue),
+ * `rd_ticket` (Open R&D ticket).
+ */
+export type BeCaseGithubIssueReason = "default" | "migration" | "rd_ticket";
+
+/** Explicit owner/repo, overriding the product-based routing lookup on the SN side. */
+export interface BeCaseGithubIssueRepoOverride {
+  owner: string;
+  repo: string;
+}
+
+/** `POST /cases/{id}/github-issues` request body. */
+export interface BeCreateCaseGithubIssuePayload {
+  reason: BeCaseGithubIssueReason;
+  title: string;
+  description: string;
+  /** Explicit target repo; when omitted, the SN side routes by the case's product unit. */
+  repoOverride?: BeCaseGithubIssueRepoOverride;
+  /** Product update level, appended to the issue body. */
+  updateLevel?: string;
+  /** Link to a related public-facing GitHub issue, appended to the issue body. */
+  publicIssueUrl?: string;
+  /** When true: adds a `regression` label and tags the case as a regression. */
+  regression?: boolean;
+  /** When true: appends "Hotfix Required : Yes" to the issue body. */
+  hotFixRequired?: boolean;
+  /** Issue-type label to apply on GitHub (e.g. "Type/Patch", "Type/Incident"). */
+  issueTypeLabel?: string;
+  /** Priority label, applied only when `issueTypeLabel` is "Type/Incident". */
+  priorityLevel?: string;
+}
+
+/** `POST /cases/{id}/github-issues` response. */
+export interface BeCreateCaseGithubIssueResponse {
+  message?: string;
+  issue?: {
+    /** URL of the created GitHub issue. */
+    url: string;
+    /** GitHub issue number. */
+    number: number;
+    /** Repo the issue was created in. */
+    repo: string;
+  };
+}
+
 /** `POST /cases/{id}/call-requests/search` request body. */
 export interface BeSearchCallRequestsPayload {
   filters?: {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseGithubIssue.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseGithubIssue.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCreateCaseGithubIssuePayload,
+  BeCreateCaseGithubIssueResponse,
+} from "@api/backend/types";
+
+export interface PostCaseGithubIssueInput extends BeCreateCaseGithubIssuePayload {
+  /** UUID of the case the issue is filed against (path param, not body). */
+  caseId: string;
+}
+
+/**
+ * File an internal GitHub issue from a case via `POST /cases/{id}/github-issues`
+ * (ISSU-020). ServiceNow-only: the entity service exposes this endpoint only
+ * when its data source is ServiceNow, and the SN scoped app both routes the
+ * issue (by the case's product unit, unless `repoOverride` is given) and writes
+ * the created issue URL back into the case's work notes.
+ *
+ * On success the case comments query is invalidated so that work-note entry
+ * shows up in the activities feed without a manual refresh. There is no issues
+ * list to refresh — SN does not track created issues (see the backend notes).
+ */
+export function usePostCaseGithubIssue(): UseMutationResult<
+  BeCreateCaseGithubIssueResponse,
+  Error,
+  PostCaseGithubIssueInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    BeCreateCaseGithubIssueResponse,
+    Error,
+    PostCaseGithubIssueInput
+  >({
+    mutationFn: async ({
+      caseId,
+      ...payload
+    }): Promise<BeCreateCaseGithubIssueResponse> => {
+      return api.post<
+        BeCreateCaseGithubIssuePayload,
+        BeCreateCaseGithubIssueResponse
+      >(`/cases/${encodeURIComponent(caseId)}/github-issues`, payload);
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CSM_CASE_COMMENTS, variables.caseId],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -44,7 +44,6 @@ import {
   ShieldAlert,
   TriangleAlert,
   User,
-  Users,
 } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import type {
@@ -184,7 +183,7 @@ interface SecondaryItem {
 /**
  * The "More" overflow lists state-independent actions on a case. Items here
  * map to documented use cases — see `UseCases.md`:
- *   - Reassign / group               → ISSU-002 (self-assign generalised)
+ *   - Reassign engineer              → ISSU-002 (self-assign generalised)
  *   - Escalate / Severity change     → ISSU-006, ISSU-007
  *   - Hold auto-closure              → ISSU-027
  *   - Create incident / link incident → ISSU-021
@@ -221,14 +220,13 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   // their backend flows land, so the menu advertises the roadmap without
   // exposing dead actions that would no-op or toast a mock message.
   items.push(
-    { key: "reassign_engineer", label: "Assign / reassign engineer…", icon: <User size={16} /> },
-    { key: "reassign_group", label: "Reassign to group…", icon: <Users size={16} />, divider: true, disabled: true },
+    { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} />, divider: true },
+    { key: "reassign_engineer", label: "Assign / reassign engineer…", icon: <User size={16} />, divider: true },
     { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} />, disabled: true },
     { key: "change_severity", label: "Request severity change…", icon: <ShieldAlert size={16} />, disabled: true },
     { key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true, disabled: true },
     { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true },
-    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, disabled: true },
-    { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} />, disabled: true },
+    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, divider: true, disabled: true },
     { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true, disabled: true },
     { key: "request_call", label: "Request a call…", icon: <Phone size={16} />, disabled: true },
     { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 import { Link as RouterLink } from "react-router";
 import RelativeTime from "@components/RelativeTime";
@@ -207,16 +207,13 @@ export default function CasesList({
               <Box sx={{ justifySelf: "start", minWidth: 0 }}>
                 <StateChip state={c.state} clickable />
                 {c.state === "work_in_progress" && c.workState && (
-                  <Typography
-                    variant="caption"
-                    noWrap
-                    color={
-                      c.workState === "paused" ? "warning.main" : "text.secondary"
-                    }
-                    sx={{ display: "block", mt: 0.25 }}
-                  >
-                    {WORK_STATE_LABEL[c.workState]}
-                  </Typography>
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    color={c.workState === "paused" ? "warning" : "default"}
+                    label={WORK_STATE_LABEL[c.workState]}
+                    sx={{ display: "flex", mt: 0.25, fontWeight: 600, width: "fit-content" }}
+                  />
                 )}
               </Box>
               <Typography variant="caption" color="text.secondary" noWrap>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
@@ -80,6 +80,10 @@ export interface CreateGithubIssueDialogProps {
   error: string | null;
   /** Prefill for the update-level field, taken from the case's product context. */
   defaultUpdateLevel?: string;
+  /** Prefill for the Summary field, taken from the case's subject. */
+  defaultTitle?: string;
+  /** Prefill for the Description field, taken from the case's description. */
+  defaultDescription?: string;
   onClose: () => void;
   /** Body for `POST /cases/{id}/github-issues` (caseId is added by the caller). */
   onSubmit: (payload: BeCreateCaseGithubIssuePayload) => void;
@@ -101,11 +105,13 @@ export function CreateGithubIssueDialog({
   submitting,
   error,
   defaultUpdateLevel,
+  defaultTitle,
+  defaultDescription,
   onClose,
   onSubmit,
 }: CreateGithubIssueDialogProps): JSX.Element {
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
+  const [title, setTitle] = useState(defaultTitle ?? "");
+  const [description, setDescription] = useState(defaultDescription ?? "");
   const [updateLevel, setUpdateLevel] = useState(defaultUpdateLevel ?? "");
   const [publicIssueUrl, setPublicIssueUrl] = useState("");
   const [issueTypeLabel, setIssueTypeLabel] = useState<string>(UNSET);
@@ -115,8 +121,8 @@ export function CreateGithubIssueDialog({
   const [regression, setRegression] = useState<string>(UNSET);
 
   const resetAndClose = () => {
-    setTitle("");
-    setDescription("");
+    setTitle(defaultTitle ?? "");
+    setDescription(defaultDescription ?? "");
     setUpdateLevel(defaultUpdateLevel ?? "");
     setPublicIssueUrl("");
     setIssueTypeLabel(UNSET);

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import type { BeCreateCaseGithubIssuePayload } from "@api/backend/types";
+
+// ---------------------------------------------------------------------------
+// Option lists. Every select starts unset ("" → "-- Select --") and omits its
+// field from the payload when left unset. Values mirror the legacy SN "Open Git
+// Issue" form: Type is a GitHub label string, priority is only meaningful for
+// incidents (the SN side applies it as a label only when Type is Incident).
+// ---------------------------------------------------------------------------
+
+const UNSET = "";
+const SELECT_PLACEHOLDER = "-- Select --";
+
+const TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "Type/Query", label: "Query" },
+  { value: "Type/Incident", label: "Incident" },
+  { value: "Type/Patch", label: "Patch" },
+];
+
+const SEVERITY_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "P1", label: "P1 - Critical" },
+  { value: "P2", label: "P2 - High" },
+  { value: "P3", label: "P3 - Medium" },
+];
+
+// Cloud-case repositories. owner is fixed to wso2-enterprise; the value is the
+// repo. Sent as repoOverride to bypass the SN product-unit routing (which only
+// covers on-prem/product-unit-mapped cases).
+const REPO_OWNER = "wso2-enterprise";
+const REPO_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "asgardeo-product", label: "Asgardeo" },
+  { value: "choreo", label: "WSO2 Developer Platform (Choreo)" },
+  { value: "wso2-apim-internal", label: "Bijira / API Manager" },
+  { value: "wso2-integration-internal", label: "Devant / Integration" },
+];
+
+const YES_NO_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "yes", label: "Yes" },
+  { value: "no", label: "No" },
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CreateGithubIssueDialogProps {
+  open: boolean;
+  submitting: boolean;
+  /** Backend error message to surface inline (cleared by the parent on retry). */
+  error: string | null;
+  /** Prefill for the update-level field, taken from the case's product context. */
+  defaultUpdateLevel?: string;
+  onClose: () => void;
+  /** Body for `POST /cases/{id}/github-issues` (caseId is added by the caller). */
+  onSubmit: (payload: BeCreateCaseGithubIssuePayload) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Form for filing an internal GitHub issue from a case (ISSU-020). Mirrors the
+ * legacy ServiceNow "Open Git Issue" form: Summary + Description are required;
+ * everything else is optional. Reason is fixed to `default` (the migration /
+ * R&D-ticket variants were separate SN actions). Repo selection is offered for
+ * cloud cases; when unset the SN side routes by the case's product unit.
+ */
+export function CreateGithubIssueDialog({
+  open,
+  submitting,
+  error,
+  defaultUpdateLevel,
+  onClose,
+  onSubmit,
+}: CreateGithubIssueDialogProps): JSX.Element {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [updateLevel, setUpdateLevel] = useState(defaultUpdateLevel ?? "");
+  const [publicIssueUrl, setPublicIssueUrl] = useState("");
+  const [issueTypeLabel, setIssueTypeLabel] = useState<string>(UNSET);
+  const [priorityLevel, setPriorityLevel] = useState<string>(UNSET);
+  const [repo, setRepo] = useState<string>(UNSET);
+  const [hotFix, setHotFix] = useState<string>(UNSET);
+  const [regression, setRegression] = useState<string>(UNSET);
+
+  const resetAndClose = () => {
+    setTitle("");
+    setDescription("");
+    setUpdateLevel(defaultUpdateLevel ?? "");
+    setPublicIssueUrl("");
+    setIssueTypeLabel(UNSET);
+    setPriorityLevel(UNSET);
+    setRepo(UNSET);
+    setHotFix(UNSET);
+    setRegression(UNSET);
+    onClose();
+  };
+
+  const canSubmit =
+    title.trim().length > 0 && description.trim().length > 0;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+
+    const payload: BeCreateCaseGithubIssuePayload = {
+      reason: "default",
+      title: title.trim(),
+      description: description.trim(),
+    };
+    if (updateLevel.trim()) payload.updateLevel = updateLevel.trim();
+    if (publicIssueUrl.trim()) payload.publicIssueUrl = publicIssueUrl.trim();
+    if (issueTypeLabel) payload.issueTypeLabel = issueTypeLabel;
+    // Priority only carries meaning for incidents on the SN side; send it
+    // whenever the user picked one and let the SN side decide to apply it.
+    if (priorityLevel) payload.priorityLevel = priorityLevel;
+    if (repo) payload.repoOverride = { owner: REPO_OWNER, repo };
+    if (hotFix === "yes") payload.hotFixRequired = true;
+    if (regression === "yes") payload.regression = true;
+
+    onSubmit(payload);
+  };
+
+  // Shared renderer for a "-- Select --" dropdown.
+  const renderSelect = (
+    id: string,
+    label: string,
+    value: string,
+    onChange: (v: string) => void,
+    options: Array<{ value: string; label: string }>,
+  ): JSX.Element => (
+    <FormControl fullWidth size="small" disabled={submitting}>
+      <InputLabel id={`${id}-label`} shrink>
+        {label}
+      </InputLabel>
+      <Select
+        labelId={`${id}-label`}
+        label={label}
+        value={value}
+        displayEmpty
+        onChange={(e) => onChange(String(e.target.value))}
+      >
+        <MenuItem value={UNSET}>
+          <Typography component="span" color="text.secondary">
+            {SELECT_PLACEHOLDER}
+          </Typography>
+        </MenuItem>
+        {options.map((o) => (
+          <MenuItem key={o.value} value={o.value}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+
+  return (
+    <Dialog open={open} onClose={resetAndClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Open Git issue</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          {error && (
+            <Typography variant="body2" color="error">
+              {error}
+            </Typography>
+          )}
+
+          <TextField
+            label="Summary"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            fullWidth
+            required
+            disabled={submitting}
+            placeholder="Short summary of the problem"
+          />
+
+          <TextField
+            label="Description"
+            multiline
+            minRows={4}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            fullWidth
+            required
+            disabled={submitting}
+            placeholder="What needs to be fixed?"
+            helperText="Case number, product and reporter are appended to the issue body automatically."
+          />
+
+          <TextField
+            label="Update Level"
+            value={updateLevel}
+            onChange={(e) => setUpdateLevel(e.target.value)}
+            disabled={submitting}
+            size="small"
+            fullWidth
+          />
+
+          <TextField
+            label="Public Git Issue or Security Internal JIRA"
+            value={publicIssueUrl}
+            onChange={(e) => setPublicIssueUrl(e.target.value)}
+            disabled={submitting}
+            size="small"
+            fullWidth
+            placeholder="https://github.com/… or JIRA link"
+          />
+
+          {renderSelect("ghi-type", "Type", issueTypeLabel, setIssueTypeLabel, TYPE_OPTIONS)}
+
+          {renderSelect("ghi-severity", "Severity", priorityLevel, setPriorityLevel, SEVERITY_OPTIONS)}
+
+          {renderSelect(
+            "ghi-repo",
+            "Choose repository (only for cloud cases)",
+            repo,
+            setRepo,
+            REPO_OPTIONS,
+          )}
+
+          {renderSelect("ghi-hotfix", "Hotfix Required", hotFix, setHotFix, YES_NO_OPTIONS)}
+
+          {renderSelect("ghi-regression", "Regression", regression, setRegression, YES_NO_OPTIONS)}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={resetAndClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!canSubmit || submitting}
+          loading={submitting}
+        >
+          Create issue
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1333,6 +1333,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
           submitting={postGithubIssue.isPending}
           error={githubIssueError}
           defaultUpdateLevel={c.productContext.updateLevel}
+          defaultTitle={c.subject}
+          defaultDescription={c.description}
           onClose={() => {
             setGithubIssueOpen(false);
             setGithubIssueError(null);

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -69,6 +69,8 @@ import {
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
 import AssignEngineerDialog from "@features/csm-cases/components/AssignEngineerDialog";
+import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
+import { usePostCaseGithubIssue } from "@features/csm-cases/api/useCsmCaseGithubIssue";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
 import {
@@ -194,7 +196,6 @@ const SECONDARY_TOAST: Record<string, string> = {
   link_case: "Link related case picker (mock).",
   link_incident: "Link to incident picker (mock).",
   manage_watchers: "Add/remove watcher dialog (mock).",
-  raise_git_issue: "Raise internal Git issue (mock).",
   create_task: "Create task dialog (mock).",
   request_call: "Request a call dialog (mock).",
   log_time: "Log time dialog (mock).",
@@ -288,6 +289,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
   const [logTimeOpen, setLogTimeOpen] = useState(false);
+  const [githubIssueOpen, setGithubIssueOpen] = useState(false);
+  // Inline error shown inside the Git-issue dialog (e.g. the SN routing 422 /
+  // state 409). Cleared when the dialog opens or a submit is retried.
+  const [githubIssueError, setGithubIssueError] = useState<string | null>(null);
+  const postGithubIssue = usePostCaseGithubIssue();
   const postTimeCard = usePostTimeCard();
   // Attachment pending delete confirmation (drives the confirm dialog).
   const [pendingDelete, setPendingDelete] = useState<CaseAttachment | null>(
@@ -588,6 +594,16 @@ export default function CsmCaseDetailPage(): JSX.Element {
           return;
         }
         setLogTimeOpen(true);
+        return;
+      }
+
+      // ISSU-020: file an internal GitHub issue from the case. The SN side
+      // gates on the case state (only certain states may file) and resolves
+      // the target repo from the product; we don't pre-gate here — open the
+      // dialog and surface any backend rejection inline.
+      if (action.secondary === "raise_git_issue") {
+        setGithubIssueError(null);
+        setGithubIssueOpen(true);
         return;
       }
 
@@ -1308,6 +1324,54 @@ export default function CsmCaseDetailPage(): JSX.Element {
               },
             })
           }
+        />
+      )}
+
+      {githubIssueOpen && (
+        <CreateGithubIssueDialog
+          open={githubIssueOpen}
+          submitting={postGithubIssue.isPending}
+          error={githubIssueError}
+          defaultUpdateLevel={c.productContext.updateLevel}
+          onClose={() => {
+            setGithubIssueOpen(false);
+            setGithubIssueError(null);
+          }}
+          onSubmit={(payload) => {
+            setGithubIssueError(null);
+            postGithubIssue.mutate(
+              { caseId: c.id, ...payload },
+              {
+                onSuccess: (res) => {
+                  setGithubIssueOpen(false);
+                  // The SN side writes the issue URL into work notes; show that
+                  // entry by switching to the activities feed (just refetched).
+                  setActiveTab("activities");
+                  setFeedback({
+                    message: res.issue?.url
+                      ? `Internal Git issue created: ${res.issue.url}`
+                      : "Internal Git issue created.",
+                    severity: "success",
+                    sticky: true,
+                  });
+                },
+                onError: (err) => {
+                  // Surface the backend's own message on 4xx (invalid state,
+                  // product not routable) inline in the dialog; fall back to a
+                  // generic banner for 5xx.
+                  if (
+                    err instanceof BackendApiError &&
+                    err.status < 500 &&
+                    err.message
+                  ) {
+                    setGithubIssueError(err.message);
+                  } else {
+                    showError("Could not create the Git issue.", err);
+                  }
+                },
+              },
+            );
+          }}
         />
       )}
 


### PR DESCRIPTION
## What

Adds a **"Raise internal Git issue"** action to the case detail page (ISSU-020) and files the issue through the existing BFF endpoint `POST /cases/{id}/github-issues` (ServiceNow data source only). Also aligns the cases-list work sub-state styling with the detail view.

### GitHub issue from a case
- New **Raise internal Git issue…** item at the top of the case overflow ("More") menu; opens a dialog that mirrors the legacy ServiceNow "Open Git Issue" form:
  - **Summary** and **Description** (required)
  - **Update Level**, **Public Git Issue or Security Internal JIRA**
  - **Type** (Query / Incident / Patch), **Severity** (P1 / P2 / P3)
  - **Choose repository** (cloud cases), **Hotfix Required**, **Regression**
  - Every dropdown defaults to `-- Select --` and is omitted from the request when left unset.
- New `usePostCaseGithubIssue` hook; on success it invalidates the case comments query so the work-note carrying the created issue URL appears in the activities feed. Success toast links the created issue.
- Backend request/response types added to `api/backend/types.ts`.
- Backend 4xx (invalid case state, unroutable product) is surfaced inline in the dialog; 5xx falls back to the error banner.
- Removes the unused disabled **"Reassign to group"** placeholder from the overflow menu.

### Cases list work sub-state chip
- Renders the `work_in_progress` sub-state (Ongoing / Paused) as an outlined `Chip` (paused → warning colour) instead of caption text, matching the case detail page.

## Notes
- Frontend only. The BFF/entity/ServiceNow layers for this endpoint already exist on `v2`/`main`.
- Repository selection maps to the endpoint's optional `repoOverride`; when unset the ServiceNow side routes by the case's product unit.

## Testing
- `pnpm build`, `pnpm lint`, `pnpm test` (122 passing) and `tsc --noEmit` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to open a GitHub issue directly from a case.
  * Introduced a dialog for entering issue details, optional labels, repo override, and other metadata.
  * Successful creation now shows a confirmation and takes you to the activities view.

* **Bug Fixes**
  * Improved error handling for issue creation, including inline validation and clearer backend error messages.
  * Updated case list work-state display for a cleaner visual indicator.

* **UI Improvements**
  * Refined the case actions menu and re-enabled relevant issue/reassignment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->