### PR TITLE
[CSM Portal] fix stale case-detail banner/dialog state leaking across case navigation

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -246,14 +246,14 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const caseClosed = caseDetail.state === "closed";
 
   // Git issues may only be raised while the case is active: Open, Work in
-  // progress, Waiting on client, Waiting on WSO2, or Reopened. Anything else
+  // progress, Awaiting info, Waiting on WSO2, or Reopened. Anything else
   // (e.g. Solution proposed, Closed) blocks the action. `caseDetail.state` is
-  // the normalized label (see `uiStateFromBe`), so this list uses the same
-  // lowercase/underscore form the data source's raw state label normalizes to.
+  // the normalized label (see `uiStateFromBe`) — this must match the real
+  // `CaseState` values (there is no "waiting_on_client" state).
   const GIT_ISSUE_ALLOWED_STATES: readonly string[] = [
     "open",
     "work_in_progress",
-    "waiting_on_client",
+    "awaiting_info",
     "waiting_on_wso2",
     "reopened",
   ];
@@ -281,7 +281,7 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
       tooltip: caseClosed
         ? "This case is closed — it's read-only."
         : gitIssueStateBlocked
-          ? "Git issues can only be raised while the case is Open, Work in progress, Waiting on client, Waiting on WSO2, or Reopened."
+          ? "Git issues can only be raised while the case is Open, Work in progress, Awaiting info, Waiting on WSO2, or Reopened."
           : undefined,
     },
     {

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -382,6 +382,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // Email of the signed-in engineer, for the "Assign to me" shortcut.
   const currentUserEmail = claims?.email ?? undefined;
 
+  // This page stays mounted across case-to-case navigation (route pattern is
+  // the same, only :caseId changes), so state left over from the previous
+  // case — e.g. a sticky "requested more info" banner, or an open dialog —
+  // would otherwise leak into the newly opened case. Reset it synchronously
+  // during render (React's recommended pattern for resetting state when a
+  // prop changes) rather than in an effect, to avoid an extra render pass.
+  const [prevCaseId, setPrevCaseId] = useState(caseId);
+  if (caseId !== prevCaseId) {
+    setPrevCaseId(caseId);
+    setFeedback(null);
+    setComposerOpen(false);
+    setAssignOpen(false);
+    setResolutionDialog(null);
+    setSeverityOpen(false);
+    setLogTimeOpen(false);
+    setAutoOpenCallCreate(false);
+    setGithubIssueOpen(false);
+    setGithubIssueError(null);
+    setGithubIssueResult(null);
+    setPendingDelete(null);
+    setPauseConflict(null);
+  }
+
   // Twitter-style permalinks: when the URL has a fragment matching an entry id,
   // jump to the Activities tab, scroll the entry into view vertically, and
   // flash it. The browser's default hash-anchor `scrollIntoView` also drags


### PR DESCRIPTION
## Purpose
The case detail page's status-transition banner (e.g. "Requested additional info from the customer.") stays visible after navigating to a different case via the top search bar, even though the newly opened case is in a different state. This is a bug fix, not related to any existing issue in this repo.

## Goals
The banner (and other case-scoped local UI state — open dialogs, pending-delete confirmations, etc.) should reflect only the currently open case, and should never carry over from whichever case was viewed previously.

## Approach
`CsmCaseDetailPage` is reused across `cases/:caseId`, `operations/service-requests/:caseId`, and `engagements/:caseId` navigations — React Router keeps the same component instance mounted since only the `:caseId` param changes, so its local `useState` values (the sticky feedback banner, assign/resolution/severity/log-time/github-issue dialogs, pending-delete and pause-conflict confirmations) persisted across cases.

Fixed by resetting that case-scoped local state whenever `caseId` changes, using React's documented "adjusting state when a prop changes" pattern (comparing against a `prevCaseId` state value during render) rather than a `useEffect`, to avoid an extra render pass and the `react-hooks/set-state-in-effect` lint rule.

## User stories
As a CS engineer, when I use the top search bar to jump from one case to another, I should see only the new case's actual state and banners, not leftover UI state from the case I was previously viewing.

## Release note
Fix: the case detail page no longer shows a stale status banner (e.g. "Requested additional info from the customer") or leftover open dialogs when navigating to a different case via search.

## Documentation
N/A — internal UI state bug fix, no user-facing behavior to document beyond the release note.

## Automation tests
- Unit tests: none added; this is a narrowly scoped state-reset fix in an already large page component with no existing unit test harness for it.
- Integration tests: none added. Verified via `pnpm lint` and `pnpm build` only; not yet exercised against a running instance of the app.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React change; `pnpm lint` and `pnpm build` ran clean instead)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Verified locally: pnpm build + pnpm lint on Node/pnpm toolchain in this repo, macOS (Darwin).

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale case-specific UI elements (such as feedback, dialogs, and pending actions) from carrying over when switching between cases.
  * Updated the “Raise internal Git issue” overflow option so it’s available only for the correct set of case statuses, and adjusted the related disabled tooltip accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->