### PR TITLE
[CSM][Web] restrict case feedback modal to solution proposed state only

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -226,8 +226,8 @@ export default function CaseDetailsActionRow({
             {
               onSuccess: () => {
                 showSuccess("State updated successfully.");
-                // Prompt for feedback after the case is closed (non-blocking).
-                if (ACTION_TO_CASE_STATE_LABEL[label] === "Closed" && caseId) {
+                // Prompt for feedback only when accepting a solution (Solution Proposed state).
+                if (label === "Accept Solution" && caseId) {
                   setFeedbackModalOpen(true);
                 }
               },


### PR DESCRIPTION
## Purpose
Prevent the case feedback modal from appearing when a case is closed from states other than "Solution Proposed".

## Goals
- Show the feedback modal only when a customer explicitly accepts a proposed solution.
- Avoid prompting for feedback on unrelated close paths (e.g., closing from Awaiting Info or Work In Progress).

## Approach
Changed the `onSuccess` condition in `CaseDetailsActionRow` from checking whether the resolved state is "Closed" to checking whether the action label is "Accept Solution" — the only close path available from the Solution Proposed state.

## Changes
- `CaseDetailsActionRow.tsx`: tightened the feedback modal trigger from `ACTION_TO_CASE_STATE_LABEL[label] === "Closed"` to `label === "Accept Solution"`.

## User stories
- As a customer, I should only be prompted for feedback when I accept a solution, not whenever I close a case.

## Release note
N/A — internal UX refinement, no API or schema changes.

## Documentation
N/A

## Test plan
- [ ] Close a case from "Awaiting Info" state — feedback modal should **not** appear
- [ ] Close a case from "Work In Progress" / "Waiting On WSO2" state — feedback modal should **not** appear
- [ ] Accept a solution from "Solution Proposed" state — feedback modal **should** appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)