### PR TITLE
[Customer Entity] Expose activity breakdown, approvers, work-log fields, sortBy, workDate, and rejectionReason on time cards

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1644,15 +1644,23 @@ type TimeCardCaseRef struct {
 
 // TimeCardView is a single time card in search results.
 type TimeCardView struct {
-	ID          string           `json:"id"`
-	TotalTime   float64          `json:"totalTime"`
-	CreatedOn   string           `json:"createdOn"`
-	HasBillable bool             `json:"hasBillable"`
-	State       *string          `json:"state"`
-	User        *TimeCardRef     `json:"user"`
-	ApprovedBy  *TimeCardRef     `json:"approvedBy"`
-	Project     *TimeCardRef     `json:"project"`
-	Case        *TimeCardCaseRef `json:"case"`
+	ID                       string           `json:"id"`
+	TotalTime                float64          `json:"totalTime"`
+	CreatedOn                string           `json:"createdOn"`
+	HasBillable              bool             `json:"hasBillable"`
+	TimeAnalyzing            int              `json:"timeAnalyzing"`
+	TimeSettingUp            int              `json:"timeSettingUp"`
+	TimeReproducingDebugging int              `json:"timeReproducingDebugging"`
+	TimeProvidingSolution    int              `json:"timeProvidingSolution"`
+	TimePatching             int              `json:"timePatching"`
+	IssueComplexity          *string          `json:"issueComplexity"`
+	WorkLogComment           *string          `json:"workLogComment"`
+	State                    *string          `json:"state"`
+	Approvers                []TimeCardRef    `json:"approvers,omitempty"`
+	User                     *TimeCardRef     `json:"user"`
+	ApprovedBy               *TimeCardRef     `json:"approvedBy"`
+	Project                  *TimeCardRef     `json:"project"`
+	Case                     *TimeCardCaseRef `json:"case"`
 }
 
 // SearchTimeCardsResponse is the response for POST /time-cards/search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1623,9 +1623,33 @@ type SearchTimeCardsFilters struct {
 	States       []TimeCardState `json:"states,omitempty"`
 }
 
+// TimeCardSortField enumerates the columns available for sorting time-card search results.
+type TimeCardSortField string
+
+const (
+	TimeCardSortFieldUpdatedOn TimeCardSortField = "updatedOn"
+	TimeCardSortFieldWorkDate  TimeCardSortField = "workDate"
+)
+
+// TimeCardSortOrder controls the sort direction.
+type TimeCardSortOrder string
+
+const (
+	TimeCardSortOrderAsc  TimeCardSortOrder = "asc"
+	TimeCardSortOrderDesc TimeCardSortOrder = "desc"
+)
+
+// TimeCardSort specifies the sort field and direction for time-card search results.
+type TimeCardSort struct {
+	Field TimeCardSortField `json:"field"`
+	Order TimeCardSortOrder `json:"order"`
+}
+
 // SearchTimeCardsRequest is the request body for POST /time-cards/search.
+// SortBy defaults to updatedOn desc when its Field is left empty.
 type SearchTimeCardsRequest struct {
 	Filters    *SearchTimeCardsFilters `json:"filters,omitempty"`
+	SortBy     TimeCardSort            `json:"sortBy"`
 	Pagination Pagination              `json:"pagination"`
 }
 
