### PR TITLE
[Customer Entity] Restore task SLA endpoints and schemas to OpenAPI spec

### DIFF
--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1666,6 +1666,85 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /slas/{id}:
+    get:
+      summary: Get a task SLA record by ID (ServiceNow data source only).
+      operationId: getTaskSla
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The task SLA record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskSlaDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Task SLA not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /slas/search:
+    post:
+      summary: Search task SLA records (ServiceNow data source only).
+      operationId: searchTaskSlas
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchTaskSlasRequest'
+      responses:
+        "200":
+          description: Task SLA records matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchTaskSlasResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /comments/search:
     post:
       summary: Search comments by reference entity (ServiceNow data source only).
@@ -4581,3 +4660,232 @@ components:
           type: integer
         message:
           type: string
+
+    SearchTaskSlasRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            taskIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+        pagination:
+          type: object
+          properties:
+            offset:
+              type: integer
+              minimum: 0
+              default: 0
+            limit:
+              type: integer
+              minimum: 1
+              maximum: 100
+              default: 20
+
+    TaskSlaDefinition:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+        target:
+          type: string
+          nullable: true
+
+    TaskSlaTaskRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+
+    TaskSlaView:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+          format: uuid
+        slaDefinition:
+          $ref: '#/components/schemas/TaskSlaDefinition'
+          nullable: true
+        stage:
+          type: string
+          nullable: true
+        task:
+          $ref: '#/components/schemas/TaskSlaTaskRef'
+          nullable: true
+        businessTimeLeft:
+          type: string
+          nullable: true
+        businessElapsedTime:
+          type: string
+          nullable: true
+        businessElapsedPercentage:
+          type: number
+          format: double
+          nullable: true
+        startTime:
+          type: string
+          nullable: true
+        endTime:
+          type: string
+          nullable: true
+
+    SearchTaskSlasResponse:
+      type: object
+      properties:
+        slas:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaskSlaView'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    TaskSlaDefinitionDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: true
+        target:
+          type: string
+          nullable: true
+        flow:
+          type: string
+          nullable: true
+        workflow:
+          type: string
+          nullable: true
+        isEnableLogging:
+          type: boolean
+          nullable: true
+        durationType:
+          type: string
+          nullable: true
+        duration:
+          type: string
+          nullable: true
+        scheduleSource:
+          type: string
+          nullable: true
+        schedule:
+          type: string
+          nullable: true
+        timezoneSource:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+        startCondition:
+          type: string
+          nullable: true
+        isRetroactiveStart:
+          type: boolean
+          nullable: true
+        isRetroactivePause:
+          type: boolean
+          nullable: true
+        whenToCancel:
+          type: string
+          nullable: true
+        cancelCondition:
+          type: string
+          nullable: true
+        pauseCondition:
+          type: string
+          nullable: true
+        whenToResume:
+          type: string
+          nullable: true
+        stopCondition:
+          type: string
+          nullable: true
+        resetCondition:
+          type: string
+          nullable: true
+        resetAction:
+          type: string
+          nullable: true
+
+    TaskSlaScheduleRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+
+    TaskSlaDetail:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+          format: uuid
+        task:
+          $ref: '#/components/schemas/TaskSlaTaskRef'
+          nullable: true
+        slaDefinition:
+          $ref: '#/components/schemas/TaskSlaDefinitionDetail'
+          nullable: true
+        stage:
+          type: string
+          nullable: true
+        businessTimeLeft:
+          type: string
+          nullable: true
+        businessElapsedTime:
+          type: string
+          nullable: true
+        businessElapsedPercentage:
+          type: number
+          format: double
+          nullable: true
+        startTime:
+          type: string
+          nullable: true
+        endTime:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+          nullable: true
+        schedule:
+          $ref: '#/components/schemas/TaskSlaScheduleRef'
+          nullable: true


### PR DESCRIPTION
## Summary
- Restore associated schemas: SearchTaskSlasRequest, SearchTaskSlasResponse, TaskSlaView, TaskSlaDefinition, TaskSlaTaskRef, TaskSlaDefinitionDetail, TaskSlaScheduleRef, TaskSlaDetail

## Test plan
- [ ] OpenAPI spec validates without errors
- [ ] GET /slas/{id} and POST /slas/search are visible in the spec


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing a single task SLA by ID.
  * Added a new search endpoint for finding task SLAs with filtering and pagination.
  * Returned SLA details now include schedule, time remaining, elapsed time, and progress metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->