### PR TITLE
[CSM][Web] Announcements page (read-only list with filters)

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -102,6 +102,9 @@ const CsmEngagementsPage = lazy(
 const CsmTimeCardsPage = lazy(
   () => import("@features/csm-timecards/pages/CsmTimeCardsPage"),
 );
+const CsmAnnouncementsPage = lazy(
+  () => import("@features/csm-announcements/pages/CsmAnnouncementsPage"),
+);
 
 /**
  * Landing for `/`. Defers to AuthGuard's post-login deep-link restore when a
@@ -297,6 +300,7 @@ export default function App(): JSX.Element {
                     element={<ProductVulnerabilityDetailPage />}
                   />
                   <Route path="time-cards" element={<CsmTimeCardsPage />} />
+                  <Route path="announcements" element={<CsmAnnouncementsPage />} />
                 </Route>
               </Route>
 

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -21,6 +21,7 @@ import {
   Clock,
   Cog,
   Headset,
+  Megaphone,
   RefreshCw,
   Settings,
   Shield,
@@ -61,6 +62,7 @@ export const CSM_NAV_ITEMS: CsmNavItem[] = [
   { id: "security-center", label: "Security Center", path: "/security-center", icon: Shield, wip: true },
   { id: "updates", label: "Updates", path: "/updates", icon: RefreshCw },
   { id: "time-cards", label: "Time cards", path: "/time-cards", icon: Clock },
+  { id: "announcements", label: "Announcements", path: "/announcements", icon: Megaphone },
   { id: "customers", label: "Customers", path: "/customers", icon: Building2, wip: true },
   { id: "admin", label: "Settings", path: "/admin", icon: Settings, wip: true },
 ];

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -91,6 +91,7 @@ export const ApiQueryKeys = {
   DEPLOYED_PRODUCT_INSTANCE_METRICS: "deployed-product-instance-metrics",
   CSM_ABT_DASHBOARD: "csm-abt-dashboard",
   CSM_CASES: "csm-cases",
+  CSM_ANNOUNCEMENTS: "csm-announcements",
   CSM_CASE_COUNTS: "csm-case-counts",
   CSM_CASE_DETAIL: "csm-case-detail",
   CSM_CASE_COMMENTS: "csm-case-comments",

--- a/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
@@ -21,11 +21,7 @@ import {
 } from "@tanstack/react-query";
 import { useBackendApi } from "@api/backend/client";
 import { ApiQueryKeys } from "@constants/apiConstants";
-import {
-  beStateFromUi,
-  priorityFromSeverity,
-  uiStateFromBe,
-} from "@api/backend/mappers";
+import { beStateFromUi, uiStateFromBe } from "@api/backend/mappers";
 import type {
   BeCaseSearchPayload,
   BeCaseSearchResponse,
@@ -44,10 +40,10 @@ import type {
  * subject / number); the backend paginates and sorts by last-updated
  * descending, so the most recent announcements load on arrival.
  *
- * The state / severity / project filters are pushed into the search payload:
- * UI `CaseState` → `beStateFromUi`, UI `Severity` → `priorityFromSeverity`,
- * project ids as-is. Empty filter arrays are omitted, so the list shows every
- * state and severity across all projects by default.
+ * The state / project filters are pushed into the search payload: UI
+ * `CaseState` → `beStateFromUi`, project ids as-is. Empty filter arrays are
+ * omitted, so the list shows every state across all projects by default.
+ * (No severity filter — announcements don't carry a severity of their own.)
  *
  * Creating / targeting / unpublishing announcements is not covered here — it
  * needs the dedicated announcement backend (digiops-cs#2053), which isn't
@@ -69,7 +65,6 @@ export function useSearchAnnouncements(
       ApiQueryKeys.CSM_ANNOUNCEMENTS,
       q,
       [...filters.states].sort(),
-      [...filters.severities].sort(),
       [...filters.projectIds].sort(),
       page,
       pageSize,
@@ -85,9 +80,6 @@ export function useSearchAnnouncements(
             ...(q.length > 0 && { searchQuery: q }),
             ...(filters.states.length > 0 && {
               states: filters.states.map(beStateFromUi),
-            }),
-            ...(filters.severities.length > 0 && {
-              severities: filters.severities.map(priorityFromSeverity),
             }),
             ...(filters.projectIds.length > 0 && {
               projectIds: filters.projectIds,

--- a/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useBackendApi } from "@api/backend/client";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import type {
+  BeCaseSearchPayload,
+  BeCaseSearchResponse,
+} from "@api/backend/types";
+import type {
+  CsmAnnouncementRow,
+  CsmAnnouncementsListResponse,
+} from "@features/csm-announcements/types/csmAnnouncements";
+
+/**
+ * Read-only announcements list. Announcements are cases of
+ * `type: "announcement"`, so this is a single `POST /cases/search` scoped to
+ * that type, mapping each search view to a trimmed {@link CsmAnnouncementRow}.
+ * A free-text `search` is pushed into the payload's `searchQuery` (matches
+ * subject / number); the backend paginates and sorts by last-updated
+ * descending, so the most recent announcements load on arrival.
+ *
+ * Creating / targeting / unpublishing announcements is not covered here — it
+ * needs the dedicated announcement backend (digiops-cs#2053), which isn't
+ * built yet. `page` is zero-based (MUI `TablePagination`); `pageSize` is the
+ * row limit.
+ */
+export function useSearchAnnouncements(
+  search: string,
+  page: number,
+  pageSize: number,
+): UseQueryResult<CsmAnnouncementsListResponse, Error> {
+  const api = useBackendApi();
+  const q = search.trim();
+  const offset = page * pageSize;
+
+  return useQuery<CsmAnnouncementsListResponse, Error>({
+    queryKey: [ApiQueryKeys.CSM_ANNOUNCEMENTS, q, page, pageSize],
+    queryFn: async (): Promise<CsmAnnouncementsListResponse> => {
+      const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+        "/cases/search",
+        {
+          pagination: { offset, limit: pageSize },
+          sortBy: { field: "updatedOn", order: "desc" },
+          filters: {
+            types: ["announcement"],
+            ...(q.length > 0 && { searchQuery: q }),
+          },
+        },
+      );
+
+      const announcements: CsmAnnouncementRow[] = (res.cases ?? []).map((c) => ({
+        id: c.id,
+        number: c.number,
+        subject: c.subject ?? "(no subject)",
+        projectName: c.project?.name ?? "—",
+        state: c.state,
+        createdBy: c.createdBy,
+        createdAt: c.createdOn ?? "",
+        updatedAt: c.updatedOn ?? c.createdOn ?? "",
+      }));
+
+      return {
+        announcements,
+        total: res.total ?? announcements.length,
+        limit: res.limit ?? pageSize,
+        offset: res.offset ?? offset,
+        hasMore: res.hasMore ?? false,
+      };
+    },
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
@@ -17,11 +17,13 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useBackendApi } from "@api/backend/client";
 import { ApiQueryKeys } from "@constants/apiConstants";
+import { beStateFromUi, priorityFromSeverity } from "@api/backend/mappers";
 import type {
   BeCaseSearchPayload,
   BeCaseSearchResponse,
 } from "@api/backend/types";
 import type {
+  AnnouncementFilters,
   CsmAnnouncementRow,
   CsmAnnouncementsListResponse,
 } from "@features/csm-announcements/types/csmAnnouncements";
@@ -34,22 +36,36 @@ import type {
  * subject / number); the backend paginates and sorts by last-updated
  * descending, so the most recent announcements load on arrival.
  *
+ * The state / severity / project filters are pushed into the search payload:
+ * UI `CaseState` → `beStateFromUi`, UI `Severity` → `priorityFromSeverity`,
+ * project ids as-is. Empty filter arrays are omitted, so the list shows every
+ * state and severity across all projects by default.
+ *
  * Creating / targeting / unpublishing announcements is not covered here — it
  * needs the dedicated announcement backend (digiops-cs#2053), which isn't
  * built yet. `page` is zero-based (MUI `TablePagination`); `pageSize` is the
  * row limit.
  */
 export function useSearchAnnouncements(
-  search: string,
+  filters: AnnouncementFilters,
   page: number,
   pageSize: number,
 ): UseQueryResult<CsmAnnouncementsListResponse, Error> {
   const api = useBackendApi();
-  const q = search.trim();
+  const q = filters.search.trim();
   const offset = page * pageSize;
 
   return useQuery<CsmAnnouncementsListResponse, Error>({
-    queryKey: [ApiQueryKeys.CSM_ANNOUNCEMENTS, q, page, pageSize],
+    // Sort the array filters so selection order doesn't fragment the cache.
+    queryKey: [
+      ApiQueryKeys.CSM_ANNOUNCEMENTS,
+      q,
+      [...filters.states].sort(),
+      [...filters.severities].sort(),
+      [...filters.projectIds].sort(),
+      page,
+      pageSize,
+    ],
     queryFn: async (): Promise<CsmAnnouncementsListResponse> => {
       const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
         "/cases/search",
@@ -59,6 +75,15 @@ export function useSearchAnnouncements(
           filters: {
             types: ["announcement"],
             ...(q.length > 0 && { searchQuery: q }),
+            ...(filters.states.length > 0 && {
+              states: filters.states.map(beStateFromUi),
+            }),
+            ...(filters.severities.length > 0 && {
+              severities: filters.severities.map(priorityFromSeverity),
+            }),
+            ...(filters.projectIds.length > 0 && {
+              projectIds: filters.projectIds,
+            }),
           },
         },
       );

--- a/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
@@ -14,7 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useQuery,
+  type UseQueryResult,
+} from "@tanstack/react-query";
 import { useBackendApi } from "@api/backend/client";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import {
@@ -114,6 +118,9 @@ export function useSearchAnnouncements(
         hasMore: res.hasMore ?? false,
       };
     },
+    // Keep the current page of rows on screen while the next page / a changed
+    // filter loads, instead of blanking the table to skeletons each time.
+    placeholderData: keepPreviousData,
     staleTime: 30_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
@@ -17,7 +17,11 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useBackendApi } from "@api/backend/client";
 import { ApiQueryKeys } from "@constants/apiConstants";
-import { beStateFromUi, priorityFromSeverity } from "@api/backend/mappers";
+import {
+  beStateFromUi,
+  priorityFromSeverity,
+  uiStateFromBe,
+} from "@api/backend/mappers";
 import type {
   BeCaseSearchPayload,
   BeCaseSearchResponse,
@@ -93,7 +97,10 @@ export function useSearchAnnouncements(
         number: c.number,
         subject: c.subject ?? "(no subject)",
         projectName: c.project?.name ?? "—",
-        state: c.state,
+        // The search view returns display-cased states (e.g. "Closed"); normalize
+        // to the canonical lowercase UI state so StateChip picks the right
+        // label/colour (matches the cases list — see useGetCsmCases).
+        state: c.state ? uiStateFromBe(c.state) : undefined,
         createdBy: c.createdBy,
         createdAt: c.createdOn ?? "",
         updatedAt: c.updatedOn ?? c.createdOn ?? "",

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
@@ -137,3 +137,36 @@ describe("CsmAnnouncementsPage — filters default to show-all", () => {
     expect(lastCall[0].severities).toContain("S0");
   });
 });
+
+describe("CsmAnnouncementsPage — loading and pagination", () => {
+  it("renders skeleton rows while the first page is loading", () => {
+    mockResult({ isLoading: true, isFetching: true });
+    const { container } = render(<CsmAnnouncementsPage />);
+    expect(container.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/no announcements found/i)).not.toBeInTheDocument();
+  });
+
+  it("advances the page when the next-page control is clicked", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 50, limit: 20, offset: 0, hasMore: true },
+    });
+    render(<CsmAnnouncementsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /go to next page/i }));
+    // useSearchAnnouncements(filters, page, pageSize) — page is the 2nd arg.
+    const lastCall = mockedUseSearch.mock.calls.at(-1)!;
+    expect(lastCall[1]).toBe(1);
+  });
+
+  it("passes an updated page size when rows-per-page changes", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 50, limit: 20, offset: 0, hasMore: true },
+    });
+    render(<CsmAnnouncementsPage />);
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /rows per page/i }));
+    fireEvent.click(screen.getByRole("option", { name: "50" }));
+    // pageSize is the 3rd arg; changing rows-per-page also resets page to 0.
+    const lastCall = mockedUseSearch.mock.calls.at(-1)!;
+    expect(lastCall[2]).toBe(50);
+    expect(lastCall[1]).toBe(0);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import CsmAnnouncementsPage from "@features/csm-announcements/pages/CsmAnnouncementsPage";
+import { useSearchAnnouncements } from "@features/csm-announcements/api/useSearchAnnouncements";
+import type { CsmAnnouncementRow } from "@features/csm-announcements/types/csmAnnouncements";
+
+// The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
+// module load, which isn't present under vitest. QueryErrorState imports
+// `BackendApiError` from it, so stub the module (same approach as
+// useCsmCaseActivities.test.ts).
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {},
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
+vi.mock("@features/csm-announcements/api/useSearchAnnouncements", () => ({
+  useSearchAnnouncements: vi.fn(),
+}));
+
+// The real project picker fetches from the backend; stub it so the page test
+// stays focused on the list + its own state/severity filters.
+vi.mock("@features/csm-cases/components/AsyncProjectMultiSelect", () => ({
+  default: () => <div data-testid="project-filter" />,
+}));
+
+const mockedUseSearch = vi.mocked(useSearchAnnouncements);
+
+const ROW: CsmAnnouncementRow = {
+  id: "a-1",
+  number: "ANN-1001",
+  subject: "Scheduled maintenance on Choreo",
+  projectName: "IAM Production",
+  state: "open",
+  createdBy: "jane@example.com",
+  createdAt: "2026-07-01T10:00:00Z",
+  updatedAt: "2026-07-02T10:00:00Z",
+};
+
+function mockResult(
+  overrides: Partial<ReturnType<typeof useSearchAnnouncements>>,
+): void {
+  mockedUseSearch.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSearchAnnouncements>);
+}
+
+beforeEach(() => {
+  mockedUseSearch.mockReset();
+});
+
+describe("CsmAnnouncementsPage — list states", () => {
+  it("renders a row from the search result", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+    expect(screen.getByText("Scheduled maintenance on Choreo")).toBeInTheDocument();
+    expect(screen.getByText("ANN-1001")).toBeInTheDocument();
+    expect(screen.getByText("IAM Production")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no announcements", () => {
+    mockResult({
+      data: { announcements: [], total: 0, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+    expect(screen.getByText(/no announcements found/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the error message on failure", () => {
+    mockResult({ isError: true, error: new Error("boom") });
+    render(<CsmAnnouncementsPage />);
+    expect(screen.getByText(/failed to load announcements: boom/i)).toBeInTheDocument();
+  });
+});
+
+describe("CsmAnnouncementsPage — filters default to show-all", () => {
+  it("calls the search with no state/severity/project filters on first render", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+    const [filters] = mockedUseSearch.mock.calls[0];
+    expect(filters).toEqual(
+      expect.objectContaining({ states: [], severities: [], projectIds: [] }),
+    );
+  });
+
+  it("pushes a picked state into the search filters", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /state/i }));
+    const listbox = screen.getByRole("listbox");
+    fireEvent.click(within(listbox).getByRole("option", { name: /closed/i }));
+
+    // The most recent render's filters carry the selected state.
+    const lastCall = mockedUseSearch.mock.calls.at(-1)!;
+    expect(lastCall[0].states).toContain("closed");
+  });
+
+  it("pushes a picked severity into the search filters", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /severity/i }));
+    const listbox = screen.getByRole("listbox");
+    fireEvent.click(within(listbox).getByRole("option", { name: /catastrophic/i }));
+
+    const lastCall = mockedUseSearch.mock.calls.at(-1)!;
+    expect(lastCall[0].severities).toContain("S0");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@features/csm-announcements/api/useSearchAnnouncements", () => ({
 }));
 
 // The real project picker fetches from the backend; stub it so the page test
