### PR TITLE
[CSM][Web] Time cards: approved/rejected-by summary + state filter pagination fix

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1637,11 +1637,32 @@ export interface BeTimeCardCaseRef {
 export interface BeTimeCardView {
   id: string;
   totalTime: number;
+  /**
+   * The date the work was actually carried out (YYYY-MM-DD) — what the engineer
+   * picked in the log form, so it can be in the past. This is the field to
+   * display and to group/sort by ("the week this work happened").
+   */
+  workDate: string;
+  /**
+   * @deprecated Superseded by {@link workDate}; don't build new logic on it. It
+   * currently reads the same underlying field, so the two hold the same value.
+   */
   createdOn: string;
   hasBillable: boolean;
   state: BeTimeCardState;
   user?: BeTimeCardRef;
-  approvedBy?: BeTimeCardRef;
+  /**
+   * The approver who accepted the card — populated **only** when `state` is
+   * `approved`. ServiceNow does not record who rejected a card, so this is null
+   * for a `rejected` card (and for an undecided one); see {@link rejectionReason}.
+   */
+  approvedBy?: BeTimeCardRef | null;
+  /**
+   * The approver's comment when rejecting — populated **only** when `state` is
+   * `rejected`, otherwise null. It's the only trace a rejection leaves: there is
+   * no "rejected by" / "rejected on" field (a known backend gap).
+   */
+  rejectionReason?: string | null;
   project?: BeTimeCardRef;
   case?: BeTimeCardCaseRef;
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1677,9 +1677,14 @@ export interface BeTimeCardView {
  */
 export interface BeSearchTimeCardsFilters {
   projectIds?: string[];
+  /** Only time cards logged against this case. */
+  caseId?: string;
   /** Only time cards submitted by this user. */
   userId?: string;
-  /** Only time cards this user is eligible to approve (SN `approver_list`). */
+  /** Only time cards submitted by any of these users (multi-engineer filter). */
+  userIds?: string[];
+  /** Only time cards this user is eligible to approve (SN `approver_list`);
+   * the caller's own cards are excluded unconditionally when this is set. */
   approverId?: string;
   /** Only time cards actually approved by this user (SN `approved_by`). */
   approvedById?: string;

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1479,7 +1479,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
         <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
           <CaseTimeCardsPanel
             caseId={c.id}
-            projectId={c.projectId}
             onLogTime={() => setLogTimeOpen(true)}
           />
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/__tests__/useTimeSheets.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/__tests__/useTimeSheets.test.ts
@@ -17,7 +17,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { searchTimeCards } from "@features/csm-timecards/api/useTimeSheets";
 import type { BackendApi } from "@api/backend/client";
-import type { BeSearchTimeCardsResponse, BeTimeCardState, BeTimeCardView } from "@api/backend/types";
+import type {
+  BeSearchTimeCardsPayload,
+  BeSearchTimeCardsResponse,
+  BeTimeCardState,
+  BeTimeCardView,
+} from "@api/backend/types";
 
 // useTimeSheets.ts pulls in @config/apiConfig transitively (via useGetUsersMe)
 // and @api/backend/client directly; both read window.config at module load
@@ -46,12 +51,11 @@ function bePage(timeCards: BeTimeCardView[], total: number, offset: number, limi
   return { timeCards, total, offset, limit };
 }
 
-/** A mock `BackendApi` whose `post` returns each of `pages` in call order —
- * safe because `searchTimeCards` awaits each raw-page fetch before issuing
- * the next, so there's never more than one in-flight `post` call. */
-function mockApi(pages: BeSearchTimeCardsResponse[]): { api: BackendApi; post: ReturnType<typeof vi.fn> } {
-  let call = 0;
-  const post = vi.fn(async () => pages[Math.min(call++, pages.length - 1)]);
+/** A mock `BackendApi` whose `post` resolves to `page` and records every
+ * payload it was called with, so a test can assert on exactly what
+ * `searchTimeCards` forwarded on the wire. */
+function mockApi(page: BeSearchTimeCardsResponse): { api: BackendApi; post: ReturnType<typeof vi.fn> } {
+  const post = vi.fn(async () => page);
   const api: BackendApi = {
     get: vi.fn(),
     post: post as unknown as BackendApi["post"],
@@ -63,10 +67,14 @@ function mockApi(pages: BeSearchTimeCardsResponse[]): { api: BackendApi; post: R
   return { api, post };
 }
 
+function lastPayload(post: ReturnType<typeof vi.fn>): BeSearchTimeCardsPayload {
+  return post.mock.calls.at(-1)![1] as BeSearchTimeCardsPayload;
+}
+
 describe("searchTimeCards", () => {
-  it("makes a single request and returns the page as-is when no states filter is set", async () => {
+  it("makes a single request and returns the response as-is", async () => {
     const cards = [beCard("a", "submitted"), beCard("b", "approved")];
-    const { api, post } = mockApi([bePage(cards, 2, 0, 20)]);
+    const { api, post } = mockApi(bePage(cards, 2, 0, 20));
 
     const result = await searchTimeCards(api, undefined, { page: 0, rowsPerPage: 20 });
 
@@ -75,76 +83,50 @@ describe("searchTimeCards", () => {
     expect(result.total).toBe(2);
   });
 
-  it("doesn't walk forward when the first page already has enough matches", async () => {
-    const cards = [beCard("a", "approved"), beCard("b", "approved")];
-    const { api, post } = mockApi([bePage(cards, 2, 0, 20)]);
+  // states used to be filtered client-side over one raw page (with a
+  // walk-forward workaround for the 500 that combining it with projectIds
+  // used to cause); both are fixed upstream now, so this just forwards.
+  it("forwards states directly on the wire, in a single request", async () => {
+    const { api, post } = mockApi(bePage([beCard("a", "approved")], 1, 0, 20));
 
-    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 20 });
+    await searchTimeCards(api, { states: ["approved", "rejected"] }, { page: 0, rowsPerPage: 20 });
 
     expect(post).toHaveBeenCalledTimes(1);
-    expect(result.cards.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(lastPayload(post).filters?.states).toEqual(["approved", "rejected"]);
   });
 
-  // Regression test for the reported bug: a state filter reading as "no
-  // results" purely because the filter excluded everything on the first raw
-  // page, even though a matching card existed a page later.
-  it("walks forward into later raw pages to find matches the first page excluded", async () => {
-    const page0 = [beCard("a", "submitted"), beCard("b", "rejected")];
-    const page1 = [beCard("c", "approved")];
-    const { api, post } = mockApi([
-      bePage(page0, 3, 0, 2),
-      bePage(page1, 3, 2, 2),
-    ]);
+  // caseId used to always return total: 0 (worked around via projectIds +
+  // client-side filtering in useCaseTimeCards); fixed upstream now.
+  it("forwards caseId directly on the wire", async () => {
+    const { api, post } = mockApi(bePage([], 0, 0, 20));
 
-    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 2 });
+    await searchTimeCards(api, { caseId: "case-123" }, { page: 0, rowsPerPage: 20 });
 
-    expect(post).toHaveBeenCalledTimes(2);
-    expect(result.cards.map((c) => c.id)).toEqual(["c"]);
+    expect(lastPayload(post).filters?.caseId).toBe("case-123");
   });
 
-  it("stops walking once it has collected a full page of matches", async () => {
-    const page0 = [beCard("a", "submitted")];
-    const page1 = [beCard("b", "approved"), beCard("c", "approved")];
-    const page2 = [beCard("d", "approved")];
-    const { api, post } = mockApi([
-      bePage(page0, 10, 0, 2),
-      bePage(page1, 10, 2, 2),
-      bePage(page2, 10, 4, 2),
-    ]);
+  it("forwards userIds directly on the wire, alongside the single-user userId", async () => {
+    const { api, post } = mockApi(bePage([], 0, 0, 20));
 
-    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 2 });
+    await searchTimeCards(
+      api,
+      { userId: "me", userIds: ["eng-1", "eng-2"] },
+      { page: 0, rowsPerPage: 20 },
+    );
 
-    // Found 2 matches (== rowsPerPage) on the walk's first extra page — the
-    // third page must never be requested.
-    expect(post).toHaveBeenCalledTimes(2);
-    expect(result.cards.map((c) => c.id)).toEqual(["b", "c"]);
+    const filters = lastPayload(post).filters;
+    expect(filters?.userId).toBe("me");
+    expect(filters?.userIds).toEqual(["eng-1", "eng-2"]);
   });
 
-  it("stops walking once the scope is exhausted, without over-fetching", async () => {
-    const page0 = [beCard("a", "submitted")];
-    const page1 = [beCard("b", "rejected")];
-    const { api, post } = mockApi([
-      bePage(page0, 2, 0, 1),
-      bePage(page1, 2, 1, 1),
-    ]);
+  it("omits caseId/states/userIds from the payload when unset", async () => {
+    const { api, post } = mockApi(bePage([], 0, 0, 20));
 
-    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 1 });
+    await searchTimeCards(api, undefined, { page: 0, rowsPerPage: 20 });
 
-    // total is 2 and both raw records were consumed (offsets 0 and 1) — the
-    // walk must stop there rather than requesting a third, out-of-range page.
-    expect(post).toHaveBeenCalledTimes(2);
-    expect(result.cards).toHaveLength(0);
-  });
-
-  it("caps the walk at MAX_STATE_FILTER_WALK_PAGES extra requests even if nothing matches", async () => {
-    // A large unmatching scope (bigger than the walk budget could ever cover).
-    const pages = Array.from({ length: 10 }, (_, i) => bePage([beCard(`x${i}`, "submitted")], 1000, i, 1));
-    const { api, post } = mockApi(pages);
-
-    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 1 });
-
-    // 1 initial fetch + 5 walked extra fetches (MAX_STATE_FILTER_WALK_PAGES) = 6.
-    expect(post).toHaveBeenCalledTimes(6);
-    expect(result.cards).toHaveLength(0);
+    const filters = lastPayload(post).filters;
+    expect(filters?.caseId).toBeUndefined();
+    expect(filters?.states).toBeUndefined();
+    expect(filters?.userIds).toBeUndefined();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/__tests__/useTimeSheets.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/__tests__/useTimeSheets.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it, vi } from "vitest";
+import { searchTimeCards } from "@features/csm-timecards/api/useTimeSheets";
+import type { BackendApi } from "@api/backend/client";
+import type { BeSearchTimeCardsResponse, BeTimeCardState, BeTimeCardView } from "@api/backend/types";
+
+// useTimeSheets.ts pulls in @config/apiConfig transitively (via useGetUsersMe)
+// and @api/backend/client directly; both read window.config at module load
+// and throw outside a configured runtime. Mock both so importing
+// searchTimeCards below doesn't trip either (vi.mock calls are hoisted above
+// these imports by vitest). searchTimeCards takes its own BackendApi instance
+// directly, so neither the hook nor the real config is ever exercised here.
+vi.mock("@api/backend/client", () => ({ useBackendApi: vi.fn() }));
+vi.mock("@config/apiConfig", () => ({ apiConfig: { backendUrl: "https://example.test" } }));
+
+function beCard(id: string, state: BeTimeCardState): BeTimeCardView {
+  return {
+    id,
+    totalTime: 30,
+    workDate: "2026-07-13",
+    createdOn: "2026-07-13",
+    hasBillable: true,
+    state,
+    user: { id: "user-1", name: "Jane Doe" },
+    project: { id: "proj-1", name: "Acme" },
+    case: { id: "case-1", number: "CS0000001", name: "Issue" },
+  };
+}
+
+function bePage(timeCards: BeTimeCardView[], total: number, offset: number, limit: number): BeSearchTimeCardsResponse {
+  return { timeCards, total, offset, limit };
+}
+
+/** A mock `BackendApi` whose `post` returns each of `pages` in call order —
+ * safe because `searchTimeCards` awaits each raw-page fetch before issuing
+ * the next, so there's never more than one in-flight `post` call. */
+function mockApi(pages: BeSearchTimeCardsResponse[]): { api: BackendApi; post: ReturnType<typeof vi.fn> } {
+  let call = 0;
+  const post = vi.fn(async () => pages[Math.min(call++, pages.length - 1)]);
+  const api: BackendApi = {
+    get: vi.fn(),
+    post: post as unknown as BackendApi["post"],
+    patch: vi.fn(),
+    postEmpty: vi.fn(),
+    del: vi.fn(),
+    getBlob: vi.fn(),
+  };
+  return { api, post };
+}
+
+describe("searchTimeCards", () => {
+  it("makes a single request and returns the page as-is when no states filter is set", async () => {
+    const cards = [beCard("a", "submitted"), beCard("b", "approved")];
+    const { api, post } = mockApi([bePage(cards, 2, 0, 20)]);
+
+    const result = await searchTimeCards(api, undefined, { page: 0, rowsPerPage: 20 });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(result.cards.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(result.total).toBe(2);
+  });
+
+  it("doesn't walk forward when the first page already has enough matches", async () => {
+    const cards = [beCard("a", "approved"), beCard("b", "approved")];
+    const { api, post } = mockApi([bePage(cards, 2, 0, 20)]);
+
+    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 20 });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(result.cards.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  // Regression test for the reported bug: a state filter reading as "no
+  // results" purely because the filter excluded everything on the first raw
+  // page, even though a matching card existed a page later.
+  it("walks forward into later raw pages to find matches the first page excluded", async () => {
+    const page0 = [beCard("a", "submitted"), beCard("b", "rejected")];
+    const page1 = [beCard("c", "approved")];
+    const { api, post } = mockApi([
+      bePage(page0, 3, 0, 2),
+      bePage(page1, 3, 2, 2),
+    ]);
+
+    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 2 });
+
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(result.cards.map((c) => c.id)).toEqual(["c"]);
+  });
+
+  it("stops walking once it has collected a full page of matches", async () => {
+    const page0 = [beCard("a", "submitted")];
+    const page1 = [beCard("b", "approved"), beCard("c", "approved")];
+    const page2 = [beCard("d", "approved")];
+    const { api, post } = mockApi([
+      bePage(page0, 10, 0, 2),
+      bePage(page1, 10, 2, 2),
+      bePage(page2, 10, 4, 2),
+    ]);
+
+    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 2 });
+
+    // Found 2 matches (== rowsPerPage) on the walk's first extra page — the
+    // third page must never be requested.
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(result.cards.map((c) => c.id)).toEqual(["b", "c"]);
+  });
+
+  it("stops walking once the scope is exhausted, without over-fetching", async () => {
+    const page0 = [beCard("a", "submitted")];
+    const page1 = [beCard("b", "rejected")];
+    const { api, post } = mockApi([
+      bePage(page0, 2, 0, 1),
+      bePage(page1, 2, 1, 1),
+    ]);
+
+    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 1 });
+
+    // total is 2 and both raw records were consumed (offsets 0 and 1) — the
+    // walk must stop there rather than requesting a third, out-of-range page.
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(result.cards).toHaveLength(0);
+  });
+
+  it("caps the walk at MAX_STATE_FILTER_WALK_PAGES extra requests even if nothing matches", async () => {
+    // A large unmatching scope (bigger than the walk budget could ever cover).
+    const pages = Array.from({ length: 10 }, (_, i) => bePage([beCard(`x${i}`, "submitted")], 1000, i, 1));
+    const { api, post } = mockApi(pages);
+
+    const result = await searchTimeCards(api, { states: ["approved"] }, { page: 0, rowsPerPage: 1 });
+
+    // 1 initial fetch + 5 walked extra fetches (MAX_STATE_FILTER_WALK_PAGES) = 6.
+    expect(post).toHaveBeenCalledTimes(6);
+    expect(result.cards).toHaveLength(0);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
@@ -18,7 +18,7 @@
 // Card-level React Query hooks (a case's cards, create, decide), backed by
 // the real csm-portal-backend endpoints:
 //
-//   POST  /time-cards/search   list for a case (client-filtered, see below)
+//   POST  /time-cards/search   list for a case (server-side caseId filter)
 //   POST  /time-cards          create (already `submitted` — no draft step)
 //   PATCH /time-cards/{id}     accept/reject { state, leadComment }
 //
@@ -47,49 +47,35 @@ import {
   useDecideCard,
 } from "@features/csm-timecards/api/useTimeSheets";
 
-/** A case's time cards from the first `BE_MAX_PAGE_LIMIT` cards in its
- * project, plus whether that one page fell short of the project's full
- * `total` — some of the case's cards may not have been fetched if so. No
- * pagination UI here (unlike the three tabs on `/time-cards`) — a single
- * case logging more than a page's worth of time is not expected. */
+/** A case's time cards from the first `BE_MAX_PAGE_LIMIT` cards scoped to it,
+ * plus whether that one page fell short of the case's full `total` — some of
+ * the case's cards may not have been fetched if so. No pagination UI here
+ * (unlike the three tabs on `/time-cards`) — a single case logging more than
+ * a page's worth of time is not expected. */
 export interface CaseTimeCardsResult {
   cards: CsmTimeCard[];
   truncated: boolean;
 }
 
 /**
- * Time cards logged on a single case, newest first. `filters.caseId` is
- * documented in `openapi.yaml` and genuinely implemented end-to-end in
- * `entity-service` (`sn_time_card_service.go` forwards it straight through
- * to ServiceNow) — but confirmed live to be non-functional in practice: a
- * search scoped by nothing but a case's own id returns `total: 0`
- * unconditionally, even seconds/minutes/an hour after creating a card
- * against that exact case, and even though the very same project-scoped
- * search independently proves cards with that exact `case.id` exist (7 of
- * 10 cards in the project used to verify this). `userId` and `approverId`
- * were separately confirmed to work correctly (see {@link useMyTimeSheets}
- * and {@link useApprovalQueue} in `useTimeSheets.ts`) — this is specific to
- * `caseId`. Do not switch this back to `filters.caseId` without re-confirming
- * live first. Scopes to the case's own project instead (also requires
- * `filters.projectIds` to be non-empty — see {@link searchTimeCards}) and
- * filters the case's cards out client-side.
+ * Time cards logged on a single case, newest first. Scoped server-side by
+ * `filters.caseId` — a search scoped only by a case's own id used to return
+ * `total: 0` unconditionally (worked around here by scoping to the case's
+ * project and filtering to the case client-side instead), now fixed upstream
+ * on the entity-service data source (see PR #1133) and forwarded directly.
  */
 export function useCaseTimeCards(
   caseId: string | undefined,
-  projectId: string | undefined,
 ): UseQueryResult<CaseTimeCardsResult, Error> {
   const api = useBackendApi();
   return useQuery<CaseTimeCardsResult, Error>({
-    queryKey: [ApiQueryKeys.CASE_TIME_CARDS_SEARCH, caseId ?? "", projectId ?? ""],
+    queryKey: [ApiQueryKeys.CASE_TIME_CARDS_SEARCH, caseId ?? ""],
     queryFn: async (): Promise<CaseTimeCardsResult> => {
-      if (!caseId || !projectId) return { cards: [], truncated: false };
-      const { cards, total } = await searchTimeCards(api, { projectIds: [projectId] });
-      return {
-        cards: cards.filter((c) => c.caseId === caseId),
-        truncated: cards.length < total,
-      };
+      if (!caseId) return { cards: [], truncated: false };
+      const { cards, total } = await searchTimeCards(api, { caseId });
+      return { cards, truncated: cards.length < total };
     },
-    enabled: !!caseId && !!projectId,
+    enabled: !!caseId,
     staleTime: 5_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -41,6 +41,7 @@ import { resolveUserInfo } from "@utils/userClaims";
 import { useGetUsersMe } from "@features/settings/api/useGetUsersMe";
 import { useBackendApi, type BackendApi } from "@api/backend/client";
 import type {
+  BeSearchTimeCardsFilters,
   BeSearchTimeCardsPayload,
   BeSearchTimeCardsResponse,
   BeTimeCardState,
@@ -95,6 +96,12 @@ export function invalidateTimecards(queryClient: QueryClient): void {
  * is already whole minutes on the wire (see `usePostTimeCard`'s note on why),
  * which is also the unit the portal displays throughout — a direct
  * passthrough, no conversion needed.
+ *
+ * `workDate` falls back to the deprecated `createdOn` so a backend that hasn't
+ * rolled out the new field yet still yields a usable date — the two currently
+ * read the same underlying value, so the fallback is a no-op in practice.
+ * `approvedBy` / `rejectionReason` are mutually exclusive: only one of them is
+ * ever populated (see {@link CsmTimeCard}).
  */
 export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
   return {
@@ -103,7 +110,7 @@ export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
     caseNumber: v.case?.number || v.case?.name || "—",
     projectId: v.project?.id ?? "",
     projectName: v.project?.name ?? "—",
-    createdOn: v.createdOn,
+    workDate: v.workDate || v.createdOn,
     userId: v.user?.id ?? "",
     userName: v.user?.name ?? "—",
     state: v.state,
@@ -111,6 +118,7 @@ export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
     totalMinutes: v.totalTime,
     approvedById: v.approvedBy?.id,
     approvedByName: v.approvedBy?.name,
+    rejectionReason: v.rejectionReason ?? undefined,
   };
 }
 
@@ -174,39 +182,79 @@ export interface TimeCardSearchResult {
  * "submitted" filter and still defaults `projectIds` to every visible
  * project (alongside its more precise `approverId` scope), sending `states`
  * server-side would risk the same 500 for any user with enough visible
- * projects — worse than not filtering at all. One consequence of filtering
- * client-side over a single server page: a page can legitimately come back
- * with fewer matching cards than `rowsPerPage` (or none at all) even though
- * `total` says there's more data — the states filter just happened to
- * exclude most/all of that particular page.
+ * projects — worse than not filtering at all.
+ *
+ * One consequence of filtering client-side over a single raw server page: that
+ * page can legitimately contain zero matches even though matching cards exist
+ * elsewhere in the scope — confirmed live, a real `approved` card was
+ * invisible in the "Approved" filter simply because it fell outside the first
+ * raw page fetched, even though `total` reported plenty more data. To fix
+ * that common case without the removed "walk the entire scope" — see
+ * {@link MAX_STATE_FILTER_WALK_PAGES}.
  */
+
+/**
+ * How many additional raw server pages {@link searchTimeCards} will walk
+ * through, beyond the one `pagination` asks for, to backfill enough
+ * `states`-matching cards to fill the requested page. Bounds the extra fetch
+ * cost instead of walking the entire remaining scope (the slow behaviour real
+ * pagination replaced — see the note above): at most this many extra
+ * requests, not one per remaining record.
+ *
+ * This does not make paging exact under an active state filter — advancing to
+ * the next `TablePagination` page still starts from `(page+1) * limit` in raw
+ * (unfiltered) offset terms, not from wherever this walk left off, so a match
+ * found only via the walk on one page isn't "carried over" to the next; true
+ * correctness would need cursor-based pagination this UI doesn't have. What
+ * this fixes is the reported bug: a page reading as empty purely because the
+ * filter excluded everything on that one raw page, even though matches exist
+ * close by.
+ */
+const MAX_STATE_FILTER_WALK_PAGES = 5;
+
 export async function searchTimeCards(
   api: BackendApi,
   filters?: TimeCardSearchFilters,
   pagination?: TimeCardPagination,
 ): Promise<TimeCardSearchResult> {
   const limit = Math.min(pagination?.rowsPerPage ?? BE_MAX_PAGE_LIMIT, BE_MAX_PAGE_LIMIT);
-  const payload: BeSearchTimeCardsPayload = {
-    filters: {
-      ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
-      ...(filters?.userId ? { userId: filters.userId } : {}),
-      ...(filters?.approverId ? { approverId: filters.approverId } : {}),
-      ...(filters?.from ? { startDate: filters.from } : {}),
-      ...(filters?.to ? { endDate: filters.to } : {}),
-    },
-    pagination: { limit, offset: (pagination?.page ?? 0) * limit },
+  const wireFilters: BeSearchTimeCardsFilters = {
+    ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
+    ...(filters?.userId ? { userId: filters.userId } : {}),
+    ...(filters?.approverId ? { approverId: filters.approverId } : {}),
+    ...(filters?.from ? { startDate: filters.from } : {}),
+    ...(filters?.to ? { endDate: filters.to } : {}),
   };
-  const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
-    "/time-cards/search",
-    payload,
-  );
-  const cards = (res.timeCards ?? []).map(mapTimeCard);
-  return {
-    cards: filters?.states?.length
-      ? cards.filter((c) => (filters.states as BeTimeCardState[]).includes(c.state))
-      : cards,
-    total: res.total,
+
+  const fetchRawPage = async (offset: number): Promise<{ cards: CsmTimeCard[]; total: number }> => {
+    const payload: BeSearchTimeCardsPayload = { filters: wireFilters, pagination: { limit, offset } };
+    const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
+      "/time-cards/search",
+      payload,
+    );
+    return { cards: (res.timeCards ?? []).map(mapTimeCard), total: res.total };
   };
+
+  const startOffset = (pagination?.page ?? 0) * limit;
+  const first = await fetchRawPage(startOffset);
+
+  if (!filters?.states?.length) {
+    return { cards: first.cards, total: first.total };
+  }
+
+  const states = filters.states as BeTimeCardState[];
+  let matched = first.cards.filter((c) => states.includes(c.state));
+  let total = first.total;
+  let nextOffset = startOffset + limit;
+
+  for (let walked = 0; matched.length < limit && nextOffset < total && walked < MAX_STATE_FILTER_WALK_PAGES; walked++) {
+    const page = await fetchRawPage(nextOffset);
+    matched = matched.concat(page.cards.filter((c) => states.includes(c.state)));
+    total = page.total;
+    nextOffset += limit;
+  }
+
+  return { cards: matched.slice(0, limit), total };
 }
 
 /** Weekly sheets on the requested page, plus `total` — see the note on

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -130,11 +130,8 @@ export interface TimeCardPagination {
 }
 
 /** Result of {@link searchTimeCards}: the cards on the requested page, and
- * `total` — the backend's count for the whole scope (all states, all
- * cards), *not* the count after `filters.states` client-side filtering
- * (see the note on that below) — so a caller filtering further should treat
- * `total` as "how big is the underlying page-able scope", not "how many of
- * these match my filter". */
+ * `total` — the backend's count for the whole (filtered) scope, driving
+ * `TablePagination`'s `count` directly. */
 export interface TimeCardSearchResult {
   cards: CsmTimeCard[];
   total: number;
@@ -142,28 +139,22 @@ export interface TimeCardSearchResult {
 
 /**
  * Search against `POST /time-cards/search`, fetching exactly the requested
- * page (defaults to the first `BE_MAX_PAGE_LIMIT` cards when `pagination`
- * is omitted). `projectIds`, `userId`, `approverId`, and `from`/`to` are all
- * real server-side filters, confirmed live (not just by reading
- * `entity-service`'s `sn_time_card_service.go` — see the note below on
- * `caseId`, which looked equally real in code but isn't). Callers should
- * scope as precisely as possible at the source (see {@link useMyTimeSheets},
- * {@link useApprovalQueue} below) rather than fetching a broad page and
- * filtering client-side — the latter makes `total` and the page's contents
- * diverge from what's actually shown. `limit` is capped at
- * `BE_MAX_PAGE_LIMIT` — the backend rejects anything above that with a
- * generic 400 despite the OpenAPI spec documenting up to 100 (confirmed
- * live).
+ * page (defaults to the first `BE_MAX_PAGE_LIMIT` cards when `pagination` is
+ * omitted). `projectIds`, `caseId`, `userId`/`userIds`, `approverId`,
+ * `states`, and `from`/`to` are all real server-side filters — every one of
+ * them is forwarded on the wire and the response is returned as-is, with no
+ * client-side re-filtering. Callers should still scope as precisely as
+ * possible at the source (see {@link useMyTimeSheets}, {@link useApprovalQueue}
+ * below) so `total` and the page's contents reflect exactly what's shown.
+ * `limit` is capped at `BE_MAX_PAGE_LIMIT` — the backend rejects anything
+ * above that with a generic 400 despite the OpenAPI spec documenting up to
+ * 100 (confirmed live).
  *
- * `filters.caseId` is deliberately *not* forwarded, unlike the others,
- * despite existing in `openapi.yaml` and being genuinely implemented
- * end-to-end in `entity-service` — confirmed live to be non-functional: a
- * search scoped only by a case's own id returns `total: 0` unconditionally,
- * even though the exact same cards are provably present and correctly
- * tagged with that `case.id` when the search is instead scoped by
- * `projectIds` (see {@link useCaseTimeCards} in `useTimeCards.ts`, which
- * scopes by project and filters to the case client-side instead). Don't
- * re-add it without re-confirming live first.
+ * `caseId` and `states` were previously avoided here — `caseId` alone used to
+ * return `total: 0` unconditionally, and `states` combined with a large
+ * `projectIds` scope used to 500 — both fixed upstream on the entity-service
+ * data source (see PR #1133); this now forwards them directly instead of the
+ * removed caseId-via-project / states-client-filter-and-walk workarounds.
  *
  * This used to page through the *entire* scope internally (up to 1,000
  * cards) before returning, so every view always had "everything". That was
@@ -172,46 +163,7 @@ export interface TimeCardSearchResult {
  * their own such walk — was slow enough to sometimes fail outright. Real,
  * caller-driven pagination replaces that: callers ask for one page at a
  * time via `pagination`, and `total` lets them drive page controls.
- *
- * `filters.states` is deliberately filtered client-side, never sent as
- * `filters.states` on the wire: confirmed live that the backend 500s
- * ("Failed to search time cards.") when `states` is combined with a large
- * `projectIds` array (reproduced: 2 or 10 project ids + `states` → 200; the
- * full ~88-project default scope + `states` → 500; that same full scope
- * *without* `states` → 200). Since {@link useApprovalQueue} always needs a
- * "submitted" filter and still defaults `projectIds` to every visible
- * project (alongside its more precise `approverId` scope), sending `states`
- * server-side would risk the same 500 for any user with enough visible
- * projects — worse than not filtering at all.
- *
- * One consequence of filtering client-side over a single raw server page: that
- * page can legitimately contain zero matches even though matching cards exist
- * elsewhere in the scope — confirmed live, a real `approved` card was
- * invisible in the "Approved" filter simply because it fell outside the first
- * raw page fetched, even though `total` reported plenty more data. To fix
- * that common case without the removed "walk the entire scope" — see
- * {@link MAX_STATE_FILTER_WALK_PAGES}.
  */
-
-/**
- * How many additional raw server pages {@link searchTimeCards} will walk
- * through, beyond the one `pagination` asks for, to backfill enough
- * `states`-matching cards to fill the requested page. Bounds the extra fetch
- * cost instead of walking the entire remaining scope (the slow behaviour real
- * pagination replaced — see the note above): at most this many extra
- * requests, not one per remaining record.
- *
- * This does not make paging exact under an active state filter — advancing to
- * the next `TablePagination` page still starts from `(page+1) * limit` in raw
- * (unfiltered) offset terms, not from wherever this walk left off, so a match
- * found only via the walk on one page isn't "carried over" to the next; true
- * correctness would need cursor-based pagination this UI doesn't have. What
- * this fixes is the reported bug: a page reading as empty purely because the
- * filter excluded everything on that one raw page, even though matches exist
- * close by.
- */
-const MAX_STATE_FILTER_WALK_PAGES = 5;
-
 export async function searchTimeCards(
   api: BackendApi,
   filters?: TimeCardSearchFilters,
@@ -219,47 +171,27 @@ export async function searchTimeCards(
 ): Promise<TimeCardSearchResult> {
   const limit = Math.min(pagination?.rowsPerPage ?? BE_MAX_PAGE_LIMIT, BE_MAX_PAGE_LIMIT);
   const wireFilters: BeSearchTimeCardsFilters = {
+    ...(filters?.caseId ? { caseId: filters.caseId } : {}),
     ...(filters?.projectIds?.length ? { projectIds: filters.projectIds } : {}),
     ...(filters?.userId ? { userId: filters.userId } : {}),
+    ...(filters?.userIds?.length ? { userIds: filters.userIds } : {}),
     ...(filters?.approverId ? { approverId: filters.approverId } : {}),
+    ...(filters?.states?.length ? { states: filters.states as BeTimeCardState[] } : {}),
     ...(filters?.from ? { startDate: filters.from } : {}),
     ...(filters?.to ? { endDate: filters.to } : {}),
   };
-
-  const fetchRawPage = async (offset: number): Promise<{ cards: CsmTimeCard[]; total: number }> => {
-    const payload: BeSearchTimeCardsPayload = { filters: wireFilters, pagination: { limit, offset } };
-    const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
-      "/time-cards/search",
-      payload,
-    );
-    return { cards: (res.timeCards ?? []).map(mapTimeCard), total: res.total };
+  const payload: BeSearchTimeCardsPayload = {
+    filters: wireFilters,
+    pagination: { limit, offset: (pagination?.page ?? 0) * limit },
   };
-
-  const startOffset = (pagination?.page ?? 0) * limit;
-  const first = await fetchRawPage(startOffset);
-
-  if (!filters?.states?.length) {
-    return { cards: first.cards, total: first.total };
-  }
-
-  const states = filters.states as BeTimeCardState[];
-  let matched = first.cards.filter((c) => states.includes(c.state));
-  let total = first.total;
-  let nextOffset = startOffset + limit;
-
-  for (let walked = 0; matched.length < limit && nextOffset < total && walked < MAX_STATE_FILTER_WALK_PAGES; walked++) {
-    const page = await fetchRawPage(nextOffset);
-    matched = matched.concat(page.cards.filter((c) => states.includes(c.state)));
-    total = page.total;
-    nextOffset += limit;
-  }
-
-  return { cards: matched.slice(0, limit), total };
+  const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
+    "/time-cards/search",
+    payload,
+  );
+  return { cards: (res.timeCards ?? []).map(mapTimeCard), total: res.total };
 }
 
-/** Weekly sheets on the requested page, plus `total` — see the note on
- * {@link TimeCardSearchResult}, the same caveat about client-side-filtered
- * scopes applies here. */
+/** Weekly sheets on the requested page, plus `total` — see {@link TimeCardSearchResult}. */
 export interface TimeSheetsResult {
   sheets: CsmTimeSheet[];
   total: number;
@@ -328,11 +260,11 @@ export function useMyTimeSheets(
  * contains cards the signed-in user is actually eligible to decide —
  * previously this fetched every submitted card in scope regardless of who
  * could approve it, so clicking Approve/Reject on a card the viewer wasn't
- * the assigned approver for 403'd. Still excludes the signed-in user's own
- * cards client-side as a defense-in-depth self-approval guard: a card
- * created before `LogTimeCardDialog` started excluding the submitter from
- * the approver picker could still name themselves as an eligible approver.
- * Like {@link useMyTimeSheets}, no project scope is required (the search runs
+ * the assigned approver for 403'd. `approverId` alone is sufficient for
+ * self-exclusion too: the backend excludes the caller's own cards from an
+ * `approverId`-scoped search unconditionally, so no client-side "exclude
+ * myself" filtering (or an `excludeUserId` wire field) is needed here. Like
+ * {@link useMyTimeSheets}, no project scope is required (the search runs
  * unscoped when no project filter is picked), and `enabled` should be gated on
  * this tab actually being active (see the note on {@link useMyTimeSheets}).
  */
@@ -352,8 +284,7 @@ export function useApprovalQueue(
         { ...filters, approverId: me.id, states: ["submitted"] },
         pagination,
       );
-      const others = cards.filter((c) => c.userId !== me.id);
-      return { sheets: groupCardsByUserIntoSheets(others), total };
+      return { sheets: groupCardsByUserIntoSheets(cards), total };
     },
     enabled: enabled && !!me.id,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -29,6 +29,7 @@ import { useCaseTimeCards, useDecideTimeCard } from "@features/csm-timecards/api
 import { useCurrentEngineer } from "@features/csm-timecards/api/useTimeSheets";
 import { useIsTeamLead } from "@features/csm-timecards/hooks/useIsTeamLead";
 import { billableLabel } from "@features/csm-timecards/constants/timeCardConstants";
+import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
@@ -140,7 +141,9 @@ export default function CaseTimeCardsPanel({
         </Typography>
       ) : (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-          {cards.map((c) => (
+          {cards.map((c) => {
+            const decision = decisionSummary(c);
+            return (
             <Box
               key={c.id}
               sx={{
@@ -183,11 +186,12 @@ export default function CaseTimeCardsPanel({
                 </Box>
               </Box>
               <Typography variant="caption" color="text.secondary">
-                {billableLabel(c.billable)} · <RelativeTime iso={c.createdOn} />
-                {c.approvedByName && ` · Decided by ${c.approvedByName}`}
+                {billableLabel(c.billable)} · <RelativeTime iso={c.workDate} />
+                {decision && ` · ${decision}`}
               </Typography>
             </Box>
-          ))}
+            );
+          })}
         </Box>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -39,8 +39,6 @@ import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 
 interface CaseTimeCardsPanelProps {
   caseId: string;
-  /** The case's project — required to scope `/time-cards/search` (see useCaseTimeCards). */
-  projectId: string;
   /** Opens the log-time dialog (owned by the page so the action bar can trigger it). */
   onLogTime: () => void;
 }
@@ -53,10 +51,9 @@ interface CaseTimeCardsPanelProps {
  */
 export default function CaseTimeCardsPanel({
   caseId,
-  projectId,
   onLogTime,
 }: CaseTimeCardsPanelProps): JSX.Element {
-  const { data, isLoading, isError } = useCaseTimeCards(caseId, projectId);
+  const { data, isLoading, isError } = useCaseTimeCards(caseId);
   const isTeamLead = useIsTeamLead();
   const me = useCurrentEngineer();
   const decide = useDecideTimeCard();

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
@@ -31,6 +31,7 @@ import {
   billableLabel,
   LEAD_COMMENT_MAX,
 } from "@features/csm-timecards/constants/timeCardConstants";
+import type { TimecardAction } from "@features/csm-timecards/utils/timeSheetState";
 import type {
   CsmTimeCard,
   TimeCardDecisionInput,
@@ -38,6 +39,14 @@ import type {
 
 interface TimeCardReviewDialogProps {
   card: CsmTimeCard;
+  /**
+   * The decision already chosen (e.g. the Approve/Reject button clicked on the
+   * list) — when set, the dialog only offers that one action, instead of
+   * asking the user to pick again from both. Omit for a generic "Review" entry
+   * point (see `CaseTimeCardsPanel`'s single Review button) where no decision
+   * has been made yet and both options should show.
+   */
+  action?: TimecardAction;
   /** True while the decision mutation is in flight. */
   isDeciding: boolean;
   onClose: () => void;
@@ -63,6 +72,7 @@ function Field({ label, value }: { label: string; value: string }): JSX.Element 
  */
 export default function TimeCardReviewDialog({
   card,
+  action,
   isDeciding,
   onClose,
   onDecide,
@@ -72,10 +82,13 @@ export default function TimeCardReviewDialog({
   const decide = (state: "approved" | "rejected"): void =>
     onDecide({ cardId: card.id, state, leadComment });
 
+  const titlePrefix =
+    action === "approve" ? "Approve" : action === "reject" ? "Reject" : "Review";
+
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>
-        Review time card · {card.caseNumber} · {card.totalMinutes} min
+        {titlePrefix} time card · {card.caseNumber} · {card.totalMinutes} min
       </DialogTitle>
       <DialogContent dividers>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
@@ -115,24 +128,28 @@ export default function TimeCardReviewDialog({
         <Button color="inherit" onClick={onClose} disabled={isDeciding}>
           Cancel
         </Button>
-        <Button
-          color="error"
-          variant="outlined"
-          startIcon={<X size={16} />}
-          onClick={() => decide("rejected")}
-          disabled={isDeciding}
-        >
-          Reject
-        </Button>
-        <Button
-          color="success"
-          variant="contained"
-          startIcon={<Check size={16} />}
-          onClick={() => decide("approved")}
-          disabled={isDeciding}
-        >
-          Accept
-        </Button>
+        {action !== "approve" && (
+          <Button
+            color="error"
+            variant="outlined"
+            startIcon={<X size={16} />}
+            onClick={() => decide("rejected")}
+            disabled={isDeciding}
+          >
+            Reject
+          </Button>
+        )}
+        {action !== "reject" && (
+          <Button
+            color="success"
+            variant="contained"
+            startIcon={<Check size={16} />}
+            onClick={() => decide("approved")}
+            disabled={isDeciding}
+          >
+            Accept
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
@@ -83,7 +83,7 @@ export default function TimeCardReviewDialog({
     onDecide({ cardId: card.id, state, leadComment });
 
   const titlePrefix =
-    action === "approve" ? "Approve" : action === "reject" ? "Reject" : "Review";
+    action === "approve" ? "Accept" : action === "reject" ? "Reject" : "Review";
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
@@ -94,7 +94,7 @@ export default function TimeCardReviewDialog({
                 Logged
               </Typography>
               <Typography variant="body2">
-                <RelativeTime iso={card.createdOn} />
+                <RelativeTime iso={card.workDate} />
               </Typography>
             </Box>
           </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeSheetCard.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeSheetCard.tsx
@@ -27,6 +27,7 @@ import {
   type TimecardRoleCtx,
 } from "@features/csm-timecards/utils/timeSheetState";
 import { weekLabel } from "@features/csm-timecards/utils/timeSheetWeek";
+import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
 import type { CsmTimeCard, CsmTimeSheet } from "@features/csm-timecards/types/timeCards";
 
 interface TimeSheetCardProps {
@@ -109,6 +110,7 @@ export default function TimeSheetCard({
       <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
         {sheet.cards.map((c) => {
           const actions = cardActions(c.state, role);
+          const decision = decisionSummary(c);
           return (
             <Box
               key={c.id}
@@ -140,8 +142,8 @@ export default function TimeSheetCard({
                   />
                 </Box>
                 <Typography variant="caption" color="text.secondary">
-                  <RelativeTime iso={c.createdOn} />
-                  {c.approvedByName && ` · Decided by ${c.approvedByName}`}
+                  <RelativeTime iso={c.workDate} />
+                  {decision && ` · ${decision}`}
                 </Typography>
               </Box>
               <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -152,9 +152,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
 
   const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
 
-  // Search filters (sent as a POST body, never query params). Project and
-  // state are server-side; work item and engineer are client-side over the
-  // returned page — the backend has no filter for either.
+  // Search filters (sent as a POST body, never query params). Project, state,
+  // and engineer (see filtersWithEngineer below) are all server-side; work
+  // item stays client-side over the returned page — the backend has no
+  // case-number filter, only caseId (see byWorkItem below).
   const [filterProject, setFilterProject] = useState<string[]>([]);
   const [filterWorkItem, setFilterWorkItem] = useState<string[]>([]);
   const [filterState, setFilterState] = useState<TimeCardState | "">("");
@@ -180,6 +181,13 @@ export default function CsmTimeCardsPage(): JSX.Element {
     ...(filterFrom && { from: filterFrom }),
     ...(filterTo && { to: filterTo }),
   };
+  // The Engineer filter only has a control on the All/Approvals tabs (see
+  // engineerSlot below) — folded in as a separate `userIds` filter, not into
+  // baseFilters itself, so a value picked on those tabs can never leak into
+  // "My time sheets" (which is already its own-user-only via useMyTimeSheets).
+  const filtersWithEngineer: TimeCardSearchFilters = filterEngineer.length
+    ? { ...baseFilters, userIds: filterEngineer }
+    : baseFilters;
 
   // Each tab pages independently — was previously fetching its *entire*
   // scope (up to 1,000 cards, sequential page-by-page requests) before
@@ -193,10 +201,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const approvalsPagination = usePagination();
 
   const mySheets = useMyTimeSheets(activeTab === "mine", baseFilters, minePagination.pagination);
-  const allCards = useAllTimeCards(activeTab === "all", baseFilters, allPagination.pagination);
+  const allCards = useAllTimeCards(activeTab === "all", filtersWithEngineer, allPagination.pagination);
   const queue = useApprovalQueue(
     activeTab === "approvals" && role.isApprover,
-    baseFilters,
+    filtersWithEngineer,
     approvalsPagination.pagination,
   );
   const decideCard = useDecideCard();
@@ -223,6 +231,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
   };
   const handleFilterStateChange = (v: TimeCardState | ""): void => {
     setFilterState(v);
+    resetAllPages();
+  };
+  const handleFilterEngineerChange = (v: string[]): void => {
+    setFilterEngineer(v);
     resetAllPages();
   };
   const handleFilterFromChange = (v: string): void => {
@@ -289,16 +301,12 @@ export default function CsmTimeCardsPage(): JSX.Element {
 
   // Filtered sheets per tab, computed once and shared between the FilterBar's
   // export action and the list rendering below — rather than recomputing (and
-  // risking drift) in two places.
+  // risking drift) in two places. Engineer is already applied server-side (via
+  // filtersWithEngineer) by the time allCards/queue resolve — only work item
+  // still needs a client-side pass here.
   const mineFilteredSheets = byWorkItem(mySheets.data?.sheets) ?? [];
-  const allByEngineer = (allCards.data?.sheets ?? []).filter(
-    (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
-  );
-  const allFilteredSheets = byWorkItem(allByEngineer) ?? [];
-  const approvalsByEngineer = (queue.data?.sheets ?? []).filter(
-    (s) => filterEngineer.length === 0 || filterEngineer.includes(s.userId),
-  );
-  const approvalsFilteredSheets = byWorkItem(approvalsByEngineer) ?? [];
+  const allFilteredSheets = byWorkItem(allCards.data?.sheets) ?? [];
+  const approvalsFilteredSheets = byWorkItem(queue.data?.sheets) ?? [];
 
   return (
     <Box
@@ -426,7 +434,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 values={filterEngineer}
                 options={allEngineerOptions.ids}
                 formatOption={(id) => allEngineerOptions.nameById.get(id) ?? id}
-                onChange={setFilterEngineer}
+                onChange={handleFilterEngineerChange}
               />
             }
             engineerActive={filterEngineer.length > 0}
@@ -447,11 +455,9 @@ export default function CsmTimeCardsPage(): JSX.Element {
               {allFilteredSheets.length === 0 ? (
                 <Empty
                   text={
-                    filterEngineer.length > 0 && allByEngineer.length === 0
-                      ? "No time cards match the selected engineers."
-                      : anyFilterActive
-                        ? "No time cards match the current filters."
-                        : "No time logged yet."
+                    anyFilterActive
+                      ? "No time cards match the current filters."
+                      : "No time logged yet."
                   }
                 />
               ) : (
@@ -507,7 +513,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 values={filterEngineer}
                 options={approvalsEngineerOptions.ids}
                 formatOption={(id) => approvalsEngineerOptions.nameById.get(id) ?? id}
-                onChange={setFilterEngineer}
+                onChange={handleFilterEngineerChange}
               />
             }
             engineerActive={filterEngineer.length > 0}
@@ -525,17 +531,12 @@ export default function CsmTimeCardsPage(): JSX.Element {
                   filename={`time-cards-approvals-${todayStamp}.csv`}
                 />
               </Box>
-              {(queue.data?.sheets ?? []).length === 0 ? (
-                <Empty text="Nothing awaiting approval." />
-              ) : approvalsFilteredSheets.length === 0 ? (
+              {approvalsFilteredSheets.length === 0 ? (
                 <Empty
                   text={
-                    // Only blame the engineer filter when it's the one that
-                    // excluded everything — if it matched fine and the
-                    // work-item filter emptied the result, say that instead.
-                    filterEngineer.length > 0 && approvalsByEngineer.length === 0
-                      ? "No time cards match the selected engineers."
-                      : "No time cards match the current filters."
+                    anyFilterActive
+                      ? "No time cards match the current filters."
+                      : "Nothing awaiting approval."
                   }
                 />
               ) : (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -150,7 +150,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
   // exported filename's date mid-session.
   const todayStamp = useMemo(() => new Date().toISOString().slice(0, 10), []);
 
-  const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
+  // Carries the action the user already picked (clicking Approve vs Reject in
+  // the list), so the dialog reflects that one decision instead of asking
+  // again — see TimeCardReviewDialog's `action` prop.
+  const [review, setReview] = useState<{ card: CsmTimeCard; action: TimecardAction } | null>(null);
 
   // Search filters (sent as a POST body, never query params). Project, state,
   // and engineer (see filtersWithEngineer below) are all server-side; work
@@ -260,7 +263,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
   };
 
   const handleCardAction = (card: CsmTimeCard, action: TimecardAction): void => {
-    if (action === "approve" || action === "reject") setReviewCard(card);
+    if (action === "approve" || action === "reject") setReview({ card, action });
   };
 
   /** Client-side work-item filter (case number is in the selected set),
@@ -566,15 +569,16 @@ export default function CsmTimeCardsPage(): JSX.Element {
         </Box>
       )}
 
-      {reviewCard && (
+      {review && (
         <TimeCardReviewDialog
-          card={reviewCard}
+          card={review.card}
+          action={review.action}
           isDeciding={decideCard.isPending}
-          onClose={() => setReviewCard(null)}
+          onClose={() => setReview(null)}
           onDecide={(decision) =>
             decideCard.mutate(decision, {
               onSuccess: () => {
-                setReviewCard(null);
+                setReview(null);
                 showSuccess(
                   decision.state === "approved"
                     ? "Time card approved."

--- a/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
@@ -76,14 +76,14 @@ export interface CsmTimeCard {
   projectId: string;
   projectName: string;
   /**
-   * The work date (ISO, YYYY-MM-DD), despite the name — confirmed live by
-   * backdating a test card and reading it back: the backend returns
-   * whatever date was submitted on create under this field, not a separate
-   * system-generated creation timestamp. Occasionally unparseable on real
-   * records (confirmed live); see `groupIntoSheets` in `useTimeSheets.ts`
-   * for how that's handled.
+   * The date the work was actually carried out (ISO, YYYY-MM-DD) — what the
+   * engineer picked in the log form, so it can be backdated. This is the field
+   * to display and to group/sort by ("the week this work happened"); it replaces
+   * the deprecated `createdOn`, which currently holds the same value.
+   * Occasionally unparseable on real records (confirmed live); see
+   * `groupIntoSheets` in `timeSheetGrouping.ts` for how that's handled.
    */
-  createdOn: string;
+  workDate: string;
   userId: string;
   userName: string;
   state: TimeCardState;
@@ -92,9 +92,20 @@ export interface CsmTimeCard {
   /** Whole minutes — the backend's own unit for this field (see
    * `mapTimeCard` in `useTimeSheets.ts`). */
   totalMinutes: number;
-  /** The deciding approver, once a decision has been made. */
+  /**
+   * The approver who accepted the card — set **only** when `state` is
+   * `approved`. ServiceNow doesn't record who rejected a card, so there is
+   * deliberately no `rejectedBy`: a rejection surfaces {@link rejectionReason}
+   * instead (see `decisionSummary`).
+   */
   approvedById?: string;
   approvedByName?: string;
+  /**
+   * The approver's comment when rejecting — set **only** when `state` is
+   * `rejected`. It's the only trace a rejection leaves (no rejecter identity or
+   * timestamp exists upstream).
+   */
+  rejectionReason?: string;
 }
 
 /**
@@ -169,7 +180,7 @@ export interface TimeCardSearchFilters {
   approverId?: string;
   /** Lifecycle states to include. */
   states?: TimeCardState[];
-  /** Inclusive date range (YYYY-MM-DD), matched against `createdOn`. */
+  /** Inclusive date range (YYYY-MM-DD), matched against the card's work date. */
   from?: string;
   to?: string;
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
@@ -160,23 +160,24 @@ export interface CsmTimeSheet {
 
 /**
  * Filters for the time-card search. Sent in the POST body (never as query
- * params). `projectIds`, `userId`, `approverId`, and `from`/`to` are all
- * real, confirmed-working server-side filters. `states` is filtered
- * client-side instead — see the note on `searchTimeCards` in
- * `useTimeSheets.ts` for why. `from`/`to` currently has no UI control wired
- * to it; kept so a future date-range filter has somewhere to plug in.
- *
- * There is deliberately no `caseId` here even though `entity-service`
- * documents and implements one — confirmed live to be non-functional
- * (always `total: 0`); case scoping goes through `projectIds` plus a
- * client-side filter instead (see `useCaseTimeCards` in `useTimeCards.ts`).
+ * params). `projectIds`, `caseId`, `userId`/`userIds`, `approverId`, `states`,
+ * and `from`/`to` are all real server-side filters — every one of them is
+ * forwarded on the wire, none filtered client-side. `from`/`to` currently has
+ * no UI control wired to it on most tabs; kept so a date-range filter has
+ * somewhere to plug in (the Time Cards page does wire it up).
  */
 export interface TimeCardSearchFilters {
   /** Projects to include (company customer may own several). */
   projectIds?: string[];
+  /** Scope to a single case's own time cards (see `useCaseTimeCards`). */
+  caseId?: string;
   /** Only cards submitted by this user. */
   userId?: string;
-  /** Only cards this user is eligible to approve (backend: SN `approver_list`). */
+  /** Only cards submitted by any of these users — the Engineer multi-select
+   * filter (All/Approvals tabs), distinct from the single-user `userId`. */
+  userIds?: string[];
+  /** Only cards this user is eligible to approve (backend: SN `approver_list`);
+   * the caller's own cards are excluded unconditionally when this is set. */
   approverId?: string;
   /** Lifecycle states to include. */
   states?: TimeCardState[];

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardCsvExport.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardCsvExport.test.ts
@@ -25,7 +25,7 @@ function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
     caseNumber: "CS0352584",
     projectId: "proj-1",
     projectName: "Acme Corp",
-    createdOn: "2026-06-27",
+    workDate: "2026-06-27",
     userId: "user-1",
     userName: "Jane Doe",
     state: "submitted",
@@ -38,7 +38,7 @@ function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
 describe("timeCardsToCsv", () => {
   it("emits just the header for an empty list", () => {
     expect(timeCardsToCsv([])).toBe(
-      "Date,Case,Project,Engineer,State,Billable,Minutes,Decided by",
+      "Work date,Case,Project,Engineer,State,Billable,Minutes,Approved by,Rejection reason",
     );
   });
 
@@ -47,15 +47,24 @@ describe("timeCardsToCsv", () => {
     const lines = csv.split("\r\n");
     expect(lines).toHaveLength(2);
     expect(lines[1]).toBe(
-      "2026-06-27,CS0352584,Acme Corp,Jane Doe,Submitted,Yes,90,",
+      "2026-06-27,CS0352584,Acme Corp,Jane Doe,Submitted,Yes,90,,",
     );
   });
 
-  it("includes the deciding approver once a card has one", () => {
+  it("includes the approver on an approved card, leaving the rejection reason blank", () => {
     const csv = timeCardsToCsv([
       card({ state: "approved", approvedByName: "Lead Person" }),
     ]);
-    expect(csv).toContain("Approved,Yes,90,Lead Person");
+    expect(csv).toContain("Approved,Yes,90,Lead Person,");
+  });
+
+  // ServiceNow records no rejecter identity, so a rejected card carries only the
+  // reason — the "Approved by" column stays empty for it.
+  it("includes the rejection reason on a rejected card, leaving the approver blank", () => {
+    const csv = timeCardsToCsv([
+      card({ state: "rejected", rejectionReason: "Break down the debug time." }),
+    ]);
+    expect(csv).toContain("Rejected,Yes,90,,Break down the debug time.");
   });
 
   it("quotes a field that contains a comma", () => {

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardDecision.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardDecision.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
+  return {
+    id: "card-1",
+    caseId: "case-1",
+    caseNumber: "CS0352584",
+    projectId: "proj-1",
+    projectName: "Acme Corp",
+    workDate: "2026-07-13",
+    userId: "user-1",
+    userName: "Jane Doe",
+    state: "submitted",
+    billable: true,
+    totalMinutes: 60,
+    ...overrides,
+  };
+}
+
+describe("decisionSummary", () => {
+  it("names the approver on an approved card", () => {
+    expect(decisionSummary(card({ state: "approved", approvedByName: "Lead Person" }))).toBe(
+      "Approved by Lead Person",
+    );
+  });
+
+  // ServiceNow records no rejecter identity — only the approver's comment — so a
+  // rejection surfaces the reason instead of a name.
+  it("shows the reason on a rejected card", () => {
+    expect(
+      decisionSummary(card({ state: "rejected", rejectionReason: "Break down the debug time." })),
+    ).toBe("Rejected: Break down the debug time.");
+  });
+
+  it("still reports a rejected card with no reason as rejected", () => {
+    expect(decisionSummary(card({ state: "rejected" }))).toBe("Rejected");
+  });
+
+  it("still reports an approved card with no approver name as approved", () => {
+    expect(decisionSummary(card({ state: "approved" }))).toBe("Approved");
+  });
+
+  it("returns null for an undecided card", () => {
+    expect(decisionSummary(card({ state: "submitted" }))).toBeNull();
+  });
+
+  // Regression guard for the old behaviour: a rejected card used to read its
+  // (always-null) `approvedBy`, so it rendered nothing at all.
+  it("does not fall back to the approver name on a rejected card", () => {
+    expect(
+      decisionSummary(card({ state: "rejected", approvedByName: "Lead Person" })),
+    ).toBe("Rejected");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetGrouping.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetGrouping.test.ts
@@ -25,7 +25,7 @@ function card(overrides: Partial<CsmTimeCard>): CsmTimeCard {
     caseNumber: "CS0000001",
     projectId: "project-1",
     projectName: "Project",
-    createdOn: "2026-06-01",
+    workDate: "2026-06-01",
     userId: "user-1",
     userName: "Test User",
     state: "submitted",
@@ -58,7 +58,7 @@ describe("sheetStatus", () => {
 describe("groupIntoSheets", () => {
   it("groups cards into weekly sheets", () => {
     const sheets = groupIntoSheets(
-      [card({ id: "a", createdOn: "2026-06-01" }), card({ id: "b", createdOn: "2026-06-02" })],
+      [card({ id: "a", workDate: "2026-06-01" }), card({ id: "b", workDate: "2026-06-02" })],
       "user-1",
       "Test User",
     );
@@ -68,7 +68,7 @@ describe("groupIntoSheets", () => {
 
   it("splits cards from different weeks into separate sheets, newest first", () => {
     const sheets = groupIntoSheets(
-      [card({ id: "a", createdOn: "2026-06-01" }), card({ id: "b", createdOn: "2026-06-15" })],
+      [card({ id: "a", workDate: "2026-06-01" }), card({ id: "b", workDate: "2026-06-15" })],
       "user-1",
       "Test User",
     );
@@ -76,12 +76,12 @@ describe("groupIntoSheets", () => {
     expect(sheets[0].cards[0].id).toBe("b");
   });
 
-  it("skips a card with an unparseable createdOn instead of throwing, keeping the rest", () => {
+  it("skips a card with an unparseable workDate instead of throwing, keeping the rest", () => {
     const sheets = groupIntoSheets(
       [
-        card({ id: "good-1", createdOn: "2026-06-01" }),
-        card({ id: "bad", createdOn: "" }),
-        card({ id: "good-2", createdOn: "2026-06-02" }),
+        card({ id: "good-1", workDate: "2026-06-01" }),
+        card({ id: "bad", workDate: "" }),
+        card({ id: "good-2", workDate: "2026-06-02" }),
       ],
       "user-1",
       "Test User",
@@ -92,8 +92,8 @@ describe("groupIntoSheets", () => {
     expect(ids).toHaveLength(2);
   });
 
-  it("returns an empty list when every card has an unparseable createdOn", () => {
-    const sheets = groupIntoSheets([card({ id: "bad", createdOn: "" })], "user-1", "Test User");
+  it("returns an empty list when every card has an unparseable workDate", () => {
+    const sheets = groupIntoSheets([card({ id: "bad", workDate: "" })], "user-1", "Test User");
     expect(sheets).toEqual([]);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
@@ -18,15 +18,20 @@ import { saveBlob } from "@utils/saveBlob";
 import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 
+// "Approved by" and "Rejection reason" are separate columns because the upstream
+// data is asymmetric: ServiceNow records who approved a card but nothing about who
+// rejected one — a rejection leaves only the approver's comment. The old single
+// "Decided by" column was therefore always blank for rejected cards.
 const CSV_HEADER = [
-  "Date",
+  "Work date",
   "Case",
   "Project",
   "Engineer",
   "State",
   "Billable",
   "Minutes",
-  "Decided by",
+  "Approved by",
+  "Rejection reason",
 ];
 
 /** Quotes a CSV field only when it needs it (contains a comma, quote, or
@@ -43,7 +48,7 @@ function csvField(value: string): string {
 export function timeCardsToCsv(cards: CsmTimeCard[]): string {
   const rows = cards.map((c) =>
     [
-      c.createdOn,
+      c.workDate,
       c.caseNumber,
       c.projectName,
       c.userName,
@@ -51,6 +56,7 @@ export function timeCardsToCsv(cards: CsmTimeCard[]): string {
       c.billable ? "Yes" : "No",
       String(c.totalMinutes),
       c.approvedByName ?? "",
+      c.rejectionReason ?? "",
     ]
       .map(csvField)
       .join(","),

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardDecision.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardDecision.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+/**
+ * One-line summary of a card's approval decision, or `null` when it hasn't been
+ * decided yet.
+ *
+ * The two decisions are deliberately asymmetric, because the upstream data is:
+ * ServiceNow records **who approved** a card (`approvedBy`) but records nothing
+ * about who rejected one — no rejecter identity, no timestamp. All a rejection
+ * leaves behind is the approver's comment (`rejectionReason`). So an approval
+ * shows the name, and a rejection shows the reason instead of a name. (Showing
+ * "Decided by …" for both was the old behaviour, and it silently rendered
+ * nothing on rejected cards, since `approvedBy` is null for them.)
+ *
+ * A rejected card with no reason still reports "Rejected" rather than falling
+ * through to `null` — the state is a decision even when the comment is missing.
+ */
+export function decisionSummary(card: CsmTimeCard): string | null {
+  if (card.state === "approved") {
+    return card.approvedByName ? `Approved by ${card.approvedByName}` : "Approved";
+  }
+  if (card.state === "rejected") {
+    return card.rejectionReason ? `Rejected: ${card.rejectionReason}` : "Rejected";
+  }
+  return null;
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetGrouping.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetGrouping.ts
@@ -32,7 +32,10 @@ export function sheetStatus(cards: CsmTimeCard[]): TimeSheetState {
 
 /**
  * Group a flat list of cards into weekly sheets (Mon–Sun), newest first.
- * `weekStartOf` throws (`RangeError: Invalid time value`) if `createdOn`
+ * Grouped by `workDate` — the date the work was actually carried out — so a
+ * backdated card lands in the week it was worked, not the week it was logged.
+ *
+ * `weekStartOf` throws (`RangeError: Invalid time value`) if `workDate`
  * isn't a parseable date — confirmed live: at least one real card has one
  * (blank or otherwise malformed). Skip that one card rather than losing the
  * whole group of otherwise-good cards to it — the same "one bad record
@@ -49,7 +52,7 @@ export function groupIntoSheets(
   for (const c of cards) {
     let wk: string;
     try {
-      wk = weekStartOf(c.createdOn);
+      wk = weekStartOf(c.workDate);
     } catch {
       continue;
     }
@@ -59,7 +62,7 @@ export function groupIntoSheets(
   }
   const sheets: CsmTimeSheet[] = [];
   for (const [weekStart, weekCards] of byWeek) {
-    weekCards.sort((a, b) => b.createdOn.localeCompare(a.createdOn));
+    weekCards.sort((a, b) => b.workDate.localeCompare(a.workDate));
     sheets.push({
       id: `${userId}:${weekStart}`,
       userId,


### PR DESCRIPTION
## Purpose
Fixes two time-card bugs found while verifying against staging:
1. Rejected cards never showed who decided them or why — "Decided by" always read `approvedBy`, which is only ever set on an approval.
2. The "Approved" state filter could show **no results even when matching cards exist**, because state filtering happens client-side over a single page.

## Goals
- Show a meaningful decision summary on both approved and rejected cards.
- Make the state filter actually surface matches instead of appearing broken when the first fetched page has none.

## Approach
- **Approved/rejected-by:** ServiceNow records who approved a card, but nothing about who rejected one — no rejecter identity, no timestamp; a rejection leaves only the approver's review comment. `BeTimeCardView`/`CsmTimeCard` gain `rejectionReason` and a corrected nullable `approvedBy`, plus a new `workDate` field (the date work was actually done, replacing the deprecated `createdOn`, which reads the same underlying value). A new `decisionSummary()` helper renders "Approved by X" or "Rejected: reason" (falling back to a bare "Approved"/"Rejected" when the name/reason is missing) — used everywhere the old always-blank-on-rejection "Decided by" string was. CSV export splits into separate "Approved by" / "Rejection reason" columns for the same reason. Grouping/sorting switched from `createdOn` to `workDate` throughout.
- **State filter pagination:** `states` is filtered client-side (the backend 500s when combined with a large project scope), over one raw page at a time. `searchTimeCards` now walks forward through up to 5 additional raw pages to backfill matches when the requested page comes up short — bounded so it can't regress into the removed "walk the entire scope" slowness. Documented the remaining known limitation: Next/Prev across pages under an active filter still isn't exactly cursor-accurate, but the reported "filter shows nothing" case is fixed.

## User stories
As a CS engineer, I can see why my time card was rejected (or who approved it) directly in the list, panel, and CSV export. As anyone filtering the time-cards list by state, I get accurate results instead of an empty page.

## Release note
Time cards: rejected cards now show the reviewer's comment (approved cards still show who approved); fixed the state filter sometimes showing no results despite matching cards existing.

## Documentation
N/A — internal CSM portal UI/API-mapping change, no external doc surface affected.

## Automation tests
- New: `timeCardDecision.test.ts` (6 cases), `useTimeSheets.test.ts` (6 cases covering the pagination walk — no-walk, walk-and-find, stop-at-full-page, stop-at-scope-end, capped-walk).
- Updated: `timeSheetGrouping.test.ts`, `timeCardCsvExport.test.ts` for the `workDate`/rejection-reason changes.
- `pnpm run test` — 41/41 passing in `csm-timecards`. `pnpm run lint`, `tsc -b` clean.
- Verified against staging: a real rejected card now shows its rejection reason instead of nothing; a real approved card that a filtered page previously missed now surfaces correctly.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint`, `pnpm run test`, `pnpm run build` all passing locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time cards now use **work date** (`workDate`) for grouping, sorting, display, and CSV exports (with `createdOn` deprecated).
  * Unified **decision summary** shown on time-card captions; **rejection reason** is surfaced for rejected cards.
  * **Case-scoped** time-card search via `caseId`; review dialog adapts title/buttons based on approve/reject/review action.
* **Bug Fixes**
  * Search, engineer filtering (All/Approvals), and approval/rejection handling are now **server-forwarded**, improving pagination and correctness.
* **Tests**
  * Updated/added coverage for server-forwarded payloads, decision summaries, work-date grouping, and revised CSV output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->