### PR TITLE
[CSM][BE] Add incident create/get and problem search passthrough endpoints

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -176,6 +176,7 @@ backend/
 │       ├── products.go                   # HTTP handlers for product endpoints
 │       ├── projects.go                   # HTTP handlers for project endpoints
 │       ├── incidents.go                  # HTTP handlers for incident endpoints (ServiceNow only)
+│       ├── problems.go                   # HTTP handlers for problem endpoints (ServiceNow only)
 │       ├── updates.go                    # HTTP handlers for updates endpoints
 │       └── users.go                      # HTTP handlers for user endpoints
 ├── .env                        # Local config (git-ignored)
@@ -271,6 +272,12 @@ backend/
 ### Incidents
 
 - `POST /incidents/search` — Search incidents; optional `filters` (`searchQuery`, `priorities`, `parentIds`) and `sortBy` (`field`: `createdOn`/`updatedOn`/`openedOn`, `order`) (ServiceNow data source only)
+- `POST /incidents` — Create an incident (`callerId`, `category`, `serviceId`, `impact`, `urgency`, `subject` required; `subcategory`, `serviceOfferingId`, `configurationItemId`, `contactType`, `assignmentGroupId`, `assignedEngineerId`, `watchList`, `additionalComments`, `workNotes`, `parentId`, `changeRequestId`, `problemId`, `causedById` optional) (ServiceNow data source only)
+- `GET /incidents/{id}` — Get full incident detail by ID (ServiceNow data source only)
+
+### Problems
+
+- `POST /problems/search` — Search problems; optional `filters` (`searchQuery`) (ServiceNow data source only)
 
 ## Run Locally
 
@@ -324,4 +331,19 @@ curl -X POST http://localhost:8080/incidents/search \
   -H "x-jwt-assertion: $JWT" \
   -H "Content-Type: application/json" \
   -d '{"filters":{"searchQuery":"outage","priorities":["CRITICAL"]},"pagination":{"limit":10,"offset":0}}'
