### PR TITLE
[CSM Portal] resolve inline comment images; add work-state filter tooltip

### DIFF
--- a/apps/csm-portal/webapp/src/components/MultiSelectField.tsx
+++ b/apps/csm-portal/webapp/src/components/MultiSelectField.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Autocomplete, Checkbox, Chip, ListItemText, TextField } from "@wso2/oxygen-ui";
+import { Autocomplete, Box, Checkbox, Chip, ListItemText, TextField, Tooltip } from "@wso2/oxygen-ui";
 import type * as React from "react";
 import type { JSX } from "react";
 
@@ -25,6 +25,13 @@ export interface MultiSelectFieldProps<T extends string> {
   options: { value: T; label: string }[];
   onChange: (next: T[]) => void;
   disabled?: boolean;
+  /**
+   * Explains why the field is disabled. Shown as a hover tooltip; ignored
+   * when `disabled` is false. A disabled MUI control has `pointer-events:
+   * none`, so the tooltip is anchored to a wrapping `<span>` rather than the
+   * `Autocomplete` itself.
+   */
+  disabledTooltip?: string;
 }
 
 /**
@@ -41,9 +48,10 @@ export default function MultiSelectField<T extends string>({
   options,
   onChange,
   disabled,
+  disabledTooltip,
 }: MultiSelectFieldProps<T>): JSX.Element {
   const selected = options.filter((o) => values.includes(o.value));
-  return (
+  const field = (
     <Autocomplete<{ value: T; label: string }, true>
       multiple
       size="small"
@@ -85,5 +93,15 @@ export default function MultiSelectField<T extends string>({
         />
       )}
     />
+  );
+
+  if (!disabled || !disabledTooltip) return field;
+
+  return (
+    <Tooltip title={disabledTooltip}>
+      <Box component="span" sx={{ display: "block" }}>
+        {field}
+      </Box>
+    </Tooltip>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.ts
@@ -26,12 +26,13 @@ import {
 
 const SAFE_IMAGE_SUBTYPES = /^(png|jpeg|jpg|gif|webp|svg\+xml|bmp|avif)$/i;
 
-function toSafeMimeType(raw: string): string {
+/** Returns the normalized image MIME type, or `null` if `raw` isn't an allowed image subtype. */
+function toSafeMimeType(raw: string): string | null {
   const lower = raw.trim().toLowerCase();
   const fullMatch = lower.match(/^image\/(.+)$/);
   if (fullMatch && SAFE_IMAGE_SUBTYPES.test(fullMatch[1])) return lower;
   if (SAFE_IMAGE_SUBTYPES.test(lower)) return `image/${lower}`;
-  return "image/png";
+  return null;
 }
 
 function blobToDataUrl(blob: Blob): Promise<string | null> {
@@ -73,12 +74,14 @@ export function useResolvedInlineImageHtml(html: string): {
           `/attachments/${encodeURIComponent(sysidToUuid(id))}/content`,
         );
         const mimeType = toSafeMimeType(blob.type);
-        if (!mimeType.startsWith("image/")) return null;
+        if (!mimeType) return null;
         return blobToDataUrl(blob);
       },
       enabled: !!id,
-      staleTime: 0,
-      retry: false,
+      // Attachment content is immutable once uploaded, so cache it
+      // indefinitely rather than refetching on every window focus.
+      staleTime: Infinity,
+      retry: 1,
     })),
   });
 
@@ -90,12 +93,17 @@ export function useResolvedInlineImageHtml(html: string): {
     if (result) dataUrls.set(id, result);
   });
 
