### PR TITLE
[CSM][BE] Add POST /incidents/search passthrough endpoint

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -175,6 +175,7 @@ backend/
 │       ├── deployments.go                # HTTP handlers for deployment endpoints
 │       ├── products.go                   # HTTP handlers for product endpoints
 │       ├── projects.go                   # HTTP handlers for project endpoints
+│       ├── incidents.go                  # HTTP handlers for incident endpoints (ServiceNow only)
 │       ├── updates.go                    # HTTP handlers for updates endpoints
 │       └── users.go                      # HTTP handlers for user endpoints
 ├── .env                        # Local config (git-ignored)
@@ -267,6 +268,10 @@ backend/
 - `GET /updates/product-update-levels` — Get product update levels
 - `POST /updates/levels/search` — Search updates between update levels
 
+### Incidents
+
+- `POST /incidents/search` — Search incidents; optional `filters` (`searchQuery`, `priorities`, `parentIds`) and `sortBy` (`field`: `createdOn`/`updatedOn`/`openedOn`, `order`) (ServiceNow data source only)
+
 ## Run Locally
 
 ```bash
@@ -313,4 +318,10 @@ curl -X POST http://localhost:8080/updates/levels/search \
   -H "x-jwt-assertion: $JWT" \
   -H "Content-Type: application/json" \
   -d '{"productName":"wso2am","productVersion":"4.2.0","startingUpdateLevel":1,"endingUpdateLevel":10}'
+
+# Search incidents
+curl -X POST http://localhost:8080/incidents/search \
+  -H "x-jwt-assertion: $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"filters":{"searchQuery":"outage","priorities":["CRITICAL"]},"pagination":{"limit":10,"offset":0}}'
 ```

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -64,6 +64,7 @@ func main() {
 	productVulnerabilityHandler := handler.NewProductVulnerabilityHandler(entityClient)
 	conversationHandler := handler.NewConversationHandler(entityClient)
 	taskSlaHandler := handler.NewTaskSlaHandler(entityClient)
+	incidentHandler := handler.NewIncidentHandler(entityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
@@ -147,6 +148,7 @@ func main() {
 	mux.HandleFunc("GET /conversations/{id}/messages", conversationHandler.GetConversationMessages)
 	mux.HandleFunc("POST /slas/search", taskSlaHandler.SearchTaskSlas)
 	mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
+	mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)
 
 	addr := envOrDefault("PORT", ":8080")
 

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -120,6 +120,12 @@ func (c *Client) SearchProductVersions(ctx context.Context, productID string, bo
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/products/%s/versions/search", url.PathEscape(productID)), body)
 }
 
+// SearchIncidents calls POST /incidents/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *Client) SearchIncidents(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/incidents/search", body)
+}
+
 // PostDeployment calls POST /deployments on the entity service to create a new deployment.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -341,6 +341,19 @@ func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, pro
 	return []byte(`{}`), nil
 }
 
