### PR TITLE
CSM Portal: case-form UX cleanup (unbuilt-action tooltips, empty dropdowns, GitHub issue confirm step)

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -308,3 +308,32 @@ describe("CaseActionBar — unbuilt roadmap items stay disabled, not silently mo
     expect(onAction).not.toHaveBeenCalled();
   });
 });
+
+describe("CaseActionBar — Raise internal Git issue is blocked on a closed case", () => {
+  it("disables the menu item once the case is closed", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar caseDetail={caseInState("closed", [])} onAction={onAction} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /raise internal git issue/i });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("keeps it enabled for a non-closed case", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("awaiting_info", ["waiting_on_wso2"])}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /raise internal git issue/i });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "raise_git_issue" });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -279,3 +279,32 @@ describe("CaseActionBar — reassign gating for WIP-Ongoing", () => {
     expect(onAction).toHaveBeenCalledWith({ secondary: "reassign_engineer" });
   });
 });
+
+describe("CaseActionBar — unbuilt roadmap items stay disabled, not silently mock", () => {
+  // Create incident / Link to incident / Create task / Hold auto-closure have
+  // no backend flow yet. They must never be clickable — a click that reaches
+  // onAction would surface a mock toast to a real user — and they must never
+  // depend on case state, since it isn't state that's missing, it's the
+  // feature itself.
+  const ROADMAP_ITEMS = [
+    /create incident from case/i,
+    /link to incident/i,
+    /create task/i,
+    /hold auto-closure/i,
+  ];
+
+  it.each(ROADMAP_ITEMS)("keeps %s disabled and inert", (name) => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("awaiting_info", ["waiting_on_wso2"])}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -249,17 +249,16 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const reassignBlocked =
     caseDetail.state === "work_in_progress" && caseDetail.workState === "ongoing";
 
-  // Hold auto-closure only makes sense while the case is sitting in a state
-  // that's subject to auto-closure (awaiting the customer's response) —
-  // showing it at any other time would offer to hold a closure that isn't
-  // pending.
-  const canHoldAutoClose =
-    caseDetail.state === "awaiting_info" || caseDetail.state === "solution_proposed";
+  // Roadmap items with no backend flow yet: kept visible (so the menu still
+  // advertises what's coming) but disabled with a tooltip explaining why,
+  // rather than clickable and silently no-op'ing or toasting a mock message.
+  // "Hold auto-closure…" belongs here too — it isn't state-gated, it's simply
+  // not built yet, regardless of the case's current state.
+  const NOT_BUILT_YET = "Not available yet — this action is planned but not built.";
 
-  // Only "Copy case link", "Request a call", and "Log time" are wired up.
-  // The rest are disabled until their backend flows land, so the menu
-  // advertises the roadmap without exposing dead actions that would no-op or
-  // toast a mock message.
+  // Only "Copy case link", "Request a call", "Log time", "Assign / reassign
+  // engineer…", and "Raise internal Git issue…" are wired up. The rest are
+  // disabled until their backend flows land.
   items.push(
     { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} />, divider: true },
     {
@@ -272,12 +271,10 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
         ? "Can't reassign while the case is in progress and ongoing. Pause the work first, or ask the current assignee or a lead to reassign."
         : undefined,
     },
-    ...(canHoldAutoClose
-      ? [{ key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true }]
-      : []),
-    { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true },
-    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, divider: true, disabled: true },
-    { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true, disabled: true },
+    { key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true, disabled: true, tooltip: NOT_BUILT_YET },
+    { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true, tooltip: NOT_BUILT_YET },
+    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, divider: true, disabled: true, tooltip: NOT_BUILT_YET },
+    { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true, disabled: true, tooltip: NOT_BUILT_YET },
     { key: "request_call", label: "Request a call…", icon: <Phone size={16} /> },
     { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },
     { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -249,6 +249,11 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const reassignBlocked =
     caseDetail.state === "work_in_progress" && caseDetail.workState === "ongoing";
 
+  // A closed case is done — filing a new Git issue against it doesn't fit
+  // the same "closed is read-only" rule already applied to comments,
+  // attachments, and time tracking (see CsmCaseDetailPage.tsx's isClosed).
+  const caseClosed = caseDetail.state === "closed";
+
   // Roadmap items with no backend flow yet: kept visible (so the menu still
   // advertises what's coming) but disabled with a tooltip explaining why,
   // rather than clickable and silently no-op'ing or toasting a mock message.
@@ -260,7 +265,14 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   // engineer…", and "Raise internal Git issue…" are wired up. The rest are
   // disabled until their backend flows land.
   items.push(
-    { key: "raise_git_issue", label: "Raise internal Git issue…", icon: <GitBranch size={16} />, divider: true },
+    {
+      key: "raise_git_issue",
+      label: "Raise internal Git issue…",
+      icon: <GitBranch size={16} />,
+      divider: true,
+      disabled: caseClosed,
+      tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
+    },
     {
       key: "reassign_engineer",
       label: "Assign / reassign engineer…",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
+
+function fillRequiredFields(): void {
+  fireEvent.change(screen.getByLabelText(/summary/i), {
+    target: { value: "Token issuance is slow" },
+  });
+  fireEvent.change(screen.getByLabelText(/description/i), {
+    target: { value: "Latency spiked after the last deploy." },
+  });
+}
+
+describe("CreateGithubIssueDialog — required fields gate submission", () => {
+  it("disables Create issue until Summary and Description are both filled", () => {
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeDisabled();
+    fillRequiredFields();
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeEnabled();
+  });
+});
+
+describe("CreateGithubIssueDialog — confirm step before filing a real issue", () => {
+  // Filing an issue is a real, permanent write to an external repo with no
+  // delete on either side, so it must never fire on the first click.
+  it("does not call onSubmit on the first click — opens a confirm step instead", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", { name: /file this github issue/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onSubmit with the built payload only after confirming", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+    fireEvent.click(screen.getByRole("button", { name: /file issue/i }));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "default",
+        title: "Token issuance is slow",
+        description: "Latency spiked after the last deploy.",
+      }),
+    );
+  });
+
+  it("backing out of the confirm step does not submit", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    // MUI's Dialog exit is animated, so the node lingers briefly after Back
+    // is clicked — wait for the unmount rather than asserting synchronously.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("heading", { name: /file this github issue/i }),
+      ).not.toBeInTheDocument(),
+    );
+    // The form itself is still open/usable, not reset or closed.
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeEnabled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
@@ -136,6 +136,37 @@ describe("CreateGithubIssueDialog — per-type field rules", () => {
   });
 });
 
