### PR TITLE
[CSM Portal] fix: break the infinite refresh-grant loop on expired sessions

### DIFF
--- a/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -17,9 +17,35 @@
 import { useCallback } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import { apiConfig } from "@config/apiConfig";
-import { AUTH_NOT_READY_ERROR_MESSAGE } from "@constants/apiConstants";
+import {
+  ASGARDEO_UNAUTHENTICATED_CODE,
+  AUTH_NOT_READY_ERROR_MESSAGE,
+} from "@constants/apiConstants";
 import { useLogger } from "@hooks/useLogger";
 import { CORRELATION_ID_HEADER, newCorrelationId } from "@utils/correlationId";
+
+// Shared across every caller's hook instance. Each useAuthApiClient() call
+// creates its own authFetch closure, so this lives at module scope to ensure
+// only ONE full sign-in redirect is triggered even when many concurrent calls
+// fail authentication at once.
+let signInInFlight = false;
+
+// Only the Asgardeo "unauthenticated" code means the token was expired/missing
+// when the call ran (e.g. the refresh token itself has expired, so the SDK's
+// periodic background refresh can no longer mint a new access token). Anything
+// else (network failures, real backend 5xx) must propagate untouched so
+// existing error handling and error pages still work. Without this
+// classification, a dead refresh token sends the SDK's periodic background
+// refresh into an infinite loop of failing refresh-grant requests instead of
+// bouncing the user to sign-in.
+function isTokenExpiredError(error: unknown): boolean {
+  return (
+    error != null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code: string }).code === ASGARDEO_UNAUTHENTICATED_CODE
+  );
+}
 
 /**
  * True when `getAccessToken()` failed because the Asgardeo SDK had not finished
@@ -122,10 +148,24 @@ function buildRequestHeaders(
 // backend; calls to any other origin are refused so credentials can't be
 // leaked to third-party hosts.
 export function useAuthApiClient() {
-  const { getAccessToken, getIdToken } = useAsgardeo();
+  const { getAccessToken, getIdToken, signIn } = useAsgardeo();
   const logger = useLogger();
 
-  return useCallback(
+  // Redirect to a full sign-in, single-flighted so concurrent auth failures
+  // don't fire multiple redirects. Returns a never-resolving promise so
+  // callers don't fall through to an error page while the browser navigates
+  // away.
+  const redirectToSignIn = useCallback((): Promise<Response> => {
+    if (!signInInFlight) {
+      signInInFlight = true;
+      void Promise.resolve(signIn()).finally(() => {
+        signInInFlight = false;
+      });
+    }
+    return new Promise<Response>(() => {});
+  }, [signIn]);
+
+  const attemptFetch = useCallback(
     async (input: RequestInfo | URL, options?: RequestInit): Promise<Response> => {
       const url = resolveRequestUrl(input);
       if (!trustedBackendOrigin || url.origin !== trustedBackendOrigin) {
@@ -194,5 +234,41 @@ export function useAuthApiClient() {
       }
     },
     [getAccessToken, getIdToken, logger],
+  );
+
+  return useCallback(
+    async (input: RequestInfo | URL, options?: RequestInit): Promise<Response> => {
+      try {
+        return await attemptFetch(input, options);
+      } catch (error) {
+        // Only an expired/missing token is recoverable here; anything else
+        // (network, real backend 5xx, auth-not-ready) must surface to
+        // existing error handling.
+        if (!isTokenExpiredError(error)) {
+          throw error;
+        }
+
+        // A concurrent caller, or the provider's periodic background refresh,
+        // may have re-minted the token in the meantime, so retry once to pick
+        // it up. If nothing refreshed it the retry fails again and we fall
+        // through to the sign-in redirect below.
+        try {
+          return await attemptFetch(input, options);
+        } catch (retryError) {
+          // Retry failed for a non-auth reason (e.g. a transient network blip
+          // on the second attempt): surface it instead of bouncing the user
+          // to sign-in.
+          if (!isTokenExpiredError(retryError)) {
+            throw retryError;
+          }
+
+          // Still unauthenticated after the retry — the session (refresh
+          // token) is gone. Redirect for a full sign-in instead of letting
+          // the SDK's periodic refresh keep retrying forever.
+          return redirectToSignIn();
+        }
+      }
+    },
+    [attemptFetch, redirectToSignIn],
   );
 }


### PR DESCRIPTION
## Purpose
When a user's session sits idle long enough that the refresh token itself expires (not just the access token), `useAuthApiClient` had no handling for the resulting auth-provider "unauthenticated" error. Every backend call kept failing with that error while the auth provider's periodic background token refresh kept retrying the dead refresh token, producing an infinite loop of failing refresh-grant requests instead of ending the session cleanly.

## Goals
- Detect the specific "unauthenticated" error code distinctly from other failures (network errors, real backend 5xx, SDK-not-ready races) so only genuine session-death triggers recovery.
- Give a concurrent or in-flight background refresh a chance to have already fixed the token before giving up.
- End dead sessions with a single, deliberate sign-in redirect instead of a silent infinite retry loop.

## Approach
`useAuthApiClient` now wraps its existing token-fetch-and-request logic (`attemptFetch`) with a retry-then-redirect ladder:
- On the "unauthenticated" error code, retry the request once — a concurrent caller or the provider's periodic background refresh may have already re-minted the token by the time the retry runs.
- If the retry still returns the unauthenticated code, the session (refresh token) is gone, so redirect to a full sign-in.
- If the retry fails for any other reason (e.g. a transient network blip), that error is rethrown untouched so existing error handling still works.
- The sign-in redirect is single-flighted at module scope so concurrent auth failures trigger exactly one redirect, and it returns a never-resolving promise so callers don't render an error page mid-navigation.

This mirrors the same fix already shipped for the customer portal's equivalent hook, adapted to this app's dual access-token/ID-token fetch and its origin-trust and correlation-ID logging wrapper, which are unchanged.

## User stories
As a CS engineer who leaves the portal open past session expiry, returning to the tab should either silently recover or cleanly prompt me to sign in again, not spin forever on failing background requests.

## Release note
Fixed an issue where an expired session could cause the portal to loop indefinitely on failing token-refresh requests instead of prompting the user to sign in again.

## Documentation
N/A — internal auth-recovery behavior change, no user-facing or API documentation impact.

## Automation tests
- Unit tests
  - No new unit tests added in this PR (existing hook had no test file). Verified via `tsc -b` (clean) and manual code-path review against the customer portal's equivalent, already-tested implementation.
- Integration tests
  - N/A

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React project; `eslint` run clean on the changed file)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Verified with `tsc -b` and `pnpm lint` on the changed file, and the existing `pnpm test` suite (no regressions versus main).

## Learning
Ported the recovery pattern from a prior fix to the customer portal's equivalent auth hook, which classifies the auth provider's expired-token error code and applies a retry-then-redirect ladder instead of an unconditional single retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in recovery when authentication tokens are missing or expired.
  * Added a safer fallback that retries requests once before sending users to sign-in.
  * Prevented multiple simultaneous sign-in redirects when several requests fail at the same time.
  * Left non-authentication errors unchanged so normal error handling still applies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->