-// stays focused on the list + its own state/severity filters.
+// stays focused on the list + its own state filter.
 vi.mock("@features/csm-cases/components/AsyncProjectMultiSelect", () => ({
   default: () => <div data-testid="project-filter" />,
 }));
@@ -97,14 +97,14 @@ describe("CsmAnnouncementsPage — list states", () => {
 });
 
 describe("CsmAnnouncementsPage — filters default to show-all", () => {
-  it("calls the search with no state/severity/project filters on first render", () => {
+  it("calls the search with no state/project filters on first render", () => {
     mockResult({
       data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
     });
     render(<CsmAnnouncementsPage />);
     const [filters] = mockedUseSearch.mock.calls[0];
     expect(filters).toEqual(
-      expect.objectContaining({ states: [], severities: [], projectIds: [] }),
+      expect.objectContaining({ states: [], projectIds: [] }),
     );
   });
 
@@ -121,20 +121,6 @@ describe("CsmAnnouncementsPage — filters default to show-all", () => {
     // The most recent render's filters carry the selected state.
     const lastCall = mockedUseSearch.mock.calls.at(-1)!;
     expect(lastCall[0].states).toContain("closed");
-  });
-
-  it("pushes a picked severity into the search filters", () => {
-    mockResult({
-      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
-    });
-    render(<CsmAnnouncementsPage />);
-
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: /severity/i }));
-    const listbox = screen.getByRole("listbox");
-    fireEvent.click(within(listbox).getByRole("option", { name: /catastrophic/i }));
-
-    const lastCall = mockedUseSearch.mock.calls.at(-1)!;
-    expect(lastCall[0].severities).toContain("S0");
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -16,8 +16,15 @@
 
 import {
   Box,
+  Button,
+  Checkbox,
+  FormControl,
   IconButton,
   InputAdornment,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Select,
   Skeleton,
   Table,
   TableBody,
@@ -29,16 +36,41 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
+import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import { Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useState, type ChangeEvent, type JSX } from "react";
 import QueryErrorState from "@components/QueryErrorState";
 import StateChip from "@components/StateChip";
+import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useSearchAnnouncements } from "@features/csm-announcements/api/useSearchAnnouncements";
+import {
+  DEFAULT_ANNOUNCEMENT_FILTERS,
+  type AnnouncementFilters,
+} from "@features/csm-announcements/types/csmAnnouncements";
+import { SEVERITY_LABEL, STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+
+// `reopened` is intentionally excluded — it only appears as a `nextStates`
+// signal, never as a case's own state (see CaseState's doc).
+const STATE_OPTIONS: { value: CaseState; label: string }[] = (
+  [
+    "open",
+    "work_in_progress",
+    "solution_proposed",
+    "awaiting_info",
+    "waiting_on_wso2",
+    "closed",
+  ] as CaseState[]
+).map((s) => ({ value: s, label: STATE_LABEL[s] }));
+
+const SEVERITY_OPTIONS: { value: Severity; label: string }[] = (
+  ["S0", "S1", "S2", "S3", "S4"] as Severity[]
+).map((s) => ({ value: s, label: SEVERITY_LABEL[s] }));
 
 function formatDate(value?: string | null): string {
   return (
@@ -50,20 +82,68 @@ function formatDate(value?: string | null): string {
   );
 }
 
+interface MultiSelectProps<T extends string> {
+  id: string;
+  label: string;
+  values: T[];
+  options: { value: T; label: string }[];
+  onChange: (next: T[]) => void;
+}
+
+/** Checkbox multi-select over a fixed enum (State / Severity). */
+function MultiSelect<T extends string>({
+  id,
+  label,
+  values,
+  options,
+  onChange,
+}: MultiSelectProps<T>): JSX.Element {
+  const handleChange = (event: SelectChangeEvent<string[]>): void => {
+    const val = event.target.value;
+    onChange((Array.isArray(val) ? val : [val]) as T[]);
+  };
+  return (
+    <FormControl fullWidth size="small">
+      <InputLabel id={`${id}-label`}>{label}</InputLabel>
+      <Select
+        multiple
+        labelId={`${id}-label`}
+        id={id}
+        value={values as unknown as string[]}
+        label={label}
+        onChange={handleChange}
+        renderValue={(selected) =>
+          (Array.isArray(selected) ? selected : [])
+            .map((v) => options.find((o) => o.value === v)?.label ?? v)
+            .join(", ")
+        }
+      >
+        {options.map((opt) => (
+          <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
+            <Checkbox size="small" checked={values.includes(opt.value)} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText primary={opt.label} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
 /**
  * Read-only announcements list. Announcements are cases of
- * `type: "announcement"` surfaced via `POST /cases/search`. Creating /
+ * `type: "announcement"` surfaced via `POST /cases/search`. Filterable by
+ * state, severity, and project (all default to "show all"). Creating /
  * targeting / unpublishing needs the dedicated announcement backend
  * (digiops-cs#2053), which isn't built yet, so this page is view-only for now.
  */
 export default function CsmAnnouncementsPage(): JSX.Element {
-  const [search, setSearch] = useState("");
+  const [filters, setFilters] = useState<AnnouncementFilters>(DEFAULT_ANNOUNCEMENT_FILTERS);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
-  const debouncedSearch = useDebouncedValue(search.trim(), 300);
+  const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
 
   const { data, isLoading, isFetching, isError, error } = useSearchAnnouncements(
-    debouncedSearch,
+    { ...filters, search: debouncedSearch },
     page,
     rowsPerPage,
   );
@@ -71,10 +151,14 @@ export default function CsmAnnouncementsPage(): JSX.Element {
   const announcements = data?.announcements ?? [];
   const total = data?.total ?? 0;
 
-  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    setSearch(e.target.value);
+  // Any filter change resets to the first page.
+  const patchFilters = (patch: Partial<AnnouncementFilters>): void => {
+    setFilters((prev) => ({ ...prev, ...patch }));
     setPage(0);
   };
+
+  const activeFilterCount =
+    filters.states.length + filters.severities.length + filters.projectIds.length;
 
   const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
     setRowsPerPage(parseInt(e.target.value, 10));
@@ -90,38 +174,75 @@ export default function CsmAnnouncementsPage(): JSX.Element {
         </Typography>
       </Box>
 
-      <Box sx={{ maxWidth: 360 }}>
-        <TextField
-          fullWidth
-          size="small"
-          placeholder="Search by subject or number…"
-          value={search}
-          onChange={handleSearchChange}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-              endAdornment: search ? (
-                <InputAdornment position="end">
-                  <IconButton
-                    size="small"
-                    edge="end"
-                    onClick={() => {
-                      setSearch("");
-                      setPage(0);
-                    }}
-                    aria-label="Clear search"
-                  >
-                    <X size={16} />
-                  </IconButton>
-                </InputAdornment>
-              ) : undefined,
-            },
-          }}
-        />
+      {/* Filters — search + state / severity / project, all "show all" by default */}
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", alignItems: "center" }}>
+        <Box sx={{ flex: "1 1 260px", minWidth: 220 }}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Search by subject or number…"
+            value={filters.search}
+            onChange={(e) => patchFilters({ search: e.target.value })}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={16} />
+                  </InputAdornment>
+                ),
+                endAdornment: filters.search ? (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      edge="end"
+                      onClick={() => patchFilters({ search: "" })}
+                      aria-label="Clear search"
+                    >
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+          />
+        </Box>
+        <Box sx={{ flex: "1 1 160px", minWidth: 150 }}>
+          <MultiSelect
+            id="announcements-filter-state"
+            label="State"
+            values={filters.states}
+            options={STATE_OPTIONS}
+            onChange={(next) => patchFilters({ states: next })}
+          />
+        </Box>
+        <Box sx={{ flex: "1 1 160px", minWidth: 150 }}>
+          <MultiSelect
+            id="announcements-filter-severity"
+            label="Severity"
+            values={filters.severities}
+            options={SEVERITY_OPTIONS}
+            onChange={(next) => patchFilters({ severities: next })}
+          />
+        </Box>
+        <Box sx={{ flex: "1 1 220px", minWidth: 200 }}>
+          <AsyncProjectMultiSelect
+            id="announcements-filter-project"
+            label="Project"
+            values={filters.projectIds}
+            onChange={(next) => patchFilters({ projectIds: next })}
+          />
+        </Box>
+        {activeFilterCount > 0 && (
+          <Button
+            variant="text"
+            size="small"
+            color="primary"
+            startIcon={<X size={16} />}
+            onClick={() => patchFilters({ states: [], severities: [], projectIds: [] })}
+          >
+            Clear filters
+          </Button>
+        )}
       </Box>
 
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -40,7 +40,7 @@ import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import { Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useState, type ChangeEvent, type JSX } from "react";
 import QueryErrorState from "@components/QueryErrorState";
-import StateChip from "@components/StateChip";
+import SemanticChip, { type SemanticRole } from "@components/SemanticChip";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
@@ -71,6 +71,22 @@ const STATE_OPTIONS: { value: CaseState; label: string }[] = (
 const SEVERITY_OPTIONS: { value: Severity; label: string }[] = (
   ["S0", "S1", "S2", "S3", "S4"] as Severity[]
 ).map((s) => ({ value: s, label: SEVERITY_LABEL[s] }));
+
+/**
+ * Chip colour for an announcement's lifecycle state — announcement-specific,
+ * not the case-state palette (which paints a closed case green). Here an Open
+ * announcement is live/published → green, a Closed one is inactive → grey.
+ */
+function announcementStateRole(state?: CaseState): SemanticRole {
+  switch (state) {
+    case "open":
+      return "success";
+    case "closed":
+      return "default";
+    default:
+      return "info";
+  }
+}
 
 function formatDate(value?: string | null): string {
   return (
@@ -293,7 +309,16 @@ export default function CsmAnnouncementsPage(): JSX.Element {
                     <TableCell>{a.number || "—"}</TableCell>
                     <TableCell>{a.subject}</TableCell>
                     <TableCell>{a.projectName}</TableCell>
-                    <TableCell>{a.state ? <StateChip state={a.state} /> : "—"}</TableCell>
+                    <TableCell>
+                      {a.state ? (
+                        <SemanticChip
+                          role={announcementStateRole(a.state)}
+                          label={STATE_LABEL[a.state] ?? a.state}
+                        />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
                     <TableCell>{a.createdBy || "—"}</TableCell>
                     <TableCell>{formatDate(a.updatedAt)}</TableCell>
                   </TableRow>

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  IconButton,
+  InputAdornment,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Search, X } from "@wso2/oxygen-ui-icons-react";
+import { useState, type ChangeEvent, type JSX } from "react";
+import QueryErrorState from "@components/QueryErrorState";
+import StateChip from "@components/StateChip";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { useSearchAnnouncements } from "@features/csm-announcements/api/useSearchAnnouncements";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+
+function formatDate(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }) ?? "—"
+  );
+}
+
+/**
+ * Read-only announcements list. Announcements are cases of
+ * `type: "announcement"` surfaced via `POST /cases/search`. Creating /
+ * targeting / unpublishing needs the dedicated announcement backend
+ * (digiops-cs#2053), which isn't built yet, so this page is view-only for now.
+ */
+export default function CsmAnnouncementsPage(): JSX.Element {
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const debouncedSearch = useDebouncedValue(search.trim(), 300);
+
+  const { data, isLoading, isFetching, isError, error } = useSearchAnnouncements(
+    debouncedSearch,
+    page,
+    rowsPerPage,
+  );
+
+  const announcements = data?.announcements ?? [];
+  const total = data?.total ?? 0;
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setSearch(e.target.value);
+    setPage(0);
+  };
+
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box>
+        <Typography variant="h5">Announcements</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Customer-facing announcements published across projects and tiers.
+        </Typography>
+      </Box>
+
+      <Box sx={{ maxWidth: 360 }}>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="Search by subject or number…"
+          value={search}
+          onChange={handleSearchChange}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={16} />
+                </InputAdornment>
+              ),
+              endAdornment: search ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    edge="end"
+                    onClick={() => {
+                      setSearch("");
+                      setPage(0);
+                    }}
+                    aria-label="Clear search"
+                  >
+                    <X size={16} />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
+            },
+          }}
+        />
+      </Box>
+
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
+        <TableContainer>
+          <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
+            <TableHead>
+              <TableRow sx={{ bgcolor: "action.hover" }}>
+                <TableCell>Number</TableCell>
+                <TableCell>Subject</TableCell>
+                <TableCell>Project</TableCell>
+                <TableCell>State</TableCell>
+                <TableCell>Created by</TableCell>
+                <TableCell>Updated</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading || isFetching ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="90%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="85%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={72} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="70%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
+                  </TableRow>
+                ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    <QueryErrorState
+                      message={`Failed to load announcements: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
+              ) : announcements.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No announcements found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                announcements.map((a) => (
+                  <TableRow key={a.id} hover>
+                    <TableCell>{a.number || "—"}</TableCell>
+                    <TableCell>{a.subject}</TableCell>
+                    <TableCell>{a.projectName}</TableCell>
+                    <TableCell>{a.state ? <StateChip state={a.state} /> : "—"}</TableCell>
+                    <TableCell>{a.createdBy || "—"}</TableCell>
+                    <TableCell>{formatDate(a.updatedAt)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(_, newPage) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -22,6 +22,7 @@ import {
   IconButton,
   InputAdornment,
   InputLabel,
+  LinearProgress,
   ListItemText,
   MenuItem,
   Select,
@@ -200,6 +201,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
             value={filters.search}
             onChange={(e) => patchFilters({ search: e.target.value })}
             slotProps={{
+              htmlInput: { "aria-label": "Search announcements" },
               input: {
                 startAdornment: (
                   <InputAdornment position="start">
@@ -262,6 +264,11 @@ export default function CsmAnnouncementsPage(): JSX.Element {
       </Box>
 
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
+        {/* Thin bar during a background refetch (page / filter change) so the
+            table isn't blanked to skeletons — cached rows stay visible. */}
+        <Box sx={{ height: 2 }}>
+          {isFetching && !isLoading && <LinearProgress sx={{ height: 2 }} />}
+        </Box>
         <TableContainer>
           <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
             <TableHead>
@@ -275,7 +282,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
               </TableRow>
             </TableHead>
             <TableBody>
-              {isLoading || isFetching ? (
+              {isLoading ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -50,8 +50,8 @@ import {
   DEFAULT_ANNOUNCEMENT_FILTERS,
   type AnnouncementFilters,
 } from "@features/csm-announcements/types/csmAnnouncements";
-import { SEVERITY_LABEL, STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
-import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
+import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -68,10 +68,6 @@ const STATE_OPTIONS: { value: CaseState; label: string }[] = (
     "closed",
   ] as CaseState[]
 ).map((s) => ({ value: s, label: STATE_LABEL[s] }));
-
-const SEVERITY_OPTIONS: { value: Severity; label: string }[] = (
-  ["S0", "S1", "S2", "S3", "S4"] as Severity[]
-).map((s) => ({ value: s, label: SEVERITY_LABEL[s] }));
 
 /**
  * Chip colour for an announcement's lifecycle state — announcement-specific,
@@ -107,7 +103,7 @@ interface MultiSelectProps<T extends string> {
   onChange: (next: T[]) => void;
 }
 
-/** Checkbox multi-select over a fixed enum (State / Severity). */
+/** Checkbox multi-select over a fixed enum (State). */
 function MultiSelect<T extends string>({
   id,
   label,
@@ -149,7 +145,7 @@ function MultiSelect<T extends string>({
 /**
  * Read-only announcements list. Announcements are cases of
  * `type: "announcement"` surfaced via `POST /cases/search`. Filterable by
- * state, severity, and project (all default to "show all"). Creating /
+ * state and project (all default to "show all"). Creating /
  * targeting / unpublishing needs the dedicated announcement backend
  * (digiops-cs#2053), which isn't built yet, so this page is view-only for now.
  */
@@ -174,8 +170,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
     setPage(0);
   };
 
-  const activeFilterCount =
-    filters.states.length + filters.severities.length + filters.projectIds.length;
+  const activeFilterCount = filters.states.length + filters.projectIds.length;
 
   const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
     setRowsPerPage(parseInt(e.target.value, 10));
@@ -191,7 +186,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
         </Typography>
       </Box>
 
-      {/* Filters — search + state / severity / project, all "show all" by default */}
+      {/* Filters — search + state + project, all "show all" by default */}
       <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", alignItems: "center" }}>
         <Box sx={{ flex: "1 1 260px", minWidth: 220 }}>
           <TextField
@@ -233,15 +228,6 @@ export default function CsmAnnouncementsPage(): JSX.Element {
             onChange={(next) => patchFilters({ states: next })}
           />
         </Box>
-        <Box sx={{ flex: "1 1 160px", minWidth: 150 }}>
-          <MultiSelect
-            id="announcements-filter-severity"
-            label="Severity"
-            values={filters.severities}
-            options={SEVERITY_OPTIONS}
-            onChange={(next) => patchFilters({ severities: next })}
-          />
-        </Box>
         <Box sx={{ flex: "1 1 220px", minWidth: 200 }}>
           <AsyncProjectMultiSelect
             id="announcements-filter-project"
@@ -256,7 +242,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
             size="small"
             color="primary"
             startIcon={<X size={16} />}
-            onClick={() => patchFilters({ states: [], severities: [], projectIds: [] })}
+            onClick={() => patchFilters({ states: [], projectIds: [] })}
           >
             Clear filters
           </Button>

--- a/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
@@ -15,6 +15,30 @@
 // under the License.
 
 import type { BeCaseState } from "@api/backend/types";
+import type {
+  CaseState,
+  Severity,
+} from "@features/csm-dashboard/types/abtDashboard";
+
+/**
+ * Filter state for the announcements list. All arrays are multi-select and
+ * empty by default, so the list shows every state and severity across all
+ * projects until the user narrows it. `search` matches subject / number.
+ */
+export interface AnnouncementFilters {
+  search: string;
+  states: CaseState[];
+  severities: Severity[];
+  /** Project ids (the project filter is id-based). */
+  projectIds: string[];
+}
+
+export const DEFAULT_ANNOUNCEMENT_FILTERS: AnnouncementFilters = {
+  search: "",
+  states: [],
+  severities: [],
+  projectIds: [],
+};
 
 /**
  * A single announcement row for the list. Announcements are stored as cases of

--- a/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeCaseState } from "@api/backend/types";
+
+/**
+ * A single announcement row for the list. Announcements are stored as cases of
+ * `type: "announcement"` and read back through `POST /cases/search`, so the row
+ * is a trimmed projection of the case search view — only the fields the
+ * read-only list renders. (Targeting/audience metadata isn't available until
+ * the dedicated announcement backend lands — see digiops-cs#2053.)
+ */
+export interface CsmAnnouncementRow {
+  id: string;
+  number?: string;
+  subject: string;
+  /** Owning project display name, or "—" when cross-customer / unset. */
+  projectName: string;
+  state?: BeCaseState;
+  createdBy?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Paginated announcements list, mirroring the backend search envelope. */
+export interface CsmAnnouncementsListResponse {
+  announcements: CsmAnnouncementRow[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}

--- a/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { BeCaseState } from "@api/backend/types";
 import type {
   CaseState,
   Severity,
@@ -53,7 +52,7 @@ export interface CsmAnnouncementRow {
   subject: string;
   /** Owning project display name, or "—" when cross-customer / unset. */
   projectName: string;
-  state?: BeCaseState;
+  state?: CaseState;
   createdBy?: string;
   createdAt: string;
   updatedAt: string;

--- a/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
@@ -14,20 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type {
-  CaseState,
-  Severity,
-} from "@features/csm-dashboard/types/abtDashboard";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 
 /**
  * Filter state for the announcements list. All arrays are multi-select and
- * empty by default, so the list shows every state and severity across all
- * projects until the user narrows it. `search` matches subject / number.
+ * empty by default, so the list shows every state across all projects until
+ * the user narrows it. `search` matches subject / number. (No severity filter
+ * — announcements don't carry a severity of their own.)
  */
 export interface AnnouncementFilters {
   search: string;
   states: CaseState[];
-  severities: Severity[];
   /** Project ids (the project filter is id-based). */
   projectIds: string[];
 }
@@ -35,7 +32,6 @@ export interface AnnouncementFilters {
 export const DEFAULT_ANNOUNCEMENT_FILTERS: AnnouncementFilters = {
   search: "",
   states: [],
-  severities: [],
   projectIds: [],
 };
 


### PR DESCRIPTION
## Purpose
Adds a CSM-portal Announcements page. Announcements are stored as cases of `type: "announcement"`, but there was no way to view them in the portal. This delivers the **read-only** slice of the announcements feature.

> **Scope note:** Create / target (all customers / project / tier) / unpublish needs the dedicated announcement backend, which isn't built yet — case-create doesn't accept `announcement`, and there's no targeting endpoint. So this PR is intentionally the read-only slice; the write/target work is tracked separately.

## Goals
- New top-level **Announcements** nav item + `/announcements` route.
- List announcements with Search / State / Project filters (all default to "show all").

## Approach
- `features/csm-announcements/` — new feature folder:
  - `api/useSearchAnnouncements.ts` — React Query hook doing `POST /cases/search` scoped to `types: ["announcement"]`, with search + State/Project filters (`CaseState → beStateFromUi`, project ids as-is; empty arrays omitted). Backend returns display-cased states (e.g. `"Closed"`), so state is normalized via `uiStateFromBe` — matching the cases list. `keepPreviousData` keeps rows visible across page/filter changes.
  - `pages/CsmAnnouncementsPage.tsx` — header, search, State multi-select, `AsyncProjectMultiSelect`, and a table (Number / Subject / Project / State / Created by / Updated) with skeleton / error (`QueryErrorState`) / empty states + `TablePagination`.
  - `types/csmAnnouncements.ts` — row + filter types.
- No severity/priority filter — announcements don't carry a severity of their own.
- State chips use an **announcement-specific** palette (open = green/live, closed = grey/inactive) rather than the case-state one (which paints a closed case green).
- Wiring: `App.tsx` route, `csmNavItems.ts` nav item, `CSM_ANNOUNCEMENTS` query key.

Reuses existing conventions throughout (`useBackendApi`, `QueryErrorState`, `SemanticChip`, `AsyncProjectMultiSelect`, the change-requests table pattern).

## User stories
As a CS engineer, I can view and filter the announcements published across projects from the portal.

## Release note
Adds a read-only Announcements page (list + Search/State/Project filters) to the CSM portal.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: `CsmAnnouncementsPage.test.tsx` — list states (rows / empty / error), filters default to show-all, State pick pushes into the search filters, loading skeletons, and pagination (page / rows-per-page). `pnpm run test` passing (pre-existing, unrelated `CaseActionBar` failures untouched).
- Verified against staging: `POST /cases/search` with `types:["announcement"]` returns records and the state filter narrows the list.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint`, `pnpm run test`, `pnpm run build` all passing locally.