### PR TITLE
[CSM Portal] case detail: closed-case read-only, friendlier state actions, tab counts

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -57,9 +57,13 @@ interface CallRequestsWidgetProps {
   caseId: string;
   /** Case severity (S0-S4) — passed to the create dialog to enforce the lead-time rule. */
   severity?: Severity;
-  /** Bump this to open the "Create call request" dialog from outside the
-   * widget (e.g. the case action bar's "Request a call" item). */
-  openCreateSignal?: number;
+  /** True to pop the "Create call request" dialog from outside the widget
+   * (e.g. the case action bar's "Request a call" item). One-shot: the
+   * widget calls `onAutoOpenCreateHandled` once it has acted on it, so the
+   * caller can drop it back to false — otherwise every remount of this
+   * widget (e.g. just clicking back onto the tab) would reopen the dialog. */
+  autoOpenCreate?: boolean;
+  onAutoOpenCreateHandled?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,7 +73,8 @@ interface CallRequestsWidgetProps {
 export function CallRequestsWidget({
   caseId,
   severity,
-  openCreateSignal,
+  autoOpenCreate,
+  onAutoOpenCreateHandled,
 }: CallRequestsWidgetProps): JSX.Element {
   // State filter — empty string means "all". Filtering happens server-side
   // via `filters.states` on the search request.
@@ -87,9 +92,12 @@ export function CallRequestsWidget({
   const [createError, setCreateError] = useState<string | null>(null);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs the dialog open to an external trigger from the case action bar
-    if (openCreateSignal !== undefined) setCreateOpen(true);
-  }, [openCreateSignal]);
+    if (autoOpenCreate) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs the dialog open to an external one-shot trigger from the case action bar
+      setCreateOpen(true);
+      onAutoOpenCreateHandled?.();
+    }
+  }, [autoOpenCreate, onAutoOpenCreateHandled]);
 
   // Dialog targets — only one dialog is ever open at a time, driven by which
   // action was clicked on a row.

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -28,7 +28,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Phone, Plus, RefreshCw } from "@wso2/oxygen-ui-icons-react";
-import { useState, type JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 import type { BeCallRequestView, BeCallRequestStateKey } from "@api/backend/types";
 import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
 import {
@@ -57,6 +57,9 @@ interface CallRequestsWidgetProps {
   caseId: string;
   /** Case severity (S0-S4) — passed to the create dialog to enforce the lead-time rule. */
   severity?: Severity;
+  /** Bump this to open the "Create call request" dialog from outside the
+   * widget (e.g. the case action bar's "Request a call" item). */
+  openCreateSignal?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +69,7 @@ interface CallRequestsWidgetProps {
 export function CallRequestsWidget({
   caseId,
   severity,
+  openCreateSignal,
 }: CallRequestsWidgetProps): JSX.Element {
   // State filter — empty string means "all". Filtering happens server-side
   // via `filters.states` on the search request.
@@ -81,6 +85,11 @@ export function CallRequestsWidget({
 
   const [createOpen, setCreateOpen] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs the dialog open to an external trigger from the case action bar
+    if (openCreateSignal !== undefined) setCreateOpen(true);
+  }, [openCreateSignal]);
 
   // Dialog targets — only one dialog is ever open at a time, driven by which
   // action was clicked on a row.

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -93,7 +93,7 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
       />,
     );
     expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^closed$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^close$/i })).toBeInTheDocument();
   });
 
   it("shows exactly the transitions the backend permits, nothing more", () => {
@@ -109,7 +109,7 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
     expect(screen.getByRole("button", { name: /propose solution/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /request information/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /^closed$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^close$/i })).not.toBeInTheDocument();
   });
 
   it("labels a target the same regardless of source state (no UI-invented verbs)", () => {
@@ -158,8 +158,8 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={onAction}
       />,
     );
-    // Clicking "Closed" must NOT dispatch yet — it opens a confirm dialog.
-    fireEvent.click(screen.getByRole("button", { name: /^closed$/i }));
+    // Clicking "Close" must NOT dispatch yet — it opens a confirm dialog.
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
     expect(onAction).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     // Confirming dispatches with the close action + closed target.
@@ -180,7 +180,7 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
     expect(screen.queryByRole("button", { name: /propose solution/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /request information/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /^closed$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^close$/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -92,7 +92,7 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /waiting on wso2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^closed$/i })).toBeInTheDocument();
   });
 
@@ -106,9 +106,9 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /solution proposed/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /awaiting info/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /waiting on wso2/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /propose solution/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /request information/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^closed$/i })).not.toBeInTheDocument();
   });
 
@@ -120,11 +120,11 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /waiting on wso2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
     unmount();
 
-    // ...and from a paused state, the SAME target reads the same — "Waiting on
+    // ...and from a paused state, the SAME target reads the same — "Wait on
     // WSO2", not a fabricated "Resume work".
     render(
       <CaseActionBar
@@ -132,7 +132,7 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /waiting on wso2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /wait on wso2/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
   });
 
@@ -144,9 +144,9 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={onAction}
       />,
     );
-    // "Waiting on WSO2" has no confirm dialog, so it dispatches immediately, and
+    // "Wait on WSO2" has no confirm dialog, so it dispatches immediately, and
     // the target must be the real backend nextState.
-    fireEvent.click(screen.getByRole("button", { name: /waiting on wso2/i }));
+    fireEvent.click(screen.getByRole("button", { name: /wait on wso2/i }));
     expect(onAction).toHaveBeenCalledWith("wait_on_wso2", "waiting_on_wso2");
   });
 
@@ -177,9 +177,9 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.queryByRole("button", { name: /solution proposed/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /awaiting info/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /waiting on wso2/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /propose solution/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /request information/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^closed$/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
   });
@@ -212,7 +212,7 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={() => {}}
       />,
     );
-    expect(screen.queryByRole("button", { name: /waiting on wso2/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /wait on wso2/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /reopened/i })).not.toBeInTheDocument();
     // The state-independent "More" overflow is unaffected.
     expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -146,6 +146,7 @@ const TRANSITION_LABEL: Partial<Record<CaseState, string>> = {
   solution_proposed: "Propose solution",
   awaiting_info: "Request information",
   waiting_on_wso2: "Wait on WSO2",
+  closed: "Close",
 };
 
 /** Build the button for a transition into `target`, labelled by the BE state. */
