### PR TITLE
[CSM Portal] cases list: product filter fixes + filter UX refinements

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -478,6 +478,9 @@ export interface BeCaseSearchView {
   /** Embedded as `{ id, name }` (name already includes the version), not the
    * `displayName`-shaped ref the GET view uses. */
   deployedProduct?: BeEntityRef | null;
+  /** The product itself (distinct from `deployedProduct`); used to populate the
+   * list Product column when no deployed product is set (e.g. cloud cases). */
+  product?: BeEntityRef | null;
 }
 
 export interface BeCaseSearchResponse extends BeSearchResponseBase {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -143,6 +143,7 @@ export function useGetCsmCases(
       [...filters.assignees].sort(),
       [...filters.projects].sort(),
       [...filters.engagementTypes].sort(),
+      [...filters.productNames].sort(),
       currentUserEmail ?? "",
       currentUserId ?? "",
       page,
@@ -287,7 +288,7 @@ export function useGetCsmCases(
           projectName: c.project?.name ?? "-",
           // Search embeds deployedProduct as { id, name } (name includes the
           // version); the GET view uses a displayName-shaped ref instead.
-          product: c.deployedProduct?.name ?? "-",
+          product: c.deployedProduct?.name ?? c.product?.name ?? "-",
           severity: severityFromPriority(c.severity),
           state: uiStateFromBe(c.state),
           caseType: c.type,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -15,31 +15,28 @@
 // under the License.
 
 import {
+  Autocomplete,
   Box,
   Button,
   Checkbox,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Divider,
-  FormControl,
   Grid,
   IconButton,
   InputAdornment,
-  InputLabel,
   ListItemIcon,
   ListItemText,
   ListSubheader,
   Menu,
   MenuItem,
   Paper,
-  Select,
   TextField,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import {
   Bookmark,
   BookmarkPlus,
@@ -52,6 +49,7 @@ import {
   X,
 } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
 import type {
   CaseState,
   Severity,
@@ -183,62 +181,51 @@ function MultiSelectField<T extends string>({
   onChange,
   disabled,
 }: MultiSelectFieldProps<T>): JSX.Element {
-  const handleChange = (event: SelectChangeEvent<string[]>): void => {
-    const val = event.target.value;
-    onChange((Array.isArray(val) ? val : [val]) as T[]);
-  };
+  // Autocomplete-based multi-select: selected values render as chips and the
+  // options are type-to-search + checkboxes — matching the product filter.
+  const selected = options.filter((o) => values.includes(o.value));
   return (
-    <FormControl fullWidth size="small" disabled={disabled}>
-      <InputLabel id={`${id}-label`}>{label}</InputLabel>
-      <Select
-        multiple
-        labelId={`${id}-label`}
-        id={id}
-        value={values as unknown as string[]}
-        label={label}
-        onChange={handleChange}
-        renderValue={(selected) => {
-          if (!Array.isArray(selected) || selected.length === 0) return "";
-          const labels = selected.map(
-            (v) => options.find((o) => o.value === v)?.label ?? v,
-          );
-          const text = labels.join(", ");
-          if (labels.length === 1) return text;
+    <Autocomplete<{ value: T; label: string }, true>
+      multiple
+      size="small"
+      id={id}
+      disabled={disabled}
+      options={options}
+      value={selected}
+      disableCloseOnSelect
+      getOptionLabel={(o) => o.label}
+      isOptionEqualToValue={(o, v) => o.value === v.value}
+      onChange={(_event, next) => onChange(next.map((o) => o.value))}
+      renderTags={(value, getTagProps) =>
+        value.map((option, index) => {
+          const { key, ...tagProps } = getTagProps({ index });
           return (
-            <Tooltip title={text} placement="top">
-              <Box
-                component="span"
-                sx={{
-                  display: "block",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {text}
-              </Box>
-            </Tooltip>
+            <Chip key={key} size="small" label={option.label} {...tagProps} />
           );
-        }}
-      >
-        {options.length === 0 ? (
-          <MenuItem disabled value="">
-            <em>No options</em>
-          </MenuItem>
-        ) : (
-          options.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
-              <Checkbox
-                size="small"
-                checked={values.includes(opt.value)}
-                sx={{ mr: 1, p: 0.25 }}
-              />
-              <ListItemText primary={opt.label} />
-            </MenuItem>
-          ))
-        )}
-      </Select>
-    </FormControl>
+        })
+      }
+      renderOption={(props, option, { selected: isSelected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={isSelected} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText
+              primary={option.label}
+              slotProps={{ primary: { style: { fontSize: 13 } } }}
+            />
+          </li>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={values.length ? undefined : "Select…"}
+        />
+      )}
+    />
   );
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -37,15 +37,15 @@ const HEADER_CELLS: string[] = [
   "Product",
   "Severity",
   "State",
-  "Work state",
   "Updated",
 ];
 
 // Subject gets the lion's share of the row; the ids sit in their own narrow
 // column so a long subject no longer has to share one cell with them.
-// State and Work state are separate columns so neither chip crowds the other.
+// The work-state chip (only present for WIP cases) stacks under the State chip
+// in the State column, so it doesn't need a column of its own.
 const GRID =
-  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto minmax(110px, 1fr) auto auto";
+  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto minmax(110px, 1fr) auto";
 
 export default function CasesList({
   cases,
@@ -201,12 +201,18 @@ export default function CasesList({
               <Box sx={{ justifySelf: "start" }}>
                 <SeverityChip severity={c.severity} clickable />
               </Box>
-              {/* State chip — lifecycle state only. */}
-              <Box sx={{ justifySelf: "start" }}>
+              {/* State chip, with the work-state chip stacked beneath it (the
+                  latter only for WIP cases). */}
+              <Box
+                sx={{
+                  justifySelf: "start",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                  gap: 0.5,
+                }}
+              >
                 <StateChip state={c.state} variant="outlined" clickable />
-              </Box>
-              {/* Work state chip — separate column; only rendered for WIP cases. */}
-              <Box sx={{ justifySelf: "start" }}>
                 {c.state === "work_in_progress" && c.workState && (
                   <Chip
                     size="small"


### PR DESCRIPTION
## Purpose
Two follow-up fixes to the case product filter (shipped in #1044):
1. Changing only the Product filter in the cases list did not trigger a new search.
2. The Product column was blank for cases returned by the filter that have no deployed product (e.g. cloud products like Asgardeo).
3. The cases list had a separate Work state column that is only ever populated for work-in-progress cases, wasting a column.
4. The filter multi-selects were inconsistent: the Product filter used a chip-style Autocomplete while the others (severity, state, work state, engagement type, case type) used a Select with comma-joined text.

## Goals
Make an in-app product-only filter change refetch like every other filter, and show a product name in the list column for those rows.

## Approach
- `useGetCsmCases.ts`: add `productNames` to the React Query `queryKey`. It was already in the `/cases/search` request payload but missing from the key, so React Query served the cached page and never refetched when only the product changed. (A full-page navigation masked this; an in-app change did not.)
- `useGetCsmCases.ts`: map the list Product column as `deployedProduct?.name ?? product?.name ?? "-"`, so a case with no deployed product (cloud cases) falls back to its product name instead of "-". Existing rows with a deployed product are unchanged.
- `api/backend/types.ts`: add `product?: BeEntityRef | null` to `BeCaseSearchView` (the entity/ServiceNow search view already returns it).
- `CasesList.tsx`: drop the separate Work state column and stack the work-state chip under the state chip in the State column (it only appears for WIP cases).
- `CasesFilterBar.tsx`: rewrite the shared `MultiSelectField` from a Select + comma text to an Autocomplete-with-chips control (type-to-search + checkboxes), so all filter fields render selected values as chips consistently with the product filter.

## User stories
As a CS engineer, when I change the Product filter the list updates immediately, and product-filtered cases show their product in the list.

## Release note
Fixed the cases Product filter not refreshing on change and the empty Product column for cloud-product cases; merged the work-state chip into the State column; made all case filter fields use a consistent chip-style multi-select.

## Documentation
N/A. Internal CS-engineer portal; no customer-facing documentation impact.

## Training
N/A.

## Certification
N/A. No impact on certification exams.

## Marketing
N/A.

## Automation tests
 - Unit tests
   > Existing cases-filter URL codec tests pass; `tsc` and `eslint` clean. (Pre-existing unrelated `CaseActionBar.test.tsx` failures exist on the base branch and are not touched by this change.)
 - Integration tests
   > Verified live against the local ServiceNow-backed stack: an in-app product-only change refetches (8,882 -> 293 for Asgardeo without a full reload), and the Product column shows "Asgardeo" for the filtered rows.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A. TypeScript/React, not a Java project; eslint + tsc run clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
Follow-up to #1044 (product filter) and #1043 (entity).

## Migrations (if applicable)
N/A.

## Test environment
Node + pnpm; tsc, eslint, vitest, and the local ServiceNow-backed stack (real Asgardeo) on macOS.
