### PR TITLE
[CSM Portal] BFF: /slas passthrough endpoints

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -144,8 +144,8 @@ func main() {
 	mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)
 	mux.HandleFunc("GET /products/vulnerabilities/{id}", productVulnerabilityHandler.GetProductVulnerability)
 	mux.HandleFunc("GET /conversations/{id}/messages", conversationHandler.GetConversationMessages)
-	mux.HandleFunc("POST /task-slas/search", taskSlaHandler.SearchTaskSlas)
-	mux.HandleFunc("GET /task-slas/{id}", taskSlaHandler.GetTaskSla)
+	mux.HandleFunc("POST /slas/search", taskSlaHandler.SearchTaskSlas)
+	mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
 
 	addr := envOrDefault("PORT", ":8080")
 

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -63,6 +63,7 @@ func main() {
 	timeCardHandler := handler.NewTimeCardHandler(entityClient)
 	productVulnerabilityHandler := handler.NewProductVulnerabilityHandler(entityClient)
 	conversationHandler := handler.NewConversationHandler(entityClient)
+	taskSlaHandler := handler.NewTaskSlaHandler(entityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
@@ -143,6 +144,8 @@ func main() {
 	mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)
 	mux.HandleFunc("GET /products/vulnerabilities/{id}", productVulnerabilityHandler.GetProductVulnerability)
 	mux.HandleFunc("GET /conversations/{id}/messages", conversationHandler.GetConversationMessages)
+	mux.HandleFunc("POST /task-slas/search", taskSlaHandler.SearchTaskSlas)
+	mux.HandleFunc("GET /task-slas/{id}", taskSlaHandler.GetTaskSla)
 
 	addr := envOrDefault("PORT", ":8080")
 

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -294,14 +294,14 @@ func (c *Client) SearchComments(ctx context.Context, body []byte) ([]byte, error
 	return c.do(ctx, http.MethodPost, "/comments/search", body)
 }
 
-// SearchTaskSlas calls POST /task-slas/search on the entity service.
+// SearchTaskSlas calls POST /slas/search on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {
-	return c.do(ctx, http.MethodPost, "/task-slas/search", body)
+	return c.do(ctx, http.MethodPost, "/slas/search", body)
 }
 
-// GetTaskSla calls GET /task-slas/{id} on the entity service.
+// GetTaskSla calls GET /slas/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) GetTaskSla(ctx context.Context, id string) ([]byte, error) {
-	return c.do(ctx, http.MethodGet, fmt.Sprintf("/task-slas/%s", url.PathEscape(id)), nil)
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/slas/%s", url.PathEscape(id)), nil)
 }

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -293,3 +293,15 @@ func (c *Client) CreateCaseGithubIssue(ctx context.Context, caseID string, body 
 func (c *Client) SearchComments(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/comments/search", body)
 }
+
+// SearchTaskSlas calls POST /task-slas/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/task-slas/search", body)
+}
+
+// GetTaskSla calls GET /task-slas/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) GetTaskSla(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/task-slas/%s", url.PathEscape(id)), nil)
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -504,6 +504,27 @@ func (m *mockEntityDeploymentClient) PatchDeployedProduct(ctx context.Context, d
 	return []byte(`{}`), nil
 }
 