+
+# Create an incident
+curl -X POST http://localhost:8080/incidents \
+  -H "x-jwt-assertion: $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"callerId":"<caller-id>","category":"SECURITY","serviceId":"<service-id>","impact":"HIGH","urgency":"HIGH","subject":"Suspicious login activity"}'
+
+# Get an incident by ID
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/incidents/<incident-id>
+
+# Search problems
+curl -X POST http://localhost:8080/problems/search \
+  -H "x-jwt-assertion: $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"filters":{"searchQuery":"database"},"pagination":{"limit":10,"offset":0}}'
 ```

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -65,6 +65,7 @@ func main() {
 	conversationHandler := handler.NewConversationHandler(entityClient)
 	taskSlaHandler := handler.NewTaskSlaHandler(entityClient)
 	incidentHandler := handler.NewIncidentHandler(entityClient)
+	problemHandler := handler.NewProblemHandler(entityClient)
 
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
@@ -149,6 +150,9 @@ func main() {
 	mux.HandleFunc("POST /slas/search", taskSlaHandler.SearchTaskSlas)
 	mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
 	mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)
+	mux.HandleFunc("POST /incidents", incidentHandler.CreateIncident)
+	mux.HandleFunc("GET /incidents/{id}", incidentHandler.GetIncident)
+	mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 
 	addr := envOrDefault("PORT", ":8080")
 

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -126,6 +126,24 @@ func (c *Client) SearchIncidents(ctx context.Context, body []byte) ([]byte, erro
 	return c.do(ctx, http.MethodPost, "/incidents/search", body)
 }
 
+// CreateIncident calls POST /incidents on the entity service to create a new incident.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) CreateIncident(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/incidents", body)
+}
+
+// GetIncident calls GET /incidents/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) GetIncident(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/incidents/%s", url.PathEscape(id)), nil)
+}
+
+// SearchProblems calls POST /problems/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *Client) SearchProblems(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/problems/search", body)
+}
+
 // PostDeployment calls POST /deployments on the entity service to create a new deployment.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -345,11 +345,40 @@ func (m *mockEntityProductClient) SearchProductVersions(ctx context.Context, pro
 
 type mockEntityIncidentClient struct {
 	searchIncidentsFn func(ctx context.Context, body []byte) ([]byte, error)
+	createIncidentFn  func(ctx context.Context, body []byte) ([]byte, error)
+	getIncidentFn     func(ctx context.Context, id string) ([]byte, error)
 }
 
 func (m *mockEntityIncidentClient) SearchIncidents(ctx context.Context, body []byte) ([]byte, error) {
 	if m.searchIncidentsFn != nil {
 		return m.searchIncidentsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityIncidentClient) CreateIncident(ctx context.Context, body []byte) ([]byte, error) {
+	if m.createIncidentFn != nil {
+		return m.createIncidentFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityIncidentClient) GetIncident(ctx context.Context, id string) ([]byte, error) {
+	if m.getIncidentFn != nil {
+		return m.getIncidentFn(ctx, id)
+	}
+	return []byte(`{}`), nil
+}
+
+// ----- mock entity problem client -----
+
+type mockEntityProblemClient struct {
+	searchProblemsFn func(ctx context.Context, body []byte) ([]byte, error)
+}
+
+func (m *mockEntityProblemClient) SearchProblems(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchProblemsFn != nil {
+		return m.searchProblemsFn(ctx, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -30,6 +30,8 @@ import (
 // entityIncidentClient abstracts the entity service incident operations used by IncidentHandler.
 type entityIncidentClient interface {
 	SearchIncidents(ctx context.Context, body []byte) ([]byte, error)
+	CreateIncident(ctx context.Context, body []byte) ([]byte, error)
+	GetIncident(ctx context.Context, id string) ([]byte, error)
 }
 
 // searchIncidentsRequest mirrors the enum/format-constrained fields of the documented
@@ -134,5 +136,66 @@ func (h *IncidentHandler) SearchIncidents(w http.ResponseWriter, r *http.Request
 	}
 
 	// TODO: Unmarshal result and filter to only the fields required by the frontend.
+	writeJSON(w, http.StatusOK, result)
+}
+
+// CreateIncident handles POST /incidents.
+func (h *IncidentHandler) CreateIncident(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	// TODO: Decode into a typed CreateIncidentRequest and validate fields before forwarding.
+
+	result, err := h.entity.CreateIncident(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateIncident failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to create incident.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
+}
+
+// GetIncident handles GET /incidents/{id}.
+func (h *IncidentHandler) GetIncident(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetIncident(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetIncident failed", "userID", user.UserID, "incidentID", id, "err", err)
+		mapUpstreamError(w, err, "Failed to retrieve incident.")
+		return
+	}
+
 	writeJSON(w, http.StatusOK, result)
 }

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -58,7 +58,114 @@ var (
 	}
 	validIncidentSortFields = map[string]bool{"createdOn": true, "updatedOn": true, "openedOn": true}
 	validIncidentSortOrders = map[string]bool{"asc": true, "desc": true}
+
+	validIncidentCategories    = map[string]bool{"INQUIRY": true, "SERVICE_INTERRUPTION": true, "SECURITY": true}
+	validIncidentSubcategories = map[string]bool{
+		"DHCP": true, "ORACLE": true, "CPU": true, "KEYBOARD": true, "DOS_DDOS": true,
+		"PRIVILEGE_ESCALATIONS": true, "THREAT_INTELLIGENCE": true, "SCANS_AND_PROBES": true,
+		"APPLICATION_SECURITY": true, "CONFIG_CHANGE_REQUEST": true, "IP_ADDRESS": true,
+		"FULL_OUTAGE": true, "SQL_SERVER": true, "SLOWNESS": true, "MEMORY": true, "MOUSE": true,
+		"PRIVACY": true, "DATA_BREACH": true, "SYSTEM_COMPROMISES": true, "DNS": true, "OS": true,
+		"DISK": true, "VPN": true, "MALWARE": true, "VULNERABILITY": true, "UNAUTHORIZED_ACCESS": true,
+		"IDENTITY_PROTECTION": true, "PHISHING": true, "IMPROPER_CONFIGURATION": true,
+		"INFORMATION_REQUEST": true, "DB2": true, "PARTIAL_OUTAGE": true, "EMAIL": true,
+		"MONITOR": true, "WIRELESS": true,
+	}
+	validIncidentContactTypes = map[string]bool{
+		"SELF_SERVICE": true, "EMAIL": true, "WALK_IN": true, "AZURE": true, "EMAIL_INTERNAL": true,
+		"SITE_247": true, "DIRECT": true, "PHONE": true, "SENTINEL": true, "VIRTUAL_AGENT": true,
+		"CHAT": true, "EMAIL_EXTERNAL": true,
+	}
+	validIncidentImpacts   = map[string]bool{"HIGH": true, "MEDIUM": true, "LOW": true}
+	validIncidentUrgencies = map[string]bool{"HIGH": true, "MEDIUM": true, "LOW": true}
 )
+
+// createIncidentRequest mirrors the enum/format-constrained fields of the documented
+// CreateIncidentPayload schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+type createIncidentRequest struct {
+	CallerID            string   `json:"callerId"`
+	Category            string   `json:"category"`
+	Subcategory         string   `json:"subcategory"`
+	ServiceID           string   `json:"serviceId"`
+	ServiceOfferingID   string   `json:"serviceOfferingId"`
+	ConfigurationItemID string   `json:"configurationItemId"`
+	ContactType         string   `json:"contactType"`
+	Impact              string   `json:"impact"`
+	Urgency             string   `json:"urgency"`
+	AssignmentGroupID   string   `json:"assignmentGroupId"`
+	AssignedEngineerID  string   `json:"assignedEngineerId"`
+	Subject             string   `json:"subject"`
+	WatchList           []string `json:"watchList"`
+	ParentID            string   `json:"parentId"`
+	ChangeRequestID     string   `json:"changeRequestId"`
+	ProblemID           string   `json:"problemId"`
+	CausedByID          string   `json:"causedById"`
+}
+
+// validateCreateIncidentBody checks the required fields, enum fields (category, subcategory,
+// contactType, impact, urgency), and every UUID-formatted field with a known, fixed set of
+// valid values so obviously invalid requests are rejected before reaching the entity service.
+func validateCreateIncidentBody(body []byte) bool {
+	var req createIncidentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if req.CallerID == "" || !uuidRe.MatchString(req.CallerID) {
+		return false
+	}
+	if !validIncidentCategories[req.Category] {
+		return false
+	}
+	if req.Subcategory != "" && !validIncidentSubcategories[req.Subcategory] {
+		return false
+	}
+	if req.ServiceID == "" || !uuidRe.MatchString(req.ServiceID) {
+		return false
+	}
+	if req.ServiceOfferingID != "" && !uuidRe.MatchString(req.ServiceOfferingID) {
+		return false
+	}
+	if req.ConfigurationItemID != "" && !uuidRe.MatchString(req.ConfigurationItemID) {
+		return false
+	}
+	if req.ContactType != "" && !validIncidentContactTypes[req.ContactType] {
+		return false
+	}
+	if !validIncidentImpacts[req.Impact] {
+		return false
+	}
+	if !validIncidentUrgencies[req.Urgency] {
+		return false
+	}
+	if req.AssignmentGroupID != "" && !uuidRe.MatchString(req.AssignmentGroupID) {
+		return false
+	}
+	if req.AssignedEngineerID != "" && !uuidRe.MatchString(req.AssignedEngineerID) {
+		return false
+	}
+	if req.Subject == "" {
+		return false
+	}
+	for _, w := range req.WatchList {
+		if !uuidRe.MatchString(w) {
+			return false
+		}
+	}
+	if req.ParentID != "" && !uuidRe.MatchString(req.ParentID) {
+		return false
+	}
+	if req.ChangeRequestID != "" && !uuidRe.MatchString(req.ChangeRequestID) {
+		return false
+	}
+	if req.ProblemID != "" && !uuidRe.MatchString(req.ProblemID) {
+		return false
+	}
+	if req.CausedByID != "" && !uuidRe.MatchString(req.CausedByID) {
+		return false
+	}
+	return true
+}
 
 // validateSearchIncidentsBody checks the filter/sort fields with a known, fixed set of
 // valid values (priority enums, parentIds as UUIDs, sort field/order enums) so obviously
@@ -164,7 +271,10 @@ func (h *IncidentHandler) CreateIncident(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// TODO: Decode into a typed CreateIncidentRequest and validate fields before forwarding.
+	if !validateCreateIncidentBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
 
 	result, err := h.entity.CreateIncident(r.Context(), body)
 	if err != nil {

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -140,3 +140,162 @@ func TestSearchIncidents(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateIncident(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
+		const reqPayload = `{"callerId":"11111111-1111-1111-1111-111111111111","category":"SECURITY","serviceId":"22222222-2222-2222-2222-222222222222","impact":"HIGH","urgency":"HIGH","subject":"Something broke"}`
+		var capturedBody []byte
+		client := &mockEntityIncidentClient{
+			createIncidentFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"message":"incident created","incident":{"id":"33333333-3333-3333-3333-333333333333","number":"INC0002"}}`), nil
+			},
+		}
+		h := NewIncidentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["message"] != "incident created" {
+			t.Errorf("message = %v, want %q", resp["message"], "incident created")
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to create incident.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityIncidentClient{
+					createIncidentFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewIncidentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.CreateIncident(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestGetIncident(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := httptest.NewRequest(http.MethodGet, "/incidents/inc-1", nil)
+		r.SetPathValue("id", "inc-1")
+		w := httptest.NewRecorder()
+		h.GetIncident(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty incident ID", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/incidents/", nil))
+		w := httptest.NewRecorder()
+		h.GetIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID incident ID", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/incidents/inc-42", nil))
+		r.SetPathValue("id", "inc-42")
+		w := httptest.NewRecorder()
+		h.GetIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("passes ID to upstream and returns 200 with response", func(t *testing.T) {
+		const incidentID = "11111111-1111-1111-1111-111111111111"
+		var capturedID string
+		client := &mockEntityIncidentClient{
+			getIncidentFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"id":"` + incidentID + `","number":"INC0001"}`), nil
+			},
+		}
+		h := NewIncidentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/incidents/"+incidentID, nil))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.GetIncident(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != incidentID {
+			t.Errorf("upstream received id %q, want %q", capturedID, incidentID)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["number"] != "INC0001" {
+			t.Errorf("number = %v, want %q", resp["number"], "INC0001")
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		const incidentID = "11111111-1111-1111-1111-111111111111"
+		for _, tc := range upstreamErrors("Failed to retrieve incident.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityIncidentClient{
+					getIncidentFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewIncidentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/incidents/"+incidentID, nil))
+				r.SetPathValue("id", incidentID)
+				w := httptest.NewRecorder()
+				h.GetIncident(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -172,6 +172,36 @@ func TestCreateIncident(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects missing required fields", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`{"category":"SECURITY","impact":"HIGH","urgency":"HIGH","subject":"Something broke"}`)))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects unknown category enum value", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`{"callerId":"11111111-1111-1111-1111-111111111111","category":"NOT_A_CATEGORY","serviceId":"22222222-2222-2222-2222-222222222222","impact":"HIGH","urgency":"HIGH","subject":"Something broke"}`)))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID callerId", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`{"callerId":"not-a-uuid","category":"SECURITY","serviceId":"22222222-2222-2222-2222-222222222222","impact":"HIGH","urgency":"HIGH","subject":"Something broke"}`)))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
 	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
 		const reqPayload = `{"callerId":"11111111-1111-1111-1111-111111111111","category":"SECURITY","serviceId":"22222222-2222-2222-2222-222222222222","impact":"HIGH","urgency":"HIGH","subject":"Something broke"}`
 		var capturedBody []byte
@@ -198,6 +228,7 @@ func TestCreateIncident(t *testing.T) {
 	})
 
 	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		const validPayload = `{"callerId":"11111111-1111-1111-1111-111111111111","category":"SECURITY","serviceId":"22222222-2222-2222-2222-222222222222","impact":"HIGH","urgency":"HIGH","subject":"Something broke"}`
 		for _, tc := range upstreamErrors("Failed to create incident.") {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
@@ -207,7 +238,7 @@ func TestCreateIncident(t *testing.T) {
 					},
 				}
 				h := NewIncidentHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(validPayload)))
 				w := httptest.NewRecorder()
 				h.CreateIncident(w, r)
 				assertStatus(t, w, tc.wantCode)
@@ -221,8 +252,8 @@ func TestCreateIncident(t *testing.T) {
 func TestGetIncident(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewIncidentHandler(&mockEntityIncidentClient{})
-		r := httptest.NewRequest(http.MethodGet, "/incidents/inc-1", nil)
-		r.SetPathValue("id", "inc-1")
+		r := httptest.NewRequest(http.MethodGet, "/incidents/11111111-1111-1111-1111-111111111111", nil)
+		r.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
 		w := httptest.NewRecorder()
 		h.GetIncident(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)

--- a/apps/csm-portal/backend/internal/handler/problems.go
+++ b/apps/csm-portal/backend/internal/handler/problems.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityProblemClient abstracts the entity service problem operations used by ProblemHandler.
+type entityProblemClient interface {
+	SearchProblems(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// ProblemHandler handles HTTP requests for problem operations, delegating to the
+// entity service for data access.
+type ProblemHandler struct {
+	entity entityProblemClient
+}
+
+// NewProblemHandler creates a ProblemHandler backed by the given entity client.
+func NewProblemHandler(entity entityProblemClient) *ProblemHandler {
+	return &ProblemHandler{entity: entity}
+}
+
+// SearchProblems handles POST /problems/search.
+func (h *ProblemHandler) SearchProblems(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchProblems(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProblems failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search problems.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/problems_test.go
+++ b/apps/csm-portal/backend/internal/handler/problems_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSearchProblems(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := httptest.NewRequest(http.MethodPost, "/problems/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchProblems(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/problems/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchProblems(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/problems/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchProblems(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"filters":{"searchQuery":"outage"},"pagination":{"limit":10,"offset":0}}`
+		var capturedBody []byte
+		client := &mockEntityProblemClient{
+			searchProblemsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"problems":[{"id":"11111111-1111-1111-1111-111111111111","number":"PRB0001"}],"total":1}`), nil
+			},
+		}
+		h := NewProblemHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/problems/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchProblems(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search problems.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityProblemClient{
+					searchProblemsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewProblemHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/problems/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchProblems(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2676,6 +2676,159 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /incidents:
+    post:
+      summary: Create a new incident (ServiceNow data source only).
+      operationId: postIncidents
+      requestBody:
+        description: Incident create payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIncidentPayload'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateIncidentResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Referenced resource not found (e.g. caller, service, or assignment group).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /incidents/{id}:
+    get:
+      summary: Get an incident by ID (ServiceNow data source only).
+      operationId: getIncidentById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Incident detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentDetail'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Incident not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /problems/search:
+    post:
+      summary: Search problems (ServiceNow data source only).
+      operationId: postProblemsSearch
+      requestBody:
+        description: Problem search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProblemSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -5839,3 +5992,242 @@ components:
           format: date-time
         updatedBy:
           type: string
+
+    CreateIncidentPayload:
+      type: object
+      required: [callerId, category, serviceId, impact, urgency, subject]
+      properties:
+        callerId:
+          type: string
+          format: uuid
+        category:
+          type: string
+          enum: [INQUIRY, SERVICE_INTERRUPTION, SECURITY]
+        subcategory:
+          type: string
+          enum: [DHCP, ORACLE, CPU, KEYBOARD, DOS_DDOS, PRIVILEGE_ESCALATIONS, THREAT_INTELLIGENCE, SCANS_AND_PROBES, APPLICATION_SECURITY, CONFIG_CHANGE_REQUEST, IP_ADDRESS, FULL_OUTAGE, SQL_SERVER, SLOWNESS, MEMORY, MOUSE, PRIVACY, DATA_BREACH, SYSTEM_COMPROMISES, DNS, OS, DISK, VPN, MALWARE, VULNERABILITY, UNAUTHORIZED_ACCESS, IDENTITY_PROTECTION, PHISHING, IMPROPER_CONFIGURATION, INFORMATION_REQUEST, DB2, PARTIAL_OUTAGE, EMAIL, MONITOR, WIRELESS]
+        serviceId:
+          type: string
+          format: uuid
+        serviceOfferingId:
+          type: string
+          format: uuid
+        configurationItemId:
+          type: string
+          format: uuid
+        contactType:
+          type: string
+          enum: [SELF_SERVICE, EMAIL, WALK_IN, AZURE, EMAIL_INTERNAL, SITE_247, DIRECT, PHONE, SENTINEL, VIRTUAL_AGENT, CHAT, EMAIL_EXTERNAL]
+        impact:
+          type: string
+          enum: [HIGH, MEDIUM, LOW]
+        urgency:
+          type: string
+          enum: [HIGH, MEDIUM, LOW]
+        assignmentGroupId:
+          type: string
+          format: uuid
+        assignedEngineerId:
+          type: string
+          format: uuid
+        subject:
+          type: string
+        watchList:
+          type: array
+          items:
+            type: string
+            format: uuid
+        additionalComments:
+          type: string
+        workNotes:
+          type: string
+        parentId:
+          type: string
+          format: uuid
+        changeRequestId:
+          type: string
+          format: uuid
+        problemId:
+          type: string
+          format: uuid
+        causedById:
+          type: string
+          format: uuid
+
+    CreateIncidentResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        incident:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            number:
+              type: string
+            createdOn:
+              type: string
+              format: date-time
+            createdBy:
+              type: string
+
+    IncidentWatchListItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        email:
+          type: string
+
+    IncidentDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        openedOn:
+          type: string
+          nullable: true
+        subject:
+          type: string
+          nullable: true
+        caller:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        priority:
+          type: string
+          nullable: true
+          enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
+        state:
+          type: string
+          nullable: true
+          enum: [NEW, IN_PROGRESS, ON_HOLD, RESOLVED, CLOSED, CANCELLED]
+        category:
+          type: string
+          nullable: true
+          enum: [INQUIRY, SERVICE_INTERRUPTION, SECURITY]
+        subcategory:
+          type: string
+          nullable: true
+          enum: [DHCP, ORACLE, CPU, KEYBOARD, DOS_DDOS, PRIVILEGE_ESCALATIONS, THREAT_INTELLIGENCE, SCANS_AND_PROBES, APPLICATION_SECURITY, CONFIG_CHANGE_REQUEST, IP_ADDRESS, FULL_OUTAGE, SQL_SERVER, SLOWNESS, MEMORY, MOUSE, PRIVACY, DATA_BREACH, SYSTEM_COMPROMISES, DNS, OS, DISK, VPN, MALWARE, VULNERABILITY, UNAUTHORIZED_ACCESS, IDENTITY_PROTECTION, PHISHING, IMPROPER_CONFIGURATION, INFORMATION_REQUEST, DB2, PARTIAL_OUTAGE, EMAIL, MONITOR, WIRELESS]
+        parent:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        assignmentGroup:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        assignedTo:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        service:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        serviceOffering:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        configurationItem:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        contactType:
+          type: string
+          nullable: true
+          enum: [SELF_SERVICE, EMAIL, WALK_IN, AZURE, EMAIL_INTERNAL, SITE_247, DIRECT, PHONE, SENTINEL, VIRTUAL_AGENT, CHAT, EMAIL_EXTERNAL]
+        impact:
+          type: string
+          nullable: true
+          enum: [HIGH, MEDIUM, LOW]
+        urgency:
+          type: string
+          nullable: true
+          enum: [HIGH, MEDIUM, LOW]
+        changeRequest:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        problem:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        causedBy:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        additionalComments:
+          type: string
+          nullable: true
+        workNotes:
+          type: string
+          nullable: true
+        watchList:
+          type: array
+          items:
+            $ref: '#/components/schemas/IncidentWatchListItem'
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
+
+    ProblemSearchPayload:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            searchQuery:
+              type: string
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+
+    Problem:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        subject:
+          type: string
+          nullable: true
+
+    ProblemSearchResponse:
+      type: object
+      properties:
+        problems:
+          type: array
+          items:
+            $ref: '#/components/schemas/Problem'
+        total:
+          type: integer
+          description: Total number of matching problems
+        limit:
+          type: integer
+        offset:
+          type: integer


### PR DESCRIPTION
## Summary
- Wires the csm-portal backend to entity-service's new incident/problem endpoints (#1127), backed by ServiceNow
- `entity.Client` gains `CreateIncident`, `GetIncident`, `SearchProblems` — raw `[]byte` passthrough, same pattern as existing endpoints
- `IncidentHandler` gains `CreateIncident` (`POST /incidents`, 201) and `GetIncident` (`GET /incidents/{id}`, UUID-validated path param)
- New `ProblemHandler` (`internal/handler/problems.go`) handles `POST /problems/search`
- Adds the corresponding OpenAPI paths/schemas (`CreateIncidentPayload`/`CreateIncidentResponse`, `IncidentDetail`, `ProblemSearchPayload`/`ProblemSearchResponse`) and README documentation

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (added handler tests: unauthenticated → 401, body >1MiB → 413, invalid JSON → 400, invalid/empty UUID → 400, successful passthrough, upstream error mapping including 404)
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] Manually started the server locally and confirmed `GET /health` returns 200
- [ ] Manual: exercise `POST /incidents`, `GET /incidents/{id}`, `POST /problems/search` against a running entity service with ServiceNow data source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added incident creation with `POST /incidents`.
  - Added detailed incident retrieval with `GET /incidents/{id}`.
  - Added problem search with `POST /problems/search`.
  - Added request validation, authentication, error handling, and documented API schemas and examples.

- **Tests**
  - Added coverage for authentication, validation, request limits, successful responses, and upstream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->