### PR TITLE
[CSM] fix: nest Comment.createdBy and map SN type strings to domain enum

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5063,17 +5063,18 @@ components:
           format: date-time
           description: Timestamp when the message was created.
         createdBy:
-          type: string
-          description: User identifier of the message author.
-        createdByFirstName:
-          type: string
-          description: First name of the message author.
-        createdByLastName:
-          type: string
-          description: Last name of the message author.
-        createdByFullName:
-          type: string
-          description: Full name of the message author.
+          type: object
+          description: Author of the message.
+          properties:
+            id:
+              type: string
+              description: User identifier (email).
+            firstName:
+              type: string
+            lastName:
+              type: string
+            fullName:
+              type: string
 
     ConversationMessagesResponse:
       type: object

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1082,15 +1082,12 @@ type SearchCaseCommentsResponse struct {
 // Comment is a generic comment associated with any reference entity type
 // (case, conversation, change_request, etc.).
 type Comment struct {
-	ID                 string    `json:"id"`
-	ReferenceID        string    `json:"referenceId"`
-	Content            string    `json:"content"`
-	Type               string    `json:"type"`
-	CreatedOn          time.Time `json:"createdOn"`
-	CreatedBy          string    `json:"createdBy"`
-	CreatedByFirstName string    `json:"createdByFirstName"`
-	CreatedByLastName  string    `json:"createdByLastName"`
-	CreatedByFullName  string    `json:"createdByFullName"`
+	ID          string         `json:"id"`
+	ReferenceID string         `json:"referenceId"`
+	Content     string         `json:"content"`
+	Type        string         `json:"type"`
+	CreatedOn   time.Time      `json:"createdOn"`
+	CreatedBy   CommentUserRef `json:"createdBy"`
 }
 
 // SearchCommentsRequest is the input for POST /comments/search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1085,7 +1085,7 @@ type Comment struct {
 	ID          string         `json:"id"`
 	ReferenceID string         `json:"referenceId"`
 	Content     string         `json:"content"`
-	Type        string         `json:"type"`
+	Type        CommentType    `json:"type"`
 	CreatedOn   time.Time      `json:"createdOn"`
 	CreatedBy   CommentUserRef `json:"createdBy"`
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -677,6 +677,13 @@ var snCommentTypeMap = map[domain.CommentType]string{
 	domain.CommentTypeWorkNote: "work_notes",
 }
 
+// snCommentTypeToCommentType maps the SN API type string back to the domain enum.
+var snCommentTypeToCommentType = map[string]domain.CommentType{
+	"comments":   domain.CommentTypeComment,
+	"work_notes": domain.CommentTypeWorkNote,
+	"activity":   domain.CommentTypeActivity,
+}
+
 func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error) {
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchCaseCommentsResponse{}, err

--- a/entity-service/internal/service/sn_comment_service.go
+++ b/entity-service/internal/service/sn_comment_service.go
@@ -88,15 +88,17 @@ func (s *snCommentSearchService) SearchComments(ctx context.Context, req domain.
 			continue
 		}
 		comments = append(comments, domain.Comment{
-			ID:                 sysidToUUID(c.ID),
-			ReferenceID:        sysidToUUID(c.ReferenceID),
-			Content:            c.Content,
-			Type:               c.Type,
-			CreatedOn:          createdAt,
-			CreatedBy:          c.CreatedBy,
-			CreatedByFirstName: c.CreatedByFirstName,
-			CreatedByLastName:  c.CreatedByLastName,
-			CreatedByFullName:  c.CreatedByFullName,
+			ID:          sysidToUUID(c.ID),
+			ReferenceID: sysidToUUID(c.ReferenceID),
+			Content:     c.Content,
+			Type:        c.Type,
+			CreatedOn:   createdAt,
+			CreatedBy: domain.CommentUserRef{
+				ID:        c.CreatedBy,
+				FirstName: c.CreatedByFirstName,
+				LastName:  c.CreatedByLastName,
+				FullName:  c.CreatedByFullName,
+			},
 		})
 	}
 

