### PR TITLE
feat(csm-timecards): export current page of time cards as CSV

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -32,6 +32,7 @@ import type {
   BeDeleteAttachmentResponse,
 } from "@api/backend/types";
 import { uiAttachmentFromBe } from "@api/backend/mappers";
+import { saveBlob } from "@utils/saveBlob";
 import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
 
 /**
@@ -60,18 +61,6 @@ function readFileAsDataUrl(file: File): Promise<string> {
       reject(reader.error ?? new Error("Failed to read the file."));
     reader.readAsDataURL(file);
   });
-}
-
-/** Trigger a browser "save as" for a fetched blob. */
-function saveBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -282,6 +282,19 @@ export default function CsmTimeCardsPage(): JSX.Element {
     [queue.data],
   );
 
+  // Filtered sheets per tab, computed once and shared between the FilterBar's
+  // export action and the list rendering below — rather than recomputing (and
+  // risking drift) in two places.
+  const mineFilteredSheets = byWorkItem(mySheets.data?.sheets) ?? [];
+  const allByEngineer = (allCards.data?.sheets ?? []).filter(
+    (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
+  );
+  const allFilteredSheets = byWorkItem(allByEngineer) ?? [];
+  const approvalsByEngineer = (queue.data?.sheets ?? []).filter(
+    (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
+  );
+  const approvalsFilteredSheets = byWorkItem(approvalsByEngineer) ?? [];
+
   return (
     <Box
       sx={{ p: { xs: 2, md: 3 }, display: "flex", flexDirection: "column", gap: 2 }}
@@ -337,37 +350,30 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load your time sheets.</Typography>
           ) : (
             <>
-              {(() => {
-                const filtered = byWorkItem(mySheets.data?.sheets) ?? [];
-                return (
-                  <>
-                    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-                      <ExportCsvButton
-                        cards={filtered.flatMap((s) => s.cards)}
-                        filename={`time-cards-my-sheets-${todayStamp}.csv`}
-                      />
-                    </Box>
-                    {filtered.length === 0 ? (
-                      <Empty
-                        text={
-                          anyFilterActive
-                            ? "No time cards match the current filters."
-                            : "No time logged yet. Open a case and use its Time tracking tab to log time."
-                        }
-                      />
-                    ) : (
-                      filtered.map((s) => (
-                        <TimeSheetCard
-                          key={s.id}
-                          sheet={s}
-                          role={{ isOwner: true, isApprover: false, isAdmin: false }}
-                          onCardAction={handleCardAction}
-                        />
-                      ))
-                    )}
-                  </>
-                );
-              })()}
+              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                <ExportCsvButton
+                  cards={mineFilteredSheets.flatMap((s) => s.cards)}
+                  filename={`time-cards-my-sheets-${todayStamp}.csv`}
+                />
+              </Box>
+              {mineFilteredSheets.length === 0 ? (
+                <Empty
+                  text={
+                    anyFilterActive
+                      ? "No time cards match the current filters."
+                      : "No time logged yet. Open a case and use its Time tracking tab to log time."
+                  }
+                />
+              ) : (
+                mineFilteredSheets.map((s) => (
+                  <TimeSheetCard
+                    key={s.id}
+                    sheet={s}
+                    role={{ isOwner: true, isApprover: false, isAdmin: false }}
+                    onCardAction={handleCardAction}
+                  />
+                ))
+              )}
               {/* Pages over raw records, not weekly sheets — a week's cards
                can legitimately span a page boundary and look incomplete
                until you've paged further; same for "my cards" being a small
@@ -409,8 +415,9 @@ export default function CsmTimeCardsPage(): JSX.Element {
             filterTo={filterTo}
             setFilterTo={handleFilterToChange}
             onClear={clearFilters}
+            compact
             engineerSlot={
-              <Box sx={{ width: 200 }}>
+              <Box sx={{ width: 170 }}>
                 <SearchableMultiSelect
                   id="timecards-filter-engineer-all"
                   label="Engineer"
@@ -442,43 +449,33 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load time cards.</Typography>
           ) : (
             <>
-              {(() => {
-                const byEngineer = (allCards.data?.sheets ?? []).filter(
-                  (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
-                );
-                const filtered = byWorkItem(byEngineer) ?? [];
-                return (
-                  <>
-                    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-                      <ExportCsvButton
-                        cards={filtered.flatMap((s) => s.cards)}
-                        filename={`time-cards-all-${todayStamp}.csv`}
-                      />
-                    </Box>
-                    {filtered.length === 0 ? (
-                      <Empty
-                        text={
-                          filterEngineer.length > 0 && byEngineer.length === 0
-                            ? "No time cards match the selected engineers."
-                            : anyFilterActive
-                              ? "No time cards match the current filters."
-                              : "No time logged yet."
-                        }
-                      />
-                    ) : (
-                      filtered.map((s) => (
-                        <TimeSheetCard
-                          key={s.id}
-                          sheet={s}
-                          role={{ isOwner: s.userId === me.id, isApprover: false, isAdmin: false }}
-                          showEngineer
-                          onCardAction={handleCardAction}
-                        />
-                      ))
-                    )}
-                  </>
-                );
-              })()}
+              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                <ExportCsvButton
+                  cards={allFilteredSheets.flatMap((s) => s.cards)}
+                  filename={`time-cards-all-${todayStamp}.csv`}
+                />
+              </Box>
+              {allFilteredSheets.length === 0 ? (
+                <Empty
+                  text={
+                    filterEngineer.length > 0 && allByEngineer.length === 0
+                      ? "No time cards match the selected engineers."
+                      : anyFilterActive
+                        ? "No time cards match the current filters."
+                        : "No time logged yet."
+                  }
+                />
+              ) : (
+                allFilteredSheets.map((s) => (
+                  <TimeSheetCard
+                    key={s.id}
+                    sheet={s}
+                    role={{ isOwner: s.userId === me.id, isApprover: false, isAdmin: false }}
+                    showEngineer
+                    onCardAction={handleCardAction}
+                  />
+                ))
+              )}
               <TablePagination
                 component="div"
                 count={allCards.data?.total ?? 0}
@@ -498,8 +495,6 @@ export default function CsmTimeCardsPage(): JSX.Element {
       {/* Approvals */}
       {activeTab === "approvals" && role.isApprover && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          <Typography variant="subtitle2">Submitted for your approval</Typography>
-
           <FilterBar
             projects={projects.data ?? []}
             filterProject={filterProject}
@@ -548,46 +543,36 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load the approval queue.</Typography>
           ) : (
             <>
-              {(() => {
-                const byEngineer = (queue.data?.sheets ?? []).filter(
-                  (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
-                );
-                const filtered = byWorkItem(byEngineer) ?? [];
-                return (
-                  <>
-                    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-                      <ExportCsvButton
-                        cards={filtered.flatMap((s) => s.cards)}
-                        filename={`time-cards-approvals-${todayStamp}.csv`}
-                      />
-                    </Box>
-                    {(queue.data?.sheets ?? []).length === 0 ? (
-                      <Empty text="Nothing awaiting approval." />
-                    ) : filtered.length === 0 ? (
-                      <Empty
-                        text={
-                          // Only blame the engineer filter when it's the one that
-                          // excluded everything — if it matched fine and the
-                          // work-item filter emptied the result, say that instead.
-                          filterEngineer.length > 0 && byEngineer.length === 0
-                            ? "No time cards match the selected engineers."
-                            : "No time cards match the current filters."
-                        }
-                      />
-                    ) : (
-                      filtered.map((s) => (
-                        <TimeSheetCard
-                          key={s.id}
-                          sheet={s}
-                          role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
-                          showEngineer
-                          onCardAction={handleCardAction}
-                        />
-                      ))
-                    )}
-                  </>
-                );
-              })()}
+              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                <ExportCsvButton
+                  cards={approvalsFilteredSheets.flatMap((s) => s.cards)}
+                  filename={`time-cards-approvals-${todayStamp}.csv`}
+                />
+              </Box>
+              {(queue.data?.sheets ?? []).length === 0 ? (
+                <Empty text="Nothing awaiting approval." />
+              ) : approvalsFilteredSheets.length === 0 ? (
+                <Empty
+                  text={
+                    // Only blame the engineer filter when it's the one that
+                    // excluded everything — if it matched fine and the
+                    // work-item filter emptied the result, say that instead.
+                    filterEngineer.length > 0 && approvalsByEngineer.length === 0
+                      ? "No time cards match the selected engineers."
+                      : "No time cards match the current filters."
+                  }
+                />
+              ) : (
+                approvalsFilteredSheets.map((s) => (
+                  <TimeSheetCard
+                    key={s.id}
+                    sheet={s}
+                    role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
+                    showEngineer
+                    onCardAction={handleCardAction}
+                  />
+                ))
+              )}
               <TablePagination
                 component="div"
                 count={queue.data?.total ?? 0}
@@ -661,6 +646,7 @@ function FilterBar({
   engineerSlot,
   engineerChip,
   hideStateFilter,
+  compact,
 }: {
   projects: BeProject[];
   filterProject: string[];
@@ -685,6 +671,10 @@ function FilterBar({
    * `useApprovalQueue`), so the State control can't actually narrow anything
    * there — hide it instead of showing a filter that silently does nothing. */
   hideStateFilter?: boolean;
+  /** Narrower field widths — only the All tab shows every filter (Project,
+   * Work item, Engineer, State) plus the date range at once, so it's the
+   * only one that needs the squeeze to still fit on one line. */
+  compact?: boolean;
 }): JSX.Element {
   const activeChips: { key: string; label: string; onDelete: () => void }[] = [];
   if (engineerChip) activeChips.push({ key: "engineer", ...engineerChip });
@@ -731,67 +721,61 @@ function FilterBar({
         overflow: "hidden",
       }}
     >
-      {/* Controls — a fixed two-row layout rather than one row that wraps
-       unpredictably: which controls land on row two would otherwise depend
-       on viewport width, and a single item stranding itself alone on a new
-       row (with a lot of empty space next to it) reads as broken overflow
-       rather than a deliberate section. Row one is the entity filters, row
-       two is always the date range, regardless of width. */}
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25, px: 2, py: 1.5 }}>
-        <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1.5 }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, color: "text.secondary", mr: 0.5 }}>
-            <ListFilter size={16} />
-            <Typography variant="caption" fontWeight={600} color="text.secondary">
-              Filters
-            </Typography>
-          </Box>
-
-          <Box sx={{ width: 220 }}>
-            <SearchableMultiSelect
-              id="timecards-filter-project"
-              label="Project"
-              placeholder="Search projects…"
-              values={filterProject}
-              options={projects.map((p) => p.id)}
-              formatOption={(id) => projects.find((p) => p.id === id)?.name ?? id}
-              onChange={setFilterProject}
-            />
-          </Box>
-
-          <Box sx={{ width: 220 }}>
-            <SearchableMultiSelect
-              id="timecards-filter-work-item"
-              label="Work item"
-              placeholder="Search work items…"
-              values={filterWorkItem}
-              options={workItemOptions}
-              onChange={setFilterWorkItem}
-            />
-          </Box>
-
-          {engineerSlot}
-
-          {!hideStateFilter && (
-            <TextField
-              select
-              size="small"
-              label="State"
-              value={filterState}
-              onChange={(e) => setFilterState(e.target.value as TimeCardState | "")}
-              sx={{ width: 150 }}
-            >
-              <MenuItem value="">All states</MenuItem>
-              {FILTER_STATES.map((s) => (
-                <MenuItem key={s} value={s}>
-                  {TIME_CARD_STATE_META[s].label}
-                </MenuItem>
-              ))}
-            </TextField>
-          )}
+      {/* Controls — a single row that wraps only if the viewport genuinely
+       can't fit everything. The date range is one grouped pill (not two
+       separate fields) so it wraps as a unit rather than splitting apart
+       mid-pair if it ever does need to drop to a second line. */}
+      <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1.5, px: 2, py: 1.5 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, color: "text.secondary", mr: 0.5 }}>
+          <ListFilter size={16} />
+          <Typography variant="caption" fontWeight={600} color="text.secondary">
+            Filters
+          </Typography>
         </Box>
 
