### PR TITLE
[Customer Portal Backend] Add case feedback API endpoints

### DIFF
--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -321,6 +321,18 @@ public isolated function createComment(string idToken, CommentCreatePayload payl
     return csEntityClient->/comments.post(payload, generateHeaders(idToken));
 }
 
+# Submit feedback for a case.
+#
+# + idToken - ID token for authorization
+# + id - ID of the case
+# + payload - Case feedback payload
+# + return - Case feedback response or error
+public isolated function submitCaseFeedback(string idToken, IdString id, CaseFeedbackPayload payload)
+    returns CaseFeedbackResponse|error {
+
+    return csEntityClient->/cases/[id]/feedback.post(payload, generateHeaders(idToken));
+}
+
 # Search product vulnerabilities.
 #
 # + idToken - ID token for authorization

--- a/apps/customer-portal/backend/modules/entity/entity.bal
+++ b/apps/customer-portal/backend/modules/entity/entity.bal
@@ -321,6 +321,15 @@ public isolated function createComment(string idToken, CommentCreatePayload payl
     return csEntityClient->/comments.post(payload, generateHeaders(idToken));
 }
 
+# Get feedback for a case.
+#
+# + idToken - ID token for authorization
+# + id - ID of the case
+# + return - Case feedback or error
+public isolated function getCaseFeedback(string idToken, IdString id) returns CaseFeedback|error {
+    return csEntityClient->/cases/[id]/feedback.get(generateHeaders(idToken));
+}
+
 # Submit feedback for a case.
 #
 # + idToken - ID token for authorization

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -1449,6 +1449,40 @@ public type CommentCreateResponse record {|
     json...;
 |};
 
