### PR TITLE
[CSM][BE] Add notifications module, engineering entity client, shared OAuth2 config

### DIFF
--- a/apps/csm-portal/backend/.env.example
+++ b/apps/csm-portal/backend/.env.example
@@ -1,22 +1,21 @@
-# Entity service
-ENTITY_BASE_URL=
-ENTITY_TOKEN_URL=
-ENTITY_CLIENT_ID=
-ENTITY_CLIENT_SECRET=
-ENTITY_SCOPES=
+# Shared OAuth2 client credentials — every upstream service client
+# (customer entity, engineering entity, updates, SCIM, and future notification
+# channels) authenticates as this same app; only each service's base URL and
+# scopes differ.
+OAUTH2_CLIENT_ID=
+OAUTH2_CLIENT_SECRET=
+OAUTH2_TOKEN_URL=
+
+# Customer entity service
+CUSTOMER_ENTITY_BASE_URL=
+CUSTOMER_ENTITY_SCOPES=
 
 # Updates service
 UPDATES_BASE_URL=
-UPDATES_TOKEN_URL=
-UPDATES_CLIENT_ID=
-UPDATES_CLIENT_SECRET=
 UPDATES_SCOPES=
 
 # SCIM operations service
 SCIM_BASE_URL=
-SCIM_TOKEN_URL=
-SCIM_CLIENT_ID=
-SCIM_CLIENT_SECRET=
 SCIM_SCOPES=
 
 # Auth — set to false for local testing (skips JWT signature verification)
@@ -26,4 +25,4 @@ AUTH_AUDIENCE=                    # comma-separated; token is accepted if any li
 AUTH_TOKEN_VALIDATOR_ENABLED=true
 
 # Server
-PORT=:8080
+PORT=8080

--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -19,11 +19,14 @@ Each upstream service has its own client package under `internal/`:
 
 | Package | Upstream | Notes |
 |---------|----------|-------|
-| `entity` | Entity service | Most case/account/project endpoints; raw `[]byte` passthrough |
+| `entity` | Multiple entity services (see below) | Hosts `CustomerEntityClient` (this repo's entity-service; most case/account/project endpoints, raw `[]byte` passthrough) and `EngineeringEntityClient` (wso2-enterprise/digiops-engineering; `CreateGitIssue`, typed request/response). **`EngineeringEntityClient` is not wired into `cmd/server/main.go` yet** — no handler calls it |
 | `scim` | SCIM service | User/group lookups |
 | `updates` | Updates service | Product update levels; returns typed structs (not raw passthrough) |
+| `notifications` | Notification channels (email today; SMS/voice-Twilio expected later) | Each channel gets its own config/client pair in its own file — `EmailConfig`/`EmailClient`/`SendEmail` in `email.go` today — since channels differ in upstream auth scheme. **Not wired into `cmd/server/main.go` yet** — no handler calls it. When the first caller is added, construct the client with `os.Getenv` (never `mustEnv`) for its config so a deployment that hasn't configured that channel yet can still start |
 
-New upstream services get their own package under `internal/` following the same `Client` + `do()` pattern.
+New upstream services get their own package under `internal/` following the same `Client` + `do()` pattern. `entity` and `notifications` are the exception: because each is expected to (or already does) host multiple, separately-deployed/differently-authenticated services, they use a `<Name>Config`/`<Name>Client` pair per service/file instead of one shared `Client` for the whole package — `CustomerEntityClient`/`EngineeringEntityClient` in `entity`, `EmailClient` (+ future `SMSClient`/`TwilioClient`) in `notifications`.
+
+**Shared OAuth2 credentials**: `CustomerEntityClient` and `EngineeringEntityClient` (both in `entity`), `updates`, and `scim` all authenticate as the same OAuth2 client-credentials app — `cmd/server/main.go` reads `OAUTH2_CLIENT_ID`/`OAUTH2_CLIENT_SECRET`/`OAUTH2_TOKEN_URL` once and passes them into every service's `Config`; only `<SERVICE>_BASE_URL`/`<SERVICE>_SCOPES` are per-service. `EngineeringEntityConfig` still has its own `ClientID`/`ClientSecret`/`TokenURL` fields (matching every other service's `Config` shape), but when it's wired into `main.go` those should be filled with the same shared `oauth2ClientID`/`oauth2ClientSecret`/`oauth2TokenURL` values, not new `ENGINEERING_ENTITY_*` env vars. Follow this pattern for any new upstream service client unless it genuinely uses a different OAuth2 app.
 
 ## Running locally
 
@@ -54,6 +57,7 @@ Follow these steps in order:
 4. **Route** (`cmd/server/main.go`) — register using Go 1.22 method-prefixed patterns: `"POST /cases/{id}/comments"`
 5. **OpenAPI spec** (`openapi.yaml`) — add the path with 200/400/401/403/404/500 responses; `403` is always required because `mapUpstreamError` can return it
 6. **Tests** — add handler tests; update the mock in `helpers_test.go` to satisfy the extended interface
