### PR TITLE
[CSM][Web] Use Oxygen UI date pickers instead of native inputs

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
@@ -278,14 +278,14 @@ export function CreateCallRequestDialog({
               UTC. Each must be at least {formatLeadTime(leadMinutes)} from now.
               Add up to {MAX_TIME_SLOTS} options.
             </Typography>
-            {timeslots.map((slot, i) => {
-              const status = slotStatus(slot, timeZone, minAllowedMs, leadMinutes);
-              return (
-                <Box
-                  key={i}
-                  sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}
-                >
-                  <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              {timeslots.map((slot, i) => {
+                const status = slotStatus(slot, timeZone, minAllowedMs, leadMinutes);
+                return (
+                  <Box
+                    key={i}
+                    sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}
+                  >
                     <DateTimePicker
                       value={parseDateTimeLocal(slot)}
                       onChange={(next) =>
@@ -309,21 +309,21 @@ export function CreateCallRequestDialog({
                         field: { clearable: true },
                       }}
                     />
-                  </LocalizationProvider>
-                  {timeslots.length > 1 && (
-                    <Button
-                      size="small"
-                      color="inherit"
-                      onClick={() => removeTimeslot(i)}
-                      disabled={submitting}
-                      sx={{ minWidth: 0, px: 1, mt: 0.5 }}
-                    >
-                      Remove
-                    </Button>
-                  )}
-                </Box>
-              );
-            })}
+                    {timeslots.length > 1 && (
+                      <Button
+                        size="small"
+                        color="inherit"
+                        onClick={() => removeTimeslot(i)}
+                        disabled={submitting}
+                        sx={{ minWidth: 0, px: 1, mt: 0.5 }}
+                      >
+                        Remove
+                      </Button>
+                    )}
+                  </Box>
+                );
+              })}
+            </LocalizationProvider>
             {timeslots.length < MAX_TIME_SLOTS && (
               <Button
                 size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
@@ -15,8 +15,10 @@
 // under the License.
 
 import {
+  AdapterDateFns,
   Box,
   Button,
+  DatePickers,
   Dialog,
   DialogActions,
   DialogContent,
@@ -28,10 +30,14 @@ import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
 import {
+  formatDateTimeLocal,
+  parseDateTimeLocal,
   resolveDisplayTimeZone,
   utcMsToZonedInputValue,
   zonedInputToUtcIso,
 } from "@utils/dateTime";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
 
 /** Formats a UTC epoch-ms instant as "Jan 23, 2026, 10:14 PM UTC" for the slot preview hint. */
 function formatUtcHint(ms: number): string {
@@ -279,17 +285,31 @@ export function CreateCallRequestDialog({
                   key={i}
                   sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}
                 >
-                  <TextField
-                    type="datetime-local"
-                    value={slot}
-                    onChange={(e) => updateTimeslot(i, e.target.value)}
-                    fullWidth
-                    disabled={submitting}
-                    size="small"
-                    error={Boolean(status.error)}
-                    helperText={status.error ?? status.hint ?? " "}
-                    inputProps={{ min: minLocal }}
-                  />
+                  <LocalizationProvider dateAdapter={AdapterDateFns}>
+                    <DateTimePicker
+                      value={parseDateTimeLocal(slot)}
+                      onChange={(next) =>
+                        updateTimeslot(
+                          i,
+                          next instanceof Date && !Number.isNaN(next.getTime())
+                            ? formatDateTimeLocal(next)
+                            : "",
+                        )
+                      }
+                      minDateTime={parseDateTimeLocal(minLocal) ?? undefined}
+                      disabled={submitting}
+                      sx={{ flex: 1 }}
+                      slotProps={{
+                        textField: {
+                          fullWidth: true,
+                          size: "small",
+                          error: Boolean(status.error),
+                          helperText: status.error ?? status.hint ?? " ",
+                        },
+                        field: { clearable: true },
+                      }}
+                    />
+                  </LocalizationProvider>
                   {timeslots.length > 1 && (
                     <Button
                       size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
@@ -15,8 +15,10 @@
 // under the License.
 
 import {
+  AdapterDateFns,
   Box,
   Button,
+  DatePickers,
   Dialog,
   DialogActions,
   DialogContent,
@@ -30,11 +32,15 @@ import {
 import { useState, type JSX } from "react";
 import type { BeCallRequestView } from "@api/backend/types";
 import {
+  formatDateTimeLocal,
+  parseDateTimeLocal,
   resolveDisplayTimeZone,
   zonedInputToUtcIso,
   normalizeBackendTimestamp,
   formatBackendTimestampForDisplay,
 } from "@utils/dateTime";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
 
 // ---------------------------------------------------------------------------
 // Constants — mirror the backend's schedule contract.
@@ -197,33 +203,38 @@ export function ScheduleCallDialog({
           )}
 
           {(preferredTimes.length === 0 || selectedTime === CUSTOM_TIME_VALUE) && (
-            <TextField
-              label={`Meeting time (${timeZone})`}
-              type="datetime-local"
-              value={customTime}
-              onChange={(e) => {
-                setCustomTime(e.target.value);
-                setPastError(false);
-              }}
-              fullWidth
-              required
-              size="small"
-              disabled={submitting}
-              // datetime-local always shows a placeholder, so force the label to
-              // float up — otherwise it overlaps the mm/dd/yyyy placeholder.
-              InputLabelProps={{ shrink: true }}
-              error={
-                (selectedTime === CUSTOM_TIME_VALUE && !!customTime && !customTimeValid) ||
-                pastError
-              }
-              helperText={
-                selectedTime === CUSTOM_TIME_VALUE && customTime && !customTimeValid
-                  ? "Invalid date/time."
-                  : pastError
-                    ? "Meeting time must be in the future."
-                    : `Entered in your timezone (${timeZone}); stored as UTC.`
-              }
-            />
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <DateTimePicker
+                label={`Meeting time (${timeZone})`}
+                value={parseDateTimeLocal(customTime)}
+                onChange={(next) => {
+                  setCustomTime(
+                    next instanceof Date && !Number.isNaN(next.getTime())
+                      ? formatDateTimeLocal(next)
+                      : "",
+                  );
+                  setPastError(false);
+                }}
+                disabled={submitting}
+                slotProps={{
+                  textField: {
+                    fullWidth: true,
+                    required: true,
+                    size: "small",
+                    error:
+                      (selectedTime === CUSTOM_TIME_VALUE && !!customTime && !customTimeValid) ||
+                      pastError,
+                    helperText:
+                      selectedTime === CUSTOM_TIME_VALUE && customTime && !customTimeValid
+                        ? "Invalid date/time."
+                        : pastError
+                          ? "Meeting time must be in the future."
+                          : `Entered in your timezone (${timeZone}); stored as UTC.`,
+                  },
+                  field: { clearable: true },
+                }}
+              />
+            </LocalizationProvider>
           )}
 
           <TextField

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ScheduleCallDialog.tsx
@@ -224,12 +224,13 @@ export function ScheduleCallDialog({
                     error:
                       (selectedTime === CUSTOM_TIME_VALUE && !!customTime && !customTimeValid) ||
                       pastError,
+                    // The pastError message is shown by the top-level Typography
+                    // above, so it's not repeated here — only the custom-time
+                    // invalid case has its own inline text.
                     helperText:
                       selectedTime === CUSTOM_TIME_VALUE && customTime && !customTimeValid
                         ? "Invalid date/time."
-                        : pastError
-                          ? "Meeting time must be in the future."
-                          : `Entered in your timezone (${timeZone}); stored as UTC.`,
+                        : `Entered in your timezone (${timeZone}); stored as UTC.`,
                   },
                   field: { clearable: true },
                 }}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
@@ -61,77 +61,77 @@ export default function CatalogVariableFields({
   onChange,
 }: CatalogVariableFieldsProps): JSX.Element {
   return (
-    <Grid container spacing={2.5}>
-      {variables.map((v) => {
-        const value = values[v.id] ?? "";
-        const label = variableLabel(v);
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Grid container spacing={2.5}>
+        {variables.map((v) => {
+          const value = values[v.id] ?? "";
+          const label = variableLabel(v);
 
-        if (isChoiceField(v)) {
-          const labelId = `sr-var-${v.id}-label`;
-          return (
-            <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
-              <FormControl fullWidth size="small" required>
-                <InputLabel id={labelId}>{label}</InputLabel>
-                <Select
-                  labelId={labelId}
-                  label={label}
-                  value={value}
-                  onChange={(e) => onChange(v.id, String(e.target.value))}
+          if (isChoiceField(v)) {
+            const labelId = `sr-var-${v.id}-label`;
+            return (
+              <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
+                <FormControl fullWidth size="small" required>
+                  <InputLabel id={labelId}>{label}</InputLabel>
+                  <Select
+                    labelId={labelId}
+                    label={label}
+                    value={value}
+                    onChange={(e) => onChange(v.id, String(e.target.value))}
+                  >
+                    <MenuItem value="Yes">Yes</MenuItem>
+                    <MenuItem value="No">No</MenuItem>
+                  </Select>
+                </FormControl>
+              </Grid>
+            );
+          }
+
+          if (isDescriptionField(v.questionText ?? "")) {
+            return (
+              <Grid key={v.id} size={{ xs: 12 }}>
+                <Typography
+                  component="label"
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mb: 0.5 }}
                 >
-                  <MenuItem value="Yes">Yes</MenuItem>
-                  <MenuItem value="No">No</MenuItem>
-                </Select>
-              </FormControl>
-            </Grid>
-          );
-        }
+                  {label} *
+                </Typography>
+                <Box role="group" aria-label={label}>
+                  <Editor
+                    value={value}
+                    onChange={(html) => onChange(v.id, html)}
+                    placeholder=""
+                    minHeight={150}
+                    maxHeight="300px"
+                    toolbarVariant="full"
+                  />
+                </Box>
+              </Grid>
+            );
+          }
 
-        if (isDescriptionField(v.questionText ?? "")) {
-          return (
-            <Grid key={v.id} size={{ xs: 12 }}>
-              <Typography
-                component="label"
-                variant="caption"
-                color="text.secondary"
-                sx={{ display: "block", mb: 0.5 }}
-              >
-                {label} *
-              </Typography>
-              <Box role="group" aria-label={label}>
-                <Editor
+          if (isMultiLineField(v)) {
+            return (
+              <Grid key={v.id} size={{ xs: 12 }}>
+                <TextField
+                  label={label}
+                  size="small"
+                  fullWidth
+                  required
+                  multiline
+                  minRows={4}
                   value={value}
-                  onChange={(html) => onChange(v.id, html)}
-                  placeholder=""
-                  minHeight={150}
-                  maxHeight="300px"
-                  toolbarVariant="full"
+                  onChange={(e) => onChange(v.id, e.target.value)}
                 />
-              </Box>
-            </Grid>
-          );
-        }
+              </Grid>
+            );
+          }
 
-        if (isMultiLineField(v)) {
-          return (
-            <Grid key={v.id} size={{ xs: 12 }}>
-              <TextField
-                label={label}
-                size="small"
-                fullWidth
-                required
-                multiline
-                minRows={4}
-                value={value}
-                onChange={(e) => onChange(v.id, e.target.value)}
-              />
-            </Grid>
-          );
-        }
-
-        if (isDateTimeField(v)) {
-          return (
-            <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
-              <LocalizationProvider dateAdapter={AdapterDateFns}>
+          if (isDateTimeField(v)) {
+            return (
+              <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
                 <DateTimePicker
                   label={label}
                   value={parseDateTimeLocal(value)}
@@ -148,26 +148,26 @@ export default function CatalogVariableFields({
                     field: { clearable: true },
                   }}
                 />
-              </LocalizationProvider>
+              </Grid>
+            );
+          }
+
+          // File Copy Path is an optional plain text input.
+          const optional = isFileCopyPathField(v);
+          return (
+            <Grid key={v.id} size={{ xs: 12 }}>
+              <TextField
+                label={label}
+                size="small"
+                fullWidth
+                required={!optional}
+                value={value}
+                onChange={(e) => onChange(v.id, e.target.value)}
+              />
             </Grid>
           );
-        }
-
-        // File Copy Path is an optional plain text input.
-        const optional = isFileCopyPathField(v);
-        return (
-          <Grid key={v.id} size={{ xs: 12 }}>
-            <TextField
-              label={label}
-              size="small"
-              fullWidth
-              required={!optional}
-              value={value}
-              onChange={(e) => onChange(v.id, e.target.value)}
-            />
-          </Grid>
-        );
-      })}
-    </Grid>
+        })}
+      </Grid>
+    </LocalizationProvider>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
@@ -15,7 +15,9 @@
 // under the License.
 
 import {
+  AdapterDateFns,
   Box,
+  DatePickers,
   FormControl,
   Grid,
   InputLabel,
@@ -35,6 +37,9 @@ import {
   isMultiLineField,
   variableLabel,
 } from "@features/csm-operations/utils/catalogVariables";
+import { formatDateTimeLocal, parseDateTimeLocal } from "@utils/dateTime";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
 
 interface CatalogVariableFieldsProps {
   /** Already filtered to user-editable variables (no context/hidden fields). */
@@ -126,16 +131,24 @@ export default function CatalogVariableFields({
         if (isDateTimeField(v)) {
           return (
             <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
-              <TextField
-                label={label}
-                size="small"
-                fullWidth
-                required
-                type="datetime-local"
-                value={value}
-                onChange={(e) => onChange(v.id, e.target.value)}
-                slotProps={{ inputLabel: { shrink: true } }}
-              />
+              <LocalizationProvider dateAdapter={AdapterDateFns}>
+                <DateTimePicker
+                  label={label}
+                  value={parseDateTimeLocal(value)}
+                  onChange={(next) =>
+                    onChange(
+                      v.id,
+                      next instanceof Date && !Number.isNaN(next.getTime())
+                        ? formatDateTimeLocal(next)
+                        : "",
+                    )
+                  }
+                  slotProps={{
+                    textField: { size: "small", fullWidth: true, required: true },
+                    field: { clearable: true },
+                  }}
+                />
+              </LocalizationProvider>
             </Grid>
           );
         }

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
@@ -15,15 +15,16 @@
 // under the License.
 
 import {
+  AdapterDateFns,
   Box,
   Button,
+  DatePickers,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   FormControlLabel,
   Switch,
-  TextField,
   Typography,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type JSX } from "react";
@@ -31,6 +32,9 @@ import type {
   BeChangeRequestDetail,
   BePatchChangeRequestPayload,
 } from "@api/backend/types";
+import { formatDateTimeLocal, parseDateTimeLocal } from "@utils/dateTime";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
 
 interface EditChangeRequestDialogProps {
   cr: BeChangeRequestDetail;
@@ -43,8 +47,9 @@ interface EditChangeRequestDialogProps {
 
 /**
  * Convert a backend timestamp (`YYYY-MM-DD HH:MM:SS`, or ISO `T`-separated) to
- * the `YYYY-MM-DDTHH:MM` shape an `<input type="datetime-local">` expects. The
- * value is treated as plain wall-clock text so no timezone shift is applied.
+ * the `YYYY-MM-DDTHH:MM` shape this form's state (and the DateTimePicker via
+ * {@link parseDateTimeLocal}) uses. The value is treated as plain wall-clock
+ * text so no timezone shift is applied.
  */
 function toDateTimeLocal(raw?: string | null): string {
   const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2})/.exec(raw?.trim() ?? "");
@@ -99,15 +104,23 @@ export default function EditChangeRequestDialog({
       <DialogTitle>Edit change request</DialogTitle>
       <DialogContent dividers>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
-          <TextField
-            label="Planned start"
-            type="datetime-local"
-            size="small"
-            fullWidth
-            value={plannedStart}
-            onChange={(e) => setPlannedStart(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-          />
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DateTimePicker
+              label="Planned start"
+              value={parseDateTimeLocal(plannedStart)}
+              onChange={(next) =>
+                setPlannedStart(
+                  next instanceof Date && !Number.isNaN(next.getTime())
+                    ? formatDateTimeLocal(next)
+                    : "",
+                )
+              }
+              slotProps={{
+                textField: { size: "small", fullWidth: true },
+                field: { clearable: true },
+              }}
+            />
+          </LocalizationProvider>
           <FormControlLabel
             control={
               <Switch

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -16,10 +16,12 @@
 
 import { useMemo, useState, type JSX, type KeyboardEvent } from "react";
 import {
+  AdapterDateFns,
   Avatar,
   Box,
   Button,
   Chip,
+  DatePickers,
   Dialog,
   DialogActions,
   DialogContent,
@@ -33,6 +35,8 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
+
+const { DatePicker, LocalizationProvider } = DatePickers;
 import { Clock, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
@@ -63,6 +67,7 @@ import {
   totalMinutes,
 } from "@features/csm-timecards/utils/timeCardTotals";
 import { localTodayIso } from "@features/csm-timecards/utils/timeSheetWeek";
+import { formatDateOnly, parseDateOnly } from "@utils/dateTime";
 
 interface LogTimeCardDialogProps {
   /** The case the time was spent on — always known, this dialog only opens
@@ -284,19 +289,30 @@ export default function LogTimeCardDialog({
             {projectName ? ` · ${projectName}` : ""}
           </Typography>
 
-          <TextField
-            type="date"
-            label="Date"
-            size="small"
-            required
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            onBlur={() => touch("date")}
-            error={isTouched("date") && !!errors.date}
-            helperText={isTouched("date") ? errors.date : undefined}
-            slotProps={{ inputLabel: { shrink: true } }}
-            sx={{ maxWidth: { sm: 220 }, minWidth: 160 }}
-          />
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DatePicker
+              label="Date"
+              value={parseDateOnly(date)}
+              onChange={(next) => {
+                setDate(
+                  next instanceof Date && !Number.isNaN(next.getTime())
+                    ? formatDateOnly(next)
+                    : "",
+                );
+                touch("date");
+              }}
+              slotProps={{
+                textField: {
+                  size: "small",
+                  required: true,
+                  error: isTouched("date") && !!errors.date,
+                  helperText: isTouched("date") ? errors.date : undefined,
+                  sx: { maxWidth: { sm: 220 }, minWidth: 160 },
+                },
+                field: { clearable: true },
+              }}
+            />
+          </LocalizationProvider>
 
           <Divider />
 

--- a/apps/csm-portal/webapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.ts
@@ -329,3 +329,52 @@ export function formatAbsoluteForUser(
   }
 }
 
+/**
+ * "YYYY-MM-DD" to a local-midnight Date, for handing a date-only field's wire
+ * value to a picker component. Avoids the UTC-parse day-shift a plain
+ * `new Date(dateString)` can cause depending on the viewer's timezone.
+ */
+export function parseDateOnly(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Local-midnight Date back to "YYYY-MM-DD", the inverse of {@link parseDateOnly}. */
+export function formatDateOnly(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * "YYYY-MM-DDTHH:MM" (the `datetime-local` wire format some fields still
+ * store their state as) to a local Date, for handing the value to a picker
+ * component. Same browser-local semantics a native `datetime-local` input
+ * already had — not timezone-aware beyond that.
+ */
+export function parseDateTimeLocal(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+  const date = new Date(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4]),
+    Number(match[5]),
+  );
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Local Date back to "YYYY-MM-DDTHH:MM", the inverse of {@link parseDateTimeLocal}. */
+export function formatDateTimeLocal(date: Date): string {
+  const y = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  const mi = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${mo}-${d}T${h}:${mi}`;
+}
+


### PR DESCRIPTION
## Purpose
Several forms reachable from the case detail page (support/engagement cases) were still using native browser `type="date"`/`type="datetime-local"` inputs instead of Oxygen UI's real date/time pickers, unlike the rest of the portal.

## Goals
Replace the remaining native date inputs with Oxygen UI's `DatePicker`/`DateTimePicker` for a consistent look and feel across the portal.

## Approach
- `LogTimeCardDialog.tsx` (case detail page → Time tracking tab → Log time): the "Date" field now uses `DatePicker`.
- `CreateCallRequestDialog.tsx` (case detail page → Call requests → Create a call request): the preferred-time slots now use `DateTimePicker`.
- `ScheduleCallDialog.tsx` (scheduling/rescheduling a call request): the "Custom time" field now uses `DateTimePicker`.

All three use the same `LocalizationProvider` + `AdapterDateFns` pattern already established elsewhere in the portal (time cards filter, change-request creation). Added `parseDateOnly`/`formatDateOnly` and `parseDateTimeLocal`/`formatDateTimeLocal` to the shared `utils/dateTime.ts` instead of re-duplicating the same Date↔string conversion in each component — this was already becoming a repeated pattern across the portal.

No behavior change to validation, submission payloads, or timezone handling — only the input widget itself changed.

## User stories
As a support/CS engineer, I get a real calendar/time picker instead of the browser's native date widget when logging time or scheduling a call from a case.

## Release note
Consistent date/time pickers for time tracking and call-request forms on the case detail page.

## Documentation
N/A — internal case management UI, no external doc surface affected.

## Automation tests
- `ScheduleCallDialog.test.tsx` (existing, unaffected by this change — its 3 tests don't touch the custom-time field) — passing.
- No existing test coverage for `LogTimeCardDialog.tsx` or `CreateCallRequestDialog.tsx` (unchanged by this PR).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint`, `pnpm run test`, `pnpm run build` all passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded date/time fields across scheduling, catalog variables, planned start, and time-card logging to use calendar/time picker controls for a more consistent input experience.
  * Standardized browser-local, timezone-agnostic formatting and parsing for stored date/time values.

* **Bug Fixes**
  * Improved validation behavior: invalid entries now show inline helper text and error styling directly on the picker inputs.
  * Time constraints and past-time feedback were updated to align with the picker.
  * Picker-clearing or invalid selections now reliably clear the underlying stored values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->