### PR TITLE
[Customer Portal MicroApp] hotfix: fix broken imports crashing all detail page headers

### DIFF
--- a/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/OverlineSlot.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion, type Variants } from "framer-motion";
 import { IconButton, Skeleton, Stack, Tooltip, Typography, pxToRem } from "@wso2/oxygen-ui";
 import { Check, Copy } from "@wso2/oxygen-ui-icons-react";
@@ -40,7 +40,7 @@ export function OverlineSlot({
   const [copied, setCopied] = useState(false);
   const [hovered, setHovered] = useState(false);
 
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const handleCopy = async (value: string) => {
     try {

--- a/apps/customer-portal/microapp/src/components/features/detail/StickyCommentBar.tsx
+++ b/apps/customer-portal/microapp/src/components/features/detail/StickyCommentBar.tsx
@@ -53,7 +53,7 @@ export function StickyCommentBar({
     onSend();
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (submitOnEnter && event.key === "Enter" && hasContent) {
       event.preventDefault();
       send();

--- a/apps/customer-portal/microapp/src/components/shared/RichText.tsx
+++ b/apps/customer-portal/microapp/src/components/shared/RichText.tsx
@@ -58,7 +58,7 @@ export const RichTextBase = styled(Box)(({ theme }) => ({
     filter: "invert(1) hue-rotate(180deg) brightness(0.88)",
     "& *": { backgroundColor: "transparent !important" },
     "& pre": { backgroundColor: "#ececec !important", color: "#000 !important" },
-    "& img": { filter: "invert(1) hue-rotate(180deg) brightness(1.136)" }
+    "& img": { filter: "invert(1) hue-rotate(180deg) brightness(1.136)" },
   }),
 }));
 

--- a/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/ChatDetailPage.tsx
@@ -57,7 +57,7 @@ export default function ChatDetailPage() {
       if (!id) {
         return Promise.reject(new Error("Conversation ID is not available"));
       }
-      return chats.send(projectId, id).mutationFn!(body);
+      return chats.send(projectId, id).mutationFn!(body, { client: queryClient, meta: undefined });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: chats.comments(id!).queryKey });
@@ -85,7 +85,7 @@ export default function ChatDetailPage() {
     );
 
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [comments]);
+  }, [comments, format]);
 
   const ref = useRef<HTMLSpanElement>(null);
   const [overlineSlotVariant, setOverlineSlotVariant] = useState<"normal" | "shrunk">("normal");
@@ -111,15 +111,17 @@ export default function ChatDetailPage() {
     return () => observer.unobserve(element);
   }, []);
 
+  const { setTitleOverride } = layout;
+
   useLayoutEffect(() => {
-    layout.setTitleOverride(
+    setTitleOverride(
       <OverlineSlot variant={overlineSlotVariant} type="chat" id={data?.number} title={data?.description} />,
     );
 
     return () => {
-      layout.setTitleOverride(undefined);
+      setTitleOverride(undefined);
     };
-  }, [data, overlineSlotVariant]);
+  }, [data, overlineSlotVariant, setTitleOverride]);
 
   return (
     <>

--- a/apps/customer-portal/microapp/src/utils/useDateTime.ts
+++ b/apps/customer-portal/microapp/src/utils/useDateTime.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
@@ -28,24 +29,23 @@ export function useDateTime() {
   const { timezone } = useMe();
   const tz = resolveTimezone(timezone);
 
-  const toUtc = (date: Date | string) => {
+  const toUtc = useCallback((date: Date | string) => {
     if (date instanceof Date) {
       return dayjs.utc(dayjs(date).format("YYYY-MM-DDTHH:mm:ss"));
     }
     return dayjs.utc(date);
-  };
+  }, []);
 
-  const format = (date: Date | string, fmt = "MMM D, YYYY h:mm A") => {
-    return toUtc(date).tz(tz).format(fmt);
-  };
+  const format = useCallback(
+    (date: Date | string, fmt = "MMM D, YYYY h:mm A") => toUtc(date).tz(tz).format(fmt),
+    [toUtc, tz],
+  );
 
-  const fromNow = (date: Date | string) => {
-    return toUtc(date).tz(tz).fromNow();
-  };
+  const fromNow = useCallback((date: Date | string) => toUtc(date).tz(tz).fromNow(), [toUtc, tz]);
 
-  const toDate = (date: Date | string) => toUtc(date).tz(tz).format("MMM D, YYYY");
+  const toDate = useCallback((date: Date | string) => toUtc(date).tz(tz).format("MMM D, YYYY"), [toUtc, tz]);
 
-  const toTime = (date: Date | string) => toUtc(date).tz(tz).format("h:mm A z");
+  const toTime = useCallback((date: Date | string) => toUtc(date).tz(tz).format("h:mm A z"), [toUtc, tz]);
 
   return { format, fromNow, toDate, toTime };
 }


### PR DESCRIPTION
## Purpose
PR #1032 was merged at commit `fec9db7fd` instead of its later fix commit. That commit came from a CodeRabbit-suggested change to `OverlineSlot.tsx` that used `useRef`/`useEffect` without importing them, and called `useRef()` with no initial value (invalid under this project's strict TS config). Since `OverlineSlot` is rendered by every detail page's header (Case, Chat, Change, Service, SRA, Engagement, Announcement — see `layout.setTitleOverride(<OverlineSlot ... />)` in each), this throws `ReferenceError: useRef is not defined` at render time, breaking all of those pages currently on `v2`. Reported symptom: opening a chat from the Support page renders completely blank.

## Goals
Restore all detail pages to working order by fixing the missing imports and the invalid `useRef()` call.

## Approach
Cherry-picked the fix commit (`add22a474`) that was already pushed to `dinijay/feat/support-page-v2` after #1032's merge point, onto current `v2`:
- `OverlineSlot.tsx`: import `useRef`/`useEffect`, give `useRef` an explicit initial value.
- `StickyCommentBar.tsx`: fix an unrelated type mismatch in the same batch of fixes (`onKeyDown` typed against `HTMLDivElement` to match what MUI's `TextField` actually exposes).
- `ChatDetailPage.tsx` / `useDateTime.ts`: pass the required `MutationFunctionContext` second argument to `mutationFn` (TanStack Query v5 requires it) and stabilize date-formatting functions with `useCallback`.
- `RichText.tsx`: formatting only.

Verified via `npx tsc --noEmit -p tsconfig.app.json` (the correct command — the root `tsconfig.json` is a references-only "solution" file, so plain `-p .` silently checks nothing). Only two pre-existing, unrelated errors remain on `v2` (`TypewriterText.tsx`, `UpdateProfileSettingsPage.tsx`), confirmed present before this change too.

## Release note
Hotfix: detail page headers (case, chat, change, service, SRA, engagement, announcement) were rendering blank due to a broken import introduced by an automated suggestion merged in #1032. Fixed.

## Test environment
Verified via `tsc --noEmit -p tsconfig.app.json`; live browser verification not performed in this environment (no local auth configured) — please verify a detail page loads before merging.