+  // A fixed-length key derived from the resolved data URLs: useMemo's
+  // dependency array must stay the same length across renders, which
+  // `queries.map((q) => q.data)` cannot guarantee as attachmentIds changes.
+  const dataUrlsKey = Array.from(dataUrls.entries())
+    .map(([id, url]) => `${id}:${url}`)
+    .join(",");
+
   const resolvedHtml = useMemo(
     () => replaceInlineImageSrcs(html, dataUrls),
-    // dataUrls is rebuilt fresh each render from `queries`; compare on the
-    // query results themselves rather than the (always-new) Map reference.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [html, ...queries.map((q) => q.data)],
+    [html, dataUrlsKey],
   );
 
   return { resolvedHtml, isLoading: attachmentIds.length > 0 && isLoading };

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { useBackendApi } from "@api/backend/client";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import {
+  extractIixAttachmentIds,
+  replaceInlineImageSrcs,
+  sysidToUuid,
+} from "@features/csm-cases/utils/inlineImages";
+
+const SAFE_IMAGE_SUBTYPES = /^(png|jpeg|jpg|gif|webp|svg\+xml|bmp|avif)$/i;
+
+function toSafeMimeType(raw: string): string {
+  const lower = raw.trim().toLowerCase();
+  const fullMatch = lower.match(/^image\/(.+)$/);
+  if (fullMatch && SAFE_IMAGE_SUBTYPES.test(fullMatch[1])) return lower;
+  if (SAFE_IMAGE_SUBTYPES.test(lower)) return `image/${lower}`;
+  return "image/png";
+}
+
+function blobToDataUrl(blob: Blob): Promise<string | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result;
+      resolve(typeof result === "string" ? result : null);
+    };
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * Fetches inline-image attachments referenced within comment/description HTML
+ * via the authenticated `GET /attachments/{id}/content` endpoint and resolves
+ * them into `data:` URLs so `<img>` tags can render them without the browser
+ * making an unauthenticated request. Mirrors the customer portal's
+ * `useResolvedInlineImageHtml`.
+ *
+ * @param html - Sanitized HTML that may contain `.iix` `<img>` src references.
+ */
+export function useResolvedInlineImageHtml(html: string): {
+  resolvedHtml: string;
+  isLoading: boolean;
+} {
+  const api = useBackendApi();
+  const attachmentIds = useMemo(() => extractIixAttachmentIds(html), [html]);
+
+  const queries = useQueries({
+    queries: attachmentIds.map((id) => ({
+      queryKey: [ApiQueryKeys.CSM_CASE_ATTACHMENTS, "inline-preview", id],
+      queryFn: async (): Promise<string | null> => {
+        // The extracted id is a bare 32-char sysid; the endpoint requires the
+        // canonical UUID shape (hyphens re-inserted), same as every other
+        // attachment id sent to this backend.
+        const blob = await api.getBlob(
+          `/attachments/${encodeURIComponent(sysidToUuid(id))}/content`,
+        );
+        const mimeType = toSafeMimeType(blob.type);
+        if (!mimeType.startsWith("image/")) return null;
+        return blobToDataUrl(blob);
+      },
+      enabled: !!id,
+      staleTime: 0,
+      retry: false,
+    })),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading);
+
+  const dataUrls = new Map<string, string>();
+  attachmentIds.forEach((id, i) => {
+    const result = queries[i]?.data;
+    if (result) dataUrls.set(id, result);
+  });
+
+  const resolvedHtml = useMemo(
+    () => replaceInlineImageSrcs(html, dataUrls),
+    // dataUrls is rebuilt fresh each render from `queries`; compare on the
+    // query results themselves rather than the (always-new) Map reference.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [html, ...queries.map((q) => q.data)],
+  );
+
+  return { resolvedHtml, isLoading: attachmentIds.length > 0 && isLoading };
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -481,6 +481,11 @@ export default function CasesFilterBar({
                 options={workStateOptions}
                 onChange={(next) => onChange({ ...filters, workStates: next })}
                 disabled={!filters.states.includes("work_in_progress")}
+                disabledTooltip={
+                  filters.states.includes("work_in_progress")
+                    ? undefined
+                    : `Select the "${STATE_LABEL.work_in_progress}" state to filter by work state`
+                }
               />
             </Grid>
             {showEngagementTypeFilter && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -84,18 +84,22 @@ export default function CsmCaseCommentBubble({
         }}
       >
         <SemanticChip role="warning" label="System" />
-        <Box
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            overflowWrap: "anywhere",
-            wordBreak: "break-word",
-            "& p": { m: 0 },
-            "& a": { color: "primary.main" },
-            ...{ "& *": { fontSize: "0.875rem" } },
-          }}
-          dangerouslySetInnerHTML={{ __html: resolvedHtml }}
-        />
+        {isImagesLoading ? (
+          <Skeleton variant="text" width="40%" sx={{ flex: 1 }} />
+        ) : (
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflowWrap: "anywhere",
+              wordBreak: "break-word",
+              "& p": { m: 0 },
+              "& a": { color: "primary.main" },
+              ...{ "& *": { fontSize: "0.875rem" } },
+            }}
+            dangerouslySetInnerHTML={{ __html: resolvedHtml }}
+          />
+        )}
         <Typography variant="caption" color="text.secondary">
           <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
         </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Avatar, Box, Chip, Paper, Typography, useTheme } from "@wso2/oxygen-ui";
