### PR TITLE
Add CI build workflow for customer-portal-microapp

### DIFF
--- a/.github/scripts/detect-version-bump.sh
+++ b/.github/scripts/detect-version-bump.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 1. Resolve bump type.
+# BUMP_TYPE comes from the workflow input (default: patch).
+BUMP_TYPE="${BUMP_TYPE:-patch}"
+
+# Validate required inputs
+[ -n "${APP_NAME:-}" ] || { echo "ERROR: APP_NAME is required" >&2; exit 1; }
+
+# 2. Find the latest existing tag
+APP_PREFIX="${APP_NAME}-v"
+LATEST_TAG=$(git tag -l "${APP_PREFIX}*" | sort -V | tail -n 1)
+
+# 3. Parse current version components
+MAJOR=1; MINOR=0; PATCH=0; BUILD=0
+
+if [ -n "$LATEST_TAG" ]; then
+  # Use the latest git tag (created automatically after each workflow run)
+  VERSION_STR=${LATEST_TAG#"$APP_PREFIX"}
+
+  if [[ "$VERSION_STR" == *"-build."* ]]; then
+    SEMVER=${VERSION_STR%-build.*}
+    BUILD=${VERSION_STR##*-build.}
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$SEMVER"
+  elif [[ "$VERSION_STR" == *"+"* ]]; then
+    SEMVER=${VERSION_STR%+*}
+    BUILD=${VERSION_STR##*+}
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$SEMVER"
+  
+  else
+    echo "ERROR: Unrecognised version format '${VERSION_STR}' from tag '${LATEST_TAG}'" >&2
+    exit 1
+  fi
+
+  MAJOR=${MAJOR:-1}
+  MINOR=${MINOR:-0}
+  PATCH=${PATCH:-0}
+  BUILD=${BUILD:-0}
+
+elif [ -n "${INITIAL_VERSION:-}" ]; then
+  # No git tag yet — use the version from the caller (last known DB version)
+  # Format: 2.4.0-build.5
+  SEMVER=${INITIAL_VERSION%-build.*}
+  BUILD=${INITIAL_VERSION##*-build.}
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$SEMVER"
+  MAJOR=${MAJOR:-1}
+  MINOR=${MINOR:-0}
+  PATCH=${PATCH:-0}
+  BUILD=${BUILD:-0}
+fi
+
+# 4. Increment based on bump type
+case "$BUMP_TYPE" in
+  major)
+    MAJOR=$((MAJOR + 1))
+    MINOR=0; PATCH=0; BUILD=$((BUILD + 1))
+    ;;
+  minor)
+    MINOR=$((MINOR + 1))
+    PATCH=0; BUILD=$((BUILD + 1))
+    ;;
+  patch )
+    PATCH=$((PATCH + 1))
+    BUILD=$((BUILD + 1))
+    ;;
+     *)
+    echo "ERROR: Unknown BUMP_TYPE '${BUMP_TYPE}'. Expected: major | minor | patch" >&2 #
+    exit 1
+    ;;
+esac
+
+# 5. Emit outputs
+VERSION="${MAJOR}.${MINOR}.${PATCH}"
+echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+echo "build=${BUILD}" >> "$GITHUB_OUTPUT"
+echo "Bump type: ${BUMP_TYPE} → version: ${VERSION}, build: ${BUILD}"

--- a/.github/workflows/customer-portal-microapp.yml
+++ b/.github/workflows/customer-portal-microapp.yml
@@ -1,0 +1,43 @@
+name: Build customer-portal-microapp
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type (patch / minor / major). Defaults to patch."
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      version:
+        description: "Optional: current version hint from Release Dashboard (e.g. 1.0.3). Used as baseline only if no git tag exists."
+        required: false
+        type: string
+        default: ""
+      build:
+        description: "Optional: current build hint from Release Dashboard (e.g. 16). Used as baseline only if no git tag exists."
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/reusable-frontend-build.yml
+    with:
+      app_name: customer-portal-microapp
+      app_path: apps/customer-portal/microapp
+      initial_version: "1.0.3-build.16"
+      bump_type: ${{ inputs.bump_type }}
+      node_version: "20"
+      build_command: npm run build
+      output_dir: dist # Vite-built frontend
+      override_version: ${{ inputs.version }}
+      override_build: ${{ inputs.build }}
+      service_url_env_name: CUSTOMER_PORTAL_BACKEND_URL
+    secrets:
+      REACT_APP_API_BASE: ${{ secrets.REACT_APP_API_BASE }}

