### PR TITLE
[CSM][Web] Fix multi-select filter height growth across filter bars

### DIFF
--- a/apps/csm-portal/webapp/src/components/MultiSelectField.tsx
+++ b/apps/csm-portal/webapp/src/components/MultiSelectField.tsx
@@ -14,8 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Autocomplete, Box, Checkbox, Chip, ListItemText, TextField, Tooltip } from "@wso2/oxygen-ui";
-import type * as React from "react";
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Select,
+  Tooltip,
+} from "@wso2/oxygen-ui";
 import type { JSX } from "react";
 
 export interface MultiSelectFieldProps<T extends string> {
@@ -27,19 +35,15 @@ export interface MultiSelectFieldProps<T extends string> {
   disabled?: boolean;
   /**
    * Explains why the field is disabled. Shown as a hover tooltip; ignored
-   * when `disabled` is false. A disabled MUI control has `pointer-events:
-   * none`, so the tooltip is anchored to a wrapping `<span>` rather than the
-   * `Autocomplete` itself.
+   * when `disabled` is false.
    */
   disabledTooltip?: string;
 }
 
 /**
- * Autocomplete-based multi-select for a fixed, small set of options (e.g. an
- * enum) — selected values render as chips, options are type-to-search +
- * checkboxes. Pairs with {@link SearchableMultiSelect} for larger/dynamic
- * option lists. Extracted from `CasesFilterBar.tsx` so other feature filter
- * bars (e.g. time cards) can reuse the same look and behavior.
+ * Select-based multi-select for a fixed, small set of options (e.g. an enum).
+ * Selected values render as comma-separated text — no chips, fixed height.
+ * Pairs with async pickers for larger/dynamic option lists.
  */
 export default function MultiSelectField<T extends string>({
   id,
@@ -50,49 +54,58 @@ export default function MultiSelectField<T extends string>({
   disabled,
   disabledTooltip,
 }: MultiSelectFieldProps<T>): JSX.Element {
-  const selected = options.filter((o) => values.includes(o.value));
   const field = (
-    <Autocomplete<{ value: T; label: string }, true>
-      multiple
-      size="small"
-      id={id}
-      disabled={disabled}
-      options={options}
-      value={selected}
-      disableCloseOnSelect
-      getOptionLabel={(o) => o.label}
-      isOptionEqualToValue={(o, v) => o.value === v.value}
-      onChange={(_event, next) => onChange(next.map((o) => o.value))}
-      renderTags={(value, getTagProps) =>
-        value.map((option, index) => {
-          const { key, ...tagProps } = getTagProps({ index });
-          return (
-            <Chip key={key} size="small" label={option.label} {...tagProps} />
+    <FormControl fullWidth size="small" disabled={disabled}>
+      <InputLabel id={`${id}-label`}>{label}</InputLabel>
+      <Select
+        multiple
+        labelId={`${id}-label`}
+        id={id}
+        value={values}
+        label={label}
+        onChange={(event) => {
+          const val = event.target.value;
+          onChange(Array.isArray(val) ? (val as T[]) : []);
+        }}
+        renderValue={(selected) => {
+          if (selected.length === 0) return "";
+          const labels = selected.map(
+            (v) => options.find((o) => o.value === v)?.label ?? v,
           );
-        })
-      }
-      renderOption={(props, option, { selected: isSelected }) => {
-        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
-          key: string;
-        };
-        return (
-          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
-            <Checkbox size="small" checked={isSelected} sx={{ mr: 1, p: 0.25 }} />
+          const displayText = labels.join(", ");
+          if (labels.length === 1) return displayText;
+          return (
+            <Tooltip title={displayText} placement="top">
+              <Box
+                component="span"
+                sx={{
+                  display: "block",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {displayText}
+              </Box>
+            </Tooltip>
+          );
+        }}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value} sx={{ py: 0.5 }}>
+            <Checkbox
+              size="small"
+              checked={values.includes(option.value)}
+              sx={{ mr: 1, p: 0.25 }}
+            />
             <ListItemText
               primary={option.label}
               slotProps={{ primary: { style: { fontSize: 13 } } }}
             />
-          </li>
-        );
-      }}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          label={label}
-          placeholder={values.length ? undefined : "Select…"}
-        />
-      )}
-    />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
 
   if (!disabled || !disabledTooltip) return field;

--- a/apps/csm-portal/webapp/src/components/SearchableMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/components/SearchableMultiSelect.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Autocomplete, Checkbox, Chip, ListItemText, TextField } from "@wso2/oxygen-ui";
+import { Autocomplete, Box, Checkbox, ListItemText, TextField, Tooltip } from "@wso2/oxygen-ui";
 import type * as React from "react";
 import type { JSX } from "react";
 
@@ -75,6 +75,10 @@ export default function SearchableMultiSelect({
           modifiers: [{ name: "flip", enabled: false }],
         },
       }}
+      sx={{
+        // Prevent selected-value text from wrapping to a second line.
+        "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" },
+      }}
       getOptionLabel={(opt) => format(opt as string)}
       isOptionEqualToValue={(opt, val) => opt === val}
       filterOptions={(opts, state) => {
@@ -82,19 +86,20 @@ export default function SearchableMultiSelect({
         if (!q) return opts;
         return opts.filter((o) => searchText(o as string).toLowerCase().includes(q));
       }}
-      renderTags={(value, getTagProps) =>
-        value.map((option, index) => {
-          const { key, ...tagProps } = getTagProps({ index });
-          return (
-            <Chip
-              key={key}
-              size="small"
-              label={format(option as string)}
-              {...tagProps}
-            />
-          );
-        })
-      }
+      renderTags={(value) => {
+        const displayText = (value as string[]).map(format).join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
       renderOption={(props, option, { selected }) => {
         const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
           key: string;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssigneeMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssigneeMultiSelect.tsx
@@ -16,10 +16,11 @@
 
 import {
   Autocomplete,
+  Box,
   Checkbox,
-  Chip,
   ListItemText,
   TextField,
+  Tooltip,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type JSX } from "react";
 import type * as React from "react";
@@ -145,6 +146,7 @@ export default function AsyncAssigneeMultiSelect({
       // Spinner only while the first page loads; later pages append on scroll.
       loading={isFetching && users.length === 0}
       disableCloseOnSelect
+      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" } }}
       // The backend already filtered by the typed term; don't re-filter locally
       // (that would also drop the manually-pinned "Me" option).
       filterOptions={(opts) => opts}
@@ -174,14 +176,20 @@ export default function AsyncAssigneeMultiSelect({
             ? "Loading engineers…"
             : "No engineers found"
       }
-      renderTags={(value, getTagProps) =>
-        value.map((option, index) => {
-          const { key, ...tagProps } = getTagProps({ index });
-          return (
-            <Chip key={key} size="small" label={option.name} {...tagProps} />
-          );
-        })
-      }
+      renderTags={(value) => {
+        const displayText = value.map((o) => o.name).join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
       renderOption={(props, option, { selected }) => {
         const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
           key: string;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
@@ -16,10 +16,11 @@
 
 import {
   Autocomplete,
+  Box,
   Checkbox,
-  Chip,
   ListItemText,
   TextField,
+  Tooltip,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type JSX } from "react";
 import type * as React from "react";
@@ -127,6 +128,7 @@ export default function AsyncProjectMultiSelect({
       // Spinner only while the first page loads; later pages append on scroll.
       loading={isFetching && projects.length === 0}
       disableCloseOnSelect
+      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" } }}
       // The backend already filtered by the typed term; don't re-filter locally.
       filterOptions={(opts) => opts}
       getOptionLabel={(opt) => opt.name}
@@ -153,14 +155,20 @@ export default function AsyncProjectMultiSelect({
             ? "Loading projects…"
             : "No projects found"
       }
-      renderTags={(value, getTagProps) =>
-        value.map((option, index) => {
-          const { key, ...tagProps } = getTagProps({ index });
-          return (
-            <Chip key={key} size="small" label={option.name} {...tagProps} />
-          );
-        })
-      }
+      renderTags={(value) => {
+        const displayText = value.map((o) => o.name).join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
       renderOption={(props, option, { selected }) => {
         const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
           key: string;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
@@ -16,10 +16,11 @@
 
 import {
   Autocomplete,
+  Box,
   Checkbox,
-  Chip,
   ListItemText,
   TextField,
+  Tooltip,
 } from "@wso2/oxygen-ui";
 import { useMemo, type JSX } from "react";
 import type * as React from "react";
@@ -66,6 +67,7 @@ export default function ProductNameMultiSelect({
       value={values}
       loading={isFetching && !data}
       disableCloseOnSelect
+      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" } }}
       getOptionLabel={(opt) => opt}
       isOptionEqualToValue={(opt, val) => opt === val}
       onChange={(_event, next) => onChange(next)}
@@ -76,12 +78,20 @@ export default function ProductNameMultiSelect({
             ? "Loading products…"
             : "No products found"
       }
-      renderTags={(value, getTagProps) =>
-        value.map((option, index) => {
-          const { key, ...tagProps } = getTagProps({ index });
-          return <Chip key={key} size="small" label={option} {...tagProps} />;
-        })
-      }
+      renderTags={(value) => {
+        const displayText = value.join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
       renderOption={(props, option, { selected }) => {
         const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
           key: string;


### PR DESCRIPTION
## Summary

- **`MultiSelectField`**: rewritten with MUI `Select` instead of `Autocomplete` so the input height is inherently fixed — chips can't wrap.
- **`SearchableMultiSelect`**, **`AsyncAssigneeMultiSelect`**, **`AsyncProjectMultiSelect`**, **`ProductNameMultiSelect`**: added `flexWrap: "nowrap"` on the Autocomplete input root and replaced `display: "block"` tag content with flex-friendly sizing (`flex: 1 1 0`, `minWidth: 0`) so selected values truncate with ellipsis rather than growing the field height.
- Selected values render as comma-joined text with a hover tooltip for 2+ selections, matching the customer-portal pattern.

## Test plan

- [ ] Open Cases filter bar → select multiple values in Status, Priority, Assignee, Project, Product — field height stays fixed at one line
- [ ] Open Time Cards filter bar → select multiple values in Project, Work item, Engineer — field height stays fixed
- [ ] Hover over truncated values to confirm tooltip shows the full selection list
- [ ] Clearing selections restores the placeholder text correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated multi-select fields to display selected values as compact, comma-separated text instead of individual chips.
  * Added truncation and hover tooltips to reveal full selections when space is limited.
  * Prevented selected values from wrapping across multiple lines.
  * Simplified fixed-option multi-selects with a dropdown-based selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->