+7. **gosec** — run `gosec -fmt=text ./...` (see README's Security Scanning section) before opening the PR; it must report 0 issues
 
 ## Handler conventions
 
@@ -90,6 +94,7 @@ Follow these steps in order:
 - **Input validation** — validate and reject unexpected input at the boundary (path params, body size, JSON structure) before forwarding to upstream services
 - **Error messages** — never leak upstream error details or stack traces to the caller; use the fixed `ErrMsg*` constants or a short fallback message
 - **Security fixes in PRs** — when a change is made to fix a security issue (gosec findings, input sanitization, etc.), do not mention it in the PR title or description; describe the change in neutral functional terms only
+- **Run gosec on every backend change** — `gosec -fmt=text ./...` (install once: `go install github.com/securego/gosec/v2/cmd/gosec@latest`) must report 0 issues before opening a PR touching this backend; fix the root cause of any finding rather than suppressing it, unless a `#nosec` annotation with a justification comment already covers that exact case
 
 ## Testing
 

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -100,24 +100,39 @@ The scan should report **0 issues**. If a new finding appears, fix the root caus
 
 Copy `.env` and fill in the values:
 
-### Entity service
+### Shared OAuth2 client credentials
+
+Every upstream service client (customer entity, engineering entity, updates, SCIM, and future notification channels) authenticates as the same OAuth2 client-credentials app — only each service's base URL and scopes differ, so the credentials are configured once and reused.
 
 | Variable | Description |
 |---|---|
-| `ENTITY_BASE_URL` | Base URL of the entity service |
-| `ENTITY_TOKEN_URL` | OAuth2 token endpoint |
-| `ENTITY_CLIENT_ID` | OAuth2 client ID |
-| `ENTITY_CLIENT_SECRET` | OAuth2 client secret |
-| `ENTITY_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+| `OAUTH2_CLIENT_ID` | OAuth2 client ID, shared by every upstream service client |
+| `OAUTH2_CLIENT_SECRET` | OAuth2 client secret, shared by every upstream service client |
+| `OAUTH2_TOKEN_URL` | OAuth2 token endpoint, shared by every upstream service client |
+
+### Customer entity service
+
+Backs `entity.CustomerEntityClient` (this repo's entity-service; cases, accounts, projects, products, etc.) — uses the shared OAuth2 credentials above.
+
+| Variable | Description |
+|---|---|
+| `CUSTOMER_ENTITY_BASE_URL` | Base URL of the customer entity service |
+| `CUSTOMER_ENTITY_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+
+### Engineering entity service (not yet wired in)
+
+Backs `entity.EngineeringEntityClient.CreateGitIssue` (wso2-enterprise/digiops-engineering) but is not constructed in `cmd/server/main.go` — no handler calls it yet. These variables are not read by any code today. It uses the same shared OAuth2 credentials above (same `OAUTH2_CLIENT_ID`/`_CLIENT_SECRET`/`_TOKEN_URL`) — only its base URL and scopes are its own.
+
+| Variable | Description |
+|---|---|
+| `ENGINEERING_ENTITY_BASE_URL` | Base URL of the engineering entity service |
+| `ENGINEERING_ENTITY_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 
 ### Updates service
 
 | Variable | Description |
 |---|---|
 | `UPDATES_BASE_URL` | Base URL of the updates service |
-| `UPDATES_TOKEN_URL` | OAuth2 token endpoint |
-| `UPDATES_CLIENT_ID` | OAuth2 client ID |
-| `UPDATES_CLIENT_SECRET` | OAuth2 client secret |
 | `UPDATES_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 
 ### SCIM operations service
@@ -125,10 +140,17 @@ Copy `.env` and fill in the values:
 | Variable | Description |
 |---|---|
 | `SCIM_BASE_URL` | Base URL of the SCIM operations service |
-| `SCIM_TOKEN_URL` | OAuth2 token endpoint |
-| `SCIM_CLIENT_ID` | OAuth2 client ID |
-| `SCIM_CLIENT_SECRET` | OAuth2 client secret |
 | `SCIM_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+
+### Notifications — email channel (not yet wired in)
+
+`internal/notifications` (`EmailClient.SendEmail`) is ready to use but is not constructed in `cmd/server/main.go` — no handler calls it yet. These variables are not read by any code today; they're documented here for when the first caller is added, which should reuse the shared `OAUTH2_*` credentials above rather than adding its own. Each notification channel gets its own `NOTIFICATIONS_<CHANNEL>_*` prefix for its channel-specific settings — SMS/Twilio will follow this same convention once added.
+
+| Variable | Description |
+|---|---|
+| `NOTIFICATIONS_EMAIL_BASE_URL` | Base URL of the email notification service |
+| `NOTIFICATIONS_EMAIL_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+| `NOTIFICATIONS_EMAIL_FROM_ADDRESS` | Fixed "From" address used for every outgoing email |
 
 ### Auth
 
@@ -143,7 +165,7 @@ Copy `.env` and fill in the values:
 
 | Variable | Description |
 |---|---|
-| `PORT` | Server listen address (default `:8080`) |
+| `PORT` | Server listen port — a plain number, not an address (default `8080`) |
 
 ## Project Structure
 
@@ -153,13 +175,18 @@ backend/
 ├── internal/
 │   ├── apierror/               # Typed upstream error types (4xx/5xx passthrough)
 │   ├── entity/
-│   │   ├── client.go           # OAuth2 HTTP client for the entity service
-│   │   └── entity.go           # Entity service operations (cases, accounts, projects, ...)
+│   │   ├── doc.go               # Package overview — one config/client pair per entity service
+│   │   ├── customer_client.go   # OAuth2 HTTP client for the customer entity service (this repo's entity-service)
+│   │   ├── customer.go          # CustomerEntityClient operations (cases, accounts, projects, ...)
+│   │   └── engineering.go       # EngineeringEntityClient — CreateGitIssue (not yet wired into main.go — no caller)
 │   ├── scim/
 │   │   └── client.go           # OAuth2 HTTP client for the SCIM operations service
 │   ├── updates/
 │   │   ├── client.go           # OAuth2 HTTP client for the updates service
 │   │   └── updates.go          # Updates service operations
+│   ├── notifications/
+│   │   ├── doc.go               # Package overview — one config/client pair per channel
+│   │   └── email.go             # EmailConfig/EmailClient/SendEmail (not yet wired into main.go — no caller)
 │   ├── middleware/
 │   │   ├── auth.go             # JWT validation; injects UserInfo into context
 │   │   ├── correlation.go      # X-CSM-Correlation-ID propagation + slog enrichment

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -39,38 +40,46 @@ import (
 func main() {
 	loadDotEnv(".env")
 	middleware.ConfigureLogger()
-	cfg := entity.Config{
-		BaseURL:      mustEnv("ENTITY_BASE_URL"),
-		TokenURL:     mustEnv("ENTITY_TOKEN_URL"),
-		ClientID:     mustEnv("ENTITY_CLIENT_ID"),
-		ClientSecret: mustEnv("ENTITY_CLIENT_SECRET"),
-		// Scopes is optional; set ENTITY_SCOPES as a comma-separated list if required.
-		Scopes: splitComma(os.Getenv("ENTITY_SCOPES")),
+
+	// All upstream service clients (entity, updates, SCIM, and future notification
+	// channels) authenticate as the same OAuth2 client-credentials app; only the
+	// base URL and scopes differ per service.
+	oauth2ClientID := mustEnv("OAUTH2_CLIENT_ID")
+	oauth2ClientSecret := mustEnv("OAUTH2_CLIENT_SECRET")
+	oauth2TokenURL := mustEnv("OAUTH2_TOKEN_URL")
+
+	customerEntityCfg := entity.CustomerEntityConfig{
+		BaseURL:      mustEnv("CUSTOMER_ENTITY_BASE_URL"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
+		// Scopes is optional; set CUSTOMER_ENTITY_SCOPES as a comma-separated list if required.
+		Scopes: splitComma(os.Getenv("CUSTOMER_ENTITY_SCOPES")),
 	}
 
-	entityClient := entity.NewClient(cfg)
-	caseHandler := handler.NewCaseHandler(entityClient)
-	accountHandler := handler.NewAccountHandler(entityClient)
-	projectHandler := handler.NewProjectHandler(entityClient)
-	productHandler := handler.NewProductHandler(entityClient)
-	deploymentHandler := handler.NewDeploymentHandler(entityClient)
-	changeRequestHandler := handler.NewChangeRequestHandler(entityClient)
-	itServiceHandler := handler.NewITServiceHandler(entityClient)
-	serviceOfferingHandler := handler.NewServiceOfferingHandler(entityClient)
-	groupHandler := handler.NewGroupHandler(entityClient)
-	configurationItemHandler := handler.NewConfigurationItemHandler(entityClient)
-	catalogHandler := handler.NewCatalogHandler(entityClient)
-	timeCardHandler := handler.NewTimeCardHandler(entityClient)
-	productVulnerabilityHandler := handler.NewProductVulnerabilityHandler(entityClient)
-	conversationHandler := handler.NewConversationHandler(entityClient)
-	taskSlaHandler := handler.NewTaskSlaHandler(entityClient)
-	incidentHandler := handler.NewIncidentHandler(entityClient)
+	customerEntityClient := entity.NewCustomerEntityClient(customerEntityCfg)
+	caseHandler := handler.NewCaseHandler(customerEntityClient)
+	accountHandler := handler.NewAccountHandler(customerEntityClient)
+	projectHandler := handler.NewProjectHandler(customerEntityClient)
+	productHandler := handler.NewProductHandler(customerEntityClient)
+	deploymentHandler := handler.NewDeploymentHandler(customerEntityClient)
+	changeRequestHandler := handler.NewChangeRequestHandler(customerEntityClient)
+	itServiceHandler := handler.NewITServiceHandler(customerEntityClient)
+	serviceOfferingHandler := handler.NewServiceOfferingHandler(customerEntityClient)
+	groupHandler := handler.NewGroupHandler(customerEntityClient)
+	configurationItemHandler := handler.NewConfigurationItemHandler(customerEntityClient)
+	catalogHandler := handler.NewCatalogHandler(customerEntityClient)
+	timeCardHandler := handler.NewTimeCardHandler(customerEntityClient)
+	productVulnerabilityHandler := handler.NewProductVulnerabilityHandler(customerEntityClient)
+	conversationHandler := handler.NewConversationHandler(customerEntityClient)
+	taskSlaHandler := handler.NewTaskSlaHandler(customerEntityClient)
+	incidentHandler := handler.NewIncidentHandler(customerEntityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
-		TokenURL:     mustEnv("UPDATES_TOKEN_URL"),
-		ClientID:     mustEnv("UPDATES_CLIENT_ID"),
-		ClientSecret: mustEnv("UPDATES_CLIENT_SECRET"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
 		Scopes:       splitComma(os.Getenv("UPDATES_SCOPES")),
 	}
 	updatesClient := updates.NewClient(updatesCfg)
@@ -78,13 +87,13 @@ func main() {
 
 	scimCfg := scim.Config{
 		BaseURL:      mustEnv("SCIM_BASE_URL"),
-		TokenURL:     mustEnv("SCIM_TOKEN_URL"),
-		ClientID:     mustEnv("SCIM_CLIENT_ID"),
-		ClientSecret: mustEnv("SCIM_CLIENT_SECRET"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
 		Scopes:       splitComma(os.Getenv("SCIM_SCOPES")),
 	}
 	scimClient := scim.NewClient(scimCfg)
-	usersHandler := handler.NewUsersHandler(scimClient, entityClient)
+	usersHandler := handler.NewUsersHandler(scimClient, customerEntityClient)
 
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
@@ -150,7 +159,7 @@ func main() {
 	mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
 	mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)
 
-	addr := envOrDefault("PORT", ":8080")
+	addr := ":" + mustPort("PORT", "8080")
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -209,6 +218,19 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// mustPort returns the value of the given environment variable (or def if
+// unset) as a bare port number, e.g. "8080" — not an address like ":8080" or
+// "localhost:8080". Exits the process if the value isn't a valid TCP port.
+func mustPort(key, def string) string {
+	v := envOrDefault(key, def)
+	port, err := strconv.Atoi(v)
+	if err != nil || port < 1 || port > 65535 {
+		slog.Error("environment variable must be a plain port number (e.g. \"8080\"), not an address", "key", key, "value", v)
+		os.Exit(1)
+	}
+	return v
 }
 
 // loadDotEnv reads a .env file and sets any unset environment variables from it.

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -25,296 +25,296 @@ import (
 
 // CreateCase calls POST /cases on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/cases", body)
 }
 
 // SearchCases calls POST /cases/search on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) SearchCases(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchCases(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/cases/search", body)
 }
 
 // GetCase calls GET /cases/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) GetCase(ctx context.Context, caseID string) ([]byte, error) {
+func (c *CustomerEntityClient) GetCase(ctx context.Context, caseID string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/cases/%s", url.PathEscape(caseID)), nil)
 }
 
 // PatchCase calls PATCH /cases/{id} on the entity service to update case state.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) PatchCase(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PatchCase(ctx context.Context, caseID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/cases/%s", url.PathEscape(caseID)), body)
 }
 
 // CreateCaseComment calls POST /cases/{id}/comments on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) CreateCaseComment(ctx context.Context, caseID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/comments", url.PathEscape(caseID)), body)
 }
 
 // SearchCaseComments calls POST /cases/{id}/comments/search on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchCaseComments(ctx context.Context, caseID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/comments/search", url.PathEscape(caseID)), body)
 }
 
 // SearchCaseActivities calls POST /cases/{id}/activities/search on the entity service.
 // The path-scoped body is forwarded verbatim and the response is returned as raw JSON;
 // typed response structs are deferred.
-func (c *Client) SearchCaseActivities(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchCaseActivities(ctx context.Context, caseID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/cases/"+url.PathEscape(caseID)+"/activities/search", body)
 }
 
 // GetUserMe calls GET /users/me on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) GetUserMe(ctx context.Context) ([]byte, error) {
+func (c *CustomerEntityClient) GetUserMe(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, "/users/me", nil)
 }
 
 // PatchUserMe calls PATCH /users/me on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) PatchUserMe(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PatchUserMe(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, "/users/me", body)
 }
 
 // SearchUsers calls POST /users/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchUsers(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchUsers(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/users/search", body)
 }
 
 // GetAccount calls GET /accounts/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) GetAccount(ctx context.Context, id string) ([]byte, error) {
+func (c *CustomerEntityClient) GetAccount(ctx context.Context, id string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/accounts/%s", url.PathEscape(id)), nil)
 }
 
 // SearchAccounts calls POST /accounts/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchAccounts(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchAccounts(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/accounts/search", body)
 }
 
 // GetProject calls GET /projects/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) GetProject(ctx context.Context, id string) ([]byte, error) {
+func (c *CustomerEntityClient) GetProject(ctx context.Context, id string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/projects/%s", url.PathEscape(id)), nil)
 }
 
 // SearchProjects calls POST /projects/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchProjects(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchProjects(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/projects/search", body)
 }
 
 // SearchProducts calls POST /products/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchProducts(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchProducts(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/products/search", body)
 }
 
 // SearchProductVersions calls POST /products/{id}/versions/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchProductVersions(ctx context.Context, productID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchProductVersions(ctx context.Context, productID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/products/%s/versions/search", url.PathEscape(productID)), body)
 }
 
 // SearchIncidents calls POST /incidents/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchIncidents(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchIncidents(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/incidents/search", body)
 }
 
 // PostDeployment calls POST /deployments on the entity service to create a new deployment.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/deployments", body)
 }
 
 // PatchDeployment calls PATCH /deployments/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) PatchDeployment(ctx context.Context, deploymentID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PatchDeployment(ctx context.Context, deploymentID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/deployments/%s", url.PathEscape(deploymentID)), body)
 }
 
 // SearchDeployments calls POST /deployments/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchDeployments(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchDeployments(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/deployments/search", body)
 }
 
 // SearchDeployedProducts calls POST /deployed-products/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
