### PR TITLE
[CSM Portal] fix Time Cards approver role check to match the corrected SN role name

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/constants/timeCardConstants.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/constants/timeCardConstants.ts
@@ -96,7 +96,7 @@ export const TIME_SHEET_STATE_META: Record<
  * Role that grants approve/reject on time cards, matched (case-insensitively)
  * against `roles` from `GET /users/me`.
  */
-export const TIMECARD_APPROVER_GROUP = "sn_customerservice_timecard_approver";
+export const TIMECARD_APPROVER_GROUP = "timecard_approver";
 
 /**
  * Role that grants time-card admin (approve by exception), matched against

--- a/apps/csm-portal/webapp/tests/e2e/specs/timecards/role-gating.spec.ts
+++ b/apps/csm-portal/webapp/tests/e2e/specs/timecards/role-gating.spec.ts
@@ -17,7 +17,7 @@
 //
 // Role gating on /time-cards. The Approvals tab is driven by useTimecardRole,
 // which resolves isApprover from GET /users/me roles
-// (sn_customerservice_timecard_approver, or the "admin" role). Approvers see
+// (timecard_approver, or the "admin" role). Approvers see
 // it; plain engineers do not, even when the tab is forced via the URL.
 //
 


### PR DESCRIPTION
## Purpose
The Time Cards "Approvals" tab stopped rendering for every approver. `TIMECARD_APPROVER_GROUP` was hardcoded to a mangled role name that a backend bug used to produce; once that backend bug was fixed, `GET /users/me` began returning the real, correctly-named SN role, and the FE's exact-match check no longer matched anything.

## Goals
Restore Approvals-tab visibility for users holding the time-card approver role, using the role name the backend now actually returns.

## Approach
One-line constant fix: `TIMECARD_APPROVER_GROUP` now matches the backend's corrected role name instead of the old mangled one. `useTimecardRole()` does a case-insensitive `.includes()` check against this constant to compute `isApprover`, which gates the "Approvals" tab and its data-fetch condition in `CsmTimeCardsPage.tsx` — no other file hardcodes the old value (confirmed via a repo-wide search), so this single constant is the fix. Also corrected a stale comment in the e2e spec referencing the old role name.

No UI change — this restores existing UI to its intended behavior, no screenshot needed.

## User stories
As a time-card approver, I can see and use the Approvals tab in the Time Cards page.

## Release note
Fixed the Time Cards "Approvals" tab not appearing for approvers after a backend role-name correction.

## Documentation
N/A — internal role-matching constant, no user-facing docs reference this string.

## Automation tests
- Unit tests: N/A, no new unit test infra for this constants file.
- Integration tests: existing e2e spec `role-gating.spec.ts` already covers Approvals-tab visibility by role; corrected its stale comment to reference the current role name.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React; ESLint ran clean on changed files)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Verified with `pnpm build` and `pnpm lint` locally (Node/pnpm toolchain per repo config); no new lint errors introduced by this change.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated time card approver access to use the current group name, helping ensure the right users can approve time cards.
* **Documentation**
  * Adjusted an internal test comment to match the updated approver role terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->