### PR TITLE
[CSM][BE] Return upstream error message for registry token creation failures

### DIFF
--- a/apps/customer-portal/backend/constants.bal
+++ b/apps/customer-portal/backend/constants.bal
@@ -34,3 +34,4 @@ public const int DEFAULT_LIMIT = 10;
 
 public const ERR_STATUS_CODE = "statusCode";
 public const ERR_BODY = "body";
+public const ERR_MESSAGE = "message";

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5009,7 +5009,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                         userInfo.userId}`, response);
                 return <http:BadRequest>{
                     body: {
-                        message: extractErrorMessage(response)
+                        message: extractClientErrorMessage(response)
                     }
                 };
             }

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -5009,7 +5009,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                         userInfo.userId}`, response);
                 return <http:BadRequest>{
                     body: {
-                        message: "Invalid request parameters for creating registry token."
+                        message: extractErrorMessage(response)
                     }
                 };
             }

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -224,14 +224,26 @@ public isolated function getStatusCode(error err) returns int {
     return statusCodeValue is int ? statusCodeValue : http:STATUS_INTERNAL_SERVER_ERROR;
 }
 
-# Get HTTP status code from the given error.
+# Get the error message from the given error.
 #
 # + err - Error to handle
 # + return - Error message
 public isolated function extractErrorMessage(error err) returns string {
     map<anydata|readonly> & readonly errorDetails = err.detail();
-    anydata|readonly errorMessage = errorDetails[ERR_BODY] ?: ();
-    return errorMessage is string ? errorMessage : UNEXPECTED_ERROR_MSG;
+    anydata|readonly errorBody = errorDetails[ERR_BODY] ?: ();
+    if errorBody is map<anydata> {
+        anydata message = errorBody[ERR_MESSAGE];
+        return message is string ? message : UNEXPECTED_ERROR_MSG;
+    }
+    if errorBody is string {
+        json|error parsedBody = errorBody.fromJsonString();
+        if parsedBody is map<json> {
+            json message = parsedBody[ERR_MESSAGE] ?: ();
+            return message is string ? message : errorBody;
+        }
+        return errorBody;
+    }
+    return UNEXPECTED_ERROR_MSG;
 }
 
 # Log forbidden project access attempt.

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -230,6 +230,16 @@ public isolated function getStatusCode(error err) returns int {
 # + return - Error message
 public isolated function extractErrorMessage(error err) returns string {
     map<anydata|readonly> & readonly errorDetails = err.detail();
+    anydata|readonly errorMessage = errorDetails[ERR_BODY] ?: ();
+    return errorMessage is string ? errorMessage : UNEXPECTED_ERROR_MSG;
+}
+
+# Get the user-facing message from the JSON error body of the given client error.
+#
+# + err - Client error to handle
+# + return - Value of the 'message' field in the error body, or a generic message if unavailable
+public isolated function extractClientErrorMessage(error err) returns string {
+    map<anydata|readonly> & readonly errorDetails = err.detail();
     anydata|readonly errorBody = errorDetails[ERR_BODY] ?: ();
     if errorBody is map<anydata> {
         anydata message = errorBody[ERR_MESSAGE];

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -224,7 +224,7 @@ public isolated function getStatusCode(error err) returns int {
     return statusCodeValue is int ? statusCodeValue : http:STATUS_INTERNAL_SERVER_ERROR;
 }
 
-# Get the error message from the given error.
+# Get HTTP status code from the given error.
 #
 # + err - Error to handle
 # + return - Error message

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -238,8 +238,8 @@ public isolated function extractErrorMessage(error err) returns string {
     if errorBody is string {
         json|error parsedBody = errorBody.fromJsonString();
         if parsedBody is map<json> {
-            json message = parsedBody[ERR_MESSAGE] ?: ();
-            return message is string ? message : errorBody;
+            json message = parsedBody[ERR_MESSAGE];
+            return message is string ? message : UNEXPECTED_ERROR_MSG;
         }
         return errorBody;
     }


### PR DESCRIPTION
## Problem

When registry token creation fails, customers see the generic message **"Invalid request parameters for creating registry token."** regardless of the actual cause. The registry-subscription-service returns meaningful 400 reasons (e.g. the 5-token limit message, or missing subscriptions), but the portal backend swallows them.

## Changes

- `service.bal`: the token-creation endpoint now returns the upstream error message in the 400 response body instead of a hardcoded generic string. Logging is unchanged.
- `utils.bal`: adds a new `extractClientErrorMessage` helper that extracts the `message` field from a client error's JSON body (map or JSON-encoded string), falling back to the generic message. The existing `extractErrorMessage` and its callers are untouched.
- `constants.bal`: adds the `ERR_MESSAGE` constant.

## Notes

- Companion change (improves the upstream 400 message texts): wso2-enterprise/digiops-sales#1608 — the two changes are independent and can be deployed in any order.

## Verification

- `bal build` (2201.12.10) passes.
- Verified end-to-end against a mock upstream returning a 400 with a `{"message": ...}` body: the exact upstream message is returned by the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes wso2-enterprise/wso2-digital-team-project-management#620