--- a/.github/workflows/reusable-frontend-build.yml
+++ b/.github/workflows/reusable-frontend-build.yml
@@ -1,0 +1,195 @@
+name: Reusable Frontend Build Release
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        required: true
+        type: string
+      app_path:
+        required: true
+        type: string
+      initial_version:
+        required: false
+        type: string
+        default: ""
+        description: "Last known version from the DB (e.g. 2.4.0-build.5). Used as baseline only when no git tag exists yet."
+      bump_type:
+        required: false
+        type: string
+        default: patch
+        description: "Version bump type (patch, minor, major). Defaults to patch for workflow_dispatch."
+      node_version:
+        required: false
+        type: string
+        default: "20"
+      build_command:
+        required: false
+        type: string
+        default: npm run build
+      output_dir:
+        required: false
+        type: string
+        default: build
+      # ── Dispatch hints: used as INITIAL_VERSION baseline when no git tag exists ──
+      # These are NEVER used verbatim as the output version — detect-version-bump.sh
+      # always auto-increments to guarantee a unique new tag on every run.
+      override_version:
+        required: false
+        type: string
+        default: ""
+        description: "Version hint from Release Dashboard (e.g. 2.0.3). Used as initial_version baseline only if no git tag exists."
+      override_build:
+        required: false
+        type: string
+        default: ""
+        description: "Build hint from Release Dashboard (e.g. 19). Used as initial_version baseline only if no git tag exists."
+      service_url_env_name:
+        required: false
+        type: string
+        default: REACT_APP_API_BASE
+        description: "Name of the process.env variable the frontend's own code reads for its backend base URL (e.g. REACT_APP_ACCESS_BE_URL, REACT_APP_MENU_BE_URL). Each app should use its own distinct name to avoid sharing a single generic secret/value across apps. Defaults to REACT_APP_API_BASE for backward compatibility."
+      extra_plain_env_json:
+        required: false
+        type: string
+        default: "{}"
+        description: "JSON object of additional build-time env var name/value pairs that are NOT sensitive and don't vary by environment (e.g. REACT_APP_DOD_IS_MICROAPP, REACT_APP_DOD_APP_NAME). Safe to hardcode directly in the calling workflow. Keys are the literal process.env names the frontend code expects."
+    secrets:
+      REACT_APP_API_BASE:
+        required: false
+      EXTRA_SECRET_ENV_JSON:
+        required: false
+        description: "JSON object of additional build-time env var name/value pairs that ARE sensitive or app/environment-specific (e.g. Asgardeo client ID, OAuth redirect URLs). Keys are the literal process.env names the frontend code expects."
+
+jobs:
+  detect_version_bump:
+    name: Detect Version Bump
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      build: ${{ steps.resolve.outputs.build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve Version (always auto-increment for a new unique tag)
+        id: resolve
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          APP_NAME: ${{ inputs.app_name }}
+          INITIAL_VERSION: ${{ inputs.initial_version }}
+          OVERRIDE_VERSION: ${{ inputs.override_version }}
+          OVERRIDE_BUILD: ${{ inputs.override_build }}
+        run: |
+          # If the Release Dashboard provides version/build hints, treat them as the
+          # initial_version baseline so the script knows where to start when no git
+          # tag exists yet.  The script ALWAYS increments → always produces a new tag.
+          if [ -n "$OVERRIDE_VERSION" ] && [ -n "$OVERRIDE_BUILD" ]; then
+            export INITIAL_VERSION="${OVERRIDE_VERSION}-build.${OVERRIDE_BUILD}"
+          fi
+          bash .github/scripts/detect-version-bump.sh
+
+  staging_build:
+    name: Staging Build
+    needs: detect_version_bump
+    # Always build staging — both staging and production are required on every run.
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.app_path }}/package-lock.json
+
+      - name: Expose build-time env vars
+        env:
+          SERVICE_URL_NAME: ${{ inputs.service_url_env_name }}
+          SERVICE_URL_VALUE: ${{ secrets.REACT_APP_API_BASE }}
+          EXTRA_SECRET_JSON: ${{ secrets.EXTRA_SECRET_ENV_JSON }}
+          EXTRA_PLAIN_JSON: ${{ inputs.extra_plain_env_json }}
+        run: |
+          echo "${SERVICE_URL_NAME}=${SERVICE_URL_VALUE}" >> "$GITHUB_ENV"
+          echo "${EXTRA_SECRET_JSON:-{\}}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
+          echo "${EXTRA_PLAIN_JSON:-{\}}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
+
+      - name: Build frontend
+        working-directory: ${{ inputs.app_path }}
+        env:
+          CI: false
+        run: |
+          npm ci
+          ${{ inputs.build_command }}
+          BUILD_FILE="${{ inputs.app_name }}-staging-v${{ needs.detect_version_bump.outputs.version }}-build.${{ needs.detect_version_bump.outputs.build }}"
+          mv "${{ inputs.output_dir }}" "$BUILD_FILE"
+          zip -r "$BUILD_FILE.zip" "$BUILD_FILE"
+
+      - name: Upload Staging Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.app_name }}-staging-build
+          path: ${{ inputs.app_path }}/${{ inputs.app_name }}-staging-v${{ needs.detect_version_bump.outputs.version }}-build.${{ needs.detect_version_bump.outputs.build }}.zip
+
+  production_build:
+    name: Production Build
+    needs: [detect_version_bump, staging_build]
+    # Always build production — runs after staging completes successfully.
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.app_path }}/package-lock.json
+
+      - name: Expose build-time env vars
+        env:
+          SERVICE_URL_NAME: ${{ inputs.service_url_env_name }}
+          SERVICE_URL_VALUE: ${{ secrets.REACT_APP_API_BASE }}
+          EXTRA_SECRET_JSON: ${{ secrets.EXTRA_SECRET_ENV_JSON }}
+          EXTRA_PLAIN_JSON: ${{ inputs.extra_plain_env_json }}
+        run: |
+          echo "${SERVICE_URL_NAME}=${SERVICE_URL_VALUE}" >> "$GITHUB_ENV"
+          echo "${EXTRA_SECRET_JSON:-{\}}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
+          echo "${EXTRA_PLAIN_JSON:-{\}}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
+
+      - name: Build frontend
+        working-directory: ${{ inputs.app_path }}
+        env:
+          CI: false
+        run: |
+          npm ci
+          ${{ inputs.build_command }}
+          BUILD_FILE="${{ inputs.app_name }}-production-v${{ needs.detect_version_bump.outputs.version }}-build.${{ needs.detect_version_bump.outputs.build }}"
+          mv "${{ inputs.output_dir }}" "$BUILD_FILE"
+          zip -r "$BUILD_FILE.zip" "$BUILD_FILE"
+
+      - name: Download Staging Artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: ${{ inputs.app_name }}-staging-build
+          path: ${{ inputs.app_path }}
+
+      - name: Create GitHub Release (staging + production)
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          tag_name: ${{ inputs.app_name }}-v${{ needs.detect_version_bump.outputs.version }}-build.${{ needs.detect_version_bump.outputs.build }}
+          name: ${{ inputs.app_name }} v${{ needs.detect_version_bump.outputs.version }}-build.${{ needs.detect_version_bump.outputs.build }}
+          files: |
+            ${{ inputs.app_path }}/${{ inputs.app_name }}-staging-v${{ needs.detect_version_bump.outputs.version }}-build.${{ needs.detect_version_bump.outputs.build }}.zip
+            ${{ inputs.app_path }}/${{ inputs.app_name }}-production-v${{ needs.detect_version_bump.outputs.version }}-build.${{ needs.detect_version_bump.outputs.build }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/customer-portal/microapp/.env.example
+++ b/apps/customer-portal/microapp/.env.example
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=https://example.com/api
+CUSTOMER_PORTAL_BACKEND_URL=https://example.com/api

--- a/apps/customer-portal/microapp/src/config/endpoints.ts
+++ b/apps/customer-portal/microapp/src/config/endpoints.ts
@@ -14,10 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+export const BACKEND_URL = import.meta.env.CUSTOMER_PORTAL_BACKEND_URL;
 
 if (!BACKEND_URL) {
-  throw new Error("VITE_BACKEND_URL is not defined");
+  throw new Error("CUSTOMER_PORTAL_BACKEND_URL is not defined");
 }
 
 export const PROJECTS_ENDPOINT = "/projects/search";
@@ -53,7 +53,7 @@ export const USER_ACTIONS_ENDPOINT = (id: string, email: string) => `/projects/$
 export const METADATA_ENDPOINT = "/metadata";
 export const ATTACHMENT_DETAIL_ENDPOINT = (id: string) => `/attachments/${id}`;
 export const NOVERA_WEBSOCKET_INITIALIZATION_ENDPOINT = (sessionId: string) =>
-  import.meta.env.VITE_BACKEND_URL.replace("https://", "wss://").replace(
+  import.meta.env.CUSTOMER_PORTAL_BACKEND_URL.replace("https://", "wss://").replace(
     "/v1.0",
     `/websocket/v1.0/ws?sessionId=${sessionId}`,
   );

--- a/apps/customer-portal/microapp/src/vite-env.d.ts
+++ b/apps/customer-portal/microapp/src/vite-env.d.ts
@@ -19,7 +19,7 @@
 type ViteTypeOptions = object;
 
 interface ImportMetaEnv {
-  readonly VITE_BACKEND_URL: string;
+  readonly CUSTOMER_PORTAL_BACKEND_URL: string;
 }
 
 interface ImportMeta {

--- a/apps/customer-portal/microapp/vite.config.ts
+++ b/apps/customer-portal/microapp/vite.config.ts
@@ -23,6 +23,10 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
   base: "./",
   plugins: [react(), tsconfigPaths()],
+  // Scoped like csm-portal's CSM_PORTAL_ prefix — avoids this app picking up
+  // (or leaking) another app's plain VITE_* env var if they're ever built
+  // from a shared CI config/secret set.
+  envPrefix: ["CUSTOMER_PORTAL_"],
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## Summary
- This repo had no reusable frontend-build workflow. Brought in `reusable-frontend-build.yml` and `detect-version-bump.sh` (already established in `wso2-enterprise/digiops-hr` and `wso2-enterprise/digiops-superapp`), plus a `customer-portal-microapp.yml` workflow wired for this app's Vite build (`output_dir: dist`).
- Renamed the generic `VITE_BACKEND_URL` to `CUSTOMER_PORTAL_BACKEND_URL` and added `envPrefix: ["CUSTOMER_PORTAL_"]` to `vite.config.ts`, matching `csm-portal/webapp`'s own `CSM_PORTAL_` convention already present in this repo — scopes which env vars Vite exposes to this app, so it can't accidentally pick up (or leak) another app's plain `VITE_*` variable if CI config/secrets are ever shared across apps.

## Required follow-up
Whoever manages this repo's GitHub secrets needs to configure `REACT_APP_API_BASE` with this app's real backend URL (the reusable workflow's secret channel name is unchanged from the other repos using it — only the app-facing env var name differs).

## Test plan
- [x] `actionlint` clean on both workflow files (0 issues)
- [x] Verified the renamed env var bakes into the built bundle correctly (`npx vite build` + bundle grep)
- [ ] Full `tsc -b && vite build` currently fails on two **pre-existing, unrelated** missing dependencies (`framer-motion`, `@mui/system` — not declared in `package.json` despite being imported in `OverlineSlot.tsx`/`NotificationBadge.tsx`, introduced in earlier commits). Not touched by this PR; confirmed by temporarily installing them locally, at which point the full build succeeds cleanly and the renamed env var is present. Flagging separately since it'll block the new CI workflow until fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)