### PR TITLE
[CSM Portal Microapp] Home dashboard, Support filters/FAB, and navigation cleanup

### DIFF
--- a/apps/csm-portal/microapp/src/components/common/ComingSoonPage.tsx
+++ b/apps/csm-portal/microapp/src/components/common/ComingSoonPage.tsx
@@ -20,16 +20,19 @@ interface ComingSoonPageProps {
   title: string;
   description: string;
   blockedOn?: string;
+  /** False for a tab-bar landing page (e.g. Operations), whose name is already shown by the
+   * active tab itself — repeating it as a page heading is redundant there. Defaults to true. */
+  showTitle?: boolean;
 }
 
 // Placeholder for microapp sections not yet built, mirroring the webapp's CsmComingSoonPage
 // (apps/csm-portal/webapp/src/features/csm-coming-soon/pages/CsmComingSoonPage.tsx) — used
 // deliberately so a reserved tab/route feels real instead of dead or missing.
-export function ComingSoonPage({ title, description, blockedOn }: ComingSoonPageProps) {
+export function ComingSoonPage({ title, description, blockedOn, showTitle = true }: ComingSoonPageProps) {
   return (
     <Stack gap={3}>
       <Stack direction="row" alignItems="center" gap={1.5}>
-        <Typography variant="h5">{title}</Typography>
+        {showTitle && <Typography variant="h5">{title}</Typography>}
         <Chip size="small" label="Coming soon" color="warning" variant="outlined" />
       </Stack>
       <Card sx={{ p: 3, display: "flex", flexDirection: "column", gap: 1.5 }}>

--- a/apps/csm-portal/microapp/src/components/common/ConfirmDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Button, Card, Dialog, Stack, Typography } from "@wso2/oxygen-ui";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  cancelLabel?: string;
+  confirmLabel?: string;
+  confirmColor?: "error" | "primary" | "secondary" | "warning" | "success" | "info";
+}
+
+// Mirrors the customer-portal microapp's own ConfirmDialog
+// (apps/customer-portal/microapp/src/components/shared/ConfirmDialog.tsx).
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  cancelLabel = "Cancel",
+  confirmLabel = "Confirm",
+  confirmColor = "primary",
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slotProps={{
+        paper: {
+          sx: {
+            bgcolor: "background.paper",
+            p: 1.5,
+            gap: 3,
+            m: 2,
+          },
+        },
+      }}
+    >
+      <Stack>
+        <Typography variant="h6" fontWeight={650} mb={0.2}>
+          {title}
+        </Typography>
+        <Typography variant="body2" sx={{ opacity: 0.8 }}>
+          {description}
+        </Typography>
+      </Stack>
+
+      <Stack direction="row" justifyContent="end" gap={1}>
+        <Button variant="outlined" onClick={onClose}>
+          {cancelLabel}
+        </Button>
+        <Button color={confirmColor} variant="contained" onClick={onConfirm}>
+          {confirmLabel}
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
@@ -47,8 +47,12 @@ export function AssignedToMeSection() {
       </Stack>
 
       {isPending ? (
+        // Only 2 (not the 6 Support's own list skeleton shows) — this is a short preview widget,
+        // not a case list. Keeping it short leaves the Case composition donuts visible in the
+        // same first viewport, so Home's loading state reads as the dashboard it is rather than
+        // looking like Support's own (much longer) loading skeleton.
         <Stack gap={1.5}>
-          {Array.from({ length: 3 }).map((_, index) => (
+          {Array.from({ length: 2 }).map((_, index) => (
             <CaseCardSkeleton key={index} />
           ))}
         </Stack>

--- a/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
@@ -25,21 +25,12 @@ import { EMPTY_FILTERS, filtersToSearchParams } from "@components/support/filter
 import { COMPOSITION_STATES, SEVERITY_SHORT_LABELS, SEVERITY_SLICE_COLOR, STATE_SLICE_COLOR } from "./config";
 import { CompositionDonut, type CompositionSlice } from "./CompositionDonut";
 
-// Mirrors the webapp's CaseCompositionCharts onSliceClick (navigate(casesHref({...}))): clicking
-// a slice replaces whatever's currently on Support with just that one filter, rather than merging
-// with it — same behavior as the webapp, since a dashboard drill-down is meant to start fresh.
 function supportHref(overrides: Partial<{ severities: CaseSeverity[]; states: CaseState[] }>): string {
   const params = filtersToSearchParams("", { ...EMPTY_FILTERS, ...overrides });
   const qs = params.toString();
   return qs ? `/support?${qs}` : "/support";
 }
 
-// Two donuts — severity composition and state composition of active cases — mirrors the webapp's
-// CaseCompositionCharts (apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx),
-// laid out side by side via the same 2-column Grid the customer-portal microapp's Home page uses
-// for its own pie-chart widgets. Self-contained plain useQuery rather than Suspense, matching how
-// TimeCardsPage.tsx already handles independent, non-blocking widgets in this app — one
-// failed/slow widget shouldn't hold up the rest of the Home page.
 export function CaseCompositionSection() {
   const navigate = useNavigate();
   const { data, isLoading, isError } = useQuery(dashboard.composition());
@@ -76,7 +67,6 @@ export function CaseCompositionSection() {
         <Grid size={6}>
           <CompositionDonut
             title="Cases by severity"
-            description="Share of active cases at each severity level, excluding closed."
             slices={severitySlices}
             total={data?.severityTotal ?? 0}
             isLoading={isLoading}
@@ -87,7 +77,6 @@ export function CaseCompositionSection() {
         <Grid size={6}>
           <CompositionDonut
             title="Cases by state"
-            description="Share of active cases in each lifecycle state, excluding closed."
             slices={stateSlices}
             total={data?.stateTotal ?? 0}
             onSliceClick={(id) => navigate(supportHref({ states: [id as CaseState] }))}

--- a/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { useMemo } from "react";
-import { Stack, Typography } from "@wso2/oxygen-ui";
+import { Grid, Stack, Typography } from "@wso2/oxygen-ui";
 import { useQuery } from "@tanstack/react-query";
 import { dashboard } from "@src/services/dashboard";
 import { ALL_SEVERITIES, SEVERITY_LABELS, STATE_LABELS } from "@components/support/config";
@@ -24,10 +24,10 @@ import { CompositionDonut, type CompositionSlice } from "./CompositionDonut";
 
 // Two donuts — severity composition and state composition of active cases — mirrors the webapp's
 // CaseCompositionCharts (apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx),
-// stacked instead of side-by-side (the webapp's own grid already collapses to one column below its
-// "md" breakpoint, which is every phone width anyway). Self-contained plain useQuery rather than
-// Suspense, matching how TimeCardsPage.tsx already handles independent, non-blocking widgets in
-// this app — one failed/slow widget shouldn't hold up the rest of the Home page.
+// laid out side by side via the same 2-column Grid the customer-portal microapp's Home page uses
+// for its own pie-chart widgets. Self-contained plain useQuery rather than Suspense, matching how
+// TimeCardsPage.tsx already handles independent, non-blocking widgets in this app — one
+// failed/slow widget shouldn't hold up the rest of the Home page.
 export function CaseCompositionSection() {
   const { data, isLoading, isError } = useQuery(dashboard.composition());
 
@@ -59,24 +59,28 @@ export function CaseCompositionSection() {
     <Stack gap={1.5}>
       <Typography variant="subtitle1">Case composition</Typography>
 
-      <Stack gap={1.5}>
-        <CompositionDonut
-          title="Cases by severity"
-          description="Share of active cases at each severity level, excluding closed."
-          slices={severitySlices}
-          total={data?.severityTotal ?? 0}
-          isLoading={isLoading}
-          isError={isError}
-        />
-        <CompositionDonut
-          title="Cases by state"
-          description="Share of active cases in each lifecycle state, excluding closed."
-          slices={stateSlices}
-          total={data?.stateTotal ?? 0}
-          isLoading={isLoading}
-          isError={isError}
-        />
-      </Stack>
+      <Grid container spacing={1.5}>
+        <Grid size={6}>
+          <CompositionDonut
+            title="Cases by severity"
+            description="Share of active cases at each severity level, excluding closed."
+            slices={severitySlices}
+            total={data?.severityTotal ?? 0}
+            isLoading={isLoading}
+            isError={isError}
+          />
+        </Grid>
+        <Grid size={6}>
+          <CompositionDonut
+            title="Cases by state"
+            description="Share of active cases in each lifecycle state, excluding closed."
+            slices={stateSlices}
+            total={data?.stateTotal ?? 0}
+            isLoading={isLoading}
+            isError={isError}
+          />
+        </Grid>
+      </Grid>
 
       {/* Reconciles with the donuts: both show active cases only, so the closed count is called
           out here rather than mixed into a slice — same as the webapp. */}

--- a/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
@@ -18,8 +18,8 @@ import { useMemo } from "react";
 import { Grid, Stack, Typography } from "@wso2/oxygen-ui";
 import { useQuery } from "@tanstack/react-query";
 import { dashboard } from "@src/services/dashboard";
-import { ALL_SEVERITIES, SEVERITY_LABELS, STATE_LABELS } from "@components/support/config";
-import { COMPOSITION_STATES, SEVERITY_SLICE_COLOR, STATE_SLICE_COLOR } from "./config";
+import { ALL_SEVERITIES, STATE_LABELS } from "@components/support/config";
+import { COMPOSITION_STATES, SEVERITY_SHORT_LABELS, SEVERITY_SLICE_COLOR, STATE_SLICE_COLOR } from "./config";
 import { CompositionDonut, type CompositionSlice } from "./CompositionDonut";
 
 // Two donuts — severity composition and state composition of active cases — mirrors the webapp's
@@ -35,7 +35,7 @@ export function CaseCompositionSection() {
     () =>
       ALL_SEVERITIES.map((severity) => ({
         id: severity,
-        name: SEVERITY_LABELS[severity],
+        name: SEVERITY_SHORT_LABELS[severity],
         value: data?.bySeverity[severity] ?? 0,
         color: SEVERITY_SLICE_COLOR[severity],
       })),

--- a/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CaseCompositionSection.tsx
@@ -16,11 +16,23 @@
 
 import { useMemo } from "react";
 import { Grid, Stack, Typography } from "@wso2/oxygen-ui";
+import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { dashboard } from "@src/services/dashboard";
+import type { CaseSeverity, CaseState } from "@src/types";
 import { ALL_SEVERITIES, STATE_LABELS } from "@components/support/config";
+import { EMPTY_FILTERS, filtersToSearchParams } from "@components/support/filters";
 import { COMPOSITION_STATES, SEVERITY_SHORT_LABELS, SEVERITY_SLICE_COLOR, STATE_SLICE_COLOR } from "./config";
 import { CompositionDonut, type CompositionSlice } from "./CompositionDonut";
+
+// Mirrors the webapp's CaseCompositionCharts onSliceClick (navigate(casesHref({...}))): clicking
+// a slice replaces whatever's currently on Support with just that one filter, rather than merging
+// with it — same behavior as the webapp, since a dashboard drill-down is meant to start fresh.
+function supportHref(overrides: Partial<{ severities: CaseSeverity[]; states: CaseState[] }>): string {
+  const params = filtersToSearchParams("", { ...EMPTY_FILTERS, ...overrides });
+  const qs = params.toString();
+  return qs ? `/support?${qs}` : "/support";
+}
 
 // Two donuts — severity composition and state composition of active cases — mirrors the webapp's
 // CaseCompositionCharts (apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx),
@@ -29,6 +41,7 @@ import { CompositionDonut, type CompositionSlice } from "./CompositionDonut";
 // TimeCardsPage.tsx already handles independent, non-blocking widgets in this app — one
 // failed/slow widget shouldn't hold up the rest of the Home page.
 export function CaseCompositionSection() {
+  const navigate = useNavigate();
   const { data, isLoading, isError } = useQuery(dashboard.composition());
 
   const severitySlices = useMemo<CompositionSlice[]>(
@@ -68,6 +81,7 @@ export function CaseCompositionSection() {
             total={data?.severityTotal ?? 0}
             isLoading={isLoading}
             isError={isError}
+            onSliceClick={(id) => navigate(supportHref({ severities: [id as CaseSeverity] }))}
           />
         </Grid>
         <Grid size={6}>
@@ -76,6 +90,7 @@ export function CaseCompositionSection() {
             description="Share of active cases in each lifecycle state, excluding closed."
             slices={stateSlices}
             total={data?.stateTotal ?? 0}
+            onSliceClick={(id) => navigate(supportHref({ states: [id as CaseState] }))}
             isLoading={isLoading}
             isError={isError}
           />

--- a/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
@@ -17,9 +17,7 @@
 import { Box, Card, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { PieChart } from "@wso2/oxygen-ui-charts-react";
 
-// Donut sits in a fixed square; the legend fills the rest of the card width. Smaller than the
-// webapp's 200px version (CompositionDonut.tsx) to fit a phone-width card comfortably.
-const DONUT_SIZE = 160;
+const DONUT_SIZE = 165;
 
 export interface CompositionSlice {
   id: string;
@@ -42,8 +40,6 @@ interface CompositionDonutProps {
 // A donut chart with a value/percentage legend and a centred total — mirrors the webapp's
 // CompositionDonut (apps/csm-portal/webapp/src/features/csm-dashboard/components/CompositionDonut.tsx).
 // Zero-value slices drop from the ring but stay in the legend so every category remains visible.
-// No slice-click drill-down here (unlike the webapp): the microapp's Support page doesn't support
-// seeding filters from the URL, so there's nowhere to deep-link a click into yet.
 export function CompositionDonut({
   title,
   description,
@@ -57,7 +53,7 @@ export function CompositionDonut({
   const isEmpty = !isLoading && !isError && total === 0;
 
   return (
-    <Card sx={{ p: 2 }}>
+    <Card sx={{ p: 1.5, height: "100%" }}>
       <Typography variant="subtitle1" fontWeight={600}>
         {title}
       </Typography>
@@ -96,6 +92,7 @@ export function CompositionDonut({
               tooltip={{ show: true }}
               width="100%"
               height={DONUT_SIZE}
+              margin={{ top: 0, right: 0, bottom: 5, left: 0 }}
               pies={[
                 {
                   dataKey: "value",
@@ -113,17 +110,32 @@ export function CompositionDonut({
             <Box
               sx={{
                 position: "absolute",
-                top: "50%",
-                left: "50%",
-                transform: "translate(-50%, -50%)",
-                textAlign: "center",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
                 pointerEvents: "none",
               }}
             >
-              <Typography variant="h5">{total}</Typography>
-              <Typography variant="caption" color="text.secondary">
-                Total
-              </Typography>
+              {/* Constrained to well inside the ring's inner radius (62% of DONUT_SIZE) so the
+                  text never touches the ring, even for a wide number. */}
+              <Box
+                sx={{
+                  width: "55%",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  textAlign: "center",
+                }}
+              >
+                <Typography variant="h5" noWrap sx={{ lineHeight: 1.2 }}>
+                  {total}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.2 }}>
+                  Total
+                </Typography>
+              </Box>
             </Box>
           </Box>
 

--- a/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
@@ -28,7 +28,6 @@ export interface CompositionSlice {
 
 interface CompositionDonutProps {
   title: string;
-  description: string;
   slices: CompositionSlice[];
   total: number;
   isLoading: boolean;
@@ -44,7 +43,6 @@ interface CompositionDonutProps {
 // Zero-value slices drop from the ring but stay in the legend so every category remains visible.
 export function CompositionDonut({
   title,
-  description,
   slices,
   total,
   isLoading,
@@ -59,9 +57,6 @@ export function CompositionDonut({
     <Card sx={{ p: 1.5, height: "100%" }}>
       <Typography variant="subtitle1" fontWeight={600}>
         {title}
-      </Typography>
-      <Typography variant="caption" color="text.secondary">
-        {description}
       </Typography>
 
       {isLoading ? (
@@ -104,6 +99,7 @@ export function CompositionDonut({
               width="100%"
               height={DONUT_SIZE}
               margin={{ top: 0, right: 0, bottom: 5, left: 0 }}
+              isAnimationActive={false}
               pies={[
                 {
                   dataKey: "value",

--- a/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
@@ -35,6 +35,8 @@ interface CompositionDonutProps {
   isError: boolean;
   /** Noun for the empty state, e.g. "cases". */
   emptyNoun?: string;
+
+  onSliceClick?: (id: string) => void;
 }
 
 // A donut chart with a value/percentage legend and a centred total — mirrors the webapp's
@@ -48,6 +50,7 @@ export function CompositionDonut({
   isLoading,
   isError,
   emptyNoun = "cases",
+  onSliceClick,
 }: CompositionDonutProps) {
   const pieData = slices.filter((s) => s.value > 0);
   const isEmpty = !isLoading && !isError && total === 0;
@@ -84,7 +87,15 @@ export function CompositionDonut({
         </Box>
       ) : (
         <Box sx={{ mt: 2, display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
-          <Box sx={{ position: "relative", width: DONUT_SIZE, height: DONUT_SIZE, flexShrink: 0 }}>
+          <Box
+            sx={{
+              position: "relative",
+              width: DONUT_SIZE,
+              height: DONUT_SIZE,
+              flexShrink: 0,
+              ...(onSliceClick && { "& .recharts-pie-sector": { cursor: "pointer" } }),
+            }}
+          >
             <PieChart
               data={pieData}
               colors={pieData.map((s) => s.color)}
@@ -104,6 +115,12 @@ export function CompositionDonut({
                   endAngle: -270,
                   label: false,
                   labelLine: false,
+                  ...(onSliceClick && {
+                    onClick: (_data: unknown, index: number) => {
+                      const slice = pieData[index];
+                      if (slice) onSliceClick(slice.id);
+                    },
+                  }),
                 },
               ]}
             />
@@ -144,7 +161,17 @@ export function CompositionDonut({
             {slices.map((s) => {
               const pct = total > 0 ? Math.round((s.value / total) * 100) : 0;
               return (
-                <Box key={s.id} sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+                <Box
+                  key={s.id}
+                  onClick={onSliceClick ? () => onSliceClick(s.id) : undefined}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 1,
+                    cursor: onSliceClick ? "pointer" : "default",
+                  }}
+                >
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 0 }}>
                     <Box sx={{ width: 12, height: 12, borderRadius: "50%", bgcolor: s.color, flexShrink: 0 }} />
                     <Typography variant="body2" color="text.secondary" noWrap>

--- a/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
@@ -85,7 +85,8 @@ export function CompositionDonut({
           <Box
             sx={{
               position: "relative",
-              width: DONUT_SIZE,
+              width: "100%",
+              maxWidth: DONUT_SIZE,
               height: DONUT_SIZE,
               flexShrink: 0,
               ...(onSliceClick && { "& .recharts-pie-sector": { cursor: "pointer" } }),

--- a/apps/csm-portal/microapp/src/components/home/config.ts
+++ b/apps/csm-portal/microapp/src/components/home/config.ts
@@ -33,6 +33,16 @@ export const COMPOSITION_STATES: CaseState[] = [
 // includes reopened unlike the composition set above.
 export const ASSIGNED_TO_ME_STATES: CaseState[] = [...COMPOSITION_STATES, "reopened"];
 
+// Short severity code only (no "(Catastrophic)" etc.) — the composition donut's legend is too
+// narrow, sitting in a half-width card, for support/config.tsx's full SEVERITY_LABELS.
+export const SEVERITY_SHORT_LABELS: Record<CaseSeverity, string> = {
+  catastrophic: "S0",
+  critical: "S1",
+  high: "S2",
+  medium: "S3",
+  low: "S4",
+};
+
 // Distinct hue per slice — mirrors the webapp's SEVERITY_SLICE_COLOR/STATE_SLICE_COLOR
 // (CaseCompositionCharts.tsx). The support/config.tsx chip color configs reuse the same role
 // color for several keys (e.g. every "info" state), which would merge pie slices together.

--- a/apps/csm-portal/microapp/src/components/layout/TabBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TabBar.tsx
@@ -21,13 +21,13 @@ import { Cog, Headset, House, LayoutGrid } from "@wso2/oxygen-ui-icons-react";
 
 // Mirrors a subset of the webapp's CSM_NAV_ITEMS (apps/csm-portal/webapp/src/config/csmNavItems.ts):
 // Home (Dashboard), Support (Cases), Operations get their own tab; Time Cards/Security
-// Center/Updates/Engagements are grouped under More; Customers/Settings aren't in the mobile nav.
-// Profile is reached from the TopBar's top-right corner instead of a tab here.
+// Center/Updates/Engagements/Settings/Profile are grouped under More; Customers isn't in the
+// mobile nav.
 function activeTabFor(pathname: string): string | false {
   if (pathname === "/") return "home";
   if (pathname.startsWith("/support") || pathname.startsWith("/cases/")) return "support";
   if (pathname.startsWith("/operations")) return "operations";
-  if (pathname.startsWith("/more")) return "more";
+  if (pathname.startsWith("/more") || pathname.startsWith("/profile")) return "more";
   return false;
 }
 

--- a/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
@@ -15,21 +15,17 @@
 // under the License.
 
 import { useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Avatar, Box, IconButton, Typography } from "@wso2/oxygen-ui";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Box, IconButton, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Grip } from "@wso2/oxygen-ui-icons-react";
-import { useUserStore } from "@src/store/user";
 import { goToMyAppsScreen } from "@components/microapp-bridge";
 import { ConfirmDialog } from "@components/common/ConfirmDialog";
-import { initialsOf } from "@utils/initials";
 
-const ROOT_PATHS = ["/", "/support", "/operations", "/more", "/profile"];
+const ROOT_PATHS = ["/", "/support", "/operations", "/more"];
 
 export function TopBar() {
   const location = useLocation();
   const navigate = useNavigate();
-  const user = useUserStore((state) => state.user);
-  const isProfileActive = location.pathname.startsWith("/profile");
   const isRootPath = ROOT_PATHS.includes(location.pathname);
 
   return (
@@ -38,7 +34,6 @@ export function TopBar() {
       top={0}
       bgcolor="background.paper"
       display="flex"
-      justifyContent="space-between"
       alignItems="center"
       px={2}
       pb={1}
@@ -58,21 +53,6 @@ export function TopBar() {
           </IconButton>
         )}
       </Box>
-
-      <IconButton component={Link} to="/profile" aria-label="Profile" size="small">
-        <Avatar
-          src={user?.avatarUrl}
-          slotProps={{ img: { referrerPolicy: "no-referrer" } }}
-          sx={{
-            width: 28,
-            height: 28,
-            fontSize: 13,
-            bgcolor: isProfileActive ? "primary.main" : "grey.400",
-          }}
-        >
-          {initialsOf(user?.name ?? "")}
-        </Avatar>
-      </IconButton>
     </Box>
   );
 }

--- a/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
@@ -36,9 +36,14 @@ export function TopBar() {
       display="flex"
       alignItems="center"
       px={2}
-      pb={1}
+      pb={2}
       sx={{
-        pt: 7,
+        // Ties directly to the device's actual safe-area inset (--safe-top, set from the native
+        // bridge) plus enough clearance for the ExitButton pill's own height, rather than a fixed
+        // value — a fixed pt (the customer-portal microapp's own AppBar.tsx uses one too) is only
+        // correct for whatever inset it was tuned against; on a Dynamic Island phone (~59px inset)
+        // it undershoots and the pill visually overflows into the page content below it.
+        pt: "calc(var(--safe-top, 44px) + 40px)",
         borderBottom: "1px solid",
         borderColor: "divider",
         zIndex: (theme) => theme.zIndex.appBar,
@@ -73,7 +78,7 @@ function ExitButton() {
         sx={{
           gap: 1,
           position: "absolute",
-          top: "var(--safe-top)",
+          top: "var(--safe-top, 44px)",
           left: 10,
           p: 0,
         }}

--- a/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
@@ -14,10 +14,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Avatar, Box, IconButton, Stack, Typography } from "@wso2/oxygen-ui";
-import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { Avatar, Box, IconButton, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft, Grip } from "@wso2/oxygen-ui-icons-react";
 import { useUserStore } from "@src/store/user";
+import { goToMyAppsScreen } from "@components/microapp-bridge";
+import { ConfirmDialog } from "@components/common/ConfirmDialog";
 import { initialsOf } from "@utils/initials";
 
 const ROOT_PATHS = ["/", "/support", "/operations", "/more", "/profile"];
@@ -27,7 +30,7 @@ export function TopBar() {
   const navigate = useNavigate();
   const user = useUserStore((state) => state.user);
   const isProfileActive = location.pathname.startsWith("/profile");
-  const showBackButton = !ROOT_PATHS.includes(location.pathname);
+  const isRootPath = ROOT_PATHS.includes(location.pathname);
 
   return (
     <Box
@@ -47,17 +50,12 @@ export function TopBar() {
       }}
     >
       <Box sx={{ minWidth: 32 }}>
-        {showBackButton ? (
+        {isRootPath ? (
+          <ExitButton />
+        ) : (
           <IconButton onClick={() => navigate(-1)} aria-label="Go back" size="small">
             <ArrowLeft size={22} />
           </IconButton>
-        ) : (
-          <Stack direction="row" alignItems="center" gap={1}>
-            <img src="/logo-dark.svg" alt="Company Logo" style={{ height: 20, width: "auto" }} />
-            <Typography variant="subtitle1" fontWeight={600}>
-              CSM Portal
-            </Typography>
-          </Stack>
         )}
       </Box>
 
@@ -76,5 +74,46 @@ export function TopBar() {
         </Avatar>
       </IconButton>
     </Box>
+  );
+}
+
+// Leaves the microapp WebView and returns to the native shell's app switcher — mirrors the
+// customer-portal microapp's own ExitButton (components/core/AppBar.tsx), shown on root pages in
+// place of the back button. Floats in the safe-area strip above the main row (same technique the
+// customer-portal version uses: absolutely positioned at `var(--safe-top)`), so it doesn't compete
+// with page content for width on narrow phones.
+function ExitButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <IconButton
+        disableRipple
+        color="error"
+        sx={{
+          gap: 1,
+          position: "absolute",
+          top: "var(--safe-top)",
+          left: 10,
+          p: 0,
+        }}
+        onClick={() => setOpen(true)}
+      >
+        <Grip size={20} />
+        <Typography variant="body2" fontWeight={600}>
+          Go to Apps
+        </Typography>
+      </IconButton>
+
+      <ConfirmDialog
+        open={open}
+        title="Return to Apps"
+        description="Are you sure you want to leave this application?"
+        confirmColor="error"
+        confirmLabel="Leave"
+        onClose={() => setOpen(false)}
+        onConfirm={goToMyAppsScreen}
+      />
+    </>
   );
 }

--- a/apps/csm-portal/microapp/src/pages/HomePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/HomePage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Stack, Typography } from "@wso2/oxygen-ui";
+import { Stack } from "@wso2/oxygen-ui";
 import { AssignedToMeSection } from "@components/home/AssignedToMeSection";
 import { CaseCompositionSection } from "@components/home/CaseCompositionSection";
 
@@ -27,7 +27,6 @@ import { CaseCompositionSection } from "@components/home/CaseCompositionSection"
 export default function HomePage() {
   return (
     <Stack gap={3}>
-      <Typography variant="h5">Home</Typography>
       <AssignedToMeSection />
       <CaseCompositionSection />
     </Stack>

--- a/apps/csm-portal/microapp/src/pages/MorePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/MorePage.tsx
@@ -24,6 +24,7 @@ import {
   RefreshCw,
   Settings,
   Shield,
+  User,
   type LucideIcon,
 } from "@wso2/oxygen-ui-icons-react";
 
@@ -35,7 +36,8 @@ interface MoreItem {
 
 // Secondary sections that don't get their own tab, mirroring a subset of the webapp's
 // CSM_NAV_ITEMS (apps/csm-portal/webapp/src/config/csmNavItems.ts) — Customers is deliberately
-// left out here. Settings is last, same position it has in CSM_NAV_ITEMS.
+// left out here. Settings is last, same position it has in CSM_NAV_ITEMS. Profile comes after
+// Settings — it moved here from the TopBar's avatar shortcut.
 const MORE_ITEMS: MoreItem[] = [
   { label: "Announcements", path: "/more/announcements", icon: Megaphone },
   { label: "Time Cards", path: "/more/time-cards", icon: Clock },
@@ -43,6 +45,7 @@ const MORE_ITEMS: MoreItem[] = [
   { label: "Updates", path: "/more/updates", icon: RefreshCw },
   { label: "Engagements", path: "/more/engagements", icon: Briefcase },
   { label: "Settings", path: "/more/settings", icon: Settings },
+  { label: "Profile", path: "/profile", icon: User },
 ];
 
 export default function MorePage() {

--- a/apps/csm-portal/microapp/src/pages/MorePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/MorePage.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { Link } from "react-router-dom";
-import { List, ListItemButton, ListItemIcon, ListItemText, Stack, Typography } from "@wso2/oxygen-ui";
+import { List, ListItemButton, ListItemIcon, ListItemText, Stack } from "@wso2/oxygen-ui";
 import {
   Briefcase,
   ChevronRight,
@@ -51,8 +51,6 @@ const MORE_ITEMS: MoreItem[] = [
 export default function MorePage() {
   return (
     <Stack gap={2}>
-      <Typography variant="h5">More</Typography>
-
       <List disablePadding>
         {MORE_ITEMS.map((item) => (
           <ListItemButton key={item.path} component={Link} to={item.path} sx={{ borderRadius: 1 }}>

--- a/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
@@ -19,5 +19,11 @@ import { ComingSoonPage } from "@components/common/ComingSoonPage";
 // The webapp itself marks Operations as wip:true (apps/csm-portal/webapp/src/config/csmNavItems.ts)
 // and shows its own coming-soon page — mirroring that here rather than building ahead of it.
 export default function OperationsPage() {
-  return <ComingSoonPage title="Operations" description="Operations tooling is still under construction." />;
+  return (
+    <ComingSoonPage
+      title="Operations"
+      description="Operations tooling is still under construction."
+      showTitle={false}
+    />
+  );
 }

--- a/apps/csm-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SupportPage.tsx
@@ -16,7 +16,7 @@
 
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Badge, Chip, IconButton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { Badge, Chip, Fab, IconButton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useQuery, useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
@@ -74,21 +74,6 @@ export default function SupportPage() {
 
   return (
     <Stack gap={2}>
-      <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
-        <Typography variant="h5">Support</Typography>
-        <IconButton
-          aria-label="Create case"
-          onClick={() => navigate("/cases/new")}
-          sx={{
-            bgcolor: "primary.main",
-            color: "primary.contrastText",
-            "&:hover": { bgcolor: "primary.dark" },
-          }}
-        >
-          <Plus size={20} />
-        </IconButton>
-      </Stack>
-
       <Stack direction="row" gap={1} alignItems="center">
         <SearchBar value={search} onChange={setSearch} />
         <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
@@ -114,6 +99,19 @@ export default function SupportPage() {
       </CaseListErrorBoundary>
 
       <FiltersSheet open={filtersOpen} onClose={() => setFiltersOpen(false)} filters={filters} onApply={setFilters} />
+
+      {/* Floating rather than inline in the header — mirrors the customer-portal microapp's own
+          Fab (components/core/Fab.tsx): fixed bottom-right, offset above the fixed TabBar by its
+          live-measured height (--tab-bar-height) plus some breathing room. */}
+      <Fab
+        aria-label="Create case"
+        size="medium"
+        color="primary"
+        onClick={() => navigate("/cases/new")}
+        sx={{ position: "fixed", right: 10, bottom: "calc(var(--tab-bar-height) + 60px)" }}
+      >
+        <Plus size={20} />
+      </Fab>
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SupportPage.tsx
@@ -15,8 +15,8 @@
 // under the License.
 
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
-import { Badge, IconButton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Badge, Chip, IconButton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useQuery, useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
@@ -28,8 +28,19 @@ import { EmptyState } from "@components/support/EmptyState";
 import { ErrorState } from "@components/support/ErrorState";
 import { SearchBar } from "@components/support/SearchBar";
 import { FiltersSheet } from "@components/support/FiltersSheet";
-import { countActiveFilters, EMPTY_FILTERS, toCaseSearchFilters, type CaseFilters } from "@components/support/filters";
-import { FILTERABLE_STATES, STATE_LABELS, TAB_CONFIG } from "@components/support/config";
+import {
+  countActiveFilters,
+  filtersFromSearchParams,
+  toCaseSearchFilters,
+  type CaseFilters,
+} from "@components/support/filters";
+import {
+  FILTERABLE_STATES,
+  SEVERITY_LABELS,
+  STATE_LABELS,
+  TAB_CONFIG,
+  WORK_STATE_LABEL,
+} from "@components/support/config";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
 
 const ALL_STATES_TAB = "all" as const;
@@ -37,12 +48,15 @@ type StateTabValue = CaseState | typeof ALL_STATES_TAB;
 
 // Cases only (mirrors AllCasesPage's former "View All" list, now the Support page itself): a
 // single infinite-scrolled, most-recently-updated-first list with search/filters/create inline,
-// no separate recent-preview + "View All" hop.
+// no separate recent-preview + "View All" hop. search/filters are seeded once from the URL on
+// mount — lets Home's composition donuts deep-link here with a filter pre-applied — then managed
+// as plain local state from there (not kept in sync back to the URL).
 export default function SupportPage() {
   const navigate = useNavigate();
-  const [search, setSearch] = useState("");
+  const [searchParams] = useSearchParams();
+  const [search, setSearch] = useState(() => filtersFromSearchParams(searchParams).search);
   const debouncedSearch = useDebouncedValue(search, 300);
-  const [filters, setFilters] = useState<CaseFilters>(EMPTY_FILTERS);
+  const [filters, setFilters] = useState<CaseFilters>(() => filtersFromSearchParams(searchParams).filters);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const activeFilterCount = countActiveFilters(filters);
 
@@ -84,6 +98,8 @@ export default function SupportPage() {
         </Badge>
       </Stack>
 
+      {activeFilterCount > 0 && <ActiveFiltersRow filters={filters} onChange={setFilters} />}
+
       <Tabs variant="scrollable" value={stateTab} onChange={(_, value: StateTabValue) => handleStateTabChange(value)}>
         <Tab label="All" value={ALL_STATES_TAB} disableRipple />
         {FILTERABLE_STATES.map((state) => (
@@ -98,6 +114,40 @@ export default function SupportPage() {
       </CaseListErrorBoundary>
 
       <FiltersSheet open={filtersOpen} onClose={() => setFiltersOpen(false)} filters={filters} onApply={setFilters} />
+    </Stack>
+  );
+}
+
+// One removable chip per active filter (severities, work states, assigned/created-by-me) — lets
+// a filter picked up via the FiltersSheet, or deep-linked in from Home's composition donuts, be
+// removed individually instead of only via the sheet's "Clear all". Deliberately excludes state
+// (it has its own dedicated Tab row above, so a chip here would just duplicate that) — same
+// exclusion countActiveFilters already makes for its badge count.
+function ActiveFiltersRow({ filters, onChange }: { filters: CaseFilters; onChange: (filters: CaseFilters) => void }) {
+  return (
+    <Stack direction="row" gap={1} flexWrap="wrap">
+      {filters.severities.map((severity) => (
+        <Chip
+          key={`severity-${severity}`}
+          label={SEVERITY_LABELS[severity]}
+          size="small"
+          onDelete={() => onChange({ ...filters, severities: filters.severities.filter((s) => s !== severity) })}
+        />
+      ))}
+      {filters.workStates.map((workState) => (
+        <Chip
+          key={`work-state-${workState}`}
+          label={WORK_STATE_LABEL[workState]}
+          size="small"
+          onDelete={() => onChange({ ...filters, workStates: filters.workStates.filter((w) => w !== workState) })}
+        />
+      ))}
+      {filters.assignedToMe && (
+        <Chip label="Assigned to me" size="small" onDelete={() => onChange({ ...filters, assignedToMe: false })} />
+      )}
+      {filters.createdByMe && (
+        <Chip label="Created by me" size="small" onDelete={() => onChange({ ...filters, createdByMe: false })} />
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary

**Home page** (mirrors the webapp's Dashboard):
- "Assigned to me" widget (signed-in user's non-closed cases, 5-item preview, refresh control) and case-composition donuts (severity + state breakdown of active cases), both backed by new `services/dashboard.ts` queries.
- Donuts sit side by side in a 2-column grid, sized up, with a properly centered total (the previous transform-based centering didn't account for the chart's default margin, so it visually drifted off-center) and short S0-S4 severity labels so the legend doesn't truncate in the half-width card.
- Clicking a donut slice or legend row navigates to Support with that severity/state filter pre-applied (mirrors the webapp's `CaseCompositionCharts` `onSliceClick`).
- Loading skeleton for "Assigned to me" trimmed from 3 cards to 2, so the composition donuts are visible in the same first viewport instead of being pushed below the fold.

**Support page:**
- Seeds its filters from the URL on mount (`filtersFromSearchParams` existed but was dead code) — this is what lets the Home donuts deep-link in with a filter applied.
- Active filters now show as a row of removable chips below the search bar (severities/work-states/assigned-to-me/created-by-me — state is excluded since it already has its own Tab row). Note: this isn't a port of existing webapp behavior — the webapp uses a single "Clear filters (N)" button instead.
- The "+" create-case button moved from an inline header button to a floating action button, bottom-right, mirroring the customer-portal microapp's own `Fab.tsx` positioning.

**Navigation cleanup:**
- Added a "Go to Apps" exit button (mirrors customer-portal's `ExitButton`, using a microapp-bridge function that already existed but was unused) and dropped the "CSM Portal" logo/text from the TopBar to match.
- Profile moved from a TopBar avatar shortcut to a "Profile" entry in More, right after Settings — it's no longer a root-level destination, so it gets a normal back button now like every other More sub-page.
- Removed the redundant page-title headings from Home/Support/Operations/More (repeated the same text the active TabBar tab already shows).
- Fixed the TopBar's top padding to scale with the actual device safe-area inset instead of a fixed value — on Dynamic Island phones the fixed padding undershot and the exit button visually overflowed into the page content.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean (worked around the pre-existing, unrelated `ignoreDeprecations` TS-version mismatch to get a real type-check signal)
- [x] `vite build` clean
- [x] Manually verified in the simulator with real data: Home shows live composition numbers and the assigned-to-me empty state, Support's filter chips and URL-seeding work end to end, FAB and Go to Apps render and position correctly, Profile shows a back button from More

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clickable severity and state charts that navigate to filtered support case lists.
  * Added removable active-filter chips on the Support page.
  * Added a Profile option to the More menu.
  * Added confirmation before exiting to the apps screen.
  * Added URL-based restoration of Support page filters and search settings.

* **Improvements**
  * Updated mobile navigation and header behavior.
  * Simplified home and operations page layouts.
  * Reduced loading placeholders on the home dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->