-func (c *Client) SearchDeployedProducts(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchDeployedProducts(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/deployed-products/search", body)
 }
 
 // PostDeployedProduct calls POST /deployed-products on the entity service to create a new deployed product.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) PostDeployedProduct(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PostDeployedProduct(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/deployed-products", body)
 }
 
 // PatchDeployedProduct calls PATCH /deployed-products/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) PatchDeployedProduct(ctx context.Context, deployedProductID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PatchDeployedProduct(ctx context.Context, deployedProductID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/deployed-products/%s", url.PathEscape(deployedProductID)), body)
 }
 
 // SearchChangeRequests calls POST /change-requests/search on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/change-requests/search", body)
 }
 
 // GetChangeRequest calls GET /change-requests/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
-func (c *Client) GetChangeRequest(ctx context.Context, id string) ([]byte, error) {
+func (c *CustomerEntityClient) GetChangeRequest(ctx context.Context, id string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/change-requests/%s", url.PathEscape(id)), nil)
 }
 
 // PatchChangeRequest calls PATCH /change-requests/{id} on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) PatchChangeRequest(ctx context.Context, id string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PatchChangeRequest(ctx context.Context, id string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/change-requests/%s", url.PathEscape(id)), body)
 }
 
 // SearchTimeCards calls POST /time-cards/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchTimeCards(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchTimeCards(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/time-cards/search", body)
 }
 
 // CreateTimeCard calls POST /time-cards on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) CreateTimeCard(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) CreateTimeCard(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/time-cards", body)
 }
 
 // UpdateTimeCard calls PATCH /time-cards/{id} on the entity service. The body may
 // carry editable fields, or a state transition ({"state":"approved"} or
 // {"state":"rejected","leadComment":"..."}). Response is returned as raw JSON.
