### PR TITLE
fix(customer-portal): remove unused type imports causing build failure

### DIFF
--- a/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
@@ -19,8 +19,6 @@ import type { UsageAggregatedMetricDefinition } from "@features/project-details/
 import type {
   DataSource,
   UsageEnvironmentProduct,
-  UsageInstanceChartBlock,
-  UsageProductInstanceRow,
   UsageTimeRange,
   MetricTypeSummary,
 } from "@features/project-details/types/usage";


### PR DESCRIPTION
## Summary

- Removes `UsageInstanceChartBlock` and `UsageProductInstanceRow` from the import list in `usageMetrics.ts` — both were left over from the accordion refactor in #1046 and were flagged as `TS6196: declared but never used`, breaking the container build.

## Test plan

- [ ] `tsc -b` passes with no errors on the usage-metrics types file
- [ ] Container build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal type references related to usage metrics.
  * No user-facing behavior, settings, or displayed data changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->