### PR TITLE
[Customer Entity] Propagate ServiceNow 409 Conflict responses as HTTP 409

### DIFF
--- a/entity-service/internal/apierror/errors.go
+++ b/entity-service/internal/apierror/errors.go
@@ -76,6 +76,15 @@ type ForbiddenError struct {
 // Error implements the error interface.
 func (e *ForbiddenError) Error() string { return e.Msg }
 
+// ConflictError signals that the request conflicts with the current state of
+// the resource and should be reported as HTTP 409.
+type ConflictError struct {
+	Msg string
+}
+
+// Error implements the error interface.
+func (e *ConflictError) Error() string { return e.Msg }
+
 // WriteJSON writes an ErrorResponse JSON body with the given HTTP status code.
 func WriteJSON(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")

--- a/entity-service/internal/handler/decode.go
+++ b/entity-service/internal/handler/decode.go
@@ -94,6 +94,7 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 		sue *apierror.ServiceUnavailableError
 		ue  *apierror.UnauthorizedError
 		fe  *apierror.ForbiddenError
+		ce  *apierror.ConflictError
 	)
 	switch {
 	case errors.As(err, &ve):
@@ -115,6 +116,11 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 		// 404 – resource not found; message is safe to return.
 		log.Printf("Not found: %s %s: %s", r.Method, sanitizeLog(r.URL.Path), sanitizeLog(nfe.Msg)) // #nosec G706 -- path and message sanitized
 		apierror.WriteJSON(w, http.StatusNotFound, nfe.Msg)
+
+	case errors.As(err, &ce):
+		// 409 – request conflicts with the current state of the resource; message is safe to return.
+		log.Printf("Conflict: %s %s: %s", r.Method, sanitizeLog(r.URL.Path), sanitizeLog(ce.Msg)) // #nosec G706 -- path and message sanitized
+		apierror.WriteJSON(w, http.StatusConflict, ce.Msg)
 
 	case errors.As(err, &sue):
 		// 503 – downstream dependency unavailable; log details, return generic message.

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -328,7 +328,7 @@ func (c *Client) do(req *http.Request, path string) (json.RawMessage, error) {
 	case resp.StatusCode == http.StatusNotFound:
 		return nil, &apierror.NotFoundError{Msg: extractDownstreamMessage(raw, "resource not found in downstream service")}
 	case resp.StatusCode == http.StatusConflict:
-		return nil, &apierror.ValidationError{Msg: extractDownstreamMessage(raw, "request conflicts with current state of the resource")}
+		return nil, &apierror.ConflictError{Msg: extractDownstreamMessage(raw, "request conflicts with current state of the resource")}
 	case resp.StatusCode == http.StatusServiceUnavailable:
 		return nil, &apierror.ServiceUnavailableError{Msg: "downstream service unavailable"}
 	default:


### PR DESCRIPTION
## Summary
- ServiceNow returns 409 when a request conflicts with the current resource state (e.g. updating severity on a closed case). The SN client had no handler for this status, causing it to fall through to a generic error and return 500 to the caller.
- Added `ConflictError` to the apierror package mapped to HTTP 409.
- Added a `http.StatusConflict` case in the SN client `do` method that returns a `ConflictError` with the human-readable SN error message.
- Added a `ConflictError` case in `writeServiceError` to write the 409 response with the SN message.

## Test plan
- [ ] PATCH /cases/{id} with severity on a closed case returns 409 with
  the SN error message ("Cannot update severity of a closed case")
- [ ] Other 409-triggering SN operations surface the correct SN message
- [ ] Existing 2xx, 400, 401, 403, 404, 503 paths are unaffected
