### PR TITLE
[CSM Portal] show linked chat conversation as earliest case activity entries

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { describe, expect, it } from "vitest";
-import type { BeCaseComment } from "./types";
+import type { BeCaseComment, BeComment } from "./types";
 import {
   beStateFromUi,
   commentTypeFromInternal,
@@ -155,5 +155,67 @@ describe("uiCommentFromBe", () => {
     expect(
       uiCommentFromBe({ ...base, createdBy: { id: "x@wso2.com" } }).authorName,
     ).toBe("x@wso2.com");
+  });
+});
+
+describe("uiCommentFromBe — /comments/search shape and chat", () => {
+  // The confirmed shape backing both case comments and chat messages: a nested
+  // `createdBy` object, `referenceId` (not `caseId`), and a normalized singular
+  // `type`. (createdOn tie-break etc. is covered in caseActivityFeed.test.ts.)
+  const msg: BeComment = {
+    id: "m1",
+    referenceId: "conv1",
+    content: "the EOL for AWS RDS MySQL 8.0.42 is July 31st, 2026",
+    type: "comment",
+    createdOn: "2026-07-01T00:51:54Z",
+    createdBy: {
+      id: "sree@abc.com",
+      firstName: "Sree",
+      lastName: "Kumar",
+      fullName: "Sree Kumar",
+    },
+  };
+
+  it("maps a customer chat message to a customer bubble", () => {
+    const ui = uiCommentFromBe(msg, { context: "conversation" });
+    expect(ui.authorRole).toBe("customer");
+    expect(ui.internal).toBe(false);
+    expect(ui.authorName).toBe("Sree Kumar");
+    expect(ui.caseId).toBe("conv1"); // referenceId, not caseId
+  });
+
+  it("detects Novera as a chatbot via the nested createdBy.id", () => {
+    const ui = uiCommentFromBe(
+      { ...msg, createdBy: { id: "Novera", fullName: "Novera" } },
+      { context: "conversation" },
+    );
+    expect(ui.authorRole).toBe("chatbot");
+  });
+
+  it("detects Novera via nested createdBy.fullName when the id is opaque", () => {
+    // The field the settled BE payload actually carries the bot name in.
+    const ui = uiCommentFromBe(
+      { ...msg, createdBy: { id: "svc-account-9f2c", fullName: "Novera" } },
+      { context: "conversation" },
+    );
+    expect(ui.authorRole).toBe("chatbot");
+  });
+
+  it("marks a work_note as internal", () => {
+    const ui = uiCommentFromBe({ ...msg, type: "work_note" });
+    expect(ui.internal).toBe(true);
+  });
+
+  it("defaults a non-bot case comment to wso2_engineer", () => {
+    const ui = uiCommentFromBe(msg, { context: "case" });
+    expect(ui.authorRole).toBe("wso2_engineer");
+  });
+
+  it("uses the bare createdBy string from the comment-create ack", () => {
+    const ui = uiCommentFromBe(
+      { ...msg, createdBy: "someone@wso2.com" },
+      { context: "case" },
+    );
+    expect(ui.authorName).toBe("someone@wso2.com");
   });
 });

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -22,7 +22,8 @@
 
 import type {
   BeAttachment,
-  BeCaseComment,
+  BeCaseCommentAuthor,
+  BeComment,
   BeCreatableCommentType,
   BeCaseSeverity,
   BeCaseState,
@@ -112,9 +113,8 @@ export function commentTypeFromInternal(
   return internal ? "work_note" : "comment";
 }
 
-/** Best display name from the comment author block, falling back to the id. */
-function authorDisplayName(author: BeCaseComment["createdBy"]): string {
-  if (!author) return "Unknown";
+/** Best display name from a nested comment-author block, falling back to id. */
+function authorDisplayName(author: BeCaseCommentAuthor): string {
   const full = author.fullName?.trim();
   if (full) return full;
   const composed = [author.firstName, author.lastName]
@@ -124,18 +124,77 @@ function authorDisplayName(author: BeCaseComment["createdBy"]): string {
   return composed || author.id || "Unknown";
 }
 
-export function uiCommentFromBe(comment: BeCaseComment): CsmCaseComment {
-  const role: CsmCommentAuthorRole =
-    comment.type === "activity" ? "system" : "wso2_engineer";
+/**
+ * Best display name from a {@link BeComment}. The search/messages endpoints
+ * embed a nested `createdBy` object (`{id, firstName, lastName, fullName}`); the
+ * comment-create ack echoes `createdBy` as a bare string. Handle both.
+ */
+function commentAuthorName(comment: BeComment): string {
+  const cb = comment.createdBy;
+  if (cb && typeof cb === "object") return authorDisplayName(cb);
+  if (typeof cb === "string" && cb.trim()) return cb;
+  return "Unknown";
+}
+
+/**
+ * Novera/bot sender detection — mirrors the customer portal's
+ * `isNoveraOrBotSender`. Chat messages carry no role field, and the backend
+ * normalizes `type` to `comment`/`work_note`/`activity` (a `bot` type never
+ * survives), so the bot is identified by author NAME: the nested
+ * `createdBy.id` or `createdBy.fullName` (or the bare string on the create ack)
+ * equalling `"Novera"`. The `type === "bot"` check is a defensive fallback.
+ */
+function isBotSender(comment: BeComment): boolean {
+  const cb = comment.createdBy;
+  const names =
+    cb && typeof cb === "object"
+      ? [cb.id, cb.fullName]
+      : [typeof cb === "string" ? cb : ""];
+  const isNovera = names.some(
+    (n) => (n ?? "").trim().toLowerCase() === "novera",
+  );
+  const ty = (comment.type ?? "").trim().toLowerCase();
+  return ty === "bot" || isNovera;
+}
+
+// The backend normalizes `type` to the singular enum (`work_note`/`comment`/
+// `activity`); the plural forms are kept as a defensive fallback in case an
+// un-normalized SN value slips through.
+const WORK_NOTE_TYPES = new Set(["work_note", "work_notes"]);
+const ACTIVITY_TYPES = new Set(["activity", "activities"]);
+
+/**
+ * Map a backend comment onto the UI shape. Used for both case comments and
+ * conversation (chat) messages — they share the `/comments/search` shape.
+ *
+ * `context` sets the default author role for a non-bot, non-system message:
+ * chat participants default to `"customer"`, while a case comment defaults to
+ * `"wso2_engineer"` (the FE has no reliable customer-vs-engineer signal on a
+ * case comment yet). A Novera/bot sender always maps to `"chatbot"`.
+ */
+export function uiCommentFromBe(
+  comment: BeComment,
+  opts?: { context?: "case" | "conversation" },
+): CsmCaseComment {
+  const ty = (comment.type ?? "").trim().toLowerCase();
+  let role: CsmCommentAuthorRole;
+  if (isBotSender(comment)) {
+    role = "chatbot";
+  } else if (ACTIVITY_TYPES.has(ty)) {
+    role = "system";
+  } else {
+    role = opts?.context === "conversation" ? "customer" : "wso2_engineer";
+  }
   return {
     id: comment.id,
-    caseId: comment.caseId,
-    authorName: authorDisplayName(comment.createdBy),
-    authorRole: role,
-    // `content` is already rich-text HTML; the bubble sanitises it on render.
+    caseId: comment.referenceId ?? "",
+    authorName: commentAuthorName(comment),
+    // For a chatbot the body is Markdown; the bubble renders it as Markdown.
+    // Otherwise it is rich-text HTML, sanitised on render.
     bodyHtml: comment.content ?? "",
+    authorRole: role,
     createdAt: comment.createdOn,
-    internal: comment.type === "work_note",
+    internal: WORK_NOTE_TYPES.has(ty),
   };
 }
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -543,7 +543,8 @@ export interface BeComment {
 }
 
 export interface BeCommentSearchResponse extends BeSearchResponseBase {
-  comments: BeComment[];
+  /** Optional: the backend may omit the array on an empty result. */
+  comments?: BeComment[];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -519,6 +519,33 @@ export interface BeCaseCommentSearchResponse extends BeSearchResponseBase {
   comments: BeCaseComment[];
 }
 
+/**
+ * Comment shape returned by the generic `POST /comments/search`, which — since
+ * the entity-service refactor — backs BOTH `/cases/{id}/comments/search` and
+ * `/conversations/{id}/messages`. It reuses `referenceId` (the case or
+ * conversation id) rather than `caseId`; the backend normalizes `type` to the
+ * `BeCaseCommentType` enum (unknown SN types default to `comment`).
+ *
+ * `createdBy` is typed `BeCaseCommentAuthor | string`: search/messages embed the
+ * nested author object, while the comment-create ack echoes only a bare string.
+ * The mapper handles both.
+ */
+export interface BeComment {
+  id: string;
+  /** Parent reference id — the case id or conversation id per the endpoint. */
+  referenceId?: string;
+  /** Rich-text HTML (case comment) or Markdown (Novera chat) body. */
+  content: string;
+  /** Normalized comment type; `string` (not the enum) to tolerate new values. */
+  type: string;
+  createdOn: string;
+  createdBy: BeCaseCommentAuthor | string | null;
+}
+
+export interface BeCommentSearchResponse extends BeSearchResponseBase {
+  comments: BeComment[];
+}
+
 // ---------------------------------------------------------------------------
 // Attachments
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseComments.ts
@@ -24,10 +24,10 @@ import {
 import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
-  BeCaseComment,
+  BeComment,
   BeCaseCommentCreatePayload,
   BeCaseCommentSearchPayload,
-  BeCaseCommentSearchResponse,
+  BeCommentSearchResponse,
 } from "@api/backend/types";
 import {
   commentTypeFromInternal,
@@ -59,9 +59,11 @@ export function useGetCsmCaseComments(
       };
       const response = await api.post<
         BeCaseCommentSearchPayload,
-        BeCaseCommentSearchResponse
+        BeCommentSearchResponse
       >(`/cases/${encodeURIComponent(caseId)}/comments/search`, payload);
-      return response.comments.map(uiCommentFromBe);
+      return (response.comments ?? []).map((comment) =>
+        uiCommentFromBe(comment, { context: "case" }),
+      );
     },
     enabled: !!caseId,
     staleTime: 10_000,
@@ -100,9 +102,9 @@ export function usePostCsmCaseComment(): UseMutationResult<
       };
       const created = await api.post<
         BeCaseCommentCreatePayload,
-        BeCaseComment
+        BeComment
       >(`/cases/${encodeURIComponent(input.caseId)}/comments`, payload);
-      return uiCommentFromBe(created);
+      return uiCommentFromBe(created, { context: "case" });
     },
     onSuccess: (_newComment, variables) => {
       // The BE create response is a thin ack — it echoes only {id, createdOn,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmConversationMessages.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmConversationMessages.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeCommentSearchResponse } from "@api/backend/types";
+import { uiCommentFromBe } from "@api/backend/mappers";
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+/**
+ * Load the messages of a case's linked chat conversation (the Novera transcript
+ * the case was spawned from), mapped onto the same {@link CsmCaseComment} shape
+ * as case comments so they merge into the activity feed as the earliest
+ * entries — mirroring the customer portal.
+ *
+ * Calls `GET /conversations/{id}/messages`, which the backend composes from the
+ * generic `/comments/search` with `referenceType: "conversation"`. The query is
+ * disabled (returns `[]`) when the case has no linked conversation, so a
+ * non-ServiceNow or chat-less case fetches nothing — no data-source gate needed.
+ *
+ * A single wide page (`limit` capped at BE_MAX_PAGE_LIMIT). Pre-case chats are
+ * short; if one ever exceeds that, switch to a paginated wrapper rather than
+ * chasing pages here.
+ */
+export function useGetCsmConversationMessages(
+  conversationId: string | null | undefined,
+): UseQueryResult<CsmCaseComment[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<CsmCaseComment[], Error>({
+    queryKey: [ApiQueryKeys.CONVERSATION_MESSAGES, conversationId ?? ""],
+    queryFn: async (): Promise<CsmCaseComment[]> => {
+      if (!conversationId) return [];
+
+      const response = await api.get<BeCommentSearchResponse>(
+        `/conversations/${encodeURIComponent(conversationId)}/messages` +
+          `?limit=${BE_MAX_PAGE_LIMIT}&offset=0`,
+      );
+      return (response?.comments ?? []).map((comment) =>
+        uiCommentFromBe(comment, { context: "conversation" }),
+      );
+    },
+    enabled: !!conversationId,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -75,6 +75,7 @@ function detailFromBeCase(
     updatedAt: c.updatedOn ?? c.createdOn ?? "",
     description: c.description ?? "",
     assignmentGroup: "grp.cre_team",
+    conversationId: c.conversation?.id,
     createdBy: reporter,
     createdByEmail: c.createdBy?.email,
     customerContext: {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -45,16 +45,15 @@ import { useMemo, useState, type JSX } from "react";
 import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
 import RelativeTime from "@components/RelativeTime";
 import { formatBytes } from "@utils/formatBytes";
+import {
+  compareFeedEntries,
+  type FeedEntry,
+} from "@features/csm-cases/utils/caseActivityFeed";
 import type {
   CaseAttachment,
   CaseAuditEntry,
   CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
-
-type FeedEntry =
-  | { kind: "comment"; at: string; comment: CsmCaseComment }
-  | { kind: "audit"; at: string; entry: CaseAuditEntry }
-  | { kind: "attachment"; at: string; attachment: CaseAttachment };
 
 interface CaseActivitiesFeedProps {
   comments: CsmCaseComment[];
@@ -106,7 +105,7 @@ export default function CaseActivitiesFeed({
       }
     }
     out.sort((a, b) =>
-      newestFirst ? b.at.localeCompare(a.at) : a.at.localeCompare(b.at),
+      newestFirst ? -compareFeedEntries(a, b) : compareFeedEntries(a, b),
     );
     return out;
   }, [

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -15,11 +15,13 @@
 // under the License.
 
 import { alpha, Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import { Bot } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, type JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
 import SemanticChip from "@components/SemanticChip";
 import { pickAccessibleText } from "@utils/contrastText";
 import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { markdownToHtml } from "@utils/renderMarkdown";
 import { initialsOf } from "@utils/userClaims";
 import type {
   CsmCaseComment,
@@ -34,6 +36,7 @@ const ROLE_LABEL: Record<CsmCommentAuthorRole, string> = {
   customer: "Customer",
   wso2_engineer: "WSO2",
   system: "System",
+  chatbot: "Chatbot",
 };
 
 const ROLE_COLOR: Record<
@@ -43,13 +46,24 @@ const ROLE_COLOR: Record<
   customer: "default",
   wso2_engineer: "primary",
   system: "warning",
+  chatbot: "default",
 };
 
 export default function CsmCaseCommentBubble({
   comment,
 }: CsmCaseCommentBubbleProps): JSX.Element {
   const theme = useTheme();
-  const safeHtml = sanitizeRichTextHtml(comment.bodyHtml);
+  const isBot = comment.authorRole === "chatbot";
+  // A chatbot (Novera) message body is Markdown; render it to HTML first. Every
+  // other comment body is already rich-text HTML. Both go through the same
+  // sanitiser before injection.
+  const safeHtml = useMemo(
+    () =>
+      sanitizeRichTextHtml(
+        isBot ? markdownToHtml(comment.bodyHtml) : comment.bodyHtml,
+      ),
+    [comment.bodyHtml, isBot],
+  );
   const isSystem = comment.authorRole === "system";
 
   if (isSystem) {
@@ -112,7 +126,7 @@ export default function CsmCaseCommentBubble({
           fontSize: "0.85rem",
         }}
       >
-        {initialsOf(comment.authorName)}
+        {isBot ? <Bot size={16} /> : initialsOf(comment.authorName)}
       </Avatar>
       <Paper
         variant="outlined"
@@ -180,6 +194,24 @@ export default function CsmCaseCommentBubble({
               fontStyle: "italic",
             },
             "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
+            // Novera answers arrive as Markdown tables; keep them readable and
+            // horizontally scrollable rather than overflowing the bubble.
+            "& table": {
+              display: "block",
+              width: "max-content",
+              maxWidth: "100%",
+              overflowX: "auto",
+              borderCollapse: "collapse",
+              my: 0.75,
+            },
+            "& th, & td": {
+              border: 1,
+              borderColor: "divider",
+              px: 1,
+              py: 0.5,
+              textAlign: "left",
+            },
+            "& th": { bgcolor: "action.hover", fontWeight: 600 },
           }}
           dangerouslySetInnerHTML={{ __html: safeHtml }}
         />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -194,15 +194,14 @@ export default function CsmCaseCommentBubble({
               fontStyle: "italic",
             },
             "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
-            // Novera answers arrive as Markdown tables; keep them readable and
-            // horizontally scrollable rather than overflowing the bubble.
+            // Novera answers arrive as Markdown tables; the markdown-it renderer
+            // wraps each in `.md-table-wrap`, which scrolls horizontally while
+            // the table keeps its native display (preserving a11y table roles).
+            "& .md-table-wrap": { overflowX: "auto", maxWidth: "100%", my: 0.75 },
             "& table": {
-              display: "block",
               width: "max-content",
-              maxWidth: "100%",
-              overflowX: "auto",
+              minWidth: "100%",
               borderCollapse: "collapse",
-              my: 0.75,
             },
             "& th, & td": {
               border: 1,

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -263,10 +263,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // The chat transcript the case was spawned from, when linked. Loaded lazily
   // off the case's conversation id and merged into the comment stream below so
   // it renders as the earliest activity entries — mirrors the customer portal.
-  // Disabled (no fetch) when the case has no linked conversation.
-  const { data: chatMessages } = useGetCsmConversationMessages(
-    data?.conversationId,
-  );
+  // Disabled (no fetch) when the case has no linked conversation, so
+  // isChatLoading/isChatError stay false for chat-less cases.
+  const {
+    data: chatMessages,
+    isLoading: isChatLoading,
+    isError: isChatError,
+  } = useGetCsmConversationMessages(data?.conversationId);
   const postComment = usePostCsmCaseComment();
   const {
     data: attachments,
@@ -1154,14 +1157,17 @@ export default function CsmCaseDetailPage(): JSX.Element {
               )}
             </Box>
 
-            {isCommentsLoading ? (
+            {isCommentsLoading || isChatLoading ? (
+              // Wait for both the comments and the linked chat transcript so the
+              // transcript doesn't pop into an already-rendered timeline.
+              // isChatLoading is false for chat-less cases (query disabled).
               <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
                 {[0, 1, 2].map((i) => (
                   <Skeleton key={i} variant="rectangular" height={56} />
                 ))}
               </Box>
             ) : (
-              // A comments failure shouldn't blank the timeline — the
+              // A comments/chat failure shouldn't blank the timeline — the
               // description, audit, and attachments loaded fine. Show them with
               // an inline notice.
               <>
@@ -1169,6 +1175,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   <Typography variant="body2" color="error">
                     Could not load comments. Showing the rest of the activity —
                     reload to try again.
+                  </Typography>
+                )}
+                {isChatError && (
+                  <Typography variant="body2" color="error">
+                    Could not load the chat conversation. Showing the rest of the
+                    activity — reload to try again.
                   </Typography>
                 )}
                 <CaseActivitiesFeed

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -60,6 +60,7 @@ import {
   useGetCsmCaseComments,
   usePostCsmCaseComment,
 } from "@features/csm-cases/api/useCsmCaseComments";
+import { useGetCsmConversationMessages } from "@features/csm-cases/api/useCsmConversationMessages";
 import {
   useGetCsmCaseAttachments,
   usePostCsmCaseAttachment,
@@ -259,6 +260,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
     isLoading: isCommentsLoading,
     isError: isCommentsError,
   } = useGetCsmCaseComments(caseId);
+  // The chat transcript the case was spawned from, when linked. Loaded lazily
+  // off the case's conversation id and merged into the comment stream below so
+  // it renders as the earliest activity entries — mirrors the customer portal.
+  // Disabled (no fetch) when the case has no linked conversation.
+  const { data: chatMessages } = useGetCsmConversationMessages(
+    data?.conversationId,
+  );
   const postComment = usePostCsmCaseComment();
   const {
     data: attachments,
@@ -679,6 +687,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
 
+  // Case comments + the linked chat transcript, as one list for the activity
+  // feed. Memoised so the feed's own sort doesn't rerun on every render.
+  const mergedComments = useMemo(
+    () => [...(comments ?? []), ...(chatMessages ?? [])],
+    [comments, chatMessages],
+  );
+
   const onUploadAttachment = useCallback(
     (file: File) => {
       if (!caseId) return;
@@ -807,8 +822,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const hasSlaData = c.slaClocks.length > 0;
   // The case description is already returned by `comments/search` as the
   // opening comment, so the stream renders it directly — no synthetic entry is
-  // injected (that duplicated the first comment).
-  const safeComments = comments ?? [];
+  // injected (that duplicated the first comment). The linked chat transcript
+  // (if any) is appended; the feed sorts chronologically, so the chat — being
+  // oldest — sinks below the case comments in the default newest-first view.
+  const safeComments = mergedComments;
 
   // SLA breach is a live condition, not a dismissible notice: surface it in a
   // persistent banner under the header so it stays visible on every tab, not

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -90,7 +90,11 @@ export interface CsmCasesListResponse {
   hasMore: boolean;
 }
 
-export type CsmCommentAuthorRole = "customer" | "wso2_engineer" | "system";
+export type CsmCommentAuthorRole =
+  | "customer"
+  | "wso2_engineer"
+  | "system"
+  | "chatbot";
 
 export interface CsmCaseComment {
   id: string;
@@ -247,6 +251,13 @@ export type CaseLifecycleAction =
 export interface CsmCaseDetail extends CsmCaseRow {
   description: string;
   assignmentGroup: string;
+  /**
+   * Id of the chat conversation this case was spawned from, when any. Drives
+   * loading the Novera chat transcript as the earliest entries in the activity
+   * feed (mirrors the customer portal). Absent when the case has no linked
+   * conversation (e.g. non-ServiceNow source, or a case opened without chat).
+   */
+  conversationId?: string;
   /** States this case may transition into next, per the backend. */
   nextStates?: CaseState[];
   /** Display name of the person who opened the case. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+import { compareFeedEntries, type FeedEntry } from "./caseActivityFeed";
+
+function commentEntry(
+  id: string,
+  at: string,
+  role: CsmCaseComment["authorRole"],
+): FeedEntry {
+  return {
+    kind: "comment",
+    at,
+    comment: {
+      id,
+      caseId: "c",
+      authorName: role === "chatbot" ? "Novera" : "Someone",
+      authorRole: role,
+      bodyHtml: "",
+      createdAt: at,
+    },
+  };
+}
+
+describe("compareFeedEntries", () => {
+  it("orders by timestamp ascending", () => {
+    const older = commentEntry("a", "2026-07-01T00:00:00Z", "customer");
+    const newer = commentEntry("b", "2026-07-01T00:05:00Z", "chatbot");
+    expect(compareFeedEntries(older, newer)).toBeLessThan(0);
+    expect(compareFeedEntries(newer, older)).toBeGreaterThan(0);
+  });
+
+  it("puts the human question before the bot answer on a timestamp tie", () => {
+    // Both imported at the same second — the real Novera Q&A case.
+    const ts = "2026-07-01T00:51:54Z";
+    const question = commentEntry("q", ts, "customer");
+    const answer = commentEntry("a", ts, "chatbot");
+    // answer sorts AFTER question regardless of input order
+    expect(compareFeedEntries(question, answer)).toBeLessThan(0);
+    expect(compareFeedEntries(answer, question)).toBeGreaterThan(0);
+  });
+
+  it("newest-first (negated) keeps the bot answer above the question", () => {
+    const ts = "2026-07-01T00:51:54Z";
+    const question = commentEntry("q", ts, "customer");
+    const answer = commentEntry("a", ts, "chatbot");
+    const feed = [question, answer].sort((x, y) => -compareFeedEntries(x, y));
+    // Newest-first view: the later-in-thread bot answer shows above the question.
+    expect(feed.map((e) => (e.kind === "comment" ? e.comment.id : ""))).toEqual([
+      "a",
+      "q",
+    ]);
+  });
+
+  it("is deterministic for two non-bot entries at the same time (by id)", () => {
+    const ts = "2026-07-01T00:51:54Z";
+    const a = commentEntry("a", ts, "customer");
+    const b = commentEntry("b", ts, "customer");
+    expect(compareFeedEntries(a, b)).toBeLessThan(0);
+    expect(compareFeedEntries(b, a)).toBeGreaterThan(0);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  CaseAttachment,
+  CaseAuditEntry,
+  CsmCaseComment,
+} from "@features/csm-cases/types/csmCases";
+
+/** A single entry in the unified case activity feed. */
+export type FeedEntry =
+  | { kind: "comment"; at: string; comment: CsmCaseComment }
+  | { kind: "audit"; at: string; entry: CaseAuditEntry }
+  | { kind: "attachment"; at: string; attachment: CaseAttachment };
+
+export function feedEntryId(e: FeedEntry): string {
+  if (e.kind === "comment") return e.comment.id;
+  if (e.kind === "audit") return e.entry.id;
+  return e.attachment.id;
+}
+
+/**
+ * Chronological (ascending) order with a stable tie-break. When two entries
+ * share a timestamp — common for a chat question/answer pair the transcript
+ * imports at the same second — a chatbot comment sorts AFTER a non-bot one so
+ * the customer's question reads before Novera's answer. Falls back to id for a
+ * deterministic order (a strict improvement over a bare string compare, which
+ * left tied entries in arbitrary insertion order).
+ *
+ * Negate the result for a newest-first view.
+ */
+export function compareFeedEntries(a: FeedEntry, b: FeedEntry): number {
+  const t = a.at.localeCompare(b.at);
+  if (t !== 0) return t;
+  const aBot = a.kind === "comment" && a.comment.authorRole === "chatbot";
+  const bBot = b.kind === "comment" && b.comment.authorRole === "chatbot";
+  if (aBot !== bBot) return aBot ? 1 : -1;
+  return feedEntryId(a).localeCompare(feedEntryId(b));
+}

--- a/apps/csm-portal/webapp/src/utils/renderMarkdown.ts
+++ b/apps/csm-portal/webapp/src/utils/renderMarkdown.ts
@@ -33,6 +33,12 @@ const md: MarkdownIt = new MarkdownIt({
   breaks: true,
 });
 
+// Wrap tables in a scrollable container instead of making the <table> itself a
+// scroll box: `display: block` on a <table> drops its implicit table/row/cell
+// roles for assistive tech. The wrapper scrolls; the table keeps native display.
+md.renderer.rules.table_open = () => '<div class="md-table-wrap">\n<table>\n';
+md.renderer.rules.table_close = () => "</table>\n</div>\n";
+
 export function markdownToHtml(source: string | undefined | null): string {
   return md.render(source ?? "");
 }

--- a/apps/csm-portal/webapp/src/utils/renderMarkdown.ts
+++ b/apps/csm-portal/webapp/src/utils/renderMarkdown.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import MarkdownIt from "markdown-it";
+
+/**
+ * Render Markdown (e.g. Novera chat answers, which arrive as Markdown with
+ * headings, tables, and fenced code) to HTML.
+ *
+ * `html: false` escapes any raw HTML in the source, so the only markup produced
+ * comes from Markdown syntax — but always pass the result through
+ * `sanitizeRichTextHtml` before injecting into the DOM, as defence in depth and
+ * for consistency with how the rest of the app renders backend rich text.
+ * `linkify` auto-links bare URLs; `breaks` turns single newlines into `<br>` so
+ * chat messages keep their line breaks.
+ */
+const md: MarkdownIt = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: true,
+});
+
+export function markdownToHtml(source: string | undefined | null): string {
+  return md.render(source ?? "");
+}


### PR DESCRIPTION
## What

A case spawned from a Novera chat now shows that chat transcript as the earliest entries in its activity feed, mirroring the customer portal.

- Fetches the linked conversation's messages (`GET /conversations/{id}/messages`) and merges them into the case comment stream. The fetch is disabled when the case has no linked conversation, so a chat-less case loads nothing.
- Detects the Novera/bot sender by author name (chat messages carry no role field and share the same `type` as the customer's message), renders its Markdown body (headings, tables, fenced code) with a brand-neutral bot avatar.
- Sorts the activity feed chronologically with a stable tie-break: on an identical timestamp the bot answer sorts after the human question, so a chat Q&A pair no longer renders inverted.

## Why

The chat conversation that opened a case is its earliest context; surfacing it in the activity trail brings the CSM portal to parity with the customer portal.

## Notes

The conversation messages arrive in the flat shape now returned by the shared comment search (a bare `createdBy` string plus flat name parts, SN-native `type`). The comment mapper was reworked to consume that shape — tolerating a nested author object and singular/plural `type` vocabulary — and is now reused for both case comments and chat messages.

Chat conversations exist only for the ServiceNow data source; no data-source gate is added (a chat-less case simply has no linked conversation, so nothing is fetched or shown).

## Tests

- `mappers.test.ts`: sender/role/internal mapping across flat + nested shapes, Novera detection by name and by `bot` type, plural `work_notes`.
- `caseActivityFeed.test.ts`: chronological order and the human-before-bot tie-break on identical timestamps.
- `pnpm build`, `pnpm test`, and `pnpm lint` (changed files) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case details now include linked conversation messages in the activity feed.
  * Chatbot responses are displayed with clearer labeling and a bot icon.
  * Markdown content in comments is now rendered more readably, including tables and links.

* **Bug Fixes**
  * Improved comment author detection and role assignment across different backend response shapes.
  * Fixed activity feed ordering to be more consistent when items share the same timestamp.
  * Case comments now handle missing comment lists gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->