### PR TITLE
[CSM Portal Microapp] Support page: case list, case detail, and app shell

### DIFF
--- a/apps/csm-portal/microapp/package.json
+++ b/apps/csm-portal/microapp/package.json
@@ -19,9 +19,9 @@
     "@mui/lab": "7.0.1-beta.20",
     "@mui/material": "7.3.6",
     "@tanstack/react-query": "5.90.12",
-    "@wso2/oxygen-ui": "0.2.1",
-    "@wso2/oxygen-ui-charts-react": "0.4.0",
-    "@wso2/oxygen-ui-icons-react": "0.2.1",
+    "@wso2/oxygen-ui": "0.6.1",
+    "@wso2/oxygen-ui-charts-react": "0.6.1",
+    "@wso2/oxygen-ui-icons-react": "0.6.1",
     "axios": "1.13.2",
     "dayjs": "1.11.19",
     "dompurify": "3.4.0",
@@ -57,8 +57,5 @@
     "typescript-eslint": "8.46.4",
     "vite": "7.1.7",
     "vite-tsconfig-paths": "5.1.4"
-  },
-  "allowScripts": {
-    "esbuild@0.25.12": true
   }
 }

--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useLayoutEffect } from "react";
+import { HashRouter as Router, Route, Routes } from "react-router-dom";
+import MainLayout from "@components/layout/MainLayout";
+import { requestDeviceSafeAreaInsets } from "@components/microapp-bridge";
+import SupportPage from "@pages/SupportPage";
+import CaseDetailPage from "@pages/CaseDetailPage";
+
+export default function App() {
+  useLayoutEffect(() => {
+    requestDeviceSafeAreaInsets((data) => {
+      if (!data?.insets) return;
+
+      const { top, right, bottom, left } = data.insets;
+      const root = document.documentElement;
+      root.style.setProperty("--safe-top", `${top}px`);
+      root.style.setProperty("--safe-right", `${right}px`);
+      root.style.setProperty("--safe-bottom", `${bottom}px`);
+      root.style.setProperty("--safe-left", `${left}px`);
+    });
+  }, []);
+
+  return (
+    <Router>
+      <Routes>
+        <Route element={<MainLayout />}>
+          <Route path="/" element={<SupportPage />} />
+          <Route path="/cases/:id" element={<CaseDetailPage />} />
+        </Route>
+      </Routes>
+    </Router>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/common/ErrorBoundary.tsx
+++ b/apps/csm-portal/microapp/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// refer: https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+import * as React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback: React.ReactNode | ((error: unknown, resetErrorBoundary: () => void) => React.ReactNode);
+  onError?: (error: unknown) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: unknown;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo): void {
+    console.error(error, info.componentStack);
+    this.props.onError?.(error);
+  }
+
+  resetErrorBoundary = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): React.ReactNode {
+    const { hasError, error } = this.state;
+    const { fallback, children } = this.props;
+
+    if (hasError && error) {
+      if (typeof fallback === "function") {
+        return fallback(error, this.resetErrorBoundary);
+      }
+      return fallback;
+    }
+
+    return children;
+  }
+}

--- a/apps/csm-portal/microapp/src/components/layout/MainLayout.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/MainLayout.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box } from "@wso2/oxygen-ui";
+import { Outlet } from "react-router-dom";
+import { TabBar } from "./TabBar";
+
+export default function MainLayout() {
+  return (
+    <>
+      <Box component="main" p={2} pb={15}>
+        <Outlet />
+      </Box>
+      <TabBar />
+    </>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/layout/TabBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TabBar.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useLayoutEffect, useRef } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { BottomNavigation, BottomNavigationAction, Box } from "@wso2/oxygen-ui";
+import { Headset } from "@wso2/oxygen-ui-icons-react";
+
+export function TabBar() {
+  const ref = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+  const isSupportActive = location.pathname === "/" || location.pathname.startsWith("/cases/");
+
+  useLayoutEffect(() => {
+    if (!ref.current) return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      document.documentElement.style.setProperty("--tab-bar-height", `${entry.contentRect.height}px`);
+    });
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Box
+      ref={ref}
+      position="fixed"
+      bgcolor="background.paper"
+      bottom={0}
+      left={0}
+      right={0}
+      pt={1}
+      pb={4}
+      sx={{ borderTop: "1px solid", borderColor: "divider" }}
+    >
+      <BottomNavigation value={isSupportActive ? "support" : false} showLabels>
+        <BottomNavigationAction
+          component={Link}
+          to="/"
+          value="support"
+          label="Support"
+          icon={<Headset />}
+          disableRipple
+        />
+      </BottomNavigation>
+    </Box>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
+++ b/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
@@ -155,6 +155,7 @@ export const saveLocalData = (
     window.nativebridge.rejectSaveLocalData = (error: string) => failedToRespondCallback(error);
   } else {
     Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+    failedToRespondCallback(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
   }
 };
 
@@ -180,6 +181,7 @@ export const getLocalData = <T>(
     window.nativebridge.rejectGetLocalData = (error: string) => failedToRespondCallback(error);
   } else {
     Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+    failedToRespondCallback(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
   }
 };
 
@@ -265,5 +267,6 @@ export const getVersion = (callback: Callback<string>): void => {
     };
   } else {
     Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+    callback();
   }
 };

