### PR TITLE
[CSM Portal Microapp] Search and filters on the Support page

### DIFF
--- a/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
+++ b/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
@@ -216,7 +216,8 @@ export const sendNativeLog = (message?: string, data?: unknown, level: LogLevel 
       level,
     });
   } else {
-    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+    // Logger.error() calls back into sendNativeLog() — must not call it here, or the two recurse forever.
+    console.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE, { message, data, level });
   }
 };
 

--- a/apps/csm-portal/microapp/src/components/support/FiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/support/FiltersSheet.tsx
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Switch,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import type { CaseState } from "@src/types";
+import {
+  ALL_SEVERITIES,
+  ALL_WORK_STATES,
+  FILTERABLE_STATES,
+  SEVERITY_LABELS,
+  STATE_LABELS,
+  WORK_STATE_LABEL,
+} from "./config";
+import { EMPTY_FILTERS, type CaseFilters } from "./filters";
+
+function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+interface ToggleChipGroupProps<T extends string> {
+  options: T[];
+  selected: T[];
+  labels: Record<T, string>;
+  onToggle: (value: T) => void;
+  disabled?: boolean;
+}
+
+function ToggleChipGroup<T extends string>({ options, selected, labels, onToggle, disabled }: ToggleChipGroupProps<T>) {
+  return (
+    <Stack direction="row" gap={1} flexWrap="wrap">
+      {options.map((option) => {
+        const isSelected = selected.includes(option);
+        return (
+          <Chip
+            key={option}
+            label={labels[option]}
+            size="small"
+            disabled={disabled}
+            variant={isSelected ? "filled" : "outlined"}
+            color={isSelected ? "primary" : "default"}
+            onClick={() => onToggle(option)}
+          />
+        );
+      })}
+    </Stack>
+  );
+}
+
+interface FiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: CaseFilters;
+  onApply: (filters: CaseFilters) => void;
+}
+
+// Mobile bottom-sheet-style equivalent of the webapp's CasesFilterBar collapsible panel: severity
+// and state are picked from the same fixed enums the webapp filters on
+// (apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx — ALL_SEVERITIES,
+// PRIMARY_STATES), work state is only enabled once "Work in progress" is among the selected
+// states (same invariant the webapp enforces). Assignee/project/product filters are deliberately
+// scoped out here in favor of simple "Assigned to me" / "Created by me" toggles — the webapp's
+// full async assignee/project search pickers aren't a good fit for a mobile filter sheet.
+export function FiltersSheet({ open, onClose, filters, onApply }: FiltersSheetProps) {
+  const [draft, setDraft] = useState<CaseFilters>(filters);
+
+  // Re-seed the draft from the last-applied filters each time the sheet opens, so reopening it
+  // doesn't show stale in-progress edits from a previous open that was dismissed without applying.
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open, not on every filters identity change
+  }, [open]);
+
+  const workStateDisabled = !draft.states.includes("work_in_progress");
+
+  const handleToggleState = (state: CaseState) => {
+    const states = toggle(draft.states, state);
+    const workStates = states.includes("work_in_progress") ? draft.workStates : [];
+    setDraft({ ...draft, states, workStates });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={2.5}>
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Severity</Typography>
+            <ToggleChipGroup
+              options={ALL_SEVERITIES}
+              selected={draft.severities}
+              labels={SEVERITY_LABELS}
+              onToggle={(severity) => setDraft({ ...draft, severities: toggle(draft.severities, severity) })}
+            />
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2">State</Typography>
+            <ToggleChipGroup
+              options={FILTERABLE_STATES}
+              selected={draft.states}
+              labels={STATE_LABELS}
+              onToggle={handleToggleState}
+            />
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2" color={workStateDisabled ? "text.disabled" : "text.primary"}>
+              Work state
+            </Typography>
+            <ToggleChipGroup
+              options={ALL_WORK_STATES}
+              selected={draft.workStates}
+              labels={WORK_STATE_LABEL}
+              disabled={workStateDisabled}
+              onToggle={(workState) => setDraft({ ...draft, workStates: toggle(draft.workStates, workState) })}
+            />
+          </Stack>
+
+          <Divider />
+
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="body2">Assigned to me</Typography>
+            <Switch
+              checked={draft.assignedToMe}
+              onChange={(event) => setDraft({ ...draft, assignedToMe: event.target.checked })}
+            />
+          </Stack>
+
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="body2">Created by me</Typography>
+            <Switch
+              checked={draft.createdByMe}
+              onChange={(event) => setDraft({ ...draft, createdByMe: event.target.checked })}
+            />
+          </Stack>
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            setDraft(EMPTY_FILTERS);
+            onApply(EMPTY_FILTERS);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/SearchBar.tsx
+++ b/apps/csm-portal/microapp/src/components/support/SearchBar.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { IconButton, InputAdornment, TextField } from "@wso2/oxygen-ui";
+import { Search, X } from "@wso2/oxygen-ui-icons-react";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+// Mirrors the webapp's case-list search box (CasesFilterBar.tsx): a controlled text field with a
+// leading search icon and a trailing clear button shown only once there's something to clear.
+export function SearchBar({ value, onChange, placeholder = "Search by case #, subject…" }: SearchBarProps) {
+  return (
+    <TextField
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      size="small"
+      fullWidth
+      slotProps={{
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <Search size={16} />
+            </InputAdornment>
+          ),
+          endAdornment: value ? (
+            <InputAdornment position="end">
+              <IconButton size="small" aria-label="Clear search" onClick={() => onChange("")}>
+                <X size={14} />
+              </IconButton>
+            </InputAdornment>
+          ) : undefined,
+        },
+      }}
+    />
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/config.tsx
+++ b/apps/csm-portal/microapp/src/components/support/config.tsx
@@ -16,7 +16,7 @@
 
 import { colors, type ChipProps } from "@wso2/oxygen-ui";
 import { Briefcase, Megaphone, OctagonAlert, Settings, Shield, type LucideIcon } from "@wso2/oxygen-ui-icons-react";
-import type { CaseSeverity, CaseState, CaseType } from "@src/types";
+import type { CaseSeverity, CaseState, CaseType, CaseWorkState } from "@src/types";
 
 export const TABS: CaseType[] = ["case", "service_request", "security_report_analysis", "engagement", "announcement"];
 
@@ -95,4 +95,25 @@ export const SEVERITY_CHIP_COLOR_CONFIG: Record<CaseSeverity, NonNullable<ChipPr
   high: "warning",
   medium: "info",
   low: "default",
+};
+
+// Filter option lists, mirroring apps/csm-portal/webapp's CasesFilterBar.tsx (ALL_SEVERITIES,
+// PRIMARY_STATES, ALL_WORK_STATES, WORK_STATE_LABEL) — same option order as the webapp.
+export const ALL_SEVERITIES: CaseSeverity[] = ["catastrophic", "critical", "high", "medium", "low"];
+
+export const FILTERABLE_STATES: CaseState[] = [
+  "open",
+  "work_in_progress",
+  "awaiting_info",
+  "solution_proposed",
+  "waiting_on_wso2",
+  "closed",
+  "reopened",
+];
+
+export const ALL_WORK_STATES: NonNullable<CaseWorkState>[] = ["ongoing", "paused"];
+
+export const WORK_STATE_LABEL: Record<NonNullable<CaseWorkState>, string> = {
+  ongoing: "Ongoing",
+  paused: "Paused",
 };

