### PR TITLE
[CSM Portal] Fix scheduling a call from a preferred time (send RFC3339)

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.test.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { ScheduleCallDialog } from "@features/csm-cases/components/ScheduleCallDialog";
+import type { BeCallRequestView } from "@api/backend/types";
+
+function makeCallRequest(preferredTimes: string[]): BeCallRequestView {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    preferredTimes,
+    durationMin: 30,
+  };
+}
+
+// The dialog selects the first preferred time only when the target *changes*
+// (null -> record), matching how the widget opens it. Mimic that with rerender.
+function renderWithTarget(cr: BeCallRequestView) {
+  const onSubmit = vi.fn();
+  const onClose = vi.fn();
+  const shared = {
+    isReschedule: false,
+    submitting: false,
+    error: null,
+    onClose,
+    onSubmit,
+  };
+  const { rerender } = render(
+    <ScheduleCallDialog callRequest={null} {...shared} />,
+  );
+  rerender(<ScheduleCallDialog callRequest={cr} {...shared} />);
+  return { onSubmit, onClose };
+}
+
+const scheduleButton = (): HTMLElement =>
+  screen.getByRole("button", { name: /^schedule$/i });
+
+describe("ScheduleCallDialog", () => {
+  it("submits a selected preferred time as an RFC3339 UTC timestamp", () => {
+    // Preferred times arrive in the backend wall-clock format (e.g. ServiceNow's
+    // MM/DD/YYYY), but the API requires RFC3339 UTC. This is the regression:
+    // sending the raw preferred-time string produced a 400. Far-future slot so
+    // the past-guard passes.
+    const { onSubmit } = renderWithTarget(
+      makeCallRequest(["12/31/2027 08:45:00"]),
+    );
+
+    fireEvent.click(scheduleButton());
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meetingDate: "2027-12-31T08:45:00Z",
+        durationInMinutes: 30,
+      }),
+    );
+  });
+
+  it("also normalizes the ISO-8601-with-space backend format", () => {
+    const { onSubmit } = renderWithTarget(
+      makeCallRequest(["2027-12-31 08:45:00"]),
+    );
+    fireEvent.click(scheduleButton());
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ meetingDate: "2027-12-31T08:45:00Z" }),
+    );
+  });
+
+  it("blocks a preferred time in the past and does not submit", () => {
+    const { onSubmit } = renderWithTarget(
+      makeCallRequest(["01/01/2020 08:45:00"]),
+    );
+    fireEvent.click(scheduleButton());
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/must be in the future/i)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
@@ -32,6 +32,7 @@ import type { BeCallRequestView } from "@api/backend/types";
 import {
   resolveDisplayTimeZone,
   zonedInputToUtcIso,
+  normalizeBackendTimestamp,
   formatBackendTimestampForDisplay,
 } from "@utils/dateTime";
 
@@ -118,8 +119,15 @@ export function ScheduleCallDialog({
       : null;
   const customTimeValid = selectedTime !== CUSTOM_TIME_VALUE || !!customUtcIso;
 
+  // Custom input is entered in the agent's timezone → convert to UTC ISO.
+  // A selected preferred time is a backend wall-clock string (e.g. SN's
+  // "MM/DD/YYYY HH:MM:SS") → normalize it to RFC3339 UTC; the API requires ISO.
   const meetingDate =
-    selectedTime === CUSTOM_TIME_VALUE ? customUtcIso : selectedTime || null;
+    selectedTime === CUSTOM_TIME_VALUE
+      ? customUtcIso
+      : selectedTime
+        ? normalizeBackendTimestamp(selectedTime)
+        : null;
 
   const canSubmit = durationValid && customTimeValid && !!meetingDate;
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
@@ -209,6 +209,9 @@ export function ScheduleCallDialog({
               required
               size="small"
               disabled={submitting}
+              // datetime-local always shows a placeholder, so force the label to
+              // float up — otherwise it overlaps the mm/dd/yyyy placeholder.
+              InputLabelProps={{ shrink: true }}
               error={
                 (selectedTime === CUSTOM_TIME_VALUE && !!customTime && !customTimeValid) ||
                 pastError


### PR DESCRIPTION
## Purpose
Scheduling a call by selecting one of the request's **preferred times** fails with `400 "Invalid request payload."` on staging. Follow-up fix to the agent call-management feature (#1066, merged): that PR's `ScheduleCallDialog` sent the selected preferred time verbatim, but preferred times arrive from the backing data source as a wall-clock string (e.g. `MM/DD/YYYY HH:MM:SS`) while the API requires an RFC3339 UTC `meetingDate`. The custom-time path already converted correctly; the preferred-time path did not.

## Goals
Selecting a preferred time submits a valid RFC3339 UTC `meetingDate`, matching the custom-time path, so scheduling succeeds.

## Approach
Run the selected preferred time through the existing `normalizeBackendTimestamp` helper before submit, so `07/08/2026 08:45:00` becomes `2026-07-08T08:45:00Z`. Added a component test (`ScheduleCallDialog.test.tsx`) that reproduces the failure: it asserts a selected preferred time is emitted as RFC3339 (for both the `MM/DD/YYYY` and ISO-with-space backend formats), and that a past time is blocked.

## Release note
CSM portal: fix scheduling a call from one of its proposed times (the time is now sent as RFC3339 UTC).

## Documentation
N/A — internal bug fix, no product-doc impact.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   > New `ScheduleCallDialog.test.tsx` (3 cases): preferred time → RFC3339 (two backend formats) and the past-time guard. Passing.
 - Integration tests
   > Verified the entity-service/stack accepts an RFC3339 `meetingDate` end to end previously; this restores that format on the preferred-time path.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript-only change; eslint clean.
 - Confirmed no keys/passwords/tokens/secrets committed? yes

## Samples
N/A

## Related PRs
- Follows #1066 (agent call management), which introduced `ScheduleCallDialog`.

## Migrations (if applicable)
N/A

## Test environment
- Node + pnpm; `pnpm build` clean, `vitest` 3/3 on the change.

## Learning
Reused the existing `normalizeBackendTimestamp` in `@utils/dateTime`, which already handles the data source's `MM/DD/YYYY` and ISO-with-space wall-clock formats.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling so preferred times submitted from the dialog are consistently sent in the correct UTC timestamp format.
  * Added validation to block past preferred times and display a clear “must be in the future” message.
* **Tests**
  * Added coverage for time-format normalization and past-time validation in the scheduling dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->