### PR TITLE
fix(customer-portal): hide Created By filter on My Cases page

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -131,6 +131,14 @@ export default function AllCasesPage(): JSX.Element {
     }
   }, [statusFilter, filterMetadata, filters.statusIds, setFilters]);
 
+  // On My Cases (createdByMe), the Created By filter is hidden, so drop any
+  // persisted createdBy value to keep it out of the case search request.
+  useEffect(() => {
+    if (createdByMe && filters.createdBy?.length) {
+      setFilters((prev) => ({ ...prev, createdBy: undefined }));
+    }
+  }, [createdByMe, filters.createdBy, setFilters]);
+
   // Fetch deployments for the deployment filter (10 at a time)
   const deploymentsQuery = usePostProjectDeploymentsSearchInfinite(
     projectId || "",

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -389,6 +389,7 @@ export default function AllCasesPage(): JSX.Element {
           restrictSeverityToLow={restrictSeverityToLow}
           hideSeverityFilter={isDashboardSeverityNavigation}
           hideDeploymentFilter={!permissions.hasDeployments}
+          hideCreatedByFilter={createdByMe}
           isProjectContextLoading={isProjectContextLoading}
           excludeFromCount={
             initialSeverityId && filters.severityIds?.includes(initialSeverityId)


### PR DESCRIPTION
## What

On the **My Cases** view (`createdByMe=true`), every case is authored by the current user, so the **Created By** filter is redundant and confusing. This hides it in that mode.

## How

Wires the existing `hideCreatedByFilter` prop through from `AllCasesPage` → `ListSearchPanel` → `ListFilters`, set to `createdByMe`. When hidden, the panel also clears any existing `createdBy` filter value. The filter remains available on the regular **All Cases** view.

One-line change:
```tsx
hideCreatedByFilter={createdByMe}
```

## Testing

- `tsc -b` and `eslint` clean (pre-existing `contactsList` dep warning unrelated to this change)
- Verified in-app: Created By no longer appears under Filters on My Cases; still present on All Cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Created by” filter is now hidden on the “My Cases” view, simplifying case search and reducing irrelevant filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->