### PR TITLE
[CSM Portal Microapp] Fix build break, text-overflow, and simplify Assigned to me

### DIFF
--- a/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
+++ b/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
@@ -27,7 +27,7 @@ export function AnnouncementCard({ item }: { item: CaseSummary }) {
     <Card variant="outlined" sx={{ p: 2 }}>
       <Stack gap={1}>
         <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
-          <Typography variant="subtitle2" noWrap>
+          <Typography variant="subtitle2" noWrap sx={{ minWidth: 0 }}>
             {item.number || "—"}
           </Typography>
           <AnnouncementStateChip state={item.state} />

--- a/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
@@ -41,7 +41,7 @@ export function AssignedToMeSection() {
         </Button>
       </Stack>
 
-      {isLoading ? (
+      {isPending ? (
         <Stack gap={1.5}>
           {Array.from({ length: 3 }).map((_, index) => (
             <CaseCardSkeleton key={index} />

--- a/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
@@ -14,21 +14,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Button, Stack, Typography } from "@wso2/oxygen-ui";
+import { Card, Stack, Typography } from "@wso2/oxygen-ui";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
 import { currentUser } from "@src/services/currentUser";
 import { dashboard } from "@src/services/dashboard";
 import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
-import { EmptyState } from "@components/support/EmptyState";
 import { ErrorState } from "@components/support/ErrorState";
+import { RefreshButton } from "./RefreshButton";
 
 // The signed-in user's own non-closed cases — mirrors the webapp's "Assigned to me" widget
 // (apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx), capped to a
-// short 5-item preview with a "View all" link out to Support, rather than paginated in place.
+// short 5-item preview. No "View all" (Support already covers the full list) — instead a
+// RefreshButton, same as the webapp's widget header.
 export function AssignedToMeSection() {
   const { data: currentUserId } = useQuery(currentUser.id());
-  const { data, isPending, isError, refetch } = useQuery(dashboard.assignedToMe(currentUserId ?? null));
+  const { data, isPending, isFetching, isError, dataUpdatedAt, refetch } = useQuery(
+    dashboard.assignedToMe(currentUserId ?? null),
+  );
 
   const items = data?.items ?? [];
 
@@ -36,9 +38,12 @@ export function AssignedToMeSection() {
     <Stack gap={1.5}>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <Typography variant="subtitle1">Assigned to me</Typography>
-        <Button component={Link} to="/support" variant="text" size="small" disableRipple>
-          View all
-        </Button>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh assigned cases"
+        />
       </Stack>
 
       {isPending ? (
@@ -50,7 +55,14 @@ export function AssignedToMeSection() {
       ) : isError ? (
         <ErrorState onRetry={() => void refetch()} />
       ) : items.length === 0 ? (
-        <EmptyState message="No cases assigned to you." />
+        // Lighter than the shared EmptyState (no icon, less padding) — a big "nothing here"
+        // block reads as too prominent for the first thing on the home page — but still boxed
+        // in a card so it's clearly this section's content, not blank/broken-looking space.
+        <Card variant="outlined" sx={{ p: 1.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            No cases assigned to you.
+          </Typography>
+        </Card>
       ) : (
         <Stack gap={1.5}>
           {items.map((item) => (

--- a/apps/csm-portal/microapp/src/components/home/RefreshButton.tsx
+++ b/apps/csm-portal/microapp/src/components/home/RefreshButton.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { RefreshCw } from "@wso2/oxygen-ui-icons-react";
+import { fromNow } from "@utils/dateTime";
+
+interface RefreshButtonProps {
+  /** Re-runs the widget's query. Wire to the react-query `refetch`. */
+  onRefresh: () => void;
+  /** True while a fetch is in flight; disables the control to avoid re-entrancy. */
+  isFetching: boolean;
+  /** react-query `dataUpdatedAt` (ms). When set, shows a "Last refreshed" hint. */
+  updatedAt?: number;
+  /** Accessible label / tooltip, e.g. "Refresh assigned cases". */
+  label: string;
+}
+
+// Reusable dashboard-widget refresh control — mirrors the webapp's RefreshButton
+// (apps/csm-portal/webapp/src/features/csm-dashboard/components/RefreshButton.tsx):
+// icon button + "Last refreshed X ago" hint, so refresh looks and behaves the same across apps.
+export function RefreshButton({ onRefresh, isFetching, updatedAt, label }: RefreshButtonProps) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      {updatedAt ? (
+        <Typography variant="caption" color="text.secondary">
+          Last refreshed {fromNow(new Date(updatedAt))}
+        </Typography>
+      ) : null}
+      <Tooltip title={label}>
+        {/* span wrapper so the tooltip still shows while the button is disabled */}
+        <span>
+          <IconButton size="small" onClick={onRefresh} disabled={isFetching} aria-label={label}>
+            <RefreshCw size={14} />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/CaseCard.tsx
+++ b/apps/csm-portal/microapp/src/components/support/CaseCard.tsx
@@ -50,13 +50,13 @@ export function CaseCard({ item }: { item: CaseSummary }) {
         </Stack>
 
         <Stack direction="row" justifyContent="space-between" alignItems="center" mt={0.5}>
-          <Stack direction="row" alignItems="center" gap={0.5}>
+          <Stack direction="row" alignItems="center" gap={0.5} flexShrink={0}>
             <Clock4 size={pxToRem(13)} color={theme.palette.text.secondary} />
             <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: pxToRem(12) }}>
               Updated {fromNow(item.updatedOn)}
             </Typography>
           </Stack>
-          <Typography variant="subtitle2" color="text.secondary" noWrap>
+          <Typography variant="subtitle2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
             {item.assignedEngineer?.name ?? "Unassigned"}
           </Typography>
         </Stack>

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -130,10 +130,10 @@ function CaseCommentsSection({ comments }: { comments: Comment[] }) {
       {comments.map((comment) => (
         <Stack key={comment.id} gap={0.5} sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
           <Stack direction="row" justifyContent="space-between" gap={2}>
-            <Typography variant="subtitle2" color="text.secondary" noWrap>
+            <Typography variant="subtitle2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
               {comment.createdBy}
             </Typography>
-            <Typography variant="subtitle2" color="text.secondary" noWrap>
+            <Typography variant="subtitle2" color="text.secondary" noWrap sx={{ flexShrink: 0 }}>
               {formatDate(comment.createdOn)}
             </Typography>
           </Stack>

--- a/apps/csm-portal/microapp/src/pages/MorePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/MorePage.tsx
@@ -22,6 +22,7 @@ import {
   Clock,
   Megaphone,
   RefreshCw,
+  Settings,
   Shield,
   type LucideIcon,
 } from "@wso2/oxygen-ui-icons-react";


### PR DESCRIPTION
## Summary
Three fixes bundled together:

**1. Build break from an incomplete #1134 merge conflict resolution.** `dev-app-csm-portal`'s build was broken:
- `MorePage.tsx` uses the `Settings` icon in `MORE_ITEMS`, but the conflict resolution dropped it from the import list.
- `AssignedToMeSection.tsx` destructured `isPending` (renamed from `isLoading` by a partial CodeRabbit-suggested commit), but the JSX below still referenced the old `isLoading` name.

**2. Text overflow on narrow screens** in three card layouts. Each has a `noWrap` `Typography` sitting alongside a sibling in a row flex container with no `minWidth: 0` guard — a flex item's default `min-width: auto` stops it from shrinking below its content's natural width, so on a narrow screen or with long content it overflows the card instead of ellipsizing:
- `AnnouncementCard.tsx`: case number vs. state chip
- `CaseCard.tsx`: assigned-engineer name vs. "Updated Xh ago" (also pins the timestamp side with `flexShrink: 0` so the name is the one that truncates)
- `CaseDetailPage.tsx`: comment author email vs. date (same fix)

Matches the `minWidth: 0` pattern already used correctly elsewhere in the app (`AttachmentsField.tsx`, `CompositionDonut.tsx`, `TimeSheetCard.tsx`).

**3. Simplified the Home page's "Assigned to me" widget**, mirroring the webapp's `MyAssignedCases` header more closely:
- Removed the "View all" link (Support already covers the full list).
- Added a `RefreshButton` (icon + "Last refreshed X ago"), ported from the webapp's `RefreshButton.tsx`.
- The empty state is now a plain line of text in a bordered card instead of the shared `EmptyState`'s icon+padding treatment, which read as too prominent for the first thing on the home page.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean (worked around the pre-existing, unrelated `ignoreDeprecations` TS-version mismatch to get a real type-check signal)
- [x] `vite build` clean
- [x] Manually verified live in the native shell with real data: refresh control shows "Last refreshed a few seconds ago", empty state renders correctly, composition donuts unaffected