### PR TITLE
[CSM][Web] fix LinearProgress color to use theme primary token

### DIFF
--- a/apps/csm-portal/webapp/src/components/route-fallback/RouteSuspenseFallback.tsx
+++ b/apps/csm-portal/webapp/src/components/route-fallback/RouteSuspenseFallback.tsx
@@ -36,8 +36,8 @@ export default function RouteSuspenseFallback(): JSX.Element {
       }}
     >
       <LinearProgress
-        color="primary"
-        sx={{ width: "80%", maxWidth: 400, height: 4 }}
+        color="inherit"
+        sx={{ color: "primary.main", width: "80%", maxWidth: 400, height: 4 }}
       />
     </Box>
   );

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -166,8 +166,9 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
             >
               {isVisible && (
                 <LinearProgress
-                  color="primary"
+                  color="inherit"
                   sx={{
+                    color: "primary.main",
                     position: "absolute",
                     top: 0,
                     left: 0,
@@ -203,8 +204,8 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
                     }}
                   >
                     <LinearProgress
-                      color="primary"
-                      sx={{ width: "80%", maxWidth: 400, height: 4 }}
+                      color="inherit"
+                      sx={{ color: "primary.main", width: "80%", maxWidth: 400, height: 4 }}
                     />
                     <Typography variant="body2" color="text.secondary">
                       {loadingMessage}


### PR DESCRIPTION
## Summary

- Replaces `color="primary"` on all `LinearProgress` bars with `color="inherit"` + `sx={{ color: "primary.main" }}`
- The Oxygen UI acrylic-purple theme caused the indeterminate animation to render a mixed orange/purple effect when `color="primary"` was used (the two animated bars were picking up different palette tokens)
- Using `color="inherit"` with `sx={{ color: "primary.main" }}` threads the theme's primary token directly to the bar via `currentColor`, so only the configured primary color appears

## Files changed

- `src/components/route-fallback/RouteSuspenseFallback.tsx` — route chunk download fallback bar
- `src/layouts/AppLayout.tsx` — init loading screen bar + nav-bar (isVisible-gated)

## Test plan

- [x] Reload the app and verify the loading bar shows only the theme's primary (purple) colour with no orange mixing
- [x] Confirm the init loading screen (`!hasInitialized`) bar also uses the correct colour on first load / OAuth callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table loading behavior across several screens so loading placeholders now appear during both initial loads and refreshes.
  * Removed the brief “Updating…” status text in favor of cleaner loading states.
  * Adjusted progress bar and table styling for more consistent visual presentation.

* **Style**
  * Updated table containers, borders, hover states, and skeleton placeholders for a more polished look and better alignment with content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->