### PR TITLE
[CSM Portal] severity filter on support cases only, drop cases-list account scan, dashboard refresh buttons

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -14,28 +14,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import {
-  useQuery,
-  useQueryClient,
-  type UseQueryResult,
-} from "@tanstack/react-query";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
-import { useBackendApi, type BackendApi } from "@api/backend/client";
+import { useBackendApi } from "@api/backend/client";
 import {
   beStateFromUi,
   priorityFromSeverity,
   severityFromPriority,
   uiStateFromBe,
 } from "@api/backend/mappers";
-import { projectOptionsQueryOptions } from "@features/csm-cases/api/useProjectOptions";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import type {
-  BeAccount,
-  BeAccountSearchPayload,
-  BeAccountSearchResponse,
   BeCaseSearchPayload,
   BeCaseSearchResponse,
   BeUserSearchResponse,
@@ -46,56 +38,17 @@ import type {
   CsmCasesListResponse,
 } from "@features/csm-cases/types/csmCases";
 
-/** Page size for the account name lookup (customer column). */
-const LOOKUP_PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
-// Cap the account scan the same way useProjectOptions caps the project scan.
-// Doubled from 20 when the page limit halved to BE_MAX_PAGE_LIMIT, so the total
-// scan ceiling (pages * limit) is unchanged.
-const LOOKUP_MAX_PAGES = 40;
-
-/**
- * Query options for the account-name lookup (`POST /accounts/search`). Kept as
- * its own stably-keyed query (resolved via `queryClient.fetchQuery`) so filter
- * changes on the cases list — which change the cases query key — reuse the
- * cached directory instead of re-fetching every account each time.
- */
-function accountOptionsQueryOptions(api: BackendApi) {
-  return {
-    queryKey: [ApiQueryKeys.CSM_ACCOUNTS, "options"],
-    queryFn: async (): Promise<BeAccount[]> => {
-      const all: BeAccount[] = [];
-      let offset = 0;
-      for (let page = 0; page < LOOKUP_MAX_PAGES; page += 1) {
-        const res = await api.post<
-          BeAccountSearchPayload,
-          BeAccountSearchResponse
-        >("/accounts/search", {
-          pagination: { offset, limit: LOOKUP_PAGE_LIMIT },
-        });
-        const accounts = res.accounts ?? [];
-        all.push(...accounts);
-        if (accounts.length < LOOKUP_PAGE_LIMIT) break;
-        offset += LOOKUP_PAGE_LIMIT;
-      }
-      return all;
-    },
-    staleTime: 60_000,
-  } as const;
-}
-
 /**
  * Cross-project CSM cases list.
  *
  * Does a single `POST /cases/search` (the flat, cross-project search)
  * and maps each rich `CaseSearchView` — which embeds project / deployment /
- * deployed-product — to the UI `CsmCaseRow`. The account (customer) name is the
- * only field not embedded, so it's resolved via `projects/search`
- * (projectId → accountId) + `accounts/search` (accountId → name). Both lookups
- * live under their own stable query keys (resolved with
- * `queryClient.fetchQuery`), so changing list filters only re-runs
- * `/cases/search`; the project/account directories come from cache until they
- * go stale. The project lookup shares `useProjectOptions`' key, which the
- * cases page already mounts for its filter options.
+ * deployed-product — to the UI `CsmCaseRow`. The list has no Customer column,
+ * so the customer (account) name is deliberately not resolved: doing so used to
+ * page the entire account directory (`/accounts/search` has no ID filter, and
+ * the case search view doesn't embed the account) to fill a field nothing
+ * renders. If a Customer column is added, resolve the name from the search view
+ * once it carries the account, not by scanning the directory.
  *
  * Search and the severity / state / case-type / project filters are pushed
  * into the search payload (searchQuery / severities / states / types /
@@ -115,7 +68,6 @@ export function useGetCsmCases(
 ): UseQueryResult<CsmCasesListResponse, Error> {
   const logger = useLogger();
   const api = useBackendApi();
-  const queryClient = useQueryClient();
   // Signed-in email, to resolve `assigneeIsMe` per row against the assigned
   // engineer's email. In the key so a late-arriving claim recomputes.
   const currentUserEmail = useIdTokenClaims()?.email;
@@ -199,13 +151,13 @@ export function useGetCsmCases(
         return { cases: [], total: 0, limit: pageSize, offset, hasMore: false };
       }
 
-      // One cross-project case search, plus project/account lookups for the
-      // customer column (cases embed the project, but not its account). The
-      // lookups go through `fetchQuery` with their own stable keys, so they
-      // hit the network only when their cache is stale — not on every filter
-      // change. Lookup failures degrade to blank names, not a failed list.
-      const [casesResponse, projects, accounts] = await Promise.all([
-        api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
+      // One cross-project case search. No account/project directory scan: the
+      // list has no Customer column, and the old scan paged the entire account
+      // directory to resolve a name nothing renders.
+      const casesResponse = await api.post<
+        BeCaseSearchPayload,
+        BeCaseSearchResponse
+      >("/cases/search", {
           pagination: { offset, limit: pageSize },
           sortBy: { field: "updatedOn", order: "desc" },
           // Filter fields are nested under `filters` (BE payload restructure).
@@ -242,36 +194,11 @@ export function useGetCsmCases(
               productNames: filters.productNames,
             }),
           },
-        }),
-        queryClient.fetchQuery(projectOptionsQueryOptions(api)).catch((err) => {
-          logger.warn(
-            `[useGetCsmCases] project lookup failed: ${(err as Error).message}`,
-          );
-          return [];
-        }),
-        queryClient.fetchQuery(accountOptionsQueryOptions(api)).catch((err) => {
-          logger.warn(
-            `[useGetCsmCases] account lookup failed: ${(err as Error).message}`,
-          );
-          return [];
-        }),
-      ]);
-
-      const projectAccount = new Map<string, string>(
-        projects
-          .filter((p) => p.accountId)
-          .map((p) => [p.id, p.accountId as string]),
-      );
-      const accountName = new Map<string, string>(
-        accounts
-          .filter((a) => a.name)
-          .map((a) => [a.id, a.name as string]),
-      );
+      });
 
       const myEmail = currentUserEmail?.toLowerCase();
       const cases: CsmCaseRow[] = (casesResponse.cases ?? []).map((c) => {
         const projectId = c.project?.id ?? "";
-        const accountId = projectAccount.get(projectId) ?? "";
         const assigneeEmail = c.assignedEngineer?.email;
         const assignee =
           c.assignedEngineer?.name?.trim() || assigneeEmail || "Unassigned";
@@ -282,8 +209,10 @@ export function useGetCsmCases(
           caseNumber: c.number,
           wso2CaseId: c.internalId,
           subject: c.subject ?? "(no subject)",
-          customer: accountName.get(accountId) ?? "-",
-          accountId,
+          // Not shown in the list; kept on the row shape but no longer resolved
+          // (see the account-scan removal note above).
+          customer: "",
+          accountId: "",
           projectId,
           projectName: c.project?.name ?? "-",
           // Search embeds deployedProduct as { id, name } (name includes the

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -121,6 +121,12 @@ interface CasesFilterBarProps {
   availableAssigneeUsers: AssigneeUser[];
   /** Projects for the (id-based) project filter — value is the id, label the name. */
   availableProjects: { id: string; name: string }[];
+  /**
+   * Show the severity control. Severity (S1-S4) is a support-case concept, so
+   * this is only meaningful when the list is scoped to support cases; other
+   * record types (service requests, engagements, etc.) hide it.
+   */
+  showSeverityFilter?: boolean;
   /** Hide the case-type control when the surrounding view locks the type. */
   hideTypeFilter?: boolean;
   /** Hide the project control when the surrounding view is project-scoped. */
@@ -169,6 +175,7 @@ export default function CasesFilterBar({
   onFiltersToggle,
   availableAssigneeUsers,
   availableProjects,
+  showSeverityFilter = true,
   hideTypeFilter = false,
   hideProjectFilter = false,
   showEngagementTypeFilter = false,
@@ -431,15 +438,17 @@ export default function CasesFilterBar({
         <>
           <Divider />
           <Grid container spacing={2} sx={{ mt: 0 }}>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              <MultiSelectField
-                id="cases-filter-severity"
-                label="Severity"
-                values={filters.severities}
-                options={severityOptions}
-                onChange={(next) => onChange({ ...filters, severities: next })}
-              />
-            </Grid>
+            {showSeverityFilter && (
+              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+                <MultiSelectField
+                  id="cases-filter-severity"
+                  label="Severity"
+                  values={filters.severities}
+                  options={severityOptions}
+                  onChange={(next) => onChange({ ...filters, severities: next })}
+                />
+              </Grid>
+            )}
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
               <MultiSelectField
                 id="cases-filter-state"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -116,12 +116,27 @@ export default function CsmIssuesView({
     [searchParams, setSearchParams],
   );
 
+  // Severity (S1-S4) is a support-case concept, so the severity filter is only
+  // shown on the support-cases list — i.e. when the surrounding view locks the
+  // record type to `case`. Every other list (service requests, engagements,
+  // security reports, mixed project issues) hides it.
+  const showSeverityFilter =
+    lockedFilters?.caseTypes?.length === 1 &&
+    lockedFilters.caseTypes[0] === "case";
+
   const debouncedSearch = useDebouncedValue(filters.search, 300);
   // User filters (debounced search) with the locked overrides applied last so
   // the fixed type/project can't be widened by a stale URL value.
   const queryFilters = useMemo<CasesFilters>(
-    () => ({ ...filters, search: debouncedSearch, ...lockedFilters }),
-    [filters, debouncedSearch, lockedFilters],
+    () => ({
+      ...filters,
+      search: debouncedSearch,
+      // The severity control is hidden for non-case lists, so don't let a stale
+      // `severities` value from a shared URL silently filter those results.
+      ...(showSeverityFilter ? {} : { severities: [] }),
+      ...lockedFilters,
+    }),
+    [filters, debouncedSearch, showSeverityFilter, lockedFilters],
   );
 
   const { data, isLoading, isError, error } = useGetCsmCases(
@@ -236,6 +251,7 @@ export default function CsmIssuesView({
         onFiltersToggle={() => setIsFiltersOpen((v) => !v)}
         availableAssigneeUsers={availableAssigneeUsers}
         availableProjects={availableProjects}
+        showSeverityFilter={showSeverityFilter}
         hideTypeFilter={hideTypeFilter}
         hideProjectFilter={hideProjectFilter}
         showEngagementTypeFilter={showEngagementTypeFilter}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
@@ -23,6 +23,7 @@ import {
   useCaseComposition,
 } from "@features/csm-dashboard/api/useCaseComposition";
 import { MATRIX_SEVERITIES } from "@features/csm-dashboard/api/useCaseCountsMatrix";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import CompositionDonut, {
   type CompositionSlice,
 } from "@features/csm-dashboard/components/CompositionDonut";
@@ -61,7 +62,8 @@ const STATE_SLICE_COLOR: Record<CaseState, string> = {
  * {@link useCaseComposition} query.
  */
 export default function CaseCompositionCharts(): JSX.Element {
-  const { data, isLoading, isError } = useCaseComposition();
+  const { data, isLoading, isError, isFetching, dataUpdatedAt, refetch } =
+    useCaseComposition();
   const navigate = useNavigate();
 
   const severitySlices = useMemo<CompositionSlice[]>(
@@ -90,6 +92,24 @@ export default function CaseCompositionCharts(): JSX.Element {
 
   return (
     <Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+          mb: 1.5,
+          flexWrap: "wrap",
+        }}
+      >
+        <Typography variant="h6">Case composition</Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh case composition"
+        />
+      </Box>
       <Box
         sx={{
           display: "grid",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -39,6 +39,7 @@ import type {
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 /** Build a `/cases?...` href for the given severity and/or state filter. */
 function casesHref(severity?: Severity, state?: CaseState): string {
@@ -81,10 +82,21 @@ function CountCell({
 }
 
 export default function CaseCountsMatrix(): JSX.Element {
-  const { data, isLoading, isError } = useCaseCountsMatrix();
+  const { data, isLoading, isError, isFetching, dataUpdatedAt, refetch } =
+    useCaseCountsMatrix();
 
   return (
-    <SectionCard title="Cases by severity and state">
+    <SectionCard
+      title="Cases by severity and state"
+      action={
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh case counts"
+        />
+      }
+    >
       {isLoading ? (
         <Skeleton variant="rounded" height={220} />
       ) : isError || !data ? (

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Link, TablePagination, Typography } from "@wso2/oxygen-ui";
+import { Box, Link, TablePagination, Typography } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
@@ -26,6 +26,7 @@ import {
 } from "@features/csm-dashboard/api/useGetMyAssignedOpenCases";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 // Deep-link to the full cases list, pre-filtered to the caller's non-closed
 // cases. `assignees=@me` resolves against the current user server-side; the
@@ -45,10 +46,8 @@ const VIEW_ALL_HREF = `/cases?assignees=${encodeURIComponent(
 export default function MyAssignedCases(): JSX.Element {
   const currentUser = useCurrentUser();
   const [page, setPage] = useState(0);
-  const { data, isLoading, isError } = useGetMyAssignedOpenCases(
-    page,
-    MY_OPEN_CASES_PAGE_SIZE,
-  );
+  const { data, isLoading, isError, isFetching, refetch } =
+    useGetMyAssignedOpenCases(page, MY_OPEN_CASES_PAGE_SIZE);
 
   // `/users/me` returned but carried no id (entity service down): we can't tell
   // which cases are the caller's, so say so rather than showing nothing.
@@ -79,16 +78,23 @@ export default function MyAssignedCases(): JSX.Element {
       title="Assigned to me"
       subtitle={subtitle}
       action={
-        total > 0 ? (
-          <Link
-            component={RouterLink}
-            to={VIEW_ALL_HREF}
-            underline="hover"
-            variant="body2"
-          >
-            View all
-          </Link>
-        ) : undefined
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          {total > 0 ? (
+            <Link
+              component={RouterLink}
+              to={VIEW_ALL_HREF}
+              underline="hover"
+              variant="body2"
+            >
+              View all
+            </Link>
+          ) : null}
+          <RefreshButton
+            onRefresh={() => void refetch()}
+            isFetching={isFetching}
+            label="Refresh assigned cases"
+          />
+        </Box>
       }
     >
       {isError ? (

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/RefreshButton.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/RefreshButton.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { RefreshCw } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
+
+interface RefreshButtonProps {
+  /** Re-runs the widget's query. Wire to the react-query `refetch`. */
+  onRefresh: () => void;
+  /** True while a fetch is in flight; disables the control to avoid re-entrancy. */
+  isFetching: boolean;
+  /** react-query `dataUpdatedAt` (ms). When set, shows a "Last refreshed" hint. */
+  updatedAt?: number;
+  /** Accessible label / tooltip, e.g. "Refresh assigned cases". */
+  label: string;
+}
+
+/**
+ * Reusable dashboard-widget refresh control. Mirrors the SLA table's refresh
+ * button (icon button + "last refreshed" hint), so refresh looks and behaves
+ * the same across the app.
+ */
+export default function RefreshButton({
+  onRefresh,
+  isFetching,
+  updatedAt,
+  label,
+}: RefreshButtonProps): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      {updatedAt ? (
+        <Typography variant="caption" color="text.secondary">
+          Last refreshed{" "}
+          {formatRelativeTime(new Date(updatedAt).toISOString())}
+        </Typography>
+      ) : null}
+      <Tooltip title={label}>
+        {/* span wrapper so the tooltip still shows while the button is disabled */}
+        <span>
+          <IconButton
+            size="small"
+            onClick={onRefresh}
+            disabled={isFetching}
+            aria-label={label}
+          >
+            <RefreshCw size={14} />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Three focused CSM-portal UI improvements, tracked on the internal delivery board:

1. **Severity filter shown everywhere.** The severity (S1–S4) multi-select is a support-case concept, but it was rendered on every issue list (service requests, engagements, security reports, mixed project issues), where it has no meaning.
2. **Cases list scanned the whole account directory.** The cross-project cases/issues list has no Customer column, yet the list query paged through the entire account directory (and a project→account bridge) to resolve a customer name that nothing renders — wasted round-trips on every list view.
3. **No way to refresh a dashboard widget.** The engineer dashboard widgets had no manual refresh; users had to reload the page to pull fresh data.

Resolves: tracked on the internal delivery board (no public issue link).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Show the severity filter only on the support-cases list; hide it on all other record types.
2. Stop the account-directory scan for the cases list; it becomes a single search call.
3. Add a per-widget refresh control to the dashboard widgets, consistent with the existing SLA-table refresh.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI.

1. **Severity filter (cases-only):** add an optional `showSeverityFilter` prop to `CasesFilterBar` (defaults to `true` for back-compat) that gates the severity control, mirroring the existing `showEngagementTypeFilter` pattern. `CsmIssuesView` derives it once from a record-type lock of exactly `case` and passes it down; it also clears any stale `severities` value from the query on non-case lists so a shared URL can't silently filter them.
2. **Drop the account scan:** `useGetCsmCases` no longer resolves customer names — that resolution required paging the entire account directory (the search endpoints accept no id filter, and the cases search view does not embed the account), all to fill a column the list does not render. The hook now issues a single cases search. `customer`/`accountId` remain on the row shape but are left blank; if a Customer column is added later, the name should come from the search view once it embeds the account, not from a directory scan.
3. **Dashboard refresh:** a small reusable `RefreshButton` (icon button wired to the widget's react-query `refetch`, disabled while a fetch is in flight, with an optional "last refreshed" hint) is added to the three engineer-dashboard widgets. Each refresh re-runs the widget's existing cases-search query only.

## User stories
> Summary of user stories addressed by this change

- As a CS engineer, I only see the severity filter where it applies (support cases), reducing filter clutter on other lists.
- As a CS engineer, the cases/issues lists load without redundant directory round-trips.
- As a CS engineer, I can refresh an individual dashboard widget without reloading the page.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

CSM portal: severity filter now appears only on the support-cases list; the cases list no longer scans the full account directory; dashboard widgets gain a refresh button.

## Documentation
> Link(s) to product documentation...

N/A — internal CS-engineer UI changes with no external product-documentation impact.

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — internal tooling change, not customer-facing.

## Automation tests
 - Unit tests
   > No new unit tests: the changes are presentational wiring (prop-gated control, hook simplification, a refresh button wired to existing react-query `refetch`). `tsc`, `eslint`, and the existing `csm-cases` test suite pass (pre-existing unrelated `CaseActionBar` test failures are present on the base branch and untouched here).
 - Integration tests
   > N/A — no new endpoints or contracts.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** — TypeScript/React change; `eslint` ran clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
N/A — no data-model or schema changes.

## Test environment
Local CSM-portal stack (Vite dev server, Chrome latest).

## Learning
Matched the existing SLA-table refresh control for the dashboard refresh button, and reused the existing filter-bar conditional-control pattern (`showEngagementTypeFilter`) for the severity gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refresh controls to dashboard widgets, including last-updated timestamps and loading states.
  * Introduced a reusable refresh button used across multiple case summary cards.
  * Made the severity filter optionally hideable and only shown for specific case lists.

* **Bug Fixes**
  * Improved case list filtering so severity selections no longer affect lists where that filter should be unavailable.
  * Simplified case list loading for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->