+import { Avatar, Box, Chip, Paper, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
 import { Bot } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
@@ -23,6 +23,7 @@ import { pickAccessibleText } from "@utils/contrastText";
 import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { markdownToHtml } from "@utils/renderMarkdown";
 import { initialsOf } from "@utils/userClaims";
+import { useResolvedInlineImageHtml } from "@features/csm-cases/api/useResolvedInlineImageHtml";
 import type {
   CsmCaseComment,
   CsmCommentAuthorRole,
@@ -64,6 +65,8 @@ export default function CsmCaseCommentBubble({
       ),
     [comment.bodyHtml, isBot],
   );
+  const { resolvedHtml, isLoading: isImagesLoading } =
+    useResolvedInlineImageHtml(safeHtml);
   const isSystem = comment.authorRole === "system";
 
   if (isSystem) {
@@ -91,7 +94,7 @@ export default function CsmCaseCommentBubble({
             "& a": { color: "primary.main" },
             ...{ "& *": { fontSize: "0.875rem" } },
           }}
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
+          dangerouslySetInnerHTML={{ __html: resolvedHtml }}
         />
         <Typography variant="caption" color="text.secondary">
           <RelativeTime iso={comment.createdAt} href={`#${comment.id}`} />
@@ -216,8 +219,13 @@ export default function CsmCaseCommentBubble({
             },
             "& th": { bgcolor: "action.hover", fontWeight: 600 },
           }}
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+        >
+          {isImagesLoading ? (
+            <Skeleton variant="rectangular" width="100%" height={120} sx={{ borderRadius: 1 }} />
+          ) : (
+            <Box dangerouslySetInnerHTML={{ __html: resolvedHtml }} />
+          )}
+        </Box>
       </Paper>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/inlineImages.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/inlineImages.ts
@@ -14,8 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Shared "img tag with quoted/bare src" grammar for both extraction and
+// replacement, so the two stay in sync as the pattern evolves. Capture groups:
+// 1=before-src attrs, 2=double-quoted src, 3=single-quoted src, 4=bare src, 5=after-src attrs.
 const IMG_TAG_SRC =
-  /<img[^>]*?\s+src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>/gi;
+  /<img([^>]*?)\s+src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))([^>]*)>/gi;
 
 /**
  * Extracts the backing attachment id from an inline `<img>` `src` value. The
@@ -56,7 +59,7 @@ export function extractIixAttachmentIds(html: string): string[] {
   let match;
   IMG_TAG_SRC.lastIndex = 0;
   while ((match = IMG_TAG_SRC.exec(html)) !== null) {
-    const src = match[1] ?? match[2] ?? match[3] ?? "";
+    const src = match[2] ?? match[3] ?? match[4] ?? "";
     if (src.includes(".iix")) {
       const id = extractInlineImageRefId(src);
       if (id && !ids.includes(id)) ids.push(id);
@@ -74,9 +77,8 @@ export function replaceInlineImageSrcs(
   html: string,
   dataUrls: Map<string, string>,
 ): string {
-  if (!dataUrls.size) return html;
   return html.replace(
-    /<img([^>]*?)\s+src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))([^>]*)>/gi,
+    IMG_TAG_SRC,
     (fullMatch, before, doubleSrc, singleSrc, bareSrc, after) => {
       const src = (doubleSrc ?? singleSrc ?? bareSrc ?? "") as string;
       if (!src.includes(".iix")) return fullMatch;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/inlineImages.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/inlineImages.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const IMG_TAG_SRC =
+  /<img[^>]*?\s+src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>/gi;
+
+/**
+ * Extracts the backing attachment id from an inline `<img>` `src` value. The
+ * backing data source embeds inline images as `.iix`-suffixed references
+ * (e.g. `.../<attachmentId>.iix`); this pulls the id out regardless of
+ * whether it appears as a full path or a bare token.
+ */
+export function extractInlineImageRefId(src: string): string {
+  const s = src.trim();
+  const fromPath = s.match(/\/([a-f0-9]{32})\.iix(?:\?|#|$)/i);
+  if (fromPath) return fromPath[1];
+  const tail =
+    s
+      .replace(/\.iix$/i, "")
+      .split("/")
+      .pop()
+      ?.trim() ?? "";
+  if (/^[a-f0-9]{32}$/i.test(tail)) return tail;
+  return s
+    .replace(/^\//, "")
+    .replace(/\.iix$/i, "")
+    .trim();
+}
+
+/**
+ * Formats a 32-character ServiceNow sysid (no hyphens) as a canonical UUID
+ * (`8-4-4-4-12`) — the shape the backend's `/attachments/{id}/content`
+ * endpoint requires. Ids already in another shape are returned unchanged.
+ */
+export function sysidToUuid(id: string): string {
+  if (!/^[a-f0-9]{32}$/i.test(id)) return id;
+  return `${id.slice(0, 8)}-${id.slice(8, 12)}-${id.slice(12, 16)}-${id.slice(16, 20)}-${id.slice(20, 32)}`;
+}
+
+/** Extracts every attachment id referenced by a `.iix` `<img>` src within an HTML string. */
+export function extractIixAttachmentIds(html: string): string[] {
+  const ids: string[] = [];
+  let match;
+  IMG_TAG_SRC.lastIndex = 0;
+  while ((match = IMG_TAG_SRC.exec(html)) !== null) {
+    const src = match[1] ?? match[2] ?? match[3] ?? "";
+    if (src.includes(".iix")) {
+      const id = extractInlineImageRefId(src);
+      if (id && !ids.includes(id)) ids.push(id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Replaces every `.iix` `<img>` src in `html` with its resolved data URL from
+ * `dataUrls`. A `.iix` reference with no matching entry is stripped (rather
+ * than left pointing at an auth-gated URL the browser cannot fetch).
+ */
+export function replaceInlineImageSrcs(
+  html: string,
+  dataUrls: Map<string, string>,
+): string {
+  if (!dataUrls.size) return html;
+  return html.replace(
+    /<img([^>]*?)\s+src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))([^>]*)>/gi,
+    (fullMatch, before, doubleSrc, singleSrc, bareSrc, after) => {
+      const src = (doubleSrc ?? singleSrc ?? bareSrc ?? "") as string;
+      if (!src.includes(".iix")) return fullMatch;
+      const refId = extractInlineImageRefId(src);
+      const dataUrl = dataUrls.get(refId);
+      const quote = doubleSrc !== undefined ? '"' : singleSrc !== undefined ? "'" : '"';
+      if (!dataUrl) {
+        return `<img${before} src=${quote}${quote} data-unresolved="true"${after}>`;
+      }
+      return `<img${before} src=${quote}${dataUrl}${quote}${after}>`;
+    },
+  );
+}


### PR DESCRIPTION
## Purpose
Two small, unrelated CSM-portal frontend fixes bundled together:

1. Inline images embedded in case comments (`.iix`-style attachment references) rendered as broken images — the `<img>` src pointed at an auth-gated URL the browser can't fetch directly.
2. The cases-search "Work state" filter is disabled until "In progress" is selected in the State filter, but gave no indication why it was greyed out.

## Goals
1. Resolve inline comment images the same way the customer portal already does: fetch each referenced attachment through the authenticated attachment-content endpoint and swap the `<img>` src for a `data:` URL.
2. Add a hover tooltip explaining why the Work state filter is disabled.

## Approach
1. Added `extractIixAttachmentIds` / `replaceInlineImageSrcs` / `sysidToUuid` helpers and a `useResolvedInlineImageHtml` hook that fetches each attachment id via the existing `GET /attachments/{id}/content` endpoint (already implemented on this backend) and resolves it to a `data:` URL, converting the extracted 32-char id to the canonical UUID shape the endpoint expects. Wired into `CsmCaseCommentBubble`, with a loading skeleton while images resolve.
2. Added an optional `disabledTooltip` prop to the shared `MultiSelectField` (wraps the disabled `Autocomplete` in a `<span>` + `Tooltip`, since disabled elements block pointer events) and used it on the Work state filter in `CasesFilterBar`.

No backend or API contract changes — both fixes are frontend-only and reuse existing endpoints/props.

## Release note
- Case comments now render embedded inline images instead of showing a broken image.
- The disabled "Work state" filter now shows a tooltip explaining it requires the "In progress" state to be selected.

## Documentation
N/A — internal UI behavior fixes, no user-facing docs to update.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React; `pnpm lint` and `tsc --noEmit` ran clean instead)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
N/A

## Test environment
Verified locally: `pnpm build`, `pnpm exec tsc --noEmit`, `pnpm exec eslint` all clean on the changed files; manually exercised against the staging backend via the local dev stack (`stg-be` mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline images in case comments now render directly in the conversation, improving readability.
  * Disabled multi-select fields can now show a helpful tooltip message.

* **Bug Fixes**
  * Comment content now shows a loading placeholder while inline images are being resolved.
  * The “Work state” filter now explains why it’s unavailable when the required parent state isn’t selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->