### PR TITLE
feat(customer-portal): show only data sources with data in usage metrics toggle

### DIFF
--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
@@ -37,6 +37,7 @@ import {
   resolveUsagePresetDateRange,
 } from "@features/usage-metrics/utils/usageMetricsTab";
 import { usePostProjectDeploymentsSearchAll } from "@api/usePostProjectDeploymentsSearch";
+import usePostProjectInstancesUsagesStats from "@features/project-details/api/usePostProjectInstancesUsagesStats";
 
 /**
  * Usage & Metrics area: time range, inner environment tabs, overview and product drill-downs.
@@ -58,12 +59,52 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
   const [appliedCustomStart, setAppliedCustomStart] = useState<string>("");
   const [appliedCustomEnd, setAppliedCustomEnd] = useState<string>("");
   const [uploadOpen, setUploadOpen] = useState<boolean>(false);
-  const [dataSource] = useState<DataSource>(DataSource.API_CALL);
 
   const dateRange = useMemo(
     () => resolveUsagePresetDateRange(timeRange),
     [timeRange],
   );
+
+  // Detect which data sources actually have data in the selected range so the
+  // toggle only offers the sources that are present (and hides entirely when
+  // neither has data).
+  const liveAvailabilityPayload = useMemo(
+    () => ({
+      filters: {
+        startDate: dateRange.startDate,
+        endDate: dateRange.endDate,
+        dataSource: DataSource.API_CALL,
+      },
+    }),
+    [dateRange],
+  );
+  const uploadAvailabilityPayload = useMemo(
+    () => ({
+      filters: {
+        startDate: dateRange.startDate,
+        endDate: dateRange.endDate,
+        dataSource: DataSource.FILE_UPLOAD,
+      },
+    }),
+    [dateRange],
+  );
+
+  const { data: liveAvailability } = usePostProjectInstancesUsagesStats(
+    projectId,
+    liveAvailabilityPayload,
+  );
+  const { data: uploadAvailability } = usePostProjectInstancesUsagesStats(
+    projectId,
+    uploadAvailabilityPayload,
+  );
+
+  const hasLiveData = (liveAvailability?.totalRecords ?? 0) > 0;
+  const hasUploadData = (uploadAvailability?.totalRecords ?? 0) > 0;
+  const showDataSourceToggle = hasLiveData || hasUploadData;
+  // When only one source has data, mark that one as selected; default to Live.
+  const selectedDataSource = hasLiveData
+    ? DataSource.API_CALL
+    : DataSource.FILE_UPLOAD;
 
   const { data: deploymentsData } = usePostProjectDeploymentsSearchAll(
     projectId ?? "",
@@ -121,7 +162,7 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
     setTimeRange(UsageTimeRange.ONE_MONTH);
   };
 
-  const dataSourceToggle: ReactNode = (
+  const dataSourceToggle: ReactNode = showDataSourceToggle ? (
     <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexShrink: 0 }}>
       <Box
         component="span"
@@ -132,19 +173,23 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
       <ToggleButtonGroup
         size="small"
         exclusive
-        value={dataSource}
+        value={selectedDataSource}
         aria-label="data source filter"
         sx={{ pointerEvents: "none" }}
       >
-        <ToggleButton value={DataSource.API_CALL} aria-label={USAGE_METRICS_DATA_SOURCE_API_CALL}>
-          {USAGE_METRICS_DATA_SOURCE_API_CALL}
-        </ToggleButton>
-        <ToggleButton value={DataSource.FILE_UPLOAD} aria-label={USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD}>
-          {USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD}
-        </ToggleButton>
+        {hasLiveData && (
+          <ToggleButton value={DataSource.API_CALL} aria-label={USAGE_METRICS_DATA_SOURCE_API_CALL}>
+            {USAGE_METRICS_DATA_SOURCE_API_CALL}
+          </ToggleButton>
+        )}
+        {hasUploadData && (
+          <ToggleButton value={DataSource.FILE_UPLOAD} aria-label={USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD}>
+            {USAGE_METRICS_DATA_SOURCE_FILE_UPLOAD}
+          </ToggleButton>
+        )}
       </ToggleButtonGroup>
     </Box>
-  );
+  ) : null;
 
   const uploadButton: ReactNode = (
     <Button

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/__tests__/UsageAndMetricsTabContent.test.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/__tests__/UsageAndMetricsTabContent.test.tsx
@@ -14,14 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router";
 import UsageAndMetricsTabContent from "@features/usage-metrics/components/UsageAndMetricsTabContent";
 
+// Mutable availability the mocked stats hook reads (hoisted for vi.mock).
+const availability = vi.hoisted(() => ({ live: 0, upload: 0 }));
+
 vi.mock("@api/usePostProjectDeploymentsSearch", () => ({
   usePostProjectDeploymentsSearchAll: () => ({
-    data: [{ id: "dep-1", name: "Production" }],
+    data: [{ id: "dep-1", name: "Production", productCount: 1 }],
     isLoading: false,
     isError: false,
     isSuccess: true,
@@ -29,9 +32,17 @@ vi.mock("@api/usePostProjectDeploymentsSearch", () => ({
   }),
 }));
 
-vi.mock("@features/usage-metrics/components/UsageOverviewPanel", () => ({
-  default: () => <div data-testid="usage-overview-panel" />,
-}));
+// DataSource.API_CALL === 1, DataSource.FILE_UPLOAD === 2.
+vi.mock(
+  "@features/project-details/api/usePostProjectInstancesUsagesStats",
+  () => ({
+    default: (_projectId: string | undefined, payload: { filters: { dataSource?: number } }) => {
+      const total =
+        payload?.filters?.dataSource === 1 ? availability.live : availability.upload;
+      return { data: { stats: {}, totalRecords: total, startDate: "", endDate: "" }, isLoading: false };
+    },
+  }),
+);
 
 vi.mock(
   "@features/usage-metrics/components/UsageEnvironmentProductsPanel",
@@ -44,27 +55,56 @@ vi.mock("@features/usage-metrics/components/DeploymentUsageUploadDialog", () => 
   default: () => null,
 }));
 
-describe("UsageAndMetricsTabContent", () => {
-  it("shows overview panel by default and switches to environment products", () => {
-    render(
-      <MemoryRouter initialEntries={["/projects/p1"]}>
-        <Routes>
-          <Route
-            path="/projects/:projectId"
-            element={<UsageAndMetricsTabContent />}
-          />
-        </Routes>
-      </MemoryRouter>,
-    );
+function renderTab() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/p1"]}>
+      <Routes>
+        <Route path="/projects/:projectId" element={<UsageAndMetricsTabContent />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
 
-    expect(screen.getByTestId("usage-overview-panel")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("usage-environment-products-panel"),
-    ).not.toBeInTheDocument();
+function dataSourceGroup(): HTMLElement | null {
+  return screen.queryByRole("group", { name: "data source filter" });
+}
 
-    fireEvent.click(screen.getByRole("tab", { name: "Production" }));
+describe("UsageAndMetricsTabContent data source toggle", () => {
+  beforeEach(() => {
+    availability.live = 0;
+    availability.upload = 0;
+  });
 
-    expect(screen.queryByTestId("usage-overview-panel")).not.toBeInTheDocument();
-    expect(screen.getByTestId("usage-environment-products-panel")).toBeInTheDocument();
+  it("hides the toggle when neither source has data", () => {
+    renderTab();
+    expect(dataSourceGroup()).not.toBeInTheDocument();
+  });
+
+  it("shows only Live when only live data exists", () => {
+    availability.live = 5;
+    renderTab();
+    const group = dataSourceGroup();
+    expect(group).toBeInTheDocument();
+    expect(within(group!).getByRole("button", { name: "Live" })).toBeInTheDocument();
+    expect(within(group!).queryByRole("button", { name: "Upload" })).not.toBeInTheDocument();
+  });
+
+  it("shows only Upload when only upload data exists", () => {
+    availability.upload = 5;
+    renderTab();
+    const group = dataSourceGroup();
+    expect(group).toBeInTheDocument();
+    expect(within(group!).getByRole("button", { name: "Upload" })).toBeInTheDocument();
+    expect(within(group!).queryByRole("button", { name: "Live" })).not.toBeInTheDocument();
+  });
+
+  it("shows both when both sources have data", () => {
+    availability.live = 5;
+    availability.upload = 5;
+    renderTab();
+    const group = dataSourceGroup();
+    expect(group).toBeInTheDocument();
+    expect(within(group!).getByRole("button", { name: "Live" })).toBeInTheDocument();
+    expect(within(group!).getByRole("button", { name: "Upload" })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

The Usage & Metrics **Data Source** toggle previously always rendered both `Live` and `Upload`, regardless of what data existed. Now it only shows the sources that actually have data:

- Only Live data → shows just **Live**
- Only Upload data → shows just **Upload**
- Both → shows **both** (Live selected by default)
- Neither → the toggle (label + buttons) is **hidden**

## How

Availability is derived from the existing `POST /projects/{id}/instances/stats/usages/search` endpoint, probed once per `dataSource` for the currently selected date range (`totalRecords > 0` ⇒ has data). No backend change required.

## Notes

- Availability is scoped to the selected date range, so it stays consistent with what's actually charted.
- The toggle remains display-only (unchanged interaction).
- Refreshes the stale `UsageAndMetricsTabContent` test (it asserted a removed overview panel) with coverage for the four visibility states (hidden / live-only / upload-only / both).

## Testing

- `vitest` — 4 toggle tests pass
- `tsc -b` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The usage metrics view now shows the data-source selector only when relevant data is available.
  * It automatically highlights the available source(s) for the selected date range, preferring Live when both are present.

* **Bug Fixes**
  * Hidden unavailable data-source options so users only see choices that contain data.
  * Improved the default selection behavior when one source has no records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->