### PR TITLE
[CSM Portal] time cards: search unscoped by default instead of forcing all-project scope

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -239,11 +239,10 @@ function groupCardsByUserIntoSheets(cards: CsmTimeCard[]): CsmTimeSheet[] {
  * reflect just this user's cards — paginating over a project-wide page and
  * filtering to "mine" client-side would make `total` and the page size
  * meaningless here (a page of 20 project-wide cards could easily contain
- * none of the signed-in user's own). `filters.projectIds` must still be
- * non-empty — the backend requires it to return anything (see
- * {@link searchTimeCards}) — so this stays disabled until the caller has
- * resolved a real project scope (defaulted to every visible project when
- * the user hasn't picked one — see `CsmTimeCardsPage.tsx`).
+ * none of the signed-in user's own). No project scope is required: with no
+ * project filter picked the search runs unscoped and the backend returns
+ * every card the caller is entitled to, bounded here to the signed-in user
+ * by `userId` (see `CsmTimeCardsPage.tsx`).
  *
  * `enabled` should be gated on the owning tab actually being active (see
  * `CsmTimeCardsPage.tsx`) — confirmed live: with this, {@link useAllTimeCards}
@@ -269,7 +268,7 @@ export function useMyTimeSheets(
       );
       return { sheets: groupIntoSheets(cards, me.id, me.name), total };
     },
-    enabled: enabled && !!me.id && !!filters?.projectIds?.length,
+    enabled: enabled && !!me.id,
     staleTime: 5_000,
   });
 }
@@ -285,9 +284,9 @@ export function useMyTimeSheets(
  * cards client-side as a defense-in-depth self-approval guard: a card
  * created before `LogTimeCardDialog` started excluding the submitter from
  * the approver picker could still name themselves as an eligible approver.
- * Like {@link useMyTimeSheets}, this requires `filters.projectIds` to be
- * non-empty to get anything back, and `enabled` should be gated on this tab
- * actually being active (see the note on {@link useMyTimeSheets} for why).
+ * Like {@link useMyTimeSheets}, no project scope is required (the search runs
+ * unscoped when no project filter is picked), and `enabled` should be gated on
+ * this tab actually being active (see the note on {@link useMyTimeSheets}).
  */
 export function useApprovalQueue(
   enabled: boolean,
@@ -308,7 +307,7 @@ export function useApprovalQueue(
       const others = cards.filter((c) => c.userId !== me.id);
       return { sheets: groupCardsByUserIntoSheets(others), total };
     },
-    enabled: enabled && !!me.id && !!filters?.projectIds?.length,
+    enabled: enabled && !!me.id,
     staleTime: 5_000,
   });
 }
