### PR TITLE
[Customer Entity] Add userIds/excludeUserId time-card search filters

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2730,6 +2730,28 @@ components:
           items:
             type: string
             format: uuid
+        caseId:
+          type: string
+          format: uuid
+          description: Only time cards logged against this case.
+        userId:
+          type: string
+          format: uuid
+          description: Only time cards submitted by this user.
+        approverId:
+          type: string
+          format: uuid
+          description: Only time cards this user is eligible to approve (SN approver_list). The approver's own cards are always excluded server-side.
+        approvedById:
+          type: string
+          format: uuid
+          description: Only time cards actually approved by this user (SN approved_by).
+        userIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Match cards submitted by any of these users.
         startDate:
           type: string
           description: ISO 8601 date (YYYY-MM-DD).

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1615,8 +1615,9 @@ type SearchTimeCardsFilters struct {
 	ProjectIDs   []string        `json:"projectIds,omitempty"`
 	CaseID       *string         `json:"caseId,omitempty"`
 	UserID       *string         `json:"userId,omitempty"`
-	ApproverID   *string         `json:"approverId,omitempty"`   // eligible approver (SN approver_list)
+	ApproverID   *string         `json:"approverId,omitempty"`   // eligible approver (SN approver_list); their own cards are always excluded server-side
 	ApprovedByID *string         `json:"approvedById,omitempty"` // who actually approved (SN approved_by)
+	UserIDs      []string        `json:"userIds,omitempty"`      // match cards submitted by any of these users (OR semantics)
 	StartDate    *string         `json:"startDate,omitempty"`
 	EndDate      *string         `json:"endDate,omitempty"`
 	States       []TimeCardState `json:"states,omitempty"`

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -69,6 +69,7 @@ type snTimeCardFilters struct {
 	UserID       string   `json:"userId,omitempty"`
 	ApproverID   string   `json:"approverId,omitempty"`
 	ApprovedByID string   `json:"approvedById,omitempty"`
+	UserIDs      []string `json:"userIds,omitempty"`
 	StartDate    string   `json:"startDate,omitempty"`
 	EndDate      string   `json:"endDate,omitempty"`
 	States       []string `json:"states,omitempty"`
@@ -197,6 +198,9 @@ func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.Sear
 				return domain.SearchTimeCardsResponse{}, err
 			}
 		}
+		if err := validateUUIDs("userIds", req.Filters.UserIDs); err != nil {
+			return domain.SearchTimeCardsResponse{}, err
+		}
 
 		snStates := make([]string, 0, len(req.Filters.States))
 		for _, state := range req.Filters.States {
@@ -218,6 +222,9 @@ func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.Sear
 		}
 		if req.Filters.ApprovedByID != nil {
 			filters.ApprovedByID = uuidToSysid(*req.Filters.ApprovedByID)
+		}
+		if len(req.Filters.UserIDs) > 0 {
+			filters.UserIDs = uuidsToSysids(req.Filters.UserIDs)
 		}
 		if req.Filters.StartDate != nil {
 			filters.StartDate = *req.Filters.StartDate

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4159,11 +4159,17 @@ components:
         approverId:
           type: string
           format: uuid
-          description: Return only time cards this user is eligible to approve (SN approver_list).
+          description: Return only time cards this user is eligible to approve (SN approver_list). The approver's own cards are always excluded server-side.
         approvedById:
           type: string
           format: uuid
           description: Return only time cards actually approved by this user (SN approved_by).
+        userIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Return only time cards submitted by any of these users.
         startDate:
           type: string
           description: ISO 8601 date (YYYY-MM-DD).


### PR DESCRIPTION
## Purpose
Adds a new optional filter to the entity-service's time-card search, alongside a fix landed in the backing data source and its integration layer (tracked separately, not part of this repo) for a bug where searching a case's own time cards had no working server-side filter.

Frontend consumption of these filters is being held back for a separate follow-up PR — this PR is the entity-service layer only.

## Goals
- Add `userIds` (match any of several submitters) to `entity-service`'s time-card search filters.
- Update the CSM backend's openapi docs to match (no code change needed there — its time-card search endpoint is a raw passthrough).

## Approach
1. `entity-service`: add `UserIDs` to `SearchTimeCardsFilters`, validate + convert to the downstream ID format, forward it.
2. CSM backend: openapi doc update only (the handler already forwards the request body as-is, so no code change is needed).

Note: an earlier version of this PR also added `excludeUserId`, meant for an approval-queue self-exclusion use case. On review, that was reworked to live entirely in the backing data source instead — an approver-scoped search now unconditionally excludes the approver's own cards server-side, rather than requiring every caller to remember to pass a second, always-identical parameter. `excludeUserId` was removed accordingly; nothing in this repo ever depended on it.

Verified against a full local stack (entity-service → integration layer → real backing data source): `userIds` OR-matching, and separately the approver-self-exclusion behavior, both match an independently-counted dataset exactly. A plain single-project search (the shape the customer-portal's own time-card search always uses) is unaffected.

## User stories
As a caller of entity-service's time-card search, I can filter by one or more submitters.

## Release note
Time-card search now supports filtering directly by case, and by one or more engineers; pagination totals are now accurate when these filters are applied.

## Documentation
N/A — internal API filter addition, no user-facing docs beyond the in-app UI.

## Automation tests
- Unit tests: `go build ./...`, `go vet ./...`, `go test ./...` all pass clean in `entity-service`.
- Integration tests: manually verified against a full local stack running against the real backing data source (see Approach).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go, not Java) — `go vet` ran clean
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Local full-stack (macOS), Go 1.26.

## Learning
N/A