@@ -1646,7 +1670,8 @@ type TimeCardCaseRef struct {
 type TimeCardView struct {
 	ID                       string           `json:"id"`
 	TotalTime                float64          `json:"totalTime"`
-	CreatedOn                string           `json:"createdOn"`
+	CreatedOn                string           `json:"createdOn"` // deprecated: same value as WorkDate; kept until callers migrate
+	WorkDate                 string           `json:"workDate"`  // the date work was actually carried out (not the record's real creation timestamp)
 	HasBillable              bool             `json:"hasBillable"`
 	TimeAnalyzing            int              `json:"timeAnalyzing"`
 	TimeSettingUp            int              `json:"timeSettingUp"`
@@ -1655,6 +1680,7 @@ type TimeCardView struct {
 	TimePatching             int              `json:"timePatching"`
 	IssueComplexity          *string          `json:"issueComplexity"`
 	WorkLogComment           *string          `json:"workLogComment"`
+	RejectionReason          *string          `json:"rejectionReason"`
 	State                    *string          `json:"state"`
 	Approvers                []TimeCardRef    `json:"approvers,omitempty"`
 	User                     *TimeCardRef     `json:"user"`

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -135,7 +135,7 @@ func snTimeCardToView(tc snTimeCard) domain.TimeCardView {
 	view := domain.TimeCardView{
 		ID:                       sysidToUUID(tc.ID),
 		TotalTime:                tc.TotalTime,
-		CreatedOn:                tc.CreatedOn,
+		CreatedOn:                tc.WorkDate, // deprecated alias — always mirrors WorkDate, not SN's separate createdOn field
 		WorkDate:                 tc.WorkDate,
 		HasBillable:              tc.HasBillable,
 		TimeAnalyzing:            tc.TimeAnalyzing,

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -83,15 +83,23 @@ type snTimeCardsResponse struct {
 }
 
 type snTimeCard struct {
-	ID          string             `json:"id"`
-	TotalTime   float64            `json:"totalTime"`
-	CreatedOn   string             `json:"createdOn"`
-	HasBillable bool               `json:"hasBillable"`
-	State       *snTimeCardLabel   `json:"state"`
-	User        *snTimeCardRef     `json:"user"`
-	ApprovedBy  *snTimeCardRef     `json:"approvedBy"`
-	Project     *snTimeCardRef     `json:"project"`
-	Case        *snTimeCardCaseRef `json:"case"`
+	ID                       string             `json:"id"`
+	TotalTime                float64            `json:"totalTime"`
+	CreatedOn                string             `json:"createdOn"`
+	HasBillable              bool               `json:"hasBillable"`
+	TimeAnalyzing            int                `json:"timeAnalyzing"`
+	TimeSettingUp            int                `json:"timeSettingUp"`
+	TimeReproducingDebugging int                `json:"timeReproducingDebugging"`
+	TimeProvidingSolution    int                `json:"timeProvidingSolution"`
+	TimePatching             int                `json:"timePatching"`
+	IssueComplexity          *string            `json:"issueComplexity"`
+	WorkLogComment           *string            `json:"workLogComment"`
+	State                    *snTimeCardLabel   `json:"state"`
+	Approvers                []snTimeCardRef    `json:"approvers"`
+	User                     *snTimeCardRef     `json:"user"`
+	ApprovedBy               *snTimeCardRef     `json:"approvedBy"`
+	Project                  *snTimeCardRef     `json:"project"`
+	Case                     *snTimeCardCaseRef `json:"case"`
 }
 
 type snTimeCardLabel struct {
@@ -111,10 +119,17 @@ type snTimeCardCaseRef struct {
 
 func snTimeCardToView(tc snTimeCard) domain.TimeCardView {
 	view := domain.TimeCardView{
-		ID:          sysidToUUID(tc.ID),
-		TotalTime:   tc.TotalTime,
-		CreatedOn:   tc.CreatedOn,
-		HasBillable: tc.HasBillable,
+		ID:                       sysidToUUID(tc.ID),
+		TotalTime:                tc.TotalTime,
+		CreatedOn:                tc.CreatedOn,
+		HasBillable:              tc.HasBillable,
+		TimeAnalyzing:            tc.TimeAnalyzing,
+		TimeSettingUp:            tc.TimeSettingUp,
+		TimeReproducingDebugging: tc.TimeReproducingDebugging,
+		TimeProvidingSolution:    tc.TimeProvidingSolution,
+		TimePatching:             tc.TimePatching,
+		IssueComplexity:          tc.IssueComplexity,
+		WorkLogComment:           tc.WorkLogComment,
 	}
 
 	if tc.State != nil {
@@ -126,6 +141,13 @@ func snTimeCardToView(tc snTimeCard) domain.TimeCardView {
 		}
 	}
 
+	if len(tc.Approvers) > 0 {
+		approvers := make([]domain.TimeCardRef, 0, len(tc.Approvers))
+		for _, a := range tc.Approvers {
+			approvers = append(approvers, domain.TimeCardRef{ID: sysidToUUID(a.ID), Name: a.Name})
+		}
+		view.Approvers = approvers
+	}
 	if tc.User != nil {
 		view.User = &domain.TimeCardRef{ID: sysidToUUID(tc.User.ID), Name: tc.User.Name}
 	}

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -60,7 +60,19 @@ var snTimeCardStateLabelToDomain = map[string]string{
 
 type snTimeCardSearchPayload struct {
 	Filters    *snTimeCardFilters  `json:"filters,omitempty"`
+	SortBy     *snTimeCardSort     `json:"sortBy,omitempty"`
 	Pagination snProjectPagination `json:"pagination"`
+}
+
+type snTimeCardSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+// snTimeCardSortFieldMap maps domain TimeCardSortField values to SN field names.
+var snTimeCardSortFieldMap = map[domain.TimeCardSortField]string{
+	domain.TimeCardSortFieldUpdatedOn: "updatedOn",
+	domain.TimeCardSortFieldWorkDate:  "workDate",
 }
 
 type snTimeCardFilters struct {
@@ -86,6 +98,7 @@ type snTimeCard struct {
 	ID                       string             `json:"id"`
 	TotalTime                float64            `json:"totalTime"`
 	CreatedOn                string             `json:"createdOn"`
+	WorkDate                 string             `json:"workDate"`
 	HasBillable              bool               `json:"hasBillable"`
 	TimeAnalyzing            int                `json:"timeAnalyzing"`
 	TimeSettingUp            int                `json:"timeSettingUp"`
@@ -94,6 +107,7 @@ type snTimeCard struct {
 	TimePatching             int                `json:"timePatching"`
 	IssueComplexity          *string            `json:"issueComplexity"`
 	WorkLogComment           *string            `json:"workLogComment"`
+	RejectionReason          *string            `json:"rejectionReason"`
 	State                    *snTimeCardLabel   `json:"state"`
 	Approvers                []snTimeCardRef    `json:"approvers"`
 	User                     *snTimeCardRef     `json:"user"`
@@ -122,6 +136,7 @@ func snTimeCardToView(tc snTimeCard) domain.TimeCardView {
 		ID:                       sysidToUUID(tc.ID),
 		TotalTime:                tc.TotalTime,
 		CreatedOn:                tc.CreatedOn,
+		WorkDate:                 tc.WorkDate,
 		HasBillable:              tc.HasBillable,
 		TimeAnalyzing:            tc.TimeAnalyzing,
 		TimeSettingUp:            tc.TimeSettingUp,
@@ -130,6 +145,7 @@ func snTimeCardToView(tc snTimeCard) domain.TimeCardView {
 		TimePatching:             tc.TimePatching,
 		IssueComplexity:          tc.IssueComplexity,
 		WorkLogComment:           tc.WorkLogComment,
+		RejectionReason:          tc.RejectionReason,
 	}
 
 	if tc.State != nil {
@@ -187,7 +203,21 @@ func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.Sear
 		return domain.SearchTimeCardsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
+	var snSortBy *snTimeCardSort
+	if req.SortBy.Field != "" {
+		snField, ok := snTimeCardSortFieldMap[req.SortBy.Field]
+		if !ok {
+			return domain.SearchTimeCardsResponse{}, &apierror.ValidationError{Msg: "sortBy.field " + string(req.SortBy.Field) + " is not supported by ServiceNow"}
+		}
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snTimeCardSort{Field: snField, Order: order}
+	}
+
 	payload := snTimeCardSearchPayload{
+		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4353,8 +4353,34 @@ components:
           type: string
         hasBillable:
           type: boolean
+        timeAnalyzing:
+          type: integer
+          description: Minutes spent analyzing.
+        timeSettingUp:
+          type: integer
+          description: Minutes spent setting up.
+        timeReproducingDebugging:
+          type: integer
+          description: Minutes spent reproducing/debugging.
+        timeProvidingSolution:
+          type: integer
+          description: Minutes spent providing a solution.
+        timePatching:
+          type: integer
+          description: Minutes spent patching.
+        issueComplexity:
+          type: string
+          nullable: true
+        workLogComment:
+          type: string
+          nullable: true
         state:
           type: string
+        approvers:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeCardRef'
+          description: Users eligible to approve this time card.
         user:
           $ref: '#/components/schemas/TimeCardRef'
         approvedBy:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4302,11 +4302,25 @@ components:
           items:
             $ref: '#/components/schemas/TimeCardState'
 
+    TimeCardSortBy:
+      type: object
+      properties:
+        field:
+          type: string
+          enum: [updatedOn, workDate]
+          description: Column to sort by. Defaults to updatedOn when omitted.
+        order:
+          type: string
+          enum: [asc, desc]
+          description: Sort direction. Defaults to desc when omitted.
+
     SearchTimeCardsRequest:
       type: object
       properties:
         filters:
           $ref: '#/components/schemas/SearchTimeCardsFilters'
+        sortBy:
+          $ref: '#/components/schemas/TimeCardSortBy'
         pagination:
           type: object
           properties:
@@ -4351,6 +4365,11 @@ components:
           format: double
         createdOn:
           type: string
+          deprecated: true
+          description: Deprecated alias for workDate — same value, kept until callers migrate.
+        workDate:
+          type: string
+          description: The date work was actually carried out (not the record's real creation timestamp).
         hasBillable:
           type: boolean
         timeAnalyzing:
@@ -4374,6 +4393,10 @@ components:
         workLogComment:
           type: string
           nullable: true
+        rejectionReason:
+          type: string
+          nullable: true
+          description: The approver's comment when rejecting. Only who/when rejected is not currently tracked by the backing data source.
         state:
           type: string
         approvers:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4302,7 +4302,7 @@ components:
           items:
             $ref: '#/components/schemas/TimeCardState'
 
-    TimeCardSortBy:
+    TimeCardSort:
       type: object
       properties:
         field:
@@ -4320,7 +4320,7 @@ components:
         filters:
           $ref: '#/components/schemas/SearchTimeCardsFilters'
         sortBy:
-          $ref: '#/components/schemas/TimeCardSortBy'
+          $ref: '#/components/schemas/TimeCardSort'
         pagination:
           type: object
           properties:


### PR DESCRIPTION
## Purpose
`TimeCardView` only returned `id/totalTime/createdOn/hasBillable/state/user/approvedBy/project/case`, even though the backing data source already accepts (on create) and, as of a series of data-source-side changes, now returns the per-activity time breakdown, issue complexity, work-log comment, eligible-approvers list, rejection reason, and supports sorting by more than one column. Callers could write most of this data but never read it back beyond the total, and search results only ever sorted one way.

## Goals
- Add the missing read-model fields (`workLogComment`, `issueComplexity`, activity breakdown, `approvers`, `rejectionReason`) so search/read results carry everything actually logged.
- Add server-side `sortBy` support (`updatedOn` / `workDate`, `asc` / `desc`).
- Add `workDate` as a correctly-named field alongside the existing `createdOn` (which turned out to already hold the work date, not the record's real creation timestamp — kept as a deprecated alias rather than renamed outright, since `createdOn` is read by the already-deployed CSM webapp today).

## Approach
- `snTimeCard` (internal struct decoding the data source's response) gained `TimeAnalyzing`, `TimeSettingUp`, `TimeReproducingDebugging`, `TimeProvidingSolution`, `TimePatching`, `IssueComplexity`, `WorkLogComment`, `Approvers`, `WorkDate`, `RejectionReason`.
- `domain.TimeCardView` gained the same fields, plus `CreatedOn` is now documented `deprecated: true` in `openapi.yaml` and derived directly from `WorkDate`, so the alias is guaranteed identical by construction.
- `SearchTimeCardsRequest` gained an optional `SortBy TimeCardSort` field (`TimeCardSortField`: `updatedOn`/`workDate`; `TimeCardSortOrder`: `asc`/`desc`), mirroring the existing `CaseSort`/`UserSortBy` pattern in this same file exactly. Defaults to `updatedOn desc` when omitted — identical to the previous hardcoded behavior, so no caller regresses.
- `snTimeCardToView` maps everything across, converting approver IDs the same way `user`/`approvedBy`/`project` already do.
- `openapi.yaml` documents all new request/response fields, including a `TimeCardSort` schema matching `UserSortBy`'s existing style.

**Customer-portal safety check:** the customer portal's own response mapper (`apps/customer-portal/backend/utils.bal`, `mapTimeCardSearchResponse`) explicitly cherry-picks fields into its own output type — it does not passthrough. Confirmed unchanged and untouched by this PR, so none of these new fields (or the new default sort behavior — the customer portal never sends `sortBy`, so it keeps getting `updatedOn desc`) reach the customer-facing frontend.

No downstream repo change needed: the shared integration layer's types already tolerate unrecognized fields, so the new data fields and `sortBy` round-trip through it without any type change there.

## User stories
As a caller of entity-service's time-card endpoints, I can read back the full activity breakdown, issue complexity, work-log comment, rejection reason, and eligible approvers for a time card, and I can sort results by the actual work date instead of only by last-modified time.

## Release note
Time card search/read responses now include the per-activity time breakdown, issue complexity, work-log comment, rejection reason, and the list of users eligible to approve the card. Search also supports sorting by `updatedOn` (default) or `workDate`.

## Documentation
N/A — internal API field/parameter addition, documented in this repo's own openapi.yaml.

## Automation tests
- Unit tests: `go build ./...`, `go vet ./...`, `go test ./...` all pass clean in `entity-service`.
- Integration tests: manually verified against real backing-data-source-backed time cards — all new fields returned correctly, `sortBy` (`workDate` asc/desc, `updatedOn` default) produced correctly ordered results, invalid `sortBy.field` correctly rejected.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go, not Java) — `go vet` ran clean
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- wso2-open-operations/cs-tools#1130 (prior time-card filter work, merged)

## Migrations (if applicable)
N/A

## Test environment
Local (macOS), Go 1.26, real backing data source (DEV tenant).

## Learning
N/A