### PR TITLE
[CSM Portal Microapp]  Add a Settings section / Add Home Page

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -30,6 +30,7 @@ import TimeCardsPage from "@pages/TimeCardsPage";
 import SecurityCenterPage from "@pages/SecurityCenterPage";
 import UpdatesPage from "@pages/UpdatesPage";
 import EngagementsPage from "@pages/EngagementsPage";
+import SettingsPage from "@pages/SettingsPage";
 import ProfilePage from "@pages/ProfilePage";
 
 export default function App() {
@@ -68,6 +69,7 @@ export default function App() {
           <Route path="/more/security-center" element={<SecurityCenterPage />} />
           <Route path="/more/updates" element={<UpdatesPage />} />
           <Route path="/more/engagements" element={<EngagementsPage />} />
+          <Route path="/more/settings" element={<SettingsPage />} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
       </Routes>

--- a/apps/csm-portal/microapp/src/components/common/ComingSoonPage.tsx
+++ b/apps/csm-portal/microapp/src/components/common/ComingSoonPage.tsx
@@ -19,20 +19,26 @@ import { Card, Chip, Stack, Typography } from "@wso2/oxygen-ui";
 interface ComingSoonPageProps {
   title: string;
   description: string;
+  blockedOn?: string;
 }
 
 // Placeholder for microapp sections not yet built, mirroring the webapp's CsmComingSoonPage
 // (apps/csm-portal/webapp/src/features/csm-coming-soon/pages/CsmComingSoonPage.tsx) — used
 // deliberately so a reserved tab/route feels real instead of dead or missing.
-export function ComingSoonPage({ title, description }: ComingSoonPageProps) {
+export function ComingSoonPage({ title, description, blockedOn }: ComingSoonPageProps) {
   return (
     <Stack gap={3}>
       <Stack direction="row" alignItems="center" gap={1.5}>
         <Typography variant="h5">{title}</Typography>
         <Chip size="small" label="Coming soon" color="warning" variant="outlined" />
       </Stack>
-      <Card sx={{ p: 3 }}>
+      <Card sx={{ p: 3, display: "flex", flexDirection: "column", gap: 1.5 }}>
         <Typography variant="body1">{description}</Typography>
+        {blockedOn && (
+          <Typography variant="body2" color="text.secondary">
+            Blocked on: {blockedOn}
+          </Typography>
+        )}
       </Card>
     </Stack>
   );

--- a/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Button, Stack, Typography } from "@wso2/oxygen-ui";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { currentUser } from "@src/services/currentUser";
+import { dashboard } from "@src/services/dashboard";
+import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+
+// The signed-in user's own non-closed cases — mirrors the webapp's "Assigned to me" widget
+// (apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx), capped to a
+// short 5-item preview with a "View all" link out to Support, rather than paginated in place.
+export function AssignedToMeSection() {
+  const { data: currentUserId } = useQuery(currentUser.id());
+  const { data, isLoading, isError, refetch } = useQuery(dashboard.assignedToMe(currentUserId ?? null));
+
+  const items = data?.items ?? [];
+
+  return (
+    <Stack gap={1.5}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Typography variant="subtitle1">Assigned to me</Typography>
+        <Button component={Link} to="/support" variant="text" size="small" disableRipple>
+          View all
+        </Button>
+      </Stack>
+
+      {isLoading ? (
+        <Stack gap={1.5}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <CaseCardSkeleton key={index} />
+          ))}
+        </Stack>
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No cases assigned to you." />
+      ) : (
+        <Stack gap={1.5}>
+          {items.map((item) => (
+            <CaseCard key={item.id} item={item} />
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
@@ -28,7 +28,7 @@ import { ErrorState } from "@components/support/ErrorState";
 // short 5-item preview with a "View all" link out to Support, rather than paginated in place.
 export function AssignedToMeSection() {
   const { data: currentUserId } = useQuery(currentUser.id());
-  const { data, isLoading, isError, refetch } = useQuery(dashboard.assignedToMe(currentUserId ?? null));
+  const { data, isPending, isError, refetch } = useQuery(dashboard.assignedToMe(currentUserId ?? null));
 
   const items = data?.items ?? [];
 

--- a/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo } from "react";
+import { Stack, Typography } from "@wso2/oxygen-ui";
+import { useQuery } from "@tanstack/react-query";
+import { dashboard } from "@src/services/dashboard";
+import { ALL_SEVERITIES, SEVERITY_LABELS, STATE_LABELS } from "@components/support/config";
+import { COMPOSITION_STATES, SEVERITY_SLICE_COLOR, STATE_SLICE_COLOR } from "./config";
+import { CompositionDonut, type CompositionSlice } from "./CompositionDonut";
+
+// Two donuts — severity composition and state composition of active cases — mirrors the webapp's
+// CaseCompositionCharts (apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx),
+// stacked instead of side-by-side (the webapp's own grid already collapses to one column below its
+// "md" breakpoint, which is every phone width anyway). Self-contained plain useQuery rather than
+// Suspense, matching how TimeCardsPage.tsx already handles independent, non-blocking widgets in
+// this app — one failed/slow widget shouldn't hold up the rest of the Home page.
+export function CaseCompositionSection() {
+  const { data, isLoading, isError } = useQuery(dashboard.composition());
+
+  const severitySlices = useMemo<CompositionSlice[]>(
+    () =>
+      ALL_SEVERITIES.map((severity) => ({
+        id: severity,
+        name: SEVERITY_LABELS[severity],
+        value: data?.bySeverity[severity] ?? 0,
+        color: SEVERITY_SLICE_COLOR[severity],
+      })),
+    [data],
+  );
+
+  const stateSlices = useMemo<CompositionSlice[]>(
+    () =>
+      COMPOSITION_STATES.map((state) => ({
+        id: state,
+        name: STATE_LABELS[state],
+        value: data?.byState[state] ?? 0,
+        color: STATE_SLICE_COLOR[state],
+      })),
+    [data],
+  );
+
+  const closedTotal = data?.closedTotal ?? 0;
+
+  return (
+    <Stack gap={1.5}>
+      <Typography variant="subtitle1">Case composition</Typography>
+
+      <Stack gap={1.5}>
+        <CompositionDonut
+          title="Cases by severity"
+          description="Share of active cases at each severity level, excluding closed."
+          slices={severitySlices}
+          total={data?.severityTotal ?? 0}
+          isLoading={isLoading}
+          isError={isError}
+        />
+        <CompositionDonut
+          title="Cases by state"
+          description="Share of active cases in each lifecycle state, excluding closed."
+          slices={stateSlices}
+          total={data?.stateTotal ?? 0}
+          isLoading={isLoading}
+          isError={isError}
+        />
+      </Stack>
+
+      {/* Reconciles with the donuts: both show active cases only, so the closed count is called
+          out here rather than mixed into a slice — same as the webapp. */}
+      {!isLoading && !isError && closedTotal > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          Excludes {closedTotal} closed {closedTotal === 1 ? "case" : "cases"}.
+        </Typography>
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Card, Skeleton, Typography } from "@wso2/oxygen-ui";
+import { PieChart } from "@wso2/oxygen-ui-charts-react";
+
+// Donut sits in a fixed square; the legend fills the rest of the card width. Smaller than the
+// webapp's 200px version (CompositionDonut.tsx) to fit a phone-width card comfortably.
+const DONUT_SIZE = 160;
+
+export interface CompositionSlice {
+  id: string;
+  name: string;
+  value: number;
+  color: string;
+}
+
+interface CompositionDonutProps {
+  title: string;
+  description: string;
+  slices: CompositionSlice[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+  /** Noun for the empty state, e.g. "cases". */
+  emptyNoun?: string;
+}
+
+// A donut chart with a value/percentage legend and a centred total — mirrors the webapp's
+// CompositionDonut (apps/csm-portal/webapp/src/features/csm-dashboard/components/CompositionDonut.tsx).
+// Zero-value slices drop from the ring but stay in the legend so every category remains visible.
+// No slice-click drill-down here (unlike the webapp): the microapp's Support page doesn't support
+// seeding filters from the URL, so there's nowhere to deep-link a click into yet.
+export function CompositionDonut({
+  title,
+  description,
+  slices,
+  total,
+  isLoading,
+  isError,
+  emptyNoun = "cases",
+}: CompositionDonutProps) {
+  const pieData = slices.filter((s) => s.value > 0);
+  const isEmpty = !isLoading && !isError && total === 0;
+
+  return (
+    <Card sx={{ p: 2 }}>
+      <Typography variant="subtitle1" fontWeight={600}>
+        {title}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {description}
+      </Typography>
+
+      {isLoading ? (
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2, mt: 2 }}>
+          <Skeleton variant="circular" width={DONUT_SIZE} height={DONUT_SIZE} />
+          <Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 1 }}>
+            {slices.map((s) => (
+              <Skeleton key={s.id} variant="rounded" height={18} />
+            ))}
+          </Box>
+        </Box>
+      ) : isError ? (
+        <Box sx={{ height: DONUT_SIZE, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <Typography variant="body2" color="text.secondary">
+            Could not load {title.toLowerCase()}.
+          </Typography>
+        </Box>
+      ) : isEmpty ? (
+        <Box sx={{ height: DONUT_SIZE, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <Typography variant="body2" color="text.disabled">
+            No {emptyNoun} to show.
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ mt: 2, display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
+          <Box sx={{ position: "relative", width: DONUT_SIZE, height: DONUT_SIZE, flexShrink: 0 }}>
+            <PieChart
+              data={pieData}
+              colors={pieData.map((s) => s.color)}
+              legend={{ show: false }}
+              tooltip={{ show: true }}
+              width="100%"
+              height={DONUT_SIZE}
+              pies={[
+                {
+                  dataKey: "value",
+                  nameKey: "name",
+                  innerRadius: "62%",
+                  outerRadius: "100%",
+                  paddingAngle: 1,
+                  startAngle: 90,
+                  endAngle: -270,
+                  label: false,
+                  labelLine: false,
+                },
+              ]}
+            />
+            <Box
+              sx={{
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+                textAlign: "center",
+                pointerEvents: "none",
+              }}
+            >
+              <Typography variant="h5">{total}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Total
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* Legend: every category, with its count and share. */}
+          <Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 1 }}>
+            {slices.map((s) => {
+              const pct = total > 0 ? Math.round((s.value / total) * 100) : 0;
+              return (
+                <Box key={s.id} sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 0 }}>
+                    <Box sx={{ width: 12, height: 12, borderRadius: "50%", bgcolor: s.color, flexShrink: 0 }} />
+                    <Typography variant="body2" color="text.secondary" noWrap>
+                      {s.name}
+                    </Typography>
+                  </Box>
+                  <Typography variant="body2" fontWeight={600} sx={{ whiteSpace: "nowrap" }}>
+                    {s.value} ({pct}%)
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/home/config.ts
+++ b/apps/csm-portal/microapp/src/components/home/config.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { colors } from "@wso2/oxygen-ui";
+import type { CaseSeverity, CaseState } from "@src/types";
+
+// The active states the composition donuts track — mirrors the webapp's MATRIX_STATES
+// (apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts): closed is
+// excluded (the dashboard tracks active work) and so is reopened (not a normal lifecycle state).
+export const COMPOSITION_STATES: CaseState[] = [
+  "open",
+  "work_in_progress",
+  "waiting_on_wso2",
+  "awaiting_info",
+  "solution_proposed",
+];
+
+// Non-closed states for "Assigned to me" — the same set the webapp's MyAssignedCases widget uses
+// (apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx), which
+// includes reopened unlike the composition set above.
+export const ASSIGNED_TO_ME_STATES: CaseState[] = [...COMPOSITION_STATES, "reopened"];
+
+// Distinct hue per slice — mirrors the webapp's SEVERITY_SLICE_COLOR/STATE_SLICE_COLOR
+// (CaseCompositionCharts.tsx). The support/config.tsx chip color configs reuse the same role
+// color for several keys (e.g. every "info" state), which would merge pie slices together.
+export const SEVERITY_SLICE_COLOR: Record<CaseSeverity, string> = {
+  catastrophic: colors.red[600],
+  critical: colors.deepOrange[500],
+  high: colors.amber[700],
+  medium: colors.blue[500],
+  low: colors.green[500],
+};
+
+export const STATE_SLICE_COLOR: Record<CaseState, string> = {
+  open: colors.blue[500],
+  work_in_progress: colors.indigo[400],
+  waiting_on_wso2: colors.amber[700],
+  awaiting_info: colors.cyan[500],
+  solution_proposed: colors.teal[500],
+  closed: colors.grey[500],
+  reopened: colors.purple[500],
+};

--- a/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
@@ -52,8 +52,6 @@ export function TopBar() {
             <ArrowLeft size={22} />
           </IconButton>
         ) : (
-          // Mirrors the webapp's Brand (apps/csm-portal/webapp/src/components/header/Brand.tsx):
-          // same logo asset + "CSM Portal" title, shown on root pages in place of the back button.
           <Stack direction="row" alignItems="center" gap={1}>
             <img src="/logo-dark.svg" alt="Company Logo" style={{ height: 20, width: "auto" }} />
             <Typography variant="subtitle1" fontWeight={600}>

--- a/apps/csm-portal/microapp/src/components/settings/Settings.tsx
+++ b/apps/csm-portal/microapp/src/components/settings/Settings.tsx
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { Badge, Chip, IconButton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { adminUsers } from "@src/services/adminUsers";
+import { ComingSoonPage } from "@components/common/ComingSoonPage";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { SearchBar } from "@components/support/SearchBar";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { ADMIN_TABS, type AdminTabId } from "./config";
+import { UserCard, UserCardSkeleton } from "./UserCard";
+import { UsersFiltersSheet } from "./UsersFiltersSheet";
+import { EMPTY_USERS_FILTERS, countActiveUsersFilters, toUserSearchFilters, type UsersFilters } from "./filters";
+
+// The account-administration section: mirrors the webapp's CsmAdminLayout (Users/Roles/Groups/
+// Permissions tabs, only Users built) rather than personal profile editing. Deliberately
+// self-contained — it owns its own tab state, search/filters, and data fetching — so it's a
+// drop-in that can move to a different page later without threading state through props.
+export default function Settings() {
+  const [tab, setTab] = useState<AdminTabId>("users");
+  const activeTab = ADMIN_TABS.find((t) => t.id === tab) ?? ADMIN_TABS[0];
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="h5">Settings</Typography>
+
+      <Tabs variant="scrollable" value={tab} onChange={(_, value: AdminTabId) => setTab(value)}>
+        {ADMIN_TABS.map((t) => (
+          <Tab
+            key={t.id}
+            value={t.id}
+            disableRipple
+            label={
+              <Stack direction="row" alignItems="center" gap={0.75}>
+                {t.label}
+                {t.wip && (
+                  <Chip size="small" label="WIP" color="warning" variant="outlined" sx={{ height: 18, fontSize: 10 }} />
+                )}
+              </Stack>
+            }
+          />
+        ))}
+      </Tabs>
+
+      {activeTab.id === "users" ? (
+        <UsersTab />
+      ) : (
+        <ComingSoonPage
+          title={activeTab.label}
+          description={activeTab.description ?? ""}
+          blockedOn={activeTab.blockedOn}
+        />
+      )}
+    </Stack>
+  );
+}
+
+function UsersTab() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [filters, setFilters] = useState<UsersFilters>(EMPTY_USERS_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const activeFilterCount = countActiveUsersFilters(filters);
+
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    adminUsers.infinite(toUserSearchFilters(debouncedSearch, filters)),
+  );
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const users = data?.pages.flatMap((page) => page.users) ?? [];
+  const total = data?.pages[0]?.total ?? users.length;
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="body2" color="text.secondary">
+        Search across username and email. Filter by role and status.
+      </Typography>
+
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar value={search} onChange={setSearch} placeholder="Search users by username or email" />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
+      {isLoading ? (
+        <UsersSkeleton />
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : users.length === 0 ? (
+        <EmptyState message="No users found." />
+      ) : (
+        <Stack gap={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {users.length} of {total}
+          </Typography>
+
+          {users.map((user) => (
+            <UserCard key={user.id} user={user} />
+          ))}
+
+          {/* IntersectionObserver can miss a zero-height target, so give the sentinel 1px to observe. */}
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <UserCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={2}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+
+      <UsersFiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        filters={filters}
+        onApply={setFilters}
+      />
+    </Stack>
+  );
+}
+
+function UsersSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <UserCardSkeleton key={index} />
+      ))}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/settings/UserCard.tsx
+++ b/apps/csm-portal/microapp/src/components/settings/UserCard.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Card, Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import type { AdminUser } from "@src/types";
+import { INTERNAL_USER_ROLES } from "./config";
+
+// Mobile-card equivalent of the webapp's CsmUsersPage table row: username, name, email, role
+// chips (or the postgres-source userType when roles aren't present), active/inactive status, and
+// timezone — same fields, same fallbacks ("—").
+export function UserCard({ user }: { user: AdminUser }) {
+  return (
+    <Card sx={{ p: 1.5 }}>
+      <Stack gap={0.75}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="subtitle2" color="text.secondary">
+            {user.userName}
+          </Typography>
+          {user.active !== undefined && (
+            <Chip
+              size="small"
+              label={user.active ? "Active" : "Inactive"}
+              color={user.active ? "success" : "default"}
+              variant="outlined"
+            />
+          )}
+        </Stack>
+
+        <Typography variant="body1" color="text.primary" noWrap>
+          {user.name || "—"}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {user.email}
+        </Typography>
+
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+          {user.roles && user.roles.length > 0 ? (
+            user.roles.map((role) => (
+              <Chip
+                key={role}
+                size="small"
+                label={role}
+                color={(INTERNAL_USER_ROLES as string[]).includes(role) ? "primary" : "default"}
+                variant="outlined"
+              />
+            ))
+          ) : user.userType ? (
+            <Chip
+              size="small"
+              label={user.userType}
+              color={user.userType === "internal" ? "primary" : "default"}
+              variant="outlined"
+            />
+          ) : null}
+        </Stack>
+
+        <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: 12 }}>
+          {user.timezone ?? "—"}
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+export function UserCardSkeleton() {
+  return (
+    <Card sx={{ p: 1.5 }}>
+      <Stack gap={0.75}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Skeleton variant="text" width={80} height={20} />
+          <Skeleton variant="rounded" width={60} height={22} sx={{ borderRadius: 1 }} />
+        </Stack>
+        <Skeleton variant="text" width="60%" height={26} />
+        <Skeleton variant="text" width="80%" height={20} />
+        <Stack direction="row" gap={1}>
+          <Skeleton variant="rounded" width={70} height={24} sx={{ borderRadius: 1 }} />
+        </Stack>
+        <Skeleton variant="text" width={100} height={18} />
+      </Stack>
+    </Card>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/settings/UsersFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/settings/UsersFiltersSheet.tsx
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import type { AdminUserRole } from "@src/types";
+import { ALL_USER_ROLES, USER_ROLE_LABELS } from "./config";
+import { EMPTY_USERS_FILTERS, type UsersFilters } from "./filters";
+
+const STATUS_OPTIONS: { value: UsersFilters["active"]; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "inactive", label: "Inactive" },
+];
+
+function toggleRole(roles: AdminUserRole[], role: AdminUserRole): AdminUserRole[] {
+  return roles.includes(role) ? roles.filter((r) => r !== role) : [...roles, role];
+}
+
+interface UsersFiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: UsersFilters;
+  onApply: (filters: UsersFilters) => void;
+}
+
+// Mobile bottom-sheet equivalent of the webapp's CsmUsersPage filter row (role multi-select +
+// status select), mirroring the microapp's own support/FiltersSheet.tsx bottom-sheet pattern.
+export function UsersFiltersSheet({ open, onClose, filters, onApply }: UsersFiltersSheetProps) {
+  const [draft, setDraft] = useState<UsersFilters>(filters);
+
+  // Re-seed the draft from the last-applied filters each time the sheet opens, so reopening it
+  // doesn't show stale in-progress edits from a previous open that was dismissed without applying.
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open, not on every filters identity change
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={2.5}>
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Roles</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {ALL_USER_ROLES.map((role) => {
+                const isSelected = draft.roles.includes(role);
+                return (
+                  <Chip
+                    key={role}
+                    label={USER_ROLE_LABELS[role]}
+                    size="small"
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => setDraft({ ...draft, roles: toggleRole(draft.roles, role) })}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Status</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {STATUS_OPTIONS.map((option) => {
+                const isSelected = draft.active === option.value;
+                return (
+                  <Chip
+                    key={option.value}
+                    label={option.label}
+                    size="small"
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => setDraft({ ...draft, active: option.value })}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            setDraft(EMPTY_USERS_FILTERS);
+            onApply(EMPTY_USERS_FILTERS);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/settings/UsersFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/settings/UsersFiltersSheet.tsx
@@ -86,6 +86,7 @@ export function UsersFiltersSheet({ open, onClose, filters, onApply }: UsersFilt
                     size="small"
                     variant={isSelected ? "filled" : "outlined"}
                     color={isSelected ? "primary" : "default"}
+                    aria-pressed={isSelected}
                     onClick={() => setDraft({ ...draft, roles: toggleRole(draft.roles, role) })}
                   />
                 );
@@ -95,7 +96,7 @@ export function UsersFiltersSheet({ open, onClose, filters, onApply }: UsersFilt
 
           <Stack gap={1}>
             <Typography variant="subtitle2">Status</Typography>
-            <Stack direction="row" gap={1} flexWrap="wrap">
+            <Stack direction="row" gap={1} flexWrap="wrap" role="radiogroup" aria-label="Status">
               {STATUS_OPTIONS.map((option) => {
                 const isSelected = draft.active === option.value;
                 return (
@@ -105,6 +106,8 @@ export function UsersFiltersSheet({ open, onClose, filters, onApply }: UsersFilt
                     size="small"
                     variant={isSelected ? "filled" : "outlined"}
                     color={isSelected ? "primary" : "default"}
+                    role="radio"
+                    aria-checked={isSelected}
                     onClick={() => setDraft({ ...draft, active: option.value })}
                   />
                 );

--- a/apps/csm-portal/microapp/src/components/settings/config.ts
+++ b/apps/csm-portal/microapp/src/components/settings/config.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { AdminUserRole } from "@src/types";
+
+// Mirrors the webapp's ALL_ROLES/INTERNAL_USER_ROLES (apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx).
+export const INTERNAL_USER_ROLES: AdminUserRole[] = ["internal", "agent", "admin"];
+
+export const ALL_USER_ROLES: AdminUserRole[] = [
+  ...INTERNAL_USER_ROLES,
+  "commenter",
+  "external",
+  "customer",
+  "customer_admin",
+  "partner",
+  "partner_admin",
+];
+
+export const USER_ROLE_LABELS: Record<AdminUserRole, string> = {
+  internal: "Internal",
+  agent: "Agent",
+  admin: "Admin",
+  commenter: "Commenter",
+  external: "External",
+  customer: "Customer",
+  customer_admin: "Customer admin",
+  partner: "Partner",
+  partner_admin: "Partner admin",
+};
+
+export type AdminTabId = "users" | "roles" | "groups" | "permissions";
+
+export interface AdminTabConfig {
+  id: AdminTabId;
+  label: string;
+  wip?: boolean;
+  description?: string;
+  blockedOn?: string;
+}
+
+// Mirrors the webapp's ADMIN_TABS (apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.tsx)
+// and the CsmComingSoonPage copy each WIP tab renders (App.tsx's /admin/* routes).
+export const ADMIN_TABS: AdminTabConfig[] = [
+  { id: "users", label: "Users" },
+  {
+    id: "roles",
+    label: "Roles",
+    wip: true,
+    description: "Role-based access control: define roles and their permission sets.",
+    blockedOn: "csm-portal/backend roles endpoints",
+  },
+  {
+    id: "groups",
+    label: "Groups",
+    wip: true,
+    description: "User groups for bulk role assignment and access control.",
+    blockedOn: "csm-portal/backend groups endpoints",
+  },
+  {
+    id: "permissions",
+    label: "Permissions",
+    wip: true,
+    description: "Fine-grained permission catalog and assignment view.",
+    blockedOn: "csm-portal/backend permissions endpoints",
+  },
+];

--- a/apps/csm-portal/microapp/src/components/settings/filters.ts
+++ b/apps/csm-portal/microapp/src/components/settings/filters.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { AdminUserRole, UserSearchFiltersDto } from "@src/types";
+
+export interface UsersFilters {
+  roles: AdminUserRole[];
+  active: "all" | "active" | "inactive";
+}
+
+export const EMPTY_USERS_FILTERS: UsersFilters = { roles: [], active: "all" };
+
+export function countActiveUsersFilters(filters: UsersFilters): number {
+  return filters.roles.length + (filters.active !== "all" ? 1 : 0);
+}
+
+export function toUserSearchFilters(search: string, filters: UsersFilters): UserSearchFiltersDto {
+  return {
+    ...(search.length > 0 && { searchQuery: search }),
+    ...(filters.roles.length > 0 && { roles: filters.roles }),
+    ...(filters.active !== "all" && { active: filters.active === "active" }),
+  };
+}

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -21,6 +21,7 @@ if (!BACKEND_URL) {
 }
 
 export const USERS_ME_ENDPOINT = "/users/me";
+export const USERS_SEARCH_ENDPOINT = "/users/search";
 
 export const CASES_ENDPOINT = "/cases";
 export const CASES_SEARCH_ENDPOINT = "/cases/search";

--- a/apps/csm-portal/microapp/src/pages/HomePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/HomePage.tsx
@@ -14,13 +14,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { ComingSoonPage } from "@components/common/ComingSoonPage";
+import { Stack, Typography } from "@wso2/oxygen-ui";
+import { AssignedToMeSection } from "@components/home/AssignedToMeSection";
+import { CaseCompositionSection } from "@components/home/CaseCompositionSection";
 
+// Mirrors the webapp's Dashboard (apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx):
+// "Assigned to me" and the case composition donuts, its two widgets with real data. The
+// severity×state matrix table is deliberately left out — it costs 25 extra fan-out requests on
+// top of the donuts' 11, with no aggregation endpoint to make it cheap, and doesn't fit a mobile
+// screen well anyway. The ABT-scope header is skipped too since it's feature-flagged off
+// (CSM_DASHBOARD_API_IMPLEMENTED = false) and only ever shows a static fallback in the webapp.
 export default function HomePage() {
   return (
-    <ComingSoonPage
-      title="Home"
-      description="A personalized home view — mirroring the webapp's Dashboard — is on the way."
-    />
+    <Stack gap={3}>
+      <Typography variant="h5">Home</Typography>
+      <AssignedToMeSection />
+      <CaseCompositionSection />
+    </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/pages/MorePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/MorePage.tsx
@@ -16,7 +16,15 @@
 
 import { Link } from "react-router-dom";
 import { List, ListItemButton, ListItemIcon, ListItemText, Stack, Typography } from "@wso2/oxygen-ui";
-import { Briefcase, ChevronRight, Clock, RefreshCw, Shield, type LucideIcon } from "@wso2/oxygen-ui-icons-react";
+import {
+  Briefcase,
+  ChevronRight,
+  Clock,
+  RefreshCw,
+  Settings,
+  Shield,
+  type LucideIcon,
+} from "@wso2/oxygen-ui-icons-react";
 
 interface MoreItem {
   label: string;
@@ -25,13 +33,14 @@ interface MoreItem {
 }
 
 // Secondary sections that don't get their own tab, mirroring a subset of the webapp's
-// CSM_NAV_ITEMS (apps/csm-portal/webapp/src/config/csmNavItems.ts) — Customers and Settings are
-// deliberately left out here.
+// CSM_NAV_ITEMS (apps/csm-portal/webapp/src/config/csmNavItems.ts) — Customers is deliberately
+// left out here. Settings is last, same position it has in CSM_NAV_ITEMS.
 const MORE_ITEMS: MoreItem[] = [
   { label: "Time Cards", path: "/more/time-cards", icon: Clock },
   { label: "Security Center", path: "/more/security-center", icon: Shield },
   { label: "Updates", path: "/more/updates", icon: RefreshCw },
   { label: "Engagements", path: "/more/engagements", icon: Briefcase },
+  { label: "Settings", path: "/more/settings", icon: Settings },
 ];
 
 export default function MorePage() {

--- a/apps/csm-portal/microapp/src/pages/ProfilePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/ProfilePage.tsx
@@ -14,27 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
-import {
-  Avatar,
-  Button,
-  Divider,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Skeleton,
-  Stack,
-  TextField,
-  Typography,
-} from "@wso2/oxygen-ui";
-import { useMutation, useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, type ReactNode } from "react";
+import { Avatar, Divider, Skeleton, Stack, TextField, Typography } from "@wso2/oxygen-ui";
+import { useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import { users } from "@src/services/users";
-import type { UserMeUpdateDto, UserProfile } from "@src/types";
+import type { UserProfile } from "@src/types";
 import { useUserStore } from "@src/store/user";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
-import { listSupportedTimeZones } from "@utils/dateTime";
 import { initialsOf } from "@utils/initials";
 
 export default function ProfilePage() {
@@ -53,99 +40,13 @@ export default function ProfilePage() {
 
 function ProfileContent() {
   const { data: profile } = useSuspenseQuery(users.me());
-  const queryClient = useQueryClient();
-  const timeZoneOptions = useMemo(() => listSupportedTimeZones(), []);
-
-  const [phoneNumber, setPhoneNumber] = useState(profile.phoneNumber ?? "");
-  const [timeZone, setTimeZone] = useState(profile.timeZone ?? "");
-
-  const isDirty = phoneNumber !== (profile.phoneNumber ?? "") || timeZone !== (profile.timeZone ?? "");
-
-  // A background refetch (window refocus, cache invalidation elsewhere) must not clobber an
-  // in-progress edit. Only re-seed from the server once the local draft matches it again, e.g.
-  // right after this page's own save invalidates the query.
-  useEffect(() => {
-    if (isDirty) return;
-    setPhoneNumber(profile.phoneNumber ?? "");
-    setTimeZone(profile.timeZone ?? "");
-  }, [profile, isDirty]);
-
-  const mutation = useMutation({
-    mutationFn: users.updateMe,
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["users", "me"] });
-    },
-  });
-
-  const handleSave = () => {
-    const payload: UserMeUpdateDto = {};
-    if (phoneNumber !== (profile.phoneNumber ?? "")) payload.phoneNumber = phoneNumber;
-    if (timeZone !== (profile.timeZone ?? "")) payload.timeZone = timeZone;
-    if (Object.keys(payload).length === 0) return;
-    mutation.mutate(payload);
-  };
 
   return (
     <Stack gap={2.5}>
       <ProfileHeader profile={profile} />
       <Divider />
 
-      <Stack gap={2}>
-        <TextField label="Email" value={profile.email} size="small" disabled fullWidth />
-
-        <TextField
-          label="Phone Number"
-          value={phoneNumber}
-          onChange={(event) => {
-            if (mutation.isSuccess || mutation.isError) mutation.reset();
-            setPhoneNumber(event.target.value);
-          }}
-          size="small"
-          fullWidth
-          disabled={mutation.isPending}
-        />
-
-        <FormControl size="small" fullWidth disabled={mutation.isPending}>
-          <InputLabel id="profile-timezone-label" shrink>
-            Time Zone
-          </InputLabel>
-          <Select
-            labelId="profile-timezone-label"
-            label="Time Zone"
-            value={timeZone}
-            displayEmpty
-            notched
-            onChange={(event) => {
-              if (mutation.isSuccess || mutation.isError) mutation.reset();
-              setTimeZone(event.target.value);
-            }}
-          >
-            <MenuItem value="" disabled>
-              <em>Select a time zone</em>
-            </MenuItem>
-            {timeZoneOptions.map((tz) => (
-              <MenuItem key={tz} value={tz}>
-                {tz}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
-        <Button variant="contained" onClick={handleSave} disabled={!isDirty || mutation.isPending}>
-          {mutation.isPending ? "Saving..." : "Save Changes"}
-        </Button>
-
-        {mutation.isSuccess && (
-          <Typography variant="body2" color="success.main">
-            Profile updated.
-          </Typography>
-        )}
-        {mutation.isError && (
-          <Typography variant="body2" color="error.main">
-            Failed to update profile. Please try again.
-          </Typography>
-        )}
-      </Stack>
+      <TextField label="Email" value={profile.email} size="small" disabled fullWidth />
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/pages/SettingsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SettingsPage.tsx
@@ -14,16 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-export * from "./case.dto";
-export * from "./case.model";
-export * from "./attachment.dto";
-export * from "./project.dto";
-export * from "./project.model";
-export * from "./deployment.dto";
-export * from "./deployment.model";
-export * from "./user.dto";
-export * from "./user.model";
-export * from "./adminUser.dto";
-export * from "./adminUser.model";
-export * from "./timecard.dto";
-export * from "./timecard.model";
+import Settings from "@components/settings/Settings";
+
+// Reached from More > Settings, mirroring the webapp's /admin route. Settings itself is
+// self-contained (components/settings/Settings.tsx) — this page is just its mount point, so it
+// stays trivial to move elsewhere again later.
+export default function SettingsPage() {
+  return <Settings />;
+}

--- a/apps/csm-portal/microapp/src/services/adminUsers.ts
+++ b/apps/csm-portal/microapp/src/services/adminUsers.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { USERS_SEARCH_ENDPOINT } from "@config/endpoints";
+import type { UserSearchFiltersDto, UserSearchPayloadDto, UserSearchResponseDto } from "@src/types";
+import { toAdminUser, type AdminUser } from "@src/types";
+import apiClient from "./apiClient";
+
+export interface AdminUserSearchResult {
+  users: AdminUser[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+const searchUsers = async (payload: UserSearchPayloadDto = {}): Promise<AdminUserSearchResult> => {
+  const { data } = await apiClient.post<UserSearchResponseDto>(USERS_SEARCH_ENDPOINT, payload);
+  const users = data.users.map(toAdminUser);
+  // The ServiceNow envelope omits `hasMore`; derive it the same way the webapp's
+  // normalizeUserSearchResponse does (csmUsers.ts).
+  const hasMore = data.hasMore ?? data.offset + users.length < data.total;
+  return { users, total: data.total, limit: data.limit, offset: data.offset, hasMore };
+};
+
+const ADMIN_USERS_PAGE_LIMIT = 20;
+
+export const adminUsers = {
+  // Mirrors the webapp's useSearchUsers.ts (POST /users/search), paged via infinite scroll —
+  // the mobile equivalent of CsmUsersPage's TablePagination.
+  infinite: (filters: UserSearchFiltersDto) =>
+    infiniteQueryOptions({
+      queryKey: ["admin-users", "infinite", filters],
+      queryFn: ({ pageParam }) =>
+        searchUsers({
+          filters,
+          sortBy: { field: "name", order: "asc" },
+          pagination: { offset: pageParam, limit: ADMIN_USERS_PAGE_LIMIT },
+        }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
+    }),
+};

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -41,7 +41,11 @@ export interface CaseSearchResult {
   hasMore: boolean;
 }
 
-const getAllCases = async (payload: CaseSearchPayloadDto = {}): Promise<CaseSearchResult> => {
+// Exported (not just used internally) so the Home dashboard's composition query can fan out
+// count-only searches (`pagination: { limit: 1 }`, read `.total`) without going through the
+// `cases.all` query-options wrapper — mirrors the webapp's useCaseComposition.ts, which calls its
+// api client directly for the same reason.
+export const getAllCases = async (payload: CaseSearchPayloadDto = {}): Promise<CaseSearchResult> => {
   const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
   return {
     items: data.cases.map(toCaseSummary),

--- a/apps/csm-portal/microapp/src/services/dashboard.ts
+++ b/apps/csm-portal/microapp/src/services/dashboard.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { queryOptions } from "@tanstack/react-query";
+import type { CaseSearchFiltersDto, CaseSeverity, CaseState } from "@src/types";
+import { ALL_SEVERITIES } from "@components/support/config";
+import { ASSIGNED_TO_ME_STATES, COMPOSITION_STATES } from "@components/home/config";
+import { getAllCases, type CaseSearchResult } from "./cases";
+
+// Mirrors the webapp's CaseComposition (useCaseComposition.ts): a 1-D breakdown by severity and a
+// 1-D breakdown by state, each over active cases only (closed excluded). The closed count is
+// returned separately so a large closed backlog can't skew the active totals.
+export interface CaseComposition {
+  bySeverity: Record<CaseSeverity, number>;
+  byState: Record<CaseState, number>;
+  severityTotal: number;
+  stateTotal: number;
+  closedTotal: number;
+}
+
+const EMPTY_RESULT: CaseSearchResult = { items: [], total: 0, limit: 0, offset: 0, hasMore: false };
+
+// The backend has no count/aggregation endpoint, so — like the webapp — this fans out
+// count-only searches (`limit: 1`, read `.total`): one per severity (scoped to active states) and
+// one per active state (scoped to every severity), plus one for the closed total. 11 requests,
+// fired in parallel.
+async function fetchComposition(): Promise<CaseComposition> {
+  const countOf = (filters: CaseSearchFiltersDto): Promise<number> =>
+    getAllCases({ filters: { types: ["case"], ...filters }, pagination: { limit: 1 } }).then((r) => r.total);
+
+  const [severityCounts, stateCounts, closedTotal] = await Promise.all([
+    Promise.all(
+      ALL_SEVERITIES.map((severity) =>
+        countOf({ severities: [severity], states: COMPOSITION_STATES }).then((n) => [severity, n] as const),
+      ),
+    ),
+    Promise.all(
+      COMPOSITION_STATES.map((state) =>
+        countOf({ states: [state], severities: ALL_SEVERITIES }).then((n) => [state, n] as const),
+      ),
+    ),
+    countOf({ states: ["closed"], severities: ALL_SEVERITIES }),
+  ]);
+
+  const bySeverity = Object.fromEntries(severityCounts) as Record<CaseSeverity, number>;
+  const byState = Object.fromEntries(stateCounts) as Record<CaseState, number>;
+  const severityTotal = severityCounts.reduce((sum, [, n]) => sum + n, 0);
+  const stateTotal = stateCounts.reduce((sum, [, n]) => sum + n, 0);
+
+  return { bySeverity, byState, severityTotal, stateTotal, closedTotal };
+}
+
+export const dashboard = {
+  // Same active-vs-closed split the webapp's dashboard donuts show; staleTime keeps a page
+  // revisit from re-firing all 11 requests immediately.
+  composition: () =>
+    queryOptions({
+      queryKey: ["dashboard", "composition"],
+      queryFn: fetchComposition,
+      staleTime: 60_000,
+    }),
+
+  // The signed-in user's own non-closed cases, newest-updated first — mirrors the webapp's
+  // MyAssignedCases widget, capped to a short preview (5) rather than paginated.
+  assignedToMe: (userId: string | null) =>
+    queryOptions({
+      queryKey: ["dashboard", "assigned-to-me", userId],
+      queryFn: () =>
+        userId
+          ? getAllCases({
+              filters: { types: ["case"], assignedUserIds: [userId], states: ASSIGNED_TO_ME_STATES },
+              sortBy: { field: "updatedOn", order: "desc" },
+              pagination: { limit: 5 },
+            })
+          : Promise.resolve(EMPTY_RESULT),
+      enabled: !!userId,
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/adminUser.dto.ts
+++ b/apps/csm-portal/microapp/src/types/adminUser.dto.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export type AdminUserType = "internal" | "customer";
+
+// Mirrors the webapp's SnUserRole (apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts).
+export type AdminUserRole =
+  | "internal"
+  | "agent"
+  | "admin"
+  | "commenter"
+  | "external"
+  | "customer"
+  | "customer_admin"
+  | "partner"
+  | "partner_admin";
+
+export type AdminUserSortField = "name" | "createdOn" | "updatedOn";
+export type AdminUserSortOrder = "asc" | "desc";
+
+/** User shape returned by the postgres data source. */
+export interface UserDto {
+  id: string;
+  userName: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string | null;
+  timezone?: string | null;
+  userType: AdminUserType;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * User shape returned by the ServiceNow data source. No `firstName`/`lastName`
+ * (use `name`), no `userType` (use `roles`), no `hasMore` on the envelope.
+ */
+export interface SnUserDto {
+  id: string;
+  userName: string;
+  name: string;
+  email: string;
+  timeZone?: string | null;
+  active: boolean;
+  createdOn: string;
+  updatedOn: string;
+  roles: string[];
+}
+
+export interface UserSearchFiltersDto {
+  searchQuery?: string;
+  /** ServiceNow data source only. */
+  roles?: AdminUserRole[];
+  /** ServiceNow data source only. */
+  active?: boolean;
+}
+
+export interface UserSearchPayloadDto {
+  pagination?: {
+    limit?: number;
+    offset?: number;
+  };
+  filters?: UserSearchFiltersDto;
+  sortBy?: {
+    field: AdminUserSortField;
+    order?: AdminUserSortOrder;
+  };
+}
+
+/** `/users/search` returns a `oneOf` (postgres `UserDto` vs ServiceNow `SnUserDto`). */
+export interface UserSearchResponseDto {
+  users: (UserDto | SnUserDto)[];
+  total: number;
+  limit: number;
+  offset: number;
+  /** Absent from the ServiceNow envelope; derived from `offset`/`total` when missing. */
+  hasMore?: boolean;
+}

--- a/apps/csm-portal/microapp/src/types/adminUser.model.ts
+++ b/apps/csm-portal/microapp/src/types/adminUser.model.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { AdminUserType, SnUserDto, UserDto } from "./adminUser.dto";
+
+/**
+ * Source-agnostic row the UI renders. Both {@link UserDto} and {@link SnUserDto}
+ * normalize into this so the list doesn't branch on the live data source —
+ * mirrors the webapp's NormalizedUser (csmUsers.ts).
+ */
+export interface AdminUser {
+  id: string;
+  userName: string;
+  name: string;
+  email: string;
+  timezone: string | null;
+  /** Present only from the postgres source. */
+  userType?: AdminUserType;
+  /** Present only from the ServiceNow source. */
+  active?: boolean;
+  /** Present only from the ServiceNow source. */
+  roles?: string[];
+}
+
+function isSnUser(u: UserDto | SnUserDto): u is SnUserDto {
+  return "name" in u || "active" in u || "roles" in u;
+}
+
+export function toAdminUser(u: UserDto | SnUserDto): AdminUser {
+  if (isSnUser(u)) {
+    return {
+      id: u.id,
+      userName: u.userName,
+      name: u.name?.trim() || "",
+      email: u.email,
+      timezone: u.timeZone ?? null,
+      active: u.active,
+      roles: u.roles,
+    };
+  }
+  return {
+    id: u.id,
+    userName: u.userName,
+    name: `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim(),
+    email: u.email,
+    timezone: u.timezone ?? null,
+    userType: u.userType,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a Settings section, mirroring the webapp's admin panel (`CsmAdminLayout` + `CsmUsersPage`): a Users tab with search/role/status filtering backed by `POST /users/search`, plus Roles/Groups/Permissions as WIP tabs reusing the existing `ComingSoonPage` (same copy as the webapp's `CsmComingSoonPage` for those sections).
- Reached from More > Settings, placed last to match the webapp's `CSM_NAV_ITEMS` order.
- New types/service mirror the webapp's `csmUsers.ts` field-for-field (the `oneOf` postgres/ServiceNow user shapes, normalized into one shape), paged via infinite scroll — the mobile equivalent of the webapp's table + `TablePagination`.
- The `Settings` component is deliberately self-contained (owns its own tab state, filters, and data fetching) so it can be relocated to a different page later without threading props through.
- Adds an optional `blockedOn` prop to the shared `ComingSoonPage` for parity with the webapp's version.

## Test plan
- [x] `eslint` clean
- [x] `vite build` clean
- [x] `tsc --noEmit` clean (worked around the pre-existing, unrelated `ignoreDeprecations` TS-version mismatch to confirm no real type errors)
- [x] Manually verified layout in a browser: More page lists Settings last with the gear icon; Settings page renders the Users/Roles(WIP)/Groups(WIP)/Permissions tabs, search bar, and filter icon correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings page accessible from the More section, including an admin Users tab with debounced search, role/status filtering, and infinite pagination.
  * Added admin user cards with loading skeletons, plus a filters sheet for mobile-style selection.
  * Updated the home experience with “Assigned to me” and case composition donut widgets.
  * Introduced upcoming Settings tabs for roles, groups, and permissions (work-in-progress).
* **Improvements**
  * Simplified the Profile page to show read-only details only.
  * Enhanced “Coming Soon” cards with optional “Blocked on” text and improved spacing/layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->