### PR TITLE
[Customer Entity] Add resolution fields to PATCH /cases/{id}

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -999,8 +999,8 @@ type UpdatedCase struct {
 	WorkState      *CaseWorkState       `json:"workState"`
 	WatchList      []WatchListUser      `json:"watchList,omitempty"`
 	AssignedTo     *AssignedEngineerRef `json:"assignedTo,omitempty"`
-	ResolutionCode *CaseLabelRef        `json:"resolutionCode,omitempty"`
-	Cause          *CaseLabelRef        `json:"cause,omitempty"`
+	ResolutionCode *CaseResolutionCode  `json:"resolutionCode,omitempty"`
+	Cause          *CaseCause           `json:"cause,omitempty"`
 	CloseNotes     *string              `json:"closeNotes,omitempty"`
 	ResolvedOn     *time.Time           `json:"resolvedOn,omitempty"`
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1002,7 +1002,7 @@ type UpdatedCase struct {
 	ResolutionCode *CaseLabelRef        `json:"resolutionCode,omitempty"`
 	Cause          *CaseLabelRef        `json:"cause,omitempty"`
 	CloseNotes     *string              `json:"closeNotes,omitempty"`
-	ResolvedAt     *time.Time           `json:"resolvedAt,omitempty"`
+	ResolvedOn     *time.Time           `json:"resolvedOn,omitempty"`
 }
 
 // WatchListUser is a compact user reference within the watch list.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -917,13 +917,18 @@ type SearchCasesResponse struct {
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
 // Exactly one of State, Severity, WorkState, WatchList, or AssigneeEmail must be provided.
 // WatchList and AssigneeEmail are only supported for the ServiceNow data source.
+// ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
+// State is closed or solution_proposed.
 type UpdateCaseRequest struct {
-	ID            string         `json:"-"`
-	State         *CaseState     `json:"state"`
-	Severity      *CaseSeverity  `json:"severity"`
-	WorkState     *CaseWorkState `json:"workState"`
-	WatchList     []string       `json:"watchList"`
-	AssigneeEmail *string        `json:"assigneeEmail"`
+	ID             string         `json:"-"`
+	State          *CaseState     `json:"state"`
+	Severity       *CaseSeverity  `json:"severity"`
+	WorkState      *CaseWorkState `json:"workState"`
+	WatchList      []string       `json:"watchList"`
+	AssigneeEmail  *string        `json:"assigneeEmail"`
+	ResolutionCode *int           `json:"resolutionCode"`
+	Cause          *string        `json:"cause"`
+	CloseNotes     *string        `json:"closeNotes"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -932,16 +937,26 @@ type UpdateCaseResponse struct {
 	Case    UpdatedCase `json:"case"`
 }
 
+// CaseLabelRef is a generic id/label pair returned by ServiceNow for choice-list fields.
+type CaseLabelRef struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
 // UpdatedCase carries the fields of a case that may change after an update.
 type UpdatedCase struct {
-	ID         string               `json:"id"`
-	UpdatedOn  time.Time            `json:"updatedOn"`
-	UpdatedBy  string               `json:"updatedBy,omitempty"`
-	State      CaseState            `json:"state,omitempty"`
-	Severity   CaseSeverity         `json:"severity,omitempty"`
-	WorkState  *CaseWorkState       `json:"workState"`
-	WatchList  []WatchListUser      `json:"watchList,omitempty"`
-	AssignedTo *AssignedEngineerRef `json:"assignedTo,omitempty"`
+	ID             string               `json:"id"`
+	UpdatedOn      time.Time            `json:"updatedOn"`
+	UpdatedBy      string               `json:"updatedBy,omitempty"`
+	State          CaseState            `json:"state,omitempty"`
+	Severity       CaseSeverity         `json:"severity,omitempty"`
+	WorkState      *CaseWorkState       `json:"workState"`
+	WatchList      []WatchListUser      `json:"watchList,omitempty"`
+	AssignedTo     *AssignedEngineerRef `json:"assignedTo,omitempty"`
+	ResolutionCode *CaseLabelRef        `json:"resolutionCode,omitempty"`
+	Cause          *CaseLabelRef        `json:"cause,omitempty"`
+	CloseNotes     *string              `json:"closeNotes,omitempty"`
+	ResolvedAt     *time.Time           `json:"resolvedAt,omitempty"`
 }
 
 // WatchListUser is a compact user reference within the watch list.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -711,6 +711,52 @@ const (
 	CaseWorkStatePaused  CaseWorkState = "paused"
 )
 
+// CaseResolutionCode enumerates the resolution codes for a resolved case.
+type CaseResolutionCode string
+
+const (
+	CaseResolutionCodeSolvedFixedBySupportGuidanceProvided    CaseResolutionCode = "SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED"
+	CaseResolutionCodeSolvedFixedByClosingRelatedIncident     CaseResolutionCode = "SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT"
+	CaseResolutionCodeSolvedFixedByClosingRelatedRDTicket     CaseResolutionCode = "SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET"
+	CaseResolutionCodeSolvedWorkaroundProvided                CaseResolutionCode = "SOLVED_WORKAROUND_PROVIDED"
+	CaseResolutionCodeSolvedByCustomer                        CaseResolutionCode = "SOLVED_BY_CUSTOMER"
+	CaseResolutionCodeConsideredForRoadmap                    CaseResolutionCode = "CONSIDERED_FOR_ROADMAP"
+	CaseResolutionCodeInconclusiveOutOfScope                  CaseResolutionCode = "INCONCLUSIVE_OUT_OF_SCOPE"
+	CaseResolutionCodeInconclusiveCannotReproduce             CaseResolutionCode = "INCONCLUSIVE_CANNOT_REPRODUCE"
+	CaseResolutionCodeInconclusiveNoWorkaround                CaseResolutionCode = "INCONCLUSIVE_NO_WORKAROUND"
+	CaseResolutionCodeDuplicateIssue                          CaseResolutionCode = "DUPLICATE_ISSUE"
+	CaseResolutionCodeVoidedCanceled                          CaseResolutionCode = "VOIDED_CANCELED"
+	CaseResolutionCodeOnHold                                  CaseResolutionCode = "ON_HOLD"
+	CaseResolutionCodeConsideredForRoadmapAlt                 CaseResolutionCode = "CONSIDERED_FOR_ROADMAP_ALT"
+	CaseResolutionCodeSolvedFixedTheIssue                     CaseResolutionCode = "SOLVED_FIXED_THE_ISSUE"
+	CaseResolutionCodeSolvedWorkaroundProvidedAlt             CaseResolutionCode = "SOLVED_WORKAROUND_PROVIDED_ALT"
+	CaseResolutionCodeSolvedByContributor                     CaseResolutionCode = "SOLVED_BY_CONTRIBUTOR"
+	CaseResolutionCodeSolvedByNovera                          CaseResolutionCode = "SOLVED_BY_NOVERA"
+	CaseResolutionCodeAbruptlyClosedDueToNonResponsiveness    CaseResolutionCode = "ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS"
+)
+
+// CaseCause enumerates the root-cause categories for a resolved case.
+type CaseCause string
+
+const (
+	CaseCauseUserMisunderstandingConcepts      CaseCause = "USER_MISUNDERSTANDING_CONCEPTS"
+	CaseCauseUserMisunderstandingDocumentation CaseCause = "USER_MISUNDERSTANDING_DOCUMENTATION"
+	CaseCauseUserNotFollowingDocumentation     CaseCause = "USER_NOT_FOLLOWING_DOCUMENTATION"
+	CaseCauseUserMistake                       CaseCause = "USER_MISTAKE"
+	CaseCauseSolutionProblematicArchitecture   CaseCause = "SOLUTION_PROBLEMATIC_SOLUTION_ARCHITECTURE"
+	CaseCauseSolutionProblematicCode           CaseCause = "SOLUTION_PROBLEMATIC_CODE"
+	CaseCauseApplicationBug                    CaseCause = "APPLICATION_BUG"
+	CaseCauseApplicationMisleadingUXUI         CaseCause = "APPLICATION_MISLEADING_UX_UI"
+	CaseCauseApplicationLimitation             CaseCause = "APPLICATION_LIMITATION"
+	CaseCauseApplicationMissingFeature         CaseCause = "APPLICATION_MISSING_FEATURE"
+	CaseCauseApplicationDocumentationGap       CaseCause = "APPLICATION_DOCUMENTATION_GAP"
+	CaseCauseApplicationDocumentationError     CaseCause = "APPLICATION_DOCUMENTATION_ERROR"
+	CaseCauseInfrastructureCustomerSide        CaseCause = "INFRASTRUCTURE_CUSTOMERS_SIDE"
+	CaseCauseInfrastructureSaaSNotEnough       CaseCause = "INFRASTRUCTURE_SAAS_SIDE_NOT_ENOUGH"
+	CaseCauseInfrastructureSaaSother           CaseCause = "INFRASTRUCTURE_SAAS_SIDE_OTHER"
+	CaseCauseUnknown                           CaseCause = "UNKNOWN"
+)
+
 // EngagementType classifies the type of an engagement case.
 type EngagementType string
 
@@ -926,8 +972,8 @@ type UpdateCaseRequest struct {
 	WorkState      *CaseWorkState `json:"workState"`
 	WatchList      []string       `json:"watchList"`
 	AssigneeEmail  *string        `json:"assigneeEmail"`
-	ResolutionCode *int           `json:"resolutionCode"`
-	Cause          *string        `json:"cause"`
+	ResolutionCode *CaseResolutionCode `json:"resolutionCode"`
+	Cause          *CaseCause     `json:"cause"`
 	CloseNotes     *string        `json:"closeNotes"`
 }
 

--- a/entity-service/internal/handler/decode.go
+++ b/entity-service/internal/handler/decode.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -65,7 +66,14 @@ func decodeErrMsg(err error) string {
 	}
 	var typeErr *json.UnmarshalTypeError
 	if errors.As(err, &typeErr) {
-		return fmt.Sprintf("invalid value for field %q: expected %s", typeErr.Field, typeErr.Type)
+		typeName := typeErr.Type.String()
+		// Strip package prefix from named types (e.g. "domain.CaseResolutionCode" → "string").
+		if typeErr.Type.Kind() == reflect.String {
+			typeName = "string"
+		} else if typeErr.Type.Kind() == reflect.Int || typeErr.Type.Kind() == reflect.Int64 {
+			typeName = "integer"
+		}
+		return fmt.Sprintf("invalid value for field %q: expected %s", typeErr.Field, typeName)
 	}
 	// DisallowUnknownFields produces "json: unknown field "<name>"".
 	msg := err.Error()

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -849,7 +849,7 @@ type snUpdateCaseResponse struct {
 			Label string `json:"label"`
 		} `json:"cause"`
 		CloseNotes *string `json:"closeNotes"`
-		ResolvedAt *string `json:"resolvedAt"`
+		ResolvedOn *string `json:"resolvedOn"`
 	} `json:"case"`
 }
 
@@ -1006,12 +1006,12 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		resp.Case.Cause = &domain.CaseLabelRef{ID: snResp.Case.Cause.ID, Label: snResp.Case.Cause.Label}
 	}
 	resp.Case.CloseNotes = snResp.Case.CloseNotes
-	if snResp.Case.ResolvedAt != nil {
-		resolvedAt, err := time.Parse(snCreatedOnLayout, *snResp.Case.ResolvedAt)
+	if snResp.Case.ResolvedOn != nil {
+		resolvedOn, err := time.Parse(snCreatedOnLayout, *snResp.Case.ResolvedOn)
 		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse resolvedAt %q: %w", *snResp.Case.ResolvedAt, err)
+			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse resolvedAt %q: %w", *snResp.Case.ResolvedOn, err)
 		}
-		resp.Case.ResolvedAt = &resolvedAt
+		resp.Case.ResolvedOn = &resolvedOn
 	}
 
 	return resp, nil

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -795,6 +795,18 @@ var snResolutionCodeKey = map[domain.CaseResolutionCode]int{
 	domain.CaseResolutionCodeAbruptlyClosedDueToNonResponsiveness: 52,
 }
 
+// snResolutionCodeByID maps ServiceNow resolution code id strings to domain CaseResolutionCode enums.
+var snResolutionCodeByID = func() map[string]domain.CaseResolutionCode {
+	m := make(map[string]domain.CaseResolutionCode, len(snResolutionCodeKey))
+	for k, v := range snResolutionCodeKey {
+		m[fmt.Sprintf("%d", v)] = k
+	}
+	return m
+}()
+
+// snCauseLabelToEnum maps ServiceNow cause label strings to domain CaseCause enums.
+var snCauseLabelToEnum map[string]domain.CaseCause
+
 // snCauseLabel maps domain CaseCause enums to the ServiceNow cause label strings.
 var snCauseLabel = map[domain.CaseCause]string{
 	domain.CaseCauseUserMisunderstandingConcepts:      "User - Misunderstanding concepts",
@@ -813,6 +825,13 @@ var snCauseLabel = map[domain.CaseCause]string{
 	domain.CaseCauseInfrastructureSaaSNotEnough:       "Infrastructure - SaaS side - Not enough ...",
 	domain.CaseCauseInfrastructureSaaSother:           "Infrastructure - SaaS side - Other",
 	domain.CaseCauseUnknown:                           "Unknown",
+}
+
+func init() {
+	snCauseLabelToEnum = make(map[string]domain.CaseCause, len(snCauseLabel))
+	for k, v := range snCauseLabel {
+		snCauseLabelToEnum[v] = k
+	}
 }
 
 // snWorkStateIDMap maps domain CaseWorkState enums to SN numeric work state IDs.
@@ -1000,10 +1019,14 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		resp.Case.WatchList = wl
 	}
 	if snResp.Case.ResolutionCode != nil {
-		resp.Case.ResolutionCode = &domain.CaseLabelRef{ID: snResp.Case.ResolutionCode.ID.String(), Label: snResp.Case.ResolutionCode.Label}
+		if rc, ok := snResolutionCodeByID[snResp.Case.ResolutionCode.ID.String()]; ok {
+			resp.Case.ResolutionCode = &rc
+		}
 	}
 	if snResp.Case.Cause != nil {
-		resp.Case.Cause = &domain.CaseLabelRef{ID: snResp.Case.Cause.ID, Label: snResp.Case.Cause.Label}
+		if c, ok := snCauseLabelToEnum[snResp.Case.Cause.Label]; ok {
+			resp.Case.Cause = &c
+		}
 	}
 	resp.Case.CloseNotes = snResp.Case.CloseNotes
 	if snResp.Case.ResolvedOn != nil {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -762,7 +762,7 @@ type snUpdateCasePayload struct {
 	WorkStateKey   *int     `json:"workStateKey,omitempty"`
 	WatchList      []string `json:"watchList,omitempty"`
 	AssigneeEmail  *string  `json:"assigneeEmail,omitempty"`
-	ResolutionCode *int     `json:"resolutionCode,omitempty"`
+	ResolutionCode *int    `json:"resolutionCode,omitempty"`
 	Cause          *string  `json:"cause,omitempty"`
 	CloseNotes     *string  `json:"closeNotes,omitempty"`
 }
@@ -771,6 +771,48 @@ type snUpdateCasePayload struct {
 var snResolutionStates = map[int]bool{
 	3: true, // closed
 	6: true, // solution_proposed
+}
+
+// snResolutionCodeKey maps domain CaseResolutionCode enums to the ServiceNow integer keys.
+var snResolutionCodeKey = map[domain.CaseResolutionCode]int{
+	domain.CaseResolutionCodeSolvedFixedBySupportGuidanceProvided: 1,
+	domain.CaseResolutionCodeSolvedFixedByClosingRelatedIncident:  16,
+	domain.CaseResolutionCodeSolvedFixedByClosingRelatedRDTicket:  17,
+	domain.CaseResolutionCodeSolvedWorkaroundProvided:             3,
+	domain.CaseResolutionCodeSolvedByCustomer:                     4,
+	domain.CaseResolutionCodeConsideredForRoadmap:                 18,
+	domain.CaseResolutionCodeInconclusiveOutOfScope:               5,
+	domain.CaseResolutionCodeInconclusiveCannotReproduce:          6,
+	domain.CaseResolutionCodeInconclusiveNoWorkaround:             7,
+	domain.CaseResolutionCodeDuplicateIssue:                       8,
+	domain.CaseResolutionCodeVoidedCanceled:                       9,
+	domain.CaseResolutionCodeOnHold:                               19,
+	domain.CaseResolutionCodeConsideredForRoadmapAlt:              20,
+	domain.CaseResolutionCodeSolvedFixedTheIssue:                  21,
+	domain.CaseResolutionCodeSolvedWorkaroundProvidedAlt:          22,
+	domain.CaseResolutionCodeSolvedByContributor:                  27,
+	domain.CaseResolutionCodeSolvedByNovera:                       51,
+	domain.CaseResolutionCodeAbruptlyClosedDueToNonResponsiveness: 52,
+}
+
+// snCauseLabel maps domain CaseCause enums to the ServiceNow cause label strings.
+var snCauseLabel = map[domain.CaseCause]string{
+	domain.CaseCauseUserMisunderstandingConcepts:      "User - Misunderstanding concepts",
+	domain.CaseCauseUserMisunderstandingDocumentation: "User - Misunderstanding documentation",
+	domain.CaseCauseUserNotFollowingDocumentation:     "User - Not following documentation",
+	domain.CaseCauseUserMistake:                       "User - Mistake",
+	domain.CaseCauseSolutionProblematicArchitecture:   "Solution - Problematic solution architecture",
+	domain.CaseCauseSolutionProblematicCode:           "Solution - Problematic code",
+	domain.CaseCauseApplicationBug:                    "Application - Bug",
+	domain.CaseCauseApplicationMisleadingUXUI:         "Application - Misleading UX / UI",
+	domain.CaseCauseApplicationLimitation:             "Application - Limitation",
+	domain.CaseCauseApplicationMissingFeature:         "Application - Missing feature",
+	domain.CaseCauseApplicationDocumentationGap:       "Application - Documentation gap",
+	domain.CaseCauseApplicationDocumentationError:     "Application - Documentation error",
+	domain.CaseCauseInfrastructureCustomerSide:        "Infrastructure - Customer's side",
+	domain.CaseCauseInfrastructureSaaSNotEnough:       "Infrastructure - SaaS side - Not enough ...",
+	domain.CaseCauseInfrastructureSaaSother:           "Infrastructure - SaaS side - Other",
+	domain.CaseCauseUnknown:                           "Unknown",
 }
 
 // snWorkStateIDMap maps domain CaseWorkState enums to SN numeric work state IDs.
@@ -862,8 +904,20 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		if hasResolutionFields && !snResolutionStates[id] {
 			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode, cause, and closeNotes are only allowed when state is closed or solution_proposed"}
 		}
-		payload.ResolutionCode = req.ResolutionCode
-		payload.Cause = req.Cause
+		if req.ResolutionCode != nil {
+			key, ok := snResolutionCodeKey[*req.ResolutionCode]
+			if !ok {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode contains invalid value: " + string(*req.ResolutionCode)}
+			}
+			payload.ResolutionCode = &key
+		}
+		if req.Cause != nil {
+			label, ok := snCauseLabel[*req.Cause]
+			if !ok {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "cause contains invalid value: " + string(*req.Cause)}
+			}
+			payload.Cause = &label
+		}
 		payload.CloseNotes = req.CloseNotes
 	}
 	if req.Severity != nil {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -757,11 +757,20 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 }
 
 type snUpdateCasePayload struct {
-	StateKey      *int     `json:"stateKey,omitempty"`
-	SeverityKey   *int     `json:"severityKey,omitempty"`
-	WorkStateKey  *int     `json:"workStateKey,omitempty"`
-	WatchList     []string `json:"watchList,omitempty"`
-	AssigneeEmail *string  `json:"assigneeEmail,omitempty"`
+	StateKey       *int     `json:"stateKey,omitempty"`
+	SeverityKey    *int     `json:"severityKey,omitempty"`
+	WorkStateKey   *int     `json:"workStateKey,omitempty"`
+	WatchList      []string `json:"watchList,omitempty"`
+	AssigneeEmail  *string  `json:"assigneeEmail,omitempty"`
+	ResolutionCode *int     `json:"resolutionCode,omitempty"`
+	Cause          *string  `json:"cause,omitempty"`
+	CloseNotes     *string  `json:"closeNotes,omitempty"`
+}
+
+// snResolutionStates are the state keys that allow resolution fields.
+var snResolutionStates = map[int]bool{
+	3: true, // closed
+	6: true, // solution_proposed
 }
 
 // snWorkStateIDMap maps domain CaseWorkState enums to SN numeric work state IDs.
@@ -773,13 +782,13 @@ var snWorkStateIDMap = map[domain.CaseWorkState]int{
 type snUpdateCaseResponse struct {
 	Message string `json:"message"`
 	Case    struct {
-		ID        string       `json:"id"`
-		UpdatedOn string       `json:"updatedOn"`
-		UpdatedBy string       `json:"updatedBy"`
-		State     *snCaseState `json:"state"`
-		Severity  *snCaseLabel `json:"severity"`
-		WorkState *snCaseLabel `json:"workState"`
-		WatchList []struct {
+		ID             string       `json:"id"`
+		UpdatedOn      string       `json:"updatedOn"`
+		UpdatedBy      string       `json:"updatedBy"`
+		State          *snCaseState `json:"state"`
+		Severity       *snCaseLabel `json:"severity"`
+		WorkState      *snCaseLabel `json:"workState"`
+		WatchList      []struct {
 			ID       string `json:"id"`
 			UserName string `json:"userName"`
 			Name     string `json:"name"`
@@ -789,6 +798,16 @@ type snUpdateCaseResponse struct {
 			ID   string `json:"id"`
 			Name string `json:"name"`
 		} `json:"assignedTo"`
+		ResolutionCode *struct {
+			ID    json.Number `json:"id"`
+			Label string      `json:"label"`
+		} `json:"resolutionCode"`
+		Cause *struct {
+			ID    string `json:"id"`
+			Label string `json:"label"`
+		} `json:"cause"`
+		CloseNotes *string `json:"closeNotes"`
+		ResolvedAt *string `json:"resolvedAt"`
 	} `json:"case"`
 }
 
@@ -796,6 +815,8 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}
+
+	hasResolutionFields := req.ResolutionCode != nil || req.Cause != nil || req.CloseNotes != nil
 
 	fieldCount := 0
 	if req.State != nil {
@@ -819,6 +840,9 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if fieldCount > 1 {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, severity, workState, watchList, or assigneeEmail may be provided per request"}
 	}
+	if hasResolutionFields && req.State == nil {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode, cause, and closeNotes are only allowed when state is also provided"}
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
@@ -835,6 +859,12 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state " + string(*req.State) + " is not supported by ServiceNow"}
 		}
 		payload.StateKey = &id
+		if hasResolutionFields && !snResolutionStates[id] {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode, cause, and closeNotes are only allowed when state is closed or solution_proposed"}
+		}
+		payload.ResolutionCode = req.ResolutionCode
+		payload.Cause = req.Cause
+		payload.CloseNotes = req.CloseNotes
 	}
 	if req.Severity != nil {
 		if !validCaseSeverity[*req.Severity] {
@@ -914,6 +944,20 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			})
 		}
 		resp.Case.WatchList = wl
+	}
+	if snResp.Case.ResolutionCode != nil {
+		resp.Case.ResolutionCode = &domain.CaseLabelRef{ID: snResp.Case.ResolutionCode.ID.String(), Label: snResp.Case.ResolutionCode.Label}
+	}
+	if snResp.Case.Cause != nil {
+		resp.Case.Cause = &domain.CaseLabelRef{ID: snResp.Case.Cause.ID, Label: snResp.Case.Cause.Label}
+	}
+	resp.Case.CloseNotes = snResp.Case.CloseNotes
+	if snResp.Case.ResolvedAt != nil {
+		resolvedAt, err := time.Parse(snCreatedOnLayout, *snResp.Case.ResolvedAt)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse resolvedAt %q: %w", *snResp.Case.ResolvedAt, err)
+		}
+		resp.Case.ResolvedAt = &resolvedAt
 	}
 
 	return resp, nil

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2763,15 +2763,49 @@ components:
           nullable: true
           $ref: '#/components/schemas/AssignedEngineerRef'
         resolutionCode:
+          type: string
           nullable: true
+          enum:
+            - SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED
+            - SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT
+            - SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET
+            - SOLVED_WORKAROUND_PROVIDED
+            - SOLVED_BY_CUSTOMER
+            - CONSIDERED_FOR_ROADMAP
+            - INCONCLUSIVE_OUT_OF_SCOPE
+            - INCONCLUSIVE_CANNOT_REPRODUCE
+            - INCONCLUSIVE_NO_WORKAROUND
+            - DUPLICATE_ISSUE
+            - VOIDED_CANCELED
+            - ON_HOLD
+            - CONSIDERED_FOR_ROADMAP_ALT
+            - SOLVED_FIXED_THE_ISSUE
+            - SOLVED_WORKAROUND_PROVIDED_ALT
+            - SOLVED_BY_CONTRIBUTOR
+            - SOLVED_BY_NOVERA
+            - ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS
           description: Resolution code, present when the case was closed or solution proposed.
-          allOf:
-            - $ref: '#/components/schemas/CaseLabelRef'
         cause:
+          type: string
           nullable: true
-          description: Cause, present when the case was closed or solution proposed.
-          allOf:
-            - $ref: '#/components/schemas/CaseLabelRef'
+          enum:
+            - USER_MISUNDERSTANDING_CONCEPTS
+            - USER_MISUNDERSTANDING_DOCUMENTATION
+            - USER_NOT_FOLLOWING_DOCUMENTATION
+            - USER_MISTAKE
+            - SOLUTION_PROBLEMATIC_SOLUTION_ARCHITECTURE
+            - SOLUTION_PROBLEMATIC_CODE
+            - APPLICATION_BUG
+            - APPLICATION_MISLEADING_UX_UI
+            - APPLICATION_LIMITATION
+            - APPLICATION_MISSING_FEATURE
+            - APPLICATION_DOCUMENTATION_GAP
+            - APPLICATION_DOCUMENTATION_ERROR
+            - INFRASTRUCTURE_CUSTOMERS_SIDE
+            - INFRASTRUCTURE_SAAS_SIDE_NOT_ENOUGH
+            - INFRASTRUCTURE_SAAS_SIDE_OTHER
+            - UNKNOWN
+          description: Root-cause category, present when the case was closed or solution proposed.
         closeNotes:
           type: string
           nullable: true

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2776,7 +2776,7 @@ components:
           type: string
           nullable: true
           description: Close notes, present when the case was closed or solution proposed.
-        resolvedAt:
+        resolvedOn:
           type: string
           format: date-time
           nullable: true

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2677,11 +2677,47 @@ components:
           format: email
           description: Email of the engineer to assign to this case (ServiceNow only).
         resolutionCode:
-          type: integer
-          description: Resolution code key. Only allowed when state is closed or solution_proposed.
+          type: string
+          enum:
+            - SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED
+            - SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT
+            - SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET
+            - SOLVED_WORKAROUND_PROVIDED
+            - SOLVED_BY_CUSTOMER
+            - CONSIDERED_FOR_ROADMAP
+            - INCONCLUSIVE_OUT_OF_SCOPE
+            - INCONCLUSIVE_CANNOT_REPRODUCE
+            - INCONCLUSIVE_NO_WORKAROUND
+            - DUPLICATE_ISSUE
+            - VOIDED_CANCELED
+            - ON_HOLD
+            - CONSIDERED_FOR_ROADMAP_ALT
+            - SOLVED_FIXED_THE_ISSUE
+            - SOLVED_WORKAROUND_PROVIDED_ALT
+            - SOLVED_BY_CONTRIBUTOR
+            - SOLVED_BY_NOVERA
+            - ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS
+          description: Resolution code. Only allowed when state is closed or solution_proposed.
         cause:
           type: string
-          description: Cause description. Only allowed when state is closed or solution_proposed.
+          enum:
+            - USER_MISUNDERSTANDING_CONCEPTS
+            - USER_MISUNDERSTANDING_DOCUMENTATION
+            - USER_NOT_FOLLOWING_DOCUMENTATION
+            - USER_MISTAKE
+            - SOLUTION_PROBLEMATIC_SOLUTION_ARCHITECTURE
+            - SOLUTION_PROBLEMATIC_CODE
+            - APPLICATION_BUG
+            - APPLICATION_MISLEADING_UX_UI
+            - APPLICATION_LIMITATION
+            - APPLICATION_MISSING_FEATURE
+            - APPLICATION_DOCUMENTATION_GAP
+            - APPLICATION_DOCUMENTATION_ERROR
+            - INFRASTRUCTURE_CUSTOMERS_SIDE
+            - INFRASTRUCTURE_SAAS_SIDE_NOT_ENOUGH
+            - INFRASTRUCTURE_SAAS_SIDE_OTHER
+            - UNKNOWN
+          description: Root-cause category. Only allowed when state is closed or solution_proposed.
         closeNotes:
           type: string
           description: Close notes. Only allowed when state is closed or solution_proposed.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2645,6 +2645,8 @@ components:
       description: |
         Exactly one of `state`, `severity`, `workState`, `watchList`, or `assigneeEmail` must be provided.
         `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
+        `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
+        `state` when the state is `closed` or `solution_proposed`.
       oneOf:
         - required: [state]
         - required: [severity]
@@ -2674,6 +2676,15 @@ components:
           type: string
           format: email
           description: Email of the engineer to assign to this case (ServiceNow only).
+        resolutionCode:
+          type: integer
+          description: Resolution code key. Only allowed when state is closed or solution_proposed.
+        cause:
+          type: string
+          description: Cause description. Only allowed when state is closed or solution_proposed.
+        closeNotes:
+          type: string
+          description: Close notes. Only allowed when state is closed or solution_proposed.
 
     UpdateCaseResponse:
       type: object
@@ -2715,6 +2726,36 @@ components:
         assignedTo:
           nullable: true
           $ref: '#/components/schemas/AssignedEngineerRef'
+        resolutionCode:
+          nullable: true
+          description: Resolution code, present when the case was closed or solution proposed.
+          allOf:
+            - $ref: '#/components/schemas/CaseLabelRef'
+        cause:
+          nullable: true
+          description: Cause, present when the case was closed or solution proposed.
+          allOf:
+            - $ref: '#/components/schemas/CaseLabelRef'
+        closeNotes:
+          type: string
+          nullable: true
+          description: Close notes, present when the case was closed or solution proposed.
+        resolvedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the case was resolved, present when state is closed or solution_proposed.
+
+    CaseLabelRef:
+      type: object
+      required: [id, label]
+      properties:
+        id:
+          type: string
+          description: Internal identifier for the choice-list value.
+        label:
+          type: string
+          description: Human-readable label for the choice-list value.
 
     WatchListUser:
       type: object


### PR DESCRIPTION
## Summary
- Adds optional `resolutionCode`, `cause`, and `closeNotes` fields to the case update request, only accepted when transitioning to `closed` or `solution_proposed`
- `resolutionCode` and `cause` use typed string enums mapped to ServiceNow integer keys and label strings respectively
- Response now includes `resolutionCode`, `cause`, `closeNotes`, and `resolvedAt` from the ServiceNow update response

## Test plan
- [ ] PATCH a case with `state: closed` and all three resolution fields — verify 200 with resolution fields in response
- [ ] PATCH a case with `state: solution_proposed` and resolution fields — verify 200
- [ ] PATCH a case with resolution fields but no `state` — verify 400
- [ ] PATCH a case with resolution fields and `state: open` — verify 400
- [ ] PATCH a case with an invalid `resolutionCode` or `cause` enum value — verify 400 with a clear message
- [ ] PATCH a case with `"resolutionCode": 16` (number instead of string) — verify 400 with `expected string`
- [ ] Existing update requests (state only, severity, watchList, etc.) — verify unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case updates now support resolution details, including resolution code, cause, close notes, and resolved time.
  * Case responses now return matching resolution information when available.

* **Bug Fixes**
  * Improved validation for case updates so resolution details are only accepted with valid state changes.
  * Error messages for invalid request values are now clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->