--- a/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
+++ b/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Logger } from "@utils/logger";
+import { ErrorMessages } from "@utils/constants";
+import { Topic, type EdgeInsets, type LogLevel, type TopicType } from "./types";
+
+type Callback<T> = (data?: T) => void;
+
+// Bridge event topics used for communication between the main app and micro apps.
+const TOPIC = {
+  TOKEN: "token",
+  QR_REQUEST: "qr_request",
+  SAVE_LOCAL_DATA: "save_local_data",
+  GET_LOCAL_DATA: "get_local_data",
+  ALERT: "alert",
+  CONFIRM_ALERT: "confirm_alert",
+  TOTP: "totp",
+  OPEN_URL: "open_url",
+  MICRO_APP_VERSION: "micro_app_version",
+};
+
+export interface BrowserConfiguration {
+  url: string;
+  presentationStyle: string;
+  dismissButtonStyle?: string;
+}
+
+declare global {
+  interface Window {
+    nativebridge?: {
+      requestToken: () => void;
+      resolveToken: (token: string) => void;
+      requestIdToken: () => void;
+      resolveIdToken: (token: string) => void;
+      resolveDeviceSafeAreaInsets?: (data: { insets: EdgeInsets }) => void;
+      resolveConfirmAlert: (action: string) => void;
+      resolveSaveLocalData: () => void;
+      rejectSaveLocalData: (error: string) => void;
+      resolveGetLocalData: (encodedData: { value?: string }) => void;
+      rejectGetLocalData: (error: string) => void;
+      resolveOpenUrl?: () => void;
+      rejectOpenUrl?: (error: string) => void;
+      requestMicroAppVersion: () => void;
+      resolveMicroAppVersion: (version: string) => void;
+      rejectMicroAppVersion: (error: string) => void;
+    };
+    ReactNativeWebView?: {
+      postMessage: (message: string) => void;
+    };
+  }
+}
+
+export const getAccessTokenFromBridge = (callback: Callback<string>): void => {
+  if (window.nativebridge) {
+    window.nativebridge.requestToken();
+    window.nativebridge.resolveToken = (token: string) => {
+      callback(token);
+    };
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+    callback();
+  }
+};
+
+// Function to get token from React Native
+export const getToken = (callback: Callback<string>): void => {
+  if (window.nativebridge) {
+    window.nativebridge.requestIdToken();
+    window.nativebridge.resolveIdToken = (token: string) => {
+      callback(token);
+    };
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+    callback();
+  }
+};
+
+// Function to show alert in React Native
+export const showAlert = (title: string, message: string, buttonText: string): void => {
+  if (window.nativebridge && window.ReactNativeWebView) {
+    const alertData = JSON.stringify({
+      topic: TOPIC.ALERT,
+      data: { title, message, buttonText },
+    });
+
+    window.ReactNativeWebView.postMessage(alertData);
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};
+
+// Function to show confirm alert in React Native
+export const showConfirmAlert = (
+  title: string,
+  message: string,
+  confirmButtonText: string,
+  cancelButtonText: string,
+  confirmCallback: () => void,
+  cancelCallback: () => void,
+): void => {
+  if (window.nativebridge && window.ReactNativeWebView) {
+    const confirmData = JSON.stringify({
+      topic: TOPIC.CONFIRM_ALERT,
+      data: { title, message, confirmButtonText, cancelButtonText },
+    });
+
+    window.ReactNativeWebView.postMessage(confirmData);
+
+    // Handling response from React Native side
+    window.nativebridge.resolveConfirmAlert = (action: string) => {
+      if (action === "confirm") {
+        confirmCallback();
+      } else if (action === "cancel") {
+        cancelCallback();
+      }
+    };
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};
+
+// Save Local Data
+export const saveLocalData = (
+  key: string,
+  value: unknown,
+  callback: () => void,
+  failedToRespondCallback: (error: string) => void,
+): void => {
+  key = key.toString().replace(" ", "-").toLowerCase();
+  const encodedValue = btoa(JSON.stringify(value));
+
+  if (window.nativebridge && window.ReactNativeWebView) {
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        topic: TOPIC.SAVE_LOCAL_DATA,
+        data: { key, value: encodedValue },
+      }),
+    );
+
+    window.nativebridge.resolveSaveLocalData = callback;
+    window.nativebridge.rejectSaveLocalData = (error: string) => failedToRespondCallback(error);
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};
+
+// Get Local Data
+export const getLocalData = <T>(
+  key: string,
+  callback: (data: T | null) => void,
+  failedToRespondCallback: (error: string) => void,
+): void => {
+  key = key.toString().replace(" ", "-").toLowerCase();
+
+  if (window.nativebridge && window.ReactNativeWebView) {
+    window.ReactNativeWebView.postMessage(JSON.stringify({ topic: TOPIC.GET_LOCAL_DATA, data: { key } }));
+
+    window.nativebridge.resolveGetLocalData = (encodedData: { value?: string }) => {
+      if (!encodedData.value) {
+        callback(null);
+      } else {
+        callback(JSON.parse(atob(encodedData.value)) as T);
+      }
+    };
+
+    window.nativebridge.rejectGetLocalData = (error: string) => failedToRespondCallback(error);
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};
+
+/**
+ * Trigger an action in the super app
+ * @param topic - The topic to trigger
+ * @param data - The data to send
+ */
+const triggerSuperAppAction = (topic: TopicType, data?: unknown): void => {
+  if (window.ReactNativeWebView) {
+    const messageData = JSON.stringify({
+      topic,
+      data,
+    });
+    window.ReactNativeWebView.postMessage(messageData);
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};
+
+/**
+ * Send a log message to the native side
+ * @param message - The message to send
+ * @param data - The data to send
+ * @param level - The level of the log
+ */
+export const sendNativeLog = (message?: string, data?: unknown, level: LogLevel = "debug"): void => {
+  if (window.nativebridge && window.ReactNativeWebView) {
+    triggerSuperAppAction(Topic.nativeLog, {
+      message,
+      data,
+      level,
+    });
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};
+
+/**
+ * Send a request to the native app to navigate back to the previous screen. I.e., close the webview.
+ */
+export const goToMyAppsScreen = (): void => {
+  if (window.nativebridge) {
+    triggerSuperAppAction(Topic.navigateToMyApps);
+  }
+};
+
+/**
+ * Request the device safe area insets from the native app
+ * @param callback - The callback to receive the device safe area insets
+ */
+export const requestDeviceSafeAreaInsets = (callback: Callback<{ insets: EdgeInsets }>): void => {
+  if (window.nativebridge) {
+    triggerSuperAppAction(Topic.deviceSafeAreaInsets);
+    window.nativebridge.resolveDeviceSafeAreaInsets = (data) => {
+      callback(data);
+    };
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE + " to fetch device safe area insets");
+    callback();
+  }
+};
+
+// Open URL in Browser
+export const openUrl = (config: BrowserConfiguration): void => {
+  if (window.nativebridge && window.ReactNativeWebView) {
+    const alertData = JSON.stringify({
+      topic: TOPIC.OPEN_URL,
+      data: { config },
+    });
+
+    window.ReactNativeWebView.postMessage(alertData);
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};
+
+export const getVersion = (callback: Callback<string>): void => {
+  if (window.nativebridge) {
+    triggerSuperAppAction(Topic.version);
+    window.nativebridge.resolveMicroAppVersion = (version) => {
+      callback(version);
+    };
+  } else {
+    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+  }
+};

--- a/apps/csm-portal/microapp/src/components/microapp-bridge/types.ts
+++ b/apps/csm-portal/microapp/src/components/microapp-bridge/types.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export const Topic = {
+  token: "token",
+  nativeLog: "native_log",
+  navigateToMyApps: "close_webview",
+  saveLocalData: "save_local_data",
+  getLocalData: "get_local_data",
+  deviceSafeAreaInsets: "device_safe_area_insets",
+  deleteLocalData: "delete_local_data",
+  openUrl: "open_url",
+  scheduleLocalNotification: "scheduling_local_notification",
+  cancelLocalNotification: "cancelling_local_notification",
+  clearAllLocalNotifications: "clearing_all_local_notifications",
+  qrRequest: "qr_request",
+  version: "micro_app_version",
+} as const;
+
+export type TopicType = (typeof Topic)[keyof typeof Topic];
+
+export type LogLevel = "error" | "warn" | "info" | "debug";
+
+export interface EdgeInsets {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}

--- a/apps/csm-portal/microapp/src/components/support/CaseCard.tsx
+++ b/apps/csm-portal/microapp/src/components/support/CaseCard.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Card, Skeleton, Stack, Typography, pxToRem, useTheme } from "@wso2/oxygen-ui";
+import { ChevronRight, Clock4 } from "@wso2/oxygen-ui-icons-react";
+import { Link } from "react-router-dom";
+import type { CaseSummary } from "@src/types";
+import { fromNow } from "@utils/dateTime";
+import { SeverityChip, StatusChip } from "./Chips";
+import { TYPE_CONFIG } from "./config";
+
+export function CaseCard({ item }: { item: CaseSummary }) {
+  const theme = useTheme();
+  const { icon: Icon, color } = TYPE_CONFIG[item.type] ?? TYPE_CONFIG.case;
+
+  return (
+    <Card component={Link} to={`/cases/${item.id}`} sx={{ textDecoration: "none", p: 1.5, display: "block" }}>
+      <Stack gap={0.75}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Icon size={pxToRem(16)} color={color} />
+            <Typography variant="subtitle2" color="text.secondary">
+              {item.number}
+            </Typography>
+          </Stack>
+          <ChevronRight size={pxToRem(18)} color={theme.palette.text.secondary} />
+        </Stack>
+
+        <Typography variant="body1" color="text.primary" noWrap>
+          {item.subject}
+        </Typography>
+
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+          <StatusChip state={item.state} />
+          <SeverityChip severity={item.severity} />
+        </Stack>
+
+        <Stack direction="row" justifyContent="space-between" alignItems="center" mt={0.5}>
+          <Stack direction="row" alignItems="center" gap={0.5}>
+            <Clock4 size={pxToRem(13)} color={theme.palette.text.secondary} />
+            <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: pxToRem(12) }}>
+              Updated {fromNow(item.updatedOn)}
+            </Typography>
+          </Stack>
+          <Typography variant="subtitle2" color="text.secondary" noWrap>
+            {item.assignedEngineer?.name ?? "Unassigned"}
+          </Typography>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}
+
+export function CaseCardSkeleton() {
+  return (
+    <Card sx={{ p: 1.5 }}>
+      <Stack gap={0.75}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Skeleton variant="circular" width={pxToRem(16)} height={pxToRem(16)} />
+            <Skeleton variant="text" width={60} height={20} />
+          </Stack>
+          <Skeleton variant="circular" width={pxToRem(18)} height={pxToRem(18)} />
+        </Stack>
+
+        <Skeleton variant="text" width="80%" height={26} />
+
+        <Stack direction="row" gap={1}>
+          <Skeleton variant="rounded" width={70} height={24} sx={{ borderRadius: 1 }} />
+          <Skeleton variant="rounded" width={70} height={24} sx={{ borderRadius: 1 }} />
+        </Stack>
+
+        <Stack direction="row" justifyContent="space-between" mt={0.5}>
+          <Skeleton variant="text" width={100} height={18} />
+          <Skeleton variant="text" width={80} height={18} />
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/Chips.tsx
+++ b/apps/csm-portal/microapp/src/components/support/Chips.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { alpha, Chip, type ChipProps } from "@wso2/oxygen-ui";
+import type { CaseSeverity, CaseState } from "@src/types";
+import { SEVERITY_CHIP_COLOR_CONFIG, SEVERITY_LABELS, STATE_CHIP_COLOR_CONFIG, STATE_LABELS } from "./config";
+
+function ColoredChip({
+  color,
+  label,
+  ...props
+}: Omit<ChipProps, "label" | "color"> & { color: NonNullable<ChipProps["color"]>; label: string }) {
+  return (
+    <Chip
+      label={label}
+      size="small"
+      {...props}
+      sx={
+        color !== "default"
+          ? (theme) => ({ bgcolor: alpha(theme.palette[color].light, 0.1), color: theme.palette[color].light })
+          : undefined
+      }
+    />
+  );
+}
+
+export function StatusChip({ state, ...props }: { state: CaseState } & Omit<ChipProps, "label" | "color">) {
+  return (
+    <ColoredChip color={STATE_CHIP_COLOR_CONFIG[state] ?? "default"} label={STATE_LABELS[state] ?? state} {...props} />
+  );
+}
+
+export function SeverityChip({ severity, ...props }: { severity: CaseSeverity } & Omit<ChipProps, "label" | "color">) {
+  return (
+    <ColoredChip
+      color={SEVERITY_CHIP_COLOR_CONFIG[severity] ?? "default"}
+      label={SEVERITY_LABELS[severity] ?? severity}
+      {...props}
+    />
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/EmptyState.tsx
+++ b/apps/csm-portal/microapp/src/components/support/EmptyState.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Stack, Typography } from "@wso2/oxygen-ui";
+import { Inbox } from "@wso2/oxygen-ui-icons-react";
+
+export function EmptyState({ message = "Nothing to show here." }: { message?: string }) {
+  return (
+    <Stack alignItems="center" justifyContent="center" gap={1} py={4}>
+      <Inbox size={28} color="currentColor" />
+      <Typography variant="body2" color="text.secondary">
+        {message}
+      </Typography>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/ErrorState.tsx
+++ b/apps/csm-portal/microapp/src/components/support/ErrorState.tsx
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Button, Stack, Typography } from "@wso2/oxygen-ui";
+import { TriangleAlert } from "@wso2/oxygen-ui-icons-react";
+
+export function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Stack alignItems="center" justifyContent="center" gap={1.5} py={4}>
+      <TriangleAlert size={28} color="currentColor" />
+      <Typography variant="body2" color="text.secondary">
+        Something went wrong. Please try again.
+      </Typography>
+      <Button variant="outlined" size="small" onClick={onRetry}>
+        Retry
+      </Button>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/config.tsx
+++ b/apps/csm-portal/microapp/src/components/support/config.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { colors, type ChipProps } from "@wso2/oxygen-ui";
+import { Briefcase, Megaphone, OctagonAlert, Settings, Shield, type LucideIcon } from "@wso2/oxygen-ui-icons-react";
+import type { CaseSeverity, CaseState, CaseType } from "@src/types";
+
+export const TABS: CaseType[] = ["case", "service_request", "security_report_analysis", "engagement", "announcement"];
+
+export const TYPE_CONFIG: Record<CaseType, { icon: LucideIcon; color: string }> = {
+  case: { icon: OctagonAlert, color: colors.red[500] },
+  service_request: { icon: Settings, color: colors.purple[500] },
+  security_report_analysis: { icon: Shield, color: colors.orange[500] },
+  engagement: { icon: Briefcase, color: colors.grey[600] },
+  announcement: { icon: Megaphone, color: colors.blue[500] },
+};
+
+export const TAB_CONFIG: Record<CaseType, { title: string; subtitle: string; emptyMessage: string }> = {
+  case: {
+    title: "Cases",
+    subtitle: "Standard support cases",
+    emptyMessage: "No cases found.",
+  },
+  service_request: {
+    title: "Service Requests",
+    subtitle: "Catalog-based service requests",
+    emptyMessage: "No service requests found.",
+  },
+  security_report_analysis: {
+    title: "Security Reports",
+    subtitle: "Security report analyses",
+    emptyMessage: "No security report analyses found.",
+  },
+  engagement: {
+    title: "Engagements",
+    subtitle: "Ongoing engagements",
+    emptyMessage: "No engagements found.",
+  },
+  announcement: {
+    title: "Announcements",
+    subtitle: "Broadcast announcements",
+    emptyMessage: "No announcements found.",
+  },
+};
+
+export const STATE_LABELS: Record<CaseState, string> = {
+  open: "Open",
+  work_in_progress: "In Progress",
+  waiting_on_wso2: "Waiting on WSO2",
+  awaiting_info: "Awaiting Info",
+  reopened: "Reopened",
+  solution_proposed: "Solution Proposed",
+  closed: "Closed",
+};
+
+export const STATE_CHIP_COLOR_CONFIG: Record<CaseState, NonNullable<ChipProps["color"]>> = {
+  open: "info",
+  work_in_progress: "primary",
+  waiting_on_wso2: "warning",
+  awaiting_info: "warning",
+  reopened: "error",
+  solution_proposed: "success",
+  closed: "default",
+};
+
+export const SEVERITY_LABELS: Record<CaseSeverity, string> = {
+  catastrophic: "Catastrophic (S0)",
+  critical: "Critical (S1)",
+  high: "High (S2)",
+  medium: "Medium (S3)",
+  low: "Low (S4)",
+};
+
+export const SEVERITY_CHIP_COLOR_CONFIG: Record<CaseSeverity, NonNullable<ChipProps["color"]>> = {
+  catastrophic: "error",
+  critical: "error",
+  high: "warning",
+  medium: "info",
+  low: "default",
+};

--- a/apps/csm-portal/microapp/src/config/config.ts
+++ b/apps/csm-portal/microapp/src/config/config.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+declare global {
+  interface Window {
+    config: {
+      CLIENT_ID: string;
+      SIGN_IN_REDIRECT_URL: string;
+      SIGN_OUT_REDIRECT_URL: string;
+      ASGARDEO_BASE_URL: string;
+      IS_MICROAPP: boolean;
+      BACKEND_BASE_URL: string;
+    };
+  }
+}
+
+export const CLIENT_ID = window.config.CLIENT_ID;
+export const SIGN_IN_REDIRECT_URL = window.config.SIGN_IN_REDIRECT_URL;
+export const SIGN_OUT_REDIRECT_URL = window.config.SIGN_OUT_REDIRECT_URL;
+export const ASGARDEO_BASE_URL = window.config.ASGARDEO_BASE_URL;
+export const IS_MICROAPP = window.config.IS_MICROAPP;
+
+// TODO: Uncomment and update the `baseUrl` variable when the backend URL configuration is available and in use.
+// const baseUrl = window.config.BACKEND_BASE_URL;
+
+export const serviceUrls = {
+  serviceUrls: {
+    // TODO: Add service URLs here as needed for future implementation.
+  },
+};

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -5,3 +5,7 @@ if (!BACKEND_URL) {
 }
 
 export const USERS_ME_ENDPOINT = "/users/me";
+
+export const CASES_SEARCH_ENDPOINT = "/cases/search";
+export const CASE_DETAILS_ENDPOINT = (id: string) => `/cases/${id}`;
+export const CASE_COMMENTS_SEARCH_ENDPOINT = (id: string) => `/cases/${id}/comments/search`;

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -1,3 +1,19 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
 if (!BACKEND_URL) {

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -1,0 +1,7 @@
+export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+
+if (!BACKEND_URL) {
+  throw new Error("VITE_BACKEND_URL is not defined");
+}
+
+export const USERS_ME_ENDPOINT = "/users/me";

--- a/apps/csm-portal/microapp/src/index.css
+++ b/apps/csm-portal/microapp/src/index.css
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
 
 WSO2 LLC. licenses this file to you under the Apache License,

--- a/apps/csm-portal/microapp/src/index.css
+++ b/apps/csm-portal/microapp/src/index.css
@@ -1,4 +1,4 @@
-/*
+/* 
 Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
 
 WSO2 LLC. licenses this file to you under the Apache License,
@@ -13,5 +13,39 @@ software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
-under the License.
+under the License. 
 */
+
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap");
+
+* {
+  font-family: "Plus Jakarta Sans", sans-serif;
+  font-optical-sizing: auto;
+}
+
+html {
+  font-size: 15px; /* base font size */
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  overscroll-behavior: none;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+body::-webkit-scrollbar {
+  display: none;
+}
+
+@keyframes gentlePulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.8; }
+}
+
+@keyframes stepIn {
+  from { opacity: 0; transform: translateX(-6px); }
+  to   { opacity: 1; transform: translateX(0); }
+}

--- a/apps/csm-portal/microapp/src/index.css
+++ b/apps/csm-portal/microapp/src/index.css
@@ -13,7 +13,7 @@ software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
-under the License. 
+under the License.
 */
 
 @import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap");

--- a/apps/csm-portal/microapp/src/main.tsx
+++ b/apps/csm-portal/microapp/src/main.tsx
@@ -14,14 +14,38 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import React from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { OxygenUIThemeProvider } from "@wso2/oxygen-ui";
+import axios from "axios";
+import App from "@src/App";
+import theme from "./theme";
+import "@src/index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) => {
+        if (axios.isAxiosError(error)) {
+          const status = error.response?.status;
+          if (status && status >= 400 && status < 500) return false;
+        }
+        return failureCount < 3;
+      },
+    },
+  },
+});
 
 const container = document.getElementById("root");
