### PR TITLE
[CSM Portal] gate repo field by subscription type, show SLA remaining as full-row bar

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
@@ -15,12 +15,12 @@
 // under the License.
 
 import {
+  alpha,
   Box,
   Button,
   Card,
   Chip,
   IconButton,
-  LinearProgress,
   Skeleton,
   Table,
   TableBody,
@@ -53,7 +53,6 @@ const SLA_STAGE_COLOR: Record<
 
 const SLA_TABLE_COLUMNS = [
   "SLA definition",
-  "Target",
   "Stage",
   "Business time left",
   "Business elapsed time",
@@ -200,38 +199,37 @@ export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
                   </TableCell>
                 </TableRow>
               ) : (
-                slas.map((sla) => (
-                  <TableRow key={sla.id} hover>
-                    <TableCell>{sla.definition}</TableCell>
-                    <TableCell>{sla.target ?? "—"}</TableCell>
-                    <TableCell>
-                      <Chip
-                        size="small"
-                        variant="outlined"
-                        color={stageColor(sla)}
-                        label={sla.stageLabel}
-                      />
-                    </TableCell>
-                    <TableCell sx={{ minWidth: 140 }}>
-                      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-                        <LinearProgress
-                          variant="determinate"
-                          value={Math.min(Math.max(sla.businessElapsedPercent, 0), 100)}
-                          color={slaProgressColor(sla)}
-                          aria-label={`${sla.definition} ${Math.round(sla.businessElapsedPercent)}% elapsed`}
-                          sx={{ height: 6, borderRadius: 1, width: "100%" }}
+                slas.map((sla) => {
+                  const elapsedPct = Math.min(Math.max(sla.businessElapsedPercent, 0), 100);
+                  return (
+                    <TableRow
+                      key={sla.id}
+                      hover
+                      aria-label={`${sla.definition} ${Math.round(elapsedPct)}% elapsed`}
+                      sx={(theme) => ({
+                        background: `linear-gradient(to right, ${alpha(
+                          theme.palette[slaProgressColor(sla)].main,
+                          0.14,
+                        )} ${elapsedPct}%, transparent ${elapsedPct}%)`,
+                      })}
+                    >
+                      <TableCell>{sla.definition}</TableCell>
+                      <TableCell>
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          color={stageColor(sla)}
+                          label={sla.stageLabel}
                         />
-                        <Typography variant="caption" color="text.secondary">
-                          {sla.businessTimeLeftLabel}
-                        </Typography>
-                      </Box>
-                    </TableCell>
-                    <TableCell>{sla.businessElapsedLabel}</TableCell>
-                    <TableCell>{`${Math.round(sla.businessElapsedPercent)}%`}</TableCell>
-                    <TableCell>{formatSlaDateTime(sla.startTime)}</TableCell>
-                    <TableCell>{formatSlaDateTime(sla.stopTime)}</TableCell>
-                  </TableRow>
-                ))
+                      </TableCell>
+                      <TableCell>{sla.businessTimeLeftLabel}</TableCell>
+                      <TableCell>{sla.businessElapsedLabel}</TableCell>
+                      <TableCell>{`${Math.round(sla.businessElapsedPercent)}%`}</TableCell>
+                      <TableCell>{formatSlaDateTime(sla.startTime)}</TableCell>
+                      <TableCell>{formatSlaDateTime(sla.stopTime)}</TableCell>
+                    </TableRow>
+                  );
+                })
               )}
             </TableBody>
           </Table>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateGithubIssueDialog.tsx
@@ -15,9 +15,6 @@
 // under the License.
 
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
   Box,
   Button,
   Dialog,