@@ -217,7 +218,7 @@ interface SecondaryItem {
  *   - Copy case link                 → ISSU-010 (per-comment + per-case permalinks)
  *
  * Intentionally NOT here:
- *   - Watch / unwatch  → managed via the Watchers widget in Details (ISSU-018)
+ *   - Watch / unwatch  → withdrawn along with the Watchers widget (ISSU-018), no backend flow planned yet
  *   - Open in ServiceNow → this platform replaces ServiceNow; no back-link
  *   - Escalate to lead / Request severity change → withdrawn, no backend flow planned yet
  */

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -41,8 +41,6 @@ import {
   Phone,
   Play,
   Send,
-  ShieldAlert,
-  TriangleAlert,
   User,
 } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
@@ -141,12 +139,36 @@ const DEFAULT_TARGET_CONFIG: TargetConfig = {
   icon: <ArrowRight size={16} />,
 };
 
+// Friendlier verbs for the transition buttons than the raw state name reads
+// as. `work_in_progress` is special-cased in `buttonFor` since its wording
+// (and underlying action) depends on who the case is assigned to.
+const TRANSITION_LABEL: Partial<Record<CaseState, string>> = {
+  solution_proposed: "Propose solution",
+  awaiting_info: "Request information",
+  waiting_on_wso2: "Wait on WSO2",
+};
+
 /** Build the button for a transition into `target`, labelled by the BE state. */
-function buttonFor(target: CaseState): PrimaryButton {
+function buttonFor(target: CaseState, caseDetail: CsmCaseDetail): PrimaryButton {
+  const config = TARGET_CONFIG[target] ?? DEFAULT_TARGET_CONFIG;
+  if (target === "work_in_progress") {
+    // Moving into Work in progress reads differently depending on whether the
+    // case is already the current engineer's: unassigned/someone-else's case
+    // needs claiming first ("Assign to me"), while an already-own case just
+    // needs its work started ("Start progress"). `onAction` uses the `action`
+    // value (not just the target state) to decide whether to PATCH the
+    // assignee before moving the state.
+    return {
+      targetState: target,
+      ...config,
+      label: caseDetail.assigneeIsMe ? "Start progress" : "Assign to me",
+      action: caseDetail.assigneeIsMe ? "start_work" : "assign_to_me",
+    };
+  }
   return {
     targetState: target,
-    label: stateLabel(target),
-    ...(TARGET_CONFIG[target] ?? DEFAULT_TARGET_CONFIG),
+    label: TRANSITION_LABEL[target] ?? stateLabel(target),
+    ...config,
   };
 }
 
@@ -186,18 +208,18 @@ interface SecondaryItem {
  * The "More" overflow lists state-independent actions on a case. Items here
  * map to documented use cases — see `UseCases.md`:
  *   - Reassign engineer              → ISSU-002 (self-assign generalised)
- *   - Escalate / Severity change     → ISSU-006, ISSU-007
- *   - Hold auto-closure              → ISSU-027
+ *   - Hold auto-closure              → ISSU-027 (only while awaiting info / solution proposed)
  *   - Create incident / link incident → ISSU-021
  *   - Raise Git issue                → ISSU-020
  *   - Create task                    → ISSU-025
- *   - Request a call                 → ISSU-008
+ *   - Request a call                 → ISSU-008 (opens the Call requests tab's create dialog)
  *   - Log time                       → ISSU-017
  *   - Copy case link                 → ISSU-010 (per-comment + per-case permalinks)
  *
  * Intentionally NOT here:
  *   - Watch / unwatch  → managed via the Watchers widget in Details (ISSU-018)
  *   - Open in ServiceNow → this platform replaces ServiceNow; no back-link
+ *   - Escalate to lead / Request severity change → withdrawn, no backend flow planned yet
  */
 function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const items: SecondaryItem[] = [];
@@ -226,9 +248,17 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const reassignBlocked =
     caseDetail.state === "work_in_progress" && caseDetail.workState === "ongoing";
 
-  // Only "Copy case link" is wired up for now. The rest are disabled until
-  // their backend flows land, so the menu advertises the roadmap without
-  // exposing dead actions that would no-op or toast a mock message.
+  // Hold auto-closure only makes sense while the case is sitting in a state
+  // that's subject to auto-closure (awaiting the customer's response) —
+  // showing it at any other time would offer to hold a closure that isn't
+  // pending.
+  const canHoldAutoClose =
+    caseDetail.state === "awaiting_info" || caseDetail.state === "solution_proposed";
+
+  // Only "Copy case link", "Request a call", and "Log time" are wired up.
+  // The rest are disabled until their backend flows land, so the menu
+  // advertises the roadmap without exposing dead actions that would no-op or
+  // toast a mock message.
   items.push(
     { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} />, divider: true },
     {
@@ -241,13 +271,13 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
         ? "Can't reassign while the case is in progress and ongoing. Pause the work first, or ask the current assignee or a lead to reassign."
         : undefined,
     },
-    { key: "escalate", label: "Escalate to lead…", icon: <TriangleAlert size={16} />, disabled: true },
-    { key: "change_severity", label: "Request severity change…", icon: <ShieldAlert size={16} />, disabled: true },
-    { key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true, disabled: true },
+    ...(canHoldAutoClose
+      ? [{ key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true }]
+      : []),
     { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true },
     { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, divider: true, disabled: true },
     { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true, disabled: true },
-    { key: "request_call", label: "Request a call…", icon: <Phone size={16} />, disabled: true },
+    { key: "request_call", label: "Request a call…", icon: <Phone size={16} /> },
     { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },
     { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },
   );
@@ -287,7 +317,7 @@ export default function CaseActionBar({
   const targets = caseDetail.nextStates ?? [];
   const lifecycle = [...new Set(targets)]
     .sort((a, b) => orderRank(a) - orderRank(b))
-    .map(buttonFor);
+    .map((target) => buttonFor(target, caseDetail));
   const primary = lifecycle;
   const secondary = buildSecondaryItems(caseDetail);
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -339,7 +339,20 @@ export default function CaseActionBar({
         justifyContent: { xs: "flex-start", md: "flex-end" },
       }}
     >
-      {primary.length > 0 && (
+      {primary.length === 1 && (
+        // A single reachable state needs no menu — show the transition
+        // itself as one click rather than "Change state" → pick the only item.
+        <Button
+          size="small"
+          variant="contained"
+          color={primary[0].color}
+          startIcon={primary[0].icon}
+          onClick={() => runPrimary(primary[0])}
+        >
+          {primary[0].label}
+        </Button>
+      )}
+      {primary.length > 1 && (
         <>
           <Button
             size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Avatar,
   Box,
   Button,
   Card,
@@ -33,10 +32,8 @@ import {
   CheckCircle,
   Clock,
   Download,
-  ExternalLink,
   History,
   Link as LinkIcon,
-  Mail,
   MapPin,
   Paperclip,
   Plus,
@@ -49,18 +46,14 @@ import {
   Users,
 } from "@wso2/oxygen-ui-icons-react";
 import { useRef, type ChangeEvent, type JSX } from "react";
-import { Link as RouterLink } from "react-router";
-import { initialsOf } from "@utils/userClaims";
 import { formatBytes } from "@utils/formatBytes";
 import type {
   CaseAttachment,
   CaseAuditEntry,
   CaseCustomerContext,
-  CaseLinkedItem,
   CaseProductContext,
   CaseTag,
   CaseTimeLogEntry,
-  CaseWatcher,
 } from "@features/csm-cases/types/csmCases";
 import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import {
@@ -190,19 +183,14 @@ export function CustomerContextWidget({
           <strong>{ctx.accountName}</strong>
         </Typography>
       </MetaRow>
-      <MetaRow label="Primary contact">
-        <Box sx={{ display: "flex", flexDirection: "column" }}>
-          <Typography variant="body2">{ctx.primaryContact}</Typography>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
-          >
-            <Mail size={12} />
-            {ctx.primaryContactEmail}
-          </Typography>
-        </Box>
+      <MetaRow label="Account Manager">
+        <Typography variant="body2">{ctx.accountManager}</Typography>
       </MetaRow>
+      {ctx.technicalOwner && (
+        <MetaRow label="Technical Owner">
+          <Typography variant="body2">{ctx.technicalOwner}</Typography>
+        </MetaRow>
+      )}
       <MetaRow label="Region">
         <Typography
           variant="body2"
@@ -212,14 +200,6 @@ export function CustomerContextWidget({
           {ctx.region}
         </Typography>
       </MetaRow>
-      <MetaRow label="Account Manager">
-        <Typography variant="body2">{ctx.accountManager}</Typography>
-      </MetaRow>
-      {ctx.technicalOwner && (
-        <MetaRow label="Technical Owner">
-          <Typography variant="body2">{ctx.technicalOwner}</Typography>
-        </MetaRow>
-      )}
       {isLoadingProject && (
         <MetaRow label="Project">
           <Typography variant="body2" color="text.secondary">
@@ -229,14 +209,17 @@ export function CustomerContextWidget({
       )}
       {project && (
         <>
-          <MetaRow label="Subscription">
-            <Typography variant="body2" sx={{ textTransform: "capitalize" }}>
-              {formatSubscriptionType(project.subscriptionType)}
-            </Typography>
+          <MetaRow label="Project name">
+            <Typography variant="body2">{project.name}</Typography>
           </MetaRow>
           <MetaRow label="Project key">
             <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
               {project.key}
+            </Typography>
+          </MetaRow>
+          <MetaRow label="Subscription type">
+            <Typography variant="body2" sx={{ textTransform: "capitalize" }}>
+              {formatSubscriptionType(project.subscriptionType)}
             </Typography>
           </MetaRow>
           <MetaRow label="Subscription period">
@@ -245,13 +228,8 @@ export function CustomerContextWidget({
               {formatDeploymentDate(project.endDate)}
             </Typography>
           </MetaRow>
-          {project.account.activationDate && (
-            <MetaRow label="Account since">
-              <Typography variant="body2">
-                {formatDeploymentDate(project.account.activationDate)}
-              </Typography>
-            </MetaRow>
-          )}
+          {/* No subscription-status field exists on the project record today
+              (only start/end dates) — omitted rather than inferring one. */}
         </>
       )}
     </WidgetCard>
@@ -261,16 +239,6 @@ export function CustomerContextWidget({
 // ---------------------------------------------------------------------------
 // 2. Product / environment context
 // ---------------------------------------------------------------------------
-
-const ENV_COLOR: Record<
-  CaseProductContext["environment"],
-  "default" | "info" | "warning" | "error"
-> = {
-  dev: "default",
-  qa: "info",
-  staging: "warning",
-  prod: "error",
-};
 
 export function ProductContextWidget({
   ctx,
@@ -293,31 +261,19 @@ export function ProductContextWidget({
   return (
     <WidgetCard title="Deployment info" icon={<Server size={16} />}>
       <MetaRow label="Deployment">
-        <Box
-          sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}
-        >
-          <Typography variant="body2">
-            <strong>
-              {isLoadingLiveDeployment ? "Loading…" : deploymentName}
-            </strong>
-          </Typography>
-          {categoryLabel && !isLoadingLiveDeployment && (
-            <Chip
-              size="small"
-              variant="outlined"
-              label={categoryLabel}
-              color={ENV_COLOR[ctx.environment]}
-            />
-          )}
-        </Box>
+        <Typography variant="body2">
+          <strong>{isLoadingLiveDeployment ? "Loading…" : deploymentName}</strong>
+        </Typography>
       </MetaRow>
+      {!isLoadingLiveDeployment && categoryLabel && (
+        <MetaRow label="Type">
+          <Typography variant="body2">{categoryLabel}</Typography>
+        </MetaRow>
+      )}
       <MetaRow label="Product">
         <Typography variant="body2">
           <strong>{ctx.product}</strong>
         </Typography>
-      </MetaRow>
-      <MetaRow label="Version">
-        <Typography variant="body2">{ctx.version}</Typography>
       </MetaRow>
       {ctx.updateLevel && (
         <MetaRow label="Update level">
@@ -336,186 +292,7 @@ export function ProductContextWidget({
 }
 
 // ---------------------------------------------------------------------------
-// 4. Watchers
-// ---------------------------------------------------------------------------
-
-const ROLE_LABEL: Record<CaseWatcher["role"], string> = {
-  wso2_engineer: "WSO2",
-  customer_contact: "Customer",
-  manager: "Manager",
-};
-
-export function WatchersWidget({
-  watchers,
-  onAdd,
-  disabled,
-}: {
-  watchers: CaseWatcher[];
-  onAdd?: () => void;
-  /** True while watcher management isn't wired up yet. */
-  disabled?: boolean;
-}): JSX.Element {
-  return (
-    <WidgetCard
-      title="Watchers"
-      icon={<Users size={16} />}
-      disabledReason={disabled ? "Watcher management isn't available yet." : undefined}
-      action={
-        <Button
-          size="small"
-          variant="text"
-          startIcon={<Plus size={14} />}
-          onClick={onAdd}
-          disabled={disabled}
-        >
-          Add
-        </Button>
-      }
-    >
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-        {watchers.map((w) => (
-          <Box
-            key={w.id}
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-              py: 0.5,
-            }}
-          >
-            <Avatar sx={{ width: 28, height: 28, fontSize: "0.75rem" }}>
-              {initialsOf(w.name)}
-            </Avatar>
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Typography variant="body2" sx={{ lineHeight: 1.2 }}>
-                {w.name} {w.isMe && <em>(you)</em>}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                {ROLE_LABEL[w.role]}
-              </Typography>
-            </Box>
-          </Box>
-        ))}
-      </Box>
-    </WidgetCard>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// 5. Linked items
-// ---------------------------------------------------------------------------
-
-const LINKED_ICON: Record<CaseLinkedItem["kind"], JSX.Element> = {
-  case: <LinkIcon size={14} />,
-  incident: <TriangleAlert size={14} />,
-  escalation: <ArrowUpRight size={14} />,
-  kb: <Shield size={14} />,
-  cr: <CheckCircle size={14} />,
-  sr: <CheckCircle size={14} />,
-};
-
-const LINKED_LABEL: Record<CaseLinkedItem["kind"], string> = {
-  case: "Case",
-  incident: "Incident",
-  escalation: "Escalation",
-  kb: "KB",
-  cr: "CR",
-  sr: "SR",
-};
-
-export function LinkedItemsWidget({
-  items,
-  onLink,
-  disabled,
-}: {
-  items: CaseLinkedItem[];
-  onLink?: () => void;
-  /** True while linking cases/incidents isn't wired up yet. */
-  disabled?: boolean;
-}): JSX.Element {
-  return (
-    <WidgetCard
-      title="Linked items"
-      icon={<LinkIcon size={16} />}
-      disabledReason={disabled ? "Linking items isn't available yet." : undefined}
-      action={
-        <Button
-          size="small"
-          variant="text"
-          startIcon={<Plus size={14} />}
-          onClick={onLink}
-          disabled={disabled}
-        >
-          Link
-        </Button>
-      }
-    >
-      {items.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          Nothing linked yet.
-        </Typography>
-      ) : (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
-          {items.map((item) => {
-            const inner = (
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1,
-                  p: 0.75,
-                  borderRadius: 1,
-                  border: 1,
-                  borderColor: "divider",
-                  "&:hover": item.href
-                    ? { backgroundColor: "action.hover", cursor: "pointer" }
-                    : undefined,
-                }}
-              >
-                {LINKED_ICON[item.kind]}
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{ display: "block", lineHeight: 1.1 }}
-                  >
-                    {LINKED_LABEL[item.kind]} · {item.reference} · {item.state}
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      lineHeight: 1.2,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {item.title}
-                  </Typography>
-                </Box>
-                {item.href && <ExternalLink size={14} />}
-              </Box>
-            );
-            return item.href ? (
-              <RouterLink
-                key={item.id}
-                to={item.href}
-                style={{ textDecoration: "none", color: "inherit" }}
-              >
-                {inner}
-              </RouterLink>
-            ) : (
-              <Box key={item.id}>{inner}</Box>
-            );
-          })}
-        </Box>
-      )}
-    </WidgetCard>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// 6. Tags
+// 3. Tags
 // ---------------------------------------------------------------------------
 
 export function TagsWidget({
@@ -562,7 +339,7 @@ export function TagsWidget({
 }
 
 // ---------------------------------------------------------------------------
-// 7. Time logs
+// 4. Time logs
 // ---------------------------------------------------------------------------
 
 export function TimeLogsWidget({
@@ -638,7 +415,7 @@ export function TimeLogsWidget({
 }
 
 // ---------------------------------------------------------------------------
-// 7b. Attachments (all files on the case, newest first)
+// 4b. Attachments (all files on the case, newest first)
 // ---------------------------------------------------------------------------
 
 /**
@@ -843,7 +620,7 @@ export function AttachmentsWidget({
 }
 
 // ---------------------------------------------------------------------------
-// 8. Audit timeline (lifecycle events, distinct from comments)
+// 5. Audit timeline (lifecycle events, distinct from comments)
 // ---------------------------------------------------------------------------
 
 const AUDIT_ICON: Record<CaseAuditEntry["kind"], JSX.Element> = {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -23,6 +23,7 @@ import {
   CircularProgress,
   IconButton,
   LinearProgress,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import {
@@ -60,9 +61,14 @@ import type {
   CaseTag,
   CaseTimeLogEntry,
   CaseWatcher,
-  DeploymentCategory,
 } from "@features/csm-cases/types/csmCases";
 import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
+import {
+  deploymentTypeLabel,
+  formatDeploymentDate,
+} from "@features/csm-projects/utils/deployments";
+import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
+import type { BeDeployment } from "@api/backend/types";
 import RelativeTime from "@components/RelativeTime";
 
 // ---------------------------------------------------------------------------
@@ -74,11 +80,23 @@ interface WidgetCardProps {
   icon?: JSX.Element;
   action?: JSX.Element;
   children: React.ReactNode;
+  /** Greys out the whole card and explains why via a tooltip on the title —
+   * for a widget whose backing feature isn't wired up yet. */
+  disabledReason?: string;
 }
 
-function WidgetCard({ title, icon, action, children }: WidgetCardProps): JSX.Element {
+function WidgetCard({
+  title,
+  icon,
+  action,
+  children,
+  disabledReason,
+}: WidgetCardProps): JSX.Element {
   return (
-    <Card variant="outlined" sx={{ p: 2 }}>
+    <Card
+      variant="outlined"
+      sx={{ p: 2, opacity: disabledReason ? 0.6 : 1 }}
+    >
       <Box
         sx={{
           display: "flex",
@@ -88,13 +106,17 @@ function WidgetCard({ title, icon, action, children }: WidgetCardProps): JSX.Ele
           mb: 1.25,
         }}
       >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-          {icon}
-          <Typography variant="subtitle2">{title}</Typography>
-        </Box>
+        <Tooltip title={disabledReason ?? ""}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+            {icon}
+            <Typography variant="subtitle2">{title}</Typography>
+          </Box>
+        </Tooltip>
         {action}
       </Box>
-      {children}
+      <Box sx={disabledReason ? { pointerEvents: "none" } : undefined}>
+        {children}
+      </Box>
     </Card>
   );
 }
@@ -133,10 +155,23 @@ function MetaRow({
 // 1. Customer / Account context
 // ---------------------------------------------------------------------------
 
+/** "cloud_support" -> "cloud support". Matches the plain formatter already
+ * used for the same enum on the project detail page. */
+function formatSubscriptionType(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
 export function CustomerContextWidget({
   ctx,
+  project,
+  isLoadingProject,
 }: {
   ctx: CaseCustomerContext;
+  /** The case's project, via `GET /projects/{id}` — carries the subscription
+   * type/dates plus a fuller account snapshot than the case-detail payload's
+   * embedded `customerContext`. */
+  project?: ProjectDetails | null;
+  isLoadingProject?: boolean;
 }): JSX.Element {
   return (
     <WidgetCard
@@ -185,9 +220,40 @@ export function CustomerContextWidget({
           <Typography variant="body2">{ctx.technicalOwner}</Typography>
         </MetaRow>
       )}
-      <MetaRow label="Open cases">
-        <Chip size="small" variant="outlined" label={`${ctx.openCases} open`} />
-      </MetaRow>
+      {isLoadingProject && (
+        <MetaRow label="Project">
+          <Typography variant="body2" color="text.secondary">
+            Loading…
+          </Typography>
+        </MetaRow>
+      )}
+      {project && (
+        <>
+          <MetaRow label="Subscription">
+            <Typography variant="body2" sx={{ textTransform: "capitalize" }}>
+              {formatSubscriptionType(project.subscriptionType)}
+            </Typography>
+          </MetaRow>
+          <MetaRow label="Project key">
+            <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+              {project.key}
+            </Typography>
+          </MetaRow>
+          <MetaRow label="Subscription period">
+            <Typography variant="body2">
+              {formatDeploymentDate(project.startDate)} –{" "}
+              {formatDeploymentDate(project.endDate)}
+            </Typography>
+          </MetaRow>
+          {project.account.activationDate && (
+            <MetaRow label="Account since">
+              <Typography variant="body2">
+                {formatDeploymentDate(project.account.activationDate)}
+              </Typography>
+            </MetaRow>
+          )}
+        </>
+      )}
     </WidgetCard>
   );
 }
@@ -206,23 +272,24 @@ const ENV_COLOR: Record<
   prod: "error",
 };
 
-const DEPLOYMENT_CATEGORY_LABEL: Record<DeploymentCategory, string> = {
-  primary_production: "Primary Production",
-  staging: "Staging",
-  qa: "QA",
-  stress: "Stress",
-  uat: "UAT",
-  development: "Development",
-};
-
 export function ProductContextWidget({
   ctx,
+  liveDeployment,
+  isLoadingLiveDeployment,
 }: {
   ctx: CaseProductContext;
+  /** The case's deployment as returned by `POST /deployments/search`
+   * (looked up by `ctx.deploymentId`) — the live name/type, rather than the
+   * snapshot embedded in the case-detail payload at creation time. */
+  liveDeployment?: BeDeployment | null;
+  isLoadingLiveDeployment?: boolean;
 }): JSX.Element {
-  const categoryLabel = ctx.deploymentCategory
-    ? DEPLOYMENT_CATEGORY_LABEL[ctx.deploymentCategory]
-    : null;
+  const deploymentName = liveDeployment?.name ?? ctx.deployment;
+  const categoryLabel = liveDeployment
+    ? deploymentTypeLabel(liveDeployment.type)
+    : ctx.deploymentCategory
+      ? deploymentTypeLabel(ctx.deploymentCategory)
+      : null;
   return (
     <WidgetCard title="Deployment info" icon={<Server size={16} />}>
       <MetaRow label="Deployment">
@@ -230,9 +297,11 @@ export function ProductContextWidget({
           sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}
         >
           <Typography variant="body2">
-            <strong>{ctx.deployment}</strong>
+            <strong>
+              {isLoadingLiveDeployment ? "Loading…" : deploymentName}
+            </strong>
           </Typography>
-          {categoryLabel && (
+          {categoryLabel && !isLoadingLiveDeployment && (
             <Chip
               size="small"
               variant="outlined"
@@ -279,20 +348,25 @@ const ROLE_LABEL: Record<CaseWatcher["role"], string> = {
 export function WatchersWidget({
   watchers,
   onAdd,
+  disabled,
 }: {
   watchers: CaseWatcher[];
   onAdd?: () => void;
+  /** True while watcher management isn't wired up yet. */
+  disabled?: boolean;
 }): JSX.Element {
   return (
     <WidgetCard
       title="Watchers"
       icon={<Users size={16} />}
+      disabledReason={disabled ? "Watcher management isn't available yet." : undefined}
       action={
         <Button
           size="small"
           variant="text"
           startIcon={<Plus size={14} />}
           onClick={onAdd}
+          disabled={disabled}
         >
           Add
         </Button>
@@ -352,20 +426,25 @@ const LINKED_LABEL: Record<CaseLinkedItem["kind"], string> = {
 export function LinkedItemsWidget({
   items,
   onLink,
+  disabled,
 }: {
   items: CaseLinkedItem[];
   onLink?: () => void;
+  /** True while linking cases/incidents isn't wired up yet. */
+  disabled?: boolean;
 }): JSX.Element {
   return (
     <WidgetCard
       title="Linked items"
       icon={<LinkIcon size={16} />}
+      disabledReason={disabled ? "Linking items isn't available yet." : undefined}
       action={
         <Button
           size="small"
           variant="text"
           startIcon={<Plus size={14} />}
           onClick={onLink}
+          disabled={disabled}
         >
           Link
         </Button>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -125,6 +125,12 @@ function LinkButton({
       noWrap
       sx={(t) => ({
         display: "block",
+        // `<button>` is a form control: browsers give it an intrinsic
+        // "auto" min-width that resolves to its content size and refuses to
+        // shrink as a grid item, unlike the `<a>` LinkText renders — without
+        // this it overflows into the next grid cell instead of truncating.
+        minWidth: 0,
+        width: "100%",
         cursor: "pointer",
         textAlign: "left",
         padding: 0,
@@ -224,7 +230,10 @@ export default function CaseMetaBand({
           sx={{
             display: "grid",
             gridTemplateColumns: {
-              xs: "1fr 1fr",
+              // `minmax(0, 1fr)` everywhere: a plain `1fr` track's implicit
+              // minimum is content-based ("auto"), so a long value in one
+              // cell pushes into its neighbour instead of truncating.
+              xs: "repeat(2, minmax(0, 1fr))",
               sm: "repeat(3, minmax(0, 1fr))",
               md: "repeat(4, minmax(0, 1fr))",
             },

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -77,9 +77,7 @@ import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
 import {
   AttachmentsWidget,
   CustomerContextWidget,
-  LinkedItemsWidget,
   ProductContextWidget,
-  WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
 import { CallRequestsWidget } from "@features/csm-cases/components/CallRequestsWidget";
 import { useGetCsmCaseCallRequests } from "@features/csm-cases/api/useCsmCaseCallRequests";
@@ -191,9 +189,7 @@ const SECONDARY_TOAST: Record<string, string> = {
   reassign_group: "Reassign group dialog (mock).",
   hold_auto_close: "Hold auto-closure dialog (mock).",
   create_incident: "Create incident from case (mock).",
-  link_case: "Link related case picker (mock).",
   link_incident: "Link to incident picker (mock).",
-  manage_watchers: "Add/remove watcher dialog (mock).",
   create_task: "Create task dialog (mock).",
   log_time: "Log time dialog (mock).",
   copy_link: "Case link copied to clipboard.",
@@ -1294,16 +1290,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
             isLoadingLiveDeployment={
               !!c.productContext.deploymentId && isProjectDeploymentsLoading
             }
-          />
-          <WatchersWidget
-            watchers={c.watchers}
-            onAdd={() => onAction({ secondary: "manage_watchers" })}
-            disabled
-          />
-          <LinkedItemsWidget
-            items={c.linkedItems}
-            onLink={() => onAction({ secondary: "link_case" })}
-            disabled
           />
         </Box>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -319,9 +319,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
   const [logTimeOpen, setLogTimeOpen] = useState(false);
-  // Bumped to pop open the Call requests tab's "Create call request" dialog
-  // from the action bar's "Request a call" item.
-  const [requestCallSignal, setRequestCallSignal] = useState(0);
+  // One-shot: true to pop open the Call requests tab's "Create call request"
+  // dialog from the action bar's "Request a call" item. The widget flips it
+  // back to false once handled, so switching tabs afterwards doesn't reopen it.
+  const [autoOpenCallCreate, setAutoOpenCallCreate] = useState(false);
   const [githubIssueOpen, setGithubIssueOpen] = useState(false);
   // Inline error shown inside the Git-issue dialog (e.g. the SN routing 422 /
   // state 409). Cleared when the dialog opens or a submit is retried.
@@ -669,7 +670,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
       // dialog, rather than a second/duplicate entry point for the same form.
       if (action.secondary === "request_call") {
         setActiveTab("call-requests");
-        setRequestCallSignal((n) => n + 1);
+        setAutoOpenCallCreate(true);
         return;
       }
 
@@ -1323,7 +1324,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
           <CallRequestsWidget
             caseId={caseId}
             severity={c.severity}
-            openCreateSignal={requestCallSignal}
+            autoOpenCreate={autoOpenCallCreate}
+            onAutoOpenCreateHandled={() => setAutoOpenCallCreate(false)}
           />
         </Box>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -83,6 +83,8 @@ import {
 } from "@features/csm-cases/components/CaseDetailWidgets";
 import { CallRequestsWidget } from "@features/csm-cases/components/CallRequestsWidget";
 import { useGetCsmCaseCallRequests } from "@features/csm-cases/api/useCsmCaseCallRequests";
+import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
+import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import { CaseSlaTable } from "@features/csm-cases/components/CaseSlaTable";
 import { useGetCsmCaseSlas } from "@features/csm-cases/api/useGetCsmCaseSlas";
 import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCardsPanel";
@@ -299,6 +301,22 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // when its tab mounts, deduped against this one by react-query's cache.
   const { data: slaList } = useGetCsmCaseSlas(caseId);
   const { data: callRequests } = useGetCsmCaseCallRequests(caseId);
+  // Live deployment lookup for the Details tab's "Deployment info" widget —
+  // only runs when the case actually has a deployment link (SN-sourced cases
+  // may have none). Reuses the project's deployment list rather than a
+  // single-deployment GET, since the backend has no `/deployments/{id}` route.
+  const { data: projectDeployments, isLoading: isProjectDeploymentsLoading } =
+    useSearchDeployments(
+      data?.productContext.deploymentId ? data.projectId : undefined,
+    );
+  const liveDeployment = projectDeployments?.find(
+    (d) => d.id === data?.productContext.deploymentId,
+  );
+  // Richer account/project facts for the Customer card, beyond what's
+  // embedded in the case-detail payload's `customerContext` snapshot.
+  const { data: caseProject, isLoading: isCaseProjectLoading } = useGetProject(
+    data?.projectId,
+  );
   const patchCase = usePatchCsmCase(caseId);
   const patchCaseById = usePatchCsmCaseById();
   const findMyOngoingCases = useFindMyOngoingCases();
@@ -428,13 +446,42 @@ export default function CsmCaseDetailPage(): JSX.Element {
     });
   }, [data, recordView]);
 
+  // Resolve the single-active-case rule once the engineer's other ongoing
+  // cases are already known: mark THIS case ongoing if there are none, or
+  // prompt to pause the others first (handled in onConfirmStartWork). Shared
+  // by `startWork` (after moving to Work in progress) and the resume-work
+  // path in `onAction` (case is already Work in progress, just un-pausing).
+  const resolveOngoingConflict = useCallback(
+    async (
+      others: MyOngoingCase[],
+      successMessage: string,
+      successSeverity: FeedbackSeverity,
+    ) => {
+      if (others.length > 0) {
+        setPauseConflict(others);
+        return;
+      }
+      try {
+        await patchCase.mutateAsync({ workState: "ongoing" });
+      } catch (err) {
+        showError("Could not mark the case ongoing. Please try again.", err);
+        return;
+      }
+      setFeedback({
+        message: successMessage,
+        severity: successSeverity,
+        sticky: true,
+      });
+    },
+    [patchCase, showError],
+  );
+
   // Starting work: enforce the single-active-case rule.
   // 1) look up the engineer's other ongoing cases (abort on failure — we
   //    must not transition without knowing), 2) move this case to
-  // work_in_progress, 3) if none ongoing → mark this one ongoing; if some
-  // exist → ask before pausing them (handled in onConfirmStartWork). Shared
-  // by the "Start progress" transition and the "Assign to me" shortcut,
-  // which also puts the case into progress once the assignment lands.
+  // work_in_progress, 3) resolve via `resolveOngoingConflict`. Shared by the
+  // "Start progress" transition and the "Assign to me" shortcut, which also
+  // puts the case into progress once the assignment lands.
   const startWork = useCallback(
     async (successMessage: string, successSeverity: FeedbackSeverity) => {
       if (!data) return;
@@ -460,28 +507,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
         );
         return;
       }
-      if (others.length === 0) {
-        // No competing case → make this the active (ongoing) one.
-        try {
-          await patchCase.mutateAsync({ workState: "ongoing" });
-        } catch (err) {
-          showError(
-            "Moved to Work in progress, but could not mark it ongoing.",
-            err,
-          );
-          return;
-        }
-        setFeedback({
-          message: successMessage,
-          severity: successSeverity,
-          sticky: true,
-        });
-        return;
-      }
-      // Others are ongoing → confirm before pausing them.
-      setPauseConflict(others);
+      await resolveOngoingConflict(others, successMessage, successSeverity);
     },
-    [data, findMyOngoingCases, patchCase, showError],
+    [data, findMyOngoingCases, patchCase, showError, resolveOngoingConflict],
   );
 
   const onAction = useCallback(
@@ -501,8 +529,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
         // "Assign to me" on the Change-state button: the case isn't the
         // engineer's yet, so claim it (PATCH assigneeEmail) before starting
         // work — a plain state PATCH would move it to Work in progress
-        // without ever making it the clicking engineer's case.
-        if (action === "assign_to_me" && data && currentUserEmail) {
+        // without ever making it the clicking engineer's case. Guarded on its
+        // own (not folded into the generic work_in_progress branch below) so
+        // a missing email surfaces an error instead of silently starting work
+        // on a case that was never actually assigned.
+        if (action === "assign_to_me" && data) {
+          if (!currentUserEmail) {
+            showError("Could not assign the case to you: no signed-in email found.");
+            return;
+          }
           patchCase.mutate(
             { assigneeEmail: currentUserEmail },
             {
@@ -603,24 +638,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             );
             return;
           }
-          if (others.length === 0) {
-            try {
-              await patchCase.mutateAsync({ workState: "ongoing" });
-            } catch (err) {
-              showError(
-                "Could not resume work on this case. Please try again.",
-                err,
-              );
-              return;
-            }
-            setFeedback({
-              message: "Resumed work on this case.",
-              severity: "info",
-              sticky: true,
-            });
-            return;
-          }
-          setPauseConflict(others);
+          await resolveOngoingConflict(others, "Resumed work on this case.", "info");
         })();
         return;
       }
@@ -687,6 +705,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
       findMyOngoingCases,
       detailPath,
       startWork,
+      resolveOngoingConflict,
       currentUserEmail,
     ],
   );
@@ -1262,22 +1281,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   <RelativeTime iso={c.updatedAt} />
                 </Typography>
               </MetaCell>
-              <MetaCell label="Assignment group (ABT)">
-                <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-                  {c.assignmentGroup}
-                </Typography>
-              </MetaCell>
             </Box>
           </Card>
-          <CustomerContextWidget ctx={c.customerContext} />
-          <ProductContextWidget ctx={c.productContext} />
+          <CustomerContextWidget
+            ctx={c.customerContext}
+            project={caseProject}
+            isLoadingProject={isCaseProjectLoading}
+          />
+          <ProductContextWidget
+            ctx={c.productContext}
+            liveDeployment={liveDeployment}
+            isLoadingLiveDeployment={
+              !!c.productContext.deploymentId && isProjectDeploymentsLoading
+            }
+          />
           <WatchersWidget
             watchers={c.watchers}
             onAdd={() => onAction({ secondary: "manage_watchers" })}
+            disabled
           />
           <LinkedItemsWidget
             items={c.linkedItems}
             onLink={() => onAction({ secondary: "link_case" })}
+            disabled
           />
         </Box>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -82,7 +82,9 @@ import {
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
 import { CallRequestsWidget } from "@features/csm-cases/components/CallRequestsWidget";
+import { useGetCsmCaseCallRequests } from "@features/csm-cases/api/useCsmCaseCallRequests";
 import { CaseSlaTable } from "@features/csm-cases/components/CaseSlaTable";
+import { useGetCsmCaseSlas } from "@features/csm-cases/api/useGetCsmCaseSlas";
 import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCardsPanel";
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import { usePostTimeCard } from "@features/csm-timecards/api/useTimeCards";
@@ -185,15 +187,12 @@ const FEEDBACK_PALETTE: Record<
 const SECONDARY_TOAST: Record<string, string> = {
   reassign_engineer: "Reassign engineer dialog (mock).",
   reassign_group: "Reassign group dialog (mock).",
-  escalate: "Escalation form (mock).",
-  change_severity: "Severity change request (mock).",
   hold_auto_close: "Hold auto-closure dialog (mock).",
   create_incident: "Create incident from case (mock).",
   link_case: "Link related case picker (mock).",
   link_incident: "Link to incident picker (mock).",
   manage_watchers: "Add/remove watcher dialog (mock).",
   create_task: "Create task dialog (mock).",
-  request_call: "Request a call dialog (mock).",
   log_time: "Log time dialog (mock).",
   copy_link: "Case link copied to clipboard.",
 };
@@ -234,7 +233,7 @@ const TAB_DEFS: Array<{
 }> = [
   { id: "activities", label: "Activities", icon: <Activity size={16} /> },
   { id: "details", label: "Details", icon: <ListChecks size={16} /> },
-  { id: "sla", label: "SLA", icon: <Clock size={16} /> },
+  { id: "sla", label: "SLAs", icon: <Clock size={16} /> },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
   { id: "time", label: "Time tracking", icon: <Layers size={16} /> },
   { id: "call-requests", label: "Call requests", icon: <Phone size={16} /> },
@@ -295,6 +294,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const postAttachment = usePostCsmCaseAttachment();
   const downloadAttachment = useDownloadCsmCaseAttachment();
   const deleteAttachment = useDeleteCsmCaseAttachment();
+  // Fetched unconditionally (not just while their tab is active) purely for
+  // the tab-label counts below; each widget still runs its own scoped query
+  // when its tab mounts, deduped against this one by react-query's cache.
+  const { data: slaList } = useGetCsmCaseSlas(caseId);
+  const { data: callRequests } = useGetCsmCaseCallRequests(caseId);
   const patchCase = usePatchCsmCase(caseId);
   const patchCaseById = usePatchCsmCaseById();
   const findMyOngoingCases = useFindMyOngoingCases();
@@ -315,6 +319,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
   const [logTimeOpen, setLogTimeOpen] = useState(false);
+  // Bumped to pop open the Call requests tab's "Create call request" dialog
+  // from the action bar's "Request a call" item.
+  const [requestCallSignal, setRequestCallSignal] = useState(0);
   const [githubIssueOpen, setGithubIssueOpen] = useState(false);
   // Inline error shown inside the Git-issue dialog (e.g. the SN routing 422 /
   // state 409). Cleared when the dialog opens or a submit is retried.
@@ -420,6 +427,62 @@ export default function CsmCaseDetailPage(): JSX.Element {
     });
   }, [data, recordView]);
 
+  // Starting work: enforce the single-active-case rule.
+  // 1) look up the engineer's other ongoing cases (abort on failure — we
+  //    must not transition without knowing), 2) move this case to
+  // work_in_progress, 3) if none ongoing → mark this one ongoing; if some
+  // exist → ask before pausing them (handled in onConfirmStartWork). Shared
+  // by the "Start progress" transition and the "Assign to me" shortcut,
+  // which also puts the case into progress once the assignment lands.
+  const startWork = useCallback(
+    async (successMessage: string, successSeverity: FeedbackSeverity) => {
+      if (!data) return;
+      const caseId = data.id;
+      let others: MyOngoingCase[];
+      try {
+        others = await findMyOngoingCases(caseId);
+      } catch (err) {
+        // Don't proceed blind: marking this ongoing without knowing the
+        // other active cases would break the single-active-case rule.
+        showError(
+          "Couldn't check your other active cases. Please try again.",
+          err,
+        );
+        return;
+      }
+      try {
+        await patchCase.mutateAsync({ state: "work_in_progress" });
+      } catch (err) {
+        showError(
+          "Could not move the case to Work in progress. Please try again.",
+          err,
+        );
+        return;
+      }
+      if (others.length === 0) {
+        // No competing case → make this the active (ongoing) one.
+        try {
+          await patchCase.mutateAsync({ workState: "ongoing" });
+        } catch (err) {
+          showError(
+            "Moved to Work in progress, but could not mark it ongoing.",
+            err,
+          );
+          return;
+        }
+        setFeedback({
+          message: successMessage,
+          severity: successSeverity,
+          sticky: true,
+        });
+        return;
+      }
+      // Others are ongoing → confirm before pausing them.
+      setPauseConflict(others);
+    },
+    [data, findMyOngoingCases, patchCase, showError],
+  );
+
   const onAction = useCallback(
     (
       action: CaseLifecycleAction | { secondary: string },
@@ -434,56 +497,25 @@ export default function CsmCaseDetailPage(): JSX.Element {
           ? beStateFromUi(nextState)
           : LIFECYCLE_TARGET_STATE[action];
 
-        // Starting work: enforce the single-active-case rule.
-        // 1) look up the engineer's other ongoing cases (abort on failure — we
-        //    must not transition without knowing), 2) move this case to
-        // work_in_progress, 3) if none ongoing → mark this one ongoing; if some
-        // exist → ask before pausing them (handled in onConfirmStartWork).
+        // "Assign to me" on the Change-state button: the case isn't the
+        // engineer's yet, so claim it (PATCH assigneeEmail) before starting
+        // work — a plain state PATCH would move it to Work in progress
+        // without ever making it the clicking engineer's case.
+        if (action === "assign_to_me" && data && currentUserEmail) {
+          patchCase.mutate(
+            { assigneeEmail: currentUserEmail },
+            {
+              onSuccess: () =>
+                void startWork(LIFECYCLE_TOAST.assign_to_me, LIFECYCLE_SEVERITY.assign_to_me),
+              onError: (err) =>
+                showError("Could not assign the case to you.", err),
+            },
+          );
+          return;
+        }
+
         if (targetState === "work_in_progress" && data) {
-          const caseId = data.id;
-          void (async () => {
-            let others: MyOngoingCase[];
-            try {
-              others = await findMyOngoingCases(caseId);
-            } catch (err) {
-              // Don't proceed blind: marking this ongoing without knowing the
-              // other active cases would break the single-active-case rule.
-              showError(
-                "Couldn't check your other active cases. Please try again.",
-                err,
-              );
-              return;
-            }
-            try {
-              await patchCase.mutateAsync({ state: "work_in_progress" });
-            } catch (err) {
-              showError(
-                "Could not move the case to Work in progress. Please try again.",
-                err,
-              );
-              return;
-            }
-            if (others.length === 0) {
-              // No competing case → make this the active (ongoing) one.
-              try {
-                await patchCase.mutateAsync({ workState: "ongoing" });
-              } catch (err) {
-                showError(
-                  "Moved to Work in progress, but could not mark it ongoing.",
-                  err,
-                );
-                return;
-              }
-              setFeedback({
-                message: LIFECYCLE_TOAST[action],
-                severity: LIFECYCLE_SEVERITY[action],
-                sticky: true,
-              });
-              return;
-            }
-            // Others are ongoing → confirm before pausing them.
-            setPauseConflict(others);
-          })();
+          void startWork(LIFECYCLE_TOAST[action], LIFECYCLE_SEVERITY[action]);
           return;
         }
 
@@ -633,13 +665,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Jump to the Call requests tab and pop its own "Create call request"
+      // dialog, rather than a second/duplicate entry point for the same form.
+      if (action.secondary === "request_call") {
+        setActiveTab("call-requests");
+        setRequestCallSignal((n) => n + 1);
+        return;
+      }
+
       setFeedback({
         message: SECONDARY_TOAST[action.secondary] ?? `Action: ${action.secondary}`,
         severity: "info",
         sticky: false,
       });
     },
-    [data, showError, patchCase, findMyOngoingCases, detailPath],
+    [
+      data,
+      showError,
+      patchCase,
+      findMyOngoingCases,
+      detailPath,
+      startWork,
+      currentUserEmail,
+    ],
   );
 
   // Confirm pausing the engineer's other ongoing case(s) and making this case
@@ -715,6 +763,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const onUploadAttachment = useCallback(
     (file: File) => {
       if (!caseId) return;
+      if (data?.state === "closed") {
+        showError("This case is closed — attachments are read-only.");
+        return;
+      }
       postAttachment.mutate(
         { caseId, file, uploadedBy: engineerName },
         {
@@ -728,7 +780,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         },
       );
     },
-    [caseId, engineerName, postAttachment],
+    [caseId, engineerName, postAttachment, data, showError],
   );
 
   const onDownloadAttachment = useCallback(
@@ -989,11 +1041,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
           {TAB_DEFS.map((t) => {
             // Counts shown only where the tab IS the list (unambiguous).
             const count =
-              t.id === "attachments"
-                ? attachmentList.length
-                : t.id === "time"
-                  ? c.timeLogs.length
-                  : undefined;
+              t.id === "sla"
+                ? slaList?.count
+                : t.id === "attachments"
+                  ? attachmentList.length
+                  : t.id === "time"
+                    ? c.timeLogs.length
+                    : t.id === "call-requests"
+                      ? callRequests?.length
+                      : undefined;
             return (
               <Tab
                 key={t.id}
@@ -1037,7 +1093,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 </Button>
               </Box>
               <CsmCaseCommentInput
-                disabled={!caseId}
+                disabled={!caseId || isClosed}
                 publicCommentDisabledReason={publicReplyGateReason}
                 autoFocus
                 onSubmit={async (bodyHtml, internal, commentAttachments) => {
@@ -1081,6 +1137,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               fullWidth
               variant="outlined"
               color="inherit"
+              disabled={isClosed}
               startIcon={<MessageSquarePlus size={18} />}
               onClick={() => setComposerOpen(true)}
               sx={{
@@ -1099,9 +1156,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 },
               }}
             >
-              {publicReplyGateReason
-                ? "Add an internal work note…"
-                : "Compose a reply to the customer…"}
+              {isClosed
+                ? "This case is closed — comments and work notes are read-only."
+                : publicReplyGateReason
+                  ? "Add an internal work note…"
+                  : "Compose a reply to the customer…"}
             </Button>
           )}
 
@@ -1239,7 +1298,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   "Could not upload the attachment.")
                 : null
             }
-            onUpload={onUploadAttachment}
+            onUpload={isClosed ? undefined : onUploadAttachment}
             onDownloadAll={onDownloadAllAttachments}
             onDownload={onDownloadAttachment}
             onDelete={setPendingDelete}
@@ -1261,7 +1320,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
       {activeTab === "call-requests" && caseId && (
         <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
-          <CallRequestsWidget caseId={caseId} severity={c.severity} />
+          <CallRequestsWidget
+            caseId={caseId}
+            severity={c.severity}
+            openCreateSignal={requestCallSignal}
+          />
         </Box>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetCsmDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetCsmDashboard.ts
@@ -29,6 +29,10 @@ import type {
  */
 export function useGetCsmDashboard(
   scope: DashboardScope,
+  options?: {
+    /** Pass `false` to skip the fetch entirely (no backend route yet). */
+    enabled?: boolean;
+  },
 ): UseQueryResult<CsmAbtDashboardData, Error> {
   const authFetch = useAuthApiClient();
 
@@ -49,6 +53,7 @@ export function useGetCsmDashboard(
       }
       return (await response.json()) as CsmAbtDashboardData;
     },
+    enabled: options?.enabled ?? true,
     staleTime: 30_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -37,6 +37,13 @@ import {
  * tab+widget model (DashboardsAndReportsProposal.md, entity-service reports
  * DSL) lands. The placeholder dashboards below are kept for that restore.
  */
+// csm-portal-backend has no route for this yet (no `/csm/dashboard` handler
+// registered in cmd/server/main.go), so the call would always 404. Skip it
+// until that backend work lands — the header already renders a graceful
+// "Engineer overview" fallback for the no-data case, same as it would for a
+// real fetch failure, so gating here is a no-op once the endpoint exists.
+const CSM_DASHBOARD_API_IMPLEMENTED = false;
+
 export default function CsmDashboardPage(): JSX.Element {
   // ABT scoping is not implemented yet, so default to (and stay on)
   // all-customers; the My ABT / All customers toggle is disabled in the header.
@@ -47,7 +54,9 @@ export default function CsmDashboardPage(): JSX.Element {
   // Only the engineer-overview header consumes this now; the queue/SLA/customer/
   // activity widgets are hidden, leaving the standalone severity-by-state matrix
   // (CaseCountsMatrix, which loads from its own source) as the only widget.
-  const { data, isError } = useGetCsmDashboard(scope);
+  const { data, isError } = useGetCsmDashboard(scope, {
+    enabled: CSM_DASHBOARD_API_IMPLEMENTED,
+  });
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -57,7 +66,7 @@ export default function CsmDashboardPage(): JSX.Element {
         onScopeChange={setScope}
         dashboardKey={dashboardKey}
         onDashboardChange={setDashboardKey}
-        isError={isError}
+        isError={isError || !CSM_DASHBOARD_API_IMPLEMENTED}
       />
       {dashboardKey === "engineer" ? (
         <>

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -49,6 +49,31 @@ if (typeof window !== "undefined") {
   }
 }
 
+// A tab left open across a deploy still holds the old build's chunk hashes;
+// fetching one 404s to the SPA fallback (text/html), which Vite reports as
+// `vite:preloadError` (and plain `import()` calls reject the same way). Reload
+// once to pick up the new build — guarded by a session flag so a genuinely
+// broken deployment doesn't reload-loop the tab forever.
+if (typeof window !== "undefined") {
+  const RELOAD_GUARD_KEY = "csm_chunk_reload_once";
+  const reloadForNewBuild = (): void => {
+    let alreadyReloaded = false;
+    try {
+      alreadyReloaded = window.sessionStorage.getItem(RELOAD_GUARD_KEY) === "1";
+      window.sessionStorage.setItem(RELOAD_GUARD_KEY, "1");
+    } catch {
+      /* sessionStorage may be unavailable; fall through and reload anyway. */
+    }
+    if (!alreadyReloaded) window.location.reload();
+  };
+  window.addEventListener("vite:preloadError", reloadForNewBuild);
+  window.addEventListener("unhandledrejection", (event) => {
+    if (/Failed to fetch dynamically imported module/.test(String(event.reason))) {
+      reloadForNewBuild();
+    }
+  });
+}
+
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <AppWithConfig />

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -66,9 +66,18 @@ if (typeof window !== "undefined") {
     }
     if (!alreadyReloaded) window.location.reload();
   };
-  window.addEventListener("vite:preloadError", reloadForNewBuild);
+  window.addEventListener("vite:preloadError", (event) => {
+    // Vite rethrows the preload failure unless we mark it handled here.
+    event.preventDefault();
+    reloadForNewBuild();
+  });
+  // Match every browser's wording for a failed dynamic import: Chrome/Edge
+  // ("Failed to fetch dynamically imported module"), Firefox ("error loading
+  // dynamically imported module"), and Safari ("Importing a module script
+  // failed").
+  const DYNAMIC_IMPORT_FAILURE = /fetch dynamically imported module|error loading dynamically imported module|importing a module script failed/i;
   window.addEventListener("unhandledrejection", (event) => {
-    if (/Failed to fetch dynamically imported module/.test(String(event.reason))) {
+    if (DYNAMIC_IMPORT_FAILURE.test(String(event.reason))) {
       reloadForNewBuild();
     }
   });


### PR DESCRIPTION
## Purpose
> The case detail page had several rough edges: a stale tab left open across a deploy would hard-fail with a MIME-type error instead of recovering; closed cases still accepted new comments/work notes/attachments; the "Change state" buttons read as raw backend state names instead of verbs; the More-actions menu advertised two actions with no backend flow and an unconditional auto-closure hold; and the SLA/Attachments/Time/Call-requests tabs gave no sense of how much was in each without opening it.

## Goals
- A tab that's been open across a deploy recovers automatically instead of showing a broken page.
- Closed cases are read-only for comments, work notes, and new attachments (matching the existing time-tracking behaviour).
- The "Change state" buttons read as actions ("Assign to me", "Start progress", "Propose solution", "Request information", "Wait on WSO2") instead of raw state names, and claiming an unassigned/other-engineer's case via "Assign to me" also starts work on it.
- The More-actions menu drops two actions with no backend flow, routes "Request a call" to the Call requests tab's own dialog instead of a dead stub, and only offers "Hold auto-closure" while the case is actually subject to auto-closure.
- The SLAs, Attachments, Time tracking, and Call requests tabs show their item count in the tab label.

## Approach
- `main.tsx`: listens for `vite:preloadError` and for the "Failed to fetch dynamically imported module" rejection, and reloads the page once (session-guarded so a genuinely broken deploy doesn't loop).
- `CsmCaseDetailPage.tsx`: extracted the existing "start work" flow (single-active-case check + PATCH) into a shared `startWork` helper so both the normal transition and the new "assign then start work" path use it; gated the comment composer and attachment upload on `state === "closed"`; added page-level SLA/call-request count queries feeding the tab labels; wired "Request a call" to switch tabs and pop the Call requests create dialog via a small open-signal counter prop.
- `CaseActionBar.tsx`: added a `TRANSITION_LABEL` map for the friendlier verbs, special-cased the `work_in_progress` target to pick "Assign to me" vs "Start progress" (and the underlying action) based on `assigneeIsMe`, dropped the two unplanned menu items, and gated "Hold auto-closure" on state.
- `CallRequestsWidget.tsx`: added an optional `openCreateSignal` prop that pops its existing create dialog when bumped externally.
- Updated `CaseActionBar.test.tsx` assertions for the renamed transition labels (pre-existing, unrelated test-environment failures in that file are untouched by this change — verified they reproduce identically on `main`).

## User stories
> As a CS engineer, closing a case should stop new replies/attachments from being added to it; claiming an unassigned case should also start my work on it; and I should be able to tell at a glance how many SLAs, attachments, time entries, or call requests a case has without switching tabs.

## Release note
Case detail page: closed cases are now read-only for comments/attachments, the state-change buttons read as actions instead of raw state names, the More-actions menu was trimmed to actions that actually work, and the SLA/Attachments/Time tracking/Call requests tabs show their item counts.

## Documentation
N/A — internal case-detail UX change, no external-facing docs.

## Automation tests
 - Unit tests
   > Updated the affected assertions in `CaseActionBar.test.tsx` for the new transition labels. Ran the full webapp suite (`pnpm test`); no new failures versus `main` (6 pre-existing failures in `CaseActionBar.test.tsx` reproduce identically on `main`, unrelated to this change).
 - Integration tests
   > N/A — no integration test suite for this app.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React app — ran `pnpm lint` and `tsc --noEmit` clean instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no data model changes.

## Test environment
Verified with `pnpm build`, `pnpm lint`, `pnpm test`, and `tsc --noEmit` on macOS (Node via corepack, pnpm 11.1.2).

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-shot trigger to open the “Create call request” dialog from case actions.
  * Case action buttons now display clearer labels and adapt to reachable next steps.
  * Case detail tabs now show SLA and call request badge counts immediately.

* **Bug Fixes**
  * Improved “start work” flow with consistent conflict handling across transitions.
  * Closed cases are now fully read-only for replying and uploading (with upload rejection).
  * Enhanced reliability after deployment chunk-load errors by reloading once per tab.
  * Improved case card/grid layout to prevent overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->