### PR TITLE
fix(customer-portal): show usage-limit message for AI credit/token errors

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -142,7 +142,20 @@ export default function ChatMessageBubble({
   const isUser = message.sender === ChatSender.USER;
   const isCurrentUserMessage = isUser && (message.isCurrentUser ?? true);
 
-  const displayText = message.isError ? "Something went wrong" : message.text;
+  /**
+   * Errors caused by AI usage/credit/token limits get a specific, customer-safe
+   * message; all other errors keep the generic text (never leak raw error details).
+   */
+  const isUsageLimitError =
+    !!message.text &&
+    /\b(credit|quota|billing)\b|token limit|usage limit|rate limit/i.test(
+      message.text,
+    );
+  const displayText = message.isError
+    ? isUsageLimitError
+      ? "The AI assistant is temporarily unavailable due to usage limits. Please try again later."
+      : "Something went wrong"
+    : message.text;
 
   /** Until the final assistant message, hide thumbs and timestamp only (header stays). */
   const hideFeedbackRow =

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
@@ -71,4 +71,35 @@ describe("ChatMessageBubble", () => {
 
     expect(screen.getByText("Something went wrong")).toBeInTheDocument();
   });
+
+  it("should show a usage-limit message for credit/token errors", () => {
+    renderBubble({
+      id: "3",
+      text: "Anthropic API error: Your credit balance is too low to access the Anthropic API.",
+      sender: ChatSender.BOT,
+      timestamp: new Date(),
+      isError: true,
+    });
+
+    expect(
+      screen.getByText(
+        "The AI assistant is temporarily unavailable due to usage limits. Please try again later.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should not leak raw error text for non usage-limit errors", () => {
+    renderBubble({
+      id: "4",
+      text: "NullPointerException at line 42",
+      sender: ChatSender.BOT,
+      timestamp: new Date(),
+      isError: true,
+    });
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.queryByText("NullPointerException at line 42"),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Purpose
The Novera AI chat bubble rendered a hardcoded **"Something went wrong"** for every errored bot message, discarding the real reason the backend sent. In particular, when the AI service hits a credit/token/usage limit (e.g. Anthropic `400 – credit balance is too low`), users had no idea why chat failed.

_No linked issue._ N/A

## Goals
- Surface a clear, **customer-safe** message when a chat error is caused by an AI usage/credit/token limit.
- Continue to hide raw error details for all other errors (no leaking internal/stack text to users).

## Approach
In `ChatMessageBubble.tsx`, before rendering the error text:
- Detect usage-limit errors via a keyword match on the error message (`credit`, `quota`, `billing`, `token limit`, `usage limit`, `rate limit`).
- Show `"The AI assistant is temporarily unavailable due to usage limits. Please try again later."` for those.
- Keep the generic `"Something went wrong"` for every other error.

The bubble already receives the backend's real error text via `message.text` (`NoveraChatPage.tsx`), so no backend change is required.

_UI change is text-only; no screenshot needed._

## User stories
As a support user, when the AI assistant is temporarily unavailable due to usage limits, I see a clear message telling me to try again later instead of a generic error.

## Release note
Chat now shows a specific "temporarily unavailable due to usage limits" message for AI credit/token-limit errors, instead of a generic error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages in the support chat now show a more specific, customer-safe notice when the issue is related to usage limits.
  * Non-usage-limit errors continue to display a generic fallback message, helping avoid exposure of raw error details.

* **Tests**
  * Added coverage for both usage-limit error handling and standard error fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->