### PR TITLE
[CSM Portal] gate case reassign while work is in-progress + ongoing

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -219,3 +219,64 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
     expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
   });
 });
+
+describe("CaseActionBar — reassign gating for WIP-Ongoing", () => {
+  /** Open the "More" overflow and return the reassign engineer menu item. */
+  function openReassignItem(): HTMLElement {
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    return screen.getByRole("menuitem", { name: /assign \/ reassign engineer/i });
+  }
+
+  it("disables reassign when the case is Work in progress + Ongoing", () => {
+    // The backend silently reverts an assignee change on a WIP-Ongoing case and
+    // still returns success, so the action must be gated rather than fired.
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...caseInState("work_in_progress", ["solution_proposed"]),
+          workState: "ongoing",
+        }}
+        onAction={onAction}
+      />,
+    );
+    const item = openReassignItem();
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("keeps reassign enabled when the WIP case is paused (not ongoing)", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...caseInState("work_in_progress", ["solution_proposed"]),
+          workState: "paused",
+        }}
+        onAction={onAction}
+      />,
+    );
+    const item = openReassignItem();
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "reassign_engineer" });
+  });
+
+  it("keeps reassign enabled for a non-WIP state regardless of workState", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...caseInState("awaiting_info", ["waiting_on_wso2"]),
+          workState: "ongoing",
+        }}
+        onAction={onAction}
+      />,
+    );
+    const item = openReassignItem();
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "reassign_engineer" });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -178,6 +178,8 @@ interface SecondaryItem {
   divider?: boolean;
   /** If true, the item is greyed out and not clickable. */
   disabled?: boolean;
+  /** Optional hover hint — used to explain why a `disabled` item is greyed out. */
+  tooltip?: string;
 }
 
 /**
@@ -216,12 +218,29 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
     });
   }
 
+  // Assignee changes are rejected while a case is Work in progress + Ongoing:
+  // the backend silently reverts the change and still reports success, so the
+  // reassign would appear to work while the assignee stays put. Gate the action
+  // here so we never fire that no-op. The work must be paused first (by the
+  // current assignee) or the reassignment handled by a lead.
+  const reassignBlocked =
+    caseDetail.state === "work_in_progress" && caseDetail.workState === "ongoing";
+
   // Only "Copy case link" is wired up for now. The rest are disabled until
   // their backend flows land, so the menu advertises the roadmap without
   // exposing dead actions that would no-op or toast a mock message.
   items.push(
     { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} />, divider: true },
-    { key: "reassign_engineer", label: "Assign / reassign engineer…", icon: <User size={16} />, divider: true },
+    {
+      key: "reassign_engineer",
+      label: "Assign / reassign engineer…",
+      icon: <User size={16} />,
+      divider: true,
+      disabled: reassignBlocked,
+      tooltip: reassignBlocked
+        ? "Can't reassign while the case is in progress and ongoing. Pause the work first, or ask the current assignee or a lead to reassign."
+        : undefined,
+    },
     { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} />, disabled: true },
     { key: "change_severity", label: "Request severity change…", icon: <ShieldAlert size={16} />, disabled: true },
     { key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true, disabled: true },
@@ -333,26 +352,44 @@ export default function CaseActionBar({
         open={!!menuAnchor}
         onClose={() => setMenuAnchor(null)}
       >
-        {secondary.map((item) => [
-          <MenuItem
-            key={item.key}
-            disabled={item.disabled}
-            onClick={() => {
-              setMenuAnchor(null);
-              void onAction({ secondary: item.key });
-            }}
-            sx={{ gap: 1.25, minHeight: 36 }}
-          >
-            {item.icon}
-            {item.label}
-          </MenuItem>,
-          item.divider ? (
-            <Box
-              key={`${item.key}-divider`}
-              sx={{ borderTop: 1, borderColor: "divider", my: 0.25 }}
-            />
-          ) : null,
-        ])}
+        {secondary.map((item) => {
+          const menuItem = (
+            <MenuItem
+              key={item.key}
+              disabled={item.disabled}
+              onClick={() => {
+                if (item.disabled) return;
+                setMenuAnchor(null);
+                void onAction({ secondary: item.key });
+              }}
+              sx={{ gap: 1.25, minHeight: 36 }}
+            >
+              {item.icon}
+              {item.label}
+            </MenuItem>
+          );
+          return [
+            // A disabled MenuItem has `pointer-events: none`, so a Tooltip only
+            // fires when it wraps a non-disabled span. Wrap only the tooltip item
+            // (which is disabled, so not keyboard-focusable anyway); leave the
+            // other items as bare MenuItems so the menu's arrow-key nav works.
+            item.tooltip ? (
+              <Tooltip key={item.key} title={item.tooltip}>
+                <Box component="span" sx={{ display: "block" }}>
+                  {menuItem}
+                </Box>
+              </Tooltip>
+            ) : (
+              menuItem
+            ),
+            item.divider ? (
+              <Box
+                key={`${item.key}-divider`}
+                sx={{ borderTop: 1, borderColor: "divider", my: 0.25 }}
+              />
+            ) : null,
+          ];
+        })}
       </Menu>
 
       <Dialog


### PR DESCRIPTION
## What

Disable the **Assign / reassign engineer** overflow action on the case detail page when the case is **Work in progress** with an **ongoing** work-state, and add a tooltip explaining why.

## Why

The backend rejects an assignee change on a WIP + ongoing case: it silently reverts the change and still returns `200` success. The portal therefore showed a "Case reassigned" success toast while the assignee never actually changed — a confusing false success.

Rather than fire a request we know will no-op, we gate the action in the UI. The tooltip tells the user to pause the work first (via the existing Pause action, available to the current assignee) or have a lead handle the reassignment.

## Notes

- This is a **case-state** gate, mirroring the existing state-based enablement of the pause/resume action. It is **not** a data-source gate.
- Interim guard: a backend change to surface the rejection as a real error (instead of a false success) is tracked separately. Once that lands, this UI gate can be revisited.

## Testing

- `pnpm test` — added 3 cases to `CaseActionBar.test.tsx` (disabled when WIP+ongoing and no dispatch on click; enabled when paused; enabled for non-WIP states). Full file passes (11/11).
- `pnpm build` — passes.
- `pnpm lint` — the changed file is clean (the 2 remaining repo lint errors are pre-existing on `v2` in unrelated files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reassignment of an engineer when a case is actively in progress, avoiding actions that would have no effect.
  * Added clearer hover guidance for disabled actions in the overflow menu.
  * Kept reassignment available in paused or non-in-progress states, with the action behaving as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->