### PR TITLE
[CSM Portal] fix(webapp): WIP nav tooltip wording + cases-list work-state chip

### DIFF
--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -25,7 +25,8 @@ import {
 
 /** Tooltip for a disabled WIP item. Includes the label so the collapsed rail
  *  (which hides the label) still says which feature it is. */
-const wipTooltip = (label: string): string => `${label} (work in progress)`;
+const wipTooltip = (label: string): string =>
+  `${label} — this section is still under construction`;
 
 const COMPANY_NAME = "WSO2 LLC";
 const TERMS_OF_SERVICE_URL = "https://wso2.com/terms-of-use/";

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import { Box, Chip, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 import { Link as RouterLink } from "react-router";
 import RelativeTime from "@components/RelativeTime";
@@ -207,16 +207,13 @@ export default function CasesList({
               <Box sx={{ justifySelf: "start", minWidth: 0 }}>
                 <StateChip state={c.state} clickable />
                 {c.state === "work_in_progress" && c.workState && (
-                  <Typography
-                    variant="caption"
-                    noWrap
-                    color={
-                      c.workState === "paused" ? "warning.main" : "text.secondary"
-                    }
-                    sx={{ display: "block", mt: 0.25 }}
-                  >
-                    {WORK_STATE_LABEL[c.workState]}
-                  </Typography>
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    color={c.workState === "paused" ? "warning" : "default"}
+                    label={WORK_STATE_LABEL[c.workState]}
+                    sx={{ display: "flex", mt: 0.25, fontWeight: 600, width: "fit-content" }}
+                  />
                 )}
               </Box>
               <Typography variant="caption" color="text.secondary" noWrap>


### PR DESCRIPTION
Two small webapp UX changes:

1. **WIP nav tooltip** — reworded the disabled work-in-progress navigation item tooltip from `<label> (work in progress)` to `<label> — this section is still under construction`, so a CS engineer hovering a dimmed section gets a clearer status (`CsmSideBar.tsx`).
2. **Cases-list work-state chip** — render the `work_in_progress` sub-state (Ongoing/Paused) as an outlined Chip (paused → warning colour) instead of caption text, matching the case detail page (`CasesList.tsx`).

Both are presentational only; no behaviour/gating change.