### PR TITLE
[Customer Entity] Add task SLA endpoints 

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1949,3 +1949,52 @@ type SearchTaskSlasResponse struct {
 	Limit    int           `json:"limit"`
 	Offset   int           `json:"offset"`
 }
+
+// TaskSlaDefinitionDetail is the extended SLA definition returned by GET /task-slas/{id}.
+type TaskSlaDefinitionDetail struct {
+	ID               *string `json:"id"`
+	Name             *string `json:"name"`
+	Type             *string `json:"type"`
+	Target           *string `json:"target"`
+	Flow             *string `json:"flow"`
+	Workflow         *string `json:"workflow"`
+	EnableLogging    *bool   `json:"enableLogging"`
+	DurationType     *string `json:"durationType"`
+	Duration         *string `json:"duration"`
+	ScheduleSource   *string `json:"scheduleSource"`
+	Schedule         *string `json:"schedule"`
+	TimezoneSource   *string `json:"timezoneSource"`
+	Timezone         *string `json:"timezone"`
+	StartCondition   *string `json:"startCondition"`
+	RetroactiveStart *bool   `json:"retroactiveStart"`
+	RetroactivePause *bool   `json:"retroactivePause"`
+	WhenToCancel     *string `json:"whenToCancel"`
+	CancelCondition  *string `json:"cancelCondition"`
+	PauseCondition   *string `json:"pauseCondition"`
+	WhenToResume     *string `json:"whenToResume"`
+	StopCondition    *string `json:"stopCondition"`
+	ResetCondition   *string `json:"resetCondition"`
+	ResetAction      *string `json:"resetAction"`
+}
+
+// TaskSlaScheduleRef is the schedule reference returned by GET /task-slas/{id}.
+type TaskSlaScheduleRef struct {
+	ID       *string `json:"id"`
+	Name     *string `json:"name"`
+	Timezone *string `json:"timezone"`
+}
+
+// TaskSlaDetail is the full task SLA record returned by GET /task-slas/{id}.
+type TaskSlaDetail struct {
+	ID                        string                   `json:"id"`
+	Task                      *TaskSlaTaskRef          `json:"task"`
+	SlaDefinition             *TaskSlaDefinitionDetail `json:"slaDefinition"`
+	Stage                     *TaskSlaStage            `json:"stage"`
+	BusinessTimeLeft          *string                  `json:"businessTimeLeft"`
+	BusinessElapsedTime       *string                  `json:"businessElapsedTime"`
+	BusinessElapsedPercentage *string                  `json:"businessElapsedPercentage"`
+	StartTime                 *string                  `json:"startTime"`
+	EndTime                   *string                  `json:"endTime"`
+	Active                    *bool                    `json:"active"`
+	Schedule                  *TaskSlaScheduleRef      `json:"schedule"`
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1896,3 +1896,56 @@ type UpdateCallRequestResponse struct {
 		UpdatedBy string `json:"updatedBy"`
 	} `json:"callRequest"`
 }