@@ -34,7 +31,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { CheckCircle, ChevronDown } from "@wso2/oxygen-ui-icons-react";
+import { CheckCircle } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import type {
   BeCreateCaseGithubIssuePayload,
@@ -95,6 +92,10 @@ export interface CreateGithubIssueDialogProps {
   defaultTitle?: string;
   /** Prefill for the Description field, taken from the case's description. */
   defaultDescription?: string;
+  /** Show the repository field only for cloud subscription / cloud
+   * evaluation subscription projects — other project types route by
+   * product unit on the SN side and have no repo to choose. */
+  showRepoField?: boolean;
   onClose: () => void;
   /** Body for `POST /cases/{id}/github-issues` (caseId is added by the caller). */
   onSubmit: (payload: BeCreateCaseGithubIssuePayload) => void;
@@ -125,6 +126,7 @@ export function CreateGithubIssueDialog({
   defaultUpdateLevel,
   defaultTitle,
   defaultDescription,
+  showRepoField,
   onClose,
   onSubmit,
 }: CreateGithubIssueDialogProps): JSX.Element {
@@ -322,27 +324,14 @@ export function CreateGithubIssueDialog({
             label="Regression"
           />
 
-          {/* Only the repo override stays optional across every type and is
-              rarely needed (the SN side routes by product unit when unset),
-              so it's the only field still tucked away by default. */}
-          <Accordion disableGutters sx={{ "&:before": { display: "none" } }}>
-            <AccordionSummary expandIcon={<ChevronDown size={16} />}>
-              <Typography variant="body2" color="text.secondary">
-                More options (optional)
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails
-              sx={{ display: "flex", flexDirection: "column", gap: 2 }}
-            >
-              {renderSelect(
-                "ghi-repo",
-                "Choose repository (only for cloud cases)",
-                repo,
-                setRepo,
-                REPO_OPTIONS,
-              )}
-            </AccordionDetails>
-          </Accordion>
+          {showRepoField &&
+            renderSelect(
+              "ghi-repo",
+              "Choose repository",
+              repo,
+              setRepo,
+              REPO_OPTIONS,
+            )}
         </Box>
       </DialogContent>
       <DialogActions>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -74,6 +74,7 @@ import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
 import AssignEngineerDialog from "@features/csm-cases/components/AssignEngineerDialog";
 import ChangeSeverityDialog from "@features/csm-cases/components/ChangeSeverityDialog";
 import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
+import { isCloudSupportSubscription } from "@features/csm-projects/utils/subscriptionType";
 import { usePostCaseGithubIssue } from "@features/csm-cases/api/useCsmCaseGithubIssue";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
@@ -1479,6 +1480,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           defaultUpdateLevel={c.productContext.updateLevel}
           defaultTitle={c.subject}
           defaultDescription={c.description}
+          showRepoField={isCloudSupportSubscription(caseProject?.subscriptionType)}
           onClose={() => {
             setGithubIssueOpen(false);
             setGithubIssueError(null);


### PR DESCRIPTION
## Purpose
The Git-issue dialog's repository picker was tucked behind a "More options" accordion while every other field in the form was shown flat, and it was offered regardless of project type even though non-cloud projects route by product unit and never use it. Separately, the case SLA table's "Target" column added little value, and its remaining/elapsed indicator was a small bar confined to a single column, making it hard to scan a row's SLA health at a glance.

## Goals
- Unfold the repository field so it renders inline like the rest of the form.
- Only show the repository field for cloud subscription / cloud evaluation subscription projects.
- Remove the SLA table's Target column.
- Replace the single-column progress bar with a full-row indicator so SLA elapsed/remaining status reads across the whole row.

## Approach
- `CreateGithubIssueDialog`: removed the `Accordion`/`AccordionSummary`/`AccordionDetails` wrapper around the repository select; it now renders directly in the form body. Added a `showRepoField` boolean prop and gated the field on it. Dropped the "(only for cloud cases)" suffix from the label since the field's visibility now expresses that directly.
- `CsmCaseDetailPage`: passes `showRepoField={isCloudSupportSubscription(caseProject?.subscriptionType)}`, reusing the project's existing subscription-type helper (`cloud_support` / `cloud_evaluation_support`) rather than introducing new gating logic.
- `CaseSlaTable`: removed the "Target" column from both the header and row cells. Replaced the per-cell `LinearProgress` with a `linear-gradient` background applied to the whole `TableRow`, tinted by the existing severity color logic (success/warning/error), so the elapsed proportion visually fills the entire row instead of one cell. The "Business time left" column keeps its text label.

## User stories
As a CS engineer filing a GitHub issue from a case, I only see the repository field when it's actually relevant to the project's subscription type, and I don't have to expand an accordion to reach it. As a CS engineer reviewing a case's SLAs, I can see each SLA's elapsed/remaining status at a glance across the row rather than in one narrow column.

## Release note
CSM Portal: the "Open Git issue" dialog now shows the repository field inline and only for cloud subscription / cloud evaluation subscription cases; the case SLA table drops the Target column and shows SLA progress as a full-row indicator.

## Documentation
N/A — internal UI behavior change, no external-facing docs to update.

## Automation tests
 - Unit tests
   Existing suites for both components (`CreateGithubIssueDialog.test.tsx`, `CaseSlaTable.test.tsx`) pass unmodified — 18 tests total.
 - Integration tests
   N/A — no integration test suite covers this flow.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React frontend, not Java) — `tsc --noEmit` and `vitest` ran clean instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no data or schema changes.

## Test environment
Verified with `pnpm exec tsc --noEmit` and `pnpm vitest run` for the two changed component test files on macOS (Darwin), Node/pnpm toolchain per repo config.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified the GitHub issue creation dialog by showing the repository selector only when needed for certain subscription types.
* **UI Improvements**
  * Updated SLA table rows to use a gradient highlight for progress instead of a separate progress bar, while keeping elapsed percentage and timing details visible.
  * Removed an extra “More options” expand/collapse section for a cleaner form experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->