### PR TITLE
[CSM Portal] collect Post Resolution Activity when closing or proposing a solution

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -87,6 +87,50 @@ export type BeCaseState =
  */
 export type BeCaseWorkState = "ongoing" | "paused";
 
+/**
+ * Resolution code for a closed or solution-proposed case (the Post
+ * Resolution Activity — see UseCases.md ISSU-026). Only accepted by
+ * `PATCH /cases/{id}` alongside `state: "closed"` or `"solution_proposed"`.
+ */
+export type BeCaseResolutionCode =
+  | "SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED"
+  | "SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT"
+  | "SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET"
+  | "SOLVED_WORKAROUND_PROVIDED"
+  | "SOLVED_BY_CUSTOMER"
+  | "CONSIDERED_FOR_ROADMAP"
+  | "INCONCLUSIVE_OUT_OF_SCOPE"
+  | "INCONCLUSIVE_CANNOT_REPRODUCE"
+  | "INCONCLUSIVE_NO_WORKAROUND"
+  | "DUPLICATE_ISSUE"
+  | "VOIDED_CANCELED"
+  | "ON_HOLD"
+  | "CONSIDERED_FOR_ROADMAP_ALT"
+  | "SOLVED_FIXED_THE_ISSUE"
+  | "SOLVED_WORKAROUND_PROVIDED_ALT"
+  | "SOLVED_BY_CONTRIBUTOR"
+  | "SOLVED_BY_NOVERA"
+  | "ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS";
+
+/** Root-cause category for a closed or solution-proposed case. Same gating as {@link BeCaseResolutionCode}. */
+export type BeCaseCause =
+  | "USER_MISUNDERSTANDING_CONCEPTS"
+  | "USER_MISUNDERSTANDING_DOCUMENTATION"
+  | "USER_NOT_FOLLOWING_DOCUMENTATION"
+  | "USER_MISTAKE"
+  | "SOLUTION_PROBLEMATIC_SOLUTION_ARCHITECTURE"
+  | "SOLUTION_PROBLEMATIC_CODE"
+  | "APPLICATION_BUG"
+  | "APPLICATION_MISLEADING_UX_UI"
+  | "APPLICATION_LIMITATION"
+  | "APPLICATION_MISSING_FEATURE"
+  | "APPLICATION_DOCUMENTATION_GAP"
+  | "APPLICATION_DOCUMENTATION_ERROR"
+  | "INFRASTRUCTURE_CUSTOMERS_SIDE"
+  | "INFRASTRUCTURE_SAAS_SIDE_NOT_ENOUGH"
+  | "INFRASTRUCTURE_SAAS_SIDE_OTHER"
+  | "UNKNOWN";
+
 export type BeCaseSortField = "createdOn" | "updatedOn" | "severity" | "state";
 
 export interface BeCase {
@@ -348,7 +392,17 @@ export interface BeGetCatalogItemVariablesResponse {
  * `work_in_progress`.
  */
 export type BeCaseUpdatePayload =
-  | { state: BeCaseState; severity?: never; workState?: never; assigneeEmail?: never; watchList?: never }
+  | {
+      state: BeCaseState;
+      severity?: never;
+      workState?: never;
+      assigneeEmail?: never;
+      watchList?: never;
+      /** Post Resolution Activity — only meaningful (and only accepted by the backend) alongside `state: "closed"` or `"solution_proposed"`. */
+      resolutionCode?: BeCaseResolutionCode;
+      cause?: BeCaseCause;
+      closeNotes?: string;
+    }
   | { state?: never; severity: BeCaseSeverity; workState?: never; assigneeEmail?: never; watchList?: never }
   /** Work sub-state toggle (`ongoing` / `paused`) for an in-progress case. */
   | { state?: never; severity?: never; workState: BeCaseWorkState; assigneeEmail?: never; watchList?: never }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -150,7 +150,10 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
     expect(onAction).toHaveBeenCalledWith("wait_on_wso2", "waiting_on_wso2");
   });
 
