### PR TITLE
[Customer Entity] Fix engagement case type sysid mapping in SN case service

### DIFF
--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -137,7 +137,7 @@ var snCaseTypeSysidMap = map[string]string{
 	"5aeff1201b74c210264c997a234bcb54": "service_request",
 	"ab36479047ccf510a0a29cd3846d43ee": "security_report_analysis",
 	"3b8b43311b58f010cb6898aebd4bcb8f": "announcement",
-	"8f8fc2c41b0bd550d64e64a2604bcb38": "announcement",
+	"8f8fc2c41b0bd550d64e64a2604bcb38": "engagement",
 }
 
 // snCaseTypeToDomain converts a SN caseType entity ref to the domain type string.


### PR DESCRIPTION
## Summary
- Corrects the ServiceNow sysid mapping for the `engagement` case type in `snCaseTypeSysidMap`
- Sysid `8f8fc2c41b0bd550d64e64a2604bcb38` was incorrectly mapped to `announcement`, causing cases filtered by `types: ["engagement"]` to return results with `"type": "announcement"` in the response

## Test plan
- [ ] POST `/cases/search` with `"types": ["engagement"]` — verify all returned cases have `"type": "engagement"`
- [ ] POST `/cases/search` with `"types": ["announcement"]` — verify announcement cases are unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated case type handling so a specific ServiceNow value now appears as **Engagement** instead of **Announcement**.
  * Improved consistency when ServiceNow cases are translated into the app’s case types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->