### PR TITLE
[CSM][Web] improve error UX: type-aware states and tracking ID copy

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/client.ts
+++ b/apps/csm-portal/webapp/src/api/backend/client.ts
@@ -17,7 +17,7 @@
 import { useCallback, useMemo } from "react";
 import { useAuthApiClient } from "@hooks/useAuthApiClient";
 import type { BeErrorPayload } from "@api/backend/types";
-import { CORRELATION_ID_HEADER } from "@utils/correlationId";
+import { CORRELATION_ID_HEADER, newCorrelationId } from "@utils/correlationId";
 
 export function backendBaseUrl(): string {
   const baseUrl = window.config?.CSM_PORTAL_BACKEND_BASE_URL;
@@ -53,7 +53,10 @@ export class BackendApiError extends Error {
   }
 }
 
-async function readError(response: Response): Promise<BackendApiError> {
+async function readError(
+  response: Response,
+  sentCorrelationId?: string,
+): Promise<BackendApiError> {
   let payload: BeErrorPayload | undefined;
   try {
     payload = (await response.json()) as BeErrorPayload;
@@ -64,8 +67,10 @@ async function readError(response: Response): Promise<BackendApiError> {
     payload?.message ??
     response.statusText ??
     `Request failed with status ${response.status}`;
+  // Prefer the backend-echoed header; fall back to the ID the frontend sent so
+  // the user always has a traceable reference even when the server omits it.
   const correlationId =
-    response.headers.get(CORRELATION_ID_HEADER) ?? undefined;
+    response.headers.get(CORRELATION_ID_HEADER) ?? sentCorrelationId;
   return new BackendApiError(response.status, msg, payload, correlationId);
 }
 
@@ -108,9 +113,13 @@ export function useBackendApi(): BackendApi {
   return useMemo<BackendApi>(
     () => ({
       async get<T>(path: string): Promise<T | null> {
-        const response = await authFetch(buildUrl(path), { method: "GET" });
+        const correlationId = newCorrelationId();
+        const response = await authFetch(buildUrl(path), {
+          method: "GET",
+          headers: { [CORRELATION_ID_HEADER]: correlationId },
+        });
         if (response.status === 404) return null;
-        if (!response.ok) throw await readError(response);
+        if (!response.ok) throw await readError(response, correlationId);
         if (response.status === 204) return null;
         return (await response.json()) as T;
       },
@@ -118,44 +127,64 @@ export function useBackendApi(): BackendApi {
         path: string,
         body: TRequest,
       ): Promise<TResponse> {
+        const correlationId = newCorrelationId();
         const response = await authFetch(buildUrl(path), {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            [CORRELATION_ID_HEADER]: correlationId,
+          },
           body: JSON.stringify(body),
         });
-        if (!response.ok) throw await readError(response);
+        if (!response.ok) throw await readError(response, correlationId);
         return (await response.json()) as TResponse;
       },
       async patch<TRequest, TResponse>(
         path: string,
         body: TRequest,
       ): Promise<TResponse> {
+        const correlationId = newCorrelationId();
         const response = await authFetch(buildUrl(path), {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            [CORRELATION_ID_HEADER]: correlationId,
+          },
           body: JSON.stringify(body),
         });
-        if (!response.ok) throw await readError(response);
+        if (!response.ok) throw await readError(response, correlationId);
         return (await response.json()) as TResponse;
       },
       async postEmpty<TResponse>(path: string): Promise<TResponse> {
+        const correlationId = newCorrelationId();
         const response = await authFetch(buildUrl(path), {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            [CORRELATION_ID_HEADER]: correlationId,
+          },
           body: "{}",
         });
-        if (!response.ok) throw await readError(response);
+        if (!response.ok) throw await readError(response, correlationId);
         return (await response.json()) as TResponse;
       },
       async del<TResponse>(path: string): Promise<TResponse | null> {
-        const response = await authFetch(buildUrl(path), { method: "DELETE" });
-        if (!response.ok) throw await readError(response);
+        const correlationId = newCorrelationId();
+        const response = await authFetch(buildUrl(path), {
+          method: "DELETE",
+          headers: { [CORRELATION_ID_HEADER]: correlationId },
+        });
+        if (!response.ok) throw await readError(response, correlationId);
         if (response.status === 204) return null;
         return (await response.json()) as TResponse;
       },
       async getBlob(path: string): Promise<Blob> {
-        const response = await authFetch(buildUrl(path), { method: "GET" });
-        if (!response.ok) throw await readError(response);
+        const correlationId = newCorrelationId();
+        const response = await authFetch(buildUrl(path), {
+          method: "GET",
+          headers: { [CORRELATION_ID_HEADER]: correlationId },
+        });
+        if (!response.ok) throw await readError(response, correlationId);
         return await response.blob();
       },
     }),

--- a/apps/csm-portal/webapp/src/components/QueryErrorState.tsx
+++ b/apps/csm-portal/webapp/src/components/QueryErrorState.tsx
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Stack, Tooltip, Typography } from "@wso2/oxygen-ui";
+import {
+  AlertTriangle,
+  Check,
+  Copy,
+  FileQuestion,
+  Lock,
+  ServerCrash,
+  ShieldAlert,
+  type LucideIcon,
+} from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import { BackendApiError } from "@api/backend/client";
+import { getErrorReferenceId } from "@utils/correlationId";
+
+interface QueryErrorStateProps {
+  message: string;
+  /** Pass the raw error object to enable error-type-aware presentation and
+   *  the tracking ID copy button when a correlation ID is available. */
+  error?: unknown;
+}
+
+interface ErrorPresentation {
+  Icon: LucideIcon;
+  title: string;
+}
+
+function resolvePresentation(error: unknown): ErrorPresentation {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) return { Icon: Lock, title: "Session expired" };
+    if (error.status === 403) return { Icon: ShieldAlert, title: "Access denied" };
+    if (error.status === 404) return { Icon: FileQuestion, title: "Not found" };
+    if (error.status >= 400 && error.status < 500) {
+      return { Icon: AlertTriangle, title: "Something's not right" };
+    }
+  }
+  return { Icon: ServerCrash, title: "Something went wrong" };
+}
+
+/**
+ * Inline error state for data-loading failures. Shows an icon and title
+ * derived from the HTTP status, the human-readable message, and — when a
+ * correlation ID is present — a tracking ID copy button for support handoffs.
+ */
+export default function QueryErrorState({ message, error }: QueryErrorStateProps): JSX.Element {
+  const { Icon, title } = resolvePresentation(error);
+  const referenceId = getErrorReferenceId(error);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (): void => {
+    if (!referenceId) return;
+    void navigator.clipboard.writeText(referenceId).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Box sx={{ display: "flex", justifyContent: "center", px: 3, py: 4 }}>
+      <Stack spacing={1.5} alignItems="center" sx={{ maxWidth: 420 }}>
+        <Icon size={36} strokeWidth={1.5} style={{ opacity: 0.6 }} aria-hidden />
+        <Typography variant="subtitle2" fontWeight={700}>
+          {title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+          {message}
+        </Typography>
+        {referenceId && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.5,
+              py: 0.75,
+              borderRadius: 1,
+              bgcolor: "action.hover",
+            }}
+          >
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+              Tracking ID: {referenceId}
+            </Typography>
+            <Tooltip title={copied ? "Copied!" : "Copy tracking ID"} placement="top">
+              <Button
+                size="small"
+                variant="text"
+                color="inherit"
+                onClick={handleCopy}
+                sx={{ minWidth: 0, p: 0.5, color: "text.disabled" }}
+                aria-label="Copy reference ID"
+              >
+                {copied ? <Check size={13} /> : <Copy size={13} />}
+              </Button>
+            </Tooltip>
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   Box,
   Chip,
   Skeleton,
@@ -31,6 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
+import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts";
 import type { SearchAccountsRequest } from "@features/csm-accounts/types/csmAccounts";
@@ -98,12 +98,6 @@ export default function CsmAccountsPage(): JSX.Element {
         sx={{ maxWidth: 480 }}
       />
 
-      {isError && (
-        <Alert severity="error">
-          Failed to load accounts: {error instanceof Error ? error.message : "unknown error"}
-        </Alert>
-      )}
-
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
           <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
@@ -129,6 +123,15 @@ export default function CsmAccountsPage(): JSX.Element {
                     <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
                   </TableRow>
                 ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    <QueryErrorState
+                      message={`Failed to load accounts: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
               ) : accounts.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -975,7 +975,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           {backLabel}
         </Button>
         <QueryErrorState
-          message="Could not load this case."
+          message={`Could not load this case: ${error instanceof Error ? error.message : "unknown error"}`}
           error={error}
         />
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -106,6 +106,7 @@ import {
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import QueryErrorState from "@components/QueryErrorState";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
 import StateChip from "@components/StateChip";
@@ -271,7 +272,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     : isServiceRequestRoute
       ? `/operations/service-requests/${caseId}`
       : `/cases/${caseId}`;
-  const { data, isLoading, isError } = useGetCsmCaseDetail(caseId);
+  const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
   const {
     data: comments,
     isLoading: isCommentsLoading,
@@ -973,9 +974,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
         >
           {backLabel}
         </Button>
-        <Typography variant="body1" color="error">
-          Could not load case {caseId}.
-        </Typography>
+        <QueryErrorState
+          message="Could not load this case."
+          error={error}
+        />
       </Box>
     );
   }

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   Box,
   Chip,
   Skeleton,
@@ -29,8 +28,8 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
-
 import { useNavTransition } from "@hooks/useNavTransition";
+import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useSearchChangeRequests } from "@features/csm-operations/api/useSearchChangeRequests";
@@ -130,13 +129,6 @@ export default function ChangeRequestsTab(): JSX.Element {
         onFiltersToggle={() => setIsFiltersOpen((prev: boolean) => !prev)}
       />
 
-      {isError && (
-        <Alert severity="error">
-          Failed to load change requests:{" "}
-          {error instanceof Error ? error.message : "unknown error"}
-        </Alert>
-      )}
-
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
           <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
@@ -164,6 +156,15 @@ export default function ChangeRequestsTab(): JSX.Element {
                     <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
                   </TableRow>
                 ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={7} align="center">
+                    <QueryErrorState
+                      message={`Failed to load change requests: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
               ) : changeRequests.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -49,6 +48,7 @@ import { useSearchCatalogs } from "@features/csm-operations/api/useSearchCatalog
 import { useCatalogItemVariables } from "@features/csm-operations/api/useCatalogItemVariables";
 import CatalogVariableFields from "@features/csm-operations/components/CatalogVariableFields";
 import { useNavTransition } from "@hooks/useNavTransition";
+import QueryErrorState from "@components/QueryErrorState";
 import {
   encodeVariableValue,
   getFirstEmptyRequiredField,
@@ -376,20 +376,9 @@ export default function CreateServiceRequestPage(): JSX.Element {
                   </Typography>
                 </Box>
               ) : variables.isError ? (
-                <Alert
-                  severity="error"
-                  action={
-                    <Button
-                      color="inherit"
-                      size="small"
-                      onClick={() => void variables.refetch()}
-                    >
-                      Retry
-                    </Button>
-                  }
-                >
-                  Could not load the request form for this catalog item.
-                </Alert>
+                <QueryErrorState
+                  message="Could not load the request form for this catalog item."
+                />
               ) : renderableVars.length === 0 ? (
                 <Typography variant="body2" color="text.secondary">
                   This catalog item has no additional fields.

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -377,7 +377,8 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 </Box>
               ) : variables.isError ? (
                 <QueryErrorState
-                  message="Could not load the request form for this catalog item."
+                  message={`Could not load the request form for this catalog item: ${variables.error instanceof Error ? variables.error.message : "unknown error"}`}
+                  error={variables.error}
                 />
               ) : renderableVars.length === 0 ? (
                 <Typography variant="body2" color="text.secondary">

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
@@ -37,6 +37,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Ban, MoreVertical, Pencil, Plus } from "@wso2/oxygen-ui-icons-react";
+import QueryErrorState from "@components/QueryErrorState";
 import { useState, type JSX } from "react";
 import { useSearchDeployedProducts } from "@features/csm-projects/api/useSearchDeployedProducts";
 import { useCreateDeployedProduct } from "@features/csm-projects/api/useCreateDeployedProduct";
@@ -174,10 +175,10 @@ export default function DeployedProductsPanel({
 
   if (isError) {
     return (
-      <Alert severity="error" sx={{ my: 1 }}>
-        Failed to load deployed products:{" "}
-        {error instanceof Error ? error.message : "unknown error"}
-      </Alert>
+      <QueryErrorState
+        message={`Failed to load deployed products: ${error instanceof Error ? error.message : "unknown error"}`}
+        error={error}
+      />
     );
   }
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
@@ -40,6 +40,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Ban, Eye, MoreVertical, Pencil, Plus } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
+import QueryErrorState from "@components/QueryErrorState";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useUpdateDeployment } from "@features/csm-projects/api/useUpdateDeployment";
 import { useCreateDeployment } from "@features/csm-projects/api/useCreateDeployment";
@@ -169,12 +170,6 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
         </Alert>
       )}
 
-      {isError && (
-        <Alert severity="error">
-          Failed to load deployments:{" "}
-          {error instanceof Error ? error.message : "unknown error"}
-        </Alert>
-      )}
 
       <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
         <Button
@@ -201,10 +196,19 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
               </TableRow>
             </TableHead>
             <TableBody>
-              {isLoading ? (
+              {isLoading || isFetching ? (
                 <TableRow>
                   <TableCell colSpan={COLUMN_COUNT} align="center" sx={{ py: 4 }}>
                     <CircularProgress size={24} />
+                  </TableCell>
+                </TableRow>
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={COLUMN_COUNT} align="center">
+                    <QueryErrorState
+                      message={`Failed to load deployments: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
                   </TableCell>
                 </TableRow>
               ) : deployments.length === 0 ? (

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   Box,
   Chip,
   Skeleton,
@@ -31,6 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
+import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects";
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
@@ -102,12 +102,6 @@ export default function CsmProjectsPage(): JSX.Element {
         sx={{ maxWidth: 480 }}
       />
 
-      {isError && (
-        <Alert severity="error">
-          Failed to load projects: {error instanceof Error ? error.message : "unknown error"}
-        </Alert>
-      )}
-
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
           <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
@@ -131,6 +125,15 @@ export default function CsmProjectsPage(): JSX.Element {
                     <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
                   </TableRow>
                 ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={5} align="center">
+                    <QueryErrorState
+                      message={`Failed to load projects: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
               ) : projects.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={5} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   Box,
   Chip,
   InputAdornment,
@@ -33,7 +32,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Search } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
-
+import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProductVulnerabilities } from "@features/csm-security-center/api/useSearchProductVulnerabilities";
 import {
@@ -132,13 +131,6 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
         </TextField>
       </Box>
 
-      {isError && (
-        <Alert severity="error">
-          Failed to load vulnerabilities:{" "}
-          {error instanceof Error ? error.message : "unknown error"}
-        </Alert>
-      )}
-
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
           <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
@@ -165,9 +157,14 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                   </TableRow>
                 ))
               ) : isError ? (
-                // The error Alert above carries the detail; don't fall through
-                // to the empty state (which would read as "0 results").
-                null
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    <QueryErrorState
+                      message={`Failed to load vulnerabilities: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
               ) : vulnerabilities.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   Box,
   Checkbox,
   Chip,
@@ -40,6 +39,7 @@ import {
   type SelectChangeEvent,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import {
@@ -178,12 +178,6 @@ export default function CsmUsersPage(): JSX.Element {
         </FormControl>
       </Stack>
 
-      {isError && (
-        <Alert severity="error">
-          Failed to load users: {error instanceof Error ? error.message : "unknown error"}
-        </Alert>
-      )}
-
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
           <Table size="small" aria-label="Users search results" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
@@ -217,6 +211,15 @@ export default function CsmUsersPage(): JSX.Element {
                     <TableCell><Skeleton variant="rounded" width="55%" height={18} /></TableCell>
                   </TableRow>
                 ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    <QueryErrorState
+                      message={`Failed to load users: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
               ) : users.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} align="center" sx={{ py: 4 }}>

--- a/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Alert,
   alpha,
   Box,
   Button,
@@ -44,6 +43,7 @@ import {
   useTheme,
 } from "@wso2/oxygen-ui";
 import { Download, FileText, X } from "@wso2/oxygen-ui-icons-react";
+import QueryErrorState from "@components/QueryErrorState";
 import { type JSX, useCallback, useMemo, useState } from "react";
 import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
@@ -670,12 +670,12 @@ export default function CsmUpdatesPage(): JSX.Element {
           <Typography variant="subtitle1" sx={{ mb: 2 }}>
             Search updates between levels
           </Typography>
-          {productLevels.isError && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              Could not load product catalog.
-            </Alert>
-          )}
-          {productLevels.isLoading ? (
+          {productLevels.isError ? (
+            <QueryErrorState
+              message={`Could not load product catalog: ${productLevels.error instanceof Error ? productLevels.error.message : "unknown error"}`}
+              error={productLevels.error}
+            />
+          ) : productLevels.isLoading ? (
             <UpdatesFilterSkeleton />
           ) : (
           <>
@@ -777,9 +777,10 @@ export default function CsmUpdatesPage(): JSX.Element {
               <CircularProgress />
             </Box>
           ) : searchResult.isError ? (
-            <Alert severity="error">
-              Could not load updates: {searchResult.error.message}
-            </Alert>
+            <QueryErrorState
+              message={`Could not load updates: ${searchResult.error instanceof Error ? searchResult.error.message : "unknown error"}`}
+              error={searchResult.error}
+            />
           ) : sortedEntries.length === 0 ? (
             <Typography variant="body2" color="text.secondary" align="center" sx={{ py: 4 }}>
               No updates found between level {search.startingUpdateLevel} and {search.endingUpdateLevel}.


### PR DESCRIPTION
## Summary

- Replaces all plain `<Alert severity="error">` inline errors across the webapp with a new shared `QueryErrorState` component
- Component shows an icon and title based on HTTP status: Lock (401), ShieldAlert (403), FileQuestion (404), AlertTriangle (4xx), ServerCrash (5xx/unknown)
- Shows the backend error message as the description
- Displays a visible **Tracking ID** pill with a copy-to-clipboard button so users can hand the correlation ID to support without digging through dev tools
- Threads the outgoing `X-CSM-Correlation-ID` through every `useBackendApi()` verb (`get`, `post`, `patch`, `postEmpty`, `del`, `getBlob`) so `BackendApiError.correlationId` is always set — the tracking ID always shows on backend failures regardless of whether the gateway echoes the header back

## Files changed

- `src/api/backend/client.ts` — pre-generate correlation ID per request, pass as header and fallback to `readError`
- `src/components/QueryErrorState.tsx` — new shared error state component
- 10 feature pages/components — replace inline alerts with `QueryErrorState`

## Test plan

- [ ] Trigger a backend error (e.g. disconnect network) on Accounts, Projects, Users, Deployments, Vulnerabilities, Change Requests, Updates pages — confirm error state shows correct icon/title/message and tracking ID pill
- [ ] Click copy icon — confirm clipboard receives the tracking ID
- [ ] Confirm no "Try again" button appears anywhere
- [ ] Confirm case detail page error state renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer inline error screens across multiple pages and tables, with status-specific messaging and a copyable tracking ID for easier support.

* **Bug Fixes**
  * Improved request error tracking so failures now carry a consistent correlation reference.
  * Updated several account, case, project, users, updates, operations, and security views to show errors in the main content area instead of a top-level alert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->