@@ -316,11 +315,11 @@ export function useApprovalQueue(
 /**
  * Every visible user's sheets on the requested page, own included — unlike
  * {@link useMyTimeSheets} (self only) and {@link useApprovalQueue} (others'
- * submitted cards only, for deciding), this is a read-only "see everything
- * in scope" view: no state restriction, no ownership exclusion. Requires
- * `filters.projectIds` to be non-empty, same as every other search here,
- * and `enabled` should be gated on this tab actually being active (see the
- * note on {@link useMyTimeSheets} for why).
+ * submitted cards only, for deciding), this is a read-only "see everything"
+ * view: no state restriction, no ownership exclusion. Runs unscoped when no
+ * project filter is picked (the backend returns the caller's full
+ * entitlement), and `enabled` should be gated on this tab actually being
+ * active (see the note on {@link useMyTimeSheets} for why).
  */
 export function useAllTimeCards(
   enabled: boolean,
@@ -335,7 +334,7 @@ export function useAllTimeCards(
       const { cards, total } = await searchTimeCards(api, filters, pagination);
       return { sheets: groupCardsByUserIntoSheets(cards), total };
     },
-    enabled: enabled && !!me.id && !!filters?.projectIds?.length,
+    enabled: enabled && !!me.id,
     staleTime: 5_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -131,15 +131,13 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const [filterEngineer, setFilterEngineer] = useState<string[]>([]);
 
   const projects = useProjectOptions();
-  // The backend requires a non-empty `projectIds` to return anything at all
-  // (confirmed live — an unscoped search always returns `total: 0`, despite
-  // the OpenAPI spec documenting it as optional). Default to every project
-  // the user can see (already fetched for the filter dropdown below) so
-  // "My time sheets" / "Approvals" work with no filter picked; the explicit
-  // project filter narrows that down when set (to one or several).
-  const scopeProjectIds = filterProject.length
-    ? filterProject
-    : (projects.data ?? []).map((p) => p.id);
+  // Search is unscoped by default: with no project filter picked we send no
+  // `projectIds`, and the backend returns every time card the caller is
+  // entitled to (internal agents get a global list). Picking the project
+  // filter narrows it to the chosen project(s). "My time sheets" and
+  // "Approvals" are further bounded server-side by the signed-in user /
+  // approver, so they stay correct unscoped too.
+  const scopeProjectIds = filterProject;
 
   const baseFilters: TimeCardSearchFilters = {
     ...(scopeProjectIds.length && { projectIds: scopeProjectIds }),


### PR DESCRIPTION
## Purpose

The three `/time-cards` tabs (My time sheets, All, Approvals) default `filters.projectIds` to *every* project the user can see when no project filter is picked. That was a workaround: the time-card search returned nothing without a project scope, so the UI padded every request with the full ~88-project list. That forces a large scope on every call and couples the search to the project list finishing loading.

The backing search now supports an **unscoped (global) query for internal agents**, so this PR makes the UI use it: with no project filter selected, send no `projectIds` and let the backend return the caller's full entitlement. This is an improvement to how the tabs scope their search, not a bug fix.

No tracked issue link (the umbrella item lives on a private board); the backing search change is tracked separately with the team.

## Goals

- Stop forcing an all-projects scope on the time-card tabs; search unscoped by default.
- Keep the explicit project filter working (narrows to the chosen project(s)).
- Keep **My time sheets** and **Approvals** correct unscoped — they are already bounded server-side by `userId` / `approverId`.

## Approach

- `CsmTimeCardsPage.tsx`: `scopeProjectIds` is now just the selected project filter (empty when none picked), instead of falling back to every visible project. `baseFilters` therefore omits `projectIds` when nothing is selected.
- `useTimeSheets.ts`: the three tab queries (`useMyTimeSheets`, `useApprovalQueue`, `useAllTimeCards`) no longer gate `enabled` on `!!filters?.projectIds?.length`, so they run unscoped. `searchTimeCards` already omits `projectIds` from the payload when the array is empty, so no change there.
- Updated the now-inaccurate JSDoc that said a non-empty `projectIds` was required.

**Depends on (merge/deploy gate):** the unscoped path only returns data when (1) the backing search change is live on the data source the target environment uses, and (2) the calling identity holds an internal agent role. Until both hold in a given environment, unscoped tabs would come back empty there. This is why it's a separate, reviewable change rather than folded into the earlier filter work.

## User stories

- As an internal agent, I see all time cards I'm entitled to without the UI having to enumerate every project, and a project filter still narrows the list.

## Release note

Time-card tabs now search across all entitled records by default instead of requiring an all-projects scope; the project filter still narrows results.

## Documentation

N/A — internal CSM portal UI, no external product documentation covers this feature.

## Training

N/A — not training content.

## Certification

N/A — no certification exam impact.

## Marketing

N/A — internal tooling, not customer-facing marketing content.

## Automation tests
 - Unit tests

   `pnpm test` — all `csm-timecards` suites pass; `tsc -b` clean; `pnpm build` clean; `eslint` clean on the two changed files. (Pre-existing, unrelated failures on the base branch: `csm-cases/CaseActionBar.test.tsx` and an `eslint` error in `csm-operations/ChangeRequestsFilterBar.tsx` — both present before this change and outside its scope.)
 - Integration tests

   Existing time-card Playwright specs are unchanged. A full live E2E run depends on the backing unscoped search being live in the target environment (see the merge/deploy gate under Approach); not re-run here.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — frontend TypeScript/React change, not a JVM component; `eslint`/`tsc` run clean on the changed files. Authorization for the unscoped path is enforced server-side (internal-agent role check), not in the client.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Follows the time-card filter/pagination work in #1055 (merged into `dev-app-csm-portal`).

## Migrations (if applicable)

N/A — no data migration; frontend request-scoping change only.

## Test environment

Node + pnpm; Vite build; Vitest unit tests. Verified locally against `dev-app-csm-portal`.

## Learning

N/A