-func (c *Client) UpdateTimeCard(ctx context.Context, id string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) UpdateTimeCard(ctx context.Context, id string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/time-cards/%s", url.PathEscape(id)), body)
 }
 
 // CreateCaseAttachment calls POST /attachments on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) CreateCaseAttachment(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) CreateCaseAttachment(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/attachments", body)
 }
 
 // SearchCaseAttachments calls POST /attachments/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchCaseAttachments(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchCaseAttachments(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/attachments/search", body)
 }
 
 // GetCaseAttachmentContent calls GET /attachments/{attachmentId}/content
 // and returns the raw binary body with its Content-Type.
-func (c *Client) GetCaseAttachmentContent(ctx context.Context, attachmentID string) ([]byte, string, error) {
+func (c *CustomerEntityClient) GetCaseAttachmentContent(ctx context.Context, attachmentID string) ([]byte, string, error) {
 	return c.doBinary(ctx, fmt.Sprintf("/attachments/%s/content", url.PathEscape(attachmentID)))
 }
 
 // DeleteCaseAttachment calls DELETE /attachments/{attachmentId} on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) DeleteCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
+func (c *CustomerEntityClient) DeleteCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/attachments/%s", url.PathEscape(attachmentID)), nil)
 }
 
 // SearchCatalogs calls POST /catalogs/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchCatalogs(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchCatalogs(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/catalogs/search", body)
 }
 
 // GetCatalogItemVariables calls GET /catalogs/{catalogId}/items/{catalogItemId}/variables
 // on the entity service. Response is returned as raw JSON.
-func (c *Client) GetCatalogItemVariables(ctx context.Context, catalogID, catalogItemID string) ([]byte, error) {
+func (c *CustomerEntityClient) GetCatalogItemVariables(ctx context.Context, catalogID, catalogItemID string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/catalogs/%s/items/%s/variables", url.PathEscape(catalogID), url.PathEscape(catalogItemID)), nil)
 }
 
 // SearchProductVulnerabilities calls POST /products/vulnerabilities/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchProductVulnerabilities(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchProductVulnerabilities(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/products/vulnerabilities/search", body)
 }
 
 // GetProductVulnerability calls GET /products/vulnerabilities/{id} on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) GetProductVulnerability(ctx context.Context, id string) ([]byte, error) {
+func (c *CustomerEntityClient) GetProductVulnerability(ctx context.Context, id string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/products/vulnerabilities/%s", url.PathEscape(id)), nil)
 }
 
 // CreateCallRequest calls POST /call-requests on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) CreateCallRequest(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) CreateCallRequest(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/call-requests", body)
 }
 
 // SearchCallRequests calls POST /call-requests/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchCallRequests(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchCallRequests(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/call-requests/search", body)
 }
 
 // PatchCallRequest calls PATCH /call-requests/{id} on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) PatchCallRequest(ctx context.Context, callRequestID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) PatchCallRequest(ctx context.Context, callRequestID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/call-requests/%s", url.PathEscape(callRequestID)), body)
 }
 
 // CreateChangeRequest calls POST /change-requests on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) CreateChangeRequest(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) CreateChangeRequest(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/change-requests", body)
 }
 
 // SearchITServices calls POST /services/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchITServices(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchITServices(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/services/search", body)
 }
 
 // SearchServiceOfferings calls POST /service-offerings/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchServiceOfferings(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchServiceOfferings(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/service-offerings/search", body)
 }
 
 // SearchGroups calls POST /groups/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchGroups(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchGroups(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/groups/search", body)
 }
 
 // SearchConfigurationItems calls POST /configuration-items/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchConfigurationItems(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchConfigurationItems(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/configuration-items/search", body)
 }
 
 // CreateCaseGithubIssue calls POST /cases/{id}/github-issues on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/cases/%s/github-issues", url.PathEscape(caseID)), body)
 }
 
 // SearchComments calls POST /comments/search on the entity service.
 // The body must be a JSON-encoded SearchCommentsRequest (referenceId, referenceType, pagination).
