### PR TITLE
[CSM][BE] Add task SLA endpoints (POST /slas/search, GET /slas/{id})

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -63,6 +63,7 @@ func main() {
 	timeCardHandler := handler.NewTimeCardHandler(entityClient)
 	productVulnerabilityHandler := handler.NewProductVulnerabilityHandler(entityClient)
 	conversationHandler := handler.NewConversationHandler(entityClient)
+	taskSlaHandler := handler.NewTaskSlaHandler(entityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
@@ -143,6 +144,8 @@ func main() {
 	mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)
 	mux.HandleFunc("GET /products/vulnerabilities/{id}", productVulnerabilityHandler.GetProductVulnerability)
 	mux.HandleFunc("GET /conversations/{id}/messages", conversationHandler.GetConversationMessages)
+	mux.HandleFunc("POST /slas/search", taskSlaHandler.SearchTaskSlas)
+	mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
 
 	addr := envOrDefault("PORT", ":8080")
 

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -293,3 +293,15 @@ func (c *Client) CreateCaseGithubIssue(ctx context.Context, caseID string, body 
 func (c *Client) SearchComments(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/comments/search", body)
 }
+
+// SearchTaskSlas calls POST /slas/search on the entity service.
+// Response is returned as raw JSON.
+func (c *Client) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/slas/search", body)
+}
+
+// GetTaskSla calls GET /slas/{id} on the entity service.
+// Response is returned as raw JSON.
+func (c *Client) GetTaskSla(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/slas/%s", url.PathEscape(id)), nil)
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -516,3 +516,24 @@ func (m *mockEntityConversationClient) SearchComments(ctx context.Context, body 
 	}
 	return []byte(`{"comments":[],"total":0,"limit":20,"offset":0,"hasMore":false}`), nil
 }
+
+// ----- mock entity task SLA client -----
+
+type mockEntityTaskSlaClient struct {
+	searchTaskSlasFn func(ctx context.Context, body []byte) ([]byte, error)
+	getTaskSlaFn     func(ctx context.Context, id string) ([]byte, error)
+}
+
+func (m *mockEntityTaskSlaClient) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchTaskSlasFn != nil {
+		return m.searchTaskSlasFn(ctx, body)
+	}
+	return []byte(`{"slas":[],"total":0,"limit":20,"offset":0}`), nil
+}
+
+func (m *mockEntityTaskSlaClient) GetTaskSla(ctx context.Context, id string) ([]byte, error) {
+	if m.getTaskSlaFn != nil {
+		return m.getTaskSlaFn(ctx, id)
+	}
+	return []byte(`{"id":"11111111-1111-1111-1111-111111111111"}`), nil
+}

--- a/apps/csm-portal/backend/internal/handler/task_slas.go
+++ b/apps/csm-portal/backend/internal/handler/task_slas.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityTaskSlaClient abstracts the entity service task SLA operations.
+type entityTaskSlaClient interface {
+	SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error)
+	GetTaskSla(ctx context.Context, id string) ([]byte, error)
+}
+
+// TaskSlaHandler handles HTTP requests for task SLA operations.
+type TaskSlaHandler struct {
+	entity entityTaskSlaClient
+}
+
+// NewTaskSlaHandler creates a TaskSlaHandler backed by the given entity client.
+func NewTaskSlaHandler(entity entityTaskSlaClient) *TaskSlaHandler {
+	return &TaskSlaHandler{entity: entity}
+}
+
+// SearchTaskSlas handles POST /task-slas/search.
+func (h *TaskSlaHandler) SearchTaskSlas(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if len(body) > 0 && !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchTaskSlas(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchTaskSlas failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search task SLAs.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetTaskSla handles GET /task-slas/{id}.
+func (h *TaskSlaHandler) GetTaskSla(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetTaskSla(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetTaskSla failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamError(w, err, "Failed to retrieve task SLA.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/task_slas_test.go
+++ b/apps/csm-portal/backend/internal/handler/task_slas_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSearchTaskSlas(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"pagination":{"limit":10,"offset":0}}`
+		var capturedBody []byte
+		client := &mockEntityTaskSlaClient{
+			searchTaskSlasFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"slas":[{"id":"11111111-1111-1111-1111-111111111111"}],"total":1,"limit":10,"offset":0}`), nil
+			},
+		}
+		h := NewTaskSlaHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchTaskSlas(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search task SLAs.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityTaskSlaClient{
+					searchTaskSlasFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewTaskSlaHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/task-slas/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchTaskSlas(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestGetTaskSla(t *testing.T) {
+	const validID = "11111111-1111-1111-1111-111111111111"
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := httptest.NewRequest(http.MethodGet, "/task-slas/"+validID, nil)
+		r.SetPathValue("id", validID)
+		w := httptest.NewRecorder()
+		h.GetTaskSla(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects missing id", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/", nil))
+		w := httptest.NewRecorder()
+		h.GetTaskSla(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID id", func(t *testing.T) {
+		h := NewTaskSlaHandler(&mockEntityTaskSlaClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/not-a-uuid", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.GetTaskSla(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("returns 200 with upstream response", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityTaskSlaClient{
+			getTaskSlaFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"id":"` + validID + `"}`), nil
+			},
+		}
+		h := NewTaskSlaHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/"+validID, nil))
+		r.SetPathValue("id", validID)
+		w := httptest.NewRecorder()
+		h.GetTaskSla(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != validID {
+			t.Errorf("upstream received id %q, want %q", capturedID, validID)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to retrieve task SLA.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityTaskSlaClient{
+					getTaskSlaFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewTaskSlaHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/task-slas/"+validID, nil))
+				r.SetPathValue("id", validID)
+				w := httptest.NewRecorder()
+				h.GetTaskSla(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5263,14 +5263,16 @@ components:
           type: string
           format: uuid
         slaDefinition:
-          $ref: '#/components/schemas/TaskSlaDefinitionRef'
           nullable: true
+          allOf:
+            - $ref: '#/components/schemas/TaskSlaDefinitionRef'
         stage:
           type: string
           nullable: true
         task:
-          $ref: '#/components/schemas/TaskSlaTaskRef'
           nullable: true
+          allOf:
+            - $ref: '#/components/schemas/TaskSlaTaskRef'
         businessTimeLeft:
           type: string
           nullable: true
@@ -5398,11 +5400,13 @@ components:
           type: string
           format: uuid
         task:
-          $ref: '#/components/schemas/TaskSlaTaskRef'
           nullable: true
+          allOf:
+            - $ref: '#/components/schemas/TaskSlaTaskRef'
         slaDefinition:
-          $ref: '#/components/schemas/TaskSlaDefinitionDetail'
           nullable: true
+          allOf:
+            - $ref: '#/components/schemas/TaskSlaDefinitionDetail'
         stage:
           type: string
           nullable: true
@@ -5426,5 +5430,6 @@ components:
           type: boolean
           nullable: true
         schedule:
-          $ref: '#/components/schemas/TaskSlaScheduleRef'
           nullable: true
+          allOf:
+            - $ref: '#/components/schemas/TaskSlaScheduleRef'

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2237,6 +2237,108 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /slas/search:
+    post:
+      summary: Search task SLA records (ServiceNow data source only).
+      operationId: searchTaskSlas
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchTaskSlasPayload'
+      responses:
+        "200":
+          description: Task SLA records matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchTaskSlasResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: Request entity too large.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /slas/{id}:
+    get:
+      summary: Get a task SLA record by ID (ServiceNow data source only).
+      operationId: getTaskSla
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Task SLA UUID.
+      responses:
+        "200":
+          description: The task SLA record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskSlaDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Task SLA not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /catalogs/{catalogId}/items/{catalogItemId}/variables:
     get:
       summary: Get variables (form fields) for a catalog item (ServiceNow data source only).
@@ -5096,3 +5198,233 @@ components:
         hasMore:
           type: boolean
           description: Whether additional pages are available.
+
+    SearchTaskSlasPayload:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            taskIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+              description: Filter by task UUIDs.
+        pagination:
+          type: object
+          properties:
+            offset:
+              type: integer
+              minimum: 0
+              default: 0
+            limit:
+              type: integer
+              minimum: 1
+              maximum: 100
+              default: 20
+
+    TaskSlaDefinitionRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+        target:
+          type: string
+          nullable: true
+
+    TaskSlaTaskRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+
+    TaskSlaView:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+          format: uuid
+        slaDefinition:
+          $ref: '#/components/schemas/TaskSlaDefinitionRef'
+          nullable: true
+        stage:
+          type: string
+          nullable: true
+        task:
+          $ref: '#/components/schemas/TaskSlaTaskRef'
+          nullable: true
+        businessTimeLeft:
+          type: string
+          nullable: true
+        businessElapsedTime:
+          type: string
+          nullable: true
+        businessElapsedPercentage:
+          type: number
+          format: double
+          nullable: true
+        startTime:
+          type: string
+          nullable: true
+        endTime:
+          type: string
+          nullable: true
+
+    SearchTaskSlasResponse:
+      type: object
+      properties:
+        slas:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaskSlaView'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    TaskSlaDefinitionDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+        target:
+          type: string
+          nullable: true
+        flow:
+          type: string
+          nullable: true
+        workflow:
+          type: string
+          nullable: true
+        isEnableLogging:
+          type: boolean
+          nullable: true
+        durationType:
+          type: string
+          nullable: true
+        duration:
+          type: string
+          nullable: true
+        scheduleSource:
+          type: string
+          nullable: true
+        schedule:
+          type: string
+          nullable: true
+        timezoneSource:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+        startCondition:
+          type: string
+          nullable: true
+        isRetroactiveStart:
+          type: boolean
+          nullable: true
+        isRetroactivePause:
+          type: boolean
+          nullable: true
+        whenToCancel:
+          type: string
+          nullable: true
+        cancelCondition:
+          type: string
+          nullable: true
+        pauseCondition:
+          type: string
+          nullable: true
+        whenToResume:
+          type: string
+          nullable: true
+        stopCondition:
+          type: string
+          nullable: true
+        resetCondition:
+          type: string
+          nullable: true
+        resetAction:
+          type: string
+          nullable: true
+
+    TaskSlaScheduleRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+
+    TaskSlaDetail:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+          format: uuid
+        task:
+          $ref: '#/components/schemas/TaskSlaTaskRef'
+          nullable: true
+        slaDefinition:
+          $ref: '#/components/schemas/TaskSlaDefinitionDetail'
+          nullable: true
+        stage:
+          type: string
+          nullable: true
+        businessTimeLeft:
+          type: string
+          nullable: true
+        businessElapsedTime:
+          type: string
+          nullable: true
+        businessElapsedPercentage:
+          type: number
+          format: double
+          nullable: true
+        startTime:
+          type: string
+          nullable: true
+        endTime:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+          nullable: true
+        schedule:
+          $ref: '#/components/schemas/TaskSlaScheduleRef'
+          nullable: true


### PR DESCRIPTION
## Summary
- Wires up `POST /slas/search` and `GET /slas/{id}` in the CSM portal backend, following entity-service PR [#1048](https://github.com/wso2-open-operations/cs-tools/pull/1048)
- Adds `SearchTaskSlas` and `GetTaskSla` methods to the entity client
- New `TaskSlaHandler` with full auth, body-size, and UUID validation guards
- OpenAPI spec updated with new paths and schemas (`SearchTaskSlasPayload`, `SearchTaskSlasResponse`, `TaskSlaDetail`, and supporting refs)

## Test plan
- [x] `POST /slas/search` with no body returns paginated results
- [x] `POST /slas/search` with `taskIds` filter returns filtered results
- [x] `GET /slas/{id}` with a valid UUID returns the full SLA detail
- [x] `GET /slas/{id}` with an invalid UUID returns 400
- [x] Both endpoints return 401 when JWT is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task SLA support with two new API endpoints for searching SLA records and fetching a single SLA by ID.
  * Exposed SLA data in the API schema, including search filters, pagination, and detailed SLA information.
* **Bug Fixes**
  * Improved request validation and error handling for invalid IDs, oversized requests, and malformed JSON.
  * Added consistent authentication checks and JSON error responses for SLA requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->