### PR TITLE
[CSM Portal] make call requests read-only on closed cases

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestRow.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestRow.tsx
@@ -18,6 +18,7 @@ import {
   Box,
   Button,
   Chip,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { type JSX } from "react";
@@ -70,13 +71,20 @@ const ACTION_LABEL: Record<CallRequestAgentAction, string> = {
 export interface CallRequestRowProps {
   cr: BeCallRequestView;
   onAction: (action: CallRequestAgentAction, cr: BeCallRequestView) => void;
+  /** True when the parent case is closed — existing call requests stay visible
+   * but can no longer be updated (scheduled, rejected, etc.). */
+  isClosed?: boolean;
 }
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-export function CallRequestRow({ cr, onAction }: CallRequestRowProps): JSX.Element {
+export function CallRequestRow({
+  cr,
+  onAction,
+  isClosed,
+}: CallRequestRowProps): JSX.Element {
   const stateKey = resolveCallRequestStateKey(cr.state);
   const actions = (stateKey && CALL_REQUEST_AGENT_ACTIONS[stateKey]) ?? [];
 
@@ -119,16 +127,23 @@ export function CallRequestRow({ cr, onAction }: CallRequestRowProps): JSX.Eleme
         {actions.length > 0 && (
           <Box sx={{ display: "flex", gap: 1, flexShrink: 0, flexWrap: "wrap" }}>
             {actions.map((action, i) => (
-              <Button
+              <Tooltip
                 key={action}
-                size="small"
-                variant={i === 0 && action !== "cancel" ? "contained" : "outlined"}
-                color={action === "reject" || action === "cancel" ? "error" : "primary"}
-                onClick={() => onAction(action, cr)}
-                sx={{ textTransform: "none" }}
+                title={isClosed ? "This case is closed — it's read-only." : ""}
               >
-                {ACTION_LABEL[action]}
-              </Button>
+                <span>
+                  <Button
+                    size="small"
+                    variant={i === 0 && action !== "cancel" ? "contained" : "outlined"}
+                    color={action === "reject" || action === "cancel" ? "error" : "primary"}
+                    onClick={() => onAction(action, cr)}
+                    disabled={isClosed}
+                    sx={{ textTransform: "none" }}
+                  >
+                    {ACTION_LABEL[action]}
+                  </Button>
+                </span>
+              </Tooltip>
             ))}
           </Box>
         )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -25,6 +25,7 @@ import {
   MenuItem,
   Select,
   Skeleton,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { Phone, Plus, RefreshCw } from "@wso2/oxygen-ui-icons-react";
@@ -64,6 +65,9 @@ interface CallRequestsWidgetProps {
    * widget (e.g. just clicking back onto the tab) would reopen the dialog. */
   autoOpenCreate?: boolean;
   onAutoOpenCreateHandled?: () => void;
+  /** True when the parent case is closed — call requests stay visible but
+   * become read-only: no new requests, no updates to existing ones. */
+  isClosed?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +79,7 @@ export function CallRequestsWidget({
   severity,
   autoOpenCreate,
   onAutoOpenCreateHandled,
+  isClosed,
 }: CallRequestsWidgetProps): JSX.Element {
   // State filter — empty string means "all". Filtering happens server-side
   // via `filters.states` on the search request.
@@ -93,11 +98,13 @@ export function CallRequestsWidget({
 
   useEffect(() => {
     if (autoOpenCreate) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs the dialog open to an external one-shot trigger from the case action bar
-      setCreateOpen(true);
+      if (!isClosed) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs the dialog open to an external one-shot trigger from the case action bar
+        setCreateOpen(true);
+      }
       onAutoOpenCreateHandled?.();
     }
-  }, [autoOpenCreate, onAutoOpenCreateHandled]);
+  }, [autoOpenCreate, isClosed, onAutoOpenCreateHandled]);
 
   // Dialog targets — only one dialog is ever open at a time, driven by which
   // action was clicked on a row.
@@ -280,15 +287,20 @@ export function CallRequestsWidget({
                 ))}
               </Select>
             </FormControl>
-            <Button
-              size="small"
-              variant="contained"
-              startIcon={<Plus size={14} />}
-              onClick={() => setCreateOpen(true)}
-              sx={{ textTransform: "none" }}
-            >
-              Create call request
-            </Button>
+            <Tooltip title={isClosed ? "This case is closed — it's read-only." : ""}>
+              <span>
+                <Button
+                  size="small"
+                  variant="contained"
+                  startIcon={<Plus size={14} />}
+                  onClick={() => setCreateOpen(true)}
+                  disabled={isClosed}
+                  sx={{ textTransform: "none" }}
+                >
+                  Create call request
+                </Button>
+              </span>
+            </Tooltip>
           </Box>
         </Box>
 
@@ -339,7 +351,12 @@ export function CallRequestsWidget({
         {!isLoading && !isError && requests.length > 0 && (
           <Box sx={{ display: "flex", flexDirection: "column" }}>
             {requests.map((cr) => (
-              <CallRequestRow key={cr.id} cr={cr} onAction={handleAction} />
+              <CallRequestRow
+                key={cr.id}
+                cr={cr}
+                onAction={handleAction}
+                isClosed={isClosed}
+              />
             ))}
           </Box>
         )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -286,7 +286,13 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
     { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true, tooltip: NOT_BUILT_YET },
     { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, divider: true, disabled: true, tooltip: NOT_BUILT_YET },
     { key: "create_task", label: "Create task…", icon: <ListChecks size={16} />, divider: true, disabled: true, tooltip: NOT_BUILT_YET },
-    { key: "request_call", label: "Request a call…", icon: <Phone size={16} /> },
+    {
+      key: "request_call",
+      label: "Request a call…",
+      icon: <Phone size={16} />,
+      disabled: caseClosed,
+      tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
+    },
     { key: "log_time", label: "Log time…", icon: <Clock size={16} />, divider: true },
     { key: "copy_link", label: "Copy case link", icon: <Copy size={16} /> },
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1464,6 +1464,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             severity={c.severity}
             autoOpenCreate={autoOpenCallCreate}
             onAutoOpenCreateHandled={() => setAutoOpenCallCreate(false)}
+            isClosed={isClosed}
           />
         </Box>
       )}


### PR DESCRIPTION
## Purpose
Closed cases are meant to be read-only, but the CSM portal's call-request actions were not gated by case state: an agent could still create a new call request, or schedule/reschedule/reject/send notes/cancel an existing one, against a closed case.

## Goals
Bring call requests in line with the read-only treatment already applied to comments, attachments, and time tracking on closed cases: keep existing call requests fully visible, but disable creating new ones and updating existing ones once the case is closed.

## Approach
- `CaseActionBar.tsx`: gate the "Request a call…" overflow-menu item on `caseClosed`, same pattern as `raise_git_issue` / `change_severity`.
- `CallRequestsWidget.tsx`: accept an `isClosed` prop, disable the "Create call request" button, and skip the auto-open-on-navigate dialog when closed. Pass `isClosed` down to each row.
- `CallRequestRow.tsx`: accept `isClosed` and disable each per-row action button (Schedule/Reschedule/Reject/Send call notes/Cancel) with a tooltip explaining why, while the row itself (and its data) stays visible.
- `CsmCaseDetailPage.tsx`: pass the existing `isClosed` derived value into `CallRequestsWidget`.

No backend or API changes; purely FE gating using state the page already computes. This is a client-side gate only — a corresponding backend validation change (rejecting call-request create/update against a closed case at the API level) is tracked separately as a follow-up so the check also holds for direct API calls.

## User stories
As a CS engineer, when I open a closed case I can still see its full call-request history, but I can no longer create or modify call requests against it.

## Release note
Call requests on a closed case are now read-only: the list of past requests stays visible, but creating new requests or updating existing ones is disabled.

## Documentation
N/A — internal FE behavior change, no user-facing docs to update.

## Automation tests
- Unit tests
  - No existing unit test suite covers this widget; verified via `pnpm build` (typecheck) and manual review of the gating logic against the established `isClosed` pattern used elsewhere on this page.
- Integration tests
  - N/A — not applicable, no integration test harness for this flow yet.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change; ran `pnpm lint` (clean on touched files) instead
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved

## Test environment
Verified with `pnpm build` (Vite + TypeScript) in the csm-portal webapp; no browser/runtime-specific behavior introduced beyond existing MUI Tooltip/Button usage already in the codebase.

## Learning
Followed the existing `isClosed` read-only convention already established for comments, attachments, and time tracking in `CsmCaseDetailPage.tsx` / `CaseActionBar.tsx`, extending it to the call-requests feature rather than introducing a new pattern.

