### PR TITLE
[CSM Portal Microapp] Fix infinite recursion crash outside the native shell

### DIFF
--- a/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
+++ b/apps/csm-portal/microapp/src/components/microapp-bridge/index.ts
@@ -216,7 +216,8 @@ export const sendNativeLog = (message?: string, data?: unknown, level: LogLevel 
       level,
     });
   } else {
-    Logger.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE);
+    // Logger.error() calls back into sendNativeLog() — must not call it here, or the two recurse forever.
+    console.error(ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE, { message, data, level });
   }
 };
 


### PR DESCRIPTION
## Summary
- Pre-existing bug in the original scaffold: `sendNativeLog()`'s fallback (when there's no native bridge) called `Logger.error()`, but `Logger.error()` calls back into `sendNativeLog()` — unconditional mutual recursion that blows the call stack and crashes the entire app the instant it runs outside the native shell (e.g. a plain browser during local dev). This blocked any local browser-based testing/demo of the app.

Stacked on #1104 (still open) — this PR will show both commits until that one merges, then shrink to just this one.

## Test plan
- [x] Verified in a headless browser: app previously crashed with "Maximum call stack size exceeded" on load; now renders correctly with no crash