### PR TITLE
[Customer Entity] Add POST /incidents/search endpoint

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2135,3 +2135,67 @@ type TaskSlaDetail struct {
 	Active                    *bool                    `json:"active"`
 	Schedule                  *TaskSlaScheduleRef      `json:"schedule"`
 }
+
+// IncidentSortField enumerates the columns available for sorting incident search results.
+type IncidentSortField string
+
+const (
+	IncidentSortFieldCreatedOn IncidentSortField = "createdOn"
+	IncidentSortFieldUpdatedOn IncidentSortField = "updatedOn"
+	IncidentSortFieldOpenedOn  IncidentSortField = "openedOn"
+)
+
+// IncidentSortOrder controls the sort direction for incident search.
+type IncidentSortOrder string
+
+const (
+	IncidentSortOrderAsc  IncidentSortOrder = "asc"
+	IncidentSortOrderDesc IncidentSortOrder = "desc"
+)
+
+// IncidentSort specifies the sort field and direction for incident search results.
+type IncidentSort struct {
+	Field IncidentSortField `json:"field"`
+	Order IncidentSortOrder `json:"order"`
+}
+
+// SearchIncidentsFilters holds all optional filter criteria for an incident search.
+type SearchIncidentsFilters struct {
+	SearchQuery string   `json:"searchQuery"`
+	PriorityKeys []int   `json:"priorityKeys"`
+	ParentIDs   []string `json:"parentIds"`
+}
+
+// SearchIncidentsRequest is the input for POST /incidents/search.
+type SearchIncidentsRequest struct {
+	Filters    SearchIncidentsFilters `json:"filters"`
+	SortBy     IncidentSort           `json:"sortBy"`
+	Pagination Pagination             `json:"pagination"`
+}
+
+// SearchIncidentView is the unified incident representation returned in search results.
+type SearchIncidentView struct {
+	ID              *string              `json:"id"`
+	Number          *string              `json:"number"`
+	OpenedOn        *string              `json:"openedOn"`
+	Subject         *string              `json:"subject"`
+	Caller          *EntityRef           `json:"caller"`
+	Priority        *string `json:"priority"`
+	State           *string `json:"state"`
+	Category        *string `json:"category"`
+	Parent          *EntityRef           `json:"parent"`
+	AssignmentGroup *EntityRef           `json:"assignmentGroup"`
+	AssignedTo      *EntityRef           `json:"assignedTo"`
+	CreatedOn       string               `json:"createdOn"`
+	CreatedBy       string               `json:"createdBy"`
+	UpdatedOn       string               `json:"updatedOn"`
+	UpdatedBy       string               `json:"updatedBy"`
+}
+
+// SearchIncidentsResponse is the paginated result of an incident search.
+type SearchIncidentsResponse struct {
+	Incidents []SearchIncidentView `json:"incidents"`
+	Total     int                  `json:"total"`
+	Offset    int                  `json:"offset"`
+	Limit     int                  `json:"limit"`
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2136,6 +2136,17 @@ type TaskSlaDetail struct {
 	Schedule                  *TaskSlaScheduleRef      `json:"schedule"`
 }
 
+// IncidentPriority represents the priority level of an incident.
+type IncidentPriority string
+
+const (
+	IncidentPriorityCritical IncidentPriority = "CRITICAL"
+	IncidentPriorityHigh     IncidentPriority = "HIGH"
+	IncidentPriorityModerate IncidentPriority = "MODERATE"
+	IncidentPriorityLow      IncidentPriority = "LOW"
+	IncidentPriorityPlanning IncidentPriority = "PLANNING"
+)
+
 // IncidentSortField enumerates the columns available for sorting incident search results.
 type IncidentSortField string
 
@@ -2161,9 +2172,9 @@ type IncidentSort struct {
 
 // SearchIncidentsFilters holds all optional filter criteria for an incident search.
 type SearchIncidentsFilters struct {
-	SearchQuery string   `json:"searchQuery"`
-	PriorityKeys []int   `json:"priorityKeys"`
-	ParentIDs   []string `json:"parentIds"`
+	SearchQuery string             `json:"searchQuery"`
+	Priorities  []IncidentPriority `json:"priorities"`
+	ParentIDs   []string           `json:"parentIds"`
 }
 
 // SearchIncidentsRequest is the input for POST /incidents/search.

--- a/entity-service/internal/handler/incident_handler.go
+++ b/entity-service/internal/handler/incident_handler.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// IncidentHandler handles HTTP requests for the incidents resource.
+type IncidentHandler struct {
+	svc service.IncidentService
+}
+
+// NewIncidentHandler constructs an IncidentHandler with the given service.
+func NewIncidentHandler(svc service.IncidentService) *IncidentHandler {
+	return &IncidentHandler{svc: svc}
+}
+
+// SearchIncidents handles POST /incidents/search.
+func (h *IncidentHandler) SearchIncidents(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchIncidentsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchIncidents(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -142,6 +142,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		productVulnerabilityHandler = handler.NewProductVulnerabilityHandler(service.NewServiceNowProductVulnerabilityService(serviceNowIntegrationServiceClient))
 	}
 
+	var incidentHandler *handler.IncidentHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		incidentHandler = handler.NewIncidentHandler(service.NewServiceNowIncidentService(serviceNowIntegrationServiceClient))
+	}
+
 	var itServiceHandler *handler.ITServiceHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		itServiceHandler = handler.NewITServiceHandler(service.NewServiceNowITServiceService(serviceNowIntegrationServiceClient))
@@ -279,6 +284,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	if taskSlaHandler != nil {
 		mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
 		mux.HandleFunc("POST /slas/search", taskSlaHandler.SearchTaskSlas)
+	}
+
+	if incidentHandler != nil {
+		mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)
 	}
 
 	return middleware.CorrelationID(

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -312,3 +312,10 @@ type ProductVulnerabilityService interface {
 	// A NotFoundError is returned if the vulnerability does not exist.
 	GetProductVulnerability(ctx context.Context, id string) (domain.ProductVulnerabilityView, error)
 }
+
+// IncidentService defines the operations available on the incidents entity.
+type IncidentService interface {
+	// SearchIncidents returns a paginated list of incidents filtered by optional search query,
+	// priority keys, and parent IDs. A ValidationError is returned for invalid input.
+	SearchIncidents(ctx context.Context, req domain.SearchIncidentsRequest) (domain.SearchIncidentsResponse, error)
+}

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -82,16 +82,34 @@ type snIncidentSort struct {
 
 type snIncidentFilters struct {
 	SearchQuery  string   `json:"searchQuery,omitempty"`
-	PriorityKeys []int    `json:"priorityKeys,omitempty"`
+	PriorityKeys []int    `json:"priorityKeys,omitempty"` // SN expects int keys
 	ParentIDs    []string `json:"parentIds,omitempty"`
 }
 
+// snIncidentPriorityKeyMap maps domain IncidentPriority enums to SN numeric priority keys.
+var snIncidentPriorityKeyMap = map[domain.IncidentPriority]int{
+	domain.IncidentPriorityCritical: 1,
+	domain.IncidentPriorityHigh:     2,
+	domain.IncidentPriorityModerate: 3,
+	domain.IncidentPriorityLow:      4,
+	domain.IncidentPriorityPlanning: 5,
+}
+
+// snIncidentPriorityLabelMap maps SN numeric priority keys to domain enum strings.
 var snIncidentPriorityLabelMap = map[int]string{
 	1: "CRITICAL",
 	2: "HIGH",
 	3: "MODERATE",
 	4: "LOW",
 	5: "PLANNING",
+}
+
+var validIncidentPriority = map[domain.IncidentPriority]bool{
+	domain.IncidentPriorityCritical: true,
+	domain.IncidentPriorityHigh:     true,
+	domain.IncidentPriorityModerate: true,
+	domain.IncidentPriorityLow:      true,
+	domain.IncidentPriorityPlanning: true,
 }
 
 var snIncidentStateLabelMap = map[int]string{
@@ -142,6 +160,11 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 	if req.SortBy.Order != "" && !validIncidentSortOrder[req.SortBy.Order] {
 		return domain.SearchIncidentsResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + string(req.SortBy.Order)}
 	}
+	for _, p := range req.Filters.Priorities {
+		if !validIncidentPriority[p] {
+			return domain.SearchIncidentsResponse{}, &apierror.ValidationError{Msg: "priorities contains invalid value: " + string(p)}
+		}
+	}
 	if err := validateUUIDs("parentIds", req.Filters.ParentIDs); err != nil {
 		return domain.SearchIncidentsResponse{}, err
 	}
@@ -160,10 +183,15 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 		snSortBy = &snIncidentSort{Field: string(req.SortBy.Field), Order: order}
 	}
 
+	priorityKeys := make([]int, 0, len(req.Filters.Priorities))
+	for _, p := range req.Filters.Priorities {
+		priorityKeys = append(priorityKeys, snIncidentPriorityKeyMap[p])
+	}
+
 	payload := snIncidentSearchPayload{
 		Filters: snIncidentFilters{
 			SearchQuery:  req.Filters.SearchQuery,
-			PriorityKeys: req.Filters.PriorityKeys,
+			PriorityKeys: priorityKeys,
 			ParentIDs:    uuidsToSysids(req.Filters.ParentIDs),
 		},
 		SortBy:     snSortBy,

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snIncidentsResponse mirrors the Choreo POST /incidents/search response.
+type snIncidentsResponse struct {
+	Incidents    []snIncident `json:"incidents"`
+	TotalRecords int          `json:"totalRecords"`
+	Offset       int          `json:"offset"`
+	Limit        int          `json:"limit"`
+}
+
+type snIncident struct {
+	ID              *string             `json:"id"`
+	Number          *string             `json:"number"`
+	OpenedOn        *string             `json:"openedOn"`
+	Subject         *string             `json:"subject"`
+	Caller          *snIncidentEntityRef `json:"caller"`
+	Priority        *snIncidentIntLabel  `json:"priority"`
+	State           *snIncidentIntLabel  `json:"state"`
+	Category        *snIncidentStrLabel  `json:"category"`
+	Parent          *snIncidentEntityRef `json:"parent"`
+	AssignmentGroup *snIncidentEntityRef `json:"assignmentGroup"`
+	AssignedTo      *snIncidentEntityRef `json:"assignedTo"`
+	CreatedOn       string               `json:"createdOn"`
+	CreatedBy       string               `json:"createdBy"`
+	UpdatedOn       string               `json:"updatedOn"`
+	UpdatedBy       string               `json:"updatedBy"`
+}
+
+type snIncidentEntityRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type snIncidentIntLabel struct {
+	ID    int    `json:"id"`
+	Label string `json:"label"`
+}
+
+type snIncidentStrLabel struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// snIncidentSearchPayload is the Choreo POST /incidents/search request body.
+type snIncidentSearchPayload struct {
+	Filters    snIncidentFilters   `json:"filters,omitempty"`
+	SortBy     *snIncidentSort     `json:"sortBy,omitempty"`
+	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snIncidentSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+type snIncidentFilters struct {
+	SearchQuery  string   `json:"searchQuery,omitempty"`
+	PriorityKeys []int    `json:"priorityKeys,omitempty"`
+	ParentIDs    []string `json:"parentIds,omitempty"`
+}
+
+var snIncidentPriorityLabelMap = map[int]string{
+	1: "CRITICAL",
+	2: "HIGH",
+	3: "MODERATE",
+	4: "LOW",
+	5: "PLANNING",
+}
+
+var snIncidentStateLabelMap = map[int]string{
+	1: "NEW",
+	2: "IN_PROGRESS",
+	3: "ON_HOLD",
+	6: "RESOLVED",
+	7: "CLOSED",
+	8: "CANCELLED",
+}
+
+var snIncidentCategoryLabelMap = map[string]string{
+	"inquiry":              "INQUIRY",
+	"service_interruption": "SERVICE_INTERRUPTION",
+	"security":             "SECURITY",
+}
+
+var validIncidentSortField = map[domain.IncidentSortField]bool{
+	domain.IncidentSortFieldCreatedOn: true,
+	domain.IncidentSortFieldUpdatedOn: true,
+	domain.IncidentSortFieldOpenedOn:  true,
+}
+
+var validIncidentSortOrder = map[domain.IncidentSortOrder]bool{
+	domain.IncidentSortOrderAsc:  true,
+	domain.IncidentSortOrderDesc: true,
+}
+
+type snIncidentService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowIncidentService constructs an IncidentService backed by the Choreo API.
+func NewServiceNowIncidentService(client *integrationservice.Client) IncidentService {
+	return &snIncidentService{client: client}
+}
+
+func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.SearchIncidentsRequest) (domain.SearchIncidentsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchIncidentsResponse{}, err
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchIncidentsResponse{}, err
+	}
+	if req.SortBy.Field != "" && !validIncidentSortField[req.SortBy.Field] {
+		return domain.SearchIncidentsResponse{}, &apierror.ValidationError{Msg: "sortBy.field contains invalid value: " + string(req.SortBy.Field)}
+	}
+	if req.SortBy.Order != "" && !validIncidentSortOrder[req.SortBy.Order] {
+		return domain.SearchIncidentsResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + string(req.SortBy.Order)}
+	}
+	if err := validateUUIDs("parentIds", req.Filters.ParentIDs); err != nil {
+		return domain.SearchIncidentsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchIncidentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	var snSortBy *snIncidentSort
+	if req.SortBy.Field != "" {
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snIncidentSort{Field: string(req.SortBy.Field), Order: order}
+	}
+
+	payload := snIncidentSearchPayload{
+		Filters: snIncidentFilters{
+			SearchQuery:  req.Filters.SearchQuery,
+			PriorityKeys: req.Filters.PriorityKeys,
+			ParentIDs:    uuidsToSysids(req.Filters.ParentIDs),
+		},
+		SortBy:     snSortBy,
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/incidents/search", token, payload)
+	if err != nil {
+		return domain.SearchIncidentsResponse{}, err
+	}
+
+	var snResp snIncidentsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchIncidentsResponse{}, fmt.Errorf("sn incidents: parse response: %w", err)
+	}
+
+	views := make([]domain.SearchIncidentView, 0, len(snResp.Incidents))
+	for _, inc := range snResp.Incidents {
+		view := domain.SearchIncidentView{
+			OpenedOn:  inc.OpenedOn,
+			Subject:   inc.Subject,
+			CreatedOn: inc.CreatedOn,
+			CreatedBy: inc.CreatedBy,
+			UpdatedOn: inc.UpdatedOn,
+			UpdatedBy: inc.UpdatedBy,
+		}
+		if inc.ID != nil && *inc.ID != "" {
+			id := sysidToUUID(*inc.ID)
+			view.ID = &id
+		}
+		if inc.Number != nil {
+			view.Number = inc.Number
+		}
+		if inc.Caller != nil {
+			view.Caller = &domain.EntityRef{ID: sysidToUUID(inc.Caller.ID), Name: inc.Caller.Name}
+		}
+		if inc.Priority != nil {
+			label := snIncidentPriorityLabelMap[inc.Priority.ID]
+			if label == "" {
+				label = inc.Priority.Label
+			}
+			view.Priority = &label
+		}
+		if inc.State != nil {
+			label := snIncidentStateLabelMap[inc.State.ID]
+			if label == "" {
+				label = inc.State.Label
+			}
+			view.State = &label
+		}
+		if inc.Category != nil {
+			label := snIncidentCategoryLabelMap[inc.Category.ID]
+			if label == "" {
+				label = inc.Category.Label
+			}
+			view.Category = &label
+		}
+		if inc.Parent != nil {
+			view.Parent = &domain.EntityRef{ID: sysidToUUID(inc.Parent.ID), Name: inc.Parent.Name}
+		}
+		if inc.AssignmentGroup != nil {
+			view.AssignmentGroup = &domain.EntityRef{ID: sysidToUUID(inc.AssignmentGroup.ID), Name: inc.AssignmentGroup.Name}
+		}
+		if inc.AssignedTo != nil {
+			view.AssignedTo = &domain.EntityRef{ID: sysidToUUID(inc.AssignedTo.ID), Name: inc.AssignedTo.Name}
+		}
+		views = append(views, view)
+	}
+
+	return domain.SearchIncidentsResponse{
+		Incidents: views,
+		Total:     snResp.TotalRecords,
+		Limit:     req.Pagination.Limit,
+		Offset:    req.Pagination.Offset,
+	}, nil
+}

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -229,25 +229,19 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 			view.Caller = &domain.EntityRef{ID: sysidToUUID(inc.Caller.ID), Name: inc.Caller.Name}
 		}
 		if inc.Priority != nil {
-			label := snIncidentPriorityLabelMap[inc.Priority.ID]
-			if label == "" {
-				label = inc.Priority.Label
+			if label, ok := snIncidentPriorityLabelMap[inc.Priority.ID]; ok {
+				view.Priority = &label
 			}
-			view.Priority = &label
 		}
 		if inc.State != nil {
-			label := snIncidentStateLabelMap[inc.State.ID]
-			if label == "" {
-				label = inc.State.Label
+			if label, ok := snIncidentStateLabelMap[inc.State.ID]; ok {
+				view.State = &label
 			}
-			view.State = &label
 		}
 		if inc.Category != nil {
-			label := snIncidentCategoryLabelMap[inc.Category.ID]
-			if label == "" {
-				label = inc.Category.Label
+			if label, ok := snIncidentCategoryLabelMap[inc.Category.ID]; ok {
+				view.Category = &label
 			}
-			view.Category = &label
 		}
 		if inc.Parent != nil {
 			view.Parent = &domain.EntityRef{ID: sysidToUUID(inc.Parent.ID), Name: inc.Parent.Name}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1830,6 +1830,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /incidents/search:
+    post:
+      summary: Search incidents (ServiceNow data source only).
+      operationId: searchIncidents
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchIncidentsRequest'
+      responses:
+        "200":
+          description: Paginated list of incidents matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchIncidentsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     Pagination:
@@ -5192,3 +5228,94 @@ components:
         schedule:
           $ref: '#/components/schemas/TaskSlaScheduleRef'
           nullable: true
+
+    SearchIncidentsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            searchQuery:
+              type: string
+            priorityKeys:
+              type: array
+              items:
+                type: integer
+            parentIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn, openedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    SearchIncidentView:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        openedOn:
+          type: string
+          nullable: true
+        subject:
+          type: string
+          nullable: true
+        caller:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        priority:
+          type: string
+          nullable: true
+          enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
+        state:
+          type: string
+          nullable: true
+          enum: [NEW, IN_PROGRESS, ON_HOLD, RESOLVED, CLOSED, CANCELLED]
+        category:
+          type: string
+          nullable: true
+          enum: [INQUIRY, SERVICE_INTERRUPTION, SECURITY]
+        parent:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignmentGroup:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTo:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        updatedOn:
+          type: string
+        updatedBy:
+          type: string
+
+    SearchIncidentsResponse:
+      type: object
+      properties:
+        incidents:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchIncidentView'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5237,10 +5237,11 @@ components:
           properties:
             searchQuery:
               type: string
-            priorityKeys:
+            priorities:
               type: array
               items:
-                type: integer
+                type: string
+                enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
             parentIds:
               type: array
               items:


### PR DESCRIPTION
## Summary
- Adds `POST /incidents/search` endpoint backed by the ServiceNow data source
- Supports optional filters (searchQuery, priorities, parentIds), sortBy, and pagination
- Priority, state, and category are returned as mapped enum strings (e.g. `CRITICAL`, `IN_PROGRESS`, `INQUIRY`)
- Filter by priority accepts enum strings (e.g. `CRITICAL`, `HIGH`) and converts to SN int keys internally

## Test plan
- [ ] POST /incidents/search with no body returns paginated results
- [ ] Filter by `priorities` (e.g. `["CRITICAL", "HIGH"]`) returns only matching incidents
- [ ] Filter by `parentIds` (valid UUIDs) converts to sysids before calling Choreo and UUIDs are returned in the response
- [ ] Invalid value in `priorities` returns 400
- [ ] `sortBy.field` with invalid value returns 400
- [ ] `sortBy.order` with invalid value returns 400
- [ ] Missing `x-user-id-token` header returns 401
- [ ] Priority `CRITICAL` maps to SN key `1`, state `2` maps to `IN_PROGRESS`, category `inquiry` maps to `INQUIRY` in the response
- [ ] Endpoint is inactive when DataSource is not ServiceNow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an incident search API endpoint backed by ServiceNow.
  - Enables filtering by keyword, priorities, and parent IDs, with configurable pagination and sorting (created/updated/opened; ascending/descending).
  - Returns a paginated list of incidents with detailed fields and related entity references.

- **Documentation**
  - Updated the API specification with the new endpoint, request/response schemas, and documented success and error responses (including validation and authorization cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->