### PR TITLE
[CSM][BE] Support multiple accepted audiences in JWT auth config

### DIFF
--- a/apps/csm-portal/backend/.env.example
+++ b/apps/csm-portal/backend/.env.example
@@ -22,7 +22,7 @@ SCIM_SCOPES=
 # Auth — set to false for local testing (skips JWT signature verification)
 AUTH_JWKS_ENDPOINT=
 AUTH_ISSUER=
-AUTH_AUDIENCE=
+AUTH_AUDIENCE=                    # comma-separated; token is accepted if any listed audience is present
 AUTH_TOKEN_VALIDATOR_ENABLED=true
 
 # Server

--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -86,6 +86,7 @@ Follow these steps in order:
 - **Never commit secrets** — API keys, tokens, passwords, and service URLs with credentials must not appear in source code or config files; use environment variables
 - **No sensitive data in logs** — do not log request bodies, JWT payloads, or user PII; log only IDs and error summaries
 - **JWT is the only auth mechanism** — all endpoints must validate the caller via `middleware.UserInfoFromContext`; there are no public endpoints
+- **Audience** — `Config.Audiences` is `[]string`; a token is accepted if its `aud` claim contains **any** of the configured values (OR logic). Set via `AUTH_AUDIENCE` as a comma-separated string
 - **Input validation** — validate and reject unexpected input at the boundary (path params, body size, JSON structure) before forwarding to upstream services
 - **Error messages** — never leak upstream error details or stack traces to the caller; use the fixed `ErrMsg*` constants or a short fallback message
 - **Security fixes in PRs** — when a change is made to fix a security issue (gosec findings, input sanitization, etc.), do not mention it in the PR title or description; describe the change in neutral functional terms only

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -130,6 +130,15 @@ Copy `.env` and fill in the values:
 | `SCIM_CLIENT_SECRET` | OAuth2 client secret |
 | `SCIM_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 
+### Auth
+
+| Variable | Description |
+|---|---|
+| `AUTH_JWKS_ENDPOINT` | JWKS endpoint used to verify JWT signatures |
+| `AUTH_ISSUER` | Expected `iss` claim value |
+| `AUTH_AUDIENCE` | Comma-separated accepted `aud` values; token passes if any listed value is present in its `aud` claim |
+| `AUTH_TOKEN_VALIDATOR_ENABLED` | Set to `false` for local development to skip signature verification (default `true`) |
+
 ### Server
 
 | Variable | Description |

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -88,7 +88,7 @@ func main() {
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
 		Issuer:                mustEnv("AUTH_ISSUER"),
-		Audience:              mustEnv("AUTH_AUDIENCE"),
+		Audiences:             splitComma(mustEnv("AUTH_AUDIENCE")),
 		ClockSkew:             5 * time.Second,
 		TokenValidatorEnabled: os.Getenv("AUTH_TOKEN_VALIDATOR_ENABLED") != "false",
 	}

--- a/apps/csm-portal/backend/internal/middleware/auth.go
+++ b/apps/csm-portal/backend/internal/middleware/auth.go
@@ -57,7 +57,7 @@ type UserInfo struct {
 type Config struct {
 	JWKSEndpoint          string
 	Issuer                string
-	Audience              string
+	Audiences             []string
 	ClockSkew             time.Duration
 	TokenValidatorEnabled bool
 }
@@ -145,7 +145,6 @@ func extractUserInfo(tokenStr string, cfg Config, keyFunc jwt.Keyfunc) (*UserInf
 	} else {
 		token, err := jwt.ParseWithClaims(tokenStr, &c, keyFunc,
 			jwt.WithIssuer(cfg.Issuer),
-			jwt.WithAudience(cfg.Audience),
 			jwt.WithLeeway(cfg.ClockSkew),
 			jwt.WithExpirationRequired(),
 		)
@@ -154,6 +153,12 @@ func extractUserInfo(tokenStr string, cfg Config, keyFunc jwt.Keyfunc) (*UserInf
 		}
 		if !token.Valid {
 			return nil, fmt.Errorf("invalid token")
+		}
+		if len(cfg.Audiences) > 0 {
+			tokenAuds, _ := token.Claims.GetAudience()
+			if !hasAnyAudience(tokenAuds, cfg.Audiences) {
+				return nil, fmt.Errorf("token audience not accepted")
+			}
 		}
 	}
 
@@ -169,6 +174,17 @@ func extractUserInfo(tokenStr string, cfg Config, keyFunc jwt.Keyfunc) (*UserInf
 		UserID: c.UserID,
 		Groups: c.Groups,
 	}, nil
+}
+
+func hasAnyAudience(tokenAuds jwt.ClaimStrings, expected []string) bool {
+	for _, want := range expected {
+		for _, got := range tokenAuds {
+			if got == want {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // addSecurityHeaders mirrors the Ballerina ResponseInterceptor security headers.

--- a/apps/csm-portal/backend/internal/middleware/auth_audience_test.go
+++ b/apps/csm-portal/backend/internal/middleware/auth_audience_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package middleware (internal test) so hasAnyAudience is accessible.
+package middleware
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestHasAnyAudience(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenAuds jwt.ClaimStrings
+		expected  []string
+		want      bool
+	}{
+		{
+			name:      "exact match — single configured audience",
+			tokenAuds: jwt.ClaimStrings{"api.example.com"},
+			expected:  []string{"api.example.com"},
+			want:      true,
+		},
+		{
+			name:      "first of multiple configured audiences matches",
+			tokenAuds: jwt.ClaimStrings{"api.example.com"},
+			expected:  []string{"api.example.com", "other.example.com"},
+			want:      true,
+		},
+		{
+			name:      "second of multiple configured audiences matches",
+			tokenAuds: jwt.ClaimStrings{"other.example.com"},
+			expected:  []string{"api.example.com", "other.example.com"},
+			want:      true,
+		},
+		{
+			name:      "token carries multiple audiences, one matches",
+			tokenAuds: jwt.ClaimStrings{"unrelated.example.com", "api.example.com"},
+			expected:  []string{"api.example.com"},
+			want:      true,
+		},
+		{
+			name:      "no overlap between token and configured audiences",
+			tokenAuds: jwt.ClaimStrings{"other.example.com"},
+			expected:  []string{"api.example.com"},
+			want:      false,
+		},
+		{
+			name:      "empty token audiences",
+			tokenAuds: jwt.ClaimStrings{},
+			expected:  []string{"api.example.com"},
+			want:      false,
+		},
+		{
+			name:      "empty configured audiences",
+			tokenAuds: jwt.ClaimStrings{"api.example.com"},
+			expected:  []string{},
+			want:      false,
+		},
+		{
+			name:      "both empty",
+			tokenAuds: jwt.ClaimStrings{},
+			expected:  []string{},
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasAnyAudience(tc.tokenAuds, tc.expected); got != tc.want {
+				t.Errorf("hasAnyAudience(%v, %v) = %v, want %v",
+					tc.tokenAuds, tc.expected, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/csm-portal/backend/internal/middleware/auth_test.go
+++ b/apps/csm-portal/backend/internal/middleware/auth_test.go
@@ -36,7 +36,7 @@ func testConfig() middleware.Config {
 	return middleware.Config{
 		JWKSEndpoint:          "http://unused.example.com",
 		Issuer:                "test-issuer",
-		Audience:              "test-audience",
+		Audiences:             []string{"test-audience"},
 		TokenValidatorEnabled: false,
 	}
 }

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -230,7 +230,6 @@ export default function ChangeRequestsTab(): JSX.Element {
           showLastButton
         />
       </Box>
-
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- `Config.Audience string` → `Config.Audiences []string` in the auth middleware
- A JWT is accepted if its `aud` claim contains **any** of the configured audience values (OR logic), matching standard OAuth2 behaviour where a token is valid for a resource server if that server's identifier appears anywhere in `aud`
- `AUTH_AUDIENCE` env var now accepts a comma-separated list (e.g. `aud1,aud2`); single-value configs continue to work unchanged

## Test plan

- [x] Existing auth middleware tests pass (updated `testConfig()` to use `Audiences: []string{...}`)
- [x] `go vet ./...` reports no errors
- [x] Deploy with a single `AUTH_AUDIENCE` value — verify tokens still accepted
- [x] Deploy with multiple comma-separated values — verify a token whose `aud` matches any one value is accepted; verify a token with no matching audience is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authentication now supports multiple accepted token audiences, improving flexibility for sign-in and API access.

- **Bug Fixes**
  - Fixed an issue in the operations tab pagination display so the footer renders cleanly without stray characters.

- **Documentation**
  - Updated backend setup and security docs with clearer authentication configuration guidance and audience handling details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->