### PR TITLE
[CSM Portal] cases: product filter + cloud-project case creation

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -422,6 +422,12 @@ export interface BeCaseSearchFilters {
    * `@me`-only selection resolves to nothing and the filter is omitted.
    */
   assignedUserIds?: string[];
+  /**
+   * Filter by product family name (e.g. `"API Manager"`, `"Asgardeo"`). Matches
+   * every version of each named product (ServiceNow matches `product.name`).
+   * SN data source only.
+   */
+  productNames?: string[];
 }
 
 export interface BeCaseSearchPayload {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -236,6 +236,10 @@ export function useGetCsmCases(
             ...(assignedUserIds && assignedUserIds.length > 0 && {
               assignedUserIds,
             }),
+            // Product family names; SN matches `product.name` (all versions).
+            ...(filters.productNames.length > 0 && {
+              productNames: filters.productNames,
+            }),
           },
         }),
         queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProductNameOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProductNameOptions.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeProductSearchPayload, BeProductSearchResponse } from "@api/backend/types";
+
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+
+/**
+ * Distinct product **family names** for the cases product filter.
+ *
+ * `POST /products/search` returns one row per product model/version (hundreds
+ * of rows, the same short `name` repeated many times, e.g. dozens of "API
+ * Manager" variants). The case product filter matches on the family name
+ * (`filters.productNames` → ServiceNow `product.name IN ...`, all versions), so
+ * this hook fetches the full (bounded) catalogue once and reduces it to the set
+ * of distinct, non-empty names, sorted for a stable dropdown order.
+ */
+export function useProductNameOptions(): UseQueryResult<string[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<string[], Error>({
+    queryKey: [ApiQueryKeys.PRODUCTS, "family-names"],
+    queryFn: async (): Promise<string[]> => {
+      const names = new Set<string>();
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const res = await api.post<BeProductSearchPayload, BeProductSearchResponse>(
+          "/products/search",
+          { pagination: { offset, limit: PAGE_LIMIT } },
+        );
+        const page = res.products ?? [];
+        for (const p of page) {
+          const name = p.name?.trim();
+          if (name) names.add(name);
+        }
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return [...names].sort((a, b) => a.localeCompare(b));
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -79,6 +79,7 @@ import {
 } from "@features/csm-cases/utils/caseType";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
+import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
 
 
 /**
@@ -102,6 +103,8 @@ export interface CasesFilters {
   projects: string[];
   /** Engagement sub-type filter; only meaningful when `caseTypes` is locked to `engagement`. */
   engagementTypes: BeEngagementType[];
+  /** Product family names (e.g. "API Manager"); matches all versions of each. */
+  productNames: string[];
 }
 
 /**
@@ -594,6 +597,14 @@ export default function CasesFilterBar({
                 />
               </Grid>
             )}
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              {/* Product family filter; the selected names map straight to
+                  `productNames` (SN matches product.name, all versions). */}
+              <ProductNameMultiSelect
+                values={filters.productNames}
+                onChange={(next) => onChange({ ...filters, productNames: next })}
+              />
+            </Grid>
           </Grid>
           {activeCount > 0 && (
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -54,6 +54,7 @@ const FILTER_PARAM_KEYS = [
   "assignees",
   "projects",
   "engagementTypes",
+  "products",
 ] as const;
 
 interface CsmIssuesViewProps {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Autocomplete,
+  Checkbox,
+  Chip,
+  ListItemText,
+  TextField,
+} from "@wso2/oxygen-ui";
+import { useMemo, type JSX } from "react";
+import type * as React from "react";
+import { useProductNameOptions } from "@features/csm-cases/api/useProductNameOptions";
+
+interface ProductNameMultiSelectProps {
+  id?: string;
+  label?: string;
+  /** Selected product family names (the filter values themselves). */
+  values: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Product filter for the cases list. Products are a bounded catalogue, so the
+ * distinct family names are fetched once ({@link useProductNameOptions}) and
+ * filtered locally as the user types. The selected values ARE the names, which
+ * flow straight into `filters.productNames` (ServiceNow matches `product.name`,
+ * so every version of a product is included). Already-selected names are kept
+ * in the option pool so their chips render even before the fetch resolves.
+ */
+export default function ProductNameMultiSelect({
+  id = "cases-filter-product",
+  label = "Product",
+  values,
+  onChange,
+}: ProductNameMultiSelectProps): JSX.Element {
+  const { data, isFetching, isError } = useProductNameOptions();
+
+  // Union of the fetched names and any current selection, so selected chips
+  // stay valid even if a name isn't in the (cached) fetch yet.
+  const options: string[] = useMemo(() => {
+    const merged = new Set<string>(data ?? []);
+    values.forEach((v) => merged.add(v));
+    return [...merged].sort((a, b) => a.localeCompare(b));
+  }, [data, values]);
+
+  return (
+    <Autocomplete<string, true>
+      multiple
+      size="small"
+      id={id}
+      options={options}
+      value={values}
+      loading={isFetching && !data}
+      disableCloseOnSelect
+      getOptionLabel={(opt) => opt}
+      isOptionEqualToValue={(opt, val) => opt === val}
+      onChange={(_event, next) => onChange(next)}
+      noOptionsText={
+        isError
+          ? "Couldn't load products. Try again."
+          : isFetching
+            ? "Loading products…"
+            : "No products found"
+      }
+      renderTags={(value, getTagProps) =>
+        value.map((option, index) => {
+          const { key, ...tagProps } = getTagProps({ index });
+          return <Chip key={key} size="small" label={option} {...tagProps} />;
+        })
+      }
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText
+              primary={option}
+              slotProps={{ primary: { style: { fontSize: 13 } } }}
+            />
+          </li>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={values.length ? undefined : "Type a product…"}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -41,6 +41,7 @@ import {
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
+import { isCloudSupportSubscription } from "@features/csm-projects/utils/subscriptionType";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
@@ -100,21 +101,42 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const [attachments, setAttachments] = useState<EncodedAttachment[]>([]);
 
   const deployments = useSearchDeployments(projectId || undefined);
-  const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
+
+  // Details for the selected project (locked or picked). Gives the display name
+  // for the locked read-only field, and the subscription type that drives the
+  // cloud-project deployment behaviour below.
+  const selectedProject = useGetProject(projectId || undefined);
+  const lockedProjectLabel = selectedProject.data?.name
+    ? selectedProject.data.name
+    : selectedProject.isLoading
+      ? "Loading project…"
+      : lockedProjectId;
+
+  // Cloud-support projects file against the single primary-production
+  // deployment, so the form hides the deployment picker and derives it
+  // automatically (mirrors the customer portal). Other subscriptions keep the
+  // normal deployment → product cascade.
+  const isCloudProject = isCloudSupportSubscription(
+    selectedProject.data?.subscriptionType,
+  );
+  const primaryProductionDeployments = useMemo(
+    () => (deployments.data ?? []).filter((d) => d.type === "primary_production"),
+    [deployments.data],
+  );
+  // For a cloud project the deployment is derived (the lone primary-production
+  // one), not user-picked; everything downstream keys off this effective id.
+  const effectiveDeploymentId = isCloudProject
+    ? (primaryProductionDeployments[0]?.id ?? "")
+    : deploymentId;
+
+  const deployedProducts = useDeployedProductOptions(
+    effectiveDeploymentId || undefined,
+  );
   const postCase = usePostCsmCase();
   const postAttachment = usePostCsmCaseAttachment();
   const uploadedBy = useEngineerDisplayName();
   // Spans the whole submit (create + post-create attachment uploads).
   const [submitting, setSubmitting] = useState(false);
-
-  // Resolve the locked project's display name so the read-only field shows the
-  // name (not the raw id). Only fetched when the form is project-scoped.
-  const lockedProject = useGetProject(isProjectLocked ? lockedProjectId : undefined);
-  const lockedProjectLabel = lockedProject.data?.name
-    ? lockedProject.data.name
-    : lockedProject.isLoading
-      ? "Loading project…"
-      : lockedProjectId;
 
   // When a selector query fails the form becomes non-completable, so surface it
   // with an explicit retry rather than leaving an empty dropdown. (Projects are
@@ -146,7 +168,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const canSubmit = useMemo(
     () =>
       !!projectId &&
-      !!deploymentId &&
+      !!effectiveDeploymentId &&
       !!deployedProductId &&
       !!severity &&
       !!issueType &&
@@ -156,7 +178,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       !submitting,
     [
       projectId,
-      deploymentId,
+      effectiveDeploymentId,
       deployedProductId,
       severity,
       issueType,
@@ -185,7 +207,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
       const created = await postCase.mutateAsync({
         type: "case",
         projectId,
-        deploymentId,
+        deploymentId: effectiveDeploymentId,
         deployedProductId,
         subject: subject.trim(),
         description,
@@ -274,29 +296,33 @@ export default function CsmCaseCreatePage(): JSX.Element {
             )}
           </Grid>
 
-          <Grid size={{ xs: 12, md: 4 }}>
-            <FormControl fullWidth size="small" required>
-              <InputLabel id="case-deployment-label">Deployment</InputLabel>
-              <Select
-                labelId="case-deployment-label"
-                label="Deployment"
-                value={deploymentId}
-                onChange={(e) => onDeploymentChange(String(e.target.value))}
-                disabled={!projectId || deployments.isLoading}
-              >
-                {(deployments.data ?? []).map((d) => (
-                  <MenuItem key={d.id} value={d.id}>
-                    {d.name ?? d.id}
-                  </MenuItem>
-                ))}
-              </Select>
-              {!projectId ? (
-                <FormHelperText>Select a project first</FormHelperText>
-              ) : deployments.isLoading ? (
-                <FormHelperText>Loading deployments…</FormHelperText>
-              ) : null}
-            </FormControl>
-          </Grid>
+          {/* Cloud-support projects file against the single primary-production
+              deployment, auto-selected above — so the picker is hidden. */}
+          {!isCloudProject && (
+            <Grid size={{ xs: 12, md: 4 }}>
+              <FormControl fullWidth size="small" required>
+                <InputLabel id="case-deployment-label">Deployment</InputLabel>
+                <Select
+                  labelId="case-deployment-label"
+                  label="Deployment"
+                  value={deploymentId}
+                  onChange={(e) => onDeploymentChange(String(e.target.value))}
+                  disabled={!projectId || deployments.isLoading}
+                >
+                  {(deployments.data ?? []).map((d) => (
+                    <MenuItem key={d.id} value={d.id}>
+                      {d.name ?? d.id}
+                    </MenuItem>
+                  ))}
+                </Select>
+                {!projectId ? (
+                  <FormHelperText>Select a project first</FormHelperText>
+                ) : deployments.isLoading ? (
+                  <FormHelperText>Loading deployments…</FormHelperText>
+                ) : null}
+              </FormControl>
+            </Grid>
+          )}
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
@@ -306,7 +332,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
                 label="Deployed product"
                 value={deployedProductId}
                 onChange={(e) => setDeployedProductId(String(e.target.value))}
-                disabled={!deploymentId || deployedProducts.isLoading}
+                disabled={!effectiveDeploymentId || deployedProducts.isLoading}
               >
                 {(deployedProducts.data ?? []).map((dp) => (
                   <MenuItem key={dp.id} value={dp.id}>
@@ -314,8 +340,15 @@ export default function CsmCaseCreatePage(): JSX.Element {
                   </MenuItem>
                 ))}
               </Select>
-              {!deploymentId ? (
-                <FormHelperText>Select a deployment first</FormHelperText>
+              {!effectiveDeploymentId ? (
+                <FormHelperText>
+                  {isCloudProject
+                    ? !deployments.isLoading &&
+                      primaryProductionDeployments.length === 0
+                      ? "No primary production deployment for this project."
+                      : "Loading products…"
+                    : "Select a deployment first"}
+                </FormHelperText>
               ) : deployedProducts.isLoading ? (
                 <FormHelperText>Loading products…</FormHelperText>
               ) : null}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -32,7 +32,7 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "q=timeout&severities=S0,S2&states=open,work_in_progress,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim",
+      "q=timeout&severities=S0,S2&states=open,work_in_progress,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim&products=API%20Manager,Asgardeo",
     );
     expect(readCasesFiltersFromUrl(params)).toEqual({
       search: "timeout",
@@ -43,6 +43,7 @@ describe("readCasesFiltersFromUrl", () => {
       assignees: ["alice@example.com", "@me"],
       workStates: ["ongoing", "paused"],
       projects: ["apim"],
+      productNames: ["API Manager", "Asgardeo"],
     });
   });
 
@@ -91,6 +92,7 @@ describe("writeCasesFiltersToUrl", () => {
       workStates: ["paused"],
       projects: ["streaming"],
       engagementTypes: [],
+      productNames: ["Identity Server", "Asgardeo"],
     };
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
     expect(round).toEqual(filters);

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -35,6 +35,7 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   workStates: [],
   projects: [],
   engagementTypes: [],
+  productNames: [],
 };
 
 const VALID_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
@@ -97,6 +98,7 @@ export function readCasesFiltersFromUrl(
     workStates,
     projects: parseFreeFormCsv(params.get("projects")),
     engagementTypes: parseCsv(params.get("engagementTypes"), VALID_ENGAGEMENT_TYPES),
+    productNames: parseFreeFormCsv(params.get("products")),
   };
 }
 
@@ -114,6 +116,7 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   if (f.workStates.length) out.set("workStates", f.workStates.join(","));
   if (f.projects.length) out.set("projects", f.projects.join(","));
   if (f.engagementTypes.length) out.set("engagementTypes", f.engagementTypes.join(","));
+  if (f.productNames.length) out.set("products", f.productNames.join(","));
   return out;
 }
 
@@ -133,6 +136,7 @@ export function countActiveFilters(f: CasesFilters): number {
   if (f.workStates.length) n += 1;
   if (f.projects.length) n += 1;
   if (f.engagementTypes.length) n += 1;
+  if (f.productNames.length) n += 1;
   return n;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/utils/subscriptionType.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/utils/subscriptionType.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { SubscriptionType } from "@features/csm-projects/types/csmProjects";
+
+/**
+ * Cloud-support subscription types. For these, a case is filed against the
+ * project's single primary-production deployment, so the case-creation form
+ * hides the deployment picker and auto-selects it (mirrors the customer
+ * portal's `shouldRestrictToPrimaryProductionDeployments`). Managed-cloud and
+ * other subscriptions keep the normal deployment → product cascade.
+ */
+export const CLOUD_SUPPORT_SUBSCRIPTION_TYPES: readonly SubscriptionType[] = [
+  "cloud_support",
+  "cloud_evaluation_support",
+];
+
+/** True when the subscription type files cases directly against the primary
+ *  production deployment (no deployment selection step). */
+export function isCloudSupportSubscription(
+  type: SubscriptionType | null | undefined,
+): boolean {
+  return !!type && CLOUD_SUPPORT_SUBSCRIPTION_TYPES.includes(type);
+}


### PR DESCRIPTION
## Purpose
CS engineers had no way to filter the case list by product. Separately, the case-creation form always required selecting a deployment before a product, even for cloud projects that have a single primary-production deployment, an unnecessary step the customer portal already avoids.

## Goals
1. Add a Product filter to the cases list.
2. For cloud-support projects, skip deployment selection in the case-creation form and go straight to product (match the customer portal).

## Approach
Product filter:
- New Product multi-select in the cases filter bar; options are the distinct product family names from `/products/search` (deduped, type-to-search).
- Selected names are sent as `filters.productNames` on `/cases/search`, which matches all versions of each product.
- Serialised to the `products` URL param via the shared filter URL codec (unit tests added).

Cloud-project case creation:
- For `cloud_support` / `cloud_evaluation_support` subscriptions, hide the deployment picker and file against the project's single primary-production deployment; product loads immediately.
- Non-cloud projects keep the normal deployment then product cascade.
- The cloud deployment is derived (not synced via an effect), so product loading, validation, and the submit payload key off the effective deployment id.

## User stories
- As a CS engineer, I can filter cases by product.
- As a CS engineer creating a case for a cloud project, I go straight to product selection without picking a deployment.

## Release note
Added a product filter to the cases list, and streamlined case creation for cloud projects to skip deployment selection.

## Documentation
N/A. Internal CS-engineer portal; no customer-facing documentation impact.

## Training
N/A.

## Certification
N/A. No impact on certification exams.

## Marketing
N/A.

## Automation tests
 - Unit tests
   > Filter URL codec round-trip tests added; full suite (135 tests) passes. `tsc` and `eslint` clean.
 - Integration tests
   > Full-stack verification on the local ServiceNow-backed stack; the product filter is exercised only against the ServiceNow data source.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A. TypeScript/React, not a Java project; eslint + tsc run clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
Product filter depends on the entity-service filter (#1043) and a corresponding ServiceNow-proxy (Ballerina entity-service) change tracked separately. Base is `v2`; until #1043 merges this PR's diff transiently includes that commit.

## Migrations (if applicable)
N/A.

## Test environment
Node + pnpm; `tsc`, `eslint`, `vitest` (135 pass), and `pnpm build` on macOS.
