### PR TITLE
feat(customer-portal): add case feedback modal on case close

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/types/projects.ts
@@ -19,6 +19,7 @@ import type {
   PaginationResponse,
   SearchRequestBase,
 } from "@/types/common";
+import type { FeedbackEmoji } from "@features/support/types/feedback";
 
 // Item type for basic project definition returned in search list responses.
 export type ProjectListItem = {
@@ -117,6 +118,7 @@ export type PortalFeatureFlags = {
 export type PortalMetadataResponse = {
   timeZones: TimeZoneOption[];
   featureFlags?: PortalFeatureFlags;
+  feedbackEmojies?: FeedbackEmoji[];
 };
 
 // Response type for project support statistics.

--- a/apps/customer-portal/webapp/src/features/support/api/usePostCaseFeedback.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/usePostCaseFeedback.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMutation } from "@tanstack/react-query";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import type {
+  CaseFeedbackPayload,
+  CaseFeedbackResponse,
+} from "@features/support/types/feedback";
+
+export type CaseFeedbackApiError = Error & { status: number };
+
+/**
+ * Submits feedback for a case (POST /cases/{caseId}/feedback).
+ *
+ * @param {string} caseId - The case ID to submit feedback for.
+ * @returns Mutation result for the feedback submission.
+ */
+export function usePostCaseFeedback(caseId: string) {
+  const authFetch = useAuthApiClient();
+
+  return useMutation<CaseFeedbackResponse, CaseFeedbackApiError, CaseFeedbackPayload>({
+    mutationFn: async (payload) => {
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL ?? "";
+      const response = await authFetch(`${baseUrl}/cases/${caseId}/feedback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as { message?: string };
+        const err = new Error(
+          body?.message ?? `Feedback submission failed: ${response.statusText}`,
+        ) as CaseFeedbackApiError;
+        err.status = response.status;
+        throw err;
+      }
+      return response.json() as Promise<CaseFeedbackResponse>;
+    },
+  });
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/feedback/CaseFeedbackModal.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/feedback/CaseFeedbackModal.tsx
@@ -1,0 +1,340 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CaseFeedbackModalProps } from "@features/support/types/supportComponents";
+import {
+  Alert,
+  Box,
+  Button,
+  ButtonBase,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+  alpha,
+  useTheme,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type JSX,
+} from "react";
+import useGetMetadata from "@api/useGetMetadata";
+import { usePostCaseFeedback } from "@features/support/api/usePostCaseFeedback";
+
+const INLINE_ERROR_STATUSES = new Set([400, 403, 404, 409]);
+const COMMENT_MAX_LENGTH = 1000;
+const EMOJI_SIZE = 44;
+
+/**
+ * Modal for submitting feedback after a case is closed. The rating emojis and
+ * their chips are served from GET /metadata. Submission is non-blocking — the
+ * case has already closed, so the user can skip. HTTP 4xx errors are shown
+ * inline; 5xx errors are forwarded via onError.
+ *
+ * @param {CaseFeedbackModalProps} props - Modal control props.
+ * @returns {JSX.Element} The case feedback modal.
+ */
+export default function CaseFeedbackModal({
+  open,
+  caseId,
+  onClose,
+  onSubmitted,
+  onError,
+}: CaseFeedbackModalProps): JSX.Element {
+  const theme = useTheme();
+  const { data: metadata, isLoading: isMetadataLoading } = useGetMetadata();
+  const emojis = useMemo(() => metadata?.feedbackEmojies ?? [], [metadata]);
+
+  const [selectedEmojiId, setSelectedEmojiId] = useState<string | null>(null);
+  const [selectedChipIds, setSelectedChipIds] = useState<string[]>([]);
+  const [comment, setComment] = useState("");
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  const { mutate, isPending } = usePostCaseFeedback(caseId);
+
+  const selectedEmoji = useMemo(
+    () => emojis.find((e) => e.id === selectedEmojiId) ?? null,
+    [emojis, selectedEmojiId],
+  );
+
+  // Nothing to collect — close silently so the flow is never blocked.
+  useEffect(() => {
+    if (open && !isMetadataLoading && emojis.length === 0) {
+      onClose();
+    }
+  }, [open, isMetadataLoading, emojis.length, onClose]);
+
+  const resetAndClose = useCallback(() => {
+    setSelectedEmojiId(null);
+    setSelectedChipIds([]);
+    setComment("");
+    setInlineError(null);
+    onClose();
+  }, [onClose]);
+
+  const handleClose = useCallback(() => {
+    if (isPending) return;
+    resetAndClose();
+  }, [isPending, resetAndClose]);
+
+  const handleSelectEmoji = useCallback((emojiId: string) => {
+    setSelectedEmojiId(emojiId);
+    setSelectedChipIds([]); // chips are emoji-specific
+    setInlineError(null);
+  }, []);
+
+  const toggleChip = useCallback((chipId: string) => {
+    setSelectedChipIds((prev) =>
+      prev.includes(chipId) ? prev.filter((c) => c !== chipId) : [...prev, chipId],
+    );
+  }, []);
+
+  const handleCommentChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setComment(e.target.value.slice(0, COMMENT_MAX_LENGTH));
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (!selectedEmojiId || isPending) return;
+    setInlineError(null);
+    const trimmedComment = comment.trim();
+    mutate(
+      {
+        emojiId: selectedEmojiId,
+        chipIds: selectedChipIds.length ? selectedChipIds : undefined,
+        additionalComment: trimmedComment ? trimmedComment : undefined,
+      },
+      {
+        onSuccess: () => {
+          resetAndClose();
+          onSubmitted?.();
+        },
+        onError: (err) => {
+          if (INLINE_ERROR_STATUSES.has(err.status)) {
+            setInlineError(err.message);
+          } else {
+            onError?.(err.message ?? "Failed to submit feedback. Please try again.");
+            resetAndClose();
+          }
+        },
+      },
+    );
+  }, [
+    selectedEmojiId,
+    isPending,
+    comment,
+    selectedChipIds,
+    mutate,
+    resetAndClose,
+    onSubmitted,
+    onError,
+  ]);
+
+  const canSubmit = !!selectedEmojiId && !isPending;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="case-feedback-modal-title"
+    >
+      <IconButton
+        aria-label="Close"
+        size="small"
+        onClick={handleClose}
+        disabled={isPending}
+        sx={{ position: "absolute", right: 12, top: 12, zIndex: 1 }}
+      >
+        <X size={18} />
+      </IconButton>
+
+      <DialogTitle id="case-feedback-modal-title" sx={{ pr: 6, pb: 0.5 }}>
+        <Typography variant="h6" component="span" fontWeight={700}>
+          How was your support experience?
+        </Typography>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mt: 0.5, fontWeight: "normal" }}
+        >
+          Your feedback helps us improve the support we provide.
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1.5 }}>
+        {inlineError && (
+          <Alert severity="error" onClose={() => setInlineError(null)} sx={{ mb: 2 }}>
+            {inlineError}
+          </Alert>
+        )}
+
+        {isMetadataLoading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <CircularProgress size={28} />
+          </Box>
+        ) : (
+          <>
+            {/* Emoji rating */}
+            <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+              Rate your experience{" "}
+              <Box component="span" sx={{ color: "error.main" }}>
+                *
+              </Box>
+            </Typography>
+            <Stack
+              direction="row"
+              spacing={1}
+              role="radiogroup"
+              aria-label="Rate your experience"
+              sx={{ justifyContent: "space-between", mb: 2.5 }}
+            >
+              {emojis.map((emoji) => {
+                const selected = selectedEmojiId === emoji.id;
+                return (
+                  <Stack key={emoji.id} alignItems="center" spacing={0.5} sx={{ flex: 1 }}>
+                    <ButtonBase
+                      role="radio"
+                      aria-label={emoji.name}
+                      aria-checked={selected}
+                      onClick={() => handleSelectEmoji(emoji.id)}
+                      disabled={isPending}
+                      sx={{
+                        borderRadius: 2,
+                        p: 0.75,
+                        border: 1,
+                        borderColor: selected ? "primary.main" : "divider",
+                        bgcolor: selected
+                          ? alpha(theme.palette.primary.main, 0.1)
+                          : "transparent",
+                        "&:hover": {
+                          bgcolor: alpha(theme.palette.primary.main, 0.16),
+                        },
+                      }}
+                    >
+                      <Box
+                        component="img"
+                        src={selected ? emoji.selectedImage : emoji.unselectedImage}
+                        alt={emoji.name}
+                        sx={{
+                          width: EMOJI_SIZE,
+                          height: EMOJI_SIZE,
+                          display: "block",
+                          objectFit: "contain",
+                        }}
+                      />
+                    </ButtonBase>
+                    <Typography
+                      variant="caption"
+                      color={selected ? "text.primary" : "text.secondary"}
+                      fontWeight={selected ? 600 : 400}
+                      sx={{ textAlign: "center" }}
+                    >
+                      {emoji.name}
+                    </Typography>
+                  </Stack>
+                );
+              })}
+            </Stack>
+
+            {/* Chips for the selected emoji */}
+            {selectedEmoji && selectedEmoji.chips.length > 0 && (
+              <>
+                <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+                  What stood out?{" "}
+                  <Box component="span" sx={{ color: "text.secondary", fontWeight: 400 }}>
+                    (optional)
+                  </Box>
+                </Typography>
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 2.5 }}>
+                  {selectedEmoji.chips.map((chip) => {
+                    const selected = selectedChipIds.includes(chip.id);
+                    return (
+                      <Chip
+                        key={chip.id}
+                        label={chip.name}
+                        onClick={() => toggleChip(chip.id)}
+                        aria-pressed={selected}
+                        variant={selected ? "filled" : "outlined"}
+                        color={selected ? "primary" : "default"}
+                        disabled={isPending}
+                        sx={{ fontSize: "0.75rem" }}
+                      />
+                    );
+                  })}
+                </Box>
+              </>
+            )}
+
+            {/* Optional comment */}
+            <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+              Additional comments{" "}
+              <Box component="span" sx={{ color: "text.secondary", fontWeight: 400 }}>
+                (optional)
+              </Box>
+            </Typography>
+            <TextField
+              id="case-feedback-comment"
+              placeholder="Tell us anything else about your experience..."
+              value={comment}
+              onChange={handleCommentChange}
+              fullWidth
+              multiline
+              rows={4}
+              disabled={isPending}
+              inputProps={{
+                "aria-label": "Additional comments",
+                maxLength: COMMENT_MAX_LENGTH,
+              }}
+              helperText={`${comment.length}/${COMMENT_MAX_LENGTH}`}
+              FormHelperTextProps={{ sx: { textAlign: "right", m: 0, mt: 0.5 } }}
+            />
+          </>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2.5, gap: 1 }}>
+        <Button variant="outlined" onClick={handleClose} disabled={isPending}>
+          Skip
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          startIcon={
+            isPending ? <CircularProgress size={16} color="inherit" /> : undefined
+          }
+        >
+          {isPending ? "Submitting..." : "Submit Feedback"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/feedback/__tests__/CaseFeedbackModal.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/feedback/__tests__/CaseFeedbackModal.test.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CaseFeedbackModal from "../CaseFeedbackModal";
+
+const EMOJIS = [
+  {
+    id: "e1",
+    name: "Poor",
+    value: "1",
+    unselectedImage: "u1.png",
+    selectedImage: "s1.png",
+    chips: [{ id: "c1a", name: "Slow", value: "slow" }],
+  },
+  {
+    id: "e2",
+    name: "Great",
+    value: "5",
+    unselectedImage: "u2.png",
+    selectedImage: "s2.png",
+    chips: [
+      { id: "c2a", name: "Fast", value: "fast" },
+      { id: "c2b", name: "Helpful", value: "helpful" },
+    ],
+  },
+];
+
+vi.mock("@api/useGetMetadata", () => ({
+  default: () => ({ data: { feedbackEmojies: EMOJIS }, isLoading: false }),
+}));
+
+const mutate = vi.fn();
+vi.mock("@features/support/api/usePostCaseFeedback", () => ({
+  usePostCaseFeedback: () => ({ isPending: false, mutate }),
+}));
+
+function renderModal(props: Partial<React.ComponentProps<typeof CaseFeedbackModal>> = {}) {
+  const onClose = vi.fn();
+  const onSubmitted = vi.fn();
+  const onError = vi.fn();
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <CaseFeedbackModal
+        open
+        caseId="c1"
+        onClose={onClose}
+        onSubmitted={onSubmitted}
+        onError={onError}
+        {...props}
+      />
+    </ThemeProvider>,
+  );
+  return { onClose, onSubmitted, onError };
+}
+
+describe("CaseFeedbackModal", () => {
+  beforeEach(() => {
+    mutate.mockReset();
+  });
+
+  it("renders the feedback prompt with emoji options", () => {
+    renderModal();
+    expect(screen.getByText(/how was your support experience/i)).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Poor" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Great" })).toBeInTheDocument();
+  });
+
+  it("disables submit until an emoji is selected", () => {
+    renderModal();
+    const submit = screen.getByRole("button", { name: /submit feedback/i });
+    expect(submit).toBeDisabled();
+    fireEvent.click(screen.getByRole("radio", { name: "Great" }));
+    expect(submit).toBeEnabled();
+  });
+
+  it("shows chips for the selected emoji and swaps them when the emoji changes", () => {
+    renderModal();
+    expect(screen.queryByText("Fast")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Great" }));
+    expect(screen.getByText("Fast")).toBeInTheDocument();
+    expect(screen.getByText("Helpful")).toBeInTheDocument();
+    expect(screen.queryByText("Slow")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Poor" }));
+    expect(screen.getByText("Slow")).toBeInTheDocument();
+    expect(screen.queryByText("Fast")).not.toBeInTheDocument();
+  });
+
+  it("submits emojiId, chipIds and comment", () => {
+    renderModal();
+    fireEvent.click(screen.getByRole("radio", { name: "Great" }));
+    fireEvent.click(screen.getByText("Fast"));
+    fireEvent.change(screen.getByLabelText(/additional comments/i), {
+      target: { value: "  nice support  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /submit feedback/i }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0][0]).toEqual({
+      emojiId: "e2",
+      chipIds: ["c2a"],
+      additionalComment: "nice support",
+    });
+  });
+
+  it("skips without submitting", () => {
+    const { onClose } = renderModal();
+    fireEvent.click(screen.getByRole("button", { name: /skip/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error on 4xx responses", () => {
+    mutate.mockImplementation((_payload, { onError }) => {
+      const err = Object.assign(new Error("Feedback already submitted"), { status: 409 });
+      onError(err);
+    });
+    renderModal();
+    fireEvent.click(screen.getByRole("radio", { name: "Great" }));
+    fireEvent.click(screen.getByRole("button", { name: /submit feedback/i }));
+    expect(screen.getByText(/feedback already submitted/i)).toBeInTheDocument();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -25,6 +25,7 @@ import {
 } from "@wso2/oxygen-ui";
 import CaseStateConfirmDialog from "@features/support/components/case-details/dialogs/CaseStateConfirmDialog";
 import EscalateCaseModal from "../escalation/EscalateCaseModal";
+import CaseFeedbackModal from "../feedback/CaseFeedbackModal";
 import { type JSX, useState } from "react";
 import {
   CASE_STATUS_ACTIONS,
@@ -114,6 +115,7 @@ export default function CaseDetailsActionRow({
     stateKey: number;
   } | null>(null);
   const [escalateModalOpen, setEscalateModalOpen] = useState(false);
+  const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
 
   const resolvedEscalationLevelId = escalationLevelId != null ? String(escalationLevelId) : null;
   const escalationLevelInfo = resolvedEscalationLevelId != null ? ESCALATION_NEXT_LEVEL[resolvedEscalationLevelId ?? "0"] : null;
@@ -224,6 +226,10 @@ export default function CaseDetailsActionRow({
             {
               onSuccess: () => {
                 showSuccess("State updated successfully.");
+                // Prompt for feedback after the case is closed (non-blocking).
+                if (ACTION_TO_CASE_STATE_LABEL[label] === "Closed" && caseId) {
+                  setFeedbackModalOpen(true);
+                }
               },
               onError: (err) => {
                 showError(
@@ -249,6 +255,15 @@ export default function CaseDetailsActionRow({
             showSuccess("Case escalated successfully.");
             onEscalateSuccess?.();
           }}
+          onError={(msg) => showError(msg)}
+        />
+      )}
+      {feedbackModalOpen && (
+        <CaseFeedbackModal
+          open
+          caseId={caseId}
+          onClose={() => setFeedbackModalOpen(false)}
+          onSubmitted={() => showSuccess("Thanks for your feedback.")}
           onError={(msg) => showError(msg)}
         />
       )}

--- a/apps/customer-portal/webapp/src/features/support/types/feedback.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/feedback.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// A selectable chip (tag) attached to a feedback emoji.
+export type FeedbackEmojiChip = {
+  id: string;
+  name: string;
+  value: string;
+};
+
+// A feedback emoji option (rating) with its images and chips, from GET /metadata.
+export type FeedbackEmoji = {
+  id: string;
+  name: string;
+  value: string;
+  unselectedImage: string;
+  selectedImage: string;
+  chips: FeedbackEmojiChip[];
+};
+
+// Request payload for submitting case feedback (POST /cases/{id}/feedback).
+export type CaseFeedbackPayload = {
+  emojiId: string;
+  chipIds?: string[];
+  additionalComment?: string;
+};
+
+// Submitted feedback details returned on POST.
+export type SubmittedFeedback = {
+  id: string;
+  assessmentId: string;
+  caseId: string;
+  createdBy: string;
+  createdOn: string;
+};
+
+// Response from submitting case feedback.
+export type CaseFeedbackResponse = {
+  message: string;
+  feedback: SubmittedFeedback;
+};
+
+// Emoji summary attached to an existing case feedback.
+export type FeedbackEmojiSummary = {
+  id: string;
+  name: string;
+  selectedImage: string;
+};
+
+// Existing case feedback (GET /cases/{id}/feedback).
+export type CaseFeedback = {
+  id: string;
+  emoji: FeedbackEmojiSummary;
+  chips?: string[] | null;
+  assessmentId: string;
+  createdBy: string;
+  createdOn: string;
+  additionalComment?: string | null;
+};

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -461,6 +461,14 @@ export type EscalateCaseModalProps = {
   onError?: (message: string) => void;
 };
 
+export type CaseFeedbackModalProps = {
+  open: boolean;
+  caseId: string;
+  onClose: () => void;
+  onSubmitted?: () => void;
+  onError?: (message: string) => void;
+};
+
 export type CasesOverviewStatCardProps = {
   isLoading: boolean;
   isError?: boolean;


### PR DESCRIPTION
## What

When a customer closes a case, show an interactive **feedback modal** to capture their support experience.

- **Rating** — emoji faces (required)
- **Chips** — quick tags shown for the selected emoji (optional)
- **Comment** — free-text (optional)

The prompt is **non-blocking**: the case close completes first, and the modal can be skipped. A submit failure never affects the already-completed close.

## Metadata-driven

Everything visible is served by the backend — nothing is hardcoded in the frontend:

- Emoji **images** (`unselectedImage` / `selectedImage`) and **names**, plus each emoji's **chips**, come from `GET /metadata` → `feedbackEmojies` (read via the existing `useGetMetadata` hook; `feedbackEmojies` added to `PortalMetadataResponse`).
- Chips are **emoji-specific** — selecting a different face shows that face's own chips.

Submits to **`POST /cases/{id}/feedback`** with `{ emojiId, chipIds?, additionalComment? }`.

## Behaviour

- Triggered from `CaseDetailsActionRow` after a successful close (`ACTION_TO_CASE_STATE_LABEL[label] === "Closed"`); conditionally mounted so the metadata query only runs when shown.
- Submit gated on an emoji selection; 4xx → inline alert, 5xx → error banner, success → "Thanks for your feedback." banner.
- If metadata returns no emojis, the modal closes silently (never blocks the flow).

## Files

- New: `types/feedback.ts`, `api/usePostCaseFeedback.ts`, `feedback/CaseFeedbackModal.tsx` (+ test)
- Modified: `project-hub/types/projects.ts`, `support/types/supportComponents.ts`, `case-details/header/CaseDetailsActionRow.tsx`

## Testing

- 6 new modal tests (submit gating, chips swap per emoji, payload shape, skip, inline 4xx) — pass
- Existing `CaseDetailsActionRow` test still passes
- `tsc -b` and `eslint` clean
- Manually verified in the running app (emoji images + per-emoji chips render from metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a case feedback flow that appears after closing a support case.
  * Users can rate their experience with an emoji, optionally pick related options, and leave a short comment.
  * Feedback submission now shows loading states and confirms success or displays helpful error messages.

* **Bug Fixes**
  * The feedback dialog now closes automatically when no feedback options are available.
  * Submission errors are handled more clearly, including cases where feedback was already sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->