--- a/apps/csm-portal/microapp/src/components/support/filters.ts
+++ b/apps/csm-portal/microapp/src/components/support/filters.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CaseSearchFiltersDto, CaseSeverity, CaseState, CaseType, CaseWorkState } from "@src/types";
+
+export interface CaseFilters {
+  severities: CaseSeverity[];
+  states: CaseState[];
+  workStates: NonNullable<CaseWorkState>[];
+  assignedToMe: boolean;
+  createdByMe: boolean;
+}
+
+export const EMPTY_FILTERS: CaseFilters = {
+  severities: [],
+  states: [],
+  workStates: [],
+  assignedToMe: false,
+  createdByMe: false,
+};
+
+export function countActiveFilters(filters: CaseFilters): number {
+  return (
+    filters.severities.length +
+    filters.states.length +
+    filters.workStates.length +
+    (filters.assignedToMe ? 1 : 0) +
+    (filters.createdByMe ? 1 : 0)
+  );
+}
+export function toCaseSearchFilters(
+  type: CaseType,
+  search: string,
+  filters: CaseFilters,
+  currentUserId: string | null,
+): CaseSearchFiltersDto {
+  return {
+    types: [type],
+    ...(search.length > 0 && { searchQuery: search }),
+    ...(filters.severities.length > 0 && { severities: filters.severities }),
+    ...(filters.states.length > 0 && { states: filters.states }),
+    ...(filters.workStates.length > 0 && { workStates: filters.workStates }),
+    ...(filters.createdByMe && { createdByMe: true }),
+    ...(filters.assignedToMe && currentUserId && { assignedUserIds: [currentUserId] }),
+  };
+}
+
+export function filtersToSearchParams(search: string, filters: CaseFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (search) params.set("q", search);
+  if (filters.severities.length) params.set("severities", filters.severities.join(","));
+  if (filters.states.length) params.set("states", filters.states.join(","));
+  if (filters.workStates.length) params.set("workStates", filters.workStates.join(","));
+  if (filters.assignedToMe) params.set("assignedToMe", "1");
+  if (filters.createdByMe) params.set("createdByMe", "1");
+  return params;
+}
+
+export function filtersFromSearchParams(params: URLSearchParams): { search: string; filters: CaseFilters } {
+  const csv = (key: string) => params.get(key)?.split(",").filter(Boolean) ?? [];
+  return {
+    search: params.get("q") ?? "",
+    filters: {
+      severities: csv("severities") as CaseSeverity[],
+      states: csv("states") as CaseState[],
+      workStates: csv("workStates") as NonNullable<CaseWorkState>[],
+      assignedToMe: params.get("assignedToMe") === "1",
+      createdByMe: params.get("createdByMe") === "1",
+    },
+  };
+}

