### PR TITLE
[CSM Portal] format absolute timestamps consistently (SLA table, comments, call slots)

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
@@ -33,6 +33,18 @@ import {
   zonedInputToUtcIso,
 } from "@utils/dateTime";
 
+/** Formats a UTC epoch-ms instant as "Jan 23, 2026, 10:14 PM UTC" for the slot preview hint. */
+function formatUtcHint(ms: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+  }).format(new Date(ms));
+}
+
 // ---------------------------------------------------------------------------
 // Constants — mirror the backend's call-request contract so we fail in the
 // dialog instead of round-tripping to a generic 400.
@@ -109,8 +121,7 @@ function slotStatus(
       error: `Must be at least ${formatLeadTime(leadMinutes)} from now for this case severity.`,
     };
   }
-  const utc = new Date(ms).toISOString().slice(0, 16).replace("T", " ");
-  return { hint: `= ${utc} UTC` };
+  return { hint: `= ${formatUtcHint(ms)} UTC` };
 }
 
 /** Filled slots mapped to future (>= lead time), de-duplicated UTC ISO instants. */

--- a/apps/csm-portal/webapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.ts
@@ -302,7 +302,7 @@ export function utcMsToZonedInputValue(
 /**
  * Formats a backend (UTC) timestamp as an absolute date-time string in the
  * user's resolved timezone, suitable for tooltip text. Format:
- *   "2026-05-31 20:28:33 GMT+5:30"
+ *   "Jan 23, 2026, 10:14:13 PM GMT+5:30"
  *
  * Returns `null` when the input is empty or unparseable.
  */
@@ -314,23 +314,16 @@ export function formatAbsoluteForUser(
   if (!date) return null;
   const timeZone = resolveDisplayTimeZone(explicitTimeZone);
   try {
-    const parts = new Intl.DateTimeFormat("en-CA", {
+    return new Intl.DateTimeFormat("en-US", {
       year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
       minute: "2-digit",
       second: "2-digit",
-      hourCycle: "h23", // 00-23; avoids the h24 midnight "24" edge case
       timeZone,
       timeZoneName: "shortOffset",
-    }).formatToParts(date);
-    const find = (type: Intl.DateTimeFormatPartTypes): string =>
-      parts.find((p) => p.type === type)?.value ?? "";
-    const datePart = `${find("year")}-${find("month")}-${find("day")}`;
-    const timePart = `${find("hour")}:${find("minute")}:${find("second")}`;
-    const tzPart = find("timeZoneName") || "UTC";
-    return `${datePart} ${timePart} ${tzPart}`;
+    }).format(date);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Purpose
The SLA table's Start time/Stop time columns (and other absolute-timestamp displays fed by the same helper: comment/activity-feed hover tooltips, case-activity field-change values) rendered a raw, hand-built string like "2026-07-08 22:14:13 GMT+5:30" instead of the short-month style used elsewhere in the app (e.g. "Jan 23, 2026"). The call-request scheduling dialog's UTC preview hint had the same issue, showing e.g. "= 2026-07-08 22:14 UTC".

## Goals
Make every absolute-timestamp display in the CSM portal use the same readable "Jul 8, 2026, 10:14 PM ..." style already used by the rest of the app, instead of a raw ISO-like/GMT-offset string.

## Approach
- `formatAbsoluteForUser` (`src/utils/dateTime.ts`) previously built its string by hand-concatenating `Intl.DateTimeFormat` parts with `month: "2-digit"`. Replaced with a single `Intl.DateTimeFormat` call using `month: "short"`, matching the pattern already used by other formatters in this file. This is the shared helper behind the SLA table's Start/Stop columns, the `RelativeTime` component's hover tooltip (used across comments, activity feed, timecards, dashboard), and case-activity field-change values, so fixing it once fixes all of those call sites.
- `CreateCallRequestDialog.tsx`'s slot preview hint built its UTC string via `.toISOString().slice(0, 16).replace("T", " ")`. Replaced with a small `formatUtcHint` helper using the same short-month `Intl.DateTimeFormat` style.

No data model, API, or backend changes — purely a display-formatting fix in the FE. Out of scope: customer-portal (not touched).

## User stories
As a CS engineer, when I hover a relative timestamp, view the SLA table, read a case's activity feed, or schedule a call, I see the exact date/time in a consistent, unambiguous "Jul 8, 2026, 10:14 PM" style rather than a raw ISO/GMT-offset string.

## Release note
Fixed inconsistent absolute-timestamp formatting (raw GMT-offset/ISO-like strings) in the SLA table, comment/activity tooltips, and the call-request scheduling dialog; timestamps now consistently display as e.g. "Jul 8, 2026, 10:14 PM GMT+5:30".

## Documentation
N/A — internal display formatting fix, no user-facing documentation to update.

## Automation tests
- Unit tests: no existing tests hardcode the old format string; the one test referencing `formatAbsoluteForUser` computes its expected value by calling the same function, so it stays valid. Verified via `pnpm build`/`pnpm lint`.
- Integration tests: N/A.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React project; ran `pnpm lint`, clean on changed files)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Builds on the same date-formatting cleanup as the numeric-slash-date fix PR.

## Migrations (if applicable)
N/A

## Test environment
Verified with `pnpm build` and `pnpm lint` on `apps/csm-portal/webapp` (Node/pnpm on macOS host).

## Learning
N/A