-if (!container) throw new Error("'Root container missing'");
-const root = createRoot(container);
-root.render(
-  <React.StrictMode>
-    <div>CSM Microapp</div>
-  </React.StrictMode>,
+if (!container) throw new Error("Root container missing");
+
+createRoot(container).render(
+  <StrictMode>
+    <OxygenUIThemeProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </OxygenUIThemeProvider>
+  </StrictMode>,
 );

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Suspense, type ReactNode } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Divider, IconButton, Skeleton, Stack, Typography, pxToRem } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { cases } from "@src/services/cases";
+import type { CaseDetail, Comment } from "@src/types";
+import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { SeverityChip, StatusChip } from "@components/support/Chips";
+import { ErrorState } from "@components/support/ErrorState";
+import { TYPE_CONFIG } from "@components/support/config";
+import { formatDate } from "@utils/dateTime";
+
+export default function CaseDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  return (
+    <Stack gap={2}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <IconButton onClick={() => navigate(-1)} size="small" aria-label="Go back">
+          <ArrowLeft size={pxToRem(20)} />
+        </IconButton>
+        <Typography variant="h6">Case Details</Typography>
+      </Stack>
+
+      <CaseDetailErrorBoundary>
+        <Suspense fallback={<CaseDetailSkeleton />}>
+          <CaseDetailContent id={id ?? ""} />
+        </Suspense>
+      </CaseDetailErrorBoundary>
+    </Stack>
+  );
+}
+
+function CaseDetailContent({ id }: { id: string }) {
+  const { data: caseDetail } = useSuspenseQuery(cases.get(id));
+  const { data: comments } = useSuspenseQuery(cases.comments(id));
+
+  return (
+    <Stack gap={2}>
+      <CaseSummarySection caseDetail={caseDetail} />
+      <Divider />
+      <CaseMetadataSection caseDetail={caseDetail} />
+      <Divider />
+      <CaseCommentsSection comments={comments} />
+    </Stack>
+  );
+}
+
+function CaseSummarySection({ caseDetail }: { caseDetail: CaseDetail }) {
+  const { icon: Icon, color } = TYPE_CONFIG[caseDetail.type ?? "case"] ?? TYPE_CONFIG.case;
+
+  return (
+    <Stack gap={1}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <Icon size={pxToRem(18)} color={color} />
+        <Typography variant="subtitle2" color="text.secondary">
+          {caseDetail.number}
+          {caseDetail.wso2Id ? ` · ${caseDetail.wso2Id}` : ""}
+        </Typography>
+      </Stack>
+
+      <Typography variant="h6">{caseDetail.subject}</Typography>
+
+      <Stack direction="row" gap={1} flexWrap="wrap">
+        <StatusChip state={caseDetail.state} />
+        <SeverityChip severity={caseDetail.severity} />
+      </Stack>
+
+      <Typography variant="body1" color="text.primary" sx={{ whiteSpace: "pre-wrap" }}>
+        {caseDetail.description}
+      </Typography>
+    </Stack>
+  );
+}
+
+function CaseMetadataSection({ caseDetail }: { caseDetail: CaseDetail }) {
+  return (
+    <Stack gap={1}>
+      <DetailRow label="Project" value={caseDetail.project?.name} />
+      <DetailRow label="Deployment" value={caseDetail.deployment?.name} />
+      <DetailRow label="Product" value={caseDetail.product?.name} />
+      <DetailRow label="Account" value={caseDetail.account?.name} />
+      <DetailRow label="Assigned Engineer" value={caseDetail.assignedEngineer?.name} />
+      <DetailRow label="Created By" value={caseDetail.createdBy?.displayName || caseDetail.createdBy?.email} />
+      <DetailRow label="Created On" value={formatDate(caseDetail.createdOn)} />
+      <DetailRow label="Updated On" value={formatDate(caseDetail.updatedOn)} />
+      {caseDetail.closedOn && <DetailRow label="Closed On" value={formatDate(caseDetail.closedOn)} />}
+    </Stack>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+
+  return (
+    <Stack direction="row" justifyContent="space-between" gap={2}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.primary" textAlign="right">
+        {value}
+      </Typography>
+    </Stack>
+  );
+}
+
+function CaseCommentsSection({ comments }: { comments: Comment[] }) {
+  return (
+    <Stack gap={1.5}>
+      <Typography variant="h6">Comments</Typography>
+
+      {comments.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          No comments yet.
+        </Typography>
+      )}
+
+      {comments.map((comment) => (
+        <Stack key={comment.id} gap={0.5} sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+          <Stack direction="row" justifyContent="space-between" gap={2}>
+            <Typography variant="subtitle2" color="text.secondary" noWrap>
+              {comment.createdBy}
+            </Typography>
+            <Typography variant="subtitle2" color="text.secondary" noWrap>
+              {formatDate(comment.createdOn)}
+            </Typography>
+          </Stack>
+          <Typography variant="body2" color="text.primary" sx={{ whiteSpace: "pre-wrap" }}>
+            {comment.content}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+function CaseDetailSkeleton() {
+  return (
+    <Stack gap={2}>
+      <Skeleton variant="text" width="40%" height={24} />
+      <Skeleton variant="text" width="80%" height={32} />
+      <Skeleton variant="rounded" height={100} />
+      <Skeleton variant="rounded" height={150} />
+    </Stack>
+  );
+}
+
+function CaseDetailErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SupportPage.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Suspense, useState, type ReactNode } from "react";
+import { useSearchParams } from "react-router-dom";
+import { Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { cases } from "@src/services/cases";
+import type { CaseType } from "@src/types";
+import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { TABS, TAB_CONFIG } from "@components/support/config";
+
+export default function SupportPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabFromParams = TABS.find((t) => t === searchParams.get("tab")) ?? "case";
+  const [tab, setTab] = useState<CaseType>(tabFromParams);
+
+  const handleTabChange = (value: CaseType) => {
+    setTab(value);
+    setSearchParams(
+      (prev) => {
+        prev.set("tab", value);
+        return prev;
+      },
+      { replace: true },
+    );
+  };
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="h5">Support</Typography>
+
+      <Tabs variant="scrollable" value={tab} onChange={(_, value) => handleTabChange(value)}>
+        {TABS.map((t) => (
+          <Tab key={t} label={TAB_CONFIG[t].title} value={t} disableRipple />
+        ))}
+      </Tabs>
+
+      <CaseListErrorBoundary>
+        <Suspense fallback={<CaseListSkeleton />}>
+          <CaseListContent type={tab} />
+        </Suspense>
+      </CaseListErrorBoundary>
+    </Stack>
+  );
+}
+
+function CaseListContent({ type }: { type: CaseType }) {
+  const { data } = useSuspenseQuery(
+    cases.all({
+      filters: { types: [type] },
+      sortBy: { field: "updatedOn", order: "desc" },
+      pagination: { limit: 20 },
+    }),
+  );
+
+  if (data.items.length === 0) return <EmptyState message={TAB_CONFIG[type].emptyMessage} />;
+
+  return (
+    <Stack gap={1.5}>
+      {data.items.map((item) => (
+        <CaseCard key={item.id} item={item} />
+      ))}
+    </Stack>
+  );
+}
+
+function CaseListSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <CaseCardSkeleton key={index} />
+      ))}
+    </Stack>
+  );
+}
+
+function CaseListErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SupportPage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Suspense, useState, type ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import { useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
@@ -28,11 +28,11 @@ import { TABS, TAB_CONFIG } from "@components/support/config";
 
 export default function SupportPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const tabFromParams = TABS.find((t) => t === searchParams.get("tab")) ?? "case";
-  const [tab, setTab] = useState<CaseType>(tabFromParams);
+  // Derived directly from the URL (not local state) so browser back/forward navigation that
+  // changes ?tab= is reflected immediately, instead of showing a stale tab.
+  const tab = TABS.find((t) => t === searchParams.get("tab")) ?? "case";
 
   const handleTabChange = (value: CaseType) => {
-    setTab(value);
     setSearchParams(
       (prev) => {
         prev.set("tab", value);

--- a/apps/csm-portal/microapp/src/services/apiClient.ts
+++ b/apps/csm-portal/microapp/src/services/apiClient.ts
@@ -16,7 +16,7 @@
 
 import axios, { type InternalAxiosRequestConfig } from "axios";
 import { Logger } from "@utils/logger";
-import { refreshToken } from "./auth";
+import { getAccessToken, refreshToken } from "./auth";
 import { BACKEND_URL } from "@config/endpoints";
 
 // Variables/constants
@@ -57,18 +57,13 @@ apiClient.interceptors.request.use(
     }
 
     try {
-      const token = await refreshTokenPromise;
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
-        config.headers["x-user-id-token"] = token;
+      const idToken = await refreshTokenPromise;
+      const accessToken = getAccessToken();
+      if (idToken && accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+        config.headers["x-user-id-token"] = idToken;
         config.headers["Content-Type"] = "application/json";
         config.headers["X-CSM-Correlation-ID"] = crypto.randomUUID();
-
-        // NOTE: This header is intended for local development testing only.
-        // This manually injects the JWT assertion header and must remain disabled in production.
-        // if (import.meta.env.DEV) {
-        //   config.headers["x-jwt-assertion"] = token;
-        // }
       } else {
         Logger.warn("No token available for request");
       }
@@ -150,7 +145,8 @@ apiClient.interceptors.response.use(
 
       try {
         Logger.info("Attempting to refresh access token");
-        const newAccessToken = await refreshToken();
+        await refreshToken();
+        const newAccessToken = getAccessToken();
         apiClient.defaults.headers.common["Authorization"] = `Bearer ${newAccessToken}`;
         originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
         processQueue(null, newAccessToken);

--- a/apps/csm-portal/microapp/src/services/apiClient.ts
+++ b/apps/csm-portal/microapp/src/services/apiClient.ts
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import axios, { type InternalAxiosRequestConfig } from "axios";
+import { Logger } from "@utils/logger";
+import { refreshToken } from "./auth";
+import { BACKEND_URL } from "@config/endpoints";
+
+// Variables/constants
+let isRefreshing = false;
+let failedQueue: {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+}[] = [];
+
+// Holds the refresh token promise
+let refreshTokenPromise: Promise<string | null> | null = null;
+
+// axios instance
+const apiClient = axios.create({
+  baseURL: BACKEND_URL,
+});
+
+/**
+ * Request Interceptor
+ */
+apiClient.interceptors.request.use(
+  async (config: InternalAxiosRequestConfig) => {
+    // Log the outgoing request
+    Logger.info(`Making ${config.method?.toUpperCase()} request to: ${config.baseURL || ""}${config.url || ""}`, {
+      url: config.url,
+      method: config.method,
+      baseURL: config.baseURL,
+      fullURL: `${config.baseURL || ""}${config.url || ""}`,
+      headers: config.headers,
+    });
+
+    // Use a singleton promise for token refresh
+    if (!refreshTokenPromise) {
+      refreshTokenPromise = refreshToken().finally(() => {
+        // Reset the promise once it's resolved or rejected
+        refreshTokenPromise = null;
+      });
+    }
+
+    try {
+      const token = await refreshTokenPromise;
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+        config.headers["x-user-id-token"] = token;
+        config.headers["Content-Type"] = "application/json";
+        config.headers["X-CSM-Correlation-ID"] = crypto.randomUUID();
+
+        // NOTE: This header is intended for local development testing only.
+        // This manually injects the JWT assertion header and must remain disabled in production.
+        // if (import.meta.env.DEV) {
+        //   config.headers["x-jwt-assertion"] = token;
+        // }
+      } else {
+        Logger.warn("No token available for request");
+      }
+    } catch (error) {
+      Logger.error("Failed to get token for request", error);
+      return Promise.reject(error);
+    }
+
+    return config;
+  },
+  (error) => {
+    Logger.error("Request interceptor error", error);
+    return Promise.reject(error);
+  },
+);
+
+/**
+ * Response Interceptor
+ */
+const processQueue = (error: unknown, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+
+  failedQueue = [];
+};
+
+apiClient.interceptors.response.use(
+  (response) => {
+    // Any status code within the range of 2xx causes this function to trigger
+    Logger.info(`Successful response from ${response.config.method?.toUpperCase()} ${response.config.url}`, {
+      status: response.status,
+      statusText: response.statusText,
+      url: response.config.url,
+      data: {
+        ...response.data,
+        dataSize: response.data ? JSON.stringify(response.data).length : 0,
+      },
+    });
+    return response;
+  },
+  async (error) => {
+    if (axios.isCancel(error)) {
+      return Promise.reject(error);
+    }
+    Logger.error(`API request failed`, {
+      status: error.response?.status,
+      statusText: error.response?.statusText,
+      url: error.config?.url,
+      method: error.config?.method,
+      message: error.message,
+    });
+
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      Logger.warn("Received 401 unauthorized, attempting token refresh");
+
+      if (isRefreshing) {
+        Logger.info("Token refresh already in progress, queuing request");
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers["Authorization"] = "Bearer " + token;
+            return apiClient(originalRequest);
+          })
+          .catch((err) => {
+            return Promise.reject(err);
+          });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        Logger.info("Attempting to refresh access token");
+        const newAccessToken = await refreshToken();
+        apiClient.defaults.headers.common["Authorization"] = `Bearer ${newAccessToken}`;
+        originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+        processQueue(null, newAccessToken);
+        Logger.info("Token refresh successful, retrying original request");
+        return apiClient(originalRequest);
+      } catch (refreshError) {
+        Logger.error("Token refresh failed", refreshError);
+        processQueue(refreshError, null);
+        console.error("Token refresh failed:", refreshError);
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default apiClient;

--- a/apps/csm-portal/microapp/src/services/apiClient.ts
+++ b/apps/csm-portal/microapp/src/services/apiClient.ts
@@ -14,10 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import axios, { type InternalAxiosRequestConfig } from "axios";
+import axios, { type AxiosError, type InternalAxiosRequestConfig } from "axios";
 import { Logger } from "@utils/logger";
 import { getAccessToken, refreshToken } from "./auth";
 import { BACKEND_URL } from "@config/endpoints";
+
+interface RetryableRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
 
 // Variables/constants
 let isRefreshing = false;
@@ -39,13 +43,14 @@ const apiClient = axios.create({
  */
 apiClient.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
-    // Log the outgoing request
+    // Log the outgoing request. Deliberately omits config.headers — on a retried request
+    // (see the 401 handler below) it already carries the prior Authorization/x-user-id-token
+    // values at this point, and this log forwards to the native bridge via sendNativeLog.
     Logger.info(`Making ${config.method?.toUpperCase()} request to: ${config.baseURL || ""}${config.url || ""}`, {
       url: config.url,
       method: config.method,
       baseURL: config.baseURL,
       fullURL: `${config.baseURL || ""}${config.url || ""}`,
-      headers: config.headers,
     });
 
     // Use a singleton promise for token refresh
@@ -97,19 +102,18 @@ const processQueue = (error: unknown, token: string | null = null) => {
 
 apiClient.interceptors.response.use(
   (response) => {
-    // Any status code within the range of 2xx causes this function to trigger
+    // Any status code within the range of 2xx causes this function to trigger. Logs only the
+    // response's size, not its content — response bodies here can carry user PII (email, phone)
+    // and case content, and this log forwards to the native bridge via sendNativeLog.
     Logger.info(`Successful response from ${response.config.method?.toUpperCase()} ${response.config.url}`, {
       status: response.status,
       statusText: response.statusText,
       url: response.config.url,
-      data: {
-        ...response.data,
-        dataSize: response.data ? JSON.stringify(response.data).length : 0,
-      },
+      dataSize: response.data ? JSON.stringify(response.data).length : 0,
     });
     return response;
   },
-  async (error) => {
+  async (error: AxiosError) => {
     if (axios.isCancel(error)) {
       return Promise.reject(error);
     }
@@ -121,7 +125,12 @@ apiClient.interceptors.response.use(
       message: error.message,
     });
 
-    const originalRequest = error.config;
+    // error.config can be undefined for some Axios errors (e.g. ones raised before a request
+    // config is fully attached), and the 401-retry logic below needs a config to retry against.
+    const originalRequest = error.config as RetryableRequestConfig | undefined;
+    if (!originalRequest) {
+      return Promise.reject(error);
+    }
 
     if (error.response?.status === 401 && !originalRequest._retry) {
       Logger.warn("Received 401 unauthorized, attempting token refresh");

--- a/apps/csm-portal/microapp/src/services/auth.ts
+++ b/apps/csm-portal/microapp/src/services/auth.ts
@@ -15,6 +15,7 @@
 // under the License.
 
 import { jwtDecode } from "jwt-decode";
+
 import { getAccessTokenFromBridge, getToken } from "@components/microapp-bridge";
 import { LocalStorageKeys } from "@utils/constants";
 import { Logger } from "@utils/logger";

--- a/apps/csm-portal/microapp/src/services/auth.ts
+++ b/apps/csm-portal/microapp/src/services/auth.ts
@@ -36,12 +36,36 @@ export const setAccessToken = (token: string): void => localStorage.setItem(Loca
 export const getIdToken = (): string | null => localStorage.getItem(LocalStorageKeys.idToken);
 export const setIdToken = (token: string): void => localStorage.setItem(LocalStorageKeys.idToken, token);
 
+// Refresh early rather than right at expiry, to cover in-flight request latency.
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+// apiClient calls refreshToken() on every request; without this check that means a native-bridge
+// round trip (plus a full user-store re-init) per request even when the current token is still
+// valid for a while. Treat undecodable/expired-soon tokens as needing refresh, same as a missing
+// token, so this fails toward refreshing rather than toward silently reusing a stale token.
+function isTokenExpiringSoon(token: string | null): boolean {
+  if (!token) return true;
+  try {
+    const { exp } = jwtDecode<{ exp?: number }>(token);
+    if (!exp) return true;
+    return exp * 1000 - Date.now() < TOKEN_EXPIRY_BUFFER_MS;
+  } catch {
+    return true;
+  }
+}
+
 /**
  * A function to refresh the token.
  * This is a simplified version of the logic in the original `handleRequestWithNewToken`.
- * It fetches a new token and updates it in storage.
+ * Skips the native-bridge round trip when the current ID token is still valid for a while,
+ * and only fetches a new token and updates storage when it's missing or near-expiry.
  */
 export const refreshToken = (): Promise<string> => {
+  const currentIdToken = getIdToken();
+  if (!isTokenExpiringSoon(currentIdToken)) {
+    return Promise.resolve(currentIdToken as string);
+  }
+
   const idTokenPromise = new Promise<string>((resolve, reject) => {
     getToken((token) => (token ? resolve(token) : reject("ID Token failed")));
   });
@@ -84,11 +108,16 @@ export const checkUserGroups = (groupNames: string | string[]): boolean => {
     return false;
   }
 
-  const decoded = jwtDecode<TokenPayload>(token);
-  const userGroups = decoded.groups ?? [];
-  const requiredGroups = Array.isArray(groupNames) ? groupNames : [groupNames];
+  try {
+    const decoded = jwtDecode<TokenPayload>(token);
+    const userGroups = decoded.groups ?? [];
+    const requiredGroups = Array.isArray(groupNames) ? groupNames : [groupNames];
 
-  return requiredGroups.some((group) => userGroups.includes(group));
+    return requiredGroups.some((group) => userGroups.includes(group));
+  } catch (error) {
+    Logger.error("Failed to decode ID token for group check.", error);
+    return false;
+  }
 };
 
 /**
@@ -114,6 +143,7 @@ export const decodeTokenAndStoreUser = (): User | null => {
       name: `${decoded.given_name || ""} ${decoded.family_name || ""}`,
     };
 
+    useUserStore.getState().setUser(user);
     return user;
   } catch (error) {
     Logger.error("Failed to decode token and store user information", error);

--- a/apps/csm-portal/microapp/src/services/auth.ts
+++ b/apps/csm-portal/microapp/src/services/auth.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { jwtDecode } from "jwt-decode";
+import { getAccessTokenFromBridge, getToken } from "@components/microapp-bridge";
+import { LocalStorageKeys } from "@utils/constants";
+import { Logger } from "@utils/logger";
+import { useUserStore, type User } from "../store/user";
+
+// Token Payload
+interface TokenPayload {
+  email?: string;
+  name?: string;
+  groups?: string[];
+  given_name: string;
+  family_name: string;
+}
+
+// These would be your actual token storage functions
+export const getAccessToken = (): string | null => localStorage.getItem(LocalStorageKeys.accessToken);
+export const setAccessToken = (token: string): void => localStorage.setItem(LocalStorageKeys.accessToken, token);
+export const getIdToken = (): string | null => localStorage.getItem(LocalStorageKeys.idToken);
+export const setIdToken = (token: string): void => localStorage.setItem(LocalStorageKeys.idToken, token);
+
+/**
+ * A function to refresh the token.
+ * This is a simplified version of the logic in the original `handleRequestWithNewToken`.
+ * It fetches a new token and updates it in storage.
+ */
+export const refreshToken = (): Promise<string> => {
+  const idTokenPromise = new Promise<string>((resolve, reject) => {
+    getToken((token) => (token ? resolve(token) : reject("ID Token failed")));
+  });
+
+  const accessTokenPromise = new Promise<string>((resolve, reject) => {
+    getAccessTokenFromBridge((token) => (token ? resolve(token) : reject("Access Token failed")));
+  });
+
+  return Promise.all([idTokenPromise, accessTokenPromise])
+    .then(([newIdToken, newAccessToken]) => {
+      setIdToken(newIdToken);
+      setAccessToken(newAccessToken);
+
+      try {
+        initializeUserFromToken();
+        Logger.info("User information updated after full token refresh");
+      } catch (error) {
+        Logger.warn("Failed to update user information", error);
+      }
+
+      return newIdToken;
+    })
+    .catch((error) => {
+      Logger.error("Failed to refresh tokens", error);
+      throw error;
+    });
+};
+
+/**
+ * Checks if the user belongs to a given group or groups based on the ID token.
+ * This is a direct replacement for `handleCheckGroups`.
+ * @param groupNames - A single group name or an array of group names.
+ * @returns boolean - True if the user is in at least one of the required groups.
+ */
+export const checkUserGroups = (groupNames: string | string[]): boolean => {
+  const token = getIdToken();
+
+  if (!token) {
+    Logger.error("ID token not found for group check.");
+    return false;
+  }
+
+  const decoded = jwtDecode<TokenPayload>(token);
+  const userGroups = decoded.groups ?? [];
+  const requiredGroups = Array.isArray(groupNames) ? groupNames : [groupNames];
+
+  return requiredGroups.some((group) => userGroups.includes(group));
+};
+
+/**
+ * Decodes the ID token and extracts user information.
+ * Stores the user information in the Zustand user store.
+ * @returns User object or null if token is invalid
+ */
+export const decodeTokenAndStoreUser = (): User | null => {
+  try {
+    const token = getIdToken();
+
+    if (!token) {
+      Logger.error("ID token not found for user decoding.");
+      useUserStore.getState().clearUser();
+      return null;
+    }
+
+    const decoded = jwtDecode<TokenPayload>(token);
+
+    // Extract user information from token
+    const user: User = {
+      email: decoded.email || "",
+      name: `${decoded.given_name || ""} ${decoded.family_name || ""}`,
+    };
+
+    return user;
+  } catch (error) {
+    Logger.error("Failed to decode token and store user information", error);
+    useUserStore.getState().clearUser();
+    return null;
+  }
+};
+
+/**
+ * Initializes user data from stored token.
+ * Should be called when the app starts or when a new token is received.
+ */
+export const initializeUserFromToken = (): void => {
+  useUserStore.getState().setLoading(true);
+
+  try {
+    decodeTokenAndStoreUser();
+  } catch (error) {
+    Logger.error("Failed to initialize user from token", error);
+    useUserStore.getState().clearUser();
+  } finally {
+    useUserStore.getState().setLoading(false);
+  }
+};

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { queryOptions } from "@tanstack/react-query";
+import { CASES_SEARCH_ENDPOINT, CASE_COMMENTS_SEARCH_ENDPOINT, CASE_DETAILS_ENDPOINT } from "@config/endpoints";
+import type {
+  CaseCommentSearchResponseDto,
+  CaseSearchPayloadDto,
+  CaseSearchResponseDto,
+  CaseViewDto,
+} from "@src/types";
+import { toCaseDetail, toCaseSummary, toComment, type CaseDetail, type CaseSummary, type Comment } from "@src/types";
+import apiClient from "./apiClient";
+
+export interface CaseSearchResult {
+  items: CaseSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+const getAllCases = async (payload: CaseSearchPayloadDto = {}): Promise<CaseSearchResult> => {
+  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  return {
+    items: data.cases.map(toCaseSummary),
+    total: data.total,
+    limit: data.limit,
+    offset: data.offset,
+    hasMore: data.hasMore,
+  };
+};
+
+const getCase = async (id: string): Promise<CaseDetail> => {
+  const { data } = await apiClient.get<CaseViewDto>(CASE_DETAILS_ENDPOINT(id));
+  return toCaseDetail(data);
+};
+
+const getCaseComments = async (id: string): Promise<Comment[]> => {
+  const { data } = await apiClient.post<CaseCommentSearchResponseDto>(CASE_COMMENTS_SEARCH_ENDPOINT(id), {
+    pagination: { limit: 50 },
+  });
+  return data.comments.map(toComment);
+};
+
+export const cases = {
+  all: (payload: CaseSearchPayloadDto = {}) =>
+    queryOptions({
+      queryKey: ["cases", payload],
+      queryFn: () => getAllCases(payload),
+    }),
+
+  get: (id: string) =>
+    queryOptions({
+      queryKey: ["case", id],
+      queryFn: () => getCase(id),
+    }),
+
+  comments: (id: string) =>
+    queryOptions({
+      queryKey: ["case", id, "comments"],
+      queryFn: () => getCaseComments(id),
+    }),
+};

--- a/apps/csm-portal/microapp/src/store/user.ts
+++ b/apps/csm-portal/microapp/src/store/user.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { create } from "zustand";
+
+export interface User {
+  email: string;
+  name: string;
+}
+
+export interface UserStore {
+  user: User | null;
+  isLoading: boolean;
+
+  setUser: (user: User) => void;
+  clearUser: () => void;
+  setLoading: (loading: boolean) => void;
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  user: null,
+  isLoading: false,
+
+  setUser: (user: User) =>
+    set({
+      user,
+      isLoading: false,
+    }),
+
+  clearUser: () =>
+    set({
+      user: null,
+      isLoading: false,
+    }),
+
+  setLoading: (loading: boolean) => set({ isLoading: loading }),
+}));

--- a/apps/csm-portal/microapp/src/theme/index.ts
+++ b/apps/csm-portal/microapp/src/theme/index.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { OxygenTheme } from "@wso2/oxygen-ui/styles/Themes/OxygenThemeBase";
+import { AcrylicOrangeTheme, extendTheme } from "@wso2/oxygen-ui";
+import { typography } from "@theme/typography";
+
+const theme = extendTheme(AcrylicOrangeTheme, {
+  typography,
+}) as OxygenTheme;
+
+export default theme;

--- a/apps/csm-portal/microapp/src/theme/typography.ts
+++ b/apps/csm-portal/microapp/src/theme/typography.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { pxToRem } from "@wso2/oxygen-ui";
+
+export const typography = {
+  h1: {
+    fontSize: pxToRem(36),
+  },
+  h2: {
+    fontSize: pxToRem(28),
+  },
+  h3: {
+    fontSize: pxToRem(24),
+  },
+  h4: {
+    fontSize: pxToRem(20),
+  },
+  h5: {
+    fontSize: pxToRem(18),
+  },
+  h6: {
+    fontSize: pxToRem(16),
+  },
+  subtitle1: {
+    fontSize: pxToRem(14),
+  },
+  subtitle2: {
+    fontSize: pxToRem(12),
+  },
+  body1: {
+    fontSize: pxToRem(14),
+  },
+  body2: {
+    fontSize: pxToRem(13),
+  },
+  button: {
+    fontSize: pxToRem(14),
+  },
+  caption: {
+    fontSize: pxToRem(11),
+  },
+  overline: {
+    fontSize: pxToRem(8),
+  },
+};

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -111,8 +111,8 @@ export interface CaseSearchViewDto {
   state: CaseState;
   workState: CaseWorkState;
   type: string;
-  createdOn: string;
-  updatedOn: string;
+  createdOn?: string;
+  updatedOn?: string;
   closedOn: string | null;
   createdBy: UserIdEmailRefDto;
   project: EntityRefDto;
@@ -145,8 +145,8 @@ export interface CaseViewDto {
   workState: CaseWorkState;
   type: string | null;
   engagementType: string | null;
-  createdOn: string;
-  updatedOn: string;
+  createdOn?: string;
+  updatedOn?: string;
   closedOn: string | null;
   createdBy: UserRefDto;
   project: EntityRefDto;

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export type CaseType = "case" | "service_request" | "security_report_analysis" | "engagement" | "announcement";
+
+export type CaseSeverity = "catastrophic" | "critical" | "high" | "medium" | "low";
+
+export type CaseState =
+  | "open"
+  | "work_in_progress"
+  | "waiting_on_wso2"
+  | "awaiting_info"
+  | "reopened"
+  | "solution_proposed"
+  | "closed";
+
+export type CaseWorkState = "ongoing" | "paused" | null;
+
+export type CaseIssueType =
+  | "error"
+  | "partial_outage"
+  | "performance_degradation"
+  | "question"
+  | "security_or_compliance"
+  | "total_outage";
+
+export interface EntityRefDto {
+  id: string;
+  name: string;
+}
+
+export interface UserRefDto {
+  id: string;
+  displayName: string;
+  userId: string;
+  email: string;
+}
+
+export interface UserIdEmailRefDto {
+  id: string;
+  email: string;
+}
+
+export interface AssignedEngineerRefDto {
+  id: string;
+  name: string;
+  email: string | null;
+}
+
+export interface CaseNumberRefDto {
+  id: string;
+  number: string;
+}
+
+export interface AccountRefDto {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface DeployedProductRefDto {
+  id: string;
+  displayName: string;
+}
+
+export interface CaseSearchFiltersDto {
+  types?: CaseType[];
+  searchQuery?: string;
+  projectIds?: string[];
+  deploymentIds?: string[];
+  states?: CaseState[];
+  severities?: CaseSeverity[];
+  issueTypes?: CaseIssueType[];
+  assignedUserIds?: string[];
+  createdByMe?: boolean;
+}
+
+export interface CaseSearchPayloadDto {
+  filters?: CaseSearchFiltersDto;
+  sortBy?: {
+    field?: "createdOn" | "updatedOn" | "severity" | "state";
+    order?: "asc" | "desc";
+  };
+  pagination?: {
+    offset?: number;
+    limit?: number;
+  };
+}
+
+export interface CaseSearchViewDto {
+  id: string;
+  number: string;
+  wso2Id: string;
+  subject: string;
+  description: string;
+  severity: CaseSeverity;
+  issueType: CaseIssueType;
+  state: CaseState;
+  workState: CaseWorkState;
+  type: string;
+  createdOn: string;
+  updatedOn: string;
+  closedOn: string | null;
+  createdBy: UserIdEmailRefDto;
+  project: EntityRefDto;
+  deployment: EntityRefDto | null;
+  deployedProduct: EntityRefDto | null;
+  product: EntityRefDto | null;
+  assignedEngineer: AssignedEngineerRefDto | null;
+  parentCase: CaseNumberRefDto | null;
+  relatedCase: CaseNumberRefDto | null;
+  account: AccountRefDto | null;
+}
+
+export interface CaseSearchResponseDto {
+  cases: CaseSearchViewDto[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+export interface CaseViewDto {
+  id: string;
+  number: string;
+  wso2Id: string;
+  subject: string;
+  description: string;
+  severity: CaseSeverity;
+  issueType: CaseIssueType;
+  state: CaseState;
+  workState: CaseWorkState;
+  type: string | null;
+  engagementType: string | null;
+  createdOn: string;
+  updatedOn: string;
+  closedOn: string | null;
+  createdBy: UserRefDto;
+  project: EntityRefDto;
+  deployment: EntityRefDto | null;
+  deployedProduct: DeployedProductRefDto | null;
+  product: EntityRefDto | null;
+  catalog: EntityRefDto | null;
+  catalogItem: EntityRefDto | null;
+  assignedTeam: EntityRefDto | null;
+  conversation: EntityRefDto | null;
+  assignedEngineer: AssignedEngineerRefDto | null;
+  parentCase: CaseNumberRefDto | null;
+  relatedCase: CaseNumberRefDto | null;
+  account: AccountRefDto | null;
+  nextStates: CaseState[];
+}
+
+export type CaseCommentType = "work_note" | "comment" | "activity";
+
+export interface CaseCommentDto {
+  id: string;
+  caseId: string;
+  type: CaseCommentType;
+  content: string;
+  createdBy: string;
+  createdOn: string;
+}
+
+export interface CaseCommentSearchResponseDto {
+  comments: CaseCommentDto[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -102,8 +102,10 @@ export function toCaseSummary(dto: CaseSearchViewDto): CaseSummary {
     state: dto.state,
     workState: dto.workState,
     type: dto.type as CaseType,
-    createdOn: parseBackendTimestamp(dto.createdOn),
-    updatedOn: parseBackendTimestamp(dto.updatedOn),
+    // The search/detail views don't always populate updatedOn (e.g. a case that hasn't been
+    // touched since creation); fall back to createdOn rather than showing an invalid time.
+    createdOn: parseBackendTimestamp(dto.createdOn ?? ""),
+    updatedOn: parseBackendTimestamp(dto.updatedOn ?? dto.createdOn ?? ""),
     closedOn: parseOptionalBackendTimestamp(dto.closedOn),
     createdBy: dto.createdBy,
     project: dto.project,
@@ -128,8 +130,10 @@ export function toCaseDetail(dto: CaseViewDto): CaseDetail {
     workState: dto.workState,
     type: dto.type as CaseType | null,
     engagementType: dto.engagementType,
-    createdOn: parseBackendTimestamp(dto.createdOn),
-    updatedOn: parseBackendTimestamp(dto.updatedOn),
+    // The search/detail views don't always populate updatedOn (e.g. a case that hasn't been
+    // touched since creation); fall back to createdOn rather than showing an invalid time.
+    createdOn: parseBackendTimestamp(dto.createdOn ?? ""),
+    updatedOn: parseBackendTimestamp(dto.updatedOn ?? dto.createdOn ?? ""),
     closedOn: parseOptionalBackendTimestamp(dto.closedOn),
     createdBy: dto.createdBy,
     project: dto.project,

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  AccountRefDto,
+  AssignedEngineerRefDto,
+  CaseCommentDto,
+  CaseCommentType,
+  CaseNumberRefDto,
+  CaseSearchViewDto,
+  CaseSeverity,
+  CaseState,
+  CaseType,
+  CaseViewDto,
+  CaseWorkState,
+  DeployedProductRefDto,
+  EntityRefDto,
+  UserIdEmailRefDto,
+  UserRefDto,
+} from "./case.dto";
+
+export interface CaseSummary {
+  id: string;
+  number: string;
+  wso2Id: string;
+  subject: string;
+  description: string;
+  severity: CaseSeverity;
+  state: CaseState;
+  workState: CaseWorkState;
+  type: CaseType;
+  createdOn: Date;
+  updatedOn: Date;
+  closedOn: Date | null;
+  createdBy: UserIdEmailRefDto;
+  project: EntityRefDto;
+  deployment: EntityRefDto | null;
+  product: EntityRefDto | null;
+  assignedEngineer: AssignedEngineerRefDto | null;
+  account: AccountRefDto | null;
+  parentCase: CaseNumberRefDto | null;
+  relatedCase: CaseNumberRefDto | null;
+}
+
+export interface CaseDetail {
+  id: string;
+  number: string;
+  wso2Id: string;
+  subject: string;
+  description: string;
+  severity: CaseSeverity;
+  state: CaseState;
+  workState: CaseWorkState;
+  type: CaseType | null;
+  engagementType: string | null;
+  createdOn: Date;
+  updatedOn: Date;
+  closedOn: Date | null;
+  createdBy: UserRefDto;
+  project: EntityRefDto;
+  deployment: EntityRefDto | null;
+  deployedProduct: DeployedProductRefDto | null;
+  product: EntityRefDto | null;
+  assignedEngineer: AssignedEngineerRefDto | null;
+  account: AccountRefDto | null;
+  parentCase: CaseNumberRefDto | null;
+  relatedCase: CaseNumberRefDto | null;
+  nextStates: CaseState[];
+}
+
+export interface Comment {
+  id: string;
+  caseId: string;
+  type: CaseCommentType;
+  content: string;
+  createdBy: string;
+  createdOn: Date;
+}
+
+export function toCaseSummary(dto: CaseSearchViewDto): CaseSummary {
+  return {
+    id: dto.id,
+    number: dto.number,
+    wso2Id: dto.wso2Id,
+    subject: dto.subject,
+    description: dto.description,
+    severity: dto.severity,
+    state: dto.state,
+    workState: dto.workState,
+    type: dto.type as CaseType,
+    createdOn: new Date(dto.createdOn),
+    updatedOn: new Date(dto.updatedOn),
+    closedOn: dto.closedOn ? new Date(dto.closedOn) : null,
+    createdBy: dto.createdBy,
+    project: dto.project,
+    deployment: dto.deployment,
+    product: dto.product,
+    assignedEngineer: dto.assignedEngineer,
+    account: dto.account,
+    parentCase: dto.parentCase,
+    relatedCase: dto.relatedCase,
+  };
+}
+
+export function toCaseDetail(dto: CaseViewDto): CaseDetail {
+  return {
+    id: dto.id,
+    number: dto.number,
+    wso2Id: dto.wso2Id,
+    subject: dto.subject,
+    description: dto.description,
+    severity: dto.severity,
+    state: dto.state,
+    workState: dto.workState,
+    type: dto.type as CaseType | null,
+    engagementType: dto.engagementType,
+    createdOn: new Date(dto.createdOn),
+    updatedOn: new Date(dto.updatedOn),
+    closedOn: dto.closedOn ? new Date(dto.closedOn) : null,
+    createdBy: dto.createdBy,
+    project: dto.project,
+    deployment: dto.deployment,
+    deployedProduct: dto.deployedProduct,
+    product: dto.product,
+    assignedEngineer: dto.assignedEngineer,
+    account: dto.account,
+    parentCase: dto.parentCase,
+    relatedCase: dto.relatedCase,
+    nextStates: dto.nextStates,
+  };
+}
+
+export function toComment(dto: CaseCommentDto): Comment {
+  return {
+    id: dto.id,
+    caseId: dto.caseId,
+    type: dto.type,
+    content: dto.content,
+    createdBy: dto.createdBy,
+    createdOn: new Date(dto.createdOn),
+  };
+}

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -31,6 +31,7 @@ import type {
   UserIdEmailRefDto,
   UserRefDto,
 } from "./case.dto";
+import { parseBackendTimestamp, parseOptionalBackendTimestamp } from "@utils/dateTime";
 
 export interface CaseSummary {
   id: string;
@@ -101,9 +102,9 @@ export function toCaseSummary(dto: CaseSearchViewDto): CaseSummary {
     state: dto.state,
     workState: dto.workState,
     type: dto.type as CaseType,
-    createdOn: new Date(dto.createdOn),
-    updatedOn: new Date(dto.updatedOn),
-    closedOn: dto.closedOn ? new Date(dto.closedOn) : null,
+    createdOn: parseBackendTimestamp(dto.createdOn),
+    updatedOn: parseBackendTimestamp(dto.updatedOn),
+    closedOn: parseOptionalBackendTimestamp(dto.closedOn),
     createdBy: dto.createdBy,
     project: dto.project,
     deployment: dto.deployment,
@@ -127,9 +128,9 @@ export function toCaseDetail(dto: CaseViewDto): CaseDetail {
     workState: dto.workState,
     type: dto.type as CaseType | null,
     engagementType: dto.engagementType,
-    createdOn: new Date(dto.createdOn),
-    updatedOn: new Date(dto.updatedOn),
-    closedOn: dto.closedOn ? new Date(dto.closedOn) : null,
+    createdOn: parseBackendTimestamp(dto.createdOn),
+    updatedOn: parseBackendTimestamp(dto.updatedOn),
+    closedOn: parseOptionalBackendTimestamp(dto.closedOn),
     createdBy: dto.createdBy,
     project: dto.project,
     deployment: dto.deployment,
@@ -150,6 +151,6 @@ export function toComment(dto: CaseCommentDto): Comment {
     type: dto.type,
     content: dto.content,
     createdBy: dto.createdBy,
-    createdOn: new Date(dto.createdOn),
+    createdOn: parseBackendTimestamp(dto.createdOn),
   };
 }

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export * from "./case.dto";
+export * from "./case.model";

--- a/apps/csm-portal/microapp/src/utils/ApiError.ts
+++ b/apps/csm-portal/microapp/src/utils/ApiError.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { isAxiosError } from "axios";
+
+interface ApiErrorMessageBody {
+  message?: string;
+}
+
+export class ApiError extends Error {
+  public readonly status: number;
+  public readonly statusText: string;
+
+  constructor(status: number, statusText: string, message?: string) {
+    super(message ?? `${status} ${statusText}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
+export function toApiError(error: unknown, fallbackMessage: string): Error {
+  if (error instanceof ApiError) {
+    return error;
+  }
+
+  if (isAxiosError<ApiErrorMessageBody>(error)) {
+    const status = error.response?.status ?? 500;
+    const statusText = error.response?.statusText ?? "Internal Server Error";
+    const apiMessage = error.response?.data?.message;
+    return new ApiError(status, statusText, apiMessage ?? fallbackMessage);
+  }
+
+  return error instanceof Error ? error : new Error(fallbackMessage);
+}
+
+export function getApiErrorMessage(error: unknown): string | undefined {
+  if (!(error instanceof ApiError)) {
+    return undefined;
+  }
+
+  const defaultMessage = `${error.status} ${error.statusText}`;
+  return error.message !== defaultMessage ? error.message : undefined;
+}

--- a/apps/csm-portal/microapp/src/utils/constants.ts
+++ b/apps/csm-portal/microapp/src/utils/constants.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export const ErrorMessages = {
+  NATIVE_BRIDGE_NOT_AVAILABLE: "Native bridge is not available",
+};
+
+export const LocalStorageKeys = {
+  accessToken: "accessToken",
+  idToken: "idToken",
+};

--- a/apps/csm-portal/microapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/microapp/src/utils/dateTime.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+dayjs.extend(relativeTime);
+
+export const formatDate = (date: Date): string => dayjs(date).format("MMM D, YYYY h:mm A");
+
+export const fromNow = (date: Date): string => dayjs(date).fromNow();

--- a/apps/csm-portal/microapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/microapp/src/utils/dateTime.ts
@@ -19,7 +19,8 @@ import relativeTime from "dayjs/plugin/relativeTime";
 
 dayjs.extend(relativeTime);
 
-export const formatDate = (date: Date): string => dayjs(date).format("MMM D, YYYY h:mm A");
+export const formatDate = (date: Date): string =>
+  Number.isNaN(date.getTime()) ? "—" : dayjs(date).format("MMM D, YYYY h:mm A");
 
 // dayjs renders an Invalid Date as "a month ago" rather than erroring, which silently masks
 // unparseable timestamps as a plausible-looking value instead of surfacing the bug.

--- a/apps/csm-portal/microapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/microapp/src/utils/dateTime.ts
@@ -21,4 +21,25 @@ dayjs.extend(relativeTime);
 
 export const formatDate = (date: Date): string => dayjs(date).format("MMM D, YYYY h:mm A");
 
-export const fromNow = (date: Date): string => dayjs(date).fromNow();
+// dayjs renders an Invalid Date as "a month ago" rather than erroring, which silently masks
+// unparseable timestamps as a plausible-looking value instead of surfacing the bug.
+export const fromNow = (date: Date): string => (Number.isNaN(date.getTime()) ? "—" : dayjs(date).fromNow());
+
+// The backend is ServiceNow-sourced and its timestamps are UTC but carry no zone marker
+// (e.g. "2026-06-08 10:15:00" or "2026-06-08T10:15:00"). `new Date()` treats a zone-less
+// date-time string as local time, so parsing it directly silently shifts it by the
+// browser's UTC offset (or fails to parse at all, depending on runtime). Normalize to an
+// explicit UTC ISO string before handing it to `Date` so the parsed instant is correct
+// regardless of the viewer's timezone.
+function normalizeBackendTimestamp(raw: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(\.\d+)?$/.exec(raw);
+  if (!match) return raw;
+
+  const [, yyyy, mm, dd, hh, mi, ss, fractional = ""] = match;
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}${fractional}Z`;
+}
+
+export const parseBackendTimestamp = (raw: string): Date => new Date(normalizeBackendTimestamp(raw));
+
+export const parseOptionalBackendTimestamp = (raw: string | null | undefined): Date | null =>
+  raw ? parseBackendTimestamp(raw) : null;

--- a/apps/csm-portal/microapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/microapp/src/utils/dateTime.ts
@@ -25,18 +25,33 @@ export const formatDate = (date: Date): string => dayjs(date).format("MMM D, YYY
 // unparseable timestamps as a plausible-looking value instead of surfacing the bug.
 export const fromNow = (date: Date): string => (Number.isNaN(date.getTime()) ? "—" : dayjs(date).fromNow());
 
-// The backend is ServiceNow-sourced and its timestamps are UTC but carry no zone marker
-// (e.g. "2026-06-08 10:15:00" or "2026-06-08T10:15:00"). `new Date()` treats a zone-less
-// date-time string as local time, so parsing it directly silently shifts it by the
-// browser's UTC offset (or fails to parse at all, depending on runtime). Normalize to an
-// explicit UTC ISO string before handing it to `Date` so the parsed instant is correct
-// regardless of the viewer's timezone.
+// The backend is ServiceNow-sourced and its timestamps are UTC but carry no zone marker,
+// in one of a few different shapes depending on which SN API served the value (e.g.
+// "2026-06-08 10:15:00", "06/08/2026 10:15:00", or "2026-06-08T10:15:00" — no Z/offset on
+// any of them). `new Date()` treats a zone-less date-time string as local time, so parsing
+// it directly silently shifts it by the browser's UTC offset (or fails to parse at all,
+// depending on runtime). Normalize to an explicit UTC ISO string before handing it to
+// `Date` so the parsed instant is correct regardless of the viewer's timezone.
 function normalizeBackendTimestamp(raw: string): string {
-  const match = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(\.\d+)?$/.exec(raw);
-  if (!match) return raw;
+  const spaceSeparated = /^(\d{4})-(\d{1,2})-(\d{1,2})\s+(\d{1,2}):(\d{1,2}):(\d{1,2})(\.\d+)?$/.exec(raw);
+  if (spaceSeparated) {
+    const [, yyyy, mm, dd, hh, mi, ss, fractional = ""] = spaceSeparated;
+    return `${yyyy}-${mm.padStart(2, "0")}-${dd.padStart(2, "0")}T${hh.padStart(2, "0")}:${mi.padStart(2, "0")}:${ss.padStart(2, "0")}${fractional}Z`;
+  }
 
-  const [, yyyy, mm, dd, hh, mi, ss, fractional = ""] = match;
-  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}${fractional}Z`;
+  const mdy = /^(\d{1,2})\/(\d{1,2})\/(\d{4})\s+(\d{1,2}):(\d{1,2}):(\d{1,2})(\.\d+)?$/.exec(raw);
+  if (mdy) {
+    const [, mm, dd, yyyy, hh, mi, ss, fractional = ""] = mdy;
+    return `${yyyy}-${mm.padStart(2, "0")}-${dd.padStart(2, "0")}T${hh.padStart(2, "0")}:${mi.padStart(2, "0")}:${ss.padStart(2, "0")}${fractional}Z`;
+  }
+
+  const tSeparated = /^(\d{4})-(\d{1,2})-(\d{1,2})T(\d{1,2}):(\d{1,2}):(\d{1,2})(\.\d+)?$/.exec(raw);
+  if (tSeparated) {
+    const [, yyyy, mm, dd, hh, mi, ss, fractional = ""] = tSeparated;
+    return `${yyyy}-${mm.padStart(2, "0")}-${dd.padStart(2, "0")}T${hh.padStart(2, "0")}:${mi.padStart(2, "0")}:${ss.padStart(2, "0")}${fractional}Z`;
+  }
+
+  return raw;
 }
 
 export const parseBackendTimestamp = (raw: string): Date => new Date(normalizeBackendTimestamp(raw));

--- a/apps/csm-portal/microapp/src/utils/logger.ts
+++ b/apps/csm-portal/microapp/src/utils/logger.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { sendNativeLog } from "@components/microapp-bridge";
+
+/**
+ * Logger class for logging messages to the React Native DevTools
+ */
+export class Logger {
+  // Info/Basic Logs
+  static info(message: string, data?: unknown) {
+    sendNativeLog(message, data, "info");
+  }
+
+  // Error Logs
+  static error(message: string, data?: unknown) {
+    sendNativeLog(message, data, "error");
+  }
+
+  // Warning Logs
+  static warn(message: string, data?: unknown) {
+    sendNativeLog(message, data, "warn");
+  }
+}


### PR DESCRIPTION
## Summary
- Wires up the app shell (routing, layout, tab bar, theme, auth/API client) needed to bootstrap the microapp.
- Implements the Support page: case list with type tabs (Cases/Service Requests/Security Reports/Engagements/Announcements) and a case detail page (summary, metadata, comments).
- Fixes case cards showing the wrong/stale "Updated X ago" time — the backend's ServiceNow-sourced timestamps are zone-less and sometimes omit `updatedOn` entirely; timestamps are now normalized to UTC with a `createdOn` fallback.

## Test plan
- [x] `npm run lint` / `tsc --noEmit` clean
- [x] Verified in a headless browser against a mocked backend: case list renders, tabs switch, case detail loads comments, and the timestamp fix renders correct relative times (including the missing-`updatedOn` fallback case)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Support and Case Detail screens with routing, Suspense loading, and retry-friendly error handling.
  * Introduced a fixed bottom tab bar, plus reusable case UI (cards, status/severity chips, empty/error states) and a shared app theme.
  * Implemented native bridge integration, token/auth flow, and API/case services for fetching and comments.
* **Bug Fixes**
  * Improved timestamp parsing/formatting and added safe-area layout sizing for mobile.
  * Enhanced request handling with automatic access-token refresh on authorization failures.
* **Chores**
  * Upgraded UI dependencies and removed obsolete script allowance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->