-func (c *Client) SearchComments(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchComments(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/comments/search", body)
 }
 
 // SearchTaskSlas calls POST /slas/search on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/slas/search", body)
 }
 
 // GetTaskSla calls GET /slas/{id} on the entity service.
 // Response is returned as raw JSON.
-func (c *Client) GetTaskSla(ctx context.Context, id string) ([]byte, error) {
+func (c *CustomerEntityClient) GetTaskSla(ctx context.Context, id string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/slas/%s", url.PathEscape(id)), nil)
 }

--- a/apps/csm-portal/backend/internal/entity/customer_client.go
+++ b/apps/csm-portal/backend/internal/entity/customer_client.go
@@ -61,8 +61,8 @@ func correlationIDFromContext(ctx context.Context) string {
 	return v
 }
 
-// Config holds the configuration for the entity service client.
-type Config struct {
+// CustomerEntityConfig holds the configuration for the customer entity service client.
+type CustomerEntityConfig struct {
 	BaseURL      string
 	TokenURL     string
 	ClientID     string
@@ -70,17 +70,20 @@ type Config struct {
 	Scopes       []string
 }
 
-// Client is an HTTP client authenticated via the OAuth2 client credentials grant.
-// Tokens are acquired and refreshed automatically; callers need not manage them.
-type Client struct {
+// CustomerEntityClient is an HTTP client for the customer entity service (this
+// repo's entity-service, covering cases/accounts/projects/products/etc.),
+// authenticated via the OAuth2 client credentials grant. Tokens are acquired
+// and refreshed automatically; callers need not manage them.
+type CustomerEntityClient struct {
 	http    *http.Client
 	baseURL string
 }
 
-// NewClient constructs a Client that authenticates against the entity service
-// using the OAuth2 client credentials grant type, mirroring the Ballerina
-// ClientCredentialsOauth2Config pattern in the customer-portal entity module.
-func NewClient(cfg Config) *Client {
+// NewCustomerEntityClient constructs a CustomerEntityClient that authenticates
+// against the customer entity service using the OAuth2 client credentials
+// grant type, mirroring the Ballerina ClientCredentialsOauth2Config pattern in
+// the customer-portal entity module.
+func NewCustomerEntityClient(cfg CustomerEntityConfig) *CustomerEntityClient {
 	cc := clientcredentials.Config{
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,
@@ -96,7 +99,7 @@ func NewClient(cfg Config) *Client {
 	httpClient := cc.Client(tokenCtx)
 	httpClient.Timeout = 25 * time.Second
 
-	return &Client{
+	return &CustomerEntityClient{
 		http:    httpClient,
 		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
 	}
@@ -104,7 +107,7 @@ func NewClient(cfg Config) *Client {
 
 // do executes an authenticated HTTP request against the entity service and
 // returns the raw JSON response body. The caller owns the returned slice.
-func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+func (c *CustomerEntityClient) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
 	var reqBody io.Reader
 	if len(body) > 0 {
 		reqBody = bytes.NewReader(body)
@@ -150,7 +153,7 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 // doBinary executes an authenticated GET request against the entity service and
 // returns the raw response body together with the upstream Content-Type header.
 // Use this instead of do for endpoints that return non-JSON binary content.
-func (c *Client) doBinary(ctx context.Context, path string) (body []byte, contentType string, err error) {
+func (c *CustomerEntityClient) doBinary(ctx context.Context, path string) (body []byte, contentType string, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("entity: build request GET %s: %w", path, err)

--- a/apps/csm-portal/backend/internal/entity/customer_client_test.go
+++ b/apps/csm-portal/backend/internal/entity/customer_client_test.go
@@ -40,7 +40,7 @@ func TestTokenFetchTimeout(t *testing.T) {
 	tokenFetchTimeout = 100 * time.Millisecond
 	t.Cleanup(func() { tokenFetchTimeout = 10 * time.Second })
 
-	client := NewClient(Config{
+	client := NewCustomerEntityClient(CustomerEntityConfig{
 		BaseURL:      tokenSrv.URL,
 		TokenURL:     tokenSrv.URL + "/token",
 		ClientID:     "test-client",

--- a/apps/csm-portal/backend/internal/entity/doc.go
+++ b/apps/csm-portal/backend/internal/entity/doc.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package entity groups the clients for every upstream "entity" service used
+// by the CSM portal backend. Each one gets its own config/client pair in its
+// own file, since they are distinct, separately-deployed services:
+//
+//   - customer.go / customer_client.go: CustomerEntityConfig/CustomerEntityClient
+//     — this repo's entity-service (cases, accounts, projects, products,
+//     deployments, users, incidents, etc.)
+//   - engineering.go: EngineeringEntityConfig/EngineeringEntityClient — the
+//     wso2-enterprise/digiops-engineering entity service, used to create
+//     GitHub issues in engineering repos.
+package entity

--- a/apps/csm-portal/backend/internal/entity/engineering.go
+++ b/apps/csm-portal/backend/internal/entity/engineering.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// engineeringTokenFetchTimeout is the HTTP client timeout for token-endpoint
+// requests. Overridden in tests to keep them fast.
+var engineeringTokenFetchTimeout = 10 * time.Second
+
+// EngineeringEntityConfig holds the configuration for the engineering entity
+// service client (wso2-enterprise/digiops-engineering).
+type EngineeringEntityConfig struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// EngineeringEntityClient is an HTTP client for the engineering entity service,
+// authenticated via the OAuth2 client credentials grant. Tokens are acquired
+// and refreshed automatically; callers need not manage them.
+//
+// NewEngineeringEntityClient never fails and never contacts the token
+// endpoint, so it is safe to construct with a zero-value EngineeringEntityConfig
+// (e.g. when this service is not yet configured for a given deployment) — a
+// missing or invalid configuration only surfaces as an error the first time a
+// method is called.
+type EngineeringEntityClient struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewEngineeringEntityClient constructs an EngineeringEntityClient that
+// authenticates against the engineering entity service using the OAuth2
+// client credentials grant type.
+func NewEngineeringEntityClient(cfg EngineeringEntityConfig) *EngineeringEntityClient {
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: engineeringTokenFetchTimeout})
+	httpClient := cc.Client(tokenCtx)
+	httpClient.Timeout = 25 * time.Second
+
+	return &EngineeringEntityClient{
+		http:    httpClient,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+	}
+}
+
+// do executes an authenticated HTTP request against the engineering entity
+// service and returns the raw JSON response body. The caller owns the
+// returned slice.
+func (c *EngineeringEntityClient) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("engineering entity: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if id := correlationIDFromContext(ctx); id != "" {
+		req.Header.Set("X-CSM-Correlation-ID", id)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("engineering entity: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("engineering entity: read response body: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	return respBody, nil
+}
+
+// GitHubIssueLabel is a label attached to a GitHub issue.
+type GitHubIssueLabel struct {
+	Name        string  `json:"name"`
+	Color       string  `json:"color"`
+	Description *string `json:"description"`
+}
+
+// GitHubIssue is the engineering entity service's representation of a GitHub issue.
+type GitHubIssue struct {
+	ID          int64              `json:"id"`
+	NodeID      string             `json:"nodeId"`
+	Number      int                `json:"number"`
+	State       string             `json:"state"`
+	StateReason *string            `json:"stateReason"`
+	Title       string             `json:"title"`
+	Body        *string            `json:"body"`
+	Labels      []GitHubIssueLabel `json:"labels"`
+}
+
+// createGitHubIssueRequest is the wire shape expected by
+// POST /orgs/{orgName}/repos/{owner}/{repoName}/issues.
+type createGitHubIssueRequest struct {
+	Title  string   `json:"title"`
+	Body   string   `json:"body,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// CreateGitIssue creates a GitHub issue in the given org/owner/repo via the
+// engineering entity service.
+func (c *EngineeringEntityClient) CreateGitIssue(ctx context.Context, orgName, owner, repoName, title, body string, labels []string) (GitHubIssue, error) {
+	if orgName == "" || owner == "" || repoName == "" {
+		return GitHubIssue{}, fmt.Errorf("engineering entity: orgName, owner, and repoName are required")
+	}
+	if title == "" {
+		return GitHubIssue{}, fmt.Errorf("engineering entity: title is required")
+	}
+
+	reqBody, err := json.Marshal(createGitHubIssueRequest{Title: title, Body: body, Labels: labels})
+	if err != nil {
+		return GitHubIssue{}, fmt.Errorf("engineering entity: encode create issue request: %w", err)
+	}
+
+	path := fmt.Sprintf("/orgs/%s/repos/%s/%s/issues",
+		url.PathEscape(orgName), url.PathEscape(owner), url.PathEscape(repoName))
+
+	raw, err := c.do(ctx, http.MethodPost, path, reqBody)
+	if err != nil {
+		return GitHubIssue{}, err
+	}
+
+	var issue GitHubIssue
+	if err := json.Unmarshal(raw, &issue); err != nil {
+		return GitHubIssue{}, fmt.Errorf("engineering entity: decode create issue response: %w", err)
+	}
+	return issue, nil
+}

--- a/apps/csm-portal/backend/internal/entity/engineering_test.go
+++ b/apps/csm-portal/backend/internal/entity/engineering_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+)
+
+func newTestEngineeringClient(t *testing.T, tokenSrv, apiSrv *httptest.Server) *EngineeringEntityClient {
+	t.Helper()
+	return NewEngineeringEntityClient(EngineeringEntityConfig{
+		BaseURL:      apiSrv.URL,
+		TokenURL:     tokenSrv.URL,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Scopes:       []string{"engineering"},
+	})
+}
+
+func newEngineeringTokenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+}
+
+func TestCreateGitIssue_ValidatesArgumentsBeforeCallingUpstream(t *testing.T) {
+	called := false
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiSrv.Close()
+	tokenSrv := newEngineeringTokenServer(t)
+	defer tokenSrv.Close()
+
+	c := newTestEngineeringClient(t, tokenSrv, apiSrv)
+
+	t.Run("rejects missing repo coordinates", func(t *testing.T) {
+		if _, err := c.CreateGitIssue(context.Background(), "", "wso2-open-operations", "cs-tools", "title", "", nil); err == nil {
+			t.Fatal("expected error for missing orgName, got nil")
+		}
+	})
+
+	t.Run("rejects empty title", func(t *testing.T) {
+		if _, err := c.CreateGitIssue(context.Background(), "wso2-open-operations", "wso2-open-operations", "cs-tools", "", "", nil); err == nil {
+			t.Fatal("expected error for empty title, got nil")
+		}
+	})
+
+	if called {
+		t.Error("upstream should not have been called for invalid arguments")
+	}
+}
+
+func TestCreateGitIssue_SendsExpectedRequest(t *testing.T) {
+	var capturedPath string
+	var capturedAuth string
+	var capturedBody createGitHubIssueRequest
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(GitHubIssue{
+			ID:     1,
+			NodeID: "node-1",
+			Number: 42,
+			State:  "open",
+			Title:  "Something broke",
+			Labels: []GitHubIssueLabel{{Name: "bug", Color: "d73a4a"}},
+		})
+	}))
+	defer apiSrv.Close()
+	tokenSrv := newEngineeringTokenServer(t)
+	defer tokenSrv.Close()
+
+	c := newTestEngineeringClient(t, tokenSrv, apiSrv)
+
+	issue, err := c.CreateGitIssue(context.Background(),
+		"wso2-open-operations", "wso2-open-operations", "cs-tools",
+		"Something broke", "steps to reproduce", []string{"bug"})
+	if err != nil {
+		t.Fatalf("CreateGitIssue returned error: %v", err)
+	}
+
+	wantPath := "/orgs/wso2-open-operations/repos/wso2-open-operations/cs-tools/issues"
+	if capturedPath != wantPath {
+		t.Errorf("path = %q, want %q", capturedPath, wantPath)
+	}
+	if capturedAuth != "Bearer test-token" {
+		t.Errorf("Authorization header = %q, want %q", capturedAuth, "Bearer test-token")
+	}
+	if capturedBody.Title != "Something broke" {
+		t.Errorf("Title = %q, want %q", capturedBody.Title, "Something broke")
+	}
+	if len(capturedBody.Labels) != 1 || capturedBody.Labels[0] != "bug" {
+		t.Errorf("Labels = %v, want [bug]", capturedBody.Labels)
+	}
+	if issue.Number != 42 {
+		t.Errorf("issue.Number = %d, want 42", issue.Number)
+	}
+}
+
+func TestCreateGitIssue_MapsUpstreamError(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Repository not found: cs-tools in organization: wso2-open-operations."})
+	}))
+	defer apiSrv.Close()
+	tokenSrv := newEngineeringTokenServer(t)
+	defer tokenSrv.Close()
+
+	c := newTestEngineeringClient(t, tokenSrv, apiSrv)
+
+	_, err := c.CreateGitIssue(context.Background(), "wso2-open-operations", "wso2-open-operations", "cs-tools", "title", "", nil)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var apiErr *apierror.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *apierror.Error, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestNewEngineeringEntityClient_ConstructsWithZeroValueConfig(t *testing.T) {
+	// NewEngineeringEntityClient must never fail or panic even when the
+	// engineering entity service has not been configured for a given deployment.
+	c := NewEngineeringEntityClient(EngineeringEntityConfig{})
+	if c == nil {
+		t.Fatal("NewEngineeringEntityClient returned nil for zero-value EngineeringEntityConfig")
+	}
+}

--- a/apps/csm-portal/backend/internal/notifications/doc.go
+++ b/apps/csm-portal/backend/internal/notifications/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package notifications groups every outbound notification channel used by
+// the CSM portal backend. Each channel gets its own config/client pair in its
+// own file — e.g. email.go's EmailConfig/EmailClient — because channels are
+// expected to differ in upstream auth scheme and base URL (email today via
+// OAuth2 client credentials; SMS and voice/Twilio calls are expected to
+// follow, likely with their own auth schemes such as Twilio's Account
+// SID/Auth Token).
+package notifications

--- a/apps/csm-portal/backend/internal/notifications/email.go
+++ b/apps/csm-portal/backend/internal/notifications/email.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// emailTokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var emailTokenFetchTimeout = 10 * time.Second
+
+// EmailConfig holds the configuration for the email notification channel.
+type EmailConfig struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+
+	// FromAddress is the fixed "From" address used for every outgoing email.
+	// It is a config value rather than a SendEmail argument so that all
+	// portal-originated emails come from a single, pre-approved sender.
+	FromAddress string
+}
+
+// EmailClient is an HTTP client for the email notification service
+// (https://github.com/wso2-open-operations/infra-operations/tree/main/operations/email-service),
+// authenticated via the OAuth2 client credentials grant. Tokens are acquired
+// and refreshed automatically; callers need not manage them.
+//
+// NewEmailClient never fails and never contacts the token endpoint, so it is
+// safe to construct with a zero-value EmailConfig (e.g. when the email
+// channel is not yet configured for a given deployment) — a missing or
+// invalid configuration only surfaces as an error the first time SendEmail
+// is called.
+type EmailClient struct {
+	http        *http.Client
+	baseURL     string
+	fromAddress string
+}
+
+// NewEmailClient constructs an EmailClient that authenticates against the
+// email notification service using the OAuth2 client credentials grant type.
+func NewEmailClient(cfg EmailConfig) *EmailClient {
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: emailTokenFetchTimeout})
+	httpClient := cc.Client(tokenCtx)
+	httpClient.Timeout = 25 * time.Second
+
+	return &EmailClient{
+		http:        httpClient,
+		baseURL:     strings.TrimRight(cfg.BaseURL, "/"),
+		fromAddress: cfg.FromAddress,
+	}
+}
+
+// do executes an authenticated HTTP request against the email notification
+// service and returns the raw JSON response body. The caller owns the
+// returned slice.
+func (c *EmailClient) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("notifications: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("notifications: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("notifications: read response body: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	return respBody, nil
+}
+
+// EmailAttachment is a single file attached to an outgoing email.
+type EmailAttachment struct {
+	// ContentName is the attachment's file name (e.g. "invoice.pdf").
+	ContentName string `json:"contentName"`
+	// ContentType is the attachment's MIME type (e.g. "application/pdf").
+	ContentType string `json:"contentType"`
+	// Attachment is the raw file content; encoding/json base64-encodes it
+	// automatically since the field type is []byte.
+	Attachment []byte `json:"attachment"`
+}
+
+// sendEmailRequest is the wire shape expected by POST /send-email.
+type sendEmailRequest struct {
+	To          []string          `json:"to"`
+	CC          []string          `json:"cc,omitempty"`
+	BCC         []string          `json:"bcc,omitempty"`
+	ReplyTo     []string          `json:"replyTo,omitempty"`
+	From        string            `json:"from"`
+	Subject     string            `json:"subject"`
+	Template    []byte            `json:"template"`
+	Attachments []EmailAttachment `json:"attachments,omitempty"`
+}
+
+// SendEmail sends an HTML email via the notification service. The sender
+// address is always the client's configured FromAddress; every other value
+// is supplied by the caller.
+func (c *EmailClient) SendEmail(ctx context.Context, to, cc, bcc, replyTo []string, subject, htmlBody string, attachments []EmailAttachment) error {
+	if len(to) == 0 {
+		return fmt.Errorf("notifications: at least one recipient (to) is required")
+	}
+	if subject == "" {
+		return fmt.Errorf("notifications: subject is required")
+	}
+
+	reqBody, err := json.Marshal(sendEmailRequest{
+		To:          to,
+		CC:          cc,
+		BCC:         bcc,
+		ReplyTo:     replyTo,
+		From:        c.fromAddress,
+		Subject:     subject,
+		Template:    []byte(htmlBody),
+		Attachments: attachments,
+	})
+	if err != nil {
+		return fmt.Errorf("notifications: encode send-email request: %w", err)
+	}
+
+	_, err = c.do(ctx, http.MethodPost, "/send-email", reqBody)
+	return err
+}

--- a/apps/csm-portal/backend/internal/notifications/email_test.go
+++ b/apps/csm-portal/backend/internal/notifications/email_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+)
+
+// newTestClient wires an EmailClient at a fake token endpoint and a fake
+// notification service endpoint, both backed by httptest servers that the
+// caller controls.
+func newTestClient(t *testing.T, tokenSrv, apiSrv *httptest.Server, fromAddress string) *EmailClient {
+	t.Helper()
+	return NewEmailClient(EmailConfig{
+		BaseURL:      apiSrv.URL,
+		TokenURL:     tokenSrv.URL,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Scopes:       []string{"email"},
+		FromAddress:  fromAddress,
+	})
+}
+
+func newTokenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+}
+
+func TestSendEmail_ValidatesArgumentsBeforeCallingUpstream(t *testing.T) {
+	called := false
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiSrv.Close()
+	tokenSrv := newTokenServer(t)
+	defer tokenSrv.Close()
+
+	c := newTestClient(t, tokenSrv, apiSrv, "noreply@example.com")
+
+	t.Run("rejects empty recipients", func(t *testing.T) {
+		if err := c.SendEmail(context.Background(), nil, nil, nil, nil, "subject", "<p>body</p>", nil); err == nil {
+			t.Fatal("expected error for empty recipients, got nil")
+		}
+	})
+
+	t.Run("rejects empty subject", func(t *testing.T) {
+		if err := c.SendEmail(context.Background(), []string{"a@example.com"}, nil, nil, nil, "", "<p>body</p>", nil); err == nil {
+			t.Fatal("expected error for empty subject, got nil")
+		}
+	})
+
+	if called {
+		t.Error("upstream should not have been called for invalid arguments")
+	}
+}
+
+func TestSendEmail_SendsExpectedRequest(t *testing.T) {
+	var capturedAuth string
+	var capturedBody sendEmailRequest
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/send-email" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		capturedAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "email sent successfully"})
+	}))
+	defer apiSrv.Close()
+	tokenSrv := newTokenServer(t)
+	defer tokenSrv.Close()
+
+	c := newTestClient(t, tokenSrv, apiSrv, "noreply@example.com")
+
+	attachments := []EmailAttachment{
+		{ContentName: "notes.txt", ContentType: "text/plain", Attachment: []byte("hello")},
+	}
+	err := c.SendEmail(context.Background(),
+		[]string{"customer@example.com"},
+		[]string{"cc@example.com"},
+		nil,
+		[]string{"support@example.com"},
+		"Your case has been updated",
+		"<p>Hello there</p>",
+		attachments,
+	)
+	if err != nil {
+		t.Fatalf("SendEmail returned error: %v", err)
+	}
+
+	if capturedAuth != "Bearer test-token" {
+		t.Errorf("Authorization header = %q, want %q", capturedAuth, "Bearer test-token")
+	}
+	if capturedBody.From != "noreply@example.com" {
+		t.Errorf("From = %q, want configured FromAddress", capturedBody.From)
+	}
+	if len(capturedBody.To) != 1 || capturedBody.To[0] != "customer@example.com" {
+		t.Errorf("To = %v, want [customer@example.com]", capturedBody.To)
+	}
+	if len(capturedBody.CC) != 1 || capturedBody.CC[0] != "cc@example.com" {
+		t.Errorf("CC = %v, want [cc@example.com]", capturedBody.CC)
+	}
+	if capturedBody.Subject != "Your case has been updated" {
+		t.Errorf("Subject = %q, want %q", capturedBody.Subject, "Your case has been updated")
+	}
+	if string(capturedBody.Template) != "<p>Hello there</p>" {
+		t.Errorf("Template = %q, want %q", capturedBody.Template, "<p>Hello there</p>")
+	}
+	if len(capturedBody.Attachments) != 1 || capturedBody.Attachments[0].ContentName != "notes.txt" {
+		t.Errorf("Attachments = %+v, want one attachment named notes.txt", capturedBody.Attachments)
+	}
+}
+
+func TestSendEmail_MapsUpstreamError(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "missing required field: subject"})
+	}))
+	defer apiSrv.Close()
+	tokenSrv := newTokenServer(t)
+	defer tokenSrv.Close()
+
+	c := newTestClient(t, tokenSrv, apiSrv, "noreply@example.com")
+
+	err := c.SendEmail(context.Background(), []string{"a@example.com"}, nil, nil, nil, "subject", "body", nil)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var apiErr *apierror.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *apierror.Error, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestSendEmail_ConstructsWithZeroValueConfig(t *testing.T) {
+	// NewEmailClient must never fail or panic even when the email channel has
+	// not been configured for a given deployment.
+	c := NewEmailClient(EmailConfig{})
+	if c == nil {
+		t.Fatal("NewEmailClient returned nil for zero-value EmailConfig")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/notifications` (`EmailClient.SendEmail`) for the email notification service, structured so SMS/Twilio voice channels can join the same package later — not wired into `main.go` yet, no caller exists
- Splits `internal/entity` into `CustomerEntityClient` (this repo's entity-service, renamed from the previous single `Client`/`Config`) and `EngineeringEntityClient` (`CreateGitIssue`, for `wso2-enterprise/digiops-engineering`) — also not wired into `main.go` yet
- Consolidates `ENTITY_*`/`UPDATES_*`/`SCIM_*` `CLIENT_ID`/`CLIENT_SECRET`/`TOKEN_URL` into shared `OAUTH2_CLIENT_ID`/`OAUTH2_CLIENT_SECRET`/`OAUTH2_TOKEN_URL` — all these services authenticate as the same OAuth2 app; only base URL/scopes differ per service. `EngineeringEntityClient` will use the same shared credentials once wired in
- Renames `ENTITY_BASE_URL`/`ENTITY_SCOPES` to `CUSTOMER_ENTITY_BASE_URL`/`CUSTOMER_ENTITY_SCOPES` for symmetry with `ENGINEERING_ENTITY_BASE_URL`/`ENGINEERING_ENTITY_SCOPES`
- `PORT` must now be a plain number (e.g. `8080`) instead of an address (`:8080`) — rejected with a clear startup error otherwise, instead of a confusing bind failure
- Updates README.md/CLAUDE.md/`.env.example` to document all of the above

## Deployment note
This renames environment variables the deployed Choreo component expects:
- `ENTITY_CLIENT_ID`/`ENTITY_CLIENT_SECRET`/`ENTITY_TOKEN_URL`, `UPDATES_CLIENT_ID`/`UPDATES_CLIENT_SECRET`/`UPDATES_TOKEN_URL`, `SCIM_CLIENT_ID`/`SCIM_CLIENT_SECRET`/`SCIM_TOKEN_URL` → single `OAUTH2_CLIENT_ID`/`OAUTH2_CLIENT_SECRET`/`OAUTH2_TOKEN_URL`
- `ENTITY_BASE_URL`/`ENTITY_SCOPES` → `CUSTOMER_ENTITY_BASE_URL`/`CUSTOMER_ENTITY_SCOPES`
- `PORT` value must change from `:8080` to `8080`

The deployed environment's config needs updating to match before/at the next deploy, or startup will fail fast with a clear "required environment variable is not set" / "must be a plain port number" error.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] Manually started the server locally with the renamed env vars and confirmed `GET /health` returns 200
- [x] Manually confirmed the old `:8080`-style `PORT` value is now rejected at startup with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend support for creating engineering-service GitHub issues.
  * Added email notification sending with recipients, HTML content, and attachments.
  * Consolidated upstream authentication configuration across services.

* **Bug Fixes**
  * Corrected server port configuration to use a valid numeric port.
  * Added validation that rejects invalid port values during startup.

* **Documentation**
  * Updated setup and configuration guidance for service URLs, scopes, authentication, and newly supported capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->