### PR TITLE
feat(csm-cases): add a Change severity action, reserved S0 for Managed Cloud

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -279,3 +279,32 @@ describe("CaseActionBar — reassign gating for WIP-Ongoing", () => {
     expect(onAction).toHaveBeenCalledWith({ secondary: "reassign_engineer" });
   });
 });
+
+describe("CaseActionBar — Change severity is blocked on a closed case", () => {
+  it("disables the menu item once the case is closed", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar caseDetail={caseInState("closed", [])} onAction={onAction} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /change severity/i });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("keeps it enabled for a non-closed case", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("awaiting_info", ["waiting_on_wso2"])}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /change severity/i });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "change_severity" });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -33,6 +33,7 @@ import {
   ChevronDown,
   Clock,
   Copy,
+  Gauge,
   GitBranch,
   Inbox,
   Link as LinkIcon,
@@ -215,12 +216,14 @@ interface SecondaryItem {
  *   - Create task                    → ISSU-025
  *   - Request a call                 → ISSU-008 (opens the Call requests tab's create dialog)
  *   - Log time                       → ISSU-017
+ *   - Change severity                → PATCH /cases/{id} { severity }, already fully
+ *                                       backend-supported (see ChangeSeverityDialog.tsx)
  *   - Copy case link                 → ISSU-010 (per-comment + per-case permalinks)
  *
  * Intentionally NOT here:
  *   - Watch / unwatch  → withdrawn along with the Watchers widget (ISSU-018), no backend flow planned yet
  *   - Open in ServiceNow → this platform replaces ServiceNow; no back-link
- *   - Escalate to lead / Request severity change → withdrawn, no backend flow planned yet
+ *   - Escalate to lead → withdrawn, no backend flow planned yet
  */
 function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const items: SecondaryItem[] = [];
@@ -256,6 +259,11 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const canHoldAutoClose =
     caseDetail.state === "awaiting_info" || caseDetail.state === "solution_proposed";
 
+  // A closed case is done — changing its severity doesn't fit the same
+  // "closed is read-only" rule already applied to comments, attachments,
+  // and time tracking (see CsmCaseDetailPage.tsx's isClosed).
+  const caseClosed = caseDetail.state === "closed";
+
   // Only "Copy case link", "Request a call", and "Log time" are wired up.
   // The rest are disabled until their backend flows land, so the menu
   // advertises the roadmap without exposing dead actions that would no-op or
@@ -271,6 +279,14 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
       tooltip: reassignBlocked
         ? "Can't reassign while the case is in progress and ongoing. Pause the work first, or ask the current assignee or a lead to reassign."
         : undefined,
+    },
+    {
+      key: "change_severity",
+      label: "Change severity…",
+      icon: <Gauge size={16} />,
+      divider: true,
+      disabled: caseClosed,
+      tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
     },
     ...(canHoldAutoClose
       ? [{ key: "hold_auto_close", label: "Hold auto-closure…", icon: <PauseCircle size={16} />, divider: true }]

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.test.tsx
@@ -24,6 +24,7 @@ describe("ChangeSeverityDialog — submission gating", () => {
     render(
       <ChangeSeverityDialog
         currentSeverity="S4"
+        isManagedCloud
         isChanging={false}
         onClose={() => {}}
         onChange={() => {}}
@@ -39,6 +40,7 @@ describe("ChangeSeverityDialog — submission gating", () => {
     render(
       <ChangeSeverityDialog
         currentSeverity="S4"
+        isManagedCloud
         isChanging={false}
         onClose={() => {}}
         onChange={onChange}
@@ -55,6 +57,7 @@ describe("ChangeSeverityDialog — submission gating", () => {
     render(
       <ChangeSeverityDialog
         currentSeverity="S4"
+        isManagedCloud
         isChanging={false}
         onClose={onClose}
         onChange={onChange}
@@ -71,6 +74,7 @@ describe("ChangeSeverityDialog — on-call paging warning", () => {
     render(
       <ChangeSeverityDialog
         currentSeverity="S4"
+        isManagedCloud
         isChanging={false}
         onClose={() => {}}
         onChange={() => {}}
@@ -85,6 +89,7 @@ describe("ChangeSeverityDialog — on-call paging warning", () => {
     render(
       <ChangeSeverityDialog
         currentSeverity="S1"
+        isManagedCloud
         isChanging={false}
         onClose={() => {}}
         onChange={() => {}}
@@ -98,6 +103,7 @@ describe("ChangeSeverityDialog — on-call paging warning", () => {
     render(
       <ChangeSeverityDialog
         currentSeverity="S1"
+        isManagedCloud
         isChanging={false}
         onClose={() => {}}
         onChange={() => {}}
@@ -105,5 +111,38 @@ describe("ChangeSeverityDialog — on-call paging warning", () => {
     );
     fireEvent.click(screen.getByRole("radio", { name: /s4/i }));
     expect(screen.queryByText(/may page on-call staff/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("ChangeSeverityDialog — S0 is reserved for Managed Cloud", () => {
+  it("disables the S0 option for a non-Managed-Cloud case", () => {
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S4"
+        isManagedCloud={false}
+        isChanging={false}
+        onClose={() => {}}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: /s0/i })).toBeDisabled();
+  });
+
+  it("allows picking S0 for a Managed Cloud case", () => {
+    const onChange = vi.fn();
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S4"
+        isManagedCloud
+        isChanging={false}
+        onClose={() => {}}
+        onChange={onChange}
+      />,
+    );
+    const s0 = screen.getByRole("radio", { name: /s0/i });
+    expect(s0).toBeEnabled();
+    fireEvent.click(s0);
+    fireEvent.click(screen.getByRole("button", { name: /change severity/i }));
+    expect(onChange).toHaveBeenCalledWith("S0");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.test.tsx
@@ -69,51 +69,6 @@ describe("ChangeSeverityDialog — submission gating", () => {
   });
 });
 
-describe("ChangeSeverityDialog — on-call paging warning", () => {
-  it("warns when raising from S4 (never pages) to a paging severity", () => {
-    render(
-      <ChangeSeverityDialog
-        currentSeverity="S4"
-        isManagedCloud
-        isChanging={false}
-        onClose={() => {}}
-        onChange={() => {}}
-      />,
-    );
-    expect(screen.queryByText(/may page on-call staff/i)).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("radio", { name: /s1/i }));
-    expect(screen.getByText(/may page on-call staff/i)).toBeInTheDocument();
-  });
-
-  it("does not warn when moving between two severities that already page", () => {
-    render(
-      <ChangeSeverityDialog
-        currentSeverity="S1"
-        isManagedCloud
-        isChanging={false}
-        onClose={() => {}}
-        onChange={() => {}}
-      />,
-    );
-    fireEvent.click(screen.getByRole("radio", { name: /s2/i }));
-    expect(screen.queryByText(/may page on-call staff/i)).not.toBeInTheDocument();
-  });
-
-  it("does not warn when lowering to S4", () => {
-    render(
-      <ChangeSeverityDialog
-        currentSeverity="S1"
-        isManagedCloud
-        isChanging={false}
-        onClose={() => {}}
-        onChange={() => {}}
-      />,
-    );
-    fireEvent.click(screen.getByRole("radio", { name: /s4/i }));
-    expect(screen.queryByText(/may page on-call staff/i)).not.toBeInTheDocument();
-  });
-});
-
 describe("ChangeSeverityDialog — S0 is reserved for Managed Cloud", () => {
   it("disables the S0 option for a non-Managed-Cloud case", () => {
     render(

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.test.tsx
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ChangeSeverityDialog from "@features/csm-cases/components/ChangeSeverityDialog";
+
+describe("ChangeSeverityDialog — submission gating", () => {
+  it("disables Change severity until a different value is picked", () => {
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S4"
+        isChanging={false}
+        onClose={() => {}}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /change severity/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole("radio", { name: /s3/i }));
+    expect(screen.getByRole("button", { name: /change severity/i })).toBeEnabled();
+  });
+
+  it("calls onChange with the newly picked severity", () => {
+    const onChange = vi.fn();
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S4"
+        isChanging={false}
+        onClose={() => {}}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /s2/i }));
+    fireEvent.click(screen.getByRole("button", { name: /change severity/i }));
+    expect(onChange).toHaveBeenCalledWith("S2");
+  });
+
+  it("calls onClose on Cancel without calling onChange", () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S4"
+        isChanging={false}
+        onClose={onClose}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChangeSeverityDialog — on-call paging warning", () => {
+  it("warns when raising from S4 (never pages) to a paging severity", () => {
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S4"
+        isChanging={false}
+        onClose={() => {}}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/may page on-call staff/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: /s1/i }));
+    expect(screen.getByText(/may page on-call staff/i)).toBeInTheDocument();
+  });
+
+  it("does not warn when moving between two severities that already page", () => {
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S1"
+        isChanging={false}
+        onClose={() => {}}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /s2/i }));
+    expect(screen.queryByText(/may page on-call staff/i)).not.toBeInTheDocument();
+  });
+
+  it("does not warn when lowering to S4", () => {
+    render(
+      <ChangeSeverityDialog
+        currentSeverity="S1"
+        isChanging={false}
+        onClose={() => {}}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /s4/i }));
+    expect(screen.queryByText(/may page on-call staff/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   Button,
   Dialog,
   DialogActions,
@@ -32,14 +31,6 @@ import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
 import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 
 const SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
-
-/** S0-S3 are the on-call-paging severities (matches the "High Severity Case
- * Alert" threshold everywhere else in the portal this distinction shows up —
- * e.g. the E2E suite deliberately only ever creates S4 test cases to avoid
- * triggering it). S4 is the only severity that never pages anyone. */
-function pagesOnCall(severity: Severity): boolean {
-  return severity !== "S4";
-}
 
 interface ChangeSeverityDialogProps {
   currentSeverity: Severity;
@@ -59,8 +50,7 @@ interface ChangeSeverityDialogProps {
  * usePatchCsmCase.ts's own doc comment ("state transitions, priority
  * changes, ...") and CaseAuditKind's `severity_change` entry, which the
  * activity feed already knows how to render — this dialog was the only
- * missing piece. Raising to S0-S3 can page on-call staff, so that's called
- * out before confirming rather than left to be discovered after the fact.
+ * missing piece.
  */
 export default function ChangeSeverityDialog({
   currentSeverity,
@@ -72,7 +62,6 @@ export default function ChangeSeverityDialog({
   const [selected, setSelected] = useState<Severity>(currentSeverity);
 
   const changed = selected !== currentSeverity;
-  const willPage = changed && pagesOnCall(selected) && !pagesOnCall(currentSeverity);
 
   return (
     <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
@@ -108,12 +97,6 @@ export default function ChangeSeverityDialog({
             })}
           </RadioGroup>
         </FormControl>
-
-        {willPage && (
-          <Alert severity="warning" sx={{ mt: 1.5 }}>
-            Raising to {selected} may page on-call staff.
-          </Alert>
-        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={isChanging}>
@@ -121,7 +104,6 @@ export default function ChangeSeverityDialog({
         </Button>
         <Button
           variant="contained"
-          color={willPage ? "warning" : "primary"}
           disabled={!changed || isChanging}
           loading={isChanging}
           onClick={() => onChange(selected)}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
@@ -43,6 +43,9 @@ function pagesOnCall(severity: Severity): boolean {
 
 interface ChangeSeverityDialogProps {
   currentSeverity: Severity;
+  /** True when the case's project is a Managed Cloud subscription — S0 is
+   * reserved for those, same rule as case creation (see CsmCaseCreatePage.tsx). */
+  isManagedCloud: boolean;
   /** True while a PATCH is in flight; disables the actions. */
   isChanging: boolean;
   onClose: () => void;
@@ -61,6 +64,7 @@ interface ChangeSeverityDialogProps {
  */
 export default function ChangeSeverityDialog({
   currentSeverity,
+  isManagedCloud,
   isChanging,
   onClose,
   onChange,
@@ -86,15 +90,22 @@ export default function ChangeSeverityDialog({
             value={selected}
             onChange={(e) => setSelected(e.target.value as Severity)}
           >
-            {SEVERITIES.map((s) => (
-              <FormControlLabel
-                key={s}
-                value={s}
-                disabled={isChanging}
-                control={<Radio size="small" />}
-                label={`${s} · ${SEVERITY_LABEL[s]}`}
-              />
-            ))}
+            {SEVERITIES.map((s) => {
+              const s0Blocked = s === "S0" && !isManagedCloud;
+              return (
+                <FormControlLabel
+                  key={s}
+                  value={s}
+                  disabled={isChanging || s0Blocked}
+                  control={<Radio size="small" />}
+                  label={
+                    s0Blocked
+                      ? `${s} · ${SEVERITY_LABEL[s]} (Managed Cloud only)`
+                      : `${s} · ${SEVERITY_LABEL[s]}`
+                  }
+                />
+              );
+            })}
           </RadioGroup>
         </FormControl>
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+
+const SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+
+/** S0-S3 are the on-call-paging severities (matches the "High Severity Case
+ * Alert" threshold everywhere else in the portal this distinction shows up —
+ * e.g. the E2E suite deliberately only ever creates S4 test cases to avoid
+ * triggering it). S4 is the only severity that never pages anyone. */
+function pagesOnCall(severity: Severity): boolean {
+  return severity !== "S4";
+}
+
+interface ChangeSeverityDialogProps {
+  currentSeverity: Severity;
+  /** True while a PATCH is in flight; disables the actions. */
+  isChanging: boolean;
+  onClose: () => void;
+  /** Apply the new severity (`PATCH { severity }`). */
+  onChange: (next: Severity) => void;
+}
+
+/**
+ * Change a case's severity via `PATCH /cases/{id}` (`severity`). The backend
+ * and the search/filter UI already fully support this — see
+ * usePatchCsmCase.ts's own doc comment ("state transitions, priority
+ * changes, ...") and CaseAuditKind's `severity_change` entry, which the
+ * activity feed already knows how to render — this dialog was the only
+ * missing piece. Raising to S0-S3 can page on-call staff, so that's called
+ * out before confirming rather than left to be discovered after the fact.
+ */
+export default function ChangeSeverityDialog({
+  currentSeverity,
+  isChanging,
+  onClose,
+  onChange,
+}: ChangeSeverityDialogProps): JSX.Element {
+  const [selected, setSelected] = useState<Severity>(currentSeverity);
+
+  const changed = selected !== currentSeverity;
+  const willPage = changed && pagesOnCall(selected) && !pagesOnCall(currentSeverity);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Change severity</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          Current severity:{" "}
+          <Typography component="span" variant="body2" sx={{ fontWeight: 600, color: "text.primary" }}>
+            {currentSeverity} · {SEVERITY_LABEL[currentSeverity]}
+          </Typography>
+        </Typography>
+
+        <FormControl>
+          <RadioGroup
+            value={selected}
+            onChange={(e) => setSelected(e.target.value as Severity)}
+          >
+            {SEVERITIES.map((s) => (
+              <FormControlLabel
+                key={s}
+                value={s}
+                disabled={isChanging}
+                control={<Radio size="small" />}
+                label={`${s} · ${SEVERITY_LABEL[s]}`}
+              />
+            ))}
+          </RadioGroup>
+        </FormControl>
+
+        {willPage && (
+          <Alert severity="warning" sx={{ mt: 1.5 }}>
+            Raising to {selected} may page on-call staff.
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isChanging}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color={willPage ? "warning" : "primary"}
+          disabled={!changed || isChanging}
+          loading={isChanging}
+          onClick={() => onChange(selected)}
+        >
+          Change severity
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -119,6 +119,21 @@ export default function CsmCaseCreatePage(): JSX.Element {
   const isCloudProject = isCloudSupportSubscription(
     selectedProject.data?.subscriptionType,
   );
+  // S0 is reserved for Managed Cloud — the highest severity is meant to page
+  // WSO2's own on-call for a subscription WSO2 directly operates, not one a
+  // customer only gets support for.
+  const isManagedCloud =
+    selectedProject.data?.subscriptionType === "managed_cloud_subscription";
+  // Clears a stale S0 pick if the project changes to a non-Managed-Cloud one
+  // after it was selected (the dropdown itself blocks picking it fresh, but
+  // can't stop an already-selected value from becoming invalid underneath).
+  // Adjusted during render (React's recommended pattern for this) rather
+  // than in an effect, which would call setState synchronously post-commit.
+  const [prevManagedCloud, setPrevManagedCloud] = useState(isManagedCloud);
+  if (isManagedCloud !== prevManagedCloud) {
+    setPrevManagedCloud(isManagedCloud);
+    if (severity === "S0" && !isManagedCloud) setSeverity("");
+  }
   const primaryProductionDeployments = useMemo(
     () => (deployments.data ?? []).filter((d) => d.type === "primary_production"),
     [deployments.data],
@@ -365,8 +380,9 @@ export default function CsmCaseCreatePage(): JSX.Element {
                 onChange={(e) => setSeverity(e.target.value as Severity)}
               >
                 {SEVERITIES.map((s) => (
-                  <MenuItem key={s} value={s}>
+                  <MenuItem key={s} value={s} disabled={s === "S0" && !isManagedCloud}>
                     {s} · {SEVERITY_LABEL[s]}
+                    {s === "S0" && !isManagedCloud ? " (Managed Cloud only)" : ""}
                   </MenuItem>
                 ))}
               </Select>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -129,8 +129,12 @@ export default function CsmCaseCreatePage(): JSX.Element {
   // can't stop an already-selected value from becoming invalid underneath).
   // Adjusted during render (React's recommended pattern for this) rather
   // than in an effect, which would call setState synchronously post-commit.
+  // Gated on the fetch having settled — while a new project's data is still
+  // loading, `selectedProject.data` (and so isManagedCloud) is transiently
+  // empty/false, which would otherwise wipe a valid S0 when moving between
+  // two Managed Cloud projects.
   const [prevManagedCloud, setPrevManagedCloud] = useState(isManagedCloud);
-  if (isManagedCloud !== prevManagedCloud) {
+  if (!selectedProject.isFetching && isManagedCloud !== prevManagedCloud) {
     setPrevManagedCloud(isManagedCloud);
     if (severity === "S0" && !isManagedCloud) setSeverity("");
   }

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1385,6 +1385,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
       {severityOpen && (
         <ChangeSeverityDialog
           currentSeverity={c.severity}
+          // S0 is reserved for Managed Cloud, same rule as case creation (see
+          // CsmCaseCreatePage.tsx) — caseProject is the same project fetch
+          // already used for the Customer card above.
+          isManagedCloud={caseProject?.subscriptionType === "managed_cloud_subscription"}
           isChanging={patchCase.isPending}
           onClose={() => setSeverityOpen(false)}
           onChange={onChangeSeverity}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -53,7 +53,8 @@ import {
   type MyOngoingCase,
 } from "@features/csm-cases/api/useFindMyOngoingCases";
 import type { BeCaseState } from "@api/backend/types";
-import { beStateFromUi } from "@api/backend/mappers";
+import { beStateFromUi, priorityFromSeverity } from "@api/backend/mappers";
+import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
 import { BackendApiError } from "@api/backend/client";
 import {
   useGetCsmCaseComments,
@@ -70,6 +71,7 @@ import {
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
 import AssignEngineerDialog from "@features/csm-cases/components/AssignEngineerDialog";
+import ChangeSeverityDialog from "@features/csm-cases/components/ChangeSeverityDialog";
 import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
 import { usePostCaseGithubIssue } from "@features/csm-cases/api/useCsmCaseGithubIssue";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
@@ -332,6 +334,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [metaCollapsed, setMetaCollapsed] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
+  const [severityOpen, setSeverityOpen] = useState(false);
   const [logTimeOpen, setLogTimeOpen] = useState(false);
   // One-shot: true to pop open the Call requests tab's "Create call request"
   // dialog from the action bar's "Request a call" item. The widget flips it
@@ -589,6 +592,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Change severity opens the severity picker; the PATCH happens in
+      // onChangeSeverity once a new value is confirmed.
+      if (action.secondary === "change_severity") {
+        setSeverityOpen(true);
+        return;
+      }
+
       // Pause / resume the work sub-state via PATCH { workState }. Only for an
       // in-progress case assigned to the current user. Pausing is a direct
       // single-field patch. Resuming sets this case `ongoing`, so it runs the
@@ -761,6 +771,26 @@ export default function CsmCaseDetailPage(): JSX.Element {
             });
           },
           onError: (err) => showError("Could not reassign the case.", err),
+        },
+      );
+    },
+    [patchCase, showError],
+  );
+
+  const onChangeSeverity = useCallback(
+    (next: Severity) => {
+      patchCase.mutate(
+        { severity: priorityFromSeverity(next) },
+        {
+          onSuccess: () => {
+            setSeverityOpen(false);
+            setFeedback({
+              message: `Severity changed to ${next}.`,
+              severity: "success",
+              sticky: true,
+            });
+          },
+          onError: (err) => showError("Could not change the severity.", err),
         },
       );
     },
@@ -1349,6 +1379,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
           isAssigning={patchCase.isPending}
           onClose={() => setAssignOpen(false)}
           onAssign={onAssign}
+        />
+      )}
+
+      {severityOpen && (
+        <ChangeSeverityDialog
+          currentSeverity={c.severity}
+          isChanging={patchCase.isPending}
+          onClose={() => setSeverityOpen(false)}
+          onChange={onChangeSeverity}
         />
       )}
 


### PR DESCRIPTION
## Purpose
There was no UI to change a case's severity after creation, even though the backend (`PATCH /cases/{id}`) and activity feed (`CaseAuditKind.severity_change`) already fully supported it.

## Goals
- Add a "Change severity" action to the case detail page.
- Restrict S0 severity to cases whose project is a Managed Cloud subscription, both at case creation and when changing severity — S0 is meant to page WSO2's own on-call for a subscription WSO2 directly operates, not one a customer only gets support for.

## Approach
- New `ChangeSeverityDialog` component, wired into `CaseActionBar`'s overflow menu (`change_severity`) and `CsmCaseDetailPage`. Disabled with a tooltip on closed cases.
- `CsmCaseCreatePage`'s severity picker disables the S0 option (labelled "Managed Cloud only") when the selected project isn't a Managed Cloud subscription; a stale S0 selection is cleared if the project changes underneath it.
- Same restriction applied inside `ChangeSeverityDialog` via an `isManagedCloud` prop derived from the case's project.

## User stories
- As a support engineer, I can change a case's severity from the case detail page.
- As a support engineer, I can't set S0 on a case unless its project is a Managed Cloud subscription, on both creation and severity change.

## Release note
Adds a "Change severity" action to case details; reserves S0 severity for Managed Cloud subscription projects.

## Documentation
N/A — internal case management UI, no external doc surface affected.

## Automation tests
- Unit tests: `ChangeSeverityDialog.test.tsx` (new), `CaseActionBar.test.tsx` (new gating tests) — `pnpm run test` passing (pre-existing, unrelated `CaseActionBar` nextStates-driven-buttons failures are untouched by this change).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint`, `pnpm run test`, `pnpm run build` all passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Change severity** option to case actions via an overflow menu.
  * Introduced a **Change severity** dialog to select a new severity, with loading, cancel, and disabled submit when no change is selected.
  * Added Managed Cloud–specific handling for **S0**: it’s available only when allowed.
* **Bug Fixes**
  * **Closed** cases now show the severity action as unavailable with a read-only tooltip and won’t trigger actions.
  * Prevents selecting or submitting invalid **S0** during case creation when not permitted.
* **Tests**
  * Added coverage for the dialog behavior and menu gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->