### PR TITLE
[CSM Portal Microapp] Add announcements page

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -27,6 +27,7 @@ import AllCasesPage from "@pages/AllCasesPage";
 import NewCasePage from "@pages/NewCasePage";
 import OperationsPage from "@pages/OperationsPage";
 import MorePage from "@pages/MorePage";
+import AnnouncementsPage from "@pages/AnnouncementsPage";
 import TimeCardsPage from "@pages/TimeCardsPage";
 import SecurityCenterPage from "@pages/SecurityCenterPage";
 import UpdatesPage from "@pages/UpdatesPage";
@@ -66,6 +67,7 @@ export default function App() {
           <Route path="/cases/:id" element={<CaseDetailPage />} />
           <Route path="/operations" element={<OperationsPage />} />
           <Route path="/more" element={<MorePage />} />
+          <Route path="/more/announcements" element={<AnnouncementsPage />} />
           <Route path="/more/time-cards" element={<TimeCardsPage />} />
           <Route path="/more/security-center" element={<SecurityCenterPage />} />
           <Route path="/more/updates" element={<UpdatesPage />} />

--- a/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
+++ b/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
@@ -37,7 +37,7 @@ export function AnnouncementCard({ item }: { item: CaseSummary }) {
           {item.project?.name ?? "—"}
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          {item.createdBy?.email || "—"} · Updated {fromNow(item.updatedOn)}
+          {item.createdBy || "—"} · Updated {fromNow(item.updatedOn)}
         </Typography>
       </Stack>
     </Card>

--- a/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
+++ b/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Card, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import type { CaseSummary } from "@src/types";
+import { fromNow } from "@utils/dateTime";
+import { AnnouncementStateChip } from "./AnnouncementStateChip";
+
+// Read-only announcement card (not tappable — mirrors the webapp's read-only
+// list). Announcements are cases of type "announcement", so `item` is a
+// `CaseSummary`; only the fields the list shows are rendered.
+export function AnnouncementCard({ item }: { item: CaseSummary }) {
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Stack gap={1}>
+        <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
+          <Typography variant="subtitle2" noWrap>
+            {item.number || "—"}
+          </Typography>
+          <AnnouncementStateChip state={item.state} />
+        </Stack>
+        <Typography variant="body2">{item.subject}</Typography>
+        <Typography variant="caption" color="text.secondary" noWrap>
+          {item.project?.name ?? "—"}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {item.createdBy?.email || "—"} · Updated {fromNow(item.updatedOn)}
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+export function AnnouncementCardSkeleton() {
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Stack gap={1}>
+        <Skeleton variant="rounded" width="40%" height={18} />
+        <Skeleton variant="rounded" width="90%" height={18} />
+        <Skeleton variant="rounded" width="60%" height={14} />
+      </Stack>
+    </Card>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/announcements/AnnouncementFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/announcements/AnnouncementFiltersSheet.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Autocomplete,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { useQuery } from "@tanstack/react-query";
+import { projects } from "@src/services/projects";
+import type { CaseState, Project } from "@src/types";
+import { STATE_LABELS } from "@components/support/config";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { ANNOUNCEMENT_FILTER_STATES, EMPTY_ANNOUNCEMENT_FILTERS, type AnnouncementFilters } from "@utils/announcements";
+
+// The Acrylic theme renders popup papers translucent, so a dropdown that opens
+// over the dialog reads as see-through — force the opaque `background.default`.
+const OPAQUE_POPUP = { sx: { backgroundColor: "background.default", backgroundImage: "none" } };
+
+function toggleState(list: CaseState[], value: CaseState): CaseState[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+// Async, type-to-search multi-select of projects (server-side `projectIds`).
+// Mirrors the support ProjectSelect (debounced 300ms); already-picked projects
+// stay in the option list so their chips keep their labels.
+function ProjectMultiSelect({ value, onChange }: { value: Project[]; onChange: (projects: Project[]) => void }) {
+  const [input, setInput] = useState("");
+  const debounced = useDebouncedValue(input, 300);
+  const { data, isFetching } = useQuery(projects.search(debounced.trim()));
+
+  const options = useMemo(() => {
+    const results = data ?? [];
+    return [...value, ...results.filter((r) => !value.some((v) => v.id === r.id))];
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={options}
+      value={value}
+      loading={isFetching}
+      getOptionLabel={(o) => o.name}
+      isOptionEqualToValue={(a, b) => a.id === b.id}
+      onChange={(_, next) => onChange(next)}
+      onInputChange={(_, next) => setInput(next)}
+      slotProps={{ paper: OPAQUE_POPUP }}
+      renderInput={(params) => <TextField {...params} label="Project" size="small" />}
+    />
+  );
+}
+
+interface AnnouncementFiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: AnnouncementFilters;
+  onApply: (filters: AnnouncementFilters) => void;
+}
+
+// Mobile bottom-sheet filters for the announcements list: State (multi) + Project
+// (async multi). Search lives in the always-visible bar on the page, not here.
+export function AnnouncementFiltersSheet({ open, onClose, filters, onApply }: AnnouncementFiltersSheetProps) {
+  const [draft, setDraft] = useState<AnnouncementFilters>(filters);
+
+  // Re-seed the draft from the last-applied filters each time the sheet opens, so reopening it
+  // doesn't show stale in-progress edits from a previous open that was dismissed without applying.
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open, not on every filters identity change
+  }, [open]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xs"
+      slotProps={{ paper: { sx: { backgroundImage: "none", backgroundColor: "background.default" } } }}
+    >
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={2.5}>
+          <Stack gap={1}>
+            <Typography variant="subtitle2">State</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {ANNOUNCEMENT_FILTER_STATES.map((state) => {
+                const isSelected = draft.states.includes(state);
+                return (
+                  <Chip
+                    key={state}
+                    label={STATE_LABELS[state] ?? state}
+                    size="small"
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => setDraft({ ...draft, states: toggleState(draft.states, state) })}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <ProjectMultiSelect value={draft.projects} onChange={(next) => setDraft({ ...draft, projects: next })} />
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            // Keep the current search text; only the sheet's own filters reset.
+            const cleared = { ...EMPTY_ANNOUNCEMENT_FILTERS, search: draft.search };
+            setDraft(cleared);
+            onApply(cleared);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/announcements/AnnouncementFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/announcements/AnnouncementFiltersSheet.tsx
@@ -123,6 +123,7 @@ export function AnnouncementFiltersSheet({ open, onClose, filters, onApply }: An
                     key={state}
                     label={STATE_LABELS[state] ?? state}
                     size="small"
+                    aria-pressed={isSelected}
                     variant={isSelected ? "filled" : "outlined"}
                     color={isSelected ? "primary" : "default"}
                     onClick={() => setDraft({ ...draft, states: toggleState(draft.states, state) })}

--- a/apps/csm-portal/microapp/src/components/announcements/AnnouncementStateChip.tsx
+++ b/apps/csm-portal/microapp/src/components/announcements/AnnouncementStateChip.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { alpha, Chip } from "@wso2/oxygen-ui";
+import type { CaseState } from "@src/types";
+import { STATE_LABELS } from "@components/support/config";
+import { announcementStateColor } from "@utils/announcements";
+
+// Announcement-specific state chip: open = green (live), closed = grey (inactive),
+// else info. Soft alpha-tinted fill for a coloured state, plain default otherwise
+// (matches the support ColoredChip look).
+export function AnnouncementStateChip({ state }: { state: CaseState }) {
+  const color = announcementStateColor(state);
+  return (
+    <Chip
+      label={STATE_LABELS[state] ?? state}
+      size="small"
+      sx={
+        color && color !== "default"
+          ? (theme) => ({ bgcolor: alpha(theme.palette[color].light, 0.1), color: theme.palette[color].light })
+          : undefined
+      }
+    />
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/AnnouncementsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/AnnouncementsPage.tsx
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { Badge, Box, IconButton, Stack, Typography } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { announcements } from "@src/services/announcements";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import {
+  countActiveAnnouncementFilters,
+  EMPTY_ANNOUNCEMENT_FILTERS,
+  type AnnouncementFilters,
+} from "@utils/announcements";
+import { SearchBar } from "@components/support/SearchBar";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { AnnouncementCard, AnnouncementCardSkeleton } from "@components/announcements/AnnouncementCard";
+import { AnnouncementFiltersSheet } from "@components/announcements/AnnouncementFiltersSheet";
+
+// Read-only announcements list (announcements are cases of type "announcement").
+// Search + State + Project filters, infinite-scrolled newest-updated first.
+export default function AnnouncementsPage() {
+  const [filters, setFilters] = useState<AnnouncementFilters>(EMPTY_ANNOUNCEMENT_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
+  const activeFilterCount = countActiveAnnouncementFilters(filters);
+
+  // Search is debounced into the query so typing doesn't refetch every keystroke.
+  const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    announcements.infinite({ ...filters, search: debouncedSearch }),
+  );
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? items.length;
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Stack gap={2}>
+      <Box>
+        <Typography variant="h5">Announcements</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Customer-facing announcements published across projects.
+        </Typography>
+      </Box>
+
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar
+          value={filters.search}
+          onChange={(value) => setFilters((prev) => ({ ...prev, search: value }))}
+          placeholder="Search by number or subject…"
+        />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
+      {isLoading ? (
+        <ListSkeleton />
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No announcements found." />
+      ) : (
+        <Stack gap={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {items.length} of {total}
+          </Typography>
+
+          {items.map((item) => (
+            <AnnouncementCard key={item.id} item={item} />
+          ))}
+
+          {/* IntersectionObserver can miss a zero-height target, so give the sentinel 1px to observe. */}
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <AnnouncementCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={1}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+
+      <AnnouncementFiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        filters={filters}
+        onApply={setFilters}
+      />
+    </Stack>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <AnnouncementCardSkeleton key={i} />
+      ))}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/MorePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/MorePage.tsx
@@ -16,7 +16,15 @@
 
 import { Link } from "react-router-dom";
 import { List, ListItemButton, ListItemIcon, ListItemText, Stack, Typography } from "@wso2/oxygen-ui";
-import { Briefcase, ChevronRight, Clock, RefreshCw, Shield, type LucideIcon } from "@wso2/oxygen-ui-icons-react";
+import {
+  Briefcase,
+  ChevronRight,
+  Clock,
+  Megaphone,
+  RefreshCw,
+  Shield,
+  type LucideIcon,
+} from "@wso2/oxygen-ui-icons-react";
 
 interface MoreItem {
   label: string;
@@ -28,6 +36,7 @@ interface MoreItem {
 // CSM_NAV_ITEMS (apps/csm-portal/webapp/src/config/csmNavItems.ts) — Customers and Settings are
 // deliberately left out here.
 const MORE_ITEMS: MoreItem[] = [
+  { label: "Announcements", path: "/more/announcements", icon: Megaphone },
   { label: "Time Cards", path: "/more/time-cards", icon: Clock },
   { label: "Security Center", path: "/more/security-center", icon: Shield },
   { label: "Updates", path: "/more/updates", icon: RefreshCw },

--- a/apps/csm-portal/microapp/src/services/announcements.ts
+++ b/apps/csm-portal/microapp/src/services/announcements.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Announcements are cases of `type: "announcement"`, so this is a single
+// `POST /cases/search` scoped to that type — read-only (create/target/unpublish
+// needs a dedicated backend that isn't built yet). Paged via infinite scroll,
+// newest-updated first, mirroring `services/cases.ts` `cases.infinite`.
+
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { CASES_SEARCH_ENDPOINT } from "@config/endpoints";
+import type { CaseSearchPayloadDto, CaseSearchResponseDto } from "@src/types";
+import { toCaseSummary, type CaseSummary } from "@src/types";
+import type { AnnouncementFilters } from "@utils/announcements";
+import apiClient from "./apiClient";
+
+export interface AnnouncementSearchResult {
+  items: CaseSummary[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+const ANNOUNCEMENTS_PAGE_LIMIT = 20;
+
+// Empty filter arrays are omitted so the search defaults to every state across
+// all projects. `searchQuery` matches subject/number. State is sent as-is (the
+// backend accepts the lowercase UI states) and `toCaseSummary` normalizes the
+// display-cased states the search view returns back to lowercase on the way out.
+async function searchAnnouncements(filters: AnnouncementFilters, offset: number): Promise<AnnouncementSearchResult> {
+  const q = filters.search.trim();
+  const payload: CaseSearchPayloadDto = {
+    pagination: { offset, limit: ANNOUNCEMENTS_PAGE_LIMIT },
+    sortBy: { field: "updatedOn", order: "desc" },
+    filters: {
+      types: ["announcement"],
+      ...(q ? { searchQuery: q } : {}),
+      ...(filters.states.length ? { states: filters.states } : {}),
+      ...(filters.projects.length ? { projectIds: filters.projects.map((p) => p.id) } : {}),
+    },
+  };
+  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  return {
+    items: data.cases.map(toCaseSummary),
+    total: data.total,
+    offset: data.offset,
+    limit: data.limit,
+    hasMore: data.hasMore,
+  };
+}
+
+export const announcements = {
+  infinite: (filters: AnnouncementFilters) =>
+    infiniteQueryOptions({
+      queryKey: ["announcements", filters],
+      queryFn: ({ pageParam }) => searchAnnouncements(filters, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (last) => (last.hasMore ? last.offset + last.limit : undefined),
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -121,7 +121,9 @@ export interface CaseSearchViewDto {
   createdOn?: string;
   updatedOn?: string;
   closedOn: string | null;
-  createdBy: UserIdEmailRefDto;
+  // The case-search view returns the creator's email as a plain string (unlike
+  // the by-id detail view, which returns a full user object).
+  createdBy: string;
   project: EntityRefDto;
   deployment: EntityRefDto | null;
   deployedProduct: EntityRefDto | null;

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -28,7 +28,6 @@ import type {
   CaseWorkState,
   DeployedProductRefDto,
   EntityRefDto,
-  UserIdEmailRefDto,
   UserRefDto,
 } from "./case.dto";
 import { parseBackendTimestamp, parseOptionalBackendTimestamp } from "@utils/dateTime";
@@ -71,7 +70,8 @@ export interface CaseSummary {
   createdOn: Date;
   updatedOn: Date;
   closedOn: Date | null;
-  createdBy: UserIdEmailRefDto;
+  /** Creator's email (the case-search view returns it as a plain string). */
+  createdBy: string;
   project: EntityRefDto;
   deployment: EntityRefDto | null;
   product: EntityRefDto | null;

--- a/apps/csm-portal/microapp/src/utils/announcements.ts
+++ b/apps/csm-portal/microapp/src/utils/announcements.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ChipProps } from "@wso2/oxygen-ui";
+import type { CaseState, Project } from "@src/types";
+
+// Announcement lifecycle states offered in the filter. `reopened` is excluded —
+// it only appears as a `nextStates` signal, never a case's own state (mirrors the
+// webapp's announcement state options).
+export const ANNOUNCEMENT_FILTER_STATES: CaseState[] = [
+  "open",
+  "work_in_progress",
+  "solution_proposed",
+  "awaiting_info",
+  "waiting_on_wso2",
+  "closed",
+];
+
+// UI-facing announcement filters. `search` matches subject/number (server-side
+// `searchQuery`); `states` → server-side `states`; `projects` → server-side
+// `projectIds`. All empty by default, so the list shows every state across all
+// projects. (No severity — announcements carry none.)
+export interface AnnouncementFilters {
+  search: string;
+  states: CaseState[];
+  projects: Project[];
+}
+
+export const EMPTY_ANNOUNCEMENT_FILTERS: AnnouncementFilters = { search: "", states: [], projects: [] };
+
+/** Active filter groups — drives the "Filters (n)" badge. Search is excluded (it
+ * has its own always-visible box). */
+export function countActiveAnnouncementFilters(filters: AnnouncementFilters): number {
+  let count = 0;
+  if (filters.states.length > 0) count += 1;
+  if (filters.projects.length > 0) count += 1;
+  return count;
+}
+
+/**
+ * Chip colour for an announcement's state — announcement-specific, NOT the
+ * case-state palette (which paints a closed case green). An Open announcement is
+ * live/published → success (green), a Closed one is inactive → default (grey),
+ * anything else → info.
+ */
+export function announcementStateColor(state: CaseState): ChipProps["color"] {
+  if (state === "open") return "success";
+  if (state === "closed") return "default";
+  return "info";
+}


### PR DESCRIPTION
## Purpose
Add a read-only announcements experience to the CSM microapp so users can discover customer-facing announcement cases from the More menu. This PR also corrects the `createdBy` type used by the case-search view so announcement cards render the creator value correctly.

## Goals
- Expose announcements from the microapp navigation.
- Provide a read-only list with search, state filters, project filters, and infinite scroll.
- Align the case-search DTO and model typing with the backend response shape for `createdBy`.

## Approach
- Added a `/more/announcements` route and linked it from the More menu.
- Implemented an announcements page backed by the existing case search API with `type: "announcement"`, sorted by most recently updated.
- Added reusable announcement UI pieces for cards, state chips, and the filters sheet.
- Added announcement-specific filter and state utilities.
- Corrected the case-search `createdBy` type from an object shape to the plain string returned by the search view, and updated the announcement card to render that string directly.

## User stories
- As a CSM microapp user, I can open Announcements from the More menu.
- As a user, I can search and filter announcements by state and project.
- As a user, I can view the announcement number, subject, project, creator, state, and recent update information in a read-only list.

## Release note
Added a read-only announcements page to the CSM microapp with search, filtering, and infinite scrolling, and fixed announcement creator rendering by correcting the `createdBy` search-view type.

## Documentation
N/A - This is an internal microapp UI addition and a small type correction; no external product documentation update is required for this change.

## Training
N/A - No training-material change is required for this microapp navigation and listing update.

## Certification
N/A - No certification exam impact for this internal UI enhancement and type fix.

## Marketing
N/A - No marketing content is needed for this change.

## Automation tests
- Unit tests
  Not run for this PR.
- Integration tests
  Not run for this PR.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - No sample assets or sample applications were added.

## Related PRs
N/A

## Migrations (if applicable)
N/A - No migration steps are required.

## Test environment
Not run locally for this PR.

## Learning
Reused the existing microapp patterns for infinite list pages, filter dialogs, and case-search backed services instead of introducing a new backend contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Announcements section in the More menu, including a new `/more/announcements` page.
  * Introduced announcement cards showing case number, subject, project, creator, status, and relative “updated” time.
  * Added debounced search plus filter chips for announcement states and a project multi-select (with “Clear all” and “Apply”).
  * Implemented infinite scrolling with loading placeholders, retry on errors, and a clear empty-state message.
  * Added color-coded status labels to announcements for quick scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->