--- a/apps/csm-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SupportPage.tsx
@@ -14,23 +14,37 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Suspense, type ReactNode } from "react";
+import { Suspense, useState, type ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
-import { useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { Badge, IconButton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useQuery, useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
+import { currentUser } from "@src/services/currentUser";
 import type { CaseType } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
 import { EmptyState } from "@components/support/EmptyState";
 import { ErrorState } from "@components/support/ErrorState";
+import { SearchBar } from "@components/support/SearchBar";
+import { FiltersSheet } from "@components/support/FiltersSheet";
+import { countActiveFilters, EMPTY_FILTERS, toCaseSearchFilters, type CaseFilters } from "@components/support/filters";
 import { TABS, TAB_CONFIG } from "@components/support/config";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
 
 export default function SupportPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   // Derived directly from the URL (not local state) so browser back/forward navigation that
   // changes ?tab= is reflected immediately, instead of showing a stale tab.
   const tab = TABS.find((t) => t === searchParams.get("tab")) ?? "case";
+
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [filters, setFilters] = useState<CaseFilters>(EMPTY_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const activeFilterCount = countActiveFilters(filters);
+
+  const { data: currentUserId } = useQuery(currentUser.id());
 
   const handleTabChange = (value: CaseType) => {
     setSearchParams(
@@ -46,6 +60,15 @@ export default function SupportPage() {
     <Stack gap={2}>
       <Typography variant="h5">Support</Typography>
 
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar value={search} onChange={setSearch} />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
       <Tabs variant="scrollable" value={tab} onChange={(_, value) => handleTabChange(value)}>
         {TABS.map((t) => (
           <Tab key={t} label={TAB_CONFIG[t].title} value={t} disableRipple />
@@ -54,17 +77,34 @@ export default function SupportPage() {
 
       <CaseListErrorBoundary>
         <Suspense fallback={<CaseListSkeleton />}>
-          <CaseListContent type={tab} />
+          <CaseListContent
+            type={tab}
+            search={debouncedSearch}
+            filters={filters}
+            currentUserId={currentUserId ?? null}
+          />
         </Suspense>
       </CaseListErrorBoundary>
+
+      <FiltersSheet open={filtersOpen} onClose={() => setFiltersOpen(false)} filters={filters} onApply={setFilters} />
     </Stack>
   );
 }
 
-function CaseListContent({ type }: { type: CaseType }) {
+function CaseListContent({
+  type,
+  search,
+  filters,
+  currentUserId,
+}: {
+  type: CaseType;
+  search: string;
+  filters: CaseFilters;
+  currentUserId: string | null;
+}) {
   const { data } = useSuspenseQuery(
     cases.all({
-      filters: { types: [type] },
+      filters: toCaseSearchFilters(type, search, filters, currentUserId),
       sortBy: { field: "updatedOn", order: "desc" },
       pagination: { limit: 20 },
     }),

--- a/apps/csm-portal/microapp/src/services/currentUser.ts
+++ b/apps/csm-portal/microapp/src/services/currentUser.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { queryOptions } from "@tanstack/react-query";
+import { USERS_ME_ENDPOINT } from "@config/endpoints";
+import apiClient from "./apiClient";
+
+interface CurrentUserIdDto {
+  id?: string;
+}
+
+// Only the platform user id is needed here (for the "Assigned to me" case filter), so this stays
+// deliberately smaller than a full user-profile service.
+const getCurrentUserId = async (): Promise<string | null> => {
+  const { data } = await apiClient.get<CurrentUserIdDto>(USERS_ME_ENDPOINT);
+  return data.id ?? null;
+};
+
+export const currentUser = {
+  id: () =>
+    queryOptions({
+      queryKey: ["currentUser", "id"],
+      queryFn: getCurrentUserId,
+      staleTime: 5 * 60_000,
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -86,6 +86,7 @@ export interface CaseSearchFiltersDto {
   issueTypes?: CaseIssueType[];
   assignedUserIds?: string[];
   createdByMe?: boolean;
+  workStates?: NonNullable<CaseWorkState>[];
 }
 
 export interface CaseSearchPayloadDto {

--- a/apps/csm-portal/microapp/src/utils/useDebouncedValue.ts
+++ b/apps/csm-portal/microapp/src/utils/useDebouncedValue.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setDebouncedValue(value);
+      timeoutRef.current = null;
+    }, delayMs);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
Ports the webapp's case-list filtering/search UX (`CasesFilterBar.tsx`), adapted for mobile:
- Search box (debounced 300ms), wired to `searchQuery`.
- Filter sheet: severity and state pulled from the same fixed enums the webapp filters on; work state is enabled only once "Work in progress" is selected (same invariant the webapp enforces); "Assigned to me" / "Created by me" toggles in place of the webapp's full async assignee/project/product pickers (a deliberate mobile scope reduction).
- New `currentUser` service (just the platform user id) backs "Assigned to me".

Stacked on #1104 (still open) — this PR will show both commits until that one merges, then shrink to just this one.

## Test plan
- [x] `npm run lint` / `tsc --noEmit` clean (verified with this commit isolated from other in-progress work)
- [x] Verified in a headless browser against a mocked backend: search debounces and sends `searchQuery`, filter sheet applies severity/state and sends them in the request payload, no console errors