### PR TITLE
[CSM Portal] closed cases are terminal; add Create related case as the reopen replacement

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -167,7 +167,7 @@ backend/
 │   │   └── security_headers.go # X-Content-Type-Options, CSP, HSTS on every response
 │   └── handler/
 │       ├── cases.go            # HTTP handlers for case endpoints
-│       ├── state.go            # Case state machine (nextStates, isValidStateTransition)
+│       ├── state.go            # Case state machine (nextStates, isValidStateTransition, canCreateRelatedCase)
 │       ├── catalogs.go                   # HTTP handlers for catalog endpoints (ServiceNow only)
 │       ├── change_requests.go            # HTTP handlers for change-request endpoints
 │       ├── product_vulnerabilities.go    # HTTP handlers for product vulnerability endpoints (ServiceNow only)

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -623,9 +623,9 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err = injectNextStates(result)
+	result, err = injectCaseComputedFields(result)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to inject nextStates", "userID", user.UserID, "caseID", caseID, "err", err)
+		slog.ErrorContext(r.Context(), "failed to inject case computed fields", "userID", user.UserID, "caseID", caseID, "err", err)
 		writeError(w, http.StatusInternalServerError, "Failed to process case details.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -623,9 +623,9 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err = injectCaseComputedFields(result)
+	result, err = injectNextStates(result)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to inject case computed fields", "userID", user.UserID, "caseID", caseID, "err", err)
+		slog.ErrorContext(r.Context(), "failed to inject nextStates", "userID", user.UserID, "caseID", caseID, "err", err)
 		writeError(w, http.StatusInternalServerError, "Failed to process case details.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
 )
@@ -1076,6 +1077,46 @@ func TestGetCase(t *testing.T) {
 					if got != tc.wantNext[i] {
 						t.Errorf("nextStates[%d] = %v, want %v", i, got, tc.wantNext[i])
 					}
+				}
+			})
+		}
+	})
+
+	t.Run("canCreateRelatedCase reflects state and closedOn window", func(t *testing.T) {
+		type getCaseRelatedResp struct {
+			CanCreateRelatedCase bool `json:"canCreateRelatedCase"`
+		}
+		recentClosed := time.Now().Add(-10 * 24 * time.Hour).Format(time.RFC3339)
+		oldClosed := time.Now().Add(-90 * 24 * time.Hour).Format(time.RFC3339)
+		cases := []struct {
+			name     string
+			body     string
+			wantTrue bool
+		}{
+			{"closed case within the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + recentClosed + `"}`, true},
+			{"closed case outside the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + oldClosed + `"}`, false},
+			{"closed case with no closedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed"}`, false},
+			{"open case with a closedOn value", `{"id":"` + testCaseID + `","type":"case","state":"open","closedOn":"` + recentClosed + `"}`, false},
+			{"closed service_request within the window", `{"id":"` + testCaseID + `","type":"service_request","state":"closed","closedOn":"` + recentClosed + `"}`, false},
+			{"closed case with no type set", `{"id":"` + testCaseID + `","state":"closed","closedOn":"` + recentClosed + `"}`, false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(tc.body), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/cases/"+testCaseID, nil))
+				r.SetPathValue("id", testCaseID)
+				w := httptest.NewRecorder()
+				h.GetCase(w, r)
+				assertStatus(t, w, http.StatusOK)
+				resp := decodeJSON[getCaseRelatedResp](t, w)
+				if resp.CanCreateRelatedCase != tc.wantTrue {
+					t.Errorf("canCreateRelatedCase = %v, want %v", resp.CanCreateRelatedCase, tc.wantTrue)
 				}
 			})
 		}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1088,6 +1088,7 @@ func TestGetCase(t *testing.T) {
 		}
 		recentClosed := time.Now().Add(-10 * 24 * time.Hour).Format(time.RFC3339)
 		oldClosed := time.Now().Add(-90 * 24 * time.Hour).Format(time.RFC3339)
+		recentClosedNoZone := time.Now().Add(-10 * 24 * time.Hour).UTC().Format("2006-01-02 15:04:05")
 		cases := []struct {
 			name     string
 			body     string
@@ -1095,6 +1096,7 @@ func TestGetCase(t *testing.T) {
 		}{
 			{"closed case within the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + recentClosed + `"}`, []string{caseStateReopened}},
 			{"closed case outside the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + oldClosed + `"}`, []string{}},
+			{"closed case with a zoneless space-separated closedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + recentClosedNoZone + `"}`, []string{caseStateReopened}},
 			{"closed case with no closedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed"}`, []string{}},
 			{"open case with a closedOn value", `{"id":"` + testCaseID + `","type":"case","state":"open","closedOn":"` + recentClosed + `"}`, []string{caseStateWorkInProgress}},
 			{"closed service_request within the window", `{"id":"` + testCaseID + `","type":"service_request","state":"closed","closedOn":"` + recentClosed + `"}`, []string{}},

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1097,10 +1097,15 @@ func TestGetCase(t *testing.T) {
 			{"closed case within the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + recentClosed + `"}`, []string{caseStateReopened}},
 			{"closed case outside the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + oldClosed + `"}`, []string{}},
 			{"closed case with a zoneless space-separated closedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + recentClosedNoZone + `"}`, []string{caseStateReopened}},
-			{"closed case with no closedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed"}`, []string{}},
+			{"closed case with no closedOn or updatedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed"}`, []string{}},
 			{"open case with a closedOn value", `{"id":"` + testCaseID + `","type":"case","state":"open","closedOn":"` + recentClosed + `"}`, []string{caseStateWorkInProgress}},
 			{"closed service_request within the window", `{"id":"` + testCaseID + `","type":"service_request","state":"closed","closedOn":"` + recentClosed + `"}`, []string{}},
 			{"closed case with no type set", `{"id":"` + testCaseID + `","state":"closed","closedOn":"` + recentClosed + `"}`, []string{}},
+			// ServiceNow-backed cases never populate closedOn today, so
+			// updatedOn stands in for it.
+			{"closed case with no closedOn, falls back to a recent updatedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed","updatedOn":"` + recentClosed + `"}`, []string{caseStateReopened}},
+			{"closed case with no closedOn, falls back to an old updatedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed","updatedOn":"` + oldClosed + `"}`, []string{}},
+			{"closed case prefers closedOn over updatedOn when both present", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + oldClosed + `","updatedOn":"` + recentClosed + `"}`, []string{}},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1082,23 +1082,23 @@ func TestGetCase(t *testing.T) {
 		}
 	})
 