+# Payload for submitting case feedback.
+public type CaseFeedbackPayload record {|
+    # Emoji ID
+    string emojiId;
+    # Chip IDs
+    string[] chipIds?;
+    # Additional comment
+    string additionalComment?;
+|};
+
+# Submitted feedback details.
+public type SubmittedFeedback record {|
+    # ID
+    IdString id;
+    # Assessment ID
+    IdString assessmentId;
+    # Case ID
+    IdString caseId;
+    # User who created the feedback
+    string createdBy;
+    # Created date and time
+    string createdOn;
+    json...;
+|};
+
+# Response from submitting case feedback.
+public type CaseFeedbackResponse record {|
+    # Success message
+    string message;
+    # Submitted feedback details
+    SubmittedFeedback feedback;
+    json...;
+|};
+
 # Response from creating an attachment.
 public type AttachmentCreateResponse record {|
     # Success message

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -54,6 +54,8 @@ public type MetadataResponse record {|
     ChoiceListItem[] timeZones;
     # List of available project types
     ReferenceTableItem[] projectTypes;
+    # List of feedback emojies
+    FeedbackEmoji[] feedbackEmojies;
     json...;
 |};
 
@@ -437,6 +439,34 @@ public type ReferenceTableItem record {|
     Date? releasedOn?;
     # End of life date (for product versions)
     Date? endOfLifeOn?;
+    json...;
+|};
+
+# Feedback emoji chip information.
+public type FeedbackEmojiChip record {|
+    # ID
+    string id;
+    # Name
+    string name;
+    # Value
+    string value;
+    json...;
+|};
+
+# Feedback emoji information.
+public type FeedbackEmoji record {|
+    # ID
+    string id;
+    # Name
+    string name;
+    # Value
+    string value;
+    # Unselected image URL
+    string unselectedImage;
+    # Selected image URL
+    string selectedImage;
+    # Chips
+    FeedbackEmojiChip[] chips;
     json...;
 |};
 

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -1449,6 +1449,36 @@ public type CommentCreateResponse record {|
     json...;
 |};
 
+# Feedback emoji summary.
+public type FeedbackEmojiSummary record {|
+    # ID
+    string id;
+    # Name
+    string name;
+    # Selected image URL
+    string selectedImage;
+    json...;
+|};
+
+# Case feedback details.
+public type CaseFeedback record {|
+    # ID
+    IdString id;
+    # Emoji summary
+    FeedbackEmojiSummary emoji;
+    # Chips
+    string[]? chips;
+    # Assessment ID
+    IdString assessmentId;
+    # User who created the feedback
+    string createdBy;
+    # Created date and time
+    string createdOn;
+    # Additional comment
+    string? additionalComment;
+    json...;
+|};
+
 # Payload for submitting case feedback.
 public type CaseFeedbackPayload record {|
     # Emoji ID

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -34,7 +34,6 @@ public type FeedbackEmojiChip record {|
     string name;
     # Value
     string value;
-    json...;
 |};
 
 # Feedback emoji information.

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -885,6 +885,39 @@ public type CommentCreatePayload record {|
     entity:CommentType 'type;
 |};
 
+# Payload for submitting case feedback.
+public type CaseFeedbackPayload record {|
+    # Emoji ID
+    string emojiId;
+    # Chip IDs
+    string[] chipIds?;
+    # Additional comment
+    string additionalComment?;
+|};
+
+# Submitted feedback details.
+public type SubmittedFeedback record {|
+    # ID
+    entity:IdString id;
+    # Assessment ID
+    entity:IdString assessmentId;
+    # Case ID
+    entity:IdString caseId;
+    # User who created the feedback
+    string createdBy;
+    # Created date and time
+    string createdOn;
+    json...;
+|};
+
+# Response from submitting case feedback.
+public type CaseFeedbackResponse record {|
+    # Success message
+    string message;
+    # Submitted feedback details
+    SubmittedFeedback feedback;
+|};
+
 # Payload for creating an attachment.
 public type AttachmentCreatePayload record {|
     # File name

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -933,7 +933,6 @@ public type SubmittedFeedback record {|
     string createdBy;
     # Created date and time
     string createdOn;
-    json...;
 |};
 
 # Response from submitting case feedback.

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -26,12 +26,42 @@ public type FeatureFlags record {|
     boolean usageMetricsEnabled;
 |};
 
+# Feedback emoji chip information.
+public type FeedbackEmojiChip record {|
+    # ID
+    string id;
+    # Name
+    string name;
+    # Value
+    string value;
+    json...;
+|};
+
+# Feedback emoji information.
+public type FeedbackEmoji record {|
+    # ID
+    string id;
+    # Name
+    string name;
+    # Value
+    string value;
+    # Unselected image URL
+    string unselectedImage;
+    # Selected image URL
+    string selectedImage;
+    # Chips
+    FeedbackEmojiChip[] chips;
+    json...;
+|};
+
 # Metadata.
 public type MetadataResponse record {|
     # List of available time zones
     ReferenceItem[] timeZones;
     # List of available project types
     ReferenceItem[] projectTypes;
+    # List of feedback emojies
+    FeedbackEmoji[] feedbackEmojies;
     # Indicate which features are enabled
     FeatureFlags featureFlags;
 |};

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -50,7 +50,6 @@ public type FeedbackEmoji record {|
     string selectedImage;
     # Chips
     FeedbackEmojiChip[] chips;
-    json...;
 |};
 
 # Metadata.

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -885,6 +885,34 @@ public type CommentCreatePayload record {|
     entity:CommentType 'type;
 |};
 
+# Feedback emoji summary.
+public type FeedbackEmojiSummary record {|
+    # ID
+    string id;
+    # Name
+    string name;
+    # Selected image URL
+    string selectedImage;
+|};
+
+# Case feedback details.
+public type CaseFeedback record {|
+    # ID
+    entity:IdString id;
+    # Emoji summary
+    FeedbackEmojiSummary emoji;
+    # Chips
+    string[]? chips;
+    # Assessment ID
+    entity:IdString assessmentId;
+    # User who created the feedback
+    string createdBy;
+    # Created date and time
+    string createdOn;
+    # Additional comment
+    string? additionalComment;
+|};
+
 # Payload for submitting case feedback.
 public type CaseFeedbackPayload record {|
     # Emoji ID

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -5228,6 +5228,56 @@ components:
           type: string
         method:
           type: string
+    FeedbackEmojiChip:
+      required:
+      - id
+      - name
+      - value
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID
+        name:
+          type: string
+          description: Name
+        value:
+          type: string
+          description: Value
+      additionalProperties: false
+      description: Feedback emoji chip information.
+    FeedbackEmoji:
+      required:
+      - chips
+      - id
+      - name
+      - selectedImage
+      - unselectedImage
+      - value
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID
+        name:
+          type: string
+          description: Name
+        value:
+          type: string
+          description: Value
+        unselectedImage:
+          type: string
+          description: Unselected image URL
+        selectedImage:
+          type: string
+          description: Selected image URL
+        chips:
+          type: array
+          description: Chips
+          items:
+            $ref: '#/components/schemas/FeedbackEmojiChip'
+      additionalProperties: false
+      description: Feedback emoji information.
     FeatureFlags:
       required:
       - usageMetricsEnabled
@@ -5431,6 +5481,7 @@ components:
     MetadataResponse:
       required:
       - featureFlags
+      - feedbackEmojies
       - projectTypes
       - timeZones
       type: object
@@ -5445,6 +5496,11 @@ components:
           description: List of available project types
           items:
             $ref: '#/components/schemas/ReferenceItem'
+        feedbackEmojies:
+          type: array
+          description: List of feedback emojies
+          items:
+            $ref: '#/components/schemas/FeedbackEmoji'
         featureFlags:
           $ref: '#/components/schemas/FeatureFlags'
       additionalProperties: false

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1173,6 +1173,8 @@ paths:
                 $ref: '#/components/schemas/CaseFeedback'
         "401":
           description: Unauthorized
+        "403":
+          description: Forbidden
         "404":
           description: NotFound
           content:

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1153,6 +1153,43 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+  /cases/{id}/feedback:
+    post:
+      summary: Submit feedback for a specific case.
+      operationId: postCasesIdFeedback
+      parameters:
+      - name: id
+        in: path
+        description: ID of the case
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Case feedback payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseFeedbackPayload'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseFeedbackResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
   /conversations/{id}/messages:
     get:
       summary: Get messages for a specific conversation.
@@ -3875,6 +3912,39 @@ components:
             items:
               $ref: '#/components/schemas/WatchList'
         additionalProperties: false
+    CaseFeedbackPayload:
+      required:
+      - emojiId
+      type: object
+      properties:
+        emojiId:
+          type: string
+          description: Emoji ID
+        chipIds:
+          type: array
+          description: Chip IDs
+          nullable: true
+          items:
+            type: string
+        additionalComment:
+          type: string
+          description: Additional comment
+          nullable: true
+      additionalProperties: false
+      description: Payload for submitting case feedback.
+    CaseFeedbackResponse:
+      required:
+      - feedback
+      - message
+      type: object
+      properties:
+        message:
+          type: string
+          description: Success message
+        feedback:
+          $ref: '#/components/schemas/SubmittedFeedback'
+      additionalProperties: false
+      description: Response from submitting case feedback.
     CaseSearchFilters:
       type: object
       properties:
@@ -6561,6 +6631,29 @@ components:
       description: Stats filter enum
       enum:
       - me
+    SubmittedFeedback:
+      required:
+      - assessmentId
+      - caseId
+      - createdBy
+      - createdOn
+      - id
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/IdString'
+        assessmentId:
+          $ref: '#/components/schemas/IdString'
+        caseId:
+          $ref: '#/components/schemas/IdString'
+        createdBy:
+          type: string
+          description: User who created the feedback
+        createdOn:
+          type: string
+          description: Created date and time
+      additionalProperties: false
+      description: Submitted feedback details.
     SubscriptionData:
       required:
       - clientId

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1154,6 +1154,33 @@ paths:
         "403":
           description: Forbidden
   /cases/{id}/feedback:
+    get:
+      summary: Get feedback for a specific case.
+      operationId: getCasesIdFeedback
+      parameters:
+      - name: id
+        in: path
+        description: ID of the case
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseFeedback'
+        "401":
+          description: Unauthorized
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
     post:
       summary: Submit feedback for a specific case.
       operationId: postCasesIdFeedback
@@ -3912,6 +3939,40 @@ components:
             items:
               $ref: '#/components/schemas/WatchList'
         additionalProperties: false
+    CaseFeedback:
+      required:
+      - assessmentId
+      - chips
+      - createdBy
+      - createdOn
+      - emoji
+      - id
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/IdString'
+        emoji:
+          $ref: '#/components/schemas/FeedbackEmojiSummary'
+        chips:
+          type: array
+          description: Chips
+          nullable: true
+          items:
+            type: string
+        assessmentId:
+          $ref: '#/components/schemas/IdString'
+        createdBy:
+          type: string
+          description: User who created the feedback
+        createdOn:
+          type: string
+          description: Created date and time
+        additionalComment:
+          type: string
+          description: Additional comment
+          nullable: true
+      additionalProperties: false
+      description: Case feedback details.
     CaseFeedbackPayload:
       required:
       - emojiId
@@ -5348,6 +5409,24 @@ components:
             $ref: '#/components/schemas/FeedbackEmojiChip'
       additionalProperties: false
       description: Feedback emoji information.
+    FeedbackEmojiSummary:
+      required:
+      - id
+      - name
+      - selectedImage
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID
+        name:
+          type: string
+          description: Name
+        selectedImage:
+          type: string
+          description: Selected image URL
+      additionalProperties: false
+      description: Feedback emoji summary.
     FeatureFlags:
       required:
       - usageMetricsEnabled

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2303,7 +2303,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + id - ID of the case
     # + return - Case feedback or error response
     resource function get cases/[entity:IdString id]/feedback(http:RequestContext ctx)
-        returns types:CaseFeedback|http:Unauthorized|http:NotFound|http:InternalServerError {
+        returns types:CaseFeedback|http:Unauthorized|http:Forbidden|http:NotFound|http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -2321,6 +2321,17 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                 return <http:Unauthorized>{
                     body: {
                         message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+
+            if getStatusCode(feedbackResponse) == http:STATUS_FORBIDDEN {
+                log:printWarn(string `User: ${userInfo.userId} is forbidden to access feedback for case with ID: ${
+                        id}!`);
+                return <http:Forbidden>{
+                    body: {
+                        message: "You're not authorized to access the feedback for the requested case. " +
+                        "Please check your access permissions or contact support."
                     }
                 };
             }

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2298,6 +2298,81 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return createdCommentResponse.comment;
     }
 
+    # Submit feedback for a specific case.
+    #
+    # + id - ID of the case
+    # + return - Submitted feedback response or error response
+    resource function post cases/[entity:IdString id]/feedback(http:RequestContext ctx,
+            types:CaseFeedbackPayload payload)
+        returns types:CaseFeedbackResponse|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:CaseFeedbackResponse|error feedbackResponse = entity:submitCaseFeedback(userInfo.idToken, id,
+                {
+                    emojiId: payload.emojiId,
+                    chipIds: payload.chipIds,
+                    additionalComment: payload.additionalComment
+                });
+        if feedbackResponse is error {
+            if getStatusCode(feedbackResponse) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+
+            if getStatusCode(feedbackResponse) == http:STATUS_FORBIDDEN {
+                log:printWarn(string `User: ${userInfo.userId} is forbidden to submit feedback for case with ID: ${
+                        id}!`);
+                return <http:Forbidden>{
+                    body: {
+                        message: "You're not authorized to submit feedback for the requested case. " +
+                        "Please check your access permissions or contact support."
+                    }
+                };
+            }
+
+            if getStatusCode(feedbackResponse) == http:STATUS_BAD_REQUEST {
+                string customError = "Invalid request parameters for submitting feedback for the case.";
+                log:printWarn(customError, feedbackResponse);
+                return <http:BadRequest>{
+                    body: {
+                        message: customError
+                    }
+                };
+            }
+
+            string customError = "Failed to submit feedback for the case.";
+            log:printError(customError, feedbackResponse);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return {
+            message: feedbackResponse.message,
+            feedback: {
+                id: feedbackResponse.feedback.id,
+                assessmentId: feedbackResponse.feedback.assessmentId,
+                caseId: feedbackResponse.feedback.caseId,
+                createdBy: feedbackResponse.feedback.createdBy,
+                createdOn: feedbackResponse.feedback.createdOn
+            }
+        };
+    }
+
     # Create a new attachment for a specific case.
     #
     # + id - ID of the case

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2298,6 +2298,65 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
         return createdCommentResponse.comment;
     }
 
+    # Get feedback for a specific case.
+    #
+    # + id - ID of the case
+    # + return - Case feedback or error response
+    resource function get cases/[entity:IdString id]/feedback(http:RequestContext ctx)
+        returns types:CaseFeedback|http:Unauthorized|http:NotFound|http:InternalServerError {
+
+        authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_INFO_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        entity:CaseFeedback|error feedbackResponse = entity:getCaseFeedback(userInfo.idToken, id);
+        if feedbackResponse is error {
+            if getStatusCode(feedbackResponse) == http:STATUS_UNAUTHORIZED {
+                log:printWarn(string `User: ${userInfo.userId} is not authorized to access the customer portal!`);
+                return <http:Unauthorized>{
+                    body: {
+                        message: ERR_MSG_UNAUTHORIZED_ACCESS
+                    }
+                };
+            }
+
+            if getStatusCode(feedbackResponse) == http:STATUS_NOT_FOUND {
+                return <http:NotFound>{
+                    body: {
+                        message: string `Feedback not found for case with ID: ${id}.`
+                    }
+                };
+            }
+
+            string customError = "Failed to retrieve feedback for the case.";
+            log:printError(customError, feedbackResponse);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return {
+            id: feedbackResponse.id,
+            emoji: {
+                id: feedbackResponse.emoji.id,
+                name: feedbackResponse.emoji.name,
+                selectedImage: feedbackResponse.emoji.selectedImage
+            },
+            chips: feedbackResponse.chips,
+            assessmentId: feedbackResponse.assessmentId,
+            createdBy: feedbackResponse.createdBy,
+            createdOn: feedbackResponse.createdOn,
+            additionalComment: feedbackResponse.additionalComment
+        };
+    }
+
     # Submit feedback for a specific case.
     #
     # + id - ID of the case

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1031,7 +1031,17 @@ public isolated function mapMetadataResponse(entity:MetadataResponse response) r
         select {id: item.id.toString(), label: item.label};
     types:ReferenceItem[] projectTypes = from entity:ReferenceTableItem item in response.projectTypes
         select {id: item.id, label: item.name};
-    return {timeZones, projectTypes, featureFlags};
+    types:FeedbackEmoji[] feedbackEmojies = from entity:FeedbackEmoji emoji in response.feedbackEmojies
+        select {
+            id: emoji.id,
+            name: emoji.name,
+            value: emoji.value,
+            unselectedImage: emoji.unselectedImage,
+            selectedImage: emoji.selectedImage,
+            chips: from entity:FeedbackEmojiChip chip in emoji.chips
+                select {id: chip.id, name: chip.name, value: chip.value}
+        };
+    return {timeZones, projectTypes, feedbackEmojies, featureFlags};
 }
 
 # Map usage stats response to the desired structure.


### PR DESCRIPTION
## Summary
- Added `GET /cases/{id}/feedback` to retrieve feedback submitted for a case
- Added `POST /cases/{id}/feedback` to submit feedback for a case
- Added `feedbackEmojies` to `GET /metadata` response to support emoji selection in the UI

## Test plan
- [ ] `GET /metadata` returns `feedbackEmojies` array with emoji options and chips
- [ ] `POST /cases/{id}/feedback` with only `emojiId` (required) succeeds
- [ ] `POST /cases/{id}/feedback` with `emojiId`, `chipIds`, and `additionalComment` succeeds
- [ ] `GET /cases/{id}/feedback` returns the submitted feedback with nullable `chips` and `additionalComment`
- [ ] `GET /cases/{id}/feedback` returns 404 for a case with no feedback
- [ ] Unauthorized requests return 401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added case feedback support, allowing users to view and submit feedback for a case.
  * Included feedback emoji options in metadata so the UI can display available reactions and chips.
  * Returned richer feedback submission details, including stored feedback information and timestamps.

* **Bug Fixes**
  * Improved API responses and error handling for feedback retrieval and submission, including clear unauthorized, forbidden, not found, and bad request outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->