+// ----- mock entity task-SLA client -----
+
+type mockEntityTaskSlaClient struct {
+	searchTaskSlasFn func(ctx context.Context, body []byte) ([]byte, error)
+	getTaskSlaFn     func(ctx context.Context, id string) ([]byte, error)
+}
+
+func (m *mockEntityTaskSlaClient) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchTaskSlasFn != nil {
+		return m.searchTaskSlasFn(ctx, body)
+	}
+	return []byte(`{"taskSlas":[],"total":0,"limit":20,"offset":0}`), nil
+}
+
+func (m *mockEntityTaskSlaClient) GetTaskSla(ctx context.Context, id string) ([]byte, error) {
+	if m.getTaskSlaFn != nil {
+		return m.getTaskSlaFn(ctx, id)
+	}
+	return []byte(`{}`), nil
+}
+
 // ----- mock entity conversation client -----
 
 type mockEntityConversationClient struct {

--- a/apps/csm-portal/backend/internal/handler/task_slas.go
+++ b/apps/csm-portal/backend/internal/handler/task_slas.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityTaskSlaClient abstracts the entity service task-SLA operations used by
+// TaskSlaHandler, allowing the handler to be tested independently of the real
+// HTTP client.
+type entityTaskSlaClient interface {
+	SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error)
+	GetTaskSla(ctx context.Context, id string) ([]byte, error)
+}
+
+// TaskSlaHandler handles HTTP requests for task-SLA operations, delegating to
+// the entity service for data access. Both routes are byte-for-byte
+// passthroughs: the response body from the entity service is forwarded
+// unchanged.
+type TaskSlaHandler struct {
+	entity entityTaskSlaClient
+}
+
+// NewTaskSlaHandler creates a TaskSlaHandler backed by the given entity client.
+func NewTaskSlaHandler(entity entityTaskSlaClient) *TaskSlaHandler {
+	return &TaskSlaHandler{entity: entity}
+}
+
+// SearchTaskSlas handles POST /task-slas/search.
+// The request body is forwarded unchanged to the entity service and the raw
+// response is returned.
+func (h *TaskSlaHandler) SearchTaskSlas(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchTaskSlas(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchTaskSlas failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search task SLAs.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetTaskSla handles GET /task-slas/{id}.
+// The raw response from the entity service is returned unchanged. The id is an
+// upstream identifier, not a platform UUID, so it is forwarded as-is (escaped by
+// the entity client) rather than validated against a UUID pattern.
+func (h *TaskSlaHandler) GetTaskSla(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.GetTaskSla(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetTaskSla failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamError(w, err, "Failed to retrieve task SLA.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/task_slas.go
+++ b/apps/csm-portal/backend/internal/handler/task_slas.go
@@ -48,7 +48,7 @@ func NewTaskSlaHandler(entity entityTaskSlaClient) *TaskSlaHandler {
 	return &TaskSlaHandler{entity: entity}
 }
 
-// SearchTaskSlas handles POST /task-slas/search.
+// SearchTaskSlas handles POST /slas/search.
 // The request body is forwarded unchanged to the entity service and the raw
 // response is returned.
 func (h *TaskSlaHandler) SearchTaskSlas(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +85,7 @@ func (h *TaskSlaHandler) SearchTaskSlas(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, result)
 }
 
-// GetTaskSla handles GET /task-slas/{id}.
+// GetTaskSla handles GET /slas/{id}.
 // The raw response from the entity service is returned unchanged. The id is an
 // upstream identifier, not a platform UUID, so it is forwarded as-is (escaped by
 // the entity client) rather than validated against a UUID pattern.

--- a/apps/csm-portal/backend/internal/handler/task_slas_test.go
+++ b/apps/csm-portal/backend/internal/handler/task_slas_test.go
@@ -29,7 +29,7 @@ const testTaskSlaID = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 func TestSearchTaskSlas(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
-		r := httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/slas/search", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
 		h.SearchTaskSlas(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -39,7 +39,7 @@ func TestSearchTaskSlas(t *testing.T) {
 
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/slas/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.SearchTaskSlas(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -49,7 +49,7 @@ func TestSearchTaskSlas(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`not-json`)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/slas/search", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.SearchTaskSlas(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -68,7 +68,7 @@ func TestSearchTaskSlas(t *testing.T) {
 			},
 		}
 		h := NewTaskSlaHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(payload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/slas/search", strings.NewReader(payload)))
 		w := httptest.NewRecorder()
 		h.SearchTaskSlas(w, r)
 
@@ -92,7 +92,7 @@ func TestSearchTaskSlas(t *testing.T) {
 					},
 				}
 				h := NewTaskSlaHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/slas/search", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
 				h.SearchTaskSlas(w, r)
 				assertStatus(t, w, tc.wantCode)
@@ -106,7 +106,7 @@ func TestSearchTaskSlas(t *testing.T) {
 func TestGetTaskSla(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
-		r := httptest.NewRequest(http.MethodGet, "/task-slas/"+testTaskSlaID, nil)
+		r := httptest.NewRequest(http.MethodGet, "/slas/"+testTaskSlaID, nil)
 		r.SetPathValue("id", testTaskSlaID)
 		w := httptest.NewRecorder()
 		h.GetTaskSla(w, r)
@@ -117,7 +117,7 @@ func TestGetTaskSla(t *testing.T) {
 
 	t.Run("rejects empty id", func(t *testing.T) {
 		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
-		r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/", nil))
+		r := withUser(httptest.NewRequest(http.MethodGet, "/slas/", nil))
 		w := httptest.NewRecorder()
 		h.GetTaskSla(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -135,7 +135,7 @@ func TestGetTaskSla(t *testing.T) {
 			},
 		}
 		h := NewTaskSlaHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/"+testTaskSlaID, nil))
+		r := withUser(httptest.NewRequest(http.MethodGet, "/slas/"+testTaskSlaID, nil))
 		r.SetPathValue("id", testTaskSlaID)
 		w := httptest.NewRecorder()
 		h.GetTaskSla(w, r)
@@ -160,7 +160,7 @@ func TestGetTaskSla(t *testing.T) {
 					},
 				}
 				h := NewTaskSlaHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/"+testTaskSlaID, nil))
+				r := withUser(httptest.NewRequest(http.MethodGet, "/slas/"+testTaskSlaID, nil))
 				r.SetPathValue("id", testTaskSlaID)
 				w := httptest.NewRecorder()
 				h.GetTaskSla(w, r)

--- a/apps/csm-portal/backend/internal/handler/task_slas_test.go
+++ b/apps/csm-portal/backend/internal/handler/task_slas_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testTaskSlaID = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+
+func TestSearchTaskSlas(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream unchanged and returns raw 200 response", func(t *testing.T) {
+		const payload = `{"filters":{"caseId":"case-1"},"pagination":{"limit":20,"offset":0}}`
+		const upstream = `{"taskSlas":[{"id":"sla-1"}],"total":1,"limit":20,"offset":0}`
+		var capturedBody []byte
+		client := &mockEntityTaskSlaClient{
+			searchTaskSlasFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(upstream), nil
+			},
+		}
+		h := NewTaskSlaHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(payload)))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != payload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, payload)
+		}
+		if w.Body.String() != upstream {
+			t.Errorf("response body = %q, want raw passthrough %q", w.Body.String(), upstream)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search task SLAs.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityTaskSlaClient{
+					searchTaskSlasFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewTaskSlaHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchTaskSlas(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestGetTaskSla(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := httptest.NewRequest(http.MethodGet, "/task-slas/"+testTaskSlaID, nil)
+		r.SetPathValue("id", testTaskSlaID)
+		w := httptest.NewRecorder()
+		h.GetTaskSla(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty id", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/", nil))
+		w := httptest.NewRecorder()
+		h.GetTaskSla(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards non-UUID id to upstream and returns raw 200 response", func(t *testing.T) {
+		const upstream = `{"id":"` + testTaskSlaID + `","definition":"Response time","stage":"in_progress"}`
+		var capturedID string
+		client := &mockEntityTaskSlaClient{
+			getTaskSlaFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(upstream), nil
+			},
+		}
+		h := NewTaskSlaHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/"+testTaskSlaID, nil))
+		r.SetPathValue("id", testTaskSlaID)
+		w := httptest.NewRecorder()
+		h.GetTaskSla(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != testTaskSlaID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testTaskSlaID)
+		}
+		if w.Body.String() != upstream {
+			t.Errorf("response body = %q, want raw passthrough %q", w.Body.String(), upstream)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to retrieve task SLA.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityTaskSlaClient{
+					getTaskSlaFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewTaskSlaHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/"+testTaskSlaID, nil))
+				r.SetPathValue("id", testTaskSlaID)
+				w := httptest.NewRecorder()
+				h.GetTaskSla(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2463,6 +2463,113 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /task-slas/search:
+    post:
+      summary: Search task SLAs (ServiceNow data source only).
+      operationId: searchTaskSlas
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Matching task SLAs.
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: Request entity too large.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /task-slas/{id}:
+    get:
+      summary: Get a task SLA by ID (ServiceNow data source only).
+      operationId: getTaskSla
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Task-SLA identifier.
+      responses:
+        "200":
+          description: The task SLA with the given ID.
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Task SLA not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
 components:
   securitySchemes:
     bearerAuth:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2463,7 +2463,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /task-slas/search:
+  /slas/search:
     post:
       summary: Search task SLAs (ServiceNow data source only).
       operationId: searchTaskSlas
@@ -2519,7 +2519,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /task-slas/{id}:
+  /slas/{id}:
     get:
       summary: Get a task SLA by ID (ServiceNow data source only).
       operationId: getTaskSla


### PR DESCRIPTION
## Purpose
The CSM webapp reaches services through the BFF + gateway. To let the case-detail SLA tab (FE, separate PR) read a case's SLA records, the BFF needs to expose the entity-service's task-SLA endpoints. Tracked on the internal delivery board (no public issue).

## Goals
Expose the entity-service task-SLA endpoints through the CSM backend as transparent passthroughs:
- `POST /slas/search`
- `GET /slas/{id}`

## Approach
Raw `[]byte` passthrough (the BFF forwards the request body and returns the upstream response bytes unchanged — the entity-service owns the contract), following the existing `change-requests` / `product-vulnerabilities` passthrough pattern:
- **entity client** (`internal/entity/entity.go`): `SearchTaskSlas(ctx, body)` → `POST /slas/search`; `GetTaskSla(ctx, id)` → `GET /slas/{id}` (id path-escaped).
- **handler** (`internal/handler/task_slas.go`, new): a dedicated `TaskSlaHandler` (task-SLAs aren't case-scoped) with its own small entity-client interface; auth guard, 1 MiB body cap + JSON-valid check on search, `mapUpstreamError`, raw `writeJSON`. The `{id}` is an upstream identifier (not a platform UUID), so it is **not** UUID-gated — only an empty-id 400 — with the rationale in a comment.
- **routes** (`cmd/server/main.go`): `POST /slas/search`, `GET /slas/{id}`, same middleware chain as siblings.
- **openapi.yaml**: both paths documented as passthroughs (generic object bodies, standard error responses), matching the file's style.

## User stories
As a CS engineer, I need the portal to fetch a case's SLA records, which requires the backend to expose the task-SLA endpoints.

## Release note
CSM backend now proxies the task-SLA search and fetch endpoints (`POST /slas/search`, `GET /slas/{id}`).

## Documentation
N/A — internal CS-engineer portal; no external product documentation impact.

## Training
N/A. ## Certification
N/A. ## Marketing
N/A.

## Automation tests
 - Unit tests
   > New `internal/handler/task_slas_test.go`: auth, oversize body, invalid JSON, raw passthrough of body/id/response, empty-id, and the full upstream-error mapping table. `make vet`/`make test` (race) pass; `make build` OK.
 - Integration tests
   > End-to-end deferred until the entity-service task-SLA endpoints (#1048) and their upstream resources are available; the BFF layer is a byte passthrough with no independent logic to integration-test.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go change; `go vet` ran clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #1048 — entity-service task-SLA endpoints (upstream of this passthrough).
- FE SLA tab that consumes these endpoints: see the companion webapp PR (linked below once opened).

## Migrations (if applicable)
N/A — no schema or data migration.

## Test environment
macOS; Go (CSM backend).

## Learning
Mirrored the repo's existing resource-passthrough handlers (`change_requests.go`, `product_vulnerabilities.go`).