-  it("gates a customer-notifying transition behind a confirm dialog before dispatch", () => {
+  it("dispatches Close immediately — confirmation happens via the Post Resolution Activity dialog upstream", () => {
+    // CaseActionBar itself no longer gates close/propose-solution behind a
+    // confirm dialog; CsmCaseDetailPage's onAction opens the resolution
+    // dialog for these two, which doubles as the confirmation step.
     const onAction = vi.fn();
     render(
       <CaseActionBar
@@ -158,12 +161,7 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
         onAction={onAction}
       />,
     );
-    // Clicking "Close" must NOT dispatch yet — it opens a confirm dialog.
     fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
-    expect(onAction).not.toHaveBeenCalled();
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-    // Confirming dispatches with the close action + closed target.
-    fireEvent.click(screen.getByRole("button", { name: /close case/i }));
     expect(onAction).toHaveBeenCalledWith("close", "closed");
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -17,14 +17,9 @@
 import {
   Box,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   Menu,
   MenuItem,
   Tooltip,
-  Typography,
 } from "@wso2/oxygen-ui";
 import {
   AlertTriangle,
@@ -51,25 +46,19 @@ import type {
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
 
-type ActionConfirm = {
-  title: string;
-  body: string;
-  confirmLabel: string;
-  confirmColor: "primary" | "error" | "warning";
-};
-
 /**
  * Presentation for a transition *into* a given state. The button LABEL is never
  * stored here — it always comes from `stateLabel(targetState)`, so the bar
  * honours the backend transition graph verbatim and never invents UI-specific
- * verbs. This only carries the icon/colour, the lifecycle action used for the
- * post-transition toast, and an optional confirm gate.
+ * verbs. This only carries the icon/colour and the lifecycle action used for
+ * the post-transition toast. `closed`/`solution_proposed` don't need a
+ * confirm gate here — `onAction` opens the Post Resolution Activity dialog
+ * for those, which doubles as the confirmation step.
  */
 type TargetConfig = {
   action: CaseLifecycleAction;
   color: "primary" | "success" | "warning" | "error";
   icon: JSX.Element;
-  confirm?: ActionConfirm;
 };
 
 /** A concrete button: a target state plus its presentation. */
@@ -79,17 +68,13 @@ type PrimaryButton = TargetConfig & {
   tooltip?: string;
 };
 
-const CLOSE_CONFIRM: ActionConfirm = {
-  title: "Close this case?",
-  body: "The customer receives a closure notification and the case moves to “Closed”.",
-  confirmLabel: "Close case",
-  confirmColor: "warning",
-};
-
 /**
  * Per-target-state presentation. One entry per state a case can move INTO.
- * Customer-notifying / hard-to-undo transitions carry a confirm gate so a stray
- * click in a busy queue can't silently close a case or email the customer.
+ * `closed` and `solution_proposed` dispatch immediately like every other
+ * target, but `onAction` (in CsmCaseDetailPage) opens the Post Resolution
+ * Activity dialog for those two (resolution code, cause, close notes —
+ * ISSU-026) instead of PATCHing right away — that dialog is the confirm
+ * gate for a customer-notifying transition, so no separate one is needed here.
  */
 const TARGET_CONFIG: Partial<Record<CaseState, TargetConfig>> = {
   work_in_progress: {
@@ -111,18 +96,11 @@ const TARGET_CONFIG: Partial<Record<CaseState, TargetConfig>> = {
     action: "propose_solution",
     color: "success",
     icon: <Send size={16} />,
-    confirm: {
-      title: "Propose solution to the customer?",
-      body: "The customer is notified that a solution has been proposed and the case moves to “Solution proposed”.",
-      confirmLabel: "Propose solution",
-      confirmColor: "primary",
-    },
   },
   closed: {
     action: "close",
     color: "warning",
     icon: <CheckCircle size={16} />,
-    confirm: CLOSE_CONFIRM,
   },
 };
 
@@ -316,9 +294,6 @@ export default function CaseActionBar({
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [stateMenuAnchor, setStateMenuAnchor] = useState<HTMLElement | null>(null);
-  const [pendingConfirm, setPendingConfirm] = useState<PrimaryButton | null>(
-    null,
-  );
 
   // Render a button for every state the backend says the case can move to. The
   // backend `nextStates` is the single source of truth: an empty/terminal list
@@ -332,10 +307,6 @@ export default function CaseActionBar({
   const secondary = buildSecondaryItems(caseDetail);
 
   const runPrimary = (p: PrimaryButton): void => {
-    if (p.confirm) {
-      setPendingConfirm(p);
-      return;
-    }
     void onAction(p.action, p.targetState);
   };
 
@@ -450,35 +421,6 @@ export default function CaseActionBar({
           ];
         })}
       </Menu>
-
-      <Dialog
-        open={!!pendingConfirm}
-        onClose={() => setPendingConfirm(null)}
-        maxWidth="xs"
-        fullWidth
-      >
-        <DialogTitle>{pendingConfirm?.confirm?.title}</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2">
-            {pendingConfirm?.confirm?.body}
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setPendingConfirm(null)}>Cancel</Button>
-          <Button
-            variant="contained"
-            color={pendingConfirm?.confirm?.confirmColor ?? "primary"}
-            startIcon={pendingConfirm?.icon}
-            onClick={() => {
-              const p = pendingConfirm;
-              setPendingConfirm(null);
-              if (p) void onAction(p.action, p.targetState);
-            }}
-          >
-            {pendingConfirm?.confirm?.confirmLabel ?? "Confirm"}
-          </Button>
-        </DialogActions>
-      </Dialog>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ResolutionDialog from "@features/csm-cases/components/ResolutionDialog";
+
+/** Opens a Select and picks the option by visible text. */
+function chooseOption(labelId: string, optionText: RegExp): void {
+  fireEvent.mouseDown(document.getElementById(labelId)!.parentElement!.querySelector('[role="combobox"]')!);
+  const listbox = screen.getByRole("listbox");
+  fireEvent.click(within(listbox).getByText(optionText));
+}
+
+describe("ResolutionDialog", () => {
+  it("disables submit until both resolution code and cause are chosen", () => {
+    render(
+      <ResolutionDialog
+        kind="close"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
+
+    chooseOption("resolution-code-label", /solved fixed by support guidance provided/i);
+    expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
+
+    chooseOption("case-cause-label", /application bug/i);
+    expect(screen.getByRole("button", { name: /close case/i })).not.toBeDisabled();
+  });
+
+  it("submits the chosen resolution code, cause, and close notes", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ResolutionDialog
+        kind="propose_solution"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    chooseOption("resolution-code-label", /solved by customer/i);
+    chooseOption("case-cause-label", /unknown/i);
+    fireEvent.change(screen.getByLabelText(/close notes/i), {
+      target: { value: "Root-caused and verified with the customer." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /propose solution/i }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      resolutionCode: "SOLVED_BY_CUSTOMER",
+      cause: "UNKNOWN",
+      closeNotes: "Root-caused and verified with the customer.",
+    });
+  });
+
+  it("calls onClose when cancelled", () => {
+    const onClose = vi.fn();
+    render(
+      <ResolutionDialog
+        kind="close"
+        isSubmitting={false}
+        onClose={onClose}
+        onSubmit={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import type { BeCaseCause, BeCaseResolutionCode } from "@api/backend/types";
+import {
+  CASE_CAUSES,
+  RESOLUTION_CODES,
+  humanizeResolutionEnum,
+} from "@features/csm-cases/utils/caseResolution";
+
+interface ResolutionDialogProps {
+  /** Which lifecycle transition this dialog is confirming. */
+  kind: "close" | "propose_solution";
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (fields: {
+    resolutionCode: BeCaseResolutionCode;
+    cause: BeCaseCause;
+    closeNotes: string;
+  }) => void;
+}
+
+const COPY: Record<
+  ResolutionDialogProps["kind"],
+  { title: string; body: string; confirmLabel: string }
+> = {
+  close: {
+    title: "Close this case",
+    body: "The customer receives a closure notification and the case moves to “Closed”. Record the Post Resolution Activity before closing.",
+    confirmLabel: "Close case",
+  },
+  propose_solution: {
+    title: "Propose a solution",
+    body: "The customer is notified that a solution has been proposed and the case moves to “Solution proposed”. Record the Post Resolution Activity before proposing.",
+    confirmLabel: "Propose solution",
+  },
+};
+
+/**
+ * Collects the Post Resolution Activity (ISSU-026) — resolution code, root
+ * cause, and free-text close notes — before closing a case or proposing a
+ * solution. The backend accepts these as optional fields alongside `state:
+ * "closed"` or `"solution_proposed"` on `PATCH /cases/{id}`; this dialog is
+ * the only place in the portal that collects them, and it doubles as the
+ * confirmation step for these two customer-notifying transitions (there is
+ * no separate plain confirm dialog for them — see CaseActionBar).
+ */
+export default function ResolutionDialog({
+  kind,
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: ResolutionDialogProps): JSX.Element {
+  const [resolutionCode, setResolutionCode] = useState<BeCaseResolutionCode | "">("");
+  const [cause, setCause] = useState<BeCaseCause | "">("");
+  const [closeNotes, setCloseNotes] = useState("");
+  const copy = COPY[kind];
+  const canSubmit = !!resolutionCode && !!cause && !isSubmitting;
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{copy.title}</DialogTitle>
+      <DialogContent
+        dividers
+        sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          {copy.body}
+        </Typography>
+
+        <FormControl fullWidth size="small" required>
+          <InputLabel id="resolution-code-label">Resolution code</InputLabel>
+          <Select
+            labelId="resolution-code-label"
+            label="Resolution code"
+            value={resolutionCode}
+            onChange={(e) =>
+              setResolutionCode(e.target.value as BeCaseResolutionCode)
+            }
+          >
+            {RESOLUTION_CODES.map((code) => (
+              <MenuItem key={code} value={code}>
+                {humanizeResolutionEnum(code)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl fullWidth size="small" required>
+          <InputLabel id="case-cause-label">Cause</InputLabel>
+          <Select
+            labelId="case-cause-label"
+            label="Cause"
+            value={cause}
+            onChange={(e) => setCause(e.target.value as BeCaseCause)}
+          >
+            {CASE_CAUSES.map((c) => (
+              <MenuItem key={c} value={c}>
+                {humanizeResolutionEnum(c)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <TextField
+          label="Close notes"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          value={closeNotes}
+          onChange={(e) => setCloseNotes(e.target.value)}
+          placeholder="Optional free-text notes about the resolution…"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color={kind === "close" ? "warning" : "primary"}
+          disabled={!canSubmit}
+          onClick={() => {
+            if (!resolutionCode || !cause) return;
+            onSubmit({ resolutionCode, cause, closeNotes });
+          }}
+        >
+          {copy.confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -52,7 +52,12 @@ import {
   useFindMyOngoingCases,
   type MyOngoingCase,
 } from "@features/csm-cases/api/useFindMyOngoingCases";
-import type { BeCaseState, BeCreateCaseGithubIssueResponse } from "@api/backend/types";
+import type {
+  BeCaseCause,
+  BeCaseResolutionCode,
+  BeCaseState,
+  BeCreateCaseGithubIssueResponse,
+} from "@api/backend/types";
 import { beStateFromUi } from "@api/backend/mappers";
 import { BackendApiError } from "@api/backend/client";
 import {
@@ -70,6 +75,7 @@ import {
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
 import AssignEngineerDialog from "@features/csm-cases/components/AssignEngineerDialog";
+import ResolutionDialog from "@features/csm-cases/components/ResolutionDialog";
 import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
 import { usePostCaseGithubIssue } from "@features/csm-cases/api/useCsmCaseGithubIssue";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
@@ -328,6 +334,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [metaCollapsed, setMetaCollapsed] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
+  // ISSU-026: closing or proposing a solution opens this instead of PATCHing
+  // immediately — it collects the Post Resolution Activity and doubles as
+  // the confirmation step for these two customer-notifying transitions.
+  const [resolutionDialog, setResolutionDialog] = useState<{
+    kind: "close" | "propose_solution";
+    targetState: BeCaseState;
+  } | null>(null);
   const [logTimeOpen, setLogTimeOpen] = useState(false);
   // One-shot: true to pop open the Call requests tab's "Create call request"
   // dialog from the action bar's "Request a call" item. The widget flips it
@@ -543,6 +556,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 showError("Could not assign the case to you.", err),
             },
           );
+          return;
+        }
+
+        // ISSU-026: closing or proposing a solution records the Post
+        // Resolution Activity first — open that dialog instead of PATCHing
+        // immediately. Must run before the generic `targetState` PATCH below.
+        if ((action === "close" || action === "propose_solution") && targetState) {
+          setResolutionDialog({ kind: action, targetState });
           return;
         }
 
@@ -770,6 +791,36 @@ export default function CsmCaseDetailPage(): JSX.Element {
       );
     },
     [patchCase, showError],
+  );
+
+  // Submits the Post Resolution Activity dialog: PATCHes state alongside
+  // resolutionCode/cause/closeNotes in one call (the backend accepts all
+  // four together for these two transitions — see BeCaseUpdatePayload).
+  const onResolutionSubmit = useCallback(
+    (fields: {
+      resolutionCode: BeCaseResolutionCode;
+      cause: BeCaseCause;
+      closeNotes: string;
+    }) => {
+      if (!resolutionDialog) return;
+      const { kind, targetState } = resolutionDialog;
+      patchCase.mutate(
+        { state: targetState, ...fields },
+        {
+          onSuccess: () => {
+            setResolutionDialog(null);
+            setFeedback({
+              message: LIFECYCLE_TOAST[kind],
+              severity: LIFECYCLE_SEVERITY[kind],
+              sticky: true,
+            });
+          },
+          onError: (err) =>
+            showError("Could not update the case. Please try again.", err),
+        },
+      );
+    },
+    [patchCase, resolutionDialog, showError],
   );
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
@@ -1354,6 +1405,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
           isAssigning={patchCase.isPending}
           onClose={() => setAssignOpen(false)}
           onAssign={onAssign}
+        />
+      )}
+
+      {resolutionDialog && (
+        <ResolutionDialog
+          kind={resolutionDialog.kind}
+          isSubmitting={patchCase.isPending}
+          onClose={() => setResolutionDialog(null)}
+          onSubmit={onResolutionSubmit}
         />
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseResolution.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseResolution.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeCaseCause, BeCaseResolutionCode } from "@api/backend/types";
+
+/** All backend resolution codes, in the order declared in openapi.yaml. */
+export const RESOLUTION_CODES: BeCaseResolutionCode[] = [
+  "SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED",
+  "SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT",
+  "SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET",
+  "SOLVED_WORKAROUND_PROVIDED",
+  "SOLVED_BY_CUSTOMER",
+  "CONSIDERED_FOR_ROADMAP",
+  "INCONCLUSIVE_OUT_OF_SCOPE",
+  "INCONCLUSIVE_CANNOT_REPRODUCE",
+  "INCONCLUSIVE_NO_WORKAROUND",
+  "DUPLICATE_ISSUE",
+  "VOIDED_CANCELED",
+  "ON_HOLD",
+  "CONSIDERED_FOR_ROADMAP_ALT",
+  "SOLVED_FIXED_THE_ISSUE",
+  "SOLVED_WORKAROUND_PROVIDED_ALT",
+  "SOLVED_BY_CONTRIBUTOR",
+  "SOLVED_BY_NOVERA",
+  "ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS",
+];
+
+/** All backend root-cause categories, in the order declared in openapi.yaml. */
+export const CASE_CAUSES: BeCaseCause[] = [
+  "USER_MISUNDERSTANDING_CONCEPTS",
+  "USER_MISUNDERSTANDING_DOCUMENTATION",
+  "USER_NOT_FOLLOWING_DOCUMENTATION",
+  "USER_MISTAKE",
+  "SOLUTION_PROBLEMATIC_SOLUTION_ARCHITECTURE",
+  "SOLUTION_PROBLEMATIC_CODE",
+  "APPLICATION_BUG",
+  "APPLICATION_MISLEADING_UX_UI",
+  "APPLICATION_LIMITATION",
+  "APPLICATION_MISSING_FEATURE",
+  "APPLICATION_DOCUMENTATION_GAP",
+  "APPLICATION_DOCUMENTATION_ERROR",
+  "INFRASTRUCTURE_CUSTOMERS_SIDE",
+  "INFRASTRUCTURE_SAAS_SIDE_NOT_ENOUGH",
+  "INFRASTRUCTURE_SAAS_SIDE_OTHER",
+  "UNKNOWN",
+];
+
+/**
+ * Title-cases an UPPER_SNAKE_CASE backend enum value for display, e.g.
+ * "SOLVED_BY_CUSTOMER" -> "Solved by customer". Mirrors `humanizeState`
+ * (abtDashboard.ts) so an enum value added on the backend still renders
+ * readably with no frontend change required.
+ */
+export function humanizeResolutionEnum(value: string): string {
+  const words = value.toLowerCase().split("_").filter(Boolean);
+  return words
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

`resolutionCode`, `cause`, and `closeNotes` were added to the `PATCH /cases/{id}` contract at the API layer only — the entity-service and this repo's own `openapi.yaml` accept them, and the BFF handler passes them through as-is. But no UI was ever built to collect these from the user: closing a case or proposing a solution just fired a plain state-transition PATCH with none of the Post Resolution Activity (PRA) fields the product requirement (case resolution management) calls for.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Collect resolution code, root cause, and optional close notes from the CS engineer before a case is closed or a solution is proposed, and send them in the same `PATCH /cases/{id}` call as the state transition.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- New `ResolutionDialog` component: a resolution-code select and a cause select (both required, populated from the full backend enums), plus a free-text close-notes field (optional). Opens for both the "Close" and "Propose solution" actions.
- `CsmCaseDetailPage`'s action handler now intercepts `close`/`propose_solution` before the generic state-PATCH branch and opens this dialog instead of PATCHing immediately; submitting sends `{ state, resolutionCode, cause, closeNotes }` in one call.
- The dialog's own confirmation copy (customer-notification text) replaces `CaseActionBar`'s old plain yes/no confirm for these two targets, so that now-unused confirm mechanism (`ActionConfirm` type, `pendingConfirm` state, its `Dialog`) is removed from `CaseActionBar` rather than left dead.
- New `caseResolution.ts` util holds the two enum value lists plus a `humanizeResolutionEnum` helper (mirrors the existing `humanizeState` convention) so dropdown labels stay readable without a hand-maintained label map.
- Extended `BeCaseUpdatePayload`'s `state` variant with the three optional fields; no other request shapes change.

No API contract change — this only starts sending fields the backend has accepted since PR #1077.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, when I close a case or propose a solution, I record the resolution code, root cause, and any closing notes as part of that action, instead of the case closing with no resolution record at all.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added: closing a case or proposing a solution now collects the Post Resolution Activity (resolution code, cause, close notes) before submitting.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal case-detail UI behavior, not separately documented.

## Automation tests
 - Unit tests
   > Code coverage information

New `ResolutionDialog.test.tsx` covers: submit disabled until both required fields are chosen, correct payload shape on submit, and cancel behavior. Updated `CaseActionBar.test.tsx` for the removed confirm-dialog behavior on Close (confirmation now happens via the resolution dialog upstream, not inside `CaseActionBar`). `pnpm build`, `pnpm test`, and `pnpm lint` all pass (two pre-existing, unrelated test failures on `origin/main` persist unchanged).
 - Integration tests
   > Details about the test cases and coverage

N/A — no integration test suite for this component.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript codebase; `eslint` runs clean)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Local: `pnpm build` + `pnpm test` + `pnpm lint`, on macOS.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new case resolution dialog for closing cases or proposing solutions.
  * Users can now select a resolution code and root cause, and add optional closing notes.
  * Case actions now open the dialog flow and save the selected details with the case update.
  * Improved case action behavior so close/propose actions respond immediately and use the shared resolution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->