### PR TITLE
[CSM Portal] add case activities search endpoint (comments, attachments, field changes)

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1080,6 +1080,71 @@ type SearchCaseCommentsResponse struct {
 	HasMore  bool          `json:"hasMore"`
 }
 
+// ActivityType classifies an entry in a case activity feed.
+type ActivityType string
+
+const (
+	// ActivityTypeComment is a comment or work note on the case.
+	ActivityTypeComment ActivityType = "comment"
+	// ActivityTypeAttachment is a file attached to the case.
+	ActivityTypeAttachment ActivityType = "attachment"
+	// ActivityTypeFieldChange is a recorded change to one or more case fields.
+	ActivityTypeFieldChange ActivityType = "field_change"
+)
+
+// FieldChange describes a single field mutation recorded on a case.
+type FieldChange struct {
+	Field         string `json:"field"`
+	FieldLabel    string `json:"fieldLabel"`
+	PreviousValue string `json:"previousValue"`
+	NewValue      string `json:"newValue"`
+}
+
+// CaseActivity is a single entry in a case activity feed. It is a discriminated
+// union on Type: the shared fields are always present, while the type-specific
+// fields are populated only for the matching Type (CommentType for comments;
+// FileName/ContentType/SizeBytes/DownloadURL for attachments; Changes for field
+// changes).
+type CaseActivity struct {
+	ID                 string       `json:"id"`
+	Type               ActivityType `json:"type"`
+	Content            string       `json:"content"`
+	CreatedOn          time.Time    `json:"createdOn"`
+	CreatedBy          string       `json:"createdBy"`
+	CreatedByFirstName string       `json:"createdByFirstName"`
+	CreatedByLastName  string       `json:"createdByLastName"`
+	CreatedByFullName  string       `json:"createdByFullName"`
+	// CommentType is set only for Type == ActivityTypeComment.
+	CommentType *CommentType `json:"commentType,omitempty"`
+	// FileName, ContentType, SizeBytes, and DownloadURL are set only for
+	// Type == ActivityTypeAttachment.
+	FileName    string `json:"fileName,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
+	SizeBytes   int    `json:"sizeBytes,omitempty"`
+	DownloadURL string `json:"downloadUrl,omitempty"`
+	// Changes is set only for Type == ActivityTypeFieldChange.
+	Changes []FieldChange `json:"changes,omitempty"`
+}
+
+// SearchCaseActivitiesRequest is the input for listing the activity feed of a case.
+// CaseID is populated from the URL path parameter and is not part of the JSON body.
+// When IncludeFieldChanges is nil or false, only comment and attachment entries are returned.
+type SearchCaseActivitiesRequest struct {
+	CaseID              string     `json:"-"`
+	Pagination          Pagination `json:"pagination"`
+	IncludeFieldChanges *bool      `json:"includeFieldChanges,omitempty"`
+}
+
+// SearchCaseActivitiesResponse is the paginated result of a case activity search.
+// HasMore is true when additional pages are available beyond the current offset.
+type SearchCaseActivitiesResponse struct {
+	Activity []CaseActivity `json:"activity"`
+	Total    int            `json:"total"`
+	Limit    int            `json:"limit"`
+	Offset   int            `json:"offset"`
+	HasMore  bool           `json:"hasMore"`
+}
+
 // Comment is a generic comment associated with any reference entity type
 // (case, conversation, change_request, etc.).
 type Comment struct {

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -134,6 +134,22 @@ func (h *CaseHandler) SearchCaseComments(w http.ResponseWriter, r *http.Request)
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// SearchCaseActivities handles POST /cases/{id}/activities/search.
+func (h *CaseHandler) SearchCaseActivities(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchCaseActivitiesRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.CaseID = r.PathValue("id")
+	resp, err := h.svc.SearchCaseActivities(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // SearchCases handles POST /cases/search.
 func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchCasesRequest

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -217,6 +217,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
+	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -445,6 +445,10 @@ func (s *caseService) SearchCaseAttachments(_ context.Context, _ domain.SearchAt
 	return domain.SearchAttachmentsResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
 }
 
+func (s *caseService) SearchCaseActivities(_ context.Context, _ domain.SearchCaseActivitiesRequest) (domain.SearchCaseActivitiesResponse, error) {
+	return domain.SearchCaseActivitiesResponse{}, &apierror.ServiceUnavailableError{Msg: "case activities are only supported for the ServiceNow data source"}
+}
+
 func (s *caseService) GetCaseAttachmentContent(_ context.Context, _ string) ([]byte, string, error) {
 	return nil, "", &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -169,6 +169,11 @@ type CaseService interface {
 	// SearchCaseAttachments returns a paginated list of attachments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseAttachments(ctx context.Context, req domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error)
+	// SearchCaseActivities returns a paginated activity feed (comments, attachments, and
+	// optionally field changes) for the case identified by req.CaseID. Field-change entries
+	// are included only when req.IncludeFieldChanges is set. A ValidationError is returned
+	// for invalid input. Supported by the ServiceNow data source only.
+	SearchCaseActivities(ctx context.Context, req domain.SearchCaseActivitiesRequest) (domain.SearchCaseActivitiesResponse, error)
 	// GetCaseAttachmentContent returns the raw binary content and its Content-Type
 	// for the attachment identified by attachmentID.
 	// A NotFoundError is returned if absent.

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1126,6 +1126,131 @@ func (s *snCaseService) SearchCaseAttachments(ctx context.Context, req domain.Se
 	}, nil
 }
 
+type snSearchActivitiesPayload struct {
+	Pagination          snProjectPagination `json:"pagination"`
+	IncludeFieldChanges *bool               `json:"includeFieldChanges,omitempty"`
+}
+
+type snFieldChange struct {
+	Field         string `json:"field"`
+	FieldLabel    string `json:"fieldLabel"`
+	PreviousValue string `json:"previousValue"`
+	NewValue      string `json:"newValue"`
+}
+
+type snActivity struct {
+	ID                 string          `json:"id"`
+	Type               string          `json:"type"`
+	Content            string          `json:"content"`
+	CreatedOn          string          `json:"createdOn"`
+	CreatedBy          string          `json:"createdBy"`
+	CreatedByFirstName string          `json:"createdByFirstName"`
+	CreatedByLastName  string          `json:"createdByLastName"`
+	CreatedByFullName  string          `json:"createdByFullName"`
+	CommentType        string          `json:"commentType"`
+	FileName           string          `json:"fileName"`
+	ContentType        string          `json:"contentType"`
+	SizeBytes          int             `json:"sizeBytes"`
+	DownloadURL        string          `json:"downloadUrl"`
+	Changes            []snFieldChange `json:"changes"`
+}
+
+type snSearchActivitiesResponse struct {
+	Activity     []snActivity `json:"activity"`
+	Offset       int          `json:"offset"`
+	Limit        int          `json:"limit"`
+	TotalRecords int          `json:"totalRecords"`
+}
+
+func (s *snCaseService) SearchCaseActivities(ctx context.Context, req domain.SearchCaseActivitiesRequest) (domain.SearchCaseActivitiesResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchCaseActivitiesResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchCaseActivitiesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	if err := validateUUIDs("id", []string{req.CaseID}); err != nil {
+		return domain.SearchCaseActivitiesResponse{}, err
+	}
+
+	payload := snSearchActivitiesPayload{
+		Pagination:          snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+		IncludeFieldChanges: req.IncludeFieldChanges,
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/"+uuidToSysid(req.CaseID)+"/activities/search", token, payload)
+	if err != nil {
+		return domain.SearchCaseActivitiesResponse{}, err
+	}
+
+	var snResp snSearchActivitiesResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchCaseActivitiesResponse{}, fmt.Errorf("sn search activities: parse response: %w", err)
+	}
+
+	activities := make([]domain.CaseActivity, 0, len(snResp.Activity))
+	for _, a := range snResp.Activity {
+		createdOn, err := time.Parse(snCreatedOnLayout, a.CreatedOn)
+		if err != nil {
+			return domain.SearchCaseActivitiesResponse{}, fmt.Errorf("sn search activities: parse createdOn %q: %w", a.CreatedOn, err)
+		}
+		activity := domain.CaseActivity{
+			ID:                 sysidToUUID(a.ID),
+			Type:               domain.ActivityType(a.Type),
+			Content:            a.Content,
+			CreatedOn:          createdOn,
+			CreatedBy:          a.CreatedBy,
+			CreatedByFirstName: a.CreatedByFirstName,
+			CreatedByLastName:  a.CreatedByLastName,
+			CreatedByFullName:  a.CreatedByFullName,
+		}
+		switch domain.ActivityType(a.Type) {
+		case domain.ActivityTypeComment:
+			var ct domain.CommentType
+			switch a.CommentType {
+			case "comments", "comment":
+				ct = domain.CommentTypeComment
+			case "work_notes", "work_note":
+				ct = domain.CommentTypeWorkNote
+			case "activity":
+				ct = domain.CommentTypeActivity
+			default:
+				ct = domain.CommentTypeComment
+			}
+			activity.CommentType = &ct
+		case domain.ActivityTypeAttachment:
+			activity.FileName = a.FileName
+			activity.ContentType = a.ContentType
+			activity.SizeBytes = a.SizeBytes
+			activity.DownloadURL = a.DownloadURL
+		case domain.ActivityTypeFieldChange:
+			changes := make([]domain.FieldChange, 0, len(a.Changes))
+			for _, ch := range a.Changes {
+				changes = append(changes, domain.FieldChange{
+					Field:         ch.Field,
+					FieldLabel:    ch.FieldLabel,
+					PreviousValue: ch.PreviousValue,
+					NewValue:      ch.NewValue,
+				})
+			}
+			activity.Changes = changes
+		}
+		activities = append(activities, activity)
+	}
+
+	total := snResp.TotalRecords
+	return domain.SearchCaseActivitiesResponse{
+		Activity: activities,
+		Total:    total,
+		Limit:    req.Pagination.Limit,
+		Offset:   req.Pagination.Offset,
+		HasMore:  req.Pagination.Offset+len(activities) < total,
+	}, nil
+}
+
 func (s *snCaseService) GetCaseAttachmentContent(ctx context.Context, attachmentID string) ([]byte, string, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -626,6 +626,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/{id}/activities/search:
+    post:
+      summary: Search the activity feed of a support case (comments, attachments, and optional field changes).
+      operationId: searchCaseActivities
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCaseActivitiesRequest'
+      responses:
+        "200":
+          description: Paginated activity feed for the case.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCaseActivitiesResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /cases/{id}/github-issues:
     post:
       summary: File a GitHub issue against a product's internal repo from a support case (ServiceNow data source only).
@@ -3225,6 +3268,101 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CaseComment'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    ActivityType:
+      type: string
+      enum:
+        - comment
+        - attachment
+        - field_change
+
+    FieldChange:
+      type: object
+      properties:
+        field:
+          type: string
+        fieldLabel:
+          type: string
+        previousValue:
+          type: string
+        newValue:
+          type: string
+
+    CaseActivity:
+      type: object
+      description: >-
+        A single entry in a case activity feed. A discriminated union on `type`:
+        the shared fields are always present, while type-specific fields are set
+        only for the matching `type` (`commentType` for comments;
+        `fileName`/`contentType`/`sizeBytes`/`downloadUrl` for attachments;
+        `changes` for field changes).
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          $ref: '#/components/schemas/ActivityType'
+        content:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        createdByFirstName:
+          type: string
+        createdByLastName:
+          type: string
+        createdByFullName:
+          type: string
+        commentType:
+          type: string
+          enum: [work_note, comment, activity]
+          description: Set only when type is comment.
+        fileName:
+          type: string
+          description: Set only when type is attachment.
+        contentType:
+          type: string
+          description: Set only when type is attachment.
+        sizeBytes:
+          type: integer
+          description: Set only when type is attachment.
+        downloadUrl:
+          type: string
+          description: Set only when type is attachment.
+        changes:
+          type: array
+          description: Set only when type is field_change.
+          items:
+            $ref: '#/components/schemas/FieldChange'
+
+    SearchCaseActivitiesRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        includeFieldChanges:
+          type: boolean
+          description: >-
+            When omitted or false, only comment and attachment entries are
+            returned. When true, field-change entries are included as well.
+
+    SearchCaseActivitiesResponse:
+      type: object
+      properties:
+        activity:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseActivity'
         total:
           type: integer
         limit:


### PR DESCRIPTION
## Purpose
The CSM portal needs a single, chronologically-ordered activity feed for a case that interleaves comments, attachments, and (optionally) field changes, so an engineer can see the full history of a case in one place. Today the entity-service only exposes comments and attachments as separate searches, and it has no way to surface recorded field changes at all. This PR adds a case activities search endpoint that returns all of these as one unified, paginated feed.

## Goals
- Add `POST /cases/{id}/activities/search` to the entity-service, returning a paginated activity feed for a case.
- Model the feed as a vendor-neutral discriminated union on `type` (`comment`, `attachment`, `field_change`) so the frontend can render each entry appropriately.
- Let the caller opt into field-change entries via `includeFieldChanges`; when it is omitted or `false`, only comment and attachment entries are returned.

## Approach
The endpoint mirrors the existing case attachment/comment search flow end to end:
- **Domain** (`internal/domain`): new `SearchCaseActivitiesRequest` (case id from the path, `pagination`, optional `includeFieldChanges`), `SearchCaseActivitiesResponse` (`activity` array plus `total`/`limit`/`offset`/`hasMore`, matching the sibling search responses), and `CaseActivity`/`FieldChange`/`ActivityType` types. `CaseActivity` carries the shared fields (id, type, content, createdOn, created-by name fields) plus type-specific fields set only for the matching `type` (`commentType` for comments; `fileName`/`contentType`/`sizeBytes`/`downloadUrl` for attachments; `changes` for field changes).
- **Service** (`internal/service`): new `SearchCaseActivities` on the `CaseService` interface. The active data-source implementation proxies the corresponding integration-service search (case id carried in the path), maps the response into the neutral domain types, and computes `hasMore` the same way the sibling searches do. The Postgres implementation returns a not-supported error, matching the existing attachment endpoints.
- **Handler + route** (`internal/handler`, `internal/server`): a new handler decodes the body, pulls the case id from the path, and the route is registered alongside the existing case attachment/comment routes.
- **OpenAPI** (`openapi.yaml`): documents the new path and the request/response/`CaseActivity`/`FieldChange`/`ActivityType` schemas in neutral vocabulary.

This is purely additive: no existing endpoint, type, or contract changes. It depends on a corresponding integration-service change (exposing the case activities search), tracked separately.

## User stories
As a CS engineer, I want a single feed of a case's comments, attachments, and field changes so I can review the case's full history without stitching together multiple views.

## Release note
Added a case activities search endpoint that returns a unified, paginated feed of a case's comments, attachments, and optional field changes.

## Documentation
N/A - internal service-to-service API; the contract is captured in the repo's `openapi.yaml`, which this PR updates. No end-user product documentation is affected.

## Training
N/A - no training-content impact.

## Certification
N/A - no impact on certification exams; this is an internal API addition with no end-user-facing behavior change.

## Marketing
N/A - internal platform change, nothing to promote.

## Automation tests
 - Unit tests
   > No new unit tests: the endpoint is a thin, additive passthrough that follows the existing case attachment/comment search pattern, which is exercised by the current suite. `go test ./...` passes.
 - Integration tests
   > Covered by the existing entity-service integration flow once the paired integration-service change lands; end-to-end verification is tracked with that change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A - FindSecurityBugs targets Java bytecode; this is Go. `go vet ./...` runs clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - no samples associated with this change.

## Related PRs
A corresponding integration-service change (exposing the case activities search) is tracked separately.

## Migrations (if applicable)
N/A - no schema or data migrations; no persistence changes.

## Test environment
Go toolchain on macOS. Verified with `go build ./...`, `go vet ./...`, and `go test ./...` (all pass).

## Learning
Followed the existing `SearchCaseAttachments`/`SearchCaseComments` implementations in the entity-service as the reference pattern; no new libraries or external research required.
