### PR TITLE
[Customer Entity] Add deployed product metrics and usage counts search endpoints

### DIFF
--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -569,11 +569,11 @@ public isolated function getProjectChangeRequestStats(string idToken, string pro
 }
 
 # Search instances by criteria.
-# 
+#
 # + idToken - ID token for authorization
 # + payload - Instance search payload containing search criteria for instances
 # + return - Instances response containing matching instances or error
-public isolated function searchInstances(string idToken, InstanceSearchPayload payload) 
+public isolated function searchInstances(string idToken, InstanceSearchPayload payload)
     returns InstancesResponse|error {
 
     return csEntityClient->/instances/search.post(payload, generateHeaders(idToken));
@@ -602,7 +602,7 @@ public isolated function searchInstanceUsage(string idToken, InstanceUsagePayloa
 }
 
 # Search case activities by criteria.
-# 
+#
 # + idToken - ID token for authorization
 # + caseId - Unique ID of the case for which activities are to be searched
 # + payload - Case activities search payload containing search criteria for case activities
@@ -682,8 +682,23 @@ public isolated function searchEscalations(string idToken, EscalationSearchPaylo
 # + payload - Metrics search payload containing deploymentId, startDate, and endDate
 # + return - Deployed product metrics response or error
 public isolated function searchDeployedProductMetrics(string idToken, IdString deployedProductId,
-    DeployedProductMetricsPayload payload) returns DeployedProductMetricsResponse|error {
+        DeployedProductMetricsPayload payload) returns DeployedProductMetricsResponse|error {
 
     return csEntityClient->/deployed\-products/[deployedProductId]/metrics/search.post(payload,
-            generateHeaders(idToken));
+        generateHeaders(idToken)
+    );
+}
+
+# Search metrics usage counts for a specific deployed product.
+#
+# + idToken - ID token for authorization
+# + deployedProductId - ID of the deployed product
+# + payload - Metrics usage counts search payload
+# + return - Deployed product metrics usage counts response or error
+public isolated function searchDeployedProductMetricsUsageCounts(string idToken, IdString deployedProductId,
+        DeployedProductMetricsUsageCountsPayload payload) returns DeployedProductMetricsUsageCountsResponse|error {
+
+    return csEntityClient->/deployed\-products/[deployedProductId]/metrics/usage\-counts/search.post(payload,
+        generateHeaders(idToken)
+    );
 }

--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -674,3 +674,16 @@ public isolated function searchEscalations(string idToken, EscalationSearchPaylo
 
     return csEntityClient->/escalations/search.post(payload, generateHeaders(idToken));
 }
+
+# Search metrics for a specific deployed product.
+#
+# + idToken - ID token for authorization
+# + deployedProductId - ID of the deployed product
+# + payload - Metrics search payload containing deploymentId, startDate, and endDate
+# + return - Deployed product metrics response or error
+public isolated function searchDeployedProductMetrics(string idToken, IdString deployedProductId,
+    DeployedProductMetricsPayload payload) returns DeployedProductMetricsResponse|error {
+
+    return csEntityClient->/deployed\-products/[deployedProductId]/metrics/search.post(payload,
+            generateHeaders(idToken));
+}

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2696,3 +2696,45 @@ public type DeployedProductMetricsResponse record {|
     DeployedProductMetricsChartDataPoint[] chartData;
     json...;
 |};
+
+# Request payload for searching deployed product metrics usage counts.
+public type DeployedProductMetricsUsageCountsPayload record {|
+    # Deployment ID
+    IdString deploymentId;
+    # Start date of the range (format: YYYY-MM-DD)
+    Date startDate;
+    # End date of the range (format: YYYY-MM-DD)
+    Date endDate;
+|};
+
+# Summary for deployed product metrics usage counts.
+public type DeployedProductMetricsUsageCountsSummary record {|
+    # Date range of the metrics query
+    record {|
+        # Start date
+        string 'start;
+        # End date
+        string 'end;
+        json...;
+    |} dateRange;
+    # Count types aggregated over the range
+    map<int> countTypes;
+    json...;
+|};
+
+# Response for deployed product metrics usage counts search.
+public type DeployedProductMetricsUsageCountsResponse record {|
+    # The deployed product reference
+    record {|
+        # Deployed product ID
+        string id;
+        # Deployed product name
+        string name;
+        json...;
+    |} deployedProduct;
+    # Summary statistics for the queried range
+    DeployedProductMetricsUsageCountsSummary summary;
+    # Chart data points ordered by date
+    json[] chartData;
+    json...;
+|};

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2667,6 +2667,7 @@ public type DeployedProductMetricsSummary record {|
         string 'start;
         # End date of the range
         string 'end;
+        json...;
     |} dateRange;
     # Total number of distinct instances in the range
     int totalInstances;

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2661,22 +2661,21 @@ public type DeployedProductMetricsChartDataPoint record {|
 
 # Summary for deployed product metrics.
 public type DeployedProductMetricsSummary record {|
-    # Date range of the metrics query
+    # Queried date range
     record {|
-        # Start date
+        # Start date of the range
         string 'start;
-        # End date
+        # End date of the range
         string 'end;
-        json...;
     |} dateRange;
-    # Total number of distinct instances
+    # Total number of distinct instances in the range
     int totalInstances;
-    # Minimum CPU cores across the range
-    int minCores;
-    # Maximum CPU cores across the range
-    int maxCores;
-    # Average CPU cores across the range
-    decimal avgCores;
+    # Minimum core count in the range; null when there are no instances
+    int? minCores;
+    # Maximum core count in the range; null when there are no instances
+    int? maxCores;
+    # Average core count in the range; null when there are no instances
+    decimal? avgCores;
     json...;
 |};
 

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2618,3 +2618,81 @@ public type GlobalSearchResponse record {|
     GlobalSearchCase[] cases;
     json...;
 |};
+
+# Request payload for searching deployed product metrics.
+public type DeployedProductMetricsPayload record {|
+    # Deployment ID reference (e.g. "deployments/<id>")
+    IdString deploymentId;
+    # Start date of the metrics range (format: YYYY-MM-DD)
+    Date startDate;
+    # End date of the metrics range (format: YYYY-MM-DD)
+    Date endDate;
+|};
+
+# A single instance entry within a chart data point.
+public type DeployedProductMetricsInstance record {|
+    # Instance ID
+    string id;
+    # Instance name
+    string name;
+    # CPU cores allocated
+    int cores;
+    json...;
+|};
+
+# A single chart data point for deployed product metrics.
+public type DeployedProductMetricsChartDataPoint record {|
+    # Date of the data point (format: YYYY-MM-DD)
+    string date;
+    # Number of instances on this date
+    int instanceCount;
+    # Total CPU cores on this date
+    int totalCores;
+    # Minimum CPU cores on this date
+    int minCores;
+    # Maximum CPU cores on this date
+    int maxCores;
+    # Average CPU cores on this date
+    decimal avgCores;
+    # Individual instances on this date
+    DeployedProductMetricsInstance[] instances;
+    json...;
+|};
+
+# Summary for deployed product metrics.
+public type DeployedProductMetricsSummary record {|
+    # Date range of the metrics query
+    record {|
+        # Start date
+        string 'start;
+        # End date
+        string 'end;
+        json...;
+    |} dateRange;
+    # Total number of distinct instances
+    int totalInstances;
+    # Minimum CPU cores across the range
+    int minCores;
+    # Maximum CPU cores across the range
+    int maxCores;
+    # Average CPU cores across the range
+    decimal avgCores;
+    json...;
+|};
+
+# Response for deployed product metrics search.
+public type DeployedProductMetricsResponse record {|
+    # The deployed product reference
+    record {|
+        # Deployed product ID
+        string id;
+        # Deployed product name
+        string name;
+        json...;
+    |} deployedProduct;
+    # Summary statistics for the queried range
+    DeployedProductMetricsSummary summary;
+    # Chart data points ordered by date
+    DeployedProductMetricsChartDataPoint[] chartData;
+    json...;
+|};

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -2094,3 +2094,35 @@ public type DeployedProductMetricsResponse record {|
     # Chart data points ordered by date
     DeployedProductMetricsChartDataPoint[] chartData;
 |};
+
+# Request payload for searching deployed product metrics usage counts.
+public type DeployedProductMetricsUsageCountsPayload record {|
+    # Start date of the range (format: YYYY-MM-DD), required
+    entity:Date startDate;
+    # End date of the range (format: YYYY-MM-DD), required
+    entity:Date endDate;
+|};
+
+# Summary for deployed product metrics usage counts.
+public type DeployedProductMetricsUsageCountsSummary record {|
+    # Date range of the metrics query
+    record {|
+        string 'start;
+        string 'end;
+    |} dateRange;
+    # Count types aggregated over the range
+    map<int> countTypes;
+|};
+
+# Response for deployed product metrics usage counts search.
+public type DeployedProductMetricsUsageCountsResponse record {|
+    # The deployed product reference
+    record {|
+        string id;
+        string name;
+    |} product;
+    # Summary statistics for the queried range
+    DeployedProductMetricsUsageCountsSummary summary;
+    # Chart data points ordered by date
+    json[] chartData;
+|};

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -2067,19 +2067,19 @@ public type DeployedProductMetricsChartDataPoint record {|
 
 # Summary for deployed product metrics.
 public type DeployedProductMetricsSummary record {|
-    # Date range of the metrics query
+    # Queried date range
     record {|
         string 'start;
         string 'end;
     |} dateRange;
-    # Total number of distinct instances
+    # Total number of distinct instances in the range
     int totalInstances;
-    # Minimum CPU cores across the range
-    int minCores;
-    # Maximum CPU cores across the range
-    int maxCores;
-    # Average CPU cores across the range
-    decimal avgCores;
+    # Minimum core count in the range; null when there are no instances
+    int? minCores;
+    # Maximum core count in the range; null when there are no instances
+    int? maxCores;
+    # Average core count in the range; null when there are no instances
+    decimal? avgCores;
 |};
 
 # Response for deployed product metrics search.

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -2028,3 +2028,69 @@ public type GlobalSearchResponse record {|
     # List of matching cases
     GlobalSearchCase[] cases;
 |};
+
+# Request payload for searching deployed product metrics.
+public type DeployedProductMetricsPayload record {|
+    # Start date of the metrics range (format: YYYY-MM-DD), required
+    entity:Date startDate;
+    # End date of the metrics range (format: YYYY-MM-DD), required
+    entity:Date endDate;
+|};
+
+# A single instance entry within a chart data point.
+public type DeployedProductMetricsInstance record {|
+    # Instance ID
+    string id;
+    # Instance name
+    string name;
+    # CPU cores allocated
+    int cores;
+|};
+
+# A single chart data point for deployed product metrics.
+public type DeployedProductMetricsChartDataPoint record {|
+    # Date of the data point (format: YYYY-MM-DD)
+    string date;
+    # Number of instances on this date
+    int instanceCount;
+    # Total CPU cores on this date
+    int totalCores;
+    # Minimum CPU cores on this date
+    int minCores;
+    # Maximum CPU cores on this date
+    int maxCores;
+    # Average CPU cores on this date
+    decimal avgCores;
+    # Individual instances on this date
+    DeployedProductMetricsInstance[] instances;
+|};
+
+# Summary for deployed product metrics.
+public type DeployedProductMetricsSummary record {|
+    # Date range of the metrics query
+    record {|
+        string 'start;
+        string 'end;
+    |} dateRange;
+    # Total number of distinct instances
+    int totalInstances;
+    # Minimum CPU cores across the range
+    int minCores;
+    # Maximum CPU cores across the range
+    int maxCores;
+    # Average CPU cores across the range
+    decimal avgCores;
+|};
+
+# Response for deployed product metrics search.
+public type DeployedProductMetricsResponse record {|
+    # The deployed product reference
+    record {|
+        string id;
+        string name;
+    |} product;
+    # Summary statistics for the queried range
+    DeployedProductMetricsSummary summary;
+    # Chart data points ordered by date
+    DeployedProductMetricsChartDataPoint[] chartData;
+|};

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -2069,7 +2069,9 @@ public type DeployedProductMetricsChartDataPoint record {|
 public type DeployedProductMetricsSummary record {|
     # Queried date range
     record {|
+        # Start date of the range
         string 'start;
+        # End date of the range
         string 'end;
     |} dateRange;
     # Total number of distinct instances in the range
@@ -2086,7 +2088,9 @@ public type DeployedProductMetricsSummary record {|
 public type DeployedProductMetricsResponse record {|
     # The deployed product reference
     record {|
+        # Deployed product ID
         string id;
+        # Deployed product name
         string name;
     |} product;
     # Summary statistics for the queried range
@@ -2107,7 +2111,9 @@ public type DeployedProductMetricsUsageCountsPayload record {|
 public type DeployedProductMetricsUsageCountsSummary record {|
     # Date range of the metrics query
     record {|
+        # Start date of the range
         string 'start;
+        # End date of the range
         string 'end;
     |} dateRange;
     # Count types aggregated over the range
@@ -2118,7 +2124,9 @@ public type DeployedProductMetricsUsageCountsSummary record {|
 public type DeployedProductMetricsUsageCountsResponse record {|
     # The deployed product reference
     record {|
+        # Deployed product ID
         string id;
+        # Deployed product name
         string name;
     |} product;
     # Summary statistics for the queried range

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1559,6 +1559,49 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+  /deployments/{deploymentId}/products/{productId}/metrics/usage-counts/search:
+    post:
+      summary: Search metrics usage counts for a deployed product within a specific deployment.
+      operationId: postDeploymentsDeploymentidProductsProductidMetricsUsageCountsSearch
+      parameters:
+      - name: deploymentId
+        in: path
+        description: ID of the deployment
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      - name: productId
+        in: path
+        description: ID of the deployed product
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: "Metrics usage counts search payload containing startDate and endDate (within a 1-year range)"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployedProductMetricsUsageCountsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployedProductMetricsUsageCountsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
   /deployments/products/{id}/catalogs/search:
     post:
       summary: Search catalogs for a specific deployed product with filters and pagination.
@@ -4949,6 +4992,67 @@ components:
           description: Chart data points ordered by date
           items:
             $ref: '#/components/schemas/DeployedProductMetricsChartDataPoint'
+    DeployedProductMetricsUsageCountsPayload:
+      required:
+      - startDate
+      - endDate
+      type: object
+      properties:
+        startDate:
+          type: string
+          description: "Start date of the metrics range (format: YYYY-MM-DD)"
+        endDate:
+          type: string
+          description: "End date of the metrics range (format: YYYY-MM-DD)"
+    DeployedProductMetricsUsageCountsSummary:
+      required:
+      - dateRange
+      - countTypes
+      type: object
+      properties:
+        dateRange:
+          required:
+          - start
+          - end
+          type: object
+          properties:
+            start:
+              type: string
+              description: Start date
+            end:
+              type: string
+              description: End date
+        countTypes:
+          type: object
+          description: Count types aggregated over the range
+          additionalProperties:
+            type: integer
+    DeployedProductMetricsUsageCountsResponse:
+      required:
+      - product
+      - summary
+      - chartData
+      type: object
+      properties:
+        product:
+          required:
+          - id
+          - name
+          type: object
+          properties:
+            id:
+              type: string
+              description: Deployed product ID
+            name:
+              type: string
+              description: Deployed product name
+        summary:
+          $ref: '#/components/schemas/DeployedProductMetricsUsageCountsSummary'
+        chartData:
+          type: array
+          description: Chart data points ordered by date
+          items:
+            type: object
     DeployedProductUpdatePayload:
       type: object
       properties:

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1516,6 +1516,49 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+  /deployments/{deploymentId}/products/{productId}/metrics/search:
+    post:
+      summary: Search metrics for a deployed product within a specific deployment.
+      operationId: postDeploymentsDeploymentidProductsProductidMetricsSearch
+      parameters:
+      - name: deploymentId
+        in: path
+        description: ID of the deployment
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      - name: productId
+        in: path
+        description: ID of the deployed product
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Metrics search payload containing startDate and endDate (within a 1-year range)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployedProductMetricsPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployedProductMetricsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
   /deployments/products/{id}/catalogs/search:
     post:
       summary: Search catalogs for a specific deployed product with filters and pagination.
@@ -4785,6 +4828,127 @@ components:
           $ref: '#/components/schemas/Pagination'
       additionalProperties: false
       description: Deployed product search payload
+    DeployedProductMetricsPayload:
+      required:
+      - startDate
+      - endDate
+      type: object
+      properties:
+        startDate:
+          type: string
+          description: "Start date of the metrics range (format: YYYY-MM-DD)"
+        endDate:
+          type: string
+          description: "End date of the metrics range (format: YYYY-MM-DD)"
+    DeployedProductMetricsInstance:
+      required:
+      - id
+      - name
+      - cores
+      type: object
+      properties:
+        id:
+          type: string
+          description: Instance ID
+        name:
+          type: string
+          description: Instance name
+        cores:
+          type: integer
+          description: CPU cores allocated
+    DeployedProductMetricsChartDataPoint:
+      required:
+      - date
+      - instanceCount
+      - totalCores
+      - minCores
+      - maxCores
+      - avgCores
+      - instances
+      type: object
+      properties:
+        date:
+          type: string
+          description: "Date of the data point (format: YYYY-MM-DD)"
+        instanceCount:
+          type: integer
+          description: Number of instances on this date
+        totalCores:
+          type: integer
+          description: Total CPU cores on this date
+        minCores:
+          type: integer
+          description: Minimum CPU cores on this date
+        maxCores:
+          type: integer
+          description: Maximum CPU cores on this date
+        avgCores:
+          type: number
+          description: Average CPU cores on this date
+        instances:
+          type: array
+          description: Individual instances on this date
+          items:
+            $ref: '#/components/schemas/DeployedProductMetricsInstance'
+    DeployedProductMetricsSummary:
+      required:
+      - dateRange
+      - totalInstances
+      - minCores
+      - maxCores
+      - avgCores
+      type: object
+      properties:
+        dateRange:
+          required:
+          - start
+          - end
+          type: object
+          properties:
+            start:
+              type: string
+              description: Start date
+            end:
+              type: string
+              description: End date
+        totalInstances:
+          type: integer
+          description: Total number of distinct instances
+        minCores:
+          type: integer
+          description: Minimum CPU cores across the range
+        maxCores:
+          type: integer
+          description: Maximum CPU cores across the range
+        avgCores:
+          type: number
+          description: Average CPU cores across the range
+    DeployedProductMetricsResponse:
+      required:
+      - product
+      - summary
+      - chartData
+      type: object
+      properties:
+        product:
+          required:
+          - id
+          - name
+          type: object
+          properties:
+            id:
+              type: string
+              description: Deployed product ID
+            name:
+              type: string
+              description: Deployed product name
+        summary:
+          $ref: '#/components/schemas/DeployedProductMetricsSummary'
+        chartData:
+          type: array
+          description: Chart data points ordered by date
+          items:
+            $ref: '#/components/schemas/DeployedProductMetricsChartDataPoint'
     DeployedProductUpdatePayload:
       type: object
       properties:

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1559,6 +1559,8 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+        "404":
+          description: NotFound
   /deployments/{deploymentId}/products/{productId}/metrics/usage-counts/search:
     post:
       summary: Search metrics usage counts for a deployed product within a specific deployment.
@@ -1602,6 +1604,8 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+        "404":
+          description: NotFound
   /deployments/products/{id}/catalogs/search:
     post:
       summary: Search catalogs for a specific deployed product with filters and pagination.
@@ -4878,11 +4882,9 @@ components:
       type: object
       properties:
         startDate:
-          type: string
-          description: "Start date of the metrics range (format: YYYY-MM-DD)"
+          $ref: '#/components/schemas/Date'
         endDate:
-          type: string
-          description: "End date of the metrics range (format: YYYY-MM-DD)"
+          $ref: '#/components/schemas/Date'
     DeployedProductMetricsInstance:
       required:
       - id
@@ -4937,9 +4939,6 @@ components:
       required:
       - dateRange
       - totalInstances
-      - minCores
-      - maxCores
-      - avgCores
       type: object
       properties:
         dateRange:
@@ -4949,23 +4948,24 @@ components:
           type: object
           properties:
             start:
-              type: string
-              description: Start date
+              $ref: '#/components/schemas/Date'
             end:
-              type: string
-              description: End date
+              $ref: '#/components/schemas/Date'
         totalInstances:
           type: integer
-          description: Total number of distinct instances
+          description: Total number of distinct instances in the range
         minCores:
           type: integer
-          description: Minimum CPU cores across the range
+          nullable: true
+          description: "Minimum core count in the range; null when there are no instances"
         maxCores:
           type: integer
-          description: Maximum CPU cores across the range
+          nullable: true
+          description: "Maximum core count in the range; null when there are no instances"
         avgCores:
           type: number
-          description: Average CPU cores across the range
+          nullable: true
+          description: "Average core count in the range; null when there are no instances"
     DeployedProductMetricsResponse:
       required:
       - product
@@ -4999,11 +4999,9 @@ components:
       type: object
       properties:
         startDate:
-          type: string
-          description: "Start date of the metrics range (format: YYYY-MM-DD)"
+          $ref: '#/components/schemas/Date'
         endDate:
-          type: string
-          description: "End date of the metrics range (format: YYYY-MM-DD)"
+          $ref: '#/components/schemas/Date'
     DeployedProductMetricsUsageCountsSummary:
       required:
       - dateRange

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2881,6 +2881,90 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return <http:Ok>{body: mapDeployedProductMetrics(response)};
     }
 
+    # Search metrics usage counts for a deployed product within a specific deployment.
+    #
+    # + deploymentId - ID of the deployment
+    # + productId - ID of the deployed product
+    # + payload - Metrics usage counts search payload containing startDate and endDate (within a 1-year range)
+    # + return - Deployed product metrics usage counts response or error response
+    resource function post deployments/[entity:IdString deploymentId]/products/[entity:IdString productId]
+            /metrics/usage\-counts/search(http:RequestContext ctx,
+            types:DeployedProductMetricsUsageCountsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        if isInvalidDateRange(payload.startDate, payload.endDate) {
+            return <http:BadRequest>{
+                body: {
+                    message: "Invalid date range: startDate must not be after endDate."
+                }
+            };
+        }
+
+        if !isWithinOneYear(payload.startDate, payload.endDate) {
+            return <http:BadRequest>{
+                body: {
+                    message: "Invalid date range: the range between startDate and endDate must not exceed 1 year."
+                }
+            };
+        }
+
+        entity:DeployedProductMetricsUsageCountsResponse|error response =
+            entity:searchDeployedProductMetricsUsageCounts(
+                userInfo.idToken,
+                productId,
+                {
+                    deploymentId: deploymentId,
+                    startDate: payload.startDate,
+                    endDate: payload.endDate
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching metrics usage counts" +
+                            " for the deployed product."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                log:printWarn(string `User: ${userInfo.userId} is forbidden to access metrics usage counts` +
+                        string ` for deployed product with ID: ${productId} in deployment with ID: ${deploymentId}!`);
+                return <http:Forbidden>{
+                    body: {
+                        message: "Access to the requested deployed product metrics usage counts is forbidden!"
+                    }
+                };
+            }
+
+            string customError = "Failed to retrieve metrics usage counts for the deployed product.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapDeployedProductMetricsUsageCounts(response)};
+    }
+
     # Search catalogs for a specific deployed product with filters and pagination.
     #
     # + id - ID of the deployed product

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2827,7 +2827,16 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
-        if !isWithinOneYear(payload.startDate, payload.endDate) {
+        boolean|error withinOneYear = isWithinOneYear(payload.startDate, payload.endDate);
+        if withinOneYear is error {
+            log:printError("Failed to parse date range for deployed product metrics search.", withinOneYear);
+            return <http:InternalServerError>{
+                body: {
+                    message: "Failed to process the requested date range."
+                }
+            };
+        }
+        if !withinOneYear {
             return <http:BadRequest>{
                 body: {
                     message: "Invalid date range: the range between startDate and endDate must not exceed 1 year."
@@ -2839,7 +2848,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                 userInfo.idToken,
                 productId,
                 {
-                    deploymentId: deploymentId,
+                    deploymentId,
                     startDate: payload.startDate,
                     endDate: payload.endDate
                 });
@@ -2916,7 +2925,17 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
-        if !isWithinOneYear(payload.startDate, payload.endDate) {
+        boolean|error withinOneYear = isWithinOneYear(payload.startDate, payload.endDate);
+        if withinOneYear is error {
+            log:printError("Failed to parse date range for deployed product metrics usage counts search.",
+                    withinOneYear);
+            return <http:InternalServerError>{
+                body: {
+                    message: "Failed to process the requested date range."
+                }
+            };
+        }
+        if !withinOneYear {
             return <http:BadRequest>{
                 body: {
                     message: "Invalid date range: the range between startDate and endDate must not exceed 1 year."
@@ -2929,7 +2948,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                 userInfo.idToken,
                 productId,
                 {
-                    deploymentId: deploymentId,
+                    deploymentId,
                     startDate: payload.startDate,
                     endDate: payload.endDate
                 });

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2808,7 +2808,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + return - Deployed product metrics response or error response
     resource function post deployments/[entity:IdString deploymentId]/products/[entity:IdString productId]
             /metrics/search(http:RequestContext ctx, types:DeployedProductMetricsPayload payload)
-        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:NotFound|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -2868,6 +2868,13 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                     }
                 };
             }
+            if getStatusCode(response) == http:STATUS_NOT_FOUND {
+                return <http:NotFound>{
+                    body: {
+                        message: "Deployed product or deployment not found."
+                    }
+                };
+            }
 
             string customError = "Failed to retrieve metrics for the deployed product.";
             log:printError(customError, response);
@@ -2890,7 +2897,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     resource function post deployments/[entity:IdString deploymentId]/products/[entity:IdString productId]
             /metrics/usage\-counts/search(http:RequestContext ctx,
             types:DeployedProductMetricsUsageCountsPayload payload)
-        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:NotFound|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -2949,6 +2956,13 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                 return <http:Forbidden>{
                     body: {
                         message: "Access to the requested deployed product metrics usage counts is forbidden!"
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_NOT_FOUND {
+                return <http:NotFound>{
+                    body: {
+                        message: "Deployed product or deployment not found."
                     }
                 };
             }

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2800,6 +2800,87 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return response.deployedProduct;
     }
 
+    # Search metrics for a deployed product within a specific deployment.
+    #
+    # + deploymentId - ID of the deployment
+    # + productId - ID of the deployed product
+    # + payload - Metrics search payload containing startDate and endDate (within a 1-year range)
+    # + return - Deployed product metrics response or error response
+    resource function post deployments/[entity:IdString deploymentId]/products/[entity:IdString productId]
+            /metrics/search(http:RequestContext ctx, types:DeployedProductMetricsPayload payload)
+        returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        if isInvalidDateRange(payload.startDate, payload.endDate) {
+            return <http:BadRequest>{
+                body: {
+                    message: "Invalid date range: startDate must not be after endDate."
+                }
+            };
+        }
+
+        if !isWithinOneYear(payload.startDate, payload.endDate) {
+            return <http:BadRequest>{
+                body: {
+                    message: "Invalid date range: the range between startDate and endDate must not exceed 1 year."
+                }
+            };
+        }
+
+        entity:DeployedProductMetricsResponse|error response = entity:searchDeployedProductMetrics(
+                userInfo.idToken,
+                productId,
+                {
+                    deploymentId: deploymentId,
+                    startDate: payload.startDate,
+                    endDate: payload.endDate
+                });
+        if response is error {
+            if getStatusCode(response) == http:STATUS_BAD_REQUEST {
+                return <http:BadRequest>{
+                    body: {
+                        message: "Invalid request parameters for searching metrics for the deployed product."
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_FORBIDDEN {
+                log:printWarn(string `User: ${userInfo.userId} is forbidden to access metrics for deployed product` +
+                        string ` with ID: ${productId} in deployment with ID: ${deploymentId}!`);
+                return <http:Forbidden>{
+                    body: {
+                        message: "Access to the requested deployed product metrics is forbidden!"
+                    }
+                };
+            }
+
+            string customError = "Failed to retrieve metrics for the deployed product.";
+            log:printError(customError, response);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return <http:Ok>{body: mapDeployedProductMetrics(response)};
+    }
+
     # Search catalogs for a specific deployed product with filters and pagination.
     #
     # + id - ID of the deployed product

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -4273,7 +4273,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     resource function post projects/[entity:IdString id]/cases/time\-cards/search(http:RequestContext ctx,
             types:TimeCardSearchPayload payload)
         returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
-        
+
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
             return <http:InternalServerError>{
@@ -4828,7 +4828,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         if response is error {
             if getStatusCode(response) == http:STATUS_BAD_REQUEST {
                 log:printWarn(string `Invalid request parameters for creating registry token by user: ${
-                    userInfo.userId}`, response);
+                        userInfo.userId}`, response);
                 return <http:BadRequest>{
                     body: {
                         message: "Invalid request parameters for creating registry token."

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1400,3 +1400,27 @@ public isolated function mapDeployedProductMetrics(entity:DeployedProductMetrics
         chartData
     };
 }
+
+# Map deployed product metrics usage counts response.
+#
+# + response - Deployed product metrics usage counts response from the entity service
+# + return - Mapped deployed product metrics usage counts response
+public isolated function mapDeployedProductMetricsUsageCounts(
+        entity:DeployedProductMetricsUsageCountsResponse response)
+        returns types:DeployedProductMetricsUsageCountsResponse {
+
+    return {
+        product: {
+            id: response.deployedProduct.id,
+            name: response.deployedProduct.name
+        },
+        summary: {
+            dateRange: {
+                'start: response.summary.dateRange.'start,
+                'end: response.summary.dateRange.'end
+            },
+            countTypes: response.summary.countTypes
+        },
+        chartData: response.chartData
+    };
+}

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -292,6 +292,32 @@ public isolated function isInvalidLimitOffset(int? 'limit, int? offset) returns 
 public isolated function isInvalidDateRange(string? startDate, string? endDate) returns boolean =>
     startDate != () && endDate != () && startDate > endDate;
 
+# Validate that the date range does not exceed 1 year.
+#
+# + startDate - Start date string (format: YYYY-MM-DD)
+# + endDate - End date string (format: YYYY-MM-DD)
+# + return - True if the range is within 1 year, else false
+public isolated function isWithinOneYear(string startDate, string endDate) returns boolean {
+    do {
+        int startYear = check int:fromString(startDate.substring(0, 4));
+        int startMonth = check int:fromString(startDate.substring(5, 7));
+        int startDay = check int:fromString(startDate.substring(8, 10));
+        int endYear = check int:fromString(endDate.substring(0, 4));
+        int endMonth = check int:fromString(endDate.substring(5, 7));
+        int endDay = check int:fromString(endDate.substring(8, 10));
+
+        if endYear - startYear > 1 {
+            return false;
+        }
+        if endYear - startYear == 1 {
+            return endMonth < startMonth || (endMonth == startMonth && endDay <= startDay);
+        }
+        return true;
+    } on fail {
+        return false;
+    }
+}
+
 # Map attachments response to map to desired structure.
 #
 # + response - Attachments response from the entity service
@@ -1331,3 +1357,46 @@ public isolated function mapInstanceMetricStats(entity:InstanceMetricStatsRespon
     startDate: response.startDate,
     endDate: response.endDate
 };
+
+# Map deployed product metrics response.
+#
+# + response - Deployed product metrics response from the entity service
+# + return - Mapped deployed product metrics response
+public isolated function mapDeployedProductMetrics(entity:DeployedProductMetricsResponse response)
+    returns types:DeployedProductMetricsResponse {
+
+    types:DeployedProductMetricsChartDataPoint[] chartData =
+        from entity:DeployedProductMetricsChartDataPoint dataPoint in response.chartData
+        select {
+            date: dataPoint.date,
+            instanceCount: dataPoint.instanceCount,
+            totalCores: dataPoint.totalCores,
+            minCores: dataPoint.minCores,
+            maxCores: dataPoint.maxCores,
+            avgCores: dataPoint.avgCores,
+            instances: from entity:DeployedProductMetricsInstance instance in dataPoint.instances
+                select {
+                    id: instance.id,
+                    name: instance.name,
+                    cores: instance.cores
+                }
+        };
+
+    return {
+        product: {
+            id: response.deployedProduct.id,
+            name: response.deployedProduct.name
+        },
+        summary: {
+            dateRange: {
+                'start: response.summary.dateRange.'start,
+                'end: response.summary.dateRange.'end
+            },
+            totalInstances: response.summary.totalInstances,
+            minCores: response.summary.minCores,
+            maxCores: response.summary.maxCores,
+            avgCores: response.summary.avgCores
+        },
+        chartData
+    };
+}

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -296,26 +296,22 @@ public isolated function isInvalidDateRange(string? startDate, string? endDate) 
 #
 # + startDate - Start date string (format: YYYY-MM-DD)
 # + endDate - End date string (format: YYYY-MM-DD)
-# + return - True if the range is within 1 year, else false
-public isolated function isWithinOneYear(string startDate, string endDate) returns boolean {
-    do {
-        int startYear = check int:fromString(startDate.substring(0, 4));
-        int startMonth = check int:fromString(startDate.substring(5, 7));
-        int startDay = check int:fromString(startDate.substring(8, 10));
-        int endYear = check int:fromString(endDate.substring(0, 4));
-        int endMonth = check int:fromString(endDate.substring(5, 7));
-        int endDay = check int:fromString(endDate.substring(8, 10));
+# + return - True if the range is within 1 year, false if it exceeds 1 year, or error if parsing fails
+public isolated function isWithinOneYear(string startDate, string endDate) returns boolean|error {
+    int startYear = check int:fromString(startDate.substring(0, 4));
+    int startMonth = check int:fromString(startDate.substring(5, 7));
+    int startDay = check int:fromString(startDate.substring(8, 10));
+    int endYear = check int:fromString(endDate.substring(0, 4));
+    int endMonth = check int:fromString(endDate.substring(5, 7));
+    int endDay = check int:fromString(endDate.substring(8, 10));
 
-        if endYear - startYear > 1 {
-            return false;
-        }
-        if endYear - startYear == 1 {
-            return endMonth < startMonth || (endMonth == startMonth && endDay <= startDay);
-        }
-        return true;
-    } on fail {
+    if endYear - startYear > 1 {
         return false;
     }
+    if endYear - startYear == 1 {
+        return endMonth < startMonth || (endMonth == startMonth && endDay <= startDay);
+    }
+    return true;
 }
 
 # Map attachments response to map to desired structure.


### PR DESCRIPTION
## Summary
- Add `POST /deployed-products/{id}/metrics/search` endpoint to fetch core usage metrics grouped by date for a deployed product
- Add `POST /deployed-products/{id}/metrics/usage-counts/search` endpoint to fetch usage counts grouped by date for a deployed product
- Both endpoints require `deploymentId`, `startDate`, and `endDate` (mandatory, max 1-year range)

## Test plan
- [ ] `POST /deployed-products/{id}/metrics/search` returns correct response structure with `deployedProduct`, `summary`, and `chartData`
- [ ] `POST /deployed-products/{id}/metrics/usage-counts/search` returns correct response structure with `deployedProduct`, `summary`, and `chartData`
- [ ] Validation rejects missing `deploymentId`, `startDate`, or `endDate`
- [ ] Validation rejects date ranges exceeding 1 year
- [ ] Validation rejects `endDate` before or equal to `startDate`
- [ ] Missing `x-user-id-token` header returns 401
- [ ] Invalid deployed product `id` returns 404 from ServiceNow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new deployed product metrics endpoints: one for metrics and one for usage counts.
  * Introduced `startDate`/`endDate` validation with a maximum one-year range.
  * Enabled API responses to return metric summaries and chart data (including per-instance details where applicable).
* **Bug Fixes**
  * Improved handling of invalid date ranges and standardized error responses for unauthorized access, not found, and server failures.
* **Refactor**
  * Updated response shapes and mapping to consistently deliver summaries and chart data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->