-	t.Run("canCreateRelatedCase reflects state and closedOn window", func(t *testing.T) {
-		type getCaseRelatedResp struct {
-			CanCreateRelatedCase bool `json:"canCreateRelatedCase"`
+	t.Run("nextStates surfaces reopened as the create-related-case signal", func(t *testing.T) {
+		type getCaseNextStatesResp struct {
+			NextStates []string `json:"nextStates"`
 		}
 		recentClosed := time.Now().Add(-10 * 24 * time.Hour).Format(time.RFC3339)
 		oldClosed := time.Now().Add(-90 * 24 * time.Hour).Format(time.RFC3339)
 		cases := []struct {
 			name     string
 			body     string
-			wantTrue bool
+			wantNext []string
 		}{
-			{"closed case within the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + recentClosed + `"}`, true},
-			{"closed case outside the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + oldClosed + `"}`, false},
-			{"closed case with no closedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed"}`, false},
-			{"open case with a closedOn value", `{"id":"` + testCaseID + `","type":"case","state":"open","closedOn":"` + recentClosed + `"}`, false},
-			{"closed service_request within the window", `{"id":"` + testCaseID + `","type":"service_request","state":"closed","closedOn":"` + recentClosed + `"}`, false},
-			{"closed case with no type set", `{"id":"` + testCaseID + `","state":"closed","closedOn":"` + recentClosed + `"}`, false},
+			{"closed case within the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + recentClosed + `"}`, []string{caseStateReopened}},
+			{"closed case outside the 60-day window", `{"id":"` + testCaseID + `","type":"case","state":"closed","closedOn":"` + oldClosed + `"}`, []string{}},
+			{"closed case with no closedOn", `{"id":"` + testCaseID + `","type":"case","state":"closed"}`, []string{}},
+			{"open case with a closedOn value", `{"id":"` + testCaseID + `","type":"case","state":"open","closedOn":"` + recentClosed + `"}`, []string{caseStateWorkInProgress}},
+			{"closed service_request within the window", `{"id":"` + testCaseID + `","type":"service_request","state":"closed","closedOn":"` + recentClosed + `"}`, []string{}},
+			{"closed case with no type set", `{"id":"` + testCaseID + `","state":"closed","closedOn":"` + recentClosed + `"}`, []string{}},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -1114,9 +1114,14 @@ func TestGetCase(t *testing.T) {
 				w := httptest.NewRecorder()
 				h.GetCase(w, r)
 				assertStatus(t, w, http.StatusOK)
-				resp := decodeJSON[getCaseRelatedResp](t, w)
-				if resp.CanCreateRelatedCase != tc.wantTrue {
-					t.Errorf("canCreateRelatedCase = %v, want %v", resp.CanCreateRelatedCase, tc.wantTrue)
+				resp := decodeJSON[getCaseNextStatesResp](t, w)
+				if len(resp.NextStates) != len(tc.wantNext) {
+					t.Fatalf("nextStates = %v, want %v", resp.NextStates, tc.wantNext)
+				}
+				for i, got := range resp.NextStates {
+					if got != tc.wantNext[i] {
+						t.Errorf("nextStates[%d] = %v, want %v", i, got, tc.wantNext[i])
+					}
 				}
 			})
 		}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1051,7 +1051,7 @@ func TestGetCase(t *testing.T) {
 			{caseStateWaitingOnWSO2, []string{caseStateWorkInProgress}},
 			{caseStateAwaitingInfo, []string{caseStateWaitingOnWSO2}},
 			{caseStateSolutionProposed, []string{caseStateClosed, caseStateWaitingOnWSO2}},
-			{caseStateClosed, []string{caseStateReopened}},
+			{caseStateClosed, []string{}},
 			{caseStateReopened, []string{caseStateWorkInProgress}},
 		}
 		for _, tc := range cases {

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -16,7 +16,15 @@
 
 package handler
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
+
+// relatedCaseWindow mirrors the upstream data source's own eligibility rule:
+// a new case may only be linked as related to a case that was closed within
+// this window.
+const relatedCaseWindow = 60 * 24 * time.Hour
 
 const (
 	caseStateOpen             = "open"
@@ -65,10 +73,35 @@ func isValidStateTransition(from, to string) bool {
 	return false
 }
 
-// injectNextStates parses raw case JSON returned by the entity service, derives
-// the valid next states from the "state" field, and returns the JSON with a
-// "nextStates" key appended.
-func injectNextStates(data []byte) ([]byte, error) {
+// caseTypeCase is the standard support case type — as opposed to
+// service_request, security_report_analysis, or engagement. Related-case
+// creation is only offered for this type; the other types have their own
+// create flows that don't accept a relatedCaseId today.
+const caseTypeCase = "case"
+
+// canCreateRelatedCase reports whether a new case may be created as related to
+// a case of the given type/state, closed at the given timestamp (RFC 3339, as
+// returned in the "closedOn" field; empty when the case was never closed).
+// The upstream data source rejects the link once a closed case falls outside
+// relatedCaseWindow, so this mirrors that rule to avoid advertising an action
+// that would fail server-side. Scoped to caseType == "case" — the other case
+// types' create flows have no related-case field yet.
+func canCreateRelatedCase(caseType, state, closedOn string) bool {
+	if caseType != caseTypeCase || state != caseStateClosed || closedOn == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, closedOn)
+	if err != nil {
+		return false
+	}
+	return time.Since(t) <= relatedCaseWindow
+}
+
+// injectCaseComputedFields parses raw case JSON returned by the entity
+// service and appends the portal-computed fields the frontend needs to
+// render case actions: "nextStates" (valid transitions from "state") and
+// "canCreateRelatedCase" (derived from "type" + "state" + "closedOn").
+func injectCaseComputedFields(data []byte) ([]byte, error) {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
@@ -79,10 +112,27 @@ func injectNextStates(data []byte) ([]byte, error) {
 			return nil, err
 		}
 	}
+	var caseType string
+	if raw, ok := m["type"]; ok {
+		// Best-effort: a null/absent type just leaves it empty, which
+		// canCreateRelatedCase treats as ineligible.
+		_ = json.Unmarshal(raw, &caseType)
+	}
+	var closedOn string
+	if raw, ok := m["closedOn"]; ok {
+		// Best-effort: a null or malformed value just leaves closedOn empty,
+		// which canCreateRelatedCase treats as "not closed".
+		_ = json.Unmarshal(raw, &closedOn)
+	}
 	ns, err := json.Marshal(nextStates(state))
 	if err != nil {
 		return nil, err
 	}
 	m["nextStates"] = ns
+	canRelate, err := json.Marshal(canCreateRelatedCase(caseType, state, closedOn))
+	if err != nil {
+		return nil, err
+	}
+	m["canCreateRelatedCase"] = canRelate
 	return json.Marshal(m)
 }

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -82,19 +82,45 @@ func isValidStateTransition(from, to string) bool {
 	return false
 }
 
+// closedOnLayouts are the timestamp shapes the "closedOn" field has been seen
+// in, in order of preference. The entity service normally emits RFC 3339, but
+// some upstream (ServiceNow) values pass through as bare "YYYY-MM-DD HH:MM:SS"
+// with no zone — the frontend's normalizeBackendTimestamp (src/utils/dateTime.ts)
+// treats that shape as UTC, so this mirrors it rather than only accepting
+// RFC 3339 and silently hiding the action for those cases.
+var closedOnLayouts = []string{
+	time.RFC3339,
+	"2006-01-02 15:04:05",
+}
+
+// parseClosedOn parses "closedOn" using the first matching layout in
+// closedOnLayouts, treating a zoneless value as UTC.
+func parseClosedOn(closedOn string) (time.Time, bool) {
+	if t, err := time.Parse(time.RFC3339, closedOn); err == nil {
+		return t, true
+	}
+	for _, layout := range closedOnLayouts[1:] {
+		if t, err := time.ParseInLocation(layout, closedOn, time.UTC); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
 // canCreateRelatedCase reports whether a new case may be created as related to
-// a case of the given type/state, closed at the given timestamp (RFC 3339, as
-// returned in the "closedOn" field; empty when the case was never closed).
-// The upstream data source rejects the link once a closed case falls outside
-// relatedCaseWindow, so this mirrors that rule to avoid advertising an action
-// that would fail server-side. Scoped to caseType == "case" — the other case
-// types' create flows have no related-case field yet.
+// a case of the given type/state, closed at the given timestamp (as returned
+// in the "closedOn" field — see parseClosedOn for accepted shapes; empty when
+// the case was never closed). The upstream data source rejects the link once
+// a closed case falls outside relatedCaseWindow, so this mirrors that rule to
+// avoid advertising an action that would fail server-side. Scoped to
+// caseType == "case" — the other case types' create flows have no
+// related-case field yet.
 func canCreateRelatedCase(caseType, state, closedOn string) bool {
 	if caseType != caseTypeCase || state != caseStateClosed || closedOn == "" {
 		return false
 	}
-	t, err := time.Parse(time.RFC3339, closedOn)
-	if err != nil {
+	t, ok := parseClosedOn(closedOn)
+	if !ok {
 		return false
 	}
 	return time.Since(t) <= relatedCaseWindow

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -108,18 +108,29 @@ func parseClosedOn(closedOn string) (time.Time, bool) {
 }
 
 // canCreateRelatedCase reports whether a new case may be created as related to
-// a case of the given type/state, closed at the given timestamp (as returned
-// in the "closedOn" field — see parseClosedOn for accepted shapes; empty when
-// the case was never closed). The upstream data source rejects the link once
-// a closed case falls outside relatedCaseWindow, so this mirrors that rule to
-// avoid advertising an action that would fail server-side. Scoped to
-// caseType == "case" — the other case types' create flows have no
-// related-case field yet.
-func canCreateRelatedCase(caseType, state, closedOn string) bool {
-	if caseType != caseTypeCase || state != caseStateClosed || closedOn == "" {
+// a case of the given type/state, closed at closedOn (as returned in the
+// "closedOn" field — see parseClosedOn for accepted shapes). The ServiceNow
+// data source does not populate "closedOn" at all today, so this falls back
+// to updatedOn (also raw case JSON, always present) when closedOn is absent —
+// a closed case is normally terminal, so its last update time is a reasonable
+// stand-in for its close time. This is a best-effort UI signal only: the
+// upstream data source's own eligibility check (closed + within
+// relatedCaseWindow) still runs server-side when the related case is
+// actually created, so a stale fallback here just fails cleanly there rather
+// than corrupting anything. Scoped to caseType == "case" — the other case
+// types' create flows have no related-case field yet.
+func canCreateRelatedCase(caseType, state, closedOn, updatedOn string) bool {
+	if caseType != caseTypeCase || state != caseStateClosed {
 		return false
 	}
-	t, ok := parseClosedOn(closedOn)
+	ts := closedOn
+	if ts == "" {
+		ts = updatedOn
+	}
+	if ts == "" {
+		return false
+	}
+	t, ok := parseClosedOn(ts)
 	if !ok {
 		return false
 	}
@@ -153,11 +164,15 @@ func injectNextStates(data []byte) ([]byte, error) {
 	var closedOn string
 	if raw, ok := m["closedOn"]; ok {
 		// Best-effort: a null or malformed value just leaves closedOn empty,
-		// which canCreateRelatedCase treats as "not closed".
+		// so canCreateRelatedCase falls back to updatedOn.
 		_ = json.Unmarshal(raw, &closedOn)
 	}
+	var updatedOn string
+	if raw, ok := m["updatedOn"]; ok {
+		_ = json.Unmarshal(raw, &updatedOn)
+	}
 	ns := nextStates(state)
-	if canCreateRelatedCase(caseType, state, closedOn) {
+	if canCreateRelatedCase(caseType, state, closedOn, updatedOn) {
 		ns = []string{caseStateReopened}
 	}
 	nsJSON, err := json.Marshal(ns)

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -30,7 +30,9 @@ const (
 
 // nextStates returns the valid next states reachable from the given case state.
 // Role-gated transitions (team-lead override, auto-close) are excluded until
-// role enforcement is implemented.
+// role enforcement is implemented. Closed is terminal: the upstream data
+// source rejects any outbound transition from a closed case, including
+// reopen, so no next states are advertised for it.
 func nextStates(state string) []string {
 	switch state {
 	case caseStateOpen:
@@ -44,7 +46,7 @@ func nextStates(state string) []string {
 	case caseStateSolutionProposed:
 		return []string{caseStateClosed, caseStateWaitingOnWSO2}
 	case caseStateClosed:
-		return []string{caseStateReopened}
+		return []string{}
 	case caseStateReopened:
 		return []string{caseStateWorkInProgress}
 	default: // unknown values are terminal

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -26,6 +26,12 @@ import (
 // this window.
 const relatedCaseWindow = 60 * 24 * time.Hour
 
+// caseTypeCase is the standard support case type — as opposed to
+// service_request, security_report_analysis, or engagement. Related-case
+// creation is only offered for this type; the other types have their own
+// create flows that don't accept a relatedCaseId today.
+const caseTypeCase = "case"
+
 const (
 	caseStateOpen             = "open"
 	caseStateWorkInProgress   = "work_in_progress"
@@ -38,9 +44,12 @@ const (
 
 // nextStates returns the valid next states reachable from the given case state.
 // Role-gated transitions (team-lead override, auto-close) are excluded until
-// role enforcement is implemented. Closed is terminal: the upstream data
-// source rejects any outbound transition from a closed case, including
-// reopen, so no next states are advertised for it.
+// role enforcement is implemented. Closed is terminal — the upstream data
+// source rejects any outbound transition from a closed case, so no next
+// states are advertised for it here. The one exception is surfaced by the
+// caller (injectNextStates): `caseStateReopened` is reused as a signal that
+// this closed case is still within its related-case window, since the
+// frontend has no real reopen to offer, only "create a related case".
 func nextStates(state string) []string {
 	switch state {
 	case caseStateOpen:
@@ -73,12 +82,6 @@ func isValidStateTransition(from, to string) bool {
 	return false
 }
 
-// caseTypeCase is the standard support case type — as opposed to
-// service_request, security_report_analysis, or engagement. Related-case
-// creation is only offered for this type; the other types have their own
-// create flows that don't accept a relatedCaseId today.
-const caseTypeCase = "case"
-
 // canCreateRelatedCase reports whether a new case may be created as related to
 // a case of the given type/state, closed at the given timestamp (RFC 3339, as
 // returned in the "closedOn" field; empty when the case was never closed).
@@ -97,11 +100,14 @@ func canCreateRelatedCase(caseType, state, closedOn string) bool {
 	return time.Since(t) <= relatedCaseWindow
 }
 
-// injectCaseComputedFields parses raw case JSON returned by the entity
-// service and appends the portal-computed fields the frontend needs to
-// render case actions: "nextStates" (valid transitions from "state") and
-// "canCreateRelatedCase" (derived from "type" + "state" + "closedOn").
-func injectCaseComputedFields(data []byte) ([]byte, error) {
+// injectNextStates parses raw case JSON returned by the entity service,
+// derives the valid next states from "state", and returns the JSON with a
+// "nextStates" key appended. For a closed case still within its related-case
+// window (see canCreateRelatedCase), "reopened" is included as the sole
+// entry — there is no separate eligibility field; the frontend renders that
+// entry as "Create related case" rather than an actual reopen, since a real
+// reopen is never valid.
+func injectNextStates(data []byte) ([]byte, error) {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
@@ -124,15 +130,14 @@ func injectCaseComputedFields(data []byte) ([]byte, error) {
 		// which canCreateRelatedCase treats as "not closed".
 		_ = json.Unmarshal(raw, &closedOn)
 	}
-	ns, err := json.Marshal(nextStates(state))
+	ns := nextStates(state)
+	if canCreateRelatedCase(caseType, state, closedOn) {
+		ns = []string{caseStateReopened}
+	}
+	nsJSON, err := json.Marshal(ns)
 	if err != nil {
 		return nil, err
 	}
-	m["nextStates"] = ns
-	canRelate, err := json.Marshal(canCreateRelatedCase(caseType, state, closedOn))
-	if err != nil {
-		return nil, err
-	}
-	m["canCreateRelatedCase"] = canRelate
+	m["nextStates"] = nsJSON
 	return json.Marshal(m)
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -3495,6 +3495,15 @@ components:
               - reopened
               - solution_proposed
               - closed
+        canCreateRelatedCase:
+          type: boolean
+          readOnly: true
+          description: >-
+            Whether a new case may be created as related to this one. True
+            only for a standard `case`-type case that is closed and within
+            its 60-day related-case window; always false for other case
+            types and for a case outside that window, since the backing
+            data source rejects the link otherwise.
 
     CaseSearchView:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -3495,15 +3495,13 @@ components:
               - reopened
               - solution_proposed
               - closed
-        canCreateRelatedCase:
-          type: boolean
-          readOnly: true
           description: >-
-            Whether a new case may be created as related to this one. True
-            only for a standard `case`-type case that is closed and within
-            its 60-day related-case window; always false for other case
-            types and for a case outside that window, since the backing
-            data source rejects the link otherwise.
+            Valid next states from the current one. A closed case can never
+            actually be reopened (the backing data source has no such
+            transition); `reopened` appears here only as a signal that a new
+            case may still be created as related to this one — true for a
+            standard `case`-type case closed within the last 60 days, empty
+            otherwise.
 
     CaseSearchView:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -105,7 +105,7 @@ export interface BeCase {
   state?: BeCaseState;
   createdAt?: string;
   updatedAt?: string;
-  closedAt?: string;
+  closedOn?: string;
 }
 
 /** A referenced user, as embedded in case views (not just an id string). */
@@ -120,6 +120,12 @@ export interface BeUserRef {
 export interface BeEntityRef {
   id: string;
   name: string;
+}
+
+/** A referenced case carrying only its display number, e.g. the related case. */
+export interface BeCaseNumberRef {
+  id: string;
+  number?: string;
 }
 
 /**
@@ -174,6 +180,10 @@ export interface BeCaseView {
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
   nextStates?: BeCaseState[];
+  /** Whether a new case may be created as related to this one (closed + within its 60-day window). */
+  canCreateRelatedCase?: boolean;
+  /** The case this one was created as related to, when any. */
+  relatedCase?: BeCaseNumberRef | null;
   createdBy?: BeUserRef;
   /** The CS engineer the case is assigned to; null when unassigned. */
   assignedEngineer?: BeAssignedEngineerRef | null;
@@ -196,7 +206,7 @@ export interface BeCaseView {
   conversation?: BeEntityRef | null;
   createdOn?: string;
   updatedOn?: string;
-  closedAt?: string | null;
+  closedOn?: string | null;
 }
 
 export interface BeCaseCreatePayload {
@@ -209,6 +219,12 @@ export interface BeCaseCreatePayload {
   description: string;
   severity: BeCaseSeverity;
   issueType: BeCaseIssueType;
+  /**
+   * UUID of the closed case this one is related to. The data source only
+   * accepts this for a case closed within the last 60 days — otherwise it
+   * rejects the create with a "related case too old" error.
+   */
+  relatedCaseId?: string;
   /** Optional supporting files (raw base64), like the customer portal. */
   attachments?: BeCaseAttachmentPayload[];
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -179,9 +179,13 @@ export interface BeCaseView {
   state?: BeCaseState;
   /** Work sub-state; only meaningful while `state` is `work_in_progress`. */
   workState?: BeCaseWorkState | null;
+  /**
+   * States this case may transition into next. For a closed case, `reopened`
+   * appearing here is not a real reopen (the data source has no such
+   * transition) — it signals that a new case may still be created as related
+   * to this one, within its 60-day window.
+   */
   nextStates?: BeCaseState[];
-  /** Whether a new case may be created as related to this one (closed + within its 60-day window). */
-  canCreateRelatedCase?: boolean;
   /** The case this one was created as related to, when any. */
   relatedCase?: BeCaseNumberRef | null;
   createdBy?: BeUserRef;

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -67,6 +67,10 @@ function detailFromBeCase(
     state: uiStateFromBe(c.state),
     workState: c.workState ?? null,
     nextStates: (c.nextStates ?? []).map(uiStateFromBe),
+    canCreateRelatedCase: c.canCreateRelatedCase ?? false,
+    relatedCase: c.relatedCase
+      ? { id: c.relatedCase.id, caseNumber: c.relatedCase.number }
+      : undefined,
     assignee,
     assigneeIsMe,
     slaClockType: "ack",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -67,7 +67,6 @@ function detailFromBeCase(
     state: uiStateFromBe(c.state),
     workState: c.workState ?? null,
     nextStates: (c.nextStates ?? []).map(uiStateFromBe),
-    canCreateRelatedCase: c.canCreateRelatedCase ?? false,
     relatedCase: c.relatedCase
       ? { id: c.relatedCase.id, caseNumber: c.relatedCase.number }
       : undefined,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -279,3 +279,52 @@ describe("CaseActionBar — reassign gating for WIP-Ongoing", () => {
     expect(onAction).toHaveBeenCalledWith({ secondary: "reassign_engineer" });
   });
 });
+
+describe("CaseActionBar — create related case (closed-case reopen replacement)", () => {
+  /** Open the "More" overflow and return the create-related-case menu item. */
+  function openRelatedCaseItem(): HTMLElement {
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    return screen.getByRole("menuitem", { name: /create related case/i });
+  }
+
+  it("is not offered on a non-closed case", () => {
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("work_in_progress", ["solution_proposed"])}
+        onAction={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    expect(
+      screen.queryByRole("menuitem", { name: /create related case/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("is disabled on a closed case the backend has not flagged as eligible", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{ ...caseInState("closed", []), canCreateRelatedCase: false }}
+        onAction={onAction}
+      />,
+    );
+    const item = openRelatedCaseItem();
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("is enabled and dispatches when the backend flags the case eligible", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{ ...caseInState("closed", []), canCreateRelatedCase: true }}
+        onAction={onAction}
+      />,
+    );
+    const item = openRelatedCaseItem();
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "create_related_case" });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -281,50 +281,40 @@ describe("CaseActionBar — reassign gating for WIP-Ongoing", () => {
 });
 
 describe("CaseActionBar — create related case (closed-case reopen replacement)", () => {
-  /** Open the "More" overflow and return the create-related-case menu item. */
-  function openRelatedCaseItem(): HTMLElement {
-    fireEvent.click(screen.getByRole("button", { name: /more/i }));
-    return screen.getByRole("menuitem", { name: /create related case/i });
-  }
-
-  it("is not offered on a non-closed case", () => {
+  it("is not offered on a closed case the backend has not flagged eligible (empty nextStates)", () => {
     render(
-      <CaseActionBar
-        caseDetail={caseInState("work_in_progress", ["solution_proposed"])}
-        onAction={() => {}}
-      />,
+      <CaseActionBar caseDetail={caseInState("closed", [])} onAction={() => {}} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /more/i }));
     expect(
-      screen.queryByRole("menuitem", { name: /create related case/i }),
+      screen.queryByRole("button", { name: /create related case/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("is disabled on a closed case the backend has not flagged as eligible", () => {
+  it("renders as a single primary button when the backend flags the case eligible", () => {
     const onAction = vi.fn();
     render(
       <CaseActionBar
-        caseDetail={{ ...caseInState("closed", []), canCreateRelatedCase: false }}
+        caseDetail={caseInState("closed", ["reopened"])}
         onAction={onAction}
       />,
     );
-    const item = openRelatedCaseItem();
-    expect(item).toHaveAttribute("aria-disabled", "true");
-    fireEvent.click(item);
-    expect(onAction).not.toHaveBeenCalled();
+    const button = screen.getByRole("button", { name: /create related case/i });
+    expect(button).toBeInTheDocument();
+    // Must dispatch the create_related_case action, never a real "reopened"
+    // state PATCH — the data source has no such transition.
+    fireEvent.click(button);
+    expect(onAction).toHaveBeenCalledWith("create_related_case", "reopened");
   });
 
-  it("is enabled and dispatches when the backend flags the case eligible", () => {
-    const onAction = vi.fn();
+  it("never renders a literal 'Reopened' state-transition button", () => {
+    // Guards against regressing to the pre-fix behavior where a closed case's
+    // stray `reopened` nextState rendered as a generic (broken) reopen action.
     render(
       <CaseActionBar
-        caseDetail={{ ...caseInState("closed", []), canCreateRelatedCase: true }}
-        onAction={onAction}
+        caseDetail={caseInState("closed", ["reopened"])}
+        onAction={() => {}}
       />,
     );
-    const item = openRelatedCaseItem();
-    expect(item).not.toHaveAttribute("aria-disabled", "true");
-    fireEvent.click(item);
-    expect(onAction).toHaveBeenCalledWith({ secondary: "create_related_case" });
+    expect(screen.queryByRole("button", { name: /^reopened$/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -216,6 +216,7 @@ interface SecondaryItem {
  *   - Request a call                 → ISSU-008 (opens the Call requests tab's create dialog)
  *   - Log time                       → ISSU-017
  *   - Copy case link                 → ISSU-010 (per-comment + per-case permalinks)
+ *   - Create related case            → ISSU-004 (closed-case replacement for reopen; backend-gated)
  *
  * Intentionally NOT here:
  *   - Watch / unwatch  → withdrawn along with the Watchers widget (ISSU-018), no backend flow planned yet
@@ -276,12 +277,29 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
       ? [{ key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true }]
       : []),
     { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true },
-    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, divider: true, disabled: true },
+    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, disabled: true },
     { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true, disabled: true },
     { key: "request_call", label: "Request a call…", icon: <Phone size={16} /> },
     { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },
     { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },
   );
+
+  // Offered as the closed-case replacement for reopening a case (the backing
+  // data source has no outbound transition from closed — see nextStates).
+  // Gated entirely on the backend-computed `canCreateRelatedCase`: the data
+  // source only accepts a related-case link within 60 days of closing, and
+  // that eligibility is derived server-side, never recomputed on the FE.
+  if (caseDetail.state === "closed") {
+    items.push({
+      key: "create_related_case",
+      label: "Create related case…",
+      icon: <ArrowRight size={16} />,
+      disabled: !caseDetail.canCreateRelatedCase,
+      tooltip: caseDetail.canCreateRelatedCase
+        ? undefined
+        : "Related cases can be created within 60 days after a case is closed.",
+    });
+  }
 
   return items;
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -124,6 +124,15 @@ const TARGET_CONFIG: Partial<Record<CaseState, TargetConfig>> = {
     icon: <CheckCircle size={16} />,
     confirm: CLOSE_CONFIRM,
   },
+  // Not a real reopen — the data source has no transition out of closed. The
+  // backend only puts `reopened` in a closed case's `nextStates` as a signal
+  // that a related case may still be created (see that field's doc); `action`
+  // routes to the create-related-case flow in `onAction` instead of a PATCH.
+  reopened: {
+    action: "create_related_case",
+    color: "primary",
+    icon: <GitBranch size={16} />,
+  },
 };
 
 /**
@@ -147,6 +156,7 @@ const TRANSITION_LABEL: Partial<Record<CaseState, string>> = {
   awaiting_info: "Request information",
   waiting_on_wso2: "Wait on WSO2",
   closed: "Close",
+  reopened: "Create related case",
 };
 
 /** Build the button for a transition into `target`, labelled by the BE state. */
@@ -216,7 +226,6 @@ interface SecondaryItem {
  *   - Request a call                 → ISSU-008 (opens the Call requests tab's create dialog)
  *   - Log time                       → ISSU-017
  *   - Copy case link                 → ISSU-010 (per-comment + per-case permalinks)
- *   - Create related case            → ISSU-004 (closed-case replacement for reopen; backend-gated)
  *
  * Intentionally NOT here:
  *   - Watch / unwatch  → withdrawn along with the Watchers widget (ISSU-018), no backend flow planned yet
@@ -283,23 +292,6 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
     { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },
     { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },
   );
-
-  // Offered as the closed-case replacement for reopening a case (the backing
-  // data source has no outbound transition from closed — see nextStates).
-  // Gated entirely on the backend-computed `canCreateRelatedCase`: the data
-  // source only accepts a related-case link within 60 days of closing, and
-  // that eligibility is derived server-side, never recomputed on the FE.
-  if (caseDetail.state === "closed") {
-    items.push({
-      key: "create_related_case",
-      label: "Create related case…",
-      icon: <ArrowRight size={16} />,
-      disabled: !caseDetail.canCreateRelatedCase,
-      tooltip: caseDetail.canCreateRelatedCase
-        ? undefined
-        : "Related cases can be created within 60 days after a case is closed.",
-    });
-  }
 
   return items;
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -131,7 +131,7 @@ const TARGET_CONFIG: Partial<Record<CaseState, TargetConfig>> = {
   reopened: {
     action: "create_related_case",
     color: "primary",
-    icon: <GitBranch size={16} />,
+    icon: <LinkIcon size={16} />,
   },
 };
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -90,6 +90,12 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const [searchParams] = useSearchParams();
   const lockedProjectId = searchParams.get("projectId") ?? "";
   const isProjectLocked = !!lockedProjectId;
+  // Set when opened from a closed case's "Create related case" action
+  // (`/cases/new?relatedCaseId=…&relatedCaseNumber=…`). The backend already
+  // validated eligibility (closed + within its 60-day window) before offering
+  // that action, so this page just carries the id through on submit.
+  const relatedCaseId = searchParams.get("relatedCaseId") ?? undefined;
+  const relatedCaseNumber = searchParams.get("relatedCaseNumber") ?? undefined;
 
   const [projectId, setProjectId] = useState(lockedProjectId);
   const [deploymentId, setDeploymentId] = useState("");
@@ -213,6 +219,7 @@ export default function CsmCaseCreatePage(): JSX.Element {
         description,
         severity: priorityFromSeverity(severity),
         issueType: issueType,
+        relatedCaseId,
       });
       // The create endpoint doesn't attach files for standard cases, so upload
       // them to the new case afterwards. A partial failure still lands the case.
@@ -244,9 +251,14 @@ export default function CsmCaseCreatePage(): JSX.Element {
       >
         Back to cases
       </Button>
-      <Typography variant="h5" sx={{ mb: 2 }}>
+      <Typography variant="h5" sx={{ mb: relatedCaseId ? 0.5 : 2 }}>
         New case
       </Typography>
+      {relatedCaseId && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Related to {relatedCaseNumber ?? "the closed case"} — its id is carried through automatically.
+        </Typography>
+      )}
 
       <Card variant="outlined" sx={{ p: 3 }}>
         {hasOptionsError && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -35,6 +35,7 @@ import {
   ArrowLeft,
   Clock,
   Layers,
+  Link as LinkIcon,
   ListChecks,
   MessageSquarePlus,
   Paperclip,
@@ -688,6 +689,18 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // ISSU-004: replaces reopening a closed case (the data source has no
+      // outbound transition from closed). The action bar only offers this
+      // when the backend's `canCreateRelatedCase` says the case is still
+      // within its 60-day window, so no eligibility check is needed here.
+      if (action.secondary === "create_related_case") {
+        if (!data) return;
+        const params = new URLSearchParams({ projectId: data.projectId, relatedCaseId: data.id });
+        if (data.caseNumber) params.set("relatedCaseNumber", data.caseNumber);
+        navigate(`/cases/new?${params.toString()}`);
+        return;
+      }
+
       setFeedback({
         message: SECONDARY_TOAST[action.secondary] ?? `Action: ${action.secondary}`,
         severity: "info",
@@ -703,6 +716,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
       startWork,
       resolveOngoingConflict,
       currentUserEmail,
+      navigate,
     ],
   );
 
@@ -983,6 +997,17 @@ export default function CsmCaseDetailPage(): JSX.Element {
             )}
             <SeverityChip severity={c.severity} withLabel />
             <StateChip state={c.state} />
+            {c.relatedCase && (
+              <Chip
+                size="small"
+                variant="outlined"
+                clickable
+                icon={<LinkIcon size={14} />}
+                label={`Related: ${c.relatedCase.caseNumber ?? c.relatedCase.id}`}
+                onClick={() => navigate(`/cases/${c.relatedCase!.id}`)}
+                sx={{ fontWeight: 600 }}
+              />
+            )}
             {c.state === "work_in_progress" && c.workState && (
               <Chip
                 size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -918,6 +918,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   }
 
   const c = data;
+  // Narrowed once here so the JSX below can use it without a non-null
+  // assertion — `c.relatedCase` on its own doesn't stay narrowed across the
+  // `onClick` closure.
+  const relatedCase = c.relatedCase;
   const isClosed = c.state === "closed";
   // The backend rejects a customer-visible comment unless the case is
   // work_in_progress + ongoing. Internal work notes are allowed in any state,
@@ -1009,14 +1013,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
             )}
             <SeverityChip severity={c.severity} withLabel />
             <StateChip state={c.state} />
-            {c.relatedCase && (
+            {relatedCase && (
               <Chip
                 size="small"
                 variant="outlined"
                 clickable
                 icon={<LinkIcon size={14} />}
-                label={`Related: ${c.relatedCase.caseNumber ?? c.relatedCase.id}`}
-                onClick={() => navigate(`/cases/${c.relatedCase!.id}`)}
+                label={`Related: ${relatedCase.caseNumber ?? relatedCase.id}`}
+                onClick={() => navigate(`/cases/${relatedCase.id}`)}
                 sx={{ fontWeight: 600 }}
               />
             )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -133,6 +133,10 @@ const LIFECYCLE_TOAST: Record<CaseLifecycleAction, string> = {
   resume_work: "Resumed work on this case.",
   close: "Case closed.",
   close_no_response: "Closed (no response received).",
+  // Unused: intercepted before this map is read (see onAction) since it
+  // navigates instead of showing a toast. Present only to satisfy the
+  // exhaustive Record.
+  create_related_case: "",
   transition: "Case updated.",
 };
 
@@ -157,6 +161,8 @@ const LIFECYCLE_SEVERITY: Record<CaseLifecycleAction, FeedbackSeverity> = {
   resume_work: "info",
   close: "success",
   close_no_response: "success",
+  // Unused — see the matching note in LIFECYCLE_TOAST.
+  create_related_case: "info",
   transition: "info",
 };
 
@@ -547,6 +553,19 @@ export default function CsmCaseDetailPage(): JSX.Element {
           return;
         }
 
+        // ISSU-004: the backend puts `reopened` in a closed case's
+        // `nextStates` only as a signal — there is no real reopen (the data
+        // source has no such transition). Never PATCH it; open the new-case
+        // form pre-filled with relatedCaseId instead. Must run before the
+        // generic `targetState` PATCH below, since `beStateFromUi("reopened")`
+        // is truthy and would otherwise be sent as a state transition.
+        if (action === "create_related_case" && data) {
+          const params = new URLSearchParams({ projectId: data.projectId, relatedCaseId: data.id });
+          if (data.caseNumber) params.set("relatedCaseNumber", data.caseNumber);
+          navigate(`/cases/new?${params.toString()}`);
+          return;
+        }
+
         if (targetState === "work_in_progress" && data) {
           void startWork(LIFECYCLE_TOAST[action], LIFECYCLE_SEVERITY[action]);
           return;
@@ -686,18 +705,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
       if (action.secondary === "request_call") {
         setActiveTab("call-requests");
         setAutoOpenCallCreate(true);
-        return;
-      }
-
-      // ISSU-004: replaces reopening a closed case (the data source has no
-      // outbound transition from closed). The action bar only offers this
-      // when the backend's `canCreateRelatedCase` says the case is still
-      // within its 60-day window, so no eligibility check is needed here.
-      if (action.secondary === "create_related_case") {
-        if (!data) return;
-        const params = new URLSearchParams({ projectId: data.projectId, relatedCaseId: data.id });
-        if (data.caseNumber) params.set("relatedCaseNumber", data.caseNumber);
-        navigate(`/cases/new?${params.toString()}`);
         return;
       }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -352,6 +352,13 @@ export interface CsmCaseDetail extends CsmCaseRow {
   conversationId?: string;
   /** States this case may transition into next, per the backend. */
   nextStates?: CaseState[];
+  /**
+   * Whether a new case may be created as related to this one — backend-computed
+   * (closed + within its 60-day related-case window), never derived on the FE.
+   */
+  canCreateRelatedCase?: boolean;
+  /** The case this one was created as related to, when any. */
+  relatedCase?: { id: string; caseNumber?: string };
   /** Display name of the person who opened the case. */
   createdBy?: string;
   /** Email of the creator — used to tell a WSO2 engineer from a customer. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -330,6 +330,11 @@ export type CaseLifecycleAction =
   | "resume_work"
   | "close"
   | "close_no_response"
+  // Closed-case replacement for reopening: the backend surfaces this via a
+  // `reopened` entry in `nextStates` (a real reopen is never valid — see
+  // that field's doc), but it must NOT be PATCHed like a real transition —
+  // it opens the new-case form pre-filled with relatedCaseId instead.
+  | "create_related_case"
   // Generic transition into a state the frontend has no curated action for
   // (e.g. a state added on the backend). Drives the post-transition toast only;
   // the PATCH target always comes from the backend `nextStates` value.
@@ -350,13 +355,12 @@ export interface CsmCaseDetail extends CsmCaseRow {
    * conversation (e.g. non-ServiceNow source, or a case opened without chat).
    */
   conversationId?: string;
-  /** States this case may transition into next, per the backend. */
-  nextStates?: CaseState[];
   /**
-   * Whether a new case may be created as related to this one — backend-computed
-   * (closed + within its 60-day related-case window), never derived on the FE.
+   * States this case may transition into next, per the backend. For a closed
+   * case, a `reopened` entry is not a real reopen (the data source has none)
+   * — it signals "Create related case" is available within its 60-day window.
    */
-  canCreateRelatedCase?: boolean;
+  nextStates?: CaseState[];
   /** The case this one was created as related to, when any. */
   relatedCase?: { id: string; caseNumber?: string };
   /** Display name of the person who opened the case. */

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
@@ -54,6 +54,7 @@ const STATE_SLICE_COLOR: Record<CaseState, string> = {
   awaiting_info: paletteColor("cyan", 500, "#06b6d4"),
   solution_proposed: paletteColor("teal", 500, "#14b8a6"),
   closed: paletteColor("grey", 500, "#6b7280"),
+  reopened: paletteColor("purple", 500, "#a855f7"),
 };
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
@@ -22,7 +22,14 @@ export type CaseState =
   | "solution_proposed"
   | "awaiting_info"
   | "waiting_on_wso2"
-  | "closed";
+  | "closed"
+  /**
+   * Only ever appears as a `nextStates` entry on a closed case, never as a
+   * case's own `state` — it signals "Create related case" is available, not
+   * an actual reopen (the data source has no such transition). See
+   * `CsmCaseDetail.nextStates` and `CaseActionBar`'s `reopened` handling.
+   */
+  | "reopened";
 
 /**
  * Work sub-state of a `work_in_progress` case. `null` / absent when the case is

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
@@ -70,7 +70,11 @@ export const STATE_COLOR: Record<
   solution_proposed: "default",
   awaiting_info: "default",
   closed: "success",
-  // Active again, on us — same bucket as open/work_in_progress.
+  // Defensive: `reopened` only appears in a closed case's `nextStates` (the
+  // "Create related case" signal, see CaseState's doc) — never as a case's
+  // own state, so this entry should be unreachable via a real case's state.
+  // Kept in the "info" bucket rather than omitted, so the exhaustive Record
+  // still compiles and any incidental rendering doesn't look broken.
   reopened: "info",
 };
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/abtDashboard.ts
@@ -46,6 +46,7 @@ export const STATE_LABEL: Record<CaseState, string> = {
   awaiting_info: "Awaiting info",
   waiting_on_wso2: "Waiting on WSO2",
   closed: "Closed",
+  reopened: "Reopened",
 };
 
 // Status chip colour by "whose move is it", so colour carries information when
@@ -69,6 +70,8 @@ export const STATE_COLOR: Record<
   solution_proposed: "default",
   awaiting_info: "default",
   closed: "success",
+  // Active again, on us — same bucket as open/work_in_progress.
+  reopened: "info",
 };
 
 /**


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The CSM portal's case detail view was showing a "Reopen" action on every closed case. The backend's `nextStates` derivation advertised `closed → reopened` as a valid transition, but the backing data source has no outbound transition defined for a closed case at all, so attempting the reopen always failed server-side. The action was surfaced to users with no way for it to ever succeed, and closed cases had no alternative way to continue the conversation.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Make `closed` a true terminal state in the portal's case state machine, matching the backing data source's actual transition rules, so the Reopen action is no longer offered.
2. Replace it with "Create related case": a new case can be filed as related to a recently-closed one, for when the underlying issue needs more follow-up.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**Backend (`apps/csm-portal/backend`):**
- `nextStates(closed)` in `internal/handler/state.go` returns an empty slice by default — a real reopen is never valid, so it's no longer advertised.
- For a case still within its 60-day related-case window (standard `case` type, closed, `closedOn` within 60 days — the backing data source's own eligibility rule), `nextStates` instead returns `["reopened"]`. This reuses the existing `nextStates` array as the single source of truth for available actions rather than adding a separate flag; `reopened` here is never a real transition, only a signal.
- `openapi.yaml`'s `nextStates` field doc explains the reuse.

**Frontend (`apps/csm-portal/webapp`):**
- `CaseActionBar` renders the `reopened` entry as a "Create related case" primary button (via the existing per-target-state config, same as every other lifecycle button) instead of a generic "Reopened" transition button.
- Clicking it does **not** PATCH the case — `onAction` intercepts `create_related_case` before the generic state-transition logic and instead navigates to the existing new-case form pre-filled with `relatedCaseId` (and locked to the same project), via a new `?relatedCaseId=&relatedCaseNumber=` query-param pattern matching the existing `?projectId=` lock.
- The case detail page shows a clickable "Related: CASE-XXXX" chip when the backend returns a `relatedCase` reference, linking straight to that case.
- Added `reopened` to the frontend's `CaseState` union (it was already a real backend case state with no FE label/color mapping — a pre-existing gap) and filled in the resulting map entries (state label, chip color, dashboard chart slice color).
- Fixed a pre-existing FE/BE field-name mismatch (`closedAt` → `closedOn`) discovered while wiring this up; it was unused, so no behavior changed.

No API contract change beyond the additive `relatedCase`/`relatedCaseId` fields and the `nextStates` reuse — nothing existing was renamed or removed except the now-terminal `closed → reopened` transition, which never succeeded anyway.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I don't see a Reopen action on a closed case that can never actually be reopened, so I don't attempt an action guaranteed to fail. When a customer's issue resurfaces shortly after closing, I can file a new case linked back to the original instead.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed: the Reopen action was shown on closed cases even though reopening was never possible. Closed cases now offer "Create related case" instead, available for 60 days after closing.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal state machine and case-detail UI behavior, not separately documented.

## Automation tests
 - Unit tests
   > Code coverage information

Backend: table-driven tests in `cases_test.go` cover `nextStates` returning `["reopened"]` vs `[]` across state/type/closedOn-window combinations. `make test` (vet + race-enabled unit tests) passes.

Frontend: `CaseActionBar` tests cover the button being absent when the backend hasn't flagged eligibility, rendering as a single primary button and dispatching `create_related_case` (never a raw "Reopened" transition) when eligible. `pnpm build`, `pnpm test`, and `pnpm lint` all pass (two pre-existing, unrelated test failures on `origin/main` were confirmed via a clean baseline checkout before this PR).
 - Integration tests
   > Details about the test cases and coverage

N/A — no integration test suite for this component.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go/TS codebase; `go vet ./...` and `eslint` both run clean)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Local: backend `make test` (go vet + go test -race), frontend `pnpm build` + `pnpm test` + `pnpm lint`, on macOS.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Create related case” flow for certain recently closed cases (based on closure date), including a related-case link on the case details page and pre-filled context on the create form.
* **Bug Fixes**
  * Closed cases no longer show “reopen” as a standard state transition.
  * Related-case action now routes to related-case creation instead of attempting a reopen transition.
* **Documentation**
  * Updated backend state-machine docs and API/UI schema descriptions for reopened/next-state behavior.
* **Tests**
  * Expanded test coverage for related-case eligibility and UI action rendering/navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->