### PR TITLE
[Customer Portal Backend] Add productCount to deployments search response

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -1329,6 +1329,8 @@ public type Deployment record {|
     ReferenceTableItem? project;
     # Type
     ChoiceListItem? 'type;
+    # Number of deployed products associated with this deployment
+    int deployedProductCount?;
     json...;
 |};
 

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -726,6 +726,8 @@ public type Deployment record {|
     ReferenceItem? project;
     # Type
     ReferenceItem? 'type;
+    # Number of deployed products associated with this deployment
+    int productCount?;
 |};
 
 # Deployments response.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -213,6 +213,10 @@ paths:
       responses:
         "200":
           description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentsResponse'
         "400":
           description: BadRequest
           content:
@@ -4828,6 +4832,73 @@ components:
           type: string
           description: Description
       description: Payload for creating a deployment.
+    Deployment:
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID
+        number:
+          type: string
+          description: Number of the deployment
+          nullable: true
+        name:
+          type: string
+          description: Name
+        createdOn:
+          type: string
+          description: Created date and time
+        updatedOn:
+          type: string
+          description: Updated date and time
+        description:
+          type: string
+          description: Description
+          nullable: true
+        url:
+          type: string
+          description: URL
+          nullable: true
+        project:
+          allOf:
+          - $ref: '#/components/schemas/ReferenceItem'
+          nullable: true
+          description: Associated project
+        type:
+          allOf:
+          - $ref: '#/components/schemas/ReferenceItem'
+          nullable: true
+          description: Type
+        productCount:
+          type: integer
+          description: Number of deployed products associated with this deployment
+          format: int64
+      description: Deployment information.
+    DeploymentsResponse:
+      required:
+      - deployments
+      - totalRecords
+      type: object
+      properties:
+        deployments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Deployment'
+          description: List of deployments
+        totalRecords:
+          type: integer
+          description: Total records count
+          format: int64
+        offset:
+          minimum: 0
+          type: integer
+          description: Offset for pagination
+          format: int64
+        limit:
+          type: integer
+          description: Limit for pagination
+          format: int64
+      description: Deployments search response.
     DeploymentSearchPayload:
       type: object
       properties:

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -335,7 +335,8 @@ public isolated function mapDeployments(entity:DeploymentsResponse response) ret
             description: deployment.description,
             url: deployment.url,
             project: project != () ? {id: project.id, label: project.name} : (),
-            'type: 'type != () ? {id: 'type.id.toString(), label: 'type.label} : ()
+            'type: 'type != () ? {id: 'type.id.toString(), label: 'type.label} : (),
+            productCount: deployment.deployedProductCount
         };
     return {deployments, totalRecords: response.totalRecords, offset: response.offset, 'limit: response.'limit};
 }


### PR DESCRIPTION
## Summary
- Added `productCount` field to the `Deployment` response type, mapped from `deployedProductCount` returned by the entity service
- Updated `mapDeployments()` in `utils.bal` to pass through the new field
- Updated `openapi.yaml` with `Deployment` and `DeploymentsResponse` schemas including `productCount`, and wired the 200 response for `POST /projects/{id}/deployments/search`

## Test plan
- [ ] Call `POST /projects/{id}/deployments/search` and verify each deployment object includes `productCount`
- [ ] Verify `productCount` is absent (not null) when entity service does not return `deployedProductCount`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment search results now return richer deployment details, including the number of deployed products.
  * API responses for deployment searches now include a defined paginated response structure.

* **Bug Fixes**
  * Deployment data returned to the customer portal now consistently includes the new product count field when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->