### PR TITLE
[Customer Portal MicroApp] (fix) clean up imports and handle timezone fallback i…

### DIFF
--- a/apps/customer-portal/microapp/src/components/shared/TypewriterText.tsx
+++ b/apps/customer-portal/microapp/src/components/shared/TypewriterText.tsx
@@ -1,4 +1,4 @@
-import { Box, colors, useTheme } from "@wso2/oxygen-ui";
+import { Box, colors } from "@wso2/oxygen-ui";
 import { useEffect, useRef, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -11,7 +11,6 @@ interface TypewriterProps {
 }
 
 export function TypewriterText({ tokens, pending = false, animated = true, onAnimationComplete }: TypewriterProps) {
-  const theme = useTheme();
   const fullText = tokens.join("");
   const [cursor, setCursor] = useState(0);
   const hasCompletedRef = useRef(false);
@@ -44,6 +43,7 @@ export function TypewriterText({ tokens, pending = false, animated = true, onAni
       <Markdown
         remarkPlugins={[remarkGfm]}
         components={{
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           table: ({ node, ...props }) => (
             <div style={{ overflowX: "auto", marginTop: 10 }}>
               <table
@@ -56,7 +56,9 @@ export function TypewriterText({ tokens, pending = false, animated = true, onAni
               />
             </div>
           ),
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           th: ({ node, ...props }) => <th style={{ border: `1px solid ${colors.grey[500]}` }} {...props} />,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           td: ({ node, ...props }) => (
             <td style={{ padding: 5, border: `1px solid ${colors.grey[500]}`, maxWidth: 500 }} {...props} />
           ),

--- a/apps/customer-portal/microapp/src/pages/UpdateProfileSettingsPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/UpdateProfileSettingsPage.tsx
@@ -77,7 +77,7 @@ export default function UpdateProfileSettingsPage() {
   const formik = useFormik<UpdateProfileFormValues>({
     initialValues: {
       phoneNumber: me.phoneNumber ?? "",
-      timeZone: me.timezone !== "--None--" ? me.timezone : "",
+      timeZone: me.timezone !== "--None--" ? (me.timezone ?? "") : "",
     },
     validationSchema: updatetProfileValidationSchema,
     validateOnBlur: true,

--- a/apps/customer-portal/package-lock.json
+++ b/apps/customer-portal/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "customer-portal",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Removes leftover/unresolved merge conflict artifacts and unused imports introduced during a prior merge (PieChartWidget.tsx, RichText.tsx, TypewriterText.tsx)
Fixes lint error in TypewriterText.tsx (node destructured but unused in react-markdown component overrides for table/th/td)
Cleans up unused imports and adds a timezone fallback in UpdateProfileSettingsPage.tsx
Updates package-lock.json
Test plan:

 npx eslint passes with no errors on changed files
 npx tsc --noEmit passes
 Manually verify profile settings page renders correctly and timezone falls back as expected when unset
 Manually verify chat/typewriter text with markdown tables still renders correctly




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time zone handling in profile settings so the field now loads more reliably, including cases where no time zone is set.
  * Cleaned up text rendering logic to avoid unnecessary warnings during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->