### PR TITLE
[CSM][Web] Consistent skeleton loading across all paginated tables

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -18,7 +18,6 @@ import {
   Alert,
   Box,
   Chip,
-  Paper,
   Skeleton,
   Table,
   TableBody,
@@ -99,11 +98,11 @@ export default function CsmAccountsPage(): JSX.Element {
         </Alert>
       )}
 
-      <Paper variant="outlined">
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
-          <Table size="small">
+          <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
             <TableHead>
-              <TableRow>
+              <TableRow sx={{ bgcolor: "action.hover" }}>
                 <TableCell>Name</TableCell>
                 <TableCell>SF ID</TableCell>
                 <TableCell>Tier</TableCell>
@@ -113,15 +112,15 @@ export default function CsmAccountsPage(): JSX.Element {
               </TableRow>
             </TableHead>
             <TableBody>
-              {isLoading ? (
-                [0, 1, 2, 3, 4, 5].map((i) => (
+              {isLoading || isFetching ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="65%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={70} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="60%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
                   </TableRow>
                 ))
               ) : accounts.length === 0 ? (
@@ -179,13 +178,7 @@ export default function CsmAccountsPage(): JSX.Element {
           showFirstButton
           showLastButton
         />
-      </Paper>
-
-      {isFetching && !isLoading && (
-        <Typography variant="caption" color="text.secondary">
-          Updating…
-        </Typography>
-      )}
+      </Box>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -26,6 +26,8 @@ import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 interface CasesListProps {
   cases: CsmCaseRow[];
   isLoading: boolean;
+  /** Number of skeleton rows to show while loading. Defaults to 6. */
+  skeletonCount?: number;
   /** Base path for detail links. Defaults to "/cases". */
   detailBasePath?: string;
 }
@@ -50,6 +52,7 @@ const GRID =
 export default function CasesList({
   cases,
   isLoading,
+  skeletonCount = 6,
   detailBasePath = "/cases",
 }: CasesListProps): JSX.Element {
   const theme = useTheme();
@@ -97,7 +100,7 @@ export default function CasesList({
 
       {/* Rows */}
       {isLoading &&
-        [0, 1, 2, 3, 4, 5].map((i) => (
+        Array.from({ length: skeletonCount }).map((_, i) => (
           <Box
             key={i}
             sx={{

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -139,7 +139,7 @@ export default function CsmIssuesView({
     [filters, debouncedSearch, showSeverityFilter, lockedFilters],
   );
 
-  const { data, isLoading, isError, error } = useGetCsmCases(
+  const { data, isLoading, isFetching, isError, error } = useGetCsmCases(
     queryFilters,
     page,
     rowsPerPage,
@@ -257,7 +257,7 @@ export default function CsmIssuesView({
         showEngagementTypeFilter={showEngagementTypeFilter}
       />
 
-      <CasesList cases={cases} isLoading={isLoading} detailBasePath={detailBasePath} />
+      <CasesList cases={cases} isLoading={isLoading || isFetching} skeletonCount={rowsPerPage} detailBasePath={detailBasePath} />
 
       <TablePagination
         component="div"

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -151,8 +151,8 @@ export default function ChangeRequestsTab(): JSX.Element {
               </TableRow>
             </TableHead>
             <TableBody>
-              {isLoading ? (
-                [0, 1, 2, 3, 4, 5].map((i) => (
+              {isLoading || isFetching ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
                     <TableCell><Skeleton variant="rounded" width="90%" height={18} /></TableCell>
@@ -231,11 +231,6 @@ export default function ChangeRequestsTab(): JSX.Element {
         />
       </Box>
 
-      {isFetching && !isLoading && (
-        <Typography variant="caption" color="text.secondary">
-          Updating…
-        </Typography>
-      )}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -18,7 +18,6 @@ import {
   Alert,
   Box,
   Chip,
-  Paper,
   Skeleton,
   Table,
   TableBody,
@@ -103,11 +102,11 @@ export default function CsmProjectsPage(): JSX.Element {
         </Alert>
       )}
 
-      <Paper variant="outlined">
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
-          <Table size="small">
+          <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
             <TableHead>
-              <TableRow>
+              <TableRow sx={{ bgcolor: "action.hover" }}>
                 <TableCell>Name</TableCell>
                 <TableCell>Project key</TableCell>
                 <TableCell>Subscription</TableCell>
@@ -116,14 +115,14 @@ export default function CsmProjectsPage(): JSX.Element {
               </TableRow>
             </TableHead>
             <TableBody>
-              {isLoading ? (
-                [0, 1, 2, 3, 4, 5].map((i) => (
+              {isLoading || isFetching ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
-                    <TableCell><Skeleton variant="text" /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="55%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={80} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
                   </TableRow>
                 ))
               ) : projects.length === 0 ? (
@@ -179,13 +178,7 @@ export default function CsmProjectsPage(): JSX.Element {
           showFirstButton
           showLastButton
         />
-      </Paper>
-
-      {isFetching && !isLoading && (
-        <Typography variant="caption" color="text.secondary">
-          Updating…
-        </Typography>
-      )}
+      </Box>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -20,7 +20,6 @@ import {
   Chip,
   InputAdornment,
   MenuItem,
-  Paper,
   Skeleton,
   Table,
   TableBody,
@@ -139,11 +138,11 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
         </Alert>
       )}
 
-      <Paper variant="outlined">
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
-          <Table size="small">
+          <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
             <TableHead>
-              <TableRow>
+              <TableRow sx={{ bgcolor: "action.hover" }}>
                 <TableCell>CVE / Vulnerability ID</TableCell>
                 <TableCell>Component</TableCell>
                 <TableCell>Product</TableCell>
@@ -153,14 +152,15 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
               </TableRow>
             </TableHead>
             <TableBody>
-              {isLoading ? (
-                Array.from({ length: 5 }).map((_, i) => (
+              {isLoading || isFetching ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
-                    {Array.from({ length: 6 }).map((__, j) => (
-                      <TableCell key={j}>
-                        <Skeleton variant="text" />
-                      </TableCell>
-                    ))}
+                    <TableCell><Skeleton variant="rounded" width="75%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="85%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={64} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="60%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="55%" height={18} /></TableCell>
                   </TableRow>
                 ))
               ) : isError ? (
@@ -267,13 +267,7 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
           showFirstButton
           showLastButton
         />
-      </Paper>
-
-      {isFetching && !isLoading && (
-        <Typography variant="caption" color="text.secondary">
-          Updating…
-        </Typography>
-      )}
+      </Box>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -24,7 +24,6 @@ import {
   ListItemText,
   MenuItem,
   OutlinedInput,
-  Paper,
   Select,
   Skeleton,
   Stack,
@@ -185,11 +184,11 @@ export default function CsmUsersPage(): JSX.Element {
         </Alert>
       )}
 
-      <Paper variant="outlined">
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
-          <Table size="small" aria-label="Users search results">
+          <Table size="small" aria-label="Users search results" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
             <TableHead>
-              <TableRow>
+              <TableRow sx={{ bgcolor: "action.hover" }}>
                 <TableCell>Username</TableCell>
                 <TableCell sortDirection={sortField === "name" ? sortOrder : false}>
                   <TableSortLabel
@@ -207,14 +206,15 @@ export default function CsmUsersPage(): JSX.Element {
               </TableRow>
             </TableHead>
             <TableBody>
-              {isLoading ? (
-                [0, 1, 2, 3, 4, 5].map((i) => (
+              {isLoading || isFetching ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
-                    {[0, 1, 2, 3, 4, 5].map((c) => (
-                      <TableCell key={c}>
-                        <Skeleton variant="text" />
-                      </TableCell>
-                    ))}
+                    <TableCell><Skeleton variant="rounded" width="70%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="75%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="85%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={64} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={60} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="55%" height={18} /></TableCell>
                   </TableRow>
                 ))
               ) : users.length === 0 ? (
@@ -283,13 +283,7 @@ export default function CsmUsersPage(): JSX.Element {
           showFirstButton
           showLastButton
         />
-      </Paper>
-
-      {isFetching && !isLoading && (
-        <Typography variant="caption" color="text.secondary">
-          Updating…
-        </Typography>
-      )}
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- All paginated tables now show skeleton rows during **every** fetch — initial load and page/filter changes (`isLoading || isFetching`)
- Skeleton row count matches the selected `rowsPerPage` value (10, 20, or 50) instead of a hardcoded 5 or 6
- Skeleton cells use `variant="rounded"` with per-column proportional widths instead of `variant="text"` / `variant="rectangular"`
- `Paper variant="outlined"` wrappers replaced with a `Box` using `borderColor: "divider"` + `borderRadius: 1` — aligns with the cases/support table style
- `TableCell` border colour normalised to theme `divider` token via `sx`
- `TableHead` row gets `bgcolor: "action.hover"` to match the cases table header

**Tables covered:** Support/cases, Change requests, Vulnerabilities, Accounts, Projects, Users

## Test plan

- [ ] Set rows-per-page to 10 in any paginated table — skeleton shows exactly 10 rows
- [ ] Set rows-per-page to 50 — skeleton shows exactly 50 rows
- [ ] Navigate to next page — skeleton appears during the fetch, not a stale previous page
- [ ] Table header background matches the cases/support table (`action.hover`)
- [ ] Table row separator borders match the cases/support table (theme divider colour)
- [ ] No squared/rectangular skeletons visible anywhere in paginated tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)