+
+// SearchTaskSlasFilters holds optional filter criteria for POST /task-slas/search.
+type SearchTaskSlasFilters struct {
+	TaskIDs []string `json:"taskIds,omitempty"`
+}
+
+// SearchTaskSlasRequest is the request body for POST /task-slas/search.
+type SearchTaskSlasRequest struct {
+	Filters    *SearchTaskSlasFilters `json:"filters,omitempty"`
+	Pagination Pagination             `json:"pagination"`
+}
+
+// TaskSlaDefinition is the SLA definition referenced by a task SLA record.
+type TaskSlaDefinition struct {
+	ID     *string `json:"id"`
+	Name   *string `json:"name"`
+	Type   *string `json:"type"`
+	Target *string `json:"target"`
+}
+
+// TaskSlaStage is the current stage of the SLA.
+type TaskSlaStage struct {
+	ID    *string `json:"id"`
+	Label *string `json:"label"`
+}
+
+// TaskSlaTaskRef is a reference to the task associated with a task SLA record.
+type TaskSlaTaskRef struct {
+	ID   *string `json:"id"`
+	Name *string `json:"name"`
+	Type *string `json:"type"`
+}
+
+// TaskSlaView is a single task SLA record in search results.
+type TaskSlaView struct {
+	ID                        string             `json:"id"`
+	SlaDefinition             *TaskSlaDefinition `json:"slaDefinition"`
+	Stage                     *TaskSlaStage      `json:"stage"`
+	Task                      *TaskSlaTaskRef    `json:"task"`
+	BusinessTimeLeft          *string            `json:"businessTimeLeft"`
+	BusinessElapsedTime       *string            `json:"businessElapsedTime"`
+	BusinessElapsedPercentage *string            `json:"businessElapsedPercentage"`
+	StartTime                 *string            `json:"startTime"`
+	EndTime                   *string            `json:"endTime"`
+}
+
+// SearchTaskSlasResponse is the response for POST /task-slas/search.
+type SearchTaskSlasResponse struct {
+	TaskSlas []TaskSlaView `json:"taskSlas"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1938,7 +1938,7 @@ type TaskSlaView struct {
 
 // SearchTaskSlasResponse is the response for POST /task-slas/search.
 type SearchTaskSlasResponse struct {
-	TaskSlas []TaskSlaView `json:"taskSlas"`
+	TaskSlas []TaskSlaView `json:"slas"`
 	Total    int           `json:"total"`
 	Limit    int           `json:"limit"`
 	Offset   int           `json:"offset"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1952,7 +1952,7 @@ type TaskSlaDefinitionDetail struct {
 	Target           *string `json:"target"`
 	Flow             *string `json:"flow"`
 	Workflow         *string `json:"workflow"`
-	EnableLogging    *bool   `json:"enableLogging"`
+	IsEnableLogging  *bool   `json:"isEnableLogging"`
 	DurationType     *string `json:"durationType"`
 	Duration         *string `json:"duration"`
 	ScheduleSource   *string `json:"scheduleSource"`
@@ -1960,8 +1960,8 @@ type TaskSlaDefinitionDetail struct {
 	TimezoneSource   *string `json:"timezoneSource"`
 	Timezone         *string `json:"timezone"`
 	StartCondition   *string `json:"startCondition"`
-	RetroactiveStart *bool   `json:"retroactiveStart"`
-	RetroactivePause *bool   `json:"retroactivePause"`
+	IsRetroactiveStart *bool   `json:"isRetroactiveStart"`
+	IsRetroactivePause *bool   `json:"isRetroactivePause"`
 	WhenToCancel     *string `json:"whenToCancel"`
 	CancelCondition  *string `json:"cancelCondition"`
 	PauseCondition   *string `json:"pauseCondition"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1916,12 +1916,6 @@ type TaskSlaDefinition struct {
 	Target *string `json:"target"`
 }
 
-// TaskSlaStage is the current stage of the SLA.
-type TaskSlaStage struct {
-	ID    *string `json:"id"`
-	Label *string `json:"label"`
-}
-
 // TaskSlaTaskRef is a reference to the task associated with a task SLA record.
 type TaskSlaTaskRef struct {
 	ID   *string `json:"id"`
@@ -1933,7 +1927,7 @@ type TaskSlaTaskRef struct {
 type TaskSlaView struct {
 	ID                        string             `json:"id"`
 	SlaDefinition             *TaskSlaDefinition `json:"slaDefinition"`
-	Stage                     *TaskSlaStage      `json:"stage"`
+	Stage                     *string      `json:"stage"`
 	Task                      *TaskSlaTaskRef    `json:"task"`
 	BusinessTimeLeft          *string            `json:"businessTimeLeft"`
 	BusinessElapsedTime       *string            `json:"businessElapsedTime"`
@@ -1989,7 +1983,7 @@ type TaskSlaDetail struct {
 	ID                        string                   `json:"id"`
 	Task                      *TaskSlaTaskRef          `json:"task"`
 	SlaDefinition             *TaskSlaDefinitionDetail `json:"slaDefinition"`
-	Stage                     *TaskSlaStage            `json:"stage"`
+	Stage                     *string            `json:"stage"`
 	BusinessTimeLeft          *string                  `json:"businessTimeLeft"`
 	BusinessElapsedTime       *string                  `json:"businessElapsedTime"`
 	BusinessElapsedPercentage *string                  `json:"businessElapsedPercentage"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1931,7 +1931,7 @@ type TaskSlaView struct {
 	Task                      *TaskSlaTaskRef    `json:"task"`
 	BusinessTimeLeft          *string            `json:"businessTimeLeft"`
 	BusinessElapsedTime       *string            `json:"businessElapsedTime"`
-	BusinessElapsedPercentage *string            `json:"businessElapsedPercentage"`
+	BusinessElapsedPercentage *float64 `json:"businessElapsedPercentage"`
 	StartTime                 *string            `json:"startTime"`
 	EndTime                   *string            `json:"endTime"`
 }
@@ -1986,7 +1986,7 @@ type TaskSlaDetail struct {
 	Stage                     *string            `json:"stage"`
 	BusinessTimeLeft          *string                  `json:"businessTimeLeft"`
 	BusinessElapsedTime       *string                  `json:"businessElapsedTime"`
-	BusinessElapsedPercentage *string                  `json:"businessElapsedPercentage"`
+	BusinessElapsedPercentage *float64                 `json:"businessElapsedPercentage"`
 	StartTime                 *string                  `json:"startTime"`
 	EndTime                   *string                  `json:"endTime"`
 	Active                    *bool                    `json:"active"`

--- a/entity-service/internal/handler/task_sla_handler.go
+++ b/entity-service/internal/handler/task_sla_handler.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// TaskSlaHandler handles HTTP requests for the task-slas resource.
+type TaskSlaHandler struct {
+	svc service.TaskSlaService
+}
+
+// NewTaskSlaHandler constructs a TaskSlaHandler with the given service.
+func NewTaskSlaHandler(svc service.TaskSlaService) *TaskSlaHandler {
+	return &TaskSlaHandler{svc: svc}
+}
+
+// SearchTaskSlas handles POST /task-slas/search.
+func (h *TaskSlaHandler) SearchTaskSlas(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchTaskSlasRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchTaskSlas(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/task_sla_handler.go
+++ b/entity-service/internal/handler/task_sla_handler.go
@@ -34,6 +34,18 @@ func NewTaskSlaHandler(svc service.TaskSlaService) *TaskSlaHandler {
 	return &TaskSlaHandler{svc: svc}
 }
 
+// GetTaskSla handles GET /task-slas/{id}.
+func (h *TaskSlaHandler) GetTaskSla(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	result, err := h.svc.GetTaskSla(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
 // SearchTaskSlas handles POST /task-slas/search.
 func (h *TaskSlaHandler) SearchTaskSlas(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchTaskSlasRequest

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -276,8 +276,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	}
 
 	if taskSlaHandler != nil {
-		mux.HandleFunc("GET /task-slas/{id}", taskSlaHandler.GetTaskSla)
-		mux.HandleFunc("POST /task-slas/search", taskSlaHandler.SearchTaskSlas)
+		mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
+		mux.HandleFunc("POST /slas/search", taskSlaHandler.SearchTaskSlas)
 	}
 
 	return middleware.CorrelationID(

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -167,6 +167,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		commentHandler = handler.NewCommentHandler(service.NewServiceNowCommentService(serviceNowIntegrationServiceClient))
 	}
 
+	var taskSlaHandler *handler.TaskSlaHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		taskSlaHandler = handler.NewTaskSlaHandler(service.NewServiceNowTaskSlaService(serviceNowIntegrationServiceClient))
+	}
+
 	var snUserHandler *handler.SNUserHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		snUserHandler = handler.NewSNUserHandler(service.NewServiceNowUserService(serviceNowIntegrationServiceClient))
@@ -268,6 +273,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 
 	if commentHandler != nil {
 		mux.HandleFunc("POST /comments/search", commentHandler.SearchComments)
+	}
+
+	if taskSlaHandler != nil {
+		mux.HandleFunc("POST /task-slas/search", taskSlaHandler.SearchTaskSlas)
 	}
 
 	return middleware.CorrelationID(

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -276,6 +276,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	}
 
 	if taskSlaHandler != nil {
+		mux.HandleFunc("GET /task-slas/{id}", taskSlaHandler.GetTaskSla)
 		mux.HandleFunc("POST /task-slas/search", taskSlaHandler.SearchTaskSlas)
 	}
 

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -282,6 +282,14 @@ type CommentService interface {
 	SearchComments(ctx context.Context, req domain.SearchCommentsRequest) (domain.SearchCommentsResponse, error)
 }
 
+// TaskSlaService defines the operations available on the task-slas entity.
+// All methods require the ServiceNow data source; there is no Postgres fallback.
+type TaskSlaService interface {
+	// SearchTaskSlas returns a paginated list of task SLA records filtered by optional case IDs.
+	// An UnauthorizedError is returned when x-user-id-token is absent.
+	SearchTaskSlas(ctx context.Context, req domain.SearchTaskSlasRequest) (domain.SearchTaskSlasResponse, error)
+}
+
 // ProductVulnerabilityService defines the operations available on product vulnerabilities.
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type ProductVulnerabilityService interface {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -285,9 +285,12 @@ type CommentService interface {
 // TaskSlaService defines the operations available on the task-slas entity.
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type TaskSlaService interface {
-	// SearchTaskSlas returns a paginated list of task SLA records filtered by optional case IDs.
+	// SearchTaskSlas returns a paginated list of task SLA records filtered by optional task IDs.
 	// An UnauthorizedError is returned when x-user-id-token is absent.
 	SearchTaskSlas(ctx context.Context, req domain.SearchTaskSlasRequest) (domain.SearchTaskSlasResponse, error)
+	// GetTaskSla returns the full detail of a single task SLA record by its UUID.
+	// A NotFoundError is returned if the record does not exist.
+	GetTaskSla(ctx context.Context, id string) (domain.TaskSlaDetail, error)
 }
 
 // ProductVulnerabilityService defines the operations available on product vulnerabilities.

--- a/entity-service/internal/service/sn_task_sla_service.go
+++ b/entity-service/internal/service/sn_task_sla_service.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+type snTaskSlaSearchPayload struct {
+	Filters    *snTaskSlaFilters   `json:"filters,omitempty"`
+	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snTaskSlaFilters struct {
+	TaskIDs []string `json:"taskIds,omitempty"`
+}
+
+type snTaskSlasResponse struct {
+	TaskSlas     []snTaskSla `json:"taskSlas"`
+	TotalRecords int         `json:"totalRecords"`
+	Limit        int         `json:"limit"`
+	Offset       int         `json:"offset"`
+}
+
+type snTaskSla struct {
+	ID                        string               `json:"id"`
+	SlaDefinition             *snTaskSlaDefinition `json:"slaDefinition"`
+	Stage                     *snTaskSlaStage      `json:"stage"`
+	Task                      *snTaskSlaTaskRef    `json:"task"`
+	BusinessTimeLeft          *string              `json:"businessTimeLeft"`
+	BusinessElapsedTime       *string              `json:"businessElapsedTime"`
+	BusinessElapsedPercentage *string              `json:"businessElapsedPercentage"`
+	StartTime                 *string              `json:"startTime"`
+	EndTime                   *string              `json:"endTime"`
+}
+
+type snTaskSlaTaskRef struct {
+	ID   *string `json:"id"`
+	Name *string `json:"name"`
+	Type *string `json:"type"`
+}
+
+type snTaskSlaDefinition struct {
+	ID     *string `json:"id"`
+	Name   *string `json:"name"`
+	Type   *string `json:"type"`
+	Target *string `json:"target"`
+}
+
+type snTaskSlaStage struct {
+	ID    *string `json:"id"`
+	Label *string `json:"label"`
+}
+
+func snTaskSlaToView(t snTaskSla) domain.TaskSlaView {
+	view := domain.TaskSlaView{
+		ID:                        sysidToUUID(t.ID),
+		BusinessTimeLeft:          t.BusinessTimeLeft,
+		BusinessElapsedTime:       t.BusinessElapsedTime,
+		BusinessElapsedPercentage: t.BusinessElapsedPercentage,
+		StartTime:                 t.StartTime,
+		EndTime:                   t.EndTime,
+	}
+
+	if t.SlaDefinition != nil {
+		def := &domain.TaskSlaDefinition{
+			Name:   t.SlaDefinition.Name,
+			Type:   t.SlaDefinition.Type,
+			Target: t.SlaDefinition.Target,
+		}
+		if t.SlaDefinition.ID != nil {
+			id := sysidToUUID(*t.SlaDefinition.ID)
+			def.ID = &id
+		}
+		view.SlaDefinition = def
+	}
+
+	if t.Stage != nil {
+		view.Stage = &domain.TaskSlaStage{
+			ID:    t.Stage.ID,
+			Label: t.Stage.Label,
+		}
+	}
+
+	if t.Task != nil {
+		ref := &domain.TaskSlaTaskRef{
+			Name: t.Task.Name,
+			Type: t.Task.Type,
+		}
+		if t.Task.ID != nil {
+			id := sysidToUUID(*t.Task.ID)
+			ref.ID = &id
+		}
+		view.Task = ref
+	}
+
+	return view
+}
+
+type snTaskSlaService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowTaskSlaService constructs a TaskSlaService backed by the Choreo API.
+func NewServiceNowTaskSlaService(client *integrationservice.Client) TaskSlaService {
+	return &snTaskSlaService{client: client}
+}
+
+func (s *snTaskSlaService) SearchTaskSlas(ctx context.Context, req domain.SearchTaskSlasRequest) (domain.SearchTaskSlasResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchTaskSlasResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchTaskSlasResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snTaskSlaSearchPayload{
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	if req.Filters != nil {
+		if err := validateUUIDs("taskIds", req.Filters.TaskIDs); err != nil {
+			return domain.SearchTaskSlasResponse{}, err
+		}
+		payload.Filters = &snTaskSlaFilters{
+			TaskIDs: uuidsToSysids(req.Filters.TaskIDs),
+		}
+	}
+
+	raw, err := s.client.Post(ctx, "/task-slas/search", token, payload)
+	if err != nil {
+		return domain.SearchTaskSlasResponse{}, err
+	}
+
+	var snResp snTaskSlasResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchTaskSlasResponse{}, fmt.Errorf("sn task slas: parse response: %w", err)
+	}
+
+	views := make([]domain.TaskSlaView, 0, len(snResp.TaskSlas))
+	for _, t := range snResp.TaskSlas {
+		views = append(views, snTaskSlaToView(t))
+	}
+
+	return domain.SearchTaskSlasResponse{
+		TaskSlas: views,
+		Total:    snResp.TotalRecords,
+		Limit:    snResp.Limit,
+		Offset:   snResp.Offset,
+	}, nil
+}

--- a/entity-service/internal/service/sn_task_sla_service.go
+++ b/entity-service/internal/service/sn_task_sla_service.go
@@ -73,6 +73,52 @@ type snTaskSlaStage struct {
 	Label *string `json:"label"`
 }
 
+type snTaskSlaDetail struct {
+	ID                        string                    `json:"id"`
+	Task                      *snTaskSlaTaskRef         `json:"task"`
+	SlaDefinition             *snTaskSlaDefinitionDetail `json:"slaDefinition"`
+	Stage                     *snTaskSlaStage           `json:"stage"`
+	BusinessTimeLeft          *string                   `json:"businessTimeLeft"`
+	BusinessElapsedTime       *string                   `json:"businessElapsedTime"`
+	BusinessElapsedPercentage *string                   `json:"businessElapsedPercentage"`
+	StartTime                 *string                   `json:"startTime"`
+	EndTime                   *string                   `json:"endTime"`
+	Active                    *bool                     `json:"active"`
+	Schedule                  *snTaskSlaScheduleRef     `json:"schedule"`
+}
+
+type snTaskSlaDefinitionDetail struct {
+	ID               *string `json:"id"`
+	Name             *string `json:"name"`
+	Type             *string `json:"type"`
+	Target           *string `json:"target"`
+	Flow             *string `json:"flow"`
+	Workflow         *string `json:"workflow"`
+	EnableLogging    *bool   `json:"enableLogging"`
+	DurationType     *string `json:"durationType"`
+	Duration         *string `json:"duration"`
+	ScheduleSource   *string `json:"scheduleSource"`
+	Schedule         *string `json:"schedule"`
+	TimezoneSource   *string `json:"timezoneSource"`
+	Timezone         *string `json:"timezone"`
+	StartCondition   *string `json:"startCondition"`
+	RetroactiveStart *bool   `json:"retroactiveStart"`
+	RetroactivePause *bool   `json:"retroactivePause"`
+	WhenToCancel     *string `json:"whenToCancel"`
+	CancelCondition  *string `json:"cancelCondition"`
+	PauseCondition   *string `json:"pauseCondition"`
+	WhenToResume     *string `json:"whenToResume"`
+	StopCondition    *string `json:"stopCondition"`
+	ResetCondition   *string `json:"resetCondition"`
+	ResetAction      *string `json:"resetAction"`
+}
+
+type snTaskSlaScheduleRef struct {
+	ID       *string `json:"id"`
+	Name     *string `json:"name"`
+	Timezone *string `json:"timezone"`
+}
+
 func snTaskSlaToView(t snTaskSla) domain.TaskSlaView {
 	view := domain.TaskSlaView{
 		ID:                        sysidToUUID(t.ID),
@@ -122,19 +168,119 @@ type snTaskSlaService struct {
 	client *integrationservice.Client
 }
 
-// NewServiceNowTaskSlaService constructs a TaskSlaService backed by the Choreo API.
+// NewServiceNowTaskSlaService constructs a TaskSlaService backed by ServiceNow via integrationservice.Client.
 func NewServiceNowTaskSlaService(client *integrationservice.Client) TaskSlaService {
 	return &snTaskSlaService{client: client}
 }
 
-func (s *snTaskSlaService) SearchTaskSlas(ctx context.Context, req domain.SearchTaskSlasRequest) (domain.SearchTaskSlasResponse, error) {
-	if err := normalizePagination(&req.Pagination); err != nil {
-		return domain.SearchTaskSlasResponse{}, err
+func snTaskSlaToDetailView(t snTaskSlaDetail) domain.TaskSlaDetail {
+	view := domain.TaskSlaDetail{
+		ID:                        sysidToUUID(t.ID),
+		BusinessTimeLeft:          t.BusinessTimeLeft,
+		BusinessElapsedTime:       t.BusinessElapsedTime,
+		BusinessElapsedPercentage: t.BusinessElapsedPercentage,
+		StartTime:                 t.StartTime,
+		EndTime:                   t.EndTime,
+		Active:                    t.Active,
 	}
 
+	if t.Task != nil {
+		ref := &domain.TaskSlaTaskRef{
+			Name: t.Task.Name,
+			Type: t.Task.Type,
+		}
+		if t.Task.ID != nil {
+			id := sysidToUUID(*t.Task.ID)
+			ref.ID = &id
+		}
+		view.Task = ref
+	}
+
+	if t.SlaDefinition != nil {
+		def := &domain.TaskSlaDefinitionDetail{
+			Name:             t.SlaDefinition.Name,
+			Type:             t.SlaDefinition.Type,
+			Target:           t.SlaDefinition.Target,
+			Flow:             t.SlaDefinition.Flow,
+			Workflow:         t.SlaDefinition.Workflow,
+			EnableLogging:    t.SlaDefinition.EnableLogging,
+			DurationType:     t.SlaDefinition.DurationType,
+			Duration:         t.SlaDefinition.Duration,
+			ScheduleSource:   t.SlaDefinition.ScheduleSource,
+			Schedule:         t.SlaDefinition.Schedule,
+			TimezoneSource:   t.SlaDefinition.TimezoneSource,
+			Timezone:         t.SlaDefinition.Timezone,
+			StartCondition:   t.SlaDefinition.StartCondition,
+			RetroactiveStart: t.SlaDefinition.RetroactiveStart,
+			RetroactivePause: t.SlaDefinition.RetroactivePause,
+			WhenToCancel:     t.SlaDefinition.WhenToCancel,
+			CancelCondition:  t.SlaDefinition.CancelCondition,
+			PauseCondition:   t.SlaDefinition.PauseCondition,
+			WhenToResume:     t.SlaDefinition.WhenToResume,
+			StopCondition:    t.SlaDefinition.StopCondition,
+			ResetCondition:   t.SlaDefinition.ResetCondition,
+			ResetAction:      t.SlaDefinition.ResetAction,
+		}
+		if t.SlaDefinition.ID != nil {
+			id := sysidToUUID(*t.SlaDefinition.ID)
+			def.ID = &id
+		}
+		view.SlaDefinition = def
+	}
+
+	if t.Stage != nil {
+		view.Stage = &domain.TaskSlaStage{
+			ID:    t.Stage.ID,
+			Label: t.Stage.Label,
+		}
+	}
+
+	if t.Schedule != nil {
+		ref := &domain.TaskSlaScheduleRef{
+			Name:     t.Schedule.Name,
+			Timezone: t.Schedule.Timezone,
+		}
+		if t.Schedule.ID != nil {
+			id := sysidToUUID(*t.Schedule.ID)
+			ref.ID = &id
+		}
+		view.Schedule = ref
+	}
+
+	return view
+}
+
+func (s *snTaskSlaService) GetTaskSla(ctx context.Context, id string) (domain.TaskSlaDetail, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.TaskSlaDetail{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.TaskSlaDetail{}, err
+	}
+
+	raw, err := s.client.Get(ctx, "/task-slas/"+uuidToSysid(id), token)
+	if err != nil {
+		return domain.TaskSlaDetail{}, err
+	}
+
+	var t snTaskSlaDetail
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return domain.TaskSlaDetail{}, fmt.Errorf("sn get task sla: parse response: %w", err)
+	}
+
+	return snTaskSlaToDetailView(t), nil
+}
+
+func (s *snTaskSlaService) SearchTaskSlas(ctx context.Context, req domain.SearchTaskSlasRequest) (domain.SearchTaskSlasResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
 		return domain.SearchTaskSlasResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchTaskSlasResponse{}, err
 	}
 
 	payload := snTaskSlaSearchPayload{

--- a/entity-service/internal/service/sn_task_sla_service.go
+++ b/entity-service/internal/service/sn_task_sla_service.go
@@ -37,7 +37,7 @@ type snTaskSlaFilters struct {
 }
 
 type snTaskSlasResponse struct {
-	TaskSlas     []snTaskSla `json:"taskSlas"`
+	TaskSlas     []snTaskSla `json:"slas"`
 	TotalRecords int         `json:"totalRecords"`
 	Limit        int         `json:"limit"`
 	Offset       int         `json:"offset"`
@@ -254,7 +254,7 @@ func (s *snTaskSlaService) GetTaskSla(ctx context.Context, id string) (domain.Ta
 		return domain.TaskSlaDetail{}, err
 	}
 
-	raw, err := s.client.Get(ctx, "/task-slas/"+uuidToSysid(id), token)
+	raw, err := s.client.Get(ctx, "/slas/"+uuidToSysid(id), token)
 	if err != nil {
 		return domain.TaskSlaDetail{}, err
 	}
@@ -290,7 +290,7 @@ func (s *snTaskSlaService) SearchTaskSlas(ctx context.Context, req domain.Search
 		}
 	}
 
-	raw, err := s.client.Post(ctx, "/task-slas/search", token, payload)
+	raw, err := s.client.Post(ctx, "/slas/search", token, payload)
 	if err != nil {
 		return domain.SearchTaskSlasResponse{}, err
 	}

--- a/entity-service/internal/service/sn_task_sla_service.go
+++ b/entity-service/internal/service/sn_task_sla_service.go
@@ -50,7 +50,7 @@ type snTaskSla struct {
 	Task                      *snTaskSlaTaskRef    `json:"task"`
 	BusinessTimeLeft          *string              `json:"businessTimeLeft"`
 	BusinessElapsedTime       *string              `json:"businessElapsedTime"`
-	BusinessElapsedPercentage *string              `json:"businessElapsedPercentage"`
+	BusinessElapsedPercentage *float64             `json:"businessElapsedPercentage"`
 	StartTime                 *string              `json:"startTime"`
 	EndTime                   *string              `json:"endTime"`
 }
@@ -80,7 +80,7 @@ type snTaskSlaDetail struct {
 	Stage                     *snTaskSlaStage           `json:"stage"`
 	BusinessTimeLeft          *string                   `json:"businessTimeLeft"`
 	BusinessElapsedTime       *string                   `json:"businessElapsedTime"`
-	BusinessElapsedPercentage *string                   `json:"businessElapsedPercentage"`
+	BusinessElapsedPercentage *float64                  `json:"businessElapsedPercentage"`
 	StartTime                 *string                   `json:"startTime"`
 	EndTime                   *string                   `json:"endTime"`
 	Active                    *bool                     `json:"active"`

--- a/entity-service/internal/service/sn_task_sla_service.go
+++ b/entity-service/internal/service/sn_task_sla_service.go
@@ -143,10 +143,7 @@ func snTaskSlaToView(t snTaskSla) domain.TaskSlaView {
 	}
 
 	if t.Stage != nil {
-		view.Stage = &domain.TaskSlaStage{
-			ID:    t.Stage.ID,
-			Label: t.Stage.Label,
-		}
+		view.Stage = t.Stage.Label
 	}
 
 	if t.Task != nil {
@@ -229,10 +226,7 @@ func snTaskSlaToDetailView(t snTaskSlaDetail) domain.TaskSlaDetail {
 	}
 
 	if t.Stage != nil {
-		view.Stage = &domain.TaskSlaStage{
-			ID:    t.Stage.ID,
-			Label: t.Stage.Label,
-		}
+		view.Stage = t.Stage.Label
 	}
 
 	if t.Schedule != nil {

--- a/entity-service/internal/service/sn_task_sla_service.go
+++ b/entity-service/internal/service/sn_task_sla_service.go
@@ -94,7 +94,7 @@ type snTaskSlaDefinitionDetail struct {
 	Target           *string `json:"target"`
 	Flow             *string `json:"flow"`
 	Workflow         *string `json:"workflow"`
-	EnableLogging    *bool   `json:"enableLogging"`
+	EnableLogging    *bool   `json:"isEnableLogging"`
 	DurationType     *string `json:"durationType"`
 	Duration         *string `json:"duration"`
 	ScheduleSource   *string `json:"scheduleSource"`
@@ -102,8 +102,8 @@ type snTaskSlaDefinitionDetail struct {
 	TimezoneSource   *string `json:"timezoneSource"`
 	Timezone         *string `json:"timezone"`
 	StartCondition   *string `json:"startCondition"`
-	RetroactiveStart *bool   `json:"retroactiveStart"`
-	RetroactivePause *bool   `json:"retroactivePause"`
+	RetroactiveStart *bool   `json:"isRetroactiveStart"`
+	RetroactivePause *bool   `json:"isRetroactivePause"`
 	WhenToCancel     *string `json:"whenToCancel"`
 	CancelCondition  *string `json:"cancelCondition"`
 	PauseCondition   *string `json:"pauseCondition"`
@@ -200,7 +200,7 @@ func snTaskSlaToDetailView(t snTaskSlaDetail) domain.TaskSlaDetail {
 			Target:           t.SlaDefinition.Target,
 			Flow:             t.SlaDefinition.Flow,
 			Workflow:         t.SlaDefinition.Workflow,
-			EnableLogging:    t.SlaDefinition.EnableLogging,
+			IsEnableLogging:  t.SlaDefinition.EnableLogging,
 			DurationType:     t.SlaDefinition.DurationType,
 			Duration:         t.SlaDefinition.Duration,
 			ScheduleSource:   t.SlaDefinition.ScheduleSource,
@@ -208,8 +208,8 @@ func snTaskSlaToDetailView(t snTaskSlaDetail) domain.TaskSlaDetail {
 			TimezoneSource:   t.SlaDefinition.TimezoneSource,
 			Timezone:         t.SlaDefinition.Timezone,
 			StartCondition:   t.SlaDefinition.StartCondition,
-			RetroactiveStart: t.SlaDefinition.RetroactiveStart,
-			RetroactivePause: t.SlaDefinition.RetroactivePause,
+			IsRetroactiveStart: t.SlaDefinition.RetroactiveStart,
+			IsRetroactivePause: t.SlaDefinition.RetroactivePause,
 			WhenToCancel:     t.SlaDefinition.WhenToCancel,
 			CancelCondition:  t.SlaDefinition.CancelCondition,
 			PauseCondition:   t.SlaDefinition.PauseCondition,

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1666,7 +1666,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /task-slas/{id}:
+  /slas/{id}:
     get:
       summary: Get a task SLA record by ID (ServiceNow data source only).
       operationId: getTaskSla
@@ -1709,7 +1709,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /task-slas/search:
+  /slas/search:
     post:
       summary: Search task SLA records (ServiceNow data source only).
       operationId: searchTaskSlas
@@ -4051,7 +4051,7 @@ components:
     SearchTaskSlasResponse:
       type: object
       properties:
-        taskSlas:
+        slas:
           type: array
           items:
             $ref: '#/components/schemas/TaskSlaView'

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1666,6 +1666,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /task-slas/{id}:
+    get:
+      summary: Get a task SLA record by ID (ServiceNow data source only).
+      operationId: getTaskSla
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The task SLA record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskSlaDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Task SLA not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /task-slas/search:
     post:
       summary: Search task SLA records (ServiceNow data source only).
@@ -4027,6 +4070,132 @@ components:
           type: integer
         offset:
           type: integer
+
+    TaskSlaDefinitionDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+        target:
+          type: string
+          nullable: true
+        flow:
+          type: string
+          nullable: true
+        workflow:
+          type: string
+          nullable: true
+        enableLogging:
+          type: boolean
+          nullable: true
+        durationType:
+          type: string
+          nullable: true
+        duration:
+          type: string
+          nullable: true
+        scheduleSource:
+          type: string
+          nullable: true
+        schedule:
+          type: string
+          nullable: true
+        timezoneSource:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+        startCondition:
+          type: string
+          nullable: true
+        retroactiveStart:
+          type: boolean
+          nullable: true
+        retroactivePause:
+          type: boolean
+          nullable: true
+        whenToCancel:
+          type: string
+          nullable: true
+        cancelCondition:
+          type: string
+          nullable: true
+        pauseCondition:
+          type: string
+          nullable: true
+        whenToResume:
+          type: string
+          nullable: true
+        stopCondition:
+          type: string
+          nullable: true
+        resetCondition:
+          type: string
+          nullable: true
+        resetAction:
+          type: string
+          nullable: true
+
+    TaskSlaScheduleRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+
+    TaskSlaDetail:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+          format: uuid
+        task:
+          $ref: '#/components/schemas/TaskSlaTaskRef'
+          nullable: true
+        slaDefinition:
+          $ref: '#/components/schemas/TaskSlaDefinitionDetail'
+          nullable: true
+        stage:
+          $ref: '#/components/schemas/TaskSlaStage'
+          nullable: true
+        businessTimeLeft:
+          type: string
+          nullable: true
+        businessElapsedTime:
+          type: string
+          nullable: true
+        businessElapsedPercentage:
+          type: string
+          nullable: true
+        startTime:
+          type: string
+          nullable: true
+        endTime:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+          nullable: true
+        schedule:
+          $ref: '#/components/schemas/TaskSlaScheduleRef'
+          nullable: true
 
     CreateTimeCardRequest:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4038,7 +4038,8 @@ components:
           type: string
           nullable: true
         businessElapsedPercentage:
-          type: string
+          type: number
+          format: double
           nullable: true
         startTime:
           type: string
@@ -4172,7 +4173,8 @@ components:
           type: string
           nullable: true
         businessElapsedPercentage:
-          type: string
+          type: number
+          format: double
           nullable: true
         startTime:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4083,7 +4083,7 @@ components:
         workflow:
           type: string
           nullable: true
-        enableLogging:
+        isEnableLogging:
           type: boolean
           nullable: true
         durationType:
@@ -4107,10 +4107,10 @@ components:
         startCondition:
           type: string
           nullable: true
-        retroactiveStart:
+        isRetroactiveStart:
           type: boolean
           nullable: true
-        retroactivePause:
+        isRetroactivePause:
           type: boolean
           nullable: true
         whenToCancel:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1666,6 +1666,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /task-slas/search:
+    post:
+      summary: Search task SLA records (ServiceNow data source only).
+      operationId: searchTaskSlas
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchTaskSlasRequest'
+      responses:
+        "200":
+          description: Task SLA records matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchTaskSlasResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /comments/search:
     post:
       summary: Search comments by reference entity (ServiceNow data source only).
@@ -3874,6 +3910,117 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TimeCardView'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    SearchTaskSlasRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            taskIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+        pagination:
+          type: object
+          properties:
+            offset:
+              type: integer
+              minimum: 0
+              default: 0
+            limit:
+              type: integer
+              minimum: 1
+              maximum: 100
+              default: 20
+
+    TaskSlaDefinition:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+        target:
+          type: string
+          nullable: true
+
+    TaskSlaStage:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        label:
+          type: string
+          nullable: true
+
+    TaskSlaTaskRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+
+    TaskSlaView:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+          format: uuid
+        slaDefinition:
+          $ref: '#/components/schemas/TaskSlaDefinition'
+          nullable: true
+        stage:
+          $ref: '#/components/schemas/TaskSlaStage'
+          nullable: true
+        task:
+          $ref: '#/components/schemas/TaskSlaTaskRef'
+          nullable: true
+        businessTimeLeft:
+          type: string
+          nullable: true
+        businessElapsedTime:
+          type: string
+          nullable: true
+        businessElapsedPercentage:
+          type: string
+          nullable: true
+        startTime:
+          type: string
+          nullable: true
+        endTime:
+          type: string
+          nullable: true
+
+    SearchTaskSlasResponse:
+      type: object
+      properties:
+        taskSlas:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaskSlaView'
         total:
           type: integer
         limit:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4001,16 +4001,6 @@ components:
           type: string
           nullable: true
 
-    TaskSlaStage:
-      type: object
-      properties:
-        id:
-          type: string
-          nullable: true
-        label:
-          type: string
-          nullable: true
-
     TaskSlaTaskRef:
       type: object
       properties:
@@ -4036,7 +4026,7 @@ components:
           $ref: '#/components/schemas/TaskSlaDefinition'
           nullable: true
         stage:
-          $ref: '#/components/schemas/TaskSlaStage'
+          type: string
           nullable: true
         task:
           $ref: '#/components/schemas/TaskSlaTaskRef'
@@ -4173,7 +4163,7 @@ components:
           $ref: '#/components/schemas/TaskSlaDefinitionDetail'
           nullable: true
         stage:
-          $ref: '#/components/schemas/TaskSlaStage'
+          type: string
           nullable: true
         businessTimeLeft:
           type: string


### PR DESCRIPTION
## Summary
- Add `POST /task-slas/search` — paginated search filtered by optional `taskIds`
- Add `GET /task-slas/{id}` — full task SLA detail including extended SLA definition, schedule, and task reference
- Both endpoints are ServiceNow data source only; all fields except `id` are nullable

## Test plan
- [ ] `POST /task-slas/search` with no filters returns paginated results
- [ ] `POST /task-slas/search` with valid `taskIds` filters results correctly
- [ ] `POST /task-slas/search` with invalid UUID in `taskIds` returns 400
- [ ] `GET /task-slas/{id}` with a valid ID returns the full detail record
- [ ] `GET /task-slas/{id}` with an unknown ID returns 404
- [ ] `GET /task-slas/{id}` with an invalid UUID returns 400
- [ ] Both endpoints return 401 when `x-user-id-token` header is absent
- [ ] All IDs in responses are standard UUIDs (not bare ServiceNow sysids)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ServiceNow-backed Task SLA APIs: `GET /task-slas/{id}` for full SLA detail and `POST /task-slas/search` for paginated search with optional task ID filters.
  * Introduced new Task SLA models for definitions, task references, schedule references, and enriched search/detail responses (including business/time metrics and configuration fields).
* **Documentation**
  * Updated the OpenAPI specification to document the new endpoints and request/response schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->