-        {/* One grouped pill instead of two separate outlined fields — reads
-         as a single "date range" control, always on its own row. */}
+        <Box sx={{ width: compact ? 170 : 220 }}>
+          <SearchableMultiSelect
+            id="timecards-filter-project"
+            label="Project"
+            placeholder="Search projects…"
+            values={filterProject}
+            options={projects.map((p) => p.id)}
+            formatOption={(id) => projects.find((p) => p.id === id)?.name ?? id}
+            onChange={setFilterProject}
+          />
+        </Box>
+
+        <Box sx={{ width: compact ? 170 : 220 }}>
+          <SearchableMultiSelect
+            id="timecards-filter-work-item"
+            label="Work item"
+            placeholder="Search work items…"
+            values={filterWorkItem}
+            options={workItemOptions}
+            onChange={setFilterWorkItem}
+          />
+        </Box>
+
+        {engineerSlot}
+
+        {!hideStateFilter && (
+          <TextField
+            select
+            size="small"
+            label="State"
+            value={filterState}
+            onChange={(e) => setFilterState(e.target.value as TimeCardState | "")}
+            sx={{ width: compact ? 120 : 150 }}
+          >
+            <MenuItem value="">All states</MenuItem>
+            {FILTER_STATES.map((s) => (
+              <MenuItem key={s} value={s}>
+                {TIME_CARD_STATE_META[s].label}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
+
         <Box
           sx={{
             display: "flex",
@@ -800,6 +784,7 @@ function FilterBar({
             width: "fit-content",
             height: 40,
             px: 1.25,
+            ml: 1,
             border: 1,
             borderColor: "divider",
             borderRadius: 1,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -27,7 +27,7 @@ import {
   Typography,
   Button,
 } from "@wso2/oxygen-ui";
-import { CalendarRange, ListFilter, X } from "@wso2/oxygen-ui-icons-react";
+import { CalendarRange, Download, ListFilter, X } from "@wso2/oxygen-ui-icons-react";
 import {
   useAllTimeCards,
   useApprovalQueue,
@@ -47,6 +47,7 @@ import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
 import TimeSheetCard from "@features/csm-timecards/components/TimeSheetCard";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
 import SearchableMultiSelect from "@components/SearchableMultiSelect";
+import { exportTimeCardsCsv } from "@features/csm-timecards/utils/timeCardCsvExport";
 import type { TimecardAction } from "@features/csm-timecards/utils/timeSheetState";
 import type {
   CsmTimeCard,
@@ -140,6 +141,9 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const { showSuccess } = useSuccessBanner();
   const [tab, setTab] = useState<TabId>("mine");
   const activeTab: TabId = tab === "approvals" && !role.isApprover ? "mine" : tab;
+  // Stable per-render so re-renders while the page is open don't shift the
+  // exported filename's date mid-session.
+  const todayStamp = useMemo(() => new Date().toISOString().slice(0, 10), []);
 
   const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
 
@@ -335,25 +339,34 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <>
               {(() => {
                 const filtered = byWorkItem(mySheets.data?.sheets) ?? [];
-                if (filtered.length === 0) {
-                  return (
-                    <Empty
-                      text={
-                        anyFilterActive
-                          ? "No time cards match the current filters."
-                          : "No time logged yet. Open a case and use its Time tracking tab to log time."
-                      }
-                    />
-                  );
-                }
-                return filtered.map((s) => (
-                  <TimeSheetCard
-                    key={s.id}
-                    sheet={s}
-                    role={{ isOwner: true, isApprover: false, isAdmin: false }}
-                    onCardAction={handleCardAction}
-                  />
-                ));
+                return (
+                  <>
+                    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                      <ExportCsvButton
+                        cards={filtered.flatMap((s) => s.cards)}
+                        filename={`time-cards-my-sheets-${todayStamp}.csv`}
+                      />
+                    </Box>
+                    {filtered.length === 0 ? (
+                      <Empty
+                        text={
+                          anyFilterActive
+                            ? "No time cards match the current filters."
+                            : "No time logged yet. Open a case and use its Time tracking tab to log time."
+                        }
+                      />
+                    ) : (
+                      filtered.map((s) => (
+                        <TimeSheetCard
+                          key={s.id}
+                          sheet={s}
+                          role={{ isOwner: true, isApprover: false, isAdmin: false }}
+                          onCardAction={handleCardAction}
+                        />
+                      ))
+                    )}
+                  </>
+                );
               })()}
               {/* Pages over raw records, not weekly sheets — a week's cards
                can legitimately span a page boundary and look incomplete
@@ -434,28 +447,37 @@ export default function CsmTimeCardsPage(): JSX.Element {
                   (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
                 );
                 const filtered = byWorkItem(byEngineer) ?? [];
-                if (filtered.length === 0) {
-                  return (
-                    <Empty
-                      text={
-                        filterEngineer.length > 0 && byEngineer.length === 0
-                          ? "No time cards match the selected engineers."
-                          : anyFilterActive
-                            ? "No time cards match the current filters."
-                            : "No time logged yet."
-                      }
-                    />
-                  );
-                }
-                return filtered.map((s) => (
-                  <TimeSheetCard
-                    key={s.id}
-                    sheet={s}
-                    role={{ isOwner: s.userId === me.id, isApprover: false, isAdmin: false }}
-                    showEngineer
-                    onCardAction={handleCardAction}
-                  />
-                ));
+                return (
+                  <>
+                    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                      <ExportCsvButton
+                        cards={filtered.flatMap((s) => s.cards)}
+                        filename={`time-cards-all-${todayStamp}.csv`}
+                      />
+                    </Box>
+                    {filtered.length === 0 ? (
+                      <Empty
+                        text={
+                          filterEngineer.length > 0 && byEngineer.length === 0
+                            ? "No time cards match the selected engineers."
+                            : anyFilterActive
+                              ? "No time cards match the current filters."
+                              : "No time logged yet."
+                        }
+                      />
+                    ) : (
+                      filtered.map((s) => (
+                        <TimeSheetCard
+                          key={s.id}
+                          sheet={s}
+                          role={{ isOwner: s.userId === me.id, isApprover: false, isAdmin: false }}
+                          showEngineer
+                          onCardAction={handleCardAction}
+                        />
+                      ))
+                    )}
+                  </>
+                );
               })()}
               <TablePagination
                 component="div"
@@ -526,16 +548,22 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load the approval queue.</Typography>
           ) : (
             <>
-              {(queue.data?.sheets ?? []).length === 0 ? (
-                <Empty text="Nothing awaiting approval." />
-              ) : (
-                (() => {
-                  const byEngineer = (queue.data?.sheets ?? []).filter(
-                    (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
-                  );
-                  const filtered = byWorkItem(byEngineer) ?? [];
-                  if (filtered.length === 0) {
-                    return (
+              {(() => {
+                const byEngineer = (queue.data?.sheets ?? []).filter(
+                  (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
+                );
+                const filtered = byWorkItem(byEngineer) ?? [];
+                return (
+                  <>
+                    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                      <ExportCsvButton
+                        cards={filtered.flatMap((s) => s.cards)}
+                        filename={`time-cards-approvals-${todayStamp}.csv`}
+                      />
+                    </Box>
+                    {(queue.data?.sheets ?? []).length === 0 ? (
+                      <Empty text="Nothing awaiting approval." />
+                    ) : filtered.length === 0 ? (
                       <Empty
                         text={
                           // Only blame the engineer filter when it's the one that
@@ -546,19 +574,20 @@ export default function CsmTimeCardsPage(): JSX.Element {
                             : "No time cards match the current filters."
                         }
                       />
-                    );
-                  }
-                  return filtered.map((s) => (
-                    <TimeSheetCard
-                      key={s.id}
-                      sheet={s}
-                      role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
-                      showEngineer
-                      onCardAction={handleCardAction}
-                    />
-                  ));
-                })()
-              )}
+                    ) : (
+                      filtered.map((s) => (
+                        <TimeSheetCard
+                          key={s.id}
+                          sheet={s}
+                          role={{ isOwner: false, isApprover: true, isAdmin: role.isAdmin }}
+                          showEngineer
+                          onCardAction={handleCardAction}
+                        />
+                      ))
+                    )}
+                  </>
+                );
+              })()}
               <TablePagination
                 component="div"
                 count={queue.data?.total ?? 0}
@@ -841,6 +870,30 @@ function FilterBar({
         </Box>
       )}
     </Box>
+  );
+}
+
+/** Downloads whatever `cards` the caller currently has loaded — a "current
+ * page" export, not a full report (see the pagination notes on
+ * `searchTimeCards` in `useTimeSheets.ts` for why a full-scope export isn't
+ * reliable yet). Disabled when there's nothing to export. */
+function ExportCsvButton({
+  cards,
+  filename,
+}: {
+  cards: CsmTimeCard[];
+  filename: string;
+}): JSX.Element {
+  return (
+    <Button
+      size="small"
+      variant="text"
+      startIcon={<Download size={14} />}
+      disabled={cards.length === 0}
+      onClick={() => exportTimeCardsCsv(cards, filename)}
+    >
+      Export CSV
+    </Button>
   );
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardCsvExport.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardCsvExport.test.ts
@@ -67,4 +67,9 @@ describe("timeCardsToCsv", () => {
     const csv = timeCardsToCsv([card({ userName: 'Jane "JD" Doe' })]);
     expect(csv).toContain('"Jane ""JD"" Doe"');
   });
+
+  it("quotes a field with a bare carriage return, not just \\n", () => {
+    const csv = timeCardsToCsv([card({ userName: "Jane\rDoe" })]);
+    expect(csv).toContain('"Jane\rDoe"');
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardCsvExport.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardCsvExport.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { timeCardsToCsv } from "@features/csm-timecards/utils/timeCardCsvExport";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
+  return {
+    id: "card-1",
+    caseId: "case-1",
+    caseNumber: "CS0352584",
+    projectId: "proj-1",
+    projectName: "Acme Corp",
+    createdOn: "2026-06-27",
+    userId: "user-1",
+    userName: "Jane Doe",
+    state: "submitted",
+    billable: true,
+    totalMinutes: 90,
+    ...overrides,
+  };
+}
+
+describe("timeCardsToCsv", () => {
+  it("emits just the header for an empty list", () => {
+    expect(timeCardsToCsv([])).toBe(
+      "Date,Case,Project,Engineer,State,Billable,Minutes,Decided by",
+    );
+  });
+
+  it("emits one row per card with human-readable state and billable", () => {
+    const csv = timeCardsToCsv([card()]);
+    const lines = csv.split("\r\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe(
+      "2026-06-27,CS0352584,Acme Corp,Jane Doe,Submitted,Yes,90,",
+    );
+  });
+
+  it("includes the deciding approver once a card has one", () => {
+    const csv = timeCardsToCsv([
+      card({ state: "approved", approvedByName: "Lead Person" }),
+    ]);
+    expect(csv).toContain("Approved,Yes,90,Lead Person");
+  });
+
+  it("quotes a field that contains a comma", () => {
+    const csv = timeCardsToCsv([card({ projectName: "Acme, Inc." })]);
+    expect(csv).toContain('"Acme, Inc."');
+  });
+
+  it("escapes internal quotes by doubling them", () => {
+    const csv = timeCardsToCsv([card({ userName: 'Jane "JD" Doe' })]);
+    expect(csv).toContain('"Jane ""JD"" Doe"');
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
@@ -30,10 +30,10 @@ const CSV_HEADER = [
 ];
 
 /** Quotes a CSV field only when it needs it (contains a comma, quote, or
- * newline), doubling any internal quotes — the minimal escaping RFC 4180
- * requires. */
+ * carriage return/newline), doubling any internal quotes — the minimal
+ * escaping RFC 4180 requires. */
 function csvField(value: string): string {
-  if (!/[",\n]/.test(value)) return value;
+  if (!/["\r\n,]/.test(value)) return value;
   return `"${value.replace(/"/g, '""')}"`;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { saveBlob } from "@utils/saveBlob";
+import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+const CSV_HEADER = [
+  "Date",
+  "Case",
+  "Project",
+  "Engineer",
+  "State",
+  "Billable",
+  "Minutes",
+  "Decided by",
+];
+
+/** Quotes a CSV field only when it needs it (contains a comma, quote, or
+ * newline), doubling any internal quotes — the minimal escaping RFC 4180
+ * requires. */
+function csvField(value: string): string {
+  if (!/[",\n]/.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/** Builds the CSV text for a list of cards — split out from
+ * {@link exportTimeCardsCsv} so it's testable without mocking the browser
+ * download APIs. */
+export function timeCardsToCsv(cards: CsmTimeCard[]): string {
+  const rows = cards.map((c) =>
+    [
+      c.createdOn,
+      c.caseNumber,
+      c.projectName,
+      c.userName,
+      TIME_CARD_STATE_META[c.state].label,
+      c.billable ? "Yes" : "No",
+      String(c.totalMinutes),
+      c.approvedByName ?? "",
+    ]
+      .map(csvField)
+      .join(","),
+  );
+  return [CSV_HEADER.join(","), ...rows].join("\r\n");
+}
+
+/**
+ * Downloads the given cards as a CSV file. Exports only the cards passed in
+ * — callers currently only have one page loaded at a time (see the
+ * pagination notes in `useTimeSheets.ts`), so this is a "current page"
+ * export, not a full report across the whole scope.
+ */
+export function exportTimeCardsCsv(cards: CsmTimeCard[], filename: string): void {
+  const csv = timeCardsToCsv(cards);
+  saveBlob(new Blob([csv], { type: "text/csv;charset=utf-8;" }), filename);
+}

--- a/apps/csm-portal/webapp/src/utils/saveBlob.ts
+++ b/apps/csm-portal/webapp/src/utils/saveBlob.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/** Trigger a browser "save as" for a blob (fetched or locally built). */
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Purpose
Time data being exportable for reporting is one of the acceptance criteria on the ISSU-009 epic (#1960). It's unbuilt, but unlike the aggregate-view and full-notification gaps, it doesn't need any backend work — the data needed to export a page is already loaded client-side.

Relates to #1960.

## Goals
Let users download the time cards they currently have loaded (My time sheets / All / Approvals) as a CSV, for ad-hoc reporting.

## Approach
Added an "Export CSV" button above the card list on each of the three tabs, downloading whatever page is currently loaded (respecting the active filters) as a CSV with Date, Case, Project, Engineer, State, Billable, Minutes, and Decided by columns. Proper RFC 4180 quoting/escaping for fields containing commas or quotes.

This is explicitly a **current-page export, not a full report** — `searchTimeCards`'s pagination/truncation behavior (tracked in #2258) means a reliable full-scope export isn't possible until that's fixed. The button and its doc comments call this out.

Extracted the existing attachment-download `saveBlob` helper (previously private to `useCsmCaseAttachments.ts`) into a shared `src/utils/saveBlob.ts` so this feature reuses it instead of duplicating a second copy.

Also folded in some filter-bar layout polish from manual testing: the date-range control now sits in the same row as the other filters (wrapping only when the viewport genuinely can't fit everything, instead of a forced two-row split), a `compact` mode narrows the fields only on the All tab (the one tab showing all four filters plus the date range at once), and removed a redundant subtitle on the Approvals tab.

## User stories
As an engineer or approver, I can export the time cards I'm currently viewing as a CSV file for reporting.

## Release note
Time cards: added an "Export CSV" button to My time sheets/All/Approvals (exports the currently loaded page).

## Documentation
N/A — internal feature addition, no user-facing docs to update.

## Training
N/A

## Certification
N/A — no exam-relevant behavior change.

## Marketing
N/A

## Automation tests
- Unit tests: 5 new tests for the CSV-building logic (empty list, normal row, approver column, comma quoting, quote escaping) plus the full existing `csm-timecards` suite (27 tests total), all passing.
- Integration tests: verified manually against the running app (button downloads a CSV matching the visible page's cards on all three tabs; disabled when there's nothing loaded).

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (frontend-only change, no backend code touched)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
#1028, #1055, #1060 (prior timecards work this branch builds on)

## Migrations (if applicable)
N/A

## Test environment
Manual verification in Chrome against the running dev server; `tsc -b`/`eslint`/`vitest` run locally.

## Learning
The export is deliberately scoped to "current page" rather than attempting a full-scope export — the latter isn't reliable until #2258 (server-side search pagination/truncation) is fixed, so promising more than that would just produce a silently incomplete report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Export CSV” to each time card tab, exporting the currently filtered, current-page results.
  * Improved time card filtering and empty-state messaging to better reflect which filters exclude results.
  * Updated filter controls layout for a more compact, cleaner experience.
* **Tests**
  * Added unit tests for time card CSV generation, including proper quoting and escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->