+// ----- mock entity incident client -----
+
+type mockEntityIncidentClient struct {
+	searchIncidentsFn func(ctx context.Context, body []byte) ([]byte, error)
+}
+
+func (m *mockEntityIncidentClient) SearchIncidents(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchIncidentsFn != nil {
+		return m.searchIncidentsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
 // ----- mock entity change request client -----
 
 type mockEntityChangeRequestClient struct {

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -32,6 +32,59 @@ type entityIncidentClient interface {
 	SearchIncidents(ctx context.Context, body []byte) ([]byte, error)
 }
 
+// searchIncidentsRequest mirrors the enum/format-constrained fields of the documented
+// IncidentSearchPayload schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+type searchIncidentsRequest struct {
+	Filters struct {
+		Priorities []string `json:"priorities"`
+		ParentIDs  []string `json:"parentIds"`
+	} `json:"filters"`
+	SortBy struct {
+		Field string `json:"field"`
+		Order string `json:"order"`
+	} `json:"sortBy"`
+}
+
+var (
+	validIncidentPriorities = map[string]bool{
+		"CRITICAL": true,
+		"HIGH":     true,
+		"MODERATE": true,
+		"LOW":      true,
+		"PLANNING": true,
+	}
+	validIncidentSortFields = map[string]bool{"createdOn": true, "updatedOn": true, "openedOn": true}
+	validIncidentSortOrders = map[string]bool{"asc": true, "desc": true}
+)
+
+// validateSearchIncidentsBody checks the filter/sort fields with a known, fixed set of
+// valid values (priority enums, parentIds as UUIDs, sort field/order enums) so obviously
+// invalid requests are rejected before reaching the entity service.
+func validateSearchIncidentsBody(body []byte) bool {
+	var req searchIncidentsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	for _, p := range req.Filters.Priorities {
+		if !validIncidentPriorities[p] {
+			return false
+		}
+	}
+	for _, id := range req.Filters.ParentIDs {
+		if !uuidRe.MatchString(id) {
+			return false
+		}
+	}
+	if req.SortBy.Field != "" && !validIncidentSortFields[req.SortBy.Field] {
+		return false
+	}
+	if req.SortBy.Order != "" && !validIncidentSortOrders[req.SortBy.Order] {
+		return false
+	}
+	return true
+}
+
 // IncidentHandler handles HTTP requests for incident operations, delegating to the
 // entity service for data access.
 type IncidentHandler struct {
@@ -68,7 +121,10 @@ func (h *IncidentHandler) SearchIncidents(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// TODO: Decode into a typed SearchIncidentsRequest and validate fields before forwarding.
+	if !validateSearchIncidentsBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
 
 	result, err := h.entity.SearchIncidents(r.Context(), body)
 	if err != nil {

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityIncidentClient abstracts the entity service incident operations used by IncidentHandler.
+type entityIncidentClient interface {
+	SearchIncidents(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// IncidentHandler handles HTTP requests for incident operations, delegating to the
+// entity service for data access.
+type IncidentHandler struct {
+	entity entityIncidentClient
+}
+
+// NewIncidentHandler creates an IncidentHandler backed by the given entity client.
+func NewIncidentHandler(entity entityIncidentClient) *IncidentHandler {
+	return &IncidentHandler{entity: entity}
+}
+
+// SearchIncidents handles POST /incidents/search.
+func (h *IncidentHandler) SearchIncidents(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	// TODO: Decode into a typed SearchIncidentsRequest and validate fields before forwarding.
+
+	result, err := h.entity.SearchIncidents(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchIncidents failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search incidents.")
+		return
+	}
+
+	// TODO: Unmarshal result and filter to only the fields required by the frontend.
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -55,6 +55,46 @@ func TestSearchIncidents(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects unknown priority enum value", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(`{"filters":{"priorities":["URGENT"]}}`)))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID parentIds entry", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(`{"filters":{"parentIds":["not-a-uuid"]}}`)))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid sortBy field", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(`{"sortBy":{"field":"subject","order":"asc"}}`)))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid sortBy order", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(`{"sortBy":{"field":"createdOn","order":"sideways"}}`)))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
 	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
 		const reqPayload = `{"filters":{"searchQuery":"outage","priorities":["CRITICAL"]},"pagination":{"limit":10,"offset":0}}`
 		var capturedBody []byte

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSearchIncidents(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"filters":{"searchQuery":"outage","priorities":["CRITICAL"]},"pagination":{"limit":10,"offset":0}}`
+		var capturedBody []byte
+		client := &mockEntityIncidentClient{
+			searchIncidentsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"incidents":[{"id":"11111111-1111-1111-1111-111111111111","number":"INC0001"}],"total":1}`), nil
+			},
+		}
+		h := NewIncidentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchIncidents(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search incidents.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityIncidentClient{
+					searchIncidentsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewIncidentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/incidents/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchIncidents(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2627,6 +2627,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /incidents/search:
+    post:
+      summary: Search incidents (ServiceNow data source only).
+      operationId: postIncidentsSearch
+      requestBody:
+        description: Incident search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -5664,3 +5713,107 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/TaskSlaScheduleRef'
+
+    IncidentSearchPayload:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            searchQuery:
+              type: string
+            priorities:
+              type: array
+              items:
+                type: string
+                enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
+            parentIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn, openedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+
+    IncidentSearchResponse:
+      type: object
+      properties:
+        incidents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Incident'
+        total:
+          type: integer
+          description: Total number of matching incidents
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    Incident:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        openedOn:
+          type: string
+          nullable: true
+        subject:
+          type: string
+          nullable: true
+        caller:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        priority:
+          type: string
+          nullable: true
+          enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
+        state:
+          type: string
+          nullable: true
+          enum: [NEW, IN_PROGRESS, ON_HOLD, RESOLVED, CLOSED, CANCELLED]
+        category:
+          type: string
+          nullable: true
+          enum: [INQUIRY, SERVICE_INTERRUPTION, SECURITY]
+        parent:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        assignmentGroup:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        assignedTo:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string


### PR DESCRIPTION
## Summary
- Wires the csm-portal backend to entity-service's new `POST /incidents/search` endpoint (#1120), backed by ServiceNow
- Follows the existing passthrough pattern used by other search endpoints (e.g. `products.go`): raw `[]byte` body forwarded to the entity service, response returned as-is
- Adds the corresponding OpenAPI spec (`IncidentSearchPayload`/`IncidentSearchResponse`/`Incident` schemas) and README documentation

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (added handler tests: unauthenticated → 401, body >1MiB → 413, invalid JSON → 400, successful passthrough, upstream error mapping)
- [ ] Manual: `POST /incidents/search` against a running entity service with ServiceNow data source returns paginated incidents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident search through `POST /incidents/search`.
  * Supports keyword, priority, parent, sorting, and pagination filters.
  * Returns incident details with pagination metadata.
  * Added authentication, request validation, size limits, and clear error responses.
* **Documentation**
  * Updated API documentation with endpoint behavior, schemas, supported filters, and usage examples.
* **Tests**
  * Added coverage for authorization, validation, request limits, successful searches, and upstream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->