+describe("CreateGithubIssueDialog — stale per-type fields don't leak into the payload", () => {
+  it("drops hotFixRequired once Type is switched away from Patch after toggling it on", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    selectType("Patch");
+    fireEvent.click(screen.getByRole("switch", { name: /hotfix required/i }));
+    // Switching away from Patch hides the control, but the toggled-on state
+    // must not still ride along in the submitted payload.
+    selectType("Query");
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Token issuance is slow" },
+    });
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Latency spiked after the last deploy." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+    fireEvent.click(screen.getByRole("button", { name: /file issue/i }));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.not.objectContaining({ hotFixRequired: true }),
+    );
+  });
+});
+
 describe("CreateGithubIssueDialog — confirm step before filing a real issue", () => {
   // Filing an issue is a real write to an external repo with no delete on
   // either side, so it must never fire on the first click.

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
@@ -19,8 +19,17 @@ import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
 
+function selectType(typeLabel: string): void {
+  fireEvent.mouseDown(screen.getByRole("combobox", { name: /^type/i }));
+  fireEvent.click(screen.getByRole("option", { name: typeLabel }));
+}
+
+/** Fills every field required for the simplest type (Query — no Severity or
+ * Hotfix Required involved) so tests unrelated to the per-type rules don't
+ * need to know about them. */
 function fillRequiredFields(): void {
-  fireEvent.change(screen.getByLabelText(/summary/i), {
+  selectType("Query");
+  fireEvent.change(screen.getByLabelText(/subject/i), {
     target: { value: "Token issuance is slow" },
   });
   fireEvent.change(screen.getByLabelText(/description/i), {
@@ -29,7 +38,7 @@ function fillRequiredFields(): void {
 }
 
 describe("CreateGithubIssueDialog — required fields gate submission", () => {
-  it("disables Create issue until Summary and Description are both filled", () => {
+  it("disables Create issue until Type, Subject, and Description are all filled", () => {
     render(
       <CreateGithubIssueDialog
         open
@@ -40,14 +49,96 @@ describe("CreateGithubIssueDialog — required fields gate submission", () => {
       />,
     );
     expect(screen.getByRole("button", { name: /create issue/i })).toBeDisabled();
-    fillRequiredFields();
+    selectType("Query");
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Token issuance is slow" },
+    });
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Latency spiked after the last deploy." },
+    });
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeEnabled();
+  });
+});
+
+describe("CreateGithubIssueDialog — per-type field rules", () => {
+  it("Query hides Severity and Hotfix Required", () => {
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    selectType("Query");
+    expect(screen.queryByRole("combobox", { name: /severity/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Hotfix Required")).not.toBeInTheDocument();
+  });
+
+  it("Incident requires Severity and hides Hotfix Required", () => {
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    selectType("Incident");
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Token issuance is slow" },
+    });
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Latency spiked after the last deploy." },
+    });
+    expect(screen.queryByText("Hotfix Required")).not.toBeInTheDocument();
+    // Severity is required for Incident — Create issue stays disabled without it.
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeDisabled();
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /severity/i }));
+    fireEvent.click(screen.getByRole("option", { name: /p1/i }));
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeEnabled();
+  });
+
+  it("Patch hides Severity and requires Update Level + Public Git Issue", () => {
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    selectType("Patch");
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Token issuance is slow" },
+    });
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Latency spiked after the last deploy." },
+    });
+    expect(screen.queryByRole("combobox", { name: /severity/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Hotfix Required")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/update level/i), {
+      target: { value: "7.1.0" },
+    });
+    expect(screen.getByRole("button", { name: /create issue/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/public git issue/i), {
+      target: { value: "https://github.com/wso2/example/issues/1" },
+    });
     expect(screen.getByRole("button", { name: /create issue/i })).toBeEnabled();
   });
 });
 
 describe("CreateGithubIssueDialog — confirm step before filing a real issue", () => {
-  // Filing an issue is a real, permanent write to an external repo with no
-  // delete on either side, so it must never fire on the first click.
+  // Filing an issue is a real write to an external repo with no delete on
+  // either side, so it must never fire on the first click.
   it("does not call onSubmit on the first click — opens a confirm step instead", () => {
     const onSubmit = vi.fn();
     render(
@@ -86,6 +177,7 @@ describe("CreateGithubIssueDialog — confirm step before filing a real issue", 
         reason: "default",
         title: "Token issuance is slow",
         description: "Latency spiked after the last deploy.",
+        issueTypeLabel: "Type/Query",
       }),
     );
   });
@@ -164,5 +256,52 @@ describe("CreateGithubIssueDialog — confirm step before filing a real issue", 
     });
     expect(within(confirmDialog).getByRole("button", { name: /^back$/i })).toBeDisabled();
     expect(within(confirmDialog).getByRole("button", { name: /file issue/i })).toBeDisabled();
+  });
+});
+
+describe("CreateGithubIssueDialog — success view", () => {
+  it("shows a clickable link to the created issue instead of closing", () => {
+    const onClose = vi.fn();
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        createdIssue={{
+          message: "Issue created.",
+          issue: { url: "https://github.com/wso2-enterprise/example/issues/42", number: 42, repo: "example" },
+        }}
+        onClose={onClose}
+        onSubmit={() => {}}
+      />,
+    );
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+
+    const link = screen.getByRole("link", { name: /example#42/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/wso2-enterprise/example/issues/42",
+    );
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /^done$/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("falls back to the response message when no issue URL is present", () => {
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        createdIssue={{ message: "Filed, awaiting SN sync." }}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+    expect(screen.getByText("Filed, awaiting SN sync.")).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
@@ -114,5 +114,55 @@ describe("CreateGithubIssueDialog — confirm step before filing a real issue", 
     );
     // The form itself is still open/usable, not reset or closed.
     expect(screen.getByRole("button", { name: /create issue/i })).toBeEnabled();
+  });
+
+  it("surfaces the error inside the confirm step, not just the form behind it", () => {
+    render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error="Something went wrong filing the issue."
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+    const confirmDialog = screen.getByRole("dialog", {
+      name: /file this github issue/i,
+    });
+    expect(
+      within(confirmDialog).getByText("Something went wrong filing the issue."),
+    ).toBeInTheDocument();
+  });
+
+  it("disables Back and File issue while a submit is in flight", () => {
+    const onSubmit = vi.fn();
+    const { rerender } = render(
+      <CreateGithubIssueDialog
+        open
+        submitting={false}
+        error={null}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+
+    rerender(
+      <CreateGithubIssueDialog
+        open
+        submitting
+        error={null}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    const confirmDialog = screen.getByRole("dialog", {
+      name: /file this github issue/i,
+    });
+    expect(within(confirmDialog).getByRole("button", { name: /^back$/i })).toBeDisabled();
+    expect(within(confirmDialog).getByRole("button", { name: /file issue/i })).toBeDisabled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
@@ -189,7 +189,7 @@ export function CreateGithubIssueDialog({
     // whenever the user picked one and let the SN side decide to apply it.
     if (priorityLevel) payload.priorityLevel = priorityLevel;
     if (repo) payload.repoOverride = { owner: REPO_OWNER, repo };
-    if (hotFix) payload.hotFixRequired = true;
+    if (showHotFix && hotFix) payload.hotFixRequired = true;
     if (regression) payload.regression = true;
 
     setConfirmPayload(payload);

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
@@ -15,6 +15,9 @@
 // under the License.
 
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
   Dialog,
@@ -28,6 +31,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
+import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import type { BeCreateCaseGithubIssuePayload } from "@api/backend/types";
 
@@ -119,6 +123,14 @@ export function CreateGithubIssueDialog({
   const [repo, setRepo] = useState<string>(UNSET);
   const [hotFix, setHotFix] = useState<string>(UNSET);
   const [regression, setRegression] = useState<string>(UNSET);
+  // Set once the user clicks "Create issue" on the form; holds the built
+  // payload until they confirm on the follow-up step below. Filing this issue
+  // is a real, permanent write to an external GitHub repo with no delete —
+  // unlike the rest of this form's state, it can't just be reopened and
+  // corrected, so it gets an explicit confirm step like the case's other
+  // hard-to-undo actions (see CaseActionBar's TARGET_CONFIG.confirm).
+  const [confirmPayload, setConfirmPayload] =
+    useState<BeCreateCaseGithubIssuePayload | null>(null);
 
   const resetAndClose = () => {
     setTitle(defaultTitle ?? "");
@@ -130,6 +142,7 @@ export function CreateGithubIssueDialog({
     setRepo(UNSET);
     setHotFix(UNSET);
     setRegression(UNSET);
+    setConfirmPayload(null);
     onClose();
   };
 
@@ -154,8 +167,10 @@ export function CreateGithubIssueDialog({
     if (hotFix === "yes") payload.hotFixRequired = true;
     if (regression === "yes") payload.regression = true;
 
-    onSubmit(payload);
+    setConfirmPayload(payload);
   };
+
+  const repoLabel = REPO_OPTIONS.find((o) => o.value === repo)?.label;
 
   // Shared renderer for a "-- Select --" dropdown.
   const renderSelect = (
@@ -224,40 +239,55 @@ export function CreateGithubIssueDialog({
             helperText="Case number, product and reporter are appended to the issue body automatically."
           />
 
-          <TextField
-            label="Update Level"
-            value={updateLevel}
-            onChange={(e) => setUpdateLevel(e.target.value)}
-            disabled={submitting}
-            size="small"
-            fullWidth
-          />
+          {/* Everything below is optional; collapsed by default so the form
+              reads as "2 required fields" rather than 9 identically-weighted
+              ones. Defaults to closed even when a field inside has a value
+              (e.g. a prefilled Update Level) — reopening it is one click. */}
+          <Accordion disableGutters sx={{ "&:before": { display: "none" } }}>
+            <AccordionSummary expandIcon={<ChevronDown size={16} />}>
+              <Typography variant="body2" color="text.secondary">
+                More options (optional)
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails
+              sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+            >
+              <TextField
+                label="Update Level"
+                value={updateLevel}
+                onChange={(e) => setUpdateLevel(e.target.value)}
+                disabled={submitting}
+                size="small"
+                fullWidth
+              />
 
-          <TextField
-            label="Public Git Issue or Security Internal JIRA"
-            value={publicIssueUrl}
-            onChange={(e) => setPublicIssueUrl(e.target.value)}
-            disabled={submitting}
-            size="small"
-            fullWidth
-            placeholder="https://github.com/… or JIRA link"
-          />
+              <TextField
+                label="Public Git Issue or Security Internal JIRA"
+                value={publicIssueUrl}
+                onChange={(e) => setPublicIssueUrl(e.target.value)}
+                disabled={submitting}
+                size="small"
+                fullWidth
+                placeholder="https://github.com/… or JIRA link"
+              />
 
-          {renderSelect("ghi-type", "Type", issueTypeLabel, setIssueTypeLabel, TYPE_OPTIONS)}
+              {renderSelect("ghi-type", "Type", issueTypeLabel, setIssueTypeLabel, TYPE_OPTIONS)}
 
-          {renderSelect("ghi-severity", "Severity", priorityLevel, setPriorityLevel, SEVERITY_OPTIONS)}
+              {renderSelect("ghi-severity", "Severity", priorityLevel, setPriorityLevel, SEVERITY_OPTIONS)}
 
-          {renderSelect(
-            "ghi-repo",
-            "Choose repository (only for cloud cases)",
-            repo,
-            setRepo,
-            REPO_OPTIONS,
-          )}
+              {renderSelect(
+                "ghi-repo",
+                "Choose repository (only for cloud cases)",
+                repo,
+                setRepo,
+                REPO_OPTIONS,
+              )}
 
-          {renderSelect("ghi-hotfix", "Hotfix Required", hotFix, setHotFix, YES_NO_OPTIONS)}
+              {renderSelect("ghi-hotfix", "Hotfix Required", hotFix, setHotFix, YES_NO_OPTIONS)}
 
-          {renderSelect("ghi-regression", "Regression", regression, setRegression, YES_NO_OPTIONS)}
+              {renderSelect("ghi-regression", "Regression", regression, setRegression, YES_NO_OPTIONS)}
+            </AccordionDetails>
+          </Accordion>
         </Box>
       </DialogContent>
       <DialogActions>
@@ -273,6 +303,52 @@ export function CreateGithubIssueDialog({
           Create issue
         </Button>
       </DialogActions>
+
+      {/* Filing a GitHub issue is a real, permanent write to an external repo
+          with no delete on either side (see useCsmCaseGithubIssue.ts) — the
+          one action in this dialog that can't be undone by just editing the
+          form again, so it gets its own explicit confirm step. */}
+      <Dialog
+        open={!!confirmPayload}
+        onClose={() => setConfirmPayload(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>File this GitHub issue?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            This creates a real, permanent issue in{" "}
+            {repoLabel
+              ? `wso2-enterprise/${repo} (${repoLabel})`
+              : "a WSO2 product repository, routed automatically by the case's product"}
+            . It can't be deleted from here afterward.
+          </Typography>
+          {/* Errors surface here too, not just on the form step behind this
+              dialog — otherwise a failed submit leaves the user looking at
+              this confirm step with no visible reason why it stopped. */}
+          {error && (
+            <Typography variant="body2" color="error" sx={{ mt: 1.5 }}>
+              {error}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmPayload(null)} disabled={submitting}>
+            Back
+          </Button>
+          <Button
+            variant="contained"
+            color="warning"
+            disabled={submitting}
+            loading={submitting}
+            onClick={() => {
+              if (confirmPayload) onSubmit(confirmPayload);
+            }}
+          >
+            File issue
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Dialog>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
@@ -25,15 +25,21 @@ import {
   DialogContent,
   DialogTitle,
   FormControl,
+  FormControlLabel,
   InputLabel,
+  Link,
   MenuItem,
   Select,
+  Switch,
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
+import { CheckCircle, ChevronDown } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
-import type { BeCreateCaseGithubIssuePayload } from "@api/backend/types";
+import type {
+  BeCreateCaseGithubIssuePayload,
+  BeCreateCaseGithubIssueResponse,
+} from "@api/backend/types";
 
 // ---------------------------------------------------------------------------
 // Option lists. Every select starts unset ("" → "-- Select --") and omits its
@@ -45,7 +51,9 @@ import type { BeCreateCaseGithubIssuePayload } from "@api/backend/types";
 const UNSET = "";
 const SELECT_PLACEHOLDER = "-- Select --";
 
-const TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+type IssueTypeValue = "" | "Type/Query" | "Type/Incident" | "Type/Patch";
+
+const TYPE_OPTIONS: Array<{ value: IssueTypeValue; label: string }> = [
   { value: "Type/Query", label: "Query" },
   { value: "Type/Incident", label: "Incident" },
   { value: "Type/Patch", label: "Patch" },
@@ -68,11 +76,6 @@ const REPO_OPTIONS: Array<{ value: string; label: string }> = [
   { value: "wso2-integration-internal", label: "Devant / Integration" },
 ];
 
-const YES_NO_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: "yes", label: "Yes" },
-  { value: "no", label: "No" },
-];
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -82,9 +85,13 @@ export interface CreateGithubIssueDialogProps {
   submitting: boolean;
   /** Backend error message to surface inline (cleared by the parent on retry). */
   error: string | null;
+  /** Set once the current submission has succeeded — the dialog shows a
+   * "created" screen with a clickable link instead of closing immediately.
+   * The parent clears this (along with `error`) when the dialog is dismissed. */
+  createdIssue?: BeCreateCaseGithubIssueResponse | null;
   /** Prefill for the update-level field, taken from the case's product context. */
   defaultUpdateLevel?: string;
-  /** Prefill for the Summary field, taken from the case's subject. */
+  /** Prefill for the Subject field, taken from the case's subject. */
   defaultTitle?: string;
   /** Prefill for the Description field, taken from the case's description. */
   defaultDescription?: string;
@@ -99,55 +106,73 @@ export interface CreateGithubIssueDialogProps {
 
 /**
  * Form for filing an internal GitHub issue from a case (ISSU-020). Mirrors the
- * legacy ServiceNow "Open Git Issue" form: Summary + Description are required;
- * everything else is optional. Reason is fixed to `default` (the migration /
- * R&D-ticket variants were separate SN actions). Repo selection is offered for
- * cloud cases; when unset the SN side routes by the case's product unit.
+ * legacy ServiceNow "Open Git Issue" form. Subject + Description are always
+ * required; Type is required too and drives which other fields are shown/
+ * required (per review on #1085):
+ *   - Query: Severity and Hotfix Required are hidden.
+ *   - Incident: Severity is required; Hotfix Required is hidden.
+ *   - Patch: Severity is hidden; Update Level, Public Git Issue, and Hotfix
+ *     Required are all required.
+ * Reason is fixed to `default` (the migration / R&D-ticket variants were
+ * separate SN actions). Repo selection is offered for cloud cases; when unset
+ * the SN side routes by the case's product unit.
  */
 export function CreateGithubIssueDialog({
   open,
   submitting,
   error,
+  createdIssue,
   defaultUpdateLevel,
   defaultTitle,
   defaultDescription,
   onClose,
   onSubmit,
 }: CreateGithubIssueDialogProps): JSX.Element {
+  const [type, setType] = useState<IssueTypeValue>(UNSET);
   const [title, setTitle] = useState(defaultTitle ?? "");
   const [description, setDescription] = useState(defaultDescription ?? "");
   const [updateLevel, setUpdateLevel] = useState(defaultUpdateLevel ?? "");
   const [publicIssueUrl, setPublicIssueUrl] = useState("");
-  const [issueTypeLabel, setIssueTypeLabel] = useState<string>(UNSET);
   const [priorityLevel, setPriorityLevel] = useState<string>(UNSET);
   const [repo, setRepo] = useState<string>(UNSET);
-  const [hotFix, setHotFix] = useState<string>(UNSET);
-  const [regression, setRegression] = useState<string>(UNSET);
+  const [hotFix, setHotFix] = useState(false);
+  const [regression, setRegression] = useState(false);
   // Set once the user clicks "Create issue" on the form; holds the built
   // payload until they confirm on the follow-up step below. Filing this issue
-  // is a real, permanent write to an external GitHub repo with no delete —
-  // unlike the rest of this form's state, it can't just be reopened and
-  // corrected, so it gets an explicit confirm step like the case's other
-  // hard-to-undo actions (see CaseActionBar's TARGET_CONFIG.confirm).
+  // is a real write to an external GitHub repo, so it gets an explicit
+  // confirm step like the case's other hard-to-undo actions (see
+  // CaseActionBar's TARGET_CONFIG.confirm).
   const [confirmPayload, setConfirmPayload] =
     useState<BeCreateCaseGithubIssuePayload | null>(null);
 
+  // Type drives which fields apply — see the component doc comment above.
+  const showSeverity = type === "Type/Incident";
+  const requireSeverity = type === "Type/Incident";
+  const showHotFix = type === "Type/Patch";
+  const requireUpdateLevel = type === "Type/Patch";
+  const requirePublicIssueUrl = type === "Type/Patch";
+
   const resetAndClose = () => {
+    setType(UNSET);
     setTitle(defaultTitle ?? "");
     setDescription(defaultDescription ?? "");
     setUpdateLevel(defaultUpdateLevel ?? "");
     setPublicIssueUrl("");
-    setIssueTypeLabel(UNSET);
     setPriorityLevel(UNSET);
     setRepo(UNSET);
-    setHotFix(UNSET);
-    setRegression(UNSET);
+    setHotFix(false);
+    setRegression(false);
     setConfirmPayload(null);
     onClose();
   };
 
   const canSubmit =
-    title.trim().length > 0 && description.trim().length > 0;
+    !!type &&
+    title.trim().length > 0 &&
+    description.trim().length > 0 &&
+    (!requireSeverity || !!priorityLevel) &&
+    (!requireUpdateLevel || updateLevel.trim().length > 0) &&
+    (!requirePublicIssueUrl || publicIssueUrl.trim().length > 0);
 
   const handleSubmit = () => {
     if (!canSubmit) return;
@@ -156,16 +181,16 @@ export function CreateGithubIssueDialog({
       reason: "default",
       title: title.trim(),
       description: description.trim(),
+      issueTypeLabel: type,
     };
     if (updateLevel.trim()) payload.updateLevel = updateLevel.trim();
     if (publicIssueUrl.trim()) payload.publicIssueUrl = publicIssueUrl.trim();
-    if (issueTypeLabel) payload.issueTypeLabel = issueTypeLabel;
     // Priority only carries meaning for incidents on the SN side; send it
     // whenever the user picked one and let the SN side decide to apply it.
     if (priorityLevel) payload.priorityLevel = priorityLevel;
     if (repo) payload.repoOverride = { owner: REPO_OWNER, repo };
-    if (hotFix === "yes") payload.hotFixRequired = true;
-    if (regression === "yes") payload.regression = true;
+    if (hotFix) payload.hotFixRequired = true;
+    if (regression) payload.regression = true;
 
     setConfirmPayload(payload);
   };
@@ -173,14 +198,15 @@ export function CreateGithubIssueDialog({
   const repoLabel = REPO_OPTIONS.find((o) => o.value === repo)?.label;
 
   // Shared renderer for a "-- Select --" dropdown.
-  const renderSelect = (
+  const renderSelect = <V extends string>(
     id: string,
     label: string,
-    value: string,
-    onChange: (v: string) => void,
-    options: Array<{ value: string; label: string }>,
+    value: V,
+    onChange: (v: V) => void,
+    options: Array<{ value: V; label: string }>,
+    required?: boolean,
   ): JSX.Element => (
-    <FormControl fullWidth size="small" disabled={submitting}>
+    <FormControl fullWidth size="small" disabled={submitting} required={required}>
       <InputLabel id={`${id}-label`} shrink>
         {label}
       </InputLabel>
@@ -189,7 +215,7 @@ export function CreateGithubIssueDialog({
         label={label}
         value={value}
         displayEmpty
-        onChange={(e) => onChange(String(e.target.value))}
+        onChange={(e) => onChange(e.target.value as V)}
       >
         <MenuItem value={UNSET}>
           <Typography component="span" color="text.secondary">
@@ -216,8 +242,10 @@ export function CreateGithubIssueDialog({
             </Typography>
           )}
 
+          {renderSelect("ghi-type", "Type", type, setType, TYPE_OPTIONS, true)}
+
           <TextField
-            label="Summary"
+            label="Subject"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             fullWidth
@@ -239,10 +267,64 @@ export function CreateGithubIssueDialog({
             helperText="Case number, product and reporter are appended to the issue body automatically."
           />
 
-          {/* Everything below is optional; collapsed by default so the form
-              reads as "2 required fields" rather than 9 identically-weighted
-              ones. Defaults to closed even when a field inside has a value
-              (e.g. a prefilled Update Level) — reopening it is one click. */}
+          {showSeverity &&
+            renderSelect(
+              "ghi-severity",
+              "Severity",
+              priorityLevel,
+              setPriorityLevel,
+              SEVERITY_OPTIONS,
+              requireSeverity,
+            )}
+
+          <TextField
+            label="Update Level"
+            value={updateLevel}
+            onChange={(e) => setUpdateLevel(e.target.value)}
+            disabled={submitting}
+            required={requireUpdateLevel}
+            size="small"
+            fullWidth
+          />
+
+          <TextField
+            label="Public Git Issue or Security Internal JIRA"
+            value={publicIssueUrl}
+            onChange={(e) => setPublicIssueUrl(e.target.value)}
+            disabled={submitting}
+            required={requirePublicIssueUrl}
+            size="small"
+            fullWidth
+            placeholder="https://github.com/… or JIRA link"
+          />
+
+          {showHotFix && (
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={hotFix}
+                  onChange={(e) => setHotFix(e.target.checked)}
+                  disabled={submitting}
+                />
+              }
+              label="Hotfix Required"
+            />
+          )}
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={regression}
+                onChange={(e) => setRegression(e.target.checked)}
+                disabled={submitting}
+              />
+            }
+            label="Regression"
+          />
+
+          {/* Only the repo override stays optional across every type and is
+              rarely needed (the SN side routes by product unit when unset),
+              so it's the only field still tucked away by default. */}
           <Accordion disableGutters sx={{ "&:before": { display: "none" } }}>
             <AccordionSummary expandIcon={<ChevronDown size={16} />}>
               <Typography variant="body2" color="text.secondary">
@@ -252,29 +334,6 @@ export function CreateGithubIssueDialog({
             <AccordionDetails
               sx={{ display: "flex", flexDirection: "column", gap: 2 }}
             >
-              <TextField
-                label="Update Level"
-                value={updateLevel}
-                onChange={(e) => setUpdateLevel(e.target.value)}
-                disabled={submitting}
-                size="small"
-                fullWidth
-              />
-
-              <TextField
-                label="Public Git Issue or Security Internal JIRA"
-                value={publicIssueUrl}
-                onChange={(e) => setPublicIssueUrl(e.target.value)}
-                disabled={submitting}
-                size="small"
-                fullWidth
-                placeholder="https://github.com/… or JIRA link"
-              />
-
-              {renderSelect("ghi-type", "Type", issueTypeLabel, setIssueTypeLabel, TYPE_OPTIONS)}
-
-              {renderSelect("ghi-severity", "Severity", priorityLevel, setPriorityLevel, SEVERITY_OPTIONS)}
-
               {renderSelect(
                 "ghi-repo",
                 "Choose repository (only for cloud cases)",
@@ -282,10 +341,6 @@ export function CreateGithubIssueDialog({
                 setRepo,
                 REPO_OPTIONS,
               )}
-
-              {renderSelect("ghi-hotfix", "Hotfix Required", hotFix, setHotFix, YES_NO_OPTIONS)}
-
-              {renderSelect("ghi-regression", "Regression", regression, setRegression, YES_NO_OPTIONS)}
             </AccordionDetails>
           </Accordion>
         </Box>
@@ -304,50 +359,88 @@ export function CreateGithubIssueDialog({
         </Button>
       </DialogActions>
 
-      {/* Filing a GitHub issue is a real, permanent write to an external repo
-          with no delete on either side (see useCsmCaseGithubIssue.ts) — the
-          one action in this dialog that can't be undone by just editing the
-          form again, so it gets its own explicit confirm step. */}
+      {/* Filing a GitHub issue is a real write to an external repo, so it
+          gets its own explicit confirm step. Once createdIssue is set (the
+          submission succeeded), the same dialog switches to a success view
+          with a clickable link instead of closing itself. */}
       <Dialog
         open={!!confirmPayload}
         onClose={() => setConfirmPayload(null)}
         maxWidth="xs"
         fullWidth
       >
-        <DialogTitle>File this GitHub issue?</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2">
-            This creates a real, permanent issue in{" "}
-            {repoLabel
-              ? `wso2-enterprise/${repo} (${repoLabel})`
-              : "a WSO2 product repository, routed automatically by the case's product"}
-            . It can't be deleted from here afterward.
-          </Typography>
-          {/* Errors surface here too, not just on the form step behind this
-              dialog — otherwise a failed submit leaves the user looking at
-              this confirm step with no visible reason why it stopped. */}
-          {error && (
-            <Typography variant="body2" color="error" sx={{ mt: 1.5 }}>
-              {error}
-            </Typography>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmPayload(null)} disabled={submitting}>
-            Back
-          </Button>
-          <Button
-            variant="contained"
-            color="warning"
-            disabled={submitting}
-            loading={submitting}
-            onClick={() => {
-              if (confirmPayload) onSubmit(confirmPayload);
-            }}
-          >
-            File issue
-          </Button>
-        </DialogActions>
+        {createdIssue ? (
+          <>
+            <DialogTitle>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, color: "success.main" }}>
+                <CheckCircle size={20} />
+                <Box component="span" sx={{ color: "text.primary" }}>
+                  Issue created
+                </Box>
+              </Box>
+            </DialogTitle>
+            <DialogContent>
+              {createdIssue.issue?.url ? (
+                <Typography variant="body2">
+                  Filed as{" "}
+                  <Link href={createdIssue.issue.url} target="_blank" rel="noopener noreferrer">
+                    {createdIssue.issue.repo && createdIssue.issue.number
+                      ? `${createdIssue.issue.repo}#${createdIssue.issue.number}`
+                      : createdIssue.issue.url}
+                  </Link>
+                  .
+                </Typography>
+              ) : (
+                <Typography variant="body2">
+                  {createdIssue.message ?? "The issue was created."}
+                </Typography>
+              )}
+            </DialogContent>
+            <DialogActions>
+              <Button variant="contained" onClick={resetAndClose}>
+                Done
+              </Button>
+            </DialogActions>
+          </>
+        ) : (
+          <>
+            <DialogTitle>File this GitHub issue?</DialogTitle>
+            <DialogContent>
+              <Typography variant="body2">
+                This files a real issue in{" "}
+                {repoLabel
+                  ? `wso2-enterprise/${repo} (${repoLabel})`
+                  : "a WSO2 product repository, routed automatically by the case's product"}
+                . Make sure no sensitive information is included.
+              </Typography>
+              {/* Errors surface here too, not just on the form step behind
+                  this dialog — otherwise a failed submit leaves the user
+                  looking at this confirm step with no visible reason why it
+                  stopped. */}
+              {error && (
+                <Typography variant="body2" color="error" sx={{ mt: 1.5 }}>
+                  {error}
+                </Typography>
+              )}
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setConfirmPayload(null)} disabled={submitting}>
+                Back
+              </Button>
+              <Button
+                variant="contained"
+                color="warning"
+                disabled={submitting}
+                loading={submitting}
+                onClick={() => {
+                  if (confirmPayload) onSubmit(confirmPayload);
+                }}
+              >
+                File issue
+              </Button>
+            </DialogActions>
+          </>
+        )}
       </Dialog>
     </Dialog>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -319,6 +319,8 @@ export default function CsmCaseCreatePage(): JSX.Element {
                   <FormHelperText>Select a project first</FormHelperText>
                 ) : deployments.isLoading ? (
                   <FormHelperText>Loading deployments…</FormHelperText>
+                ) : (deployments.data ?? []).length === 0 ? (
+                  <FormHelperText>No deployments found for this project.</FormHelperText>
                 ) : null}
               </FormControl>
             </Grid>
@@ -351,6 +353,8 @@ export default function CsmCaseCreatePage(): JSX.Element {
                 </FormHelperText>
               ) : deployedProducts.isLoading ? (
                 <FormHelperText>Loading products…</FormHelperText>
+              ) : (deployedProducts.data ?? []).length === 0 ? (
+                <FormHelperText>No deployed products found for this deployment.</FormHelperText>
               ) : null}
             </FormControl>
           </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -184,14 +184,10 @@ const FEEDBACK_PALETTE: Record<
   error: { bg: "error.50", border: "error.main", fg: "error.main" },
 };
 
+// Only covers secondary actions that are handled inline below with a fixed,
+// literal toast — every action with real branching feedback (success/error,
+// dynamic text) sets its own message directly instead of reading this map.
 const SECONDARY_TOAST: Record<string, string> = {
-  reassign_engineer: "Reassign engineer dialog (mock).",
-  reassign_group: "Reassign group dialog (mock).",
-  hold_auto_close: "Hold auto-closure dialog (mock).",
-  create_incident: "Create incident from case (mock).",
-  link_incident: "Link to incident picker (mock).",
-  create_task: "Create task dialog (mock).",
-  log_time: "Log time dialog (mock).",
   copy_link: "Case link copied to clipboard.",
 };
 
@@ -688,8 +684,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Reachable only for a secondary action with no handler above — every
+      // menu item that isn't wired up yet is disabled in CaseActionBar, so
+      // this is a defensive fallback, not a normal path.
       setFeedback({
-        message: SECONDARY_TOAST[action.secondary] ?? `Action: ${action.secondary}`,
+        message: SECONDARY_TOAST[action.secondary] ?? "This action isn't available yet.",
         severity: "info",
         sticky: false,
       });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -52,7 +52,7 @@ import {
   useFindMyOngoingCases,
   type MyOngoingCase,
 } from "@features/csm-cases/api/useFindMyOngoingCases";
-import type { BeCaseState } from "@api/backend/types";
+import type { BeCaseState, BeCreateCaseGithubIssueResponse } from "@api/backend/types";
 import { beStateFromUi } from "@api/backend/mappers";
 import { BackendApiError } from "@api/backend/client";
 import {
@@ -337,6 +337,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // Inline error shown inside the Git-issue dialog (e.g. the SN routing 422 /
   // state 409). Cleared when the dialog opens or a submit is retried.
   const [githubIssueError, setGithubIssueError] = useState<string | null>(null);
+  // Set on a successful submit so the dialog can show its own "created" view
+  // with a clickable link instead of closing itself immediately.
+  const [githubIssueResult, setGithubIssueResult] =
+    useState<BeCreateCaseGithubIssueResponse | null>(null);
   const postGithubIssue = usePostCaseGithubIssue();
   const postTimeCard = usePostTimeCard();
   // Attachment pending delete confirmation (drives the confirm dialog).
@@ -666,10 +670,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
-      // ISSU-020: file an internal GitHub issue from the case. The SN side
-      // gates on the case state (only certain states may file) and resolves
-      // the target repo from the product; we don't pre-gate here — open the
-      // dialog and surface any backend rejection inline.
+      // ISSU-020: file an internal GitHub issue from the case. Closed cases
+      // are blocked at the menu level (CaseActionBar's raise_git_issue item
+      // is disabled — see caseClosed there); this handler only runs for a
+      // non-closed case. The SN side still resolves the target repo from the
+      // product and may reject other states we don't otherwise pre-gate, so
+      // any backend rejection still surfaces inline in the dialog.
       if (action.secondary === "raise_git_issue") {
         setGithubIssueError(null);
         setGithubIssueOpen(true);
@@ -1390,12 +1396,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
           open={githubIssueOpen}
           submitting={postGithubIssue.isPending}
           error={githubIssueError}
+          createdIssue={githubIssueResult}
           defaultUpdateLevel={c.productContext.updateLevel}
           defaultTitle={c.subject}
           defaultDescription={c.description}
           onClose={() => {
             setGithubIssueOpen(false);
             setGithubIssueError(null);
+            setGithubIssueResult(null);
           }}
           onSubmit={(payload) => {
             setGithubIssueError(null);
@@ -1403,17 +1411,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
               { caseId: c.id, ...payload },
               {
                 onSuccess: (res) => {
-                  setGithubIssueOpen(false);
-                  // The SN side writes the issue URL into work notes; show that
-                  // entry by switching to the activities feed (just refetched).
+                  // Dialog shows its own "created" view with a clickable
+                  // link (see createdIssue) instead of closing immediately —
+                  // still switch to the activities feed in the background so
+                  // the SN-written work-note entry is visible once they're
+                  // done reading the confirmation.
                   setActiveTab("activities");
-                  setFeedback({
-                    message: res.issue?.url
-                      ? `Internal Git issue created: ${res.issue.url}`
-                      : "Internal Git issue created.",
-                    severity: "success",
-                    sticky: true,
-                  });
+                  setGithubIssueResult(res);
                 },
                 onError: (err) => {
                   // Surface the backend's own message on 4xx (invalid state,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -280,6 +280,8 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 <FormHelperText>Select a project first</FormHelperText>
               ) : deployments.isLoading ? (
                 <FormHelperText>Loading deployments…</FormHelperText>
+              ) : (deployments.data ?? []).length === 0 ? (
+                <FormHelperText>No deployments found for this project.</FormHelperText>
               ) : null}
             </FormControl>
           </Grid>
@@ -304,6 +306,8 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 <FormHelperText>Select a deployment first</FormHelperText>
               ) : deployedProducts.isLoading ? (
                 <FormHelperText>Loading products…</FormHelperText>
+              ) : (deployedProducts.data ?? []).length === 0 ? (
+                <FormHelperText>No deployed products found for this deployment.</FormHelperText>
               ) : null}
             </FormControl>
           </Grid>
@@ -354,6 +358,8 @@ export default function CreateServiceRequestPage(): JSX.Element {
               </Select>
               {!catalogId ? (
                 <FormHelperText>Select a catalog first</FormHelperText>
+              ) : catalogItems.length === 0 ? (
+                <FormHelperText>No items found in this catalog.</FormHelperText>
               ) : null}
             </FormControl>
           </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -233,6 +233,8 @@ export default function CreateSecurityReportPage(): JSX.Element {
                 <FormHelperText>Select a project first</FormHelperText>
               ) : deployments.isLoading ? (
                 <FormHelperText>Loading deployments…</FormHelperText>
+              ) : (deployments.data ?? []).length === 0 ? (
+                <FormHelperText>No deployments found for this project.</FormHelperText>
               ) : null}
             </FormControl>
           </Grid>
@@ -257,6 +259,8 @@ export default function CreateSecurityReportPage(): JSX.Element {
                 <FormHelperText>Select a deployment first</FormHelperText>
               ) : deployedProducts.isLoading ? (
                 <FormHelperText>Loading products…</FormHelperText>
+              ) : (deployedProducts.data ?? []).length === 0 ? (
+                <FormHelperText>No deployed products found for this deployment.</FormHelperText>
               ) : null}
             </FormControl>
           </Grid>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

No tracked issue — found during a UX pass over the case-management pages. Three concrete gaps:
1. Several overflow-menu actions in the case detail page's "More" menu (Create incident, Link to incident, Create task) were disabled with no explanation, and "Hold auto-closure" was actually clickable and would toast a message containing the literal text "(mock)" to a real user.
2. Cascading dropdowns (project → deployment → deployed product, and the service request catalog chain) opened to a blank popup with no explanation when the parent had zero children.
3. The "Raise internal Git issue…" dialog fired an irreversible, permanent write to a real external GitHub repo on the very first click, with no confirmation step, and mixed 2 required fields with 7 optional ones at equal visual weight.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Every not-yet-built overflow action shows a consistent tooltip explaining it isn't available yet, regardless of case state.
- Cleaned up the dead `SECONDARY_TOAST` fallback map (including an orphaned, unused `reassign_group` entry) and removed the raw dev-facing fallback string.
- Cascading dropdowns show "No X found for this Y" once loaded with zero results, instead of silently opening empty. Applied consistently across case creation, security report creation, and service request creation (including a previously-unhandled Catalog item dropdown).
- The GitHub issue dialog now has an explicit "File this GitHub issue?" confirm step naming the target repo (or noting it's auto-routed by product), with the optional fields collapsed under a "More options" accordion.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text).

Pure frontend changes in `apps/csm-portal/webapp`, no backend/API changes. See commit messages for the specific diff per change (3 commits, one per UI change). Screenshots not attached — this environment doesn't have an authenticated staging session to drive the SPA end-to-end; recommend a manual visual pass before merge.

## User stories
> Summary of user stories addressed by this change

General UX polish on the case-management create/detail flows; not tied to a specific formal user story.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Case management: unbuilt actions in the case overflow menu now explain themselves instead of appearing broken; empty dropdowns now say so; filing a GitHub issue from a case now requires an explicit confirmation.

## Documentation
N/A — no user-facing documentation impact beyond in-app copy changes described above.

## Automation tests
- Unit tests
  > Extended `CaseActionBar.test.tsx` (4 new cases covering the disabled roadmap items) and added `CreateGithubIssueDialog.test.tsx` (4 new cases covering the required-field gate and the confirm step). Full webapp suite: 182 passing; 2 pre-existing failures in `CaseActionBar.test.tsx` confirmed unrelated to this change (reproduced identically on `main` before these commits).
- Integration tests
  > None added; no backend/API surface changed.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (frontend-only TypeScript/React change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Test environment
`pnpm`-equivalent local tool run (eslint, vitest, tsc -b, vite build) on macOS, Node 20.

## Learning
> Describe the research phase

Traced the "(mock)" toast text back to `CsmCaseDetailPage.tsx`'s secondary-action fallback and confirmed which keys were actually reachable vs. already dead code from prior refactors; the same cascading-dropdown gap was found by grepping for the `Select` + `isLoading` + `FormHelperText` pattern across all case-adjacent create-forms rather than assuming case creation was the only instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-step GitHub issue creation flow with a confirmation step, plus an “issue created” view that includes a link when available.

* **Bug Fixes**
  * Disabled “More” menu actions for planned-but-not-yet-built items and ensured they remain non-interactive with clear “not built yet” messaging.
  * Disabled “Raise internal Git issue” for closed cases (read-only) with tooltip guidance.
  * Improved the messaging shown when a secondary action isn’t supported yet.

* **Documentation**
  * Added/expanded “no options found” helper text across creation flows when dropdown lists are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->