### PR TITLE
[Customer Entity] Return 400 for ServiceNow 409 Conflict responses

### DIFF
--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -327,6 +327,8 @@ func (c *Client) do(req *http.Request, path string) (json.RawMessage, error) {
 		return nil, &apierror.ForbiddenError{Msg: extractDownstreamMessage(raw, "not authorized to access this resource")}
 	case resp.StatusCode == http.StatusNotFound:
 		return nil, &apierror.NotFoundError{Msg: extractDownstreamMessage(raw, "resource not found in downstream service")}
+	case resp.StatusCode == http.StatusConflict:
+		return nil, &apierror.ValidationError{Msg: extractDownstreamMessage(raw, "request conflicts with current state of the resource")}
 	case resp.StatusCode == http.StatusServiceUnavailable:
 		return nil, &apierror.ServiceUnavailableError{Msg: "downstream service unavailable"}
 	default:


### PR DESCRIPTION
## Summary
- ServiceNow returns 409 when a state transition is invalid (e.g. updating
  severity on a closed case). The SN client had no handler for this status,
  causing it to fall through to a generic error and return 500 to the caller.
- Added a `http.StatusConflict` case in the `do` method that maps 409 to a
  `ValidationError`, returning 400 with the human-readable SN error message.

## Test plan
- [ ] PATCH /cases/{id} with severity on a closed case returns 400 with the
  SN error message ("Cannot update severity of a closed case")
- [ ] Other 409-triggering operations surface the correct SN message
- [ ] Existing 2xx, 400, 401, 403, 404, 503 paths are unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ServiceNow conflict responses now return a clearer validation-style error instead of an unexpected server error.
  * Users will see a more helpful message when a request conflicts with the current state of a resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->