### PR TITLE
[CSM Portal] add case activities search passthrough route

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -102,6 +102,7 @@ func main() {
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/comments/search", caseHandler.SearchCaseComments)
+	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -59,6 +59,13 @@ func (c *Client) SearchCaseComments(ctx context.Context, caseID string, body []b
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/comments/search", url.PathEscape(caseID)), body)
 }
 
+// SearchCaseActivities calls POST /cases/{id}/activities/search on the entity service.
+// The path-scoped body is forwarded verbatim and the response is returned as raw JSON;
+// typed response structs are deferred.
+func (c *Client) SearchCaseActivities(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/cases/"+url.PathEscape(caseID)+"/activities/search", body)
+}
+
 // GetUserMe calls GET /users/me on the entity service.
 // Response is returned as raw JSON.
 func (c *Client) GetUserMe(ctx context.Context) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -48,6 +48,7 @@ type entityCaseClient interface {
 	PatchCase(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchComments(ctx context.Context, body []byte) ([]byte, error)
+	SearchCaseActivities(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
 	CreateCaseAttachment(ctx context.Context, body []byte) ([]byte, error)
@@ -267,6 +268,48 @@ func (h *CaseHandler) SearchCaseComments(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchComments failed", "userID", user.UserID, "caseID", caseID, "err", err)
 		mapUpstreamError(w, err, "Failed to search case comments.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// SearchCaseActivities handles POST /cases/{id}/activities/search.
+// The endpoint is path-scoped, so the request body is capped and forwarded to the
+// entity service as-is (no fields are injected) and the response is returned verbatim.
+func (h *CaseHandler) SearchCaseActivities(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("id")
+	if caseID == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if len(body) > 0 && !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchCaseActivities(r.Context(), caseID, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchCaseActivities failed", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamError(w, err, "Failed to search case activities.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -456,6 +456,107 @@ func TestSearchCaseComments(t *testing.T) {
 	})
 }
 
+// ----- SearchCaseActivities -----
+
+func TestSearchCaseActivities(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPost, "/cases/case-1/activities/search", strings.NewReader(`{}`))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.SearchCaseActivities(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty case ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases//activities/search", strings.NewReader(`{}`)))
+		w := httptest.NewRecorder()
+		h.SearchCaseActivities(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/activities/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.SearchCaseActivities(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/activities/search", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.SearchCaseActivities(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body verbatim and returns upstream response", func(t *testing.T) {
+		var capturedCaseID string
+		var capturedBody []byte
+		reqBody := `{"pagination":{"limit":20,"offset":0},"includeFieldChanges":true}`
+		client := &mockEntityCaseClient{
+			searchCaseActivitiesFn: func(_ context.Context, caseID string, body []byte) ([]byte, error) {
+				capturedCaseID = caseID
+				capturedBody = body
+				return []byte(`{"activities":[{"id":"a-1"}],"total":1,"limit":20,"offset":0,"hasMore":false}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-42/activities/search", strings.NewReader(reqBody)))
+		r.SetPathValue("id", "case-42")
+		w := httptest.NewRecorder()
+		h.SearchCaseActivities(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedCaseID != "case-42" {
+			t.Errorf("caseID = %q, want %q", capturedCaseID, "case-42")
+		}
+		if string(capturedBody) != reqBody {
+			t.Errorf("upstream body = %q, want verbatim %q", string(capturedBody), reqBody)
+		}
+
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search case activities.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					searchCaseActivitiesFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/activities/search", strings.NewReader(`{}`)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.SearchCaseActivities(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 // ----- SearchCases -----
 
 func TestSearchCases(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -89,6 +89,7 @@ type mockEntityCaseClient struct {
 	patchCaseFn                func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	createCaseCommentFn        func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCommentsFn           func(ctx context.Context, body []byte) ([]byte, error)
+	searchCaseActivitiesFn     func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCasesFn              func(ctx context.Context, body []byte) ([]byte, error)
 	getCaseFn                  func(ctx context.Context, caseID string) ([]byte, error)
 	createCaseAttachmentFn     func(ctx context.Context, body []byte) ([]byte, error)
@@ -127,6 +128,13 @@ func (m *mockEntityCaseClient) SearchComments(ctx context.Context, body []byte) 
 		return m.searchCommentsFn(ctx, body)
 	}
 	return []byte(`{"comments":[],"total":0,"limit":20,"offset":0,"hasMore":false}`), nil
+}
+
+func (m *mockEntityCaseClient) SearchCaseActivities(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+	if m.searchCaseActivitiesFn != nil {
+		return m.searchCaseActivitiesFn(ctx, caseID, body)
+	}
+	return []byte(`{"activities":[],"total":0,"limit":20,"offset":0,"hasMore":false}`), nil
 }
 
 func (m *mockEntityCaseClient) SearchCases(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -322,6 +322,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /cases/{id}/activities/search:
+    post:
+      summary: Search the activity trail of a case.
+      description: >
+        Returns the chronological activity trail for a case (comments, work notes,
+        state transitions, and other recorded field changes). The request body is
+        forwarded to the integration service as-is and the response is returned
+        verbatim. Set includeFieldChanges to also include per-field value changes.
+      operationId: postCasesIdActivitiesSearch
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the case.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Case activity search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseActivitySearchPayload'
+        required: false
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseActivitySearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /attachments:
     post:
       summary: Upload a file attachment to a case.
@@ -4257,6 +4313,58 @@ components:
         total:
           type: integer
           description: Total number of comments on the case
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    CaseActivitySearchPayload:
+      type: object
+      nullable: true
+      description: >
+        Payload for paginating the activity trail of a case. The case ID is taken
+        from the URL path. The payload is forwarded to the integration service as-is.
+      properties:
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+        includeFieldChanges:
+          type: boolean
+          description: When true, include per-field value changes in each activity entry.
+
+    CaseActivity:
+      type: object
+      description: A single entry in a case's activity trail. Shape is defined by the integration service.
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        caseId:
+          type: string
+        type:
+          type: string
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+
+    CaseActivitySearchResponse:
+      type: object
+      properties:
+        activities:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseActivity'
+        total:
+          type: integer
+          description: Total number of activity entries on the case
         limit:
           type: integer
         offset:


### PR DESCRIPTION
## Purpose
The CSM portal needs to show a case's full activity trail (comments, work notes, state transitions, and other recorded field changes) on the case view. The integration service is gaining a path-scoped `POST /cases/{id}/activities/search` endpoint for this, but the CSM backend (BFF) currently has no route that reaches it, so the webapp cannot fetch a case's activity trail.

This PR adds that missing passthrough route to the CSM backend so the webapp can call it through the gateway.

## Goals
- Add a `POST /cases/{id}/activities/search` route to the CSM backend that forwards to the integration service's path-scoped `POST /cases/{id}/activities/search`.
- Keep the backend a thin pass-through: cap and forward the request body as-is, and return the integration-service response bytes verbatim. No parsing or reshaping of the payload.
- Document the new endpoint in the backend OpenAPI spec.

## Approach
- `internal/entity`: added `SearchCaseActivities(ctx, caseID, body)` that calls the integration service's `POST /cases/{id}/activities/search` with the case ID path-escaped, mirroring the existing `SearchCaseComments` client method.
- `internal/handler` (`cases.go`): added a `SearchCaseActivities` handler that authenticates the request, reads the case ID from the path, caps the body at the standard 1 MiB request limit, validates that any non-empty body is valid JSON, and forwards it unchanged. Unlike the case-comments search handler (which forwards to the global `/comments/search` and injects `referenceId`/`referenceType`), this endpoint is path-scoped, so nothing is injected into the body. The new method is added to the local `entityCaseClient` interface.
- `cmd/server/main.go`: registered the new route next to the case-comments search route.
- `openapi.yaml`: documented the path plus `CaseActivitySearchPayload` / `CaseActivity` / `CaseActivitySearchResponse` schemas. The body may carry `{ pagination, includeFieldChanges? }`.
- Added handler unit tests covering auth, empty case ID, oversized body, invalid JSON, verbatim body forwarding, and upstream error mapping.

The integration service that exposes `POST /cases/{id}/activities/search` is delivered separately (see Related PRs); this backend change depends on it being deployed.

## User stories
As a CS engineer, I want to see the full activity trail of a case so I can understand its history at a glance.

## Release note
Added a case activity trail search endpoint (`POST /cases/{id}/activities/search`) to the CSM backend.

## Documentation
N/A - internal BFF passthrough route; no end-user product documentation impact. The endpoint is documented in the service's own `openapi.yaml`.

## Training
N/A - no training-content impact.

## Certification
N/A - no impact on certification exams.

## Marketing
N/A - internal platform change with no marketing impact.

## Automation tests
 - Unit tests
   > Added `TestSearchCaseActivities` covering: unauthenticated request, empty case ID, body exceeding the 1 MiB cap, invalid JSON body, verbatim body forwarding with case ID propagation, and upstream error mapping across all mapped status codes. `make test` (go vet + `go test -race ./...`) passes.
 - Integration tests
   > N/A - covered by handler-level unit tests against a mocked integration client; end-to-end wiring verified once the dependent integration-service route is deployed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A - Go/TS codebase; `go vet` and `go test -race` run clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - no samples related to this change.

## Related PRs
- Integration-service endpoint this route forwards to: https://github.com/wso2-open-operations/cs-tools/pull/1062

## Migrations (if applicable)
N/A - no schema or data migrations.

## Test environment
- Go (module toolchain per `go.mod`), macOS. `make build`, `make test`, and `make vet` run clean.

## Learning
Followed the existing `SearchCaseComments` handler/client pattern already established in this backend; the only deliberate deviation is not injecting `referenceId`/`referenceType`, since the new endpoint is path-scoped rather than routed through the global comments search.
