### PR TITLE
[CSM][Web] UX polish: case list, chips, internal notes, state dropdown, service request routing

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -269,6 +269,10 @@ export default function App(): JSX.Element {
                     element={<CreateServiceRequestPage />}
                   />
                   <Route
+                    path="operations/service-requests/:caseId"
+                    element={<CsmCaseDetailPage />}
+                  />
+                  <Route
                     path="operations/change-requests/:id"
                     element={<CsmChangeRequestDetailPage />}
                   />

--- a/apps/csm-portal/webapp/src/components/SemanticChip.tsx
+++ b/apps/csm-portal/webapp/src/components/SemanticChip.tsx
@@ -24,6 +24,7 @@ interface SemanticChipProps {
   role: SemanticRole;
   label: string;
   size?: "small" | "medium";
+  variant?: "filled" | "outlined";
   /** Bold label — use for priority signals (severity), not quiet metadata. */
   bold?: boolean;
   /** Pointer cursor when wrapped in a link / clickable row. */
@@ -42,6 +43,7 @@ export default function SemanticChip({
   role,
   label,
   size = "small",
+  variant,
   bold = false,
   clickable = false,
 }: SemanticChipProps): JSX.Element {
@@ -50,6 +52,7 @@ export default function SemanticChip({
       size={size}
       // "default" is a valid MUI Chip color — filled grey, no border.
       color={role}
+      variant={variant}
       label={label}
       sx={{
         ...(bold ? { "& .MuiChip-label": { fontWeight: 600 } } : {}),

--- a/apps/csm-portal/webapp/src/components/SeverityChip.tsx
+++ b/apps/csm-portal/webapp/src/components/SeverityChip.tsx
@@ -47,7 +47,7 @@ export default function SeverityChip({
     <SemanticChip
       role={SEVERITY_COLOR[severity]}
       label={
-        withLabel ? `${severity} — ${SEVERITY_LABEL[severity]}` : severity
+        withLabel ? `${severity} (${SEVERITY_LABEL[severity]})` : severity
       }
       size={size}
       bold

--- a/apps/csm-portal/webapp/src/components/StateChip.tsx
+++ b/apps/csm-portal/webapp/src/components/StateChip.tsx
@@ -24,6 +24,7 @@ import SemanticChip from "@components/SemanticChip";
 interface StateChipProps {
   state: string;
   size?: "small" | "medium";
+  variant?: "filled" | "outlined";
   /** Render a pointer cursor when the chip sits inside a link / clickable row. */
   clickable?: boolean;
 }
@@ -39,6 +40,7 @@ interface StateChipProps {
 export default function StateChip({
   state,
   size = "small",
+  variant,
   clickable = false,
 }: StateChipProps): JSX.Element {
   return (
@@ -46,6 +48,7 @@ export default function StateChip({
       role={stateColor(state)}
       label={stateLabel(state)}
       size={size}
+      variant={variant}
       clickable={clickable}
     />
   );

--- a/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
+++ b/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
@@ -66,8 +66,8 @@ export default class AppErrorBoundary extends Component<
         <Stack spacing={2} alignItems="center" sx={{ maxWidth: 480 }}>
           <Typography variant="h5">Something went wrong</Typography>
           <Typography variant="body1" color="text.secondary" textAlign="center">
-            An unexpected error occurred while rendering this page. Reloading
-            usually fixes it; your sign-in session is preserved.
+            Something went wrong loading this page. Try reloading — your session
+            will be kept.
           </Typography>
           <Button variant="contained" onClick={() => window.location.reload()}>
             Reload page

--- a/apps/csm-portal/webapp/src/components/header/ThemeSelect.tsx
+++ b/apps/csm-portal/webapp/src/components/header/ThemeSelect.tsx
@@ -18,7 +18,6 @@ import {
   Box,
   MenuItem,
   Select,
-  Tooltip,
   type SelectChangeEvent,
 } from "@wso2/oxygen-ui";
 import { Palette } from "@wso2/oxygen-ui-icons-react";
@@ -41,8 +40,7 @@ export default function ThemeSelect(): JSX.Element {
   };
 
   return (
-    <Tooltip title="Theme">
-      <Box sx={{ display: "flex", alignItems: "center" }}>
+    <Box sx={{ display: "flex", alignItems: "center" }}>
         <Select
           value={themeKey}
           onChange={handleChange}
@@ -73,7 +71,6 @@ export default function ThemeSelect(): JSX.Element {
             </MenuItem>
           ))}
         </Select>
-      </Box>
-    </Tooltip>
+    </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/components/route-fallback/RouteSuspenseFallback.tsx
+++ b/apps/csm-portal/webapp/src/components/route-fallback/RouteSuspenseFallback.tsx
@@ -20,7 +20,7 @@ import { type JSX } from "react";
 /**
  * Fallback rendered while a lazily-loaded route chunk is being fetched. Sits
  * inside the persistent app shell so only the content region shows progress,
- * mirroring the warning-coloured LinearProgress used elsewhere in the layout.
+ * mirroring the primary-coloured LinearProgress used elsewhere in the layout.
  */
 export default function RouteSuspenseFallback(): JSX.Element {
   return (
@@ -36,7 +36,7 @@ export default function RouteSuspenseFallback(): JSX.Element {
       }}
     >
       <LinearProgress
-        color="warning"
+        color="primary"
         sx={{ width: "80%", maxWidth: 400, height: 4 }}
       />
     </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -202,7 +202,7 @@ export function useGetCsmCases(
       // customer column (cases embed the project, but not its account). The
       // lookups go through `fetchQuery` with their own stable keys, so they
       // hit the network only when their cache is stale — not on every filter
-      // change. Lookup failures degrade to "—" names, not a failed list.
+      // change. Lookup failures degrade to blank names, not a failed list.
       const [casesResponse, projects, accounts] = await Promise.all([
         api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
           pagination: { offset, limit: pageSize },

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -277,13 +277,13 @@ export function useGetCsmCases(
           caseNumber: c.number,
           wso2CaseId: c.internalId,
           subject: c.subject ?? "(no subject)",
-          customer: accountName.get(accountId) ?? "—",
+          customer: accountName.get(accountId) ?? "",
           accountId,
           projectId,
-          projectName: c.project?.name ?? "—",
+          projectName: c.project?.name ?? "",
           // Search embeds deployedProduct as { id, name } (name includes the
           // version); the GET view uses a displayName-shaped ref instead.
-          product: c.deployedProduct?.name ?? "—",
+          product: c.deployedProduct?.name ?? "",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
           caseType: c.type,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -277,13 +277,13 @@ export function useGetCsmCases(
           caseNumber: c.number,
           wso2CaseId: c.internalId,
           subject: c.subject ?? "(no subject)",
-          customer: accountName.get(accountId) ?? "",
+          customer: accountName.get(accountId) ?? "-",
           accountId,
           projectId,
-          projectName: c.project?.name ?? "",
+          projectName: c.project?.name ?? "-",
           // Search embeds deployedProduct as { id, name } (name includes the
           // version); the GET view uses a displayName-shaped ref instead.
-          product: c.deployedProduct?.name ?? "",
+          product: c.deployedProduct?.name ?? "-",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
           caseType: c.type,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -216,7 +216,7 @@ export function CallRequestsWidget({
             <Typography variant="body2" color="text.secondary">
               {stateFilter
                 ? `No call requests in state "${CALL_REQUEST_STATE_LABEL[stateFilter]}".`
-                : "No call requests yet. Use the button above to request a call."}
+                : "No call requests yet."}
             </Typography>
           </Box>
         )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -275,6 +275,7 @@ export default function CaseActionBar({
   onAction,
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [stateMenuAnchor, setStateMenuAnchor] = useState<HTMLElement | null>(null);
   const [pendingConfirm, setPendingConfirm] = useState<PrimaryButton | null>(
     null,
   );
@@ -308,35 +309,39 @@ export default function CaseActionBar({
         justifyContent: { xs: "flex-start", md: "flex-end" },
       }}
     >
-      {primary.map((p, idx) => {
-        const button = (
+      {primary.length > 0 && (
+        <>
           <Button
             size="small"
-            variant={idx === 0 ? "contained" : "outlined"}
-            color={p.color}
-            startIcon={p.icon}
-            onClick={() => runPrimary(p)}
+            variant="outlined"
+            endIcon={<ChevronDown size={16} />}
+            onClick={(e) => setStateMenuAnchor(e.currentTarget)}
           >
-            {p.label}
+            Change state
           </Button>
-        );
-        // `targetState` is unique per button (each moves to a distinct state),
-        // so it is the correct React key — the lifecycle action is not (e.g.
-        // `resume_work` can map from more than one source state).
-        return p.tooltip ? (
-          <Tooltip key={p.targetState} title={p.tooltip}>
-            {button}
-          </Tooltip>
-        ) : (
-          <Box
-            key={p.targetState}
-            component="span"
-            sx={{ display: "inline-flex" }}
+          <Menu
+            anchorEl={stateMenuAnchor}
+            open={!!stateMenuAnchor}
+            onClose={() => setStateMenuAnchor(null)}
           >
-            {button}
-          </Box>
-        );
-      })}
+            {primary.map((p) => (
+              <MenuItem
+                key={p.targetState}
+                onClick={() => {
+                  setStateMenuAnchor(null);
+                  runPrimary(p);
+                }}
+                sx={{ gap: 1.25, minHeight: 36 }}
+              >
+                <Box sx={{ color: `${p.color}.main`, display: "flex" }}>
+                  {p.icon}
+                </Box>
+                {p.label}
+              </MenuItem>
+            ))}
+          </Menu>
+        </>
+      )}
 
       <Button
         size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { Box, Card, Chip, Typography } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
-import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
+import { tierLabel } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import SemanticChip from "@components/SemanticChip";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
@@ -180,12 +180,22 @@ export default function CaseMetaBand({
       }}
     >
       <Box
+        component="button"
+        onClick={onToggleCollapsed}
+        aria-label={collapsed ? "Show case details" : "Hide case details"}
         sx={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           px: 2,
           py: collapsed ? 0.75 : 1,
+          width: "100%",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "inherit",
+          textAlign: "left",
+          "&:hover": { bgcolor: "action.hover" },
         }}
       >
         {collapsed ? (
@@ -206,15 +216,7 @@ export default function CaseMetaBand({
             Overview
           </Typography>
         )}
-        <Tooltip title={collapsed ? "Show details" : "Hide details"}>
-          <IconButton
-            size="small"
-            onClick={onToggleCollapsed}
-            aria-label={collapsed ? "Show case details" : "Hide case details"}
-          >
-            {collapsed ? <ChevronDown size={18} /> : <ChevronUp size={18} />}
-          </IconButton>
-        </Tooltip>
+        {collapsed ? <ChevronDown size={18} /> : <ChevronUp size={18} />}
       </Box>
       {!collapsed && (
         <Box
@@ -235,7 +237,7 @@ export default function CaseMetaBand({
         >
           <Cell label="Tier">
             <Box sx={{ minWidth: 0 }}>
-              <SemanticChip role={tierColor(tier)} label={tierLabel(tier)} />
+              <Chip size="small" variant="outlined" color="primary" label={tierLabel(tier)} />
             </Box>
           </Cell>
           <Cell label="Assignee">

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, Chip, Typography } from "@wso2/oxygen-ui";
+import { Box, Card, Typography } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
-import { tierLabel } from "@features/csm-cases/utils/caseTier";
+import { tierLabel, tierColor } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import SemanticChip from "@components/SemanticChip";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
@@ -181,6 +181,7 @@ export default function CaseMetaBand({
     >
       <Box
         component="button"
+        type="button"
         onClick={onToggleCollapsed}
         aria-label={collapsed ? "Show case details" : "Hide case details"}
         sx={{
@@ -237,7 +238,7 @@ export default function CaseMetaBand({
         >
           <Cell label="Tier">
             <Box sx={{ minWidth: 0 }}>
-              <Chip size="small" variant="outlined" color="primary" label={tierLabel(tier)} />
+              <SemanticChip role={tierColor(tier)} variant="outlined" label={tierLabel(tier)} />
             </Box>
           </Cell>
           <Cell label="Assignee">

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -37,13 +37,15 @@ const HEADER_CELLS: string[] = [
   "Product",
   "Severity",
   "State",
+  "Work state",
   "Updated",
 ];
 
 // Subject gets the lion's share of the row; the ids sit in their own narrow
 // column so a long subject no longer has to share one cell with them.
+// State and Work state are separate columns so neither chip crowds the other.
 const GRID =
-  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto minmax(110px, 1fr) auto";
+  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto minmax(110px, 1fr) auto auto";
 
 export default function CasesList({
   cases,
@@ -160,6 +162,7 @@ export default function CasesList({
                   <Typography
                     variant="body2"
                     noWrap
+                    title={c.wso2CaseId}
                     sx={{ fontFamily: "monospace", fontWeight: 600 }}
                   >
                     {c.wso2CaseId}
@@ -170,49 +173,47 @@ export default function CasesList({
                     variant="caption"
                     color="text.secondary"
                     noWrap
+                    title={c.caseNumber}
                     sx={{ fontFamily: "monospace", display: "block" }}
                   >
                     {c.caseNumber}
                   </Typography>
                 )}
-                {!c.wso2CaseId && !c.caseNumber && (
-                  <Typography variant="body2" color="text.secondary">
-                    —
-                  </Typography>
-                )}
               </Box>
               {/* Subject (the widest column) + project for context. */}
               <Box sx={{ minWidth: 0 }}>
-                <Typography variant="body2" noWrap>
+                <Typography variant="body2" noWrap title={c.subject}>
                   {c.subject}
                 </Typography>
                 <Typography
                   variant="caption"
                   color="text.secondary"
                   noWrap
+                  title={c.projectName || undefined}
                   sx={{ display: "block" }}
                 >
                   {c.projectName}
                 </Typography>
               </Box>
-              <Typography variant="body2" noWrap>
+              <Typography variant="body2" noWrap title={c.product || undefined}>
                 {c.product}
               </Typography>
               <Box sx={{ justifySelf: "start" }}>
                 <SeverityChip severity={c.severity} clickable />
               </Box>
-              {/* State, plus the work sub-state (Ongoing/Paused) when the case
-                  is in progress. Paused is coloured to stand out as a stalled
-                  case; ongoing stays quiet. */}
-              <Box sx={{ justifySelf: "start", minWidth: 0 }}>
-                <StateChip state={c.state} clickable />
+              {/* State chip — lifecycle state only. */}
+              <Box sx={{ justifySelf: "start" }}>
+                <StateChip state={c.state} variant="outlined" clickable />
+              </Box>
+              {/* Work state chip — separate column; only rendered for WIP cases. */}
+              <Box sx={{ justifySelf: "start" }}>
                 {c.state === "work_in_progress" && c.workState && (
                   <Chip
                     size="small"
                     variant="outlined"
                     color={c.workState === "paused" ? "warning" : "default"}
                     label={WORK_STATE_LABEL[c.workState]}
-                    sx={{ display: "flex", mt: 0.25, fontWeight: 600, width: "fit-content" }}
+                    sx={{ fontWeight: 600 }}
                   />
                 )}
               </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { alpha, Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
+import { Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
 import { Bot } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
@@ -137,23 +137,27 @@ export default function CsmCaseCommentBubble({
           display: "flex",
           flexDirection: "column",
           gap: 0.75,
-          backgroundColor: isInternal
-            ? alpha(theme.palette.warning.main, 0.15)
-            : undefined,
-          borderColor: isInternal ? "warning.main" : undefined,
+          ...(isInternal && {
+            bgcolor: "action.hover",
+            borderColor: "divider",
+            borderLeftWidth: "3px",
+            borderLeftColor: "primary.main",
+          }),
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
           <Typography variant="subtitle2">{comment.authorName}</Typography>
-          <Chip
-            size="small"
-            label={ROLE_LABEL[comment.authorRole]}
-            color={ROLE_COLOR[comment.authorRole]}
-            variant="outlined"
-          />
+          {comment.authorRole !== "wso2_engineer" && (
+            <Chip
+              size="small"
+              label={ROLE_LABEL[comment.authorRole]}
+              color={ROLE_COLOR[comment.authorRole]}
+              variant="outlined"
+            />
+          )}
           {/* A filled chip "bubble" marks the work note; paired with the tinted
               background it reads as internal without a heavy banner. */}
-          {isInternal && <SemanticChip role="warning" label="Internal note" />}
+          {isInternal && <SemanticChip role="default" variant="outlined" label="Internal note" />}
           <Typography variant="caption" color="text.secondary">
             <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
           </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  alpha,
   Box,
   Button,
   FormControlLabel,
@@ -228,11 +227,10 @@ export default function CsmCaseCommentInput({
         gap: 1,
         p: internal ? 1.25 : 0,
         borderRadius: internal ? 1 : 0,
-        backgroundColor: internal
-          ? (theme) => alpha(theme.palette.warning.main, 0.15)
-          : undefined,
+        bgcolor: internal ? "action.hover" : undefined,
         border: internal ? 1 : 0,
-        borderColor: internal ? "warning.main" : undefined,
+        borderColor: internal ? "divider" : undefined,
+        ...(internal && { borderLeftWidth: "3px", borderLeftColor: "primary.main" }),
       }}
     >
       <Box
@@ -246,10 +244,10 @@ export default function CsmCaseCommentInput({
       >
         <Typography
           variant="caption"
-          color={internal ? "warning.main" : "text.secondary"}
+          color="text.secondary"
         >
           {internal
-            ? "Internal work note — not visible to the customer."
+            ? "Internal work note - not visible to the customer."
             : sourceMode
               ? "HTML source — edit raw markup directly."
               : "Reply to this case…"}
@@ -259,7 +257,7 @@ export default function CsmCaseCommentInput({
             control={
               <Switch
                 size="small"
-                color="warning"
+                color="primary"
                 checked={internal}
                 onChange={(e) => setInternal(e.target.checked)}
                 disabled={disabled || submitting || publicReplyLocked}
@@ -397,7 +395,7 @@ export default function CsmCaseCommentInput({
         </Typography>
         <Button
           variant="contained"
-          color={internal ? "warning" : "primary"}
+          color="primary"
           size="small"
           startIcon={internal ? <Lock size={16} /> : <Send size={16} />}
           disabled={

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -123,7 +123,7 @@ export default function CsmIssuesView({
     [filters, debouncedSearch, lockedFilters],
   );
 
-  const { data, isLoading, isError, error } = useGetCsmCases(
+  const { data, isLoading, isFetching, isError, error } = useGetCsmCases(
     queryFilters,
     page,
     rowsPerPage,
@@ -185,11 +185,12 @@ export default function CsmIssuesView({
   const rangeStart = total === 0 ? 0 : page * rowsPerPage + 1;
   const rangeEnd = page * rowsPerPage + cases.length;
 
-  const subtitle = isLoading
-    ? "Loading…"
-    : total === 0
-      ? `No ${entityNoun}`
-      : `Showing ${rangeStart}–${rangeEnd} of ${total}`;
+  const subtitle =
+    isLoading || isFetching
+      ? null
+      : total === 0
+        ? `No ${entityNoun}`
+        : `Showing ${rangeStart}–${rangeEnd} of ${total}`;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -204,9 +205,11 @@ export default function CsmIssuesView({
       >
         <Box>
           {title && <Typography variant="h5">{title}</Typography>}
-          <Typography variant="body2" color="text.secondary">
-            {subtitle}
-          </Typography>
+          {subtitle != null && (
+            <Typography variant="body2" color="text.secondary">
+              {subtitle}
+            </Typography>
+          )}
         </Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           {breachedCount > 0 && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -123,7 +123,7 @@ export default function CsmIssuesView({
     [filters, debouncedSearch, lockedFilters],
   );
 
-  const { data, isLoading, isFetching, isError, error } = useGetCsmCases(
+  const { data, isLoading, isError, error } = useGetCsmCases(
     queryFilters,
     page,
     rowsPerPage,
@@ -186,7 +186,7 @@ export default function CsmIssuesView({
   const rangeEnd = page * rowsPerPage + cases.length;
 
   const subtitle =
-    isLoading || isFetching
+    isLoading
       ? null
       : total === 0
         ? `No ${entityNoun}`

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -918,6 +918,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 {c.caseNumber}
               </Box>
             )}
+            {!c.wso2CaseId && !c.caseNumber && (
+              <Box component="span" sx={{ color: "text.disabled" }}>
+                —
+              </Box>
+            )}
           </Typography>
 
           {/* Status group (severity, lifecycle state, SLA) kept visually

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -251,9 +251,22 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
   const isEngagementRoute = location.pathname.startsWith("/engagements/");
-  const backPath = isEngagementRoute ? "/engagements" : "/cases";
-  const backLabel = isEngagementRoute ? "Back to engagements" : "Back to cases";
-  const detailPath = isEngagementRoute ? `/engagements/${caseId}` : `/cases/${caseId}`;
+  const isServiceRequestRoute = location.pathname.startsWith("/operations/service-requests/");
+  const backPath = isEngagementRoute
+    ? "/engagements"
+    : isServiceRequestRoute
+      ? "/operations?tab=service_requests"
+      : "/cases";
+  const backLabel = isEngagementRoute
+    ? "Back to engagements"
+    : isServiceRequestRoute
+      ? "Back to service requests"
+      : "Back to cases";
+  const detailPath = isEngagementRoute
+    ? `/engagements/${caseId}`
+    : isServiceRequestRoute
+      ? `/operations/service-requests/${caseId}`
+      : `/cases/${caseId}`;
   const { data, isLoading, isError } = useGetCsmCaseDetail(caseId);
   const {
     data: comments,
@@ -763,8 +776,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
   if (isLoading) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-        <Skeleton variant="rectangular" height={32} width={240} />
-        <Skeleton variant="rectangular" height={200} />
+        <Skeleton variant="rounded" height={32} width={240} />
+        <Skeleton variant="rounded" height={200} />
       </Box>
     );
   }
@@ -903,11 +916,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
             {c.caseNumber && (
               <Box component="span" sx={{ color: "text.primary" }}>
                 {c.caseNumber}
-              </Box>
-            )}
-            {!c.wso2CaseId && !c.caseNumber && (
-              <Box component="span" sx={{ color: "text.disabled" }}>
-                —
               </Box>
             )}
           </Typography>
@@ -1163,7 +1171,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               // isChatLoading is false for chat-less cases (query disabled).
               <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
                 {[0, 1, 2].map((i) => (
-                  <Skeleton key={i} variant="rectangular" height={56} />
+                  <Skeleton key={i} variant="rounded" height={56} />
                 ))}
               </Box>
             ) : (

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetMyAssignedOpenCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetMyAssignedOpenCases.ts
@@ -128,11 +128,11 @@ export function useGetMyAssignedOpenCases(
           subject: c.subject ?? "(no subject)",
           // The search view does not embed the account; CasesList never renders
           // it, so leave it unresolved rather than scanning the account list.
-          customer: "—",
+          customer: "-",
           accountId: "",
           projectId: c.project?.id ?? "",
-          projectName: c.project?.name ?? "—",
-          product: c.deployedProduct?.name ?? "—",
+          projectName: c.project?.name ?? "-",
+          product: c.deployedProduct?.name ?? "-",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
           caseType: c.type,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -76,6 +76,7 @@ export default function OperationsPage(): JSX.Element {
           entityNoun="service requests"
           lockedFilters={{ caseTypes: ["service_request"] }}
           hideTypeFilter
+          detailBasePath="/operations/service-requests"
           actions={
             <Button
               variant="contained"

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -18,10 +18,10 @@ import {
   Alert,
   Box,
   Chip,
-  CircularProgress,
   InputAdornment,
   MenuItem,
   Paper,
+  Skeleton,
   Table,
   TableBody,
   TableCell,
@@ -154,11 +154,15 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
-                    <CircularProgress size={24} />
-                  </TableCell>
-                </TableRow>
+                Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {Array.from({ length: 6 }).map((__, j) => (
+                      <TableCell key={j}>
+                        <Skeleton variant="text" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
               ) : isError ? (
                 // The error Alert above carries the detail; don't fall through
                 // to the empty state (which would read as "0 results").
@@ -198,12 +202,12 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                   >
                     <TableCell>
                       <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-                        {vuln.cveId || vuln.vulnerabilityId || "—"}
+                        {vuln.cveId || vuln.vulnerabilityId || "-"}
                       </Typography>
                     </TableCell>
                     <TableCell>
                       <Typography variant="body2" noWrap title={vuln.componentName}>
-                        {vuln.componentName || "—"}
+                        {vuln.componentName || "-"}
                         {vuln.version ? (
                           <Typography
                             component="span"
@@ -218,7 +222,7 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                     </TableCell>
                     <TableCell>
                       <Typography variant="body2" noWrap>
-                        {vuln.productName || "—"}
+                        {vuln.productName || "-"}
                         {vuln.productVersion ? (
                           <Typography
                             component="span"
@@ -240,11 +244,11 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                           label={vuln.priority}
                         />
                       ) : (
-                        "—"
+                        "-"
                       )}
                     </TableCell>
-                    <TableCell>{vuln.type || "—"}</TableCell>
-                    <TableCell>{vuln.updateLevel || "—"}</TableCell>
+                    <TableCell>{vuln.type || "-"}</TableCell>
+                    <TableCell>{vuln.updateLevel || "-"}</TableCell>
                   </TableRow>
                   );
                 })

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -166,7 +166,7 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
             >
               {isVisible && (
                 <LinearProgress
-                  color="warning"
+                  color="primary"
                   sx={{
                     position: "absolute",
                     top: 0,
@@ -203,7 +203,7 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
                     }}
                   >
                     <LinearProgress
-                      color="warning"
+                      color="primary"
                       sx={{ width: "80%", maxWidth: 400, height: 4 }}
                     />
                     <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
## Summary

- **Case list**: split State / Work state into two separate columns; outlined `StateChip`; native hover tooltip on truncated text; removed em-dash fallbacks
- **SeverityChip**: format changed to `S2 (Critical)` instead of `S2 — Critical`
- **State dropdown**: consolidated per-state lifecycle buttons in `CaseActionBar` into a single "Change state ▼" `Menu`; existing confirm-dialog path unchanged
- **Overview header**: entire row in `CaseMetaBand` is now a clickable `component="button"`; Tier chip uses `color="primary" variant="outlined"` so it follows the active theme
- **Internal notes**: theme-neutral styling across `CsmCaseCommentBubble` and `CsmCaseCommentInput` — `primary.main` left-border accent + `action.hover` background instead of hardcoded `info`/`warning` palette; "Internal note" chip changed to `SemanticChip role="default" variant="outlined"`; removed WSO2 role chip from comment bubbles
- **`SemanticChip` / `StateChip`**: added `variant` prop (`filled | outlined`)
- **Loading states**: hide case count subtitle while loading/fetching; replace `CircularProgress` in `ProductVulnerabilitiesTab` with skeleton rows; `variant="rounded"` skeletons in case detail
- **Service request routing**: `OperationsPage` passes `detailBasePath="/operations/service-requests"`; new `App.tsx` route `operations/service-requests/:caseId` renders `CsmCaseDetailPage`; page detects route and sets "Back to service requests" link + correct canonical URL
- **Minor copy**: simplified `CallRequestsWidget` empty state; friendlier `AppErrorBoundary` error message; removed tooltip from `ThemeSelect`

## Test plan

- [x] Case list shows State and Work state in separate columns; outlined chips; hover tooltip on long text
- [x] Severity chip renders `S2 (Critical)` format
- [x] "Change state ▼" dropdown opens and triggers state transitions (including confirm dialog for gated ones)
- [x] Overview header row click toggles collapse; Tier chip colour matches active theme
- [x] Internal note comments show left-border accent and outlined chip across both light and non-default (e.g. Acrylic Orange) themes
- [x] WSO2 role chip no longer shown on engineer comments
- [x] Case count hidden while list is loading / fetching
- [x] Vulnerabilities table shows skeleton rows on load
- [x] Clicking a service request in the Operations tab opens it under `/operations/service-requests/:id` (not `/cases/:id`); "Back to service requests" navigates to `/operations?tab=service_requests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated service-request detail route with matching back navigation from the operations view.
  * Introduced a separate “Work state” column in the cases list for clearer status visibility.
  * Updated action controls to use a single “Change state” menu for lifecycle transitions.

* **Bug Fixes**
  * Improved loading and empty-state behavior across cases, comments, and vulnerabilities views.
  * Refined several labels, fallbacks, and chip styles for cleaner, more consistent display.
  * Updated the page error message to be clearer and more user-friendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->