--- a/entity-service/internal/service/sn_comment_service.go
+++ b/entity-service/internal/service/sn_comment_service.go
@@ -87,11 +87,12 @@ func (s *snCommentSearchService) SearchComments(ctx context.Context, req domain.
 				"commentID", c.ID, "createdOn", c.CreatedOn, "error", err)
 			continue
 		}
+		commentType := snCommentTypeToCommentType[c.Type]
 		comments = append(comments, domain.Comment{
 			ID:          sysidToUUID(c.ID),
 			ReferenceID: sysidToUUID(c.ReferenceID),
 			Content:     c.Content,
-			Type:        c.Type,
+			Type:        commentType,
 			CreatedOn:   createdAt,
 			CreatedBy: domain.CommentUserRef{
 				ID:        c.CreatedBy,

--- a/entity-service/internal/service/sn_comment_service.go
+++ b/entity-service/internal/service/sn_comment_service.go
@@ -87,7 +87,10 @@ func (s *snCommentSearchService) SearchComments(ctx context.Context, req domain.
 				"commentID", c.ID, "createdOn", c.CreatedOn, "error", err)
 			continue
 		}
-		commentType := snCommentTypeToCommentType[c.Type]
+		commentType, ok := snCommentTypeToCommentType[c.Type]
+		if !ok {
+			commentType = domain.CommentTypeComment
+		}
 		comments = append(comments, domain.Comment{
 			ID:          sysidToUUID(c.ID),
 			ReferenceID: sysidToUUID(c.ReferenceID),

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3167,6 +3167,19 @@ components:
         content:
           type: string
 
+    CommentUserRef:
+      type: object
+      properties:
+        id:
+          type: string
+          description: User identifier (email).
+        firstName:
+          type: string
+        lastName:
+          type: string
+        fullName:
+          type: string
+
     CaseComment:
       type: object
       properties:
@@ -3180,7 +3193,7 @@ components:
         content:
           type: string
         createdBy:
-          type: string
+          $ref: '#/components/schemas/CommentUserRef'
         createdOn:
           type: string
           format: date-time
@@ -4513,17 +4526,7 @@ components:
           format: date-time
           description: Timestamp when the comment was created.
         createdBy:
-          type: string
-          description: User identifier of the comment author.
-        createdByFirstName:
-          type: string
-          description: First name of the comment author.
-        createdByLastName:
-          type: string
-          description: Last name of the comment author.
-        createdByFullName:
-          type: string
-          description: Full name of the comment author.
+          $ref: '#/components/schemas/CommentUserRef'
 
     SearchCommentsRequest:
       type: object


### PR DESCRIPTION
## Summary

- Replaces the flat `createdBy`, `createdByFirstName`, `createdByLastName`, `createdByFullName` fields on `Comment` with a single nested `createdBy` object (`{ id, firstName, lastName, fullName }`) — matching the shape already used by `CaseComment`
- Types `Comment.Type` as `CommentType` instead of `string`, and maps SN plural type strings (`"comments"`, `"work_notes"`) back to the canonical domain values (`"comment"`, `"work_note"`, `"activity"`) via a reverse lookup map
- Applies to both `GET /conversations/{id}/messages` and `POST /cases/{id}/comments/search` responses in the CSM portal

## Test plan

- [ ] `POST /comments/search` (entity service) returns `createdBy` as a nested object with `id`/`firstName`/`lastName`/`fullName`
- [ ] Comment `type` field returns `"comment"` / `"work_note"` / `"activity"` (not `"comments"` / `"work_notes"`)
- [ ] CSM portal `GET /conversations/{id}/messages` and `POST /cases/{id}/comments/search` both reflect the new shapes
- [ ] All backend tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment author details are now returned in a structured format with separate ID, first name, last name, and full name fields.
  * Comment types are now standardized across the app for more consistent display and handling.

* **Bug Fixes**
  * Improved consistency when loading comments so author and type information is mapped correctly in returned results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->