### PR TITLE
[Customer Entity] Update POST /accounts/search and implement GET /accounts/{id} for ServiceNow

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -227,7 +227,6 @@ type SearchAccountsResponse struct {
 // SupportTier is returned as a plain label string (no ID).
 type SNAccountView struct {
 	ID               string     `json:"id"`
-	SysID            string     `json:"sysId"`
 	Name             string     `json:"name"`
 	Classification   string     `json:"classification"`
 	Pod              *string    `json:"pod"`
@@ -252,6 +251,33 @@ type SearchSNAccountsResponse struct {
 	Limit    int             `json:"limit"`
 	Offset   int             `json:"offset"`
 	HasMore  bool            `json:"hasMore"`
+}
+
+// SNSupportTierRef is a compact reference to a support tier carrying its label.
+type SNSupportTierRef struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// SNAccountDetail is the full account detail returned by the ServiceNow data source
+// for GET /accounts/{id}. SupportTier is returned as an {id, label} object.
+type SNAccountDetail struct {
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	Classification   string            `json:"classification"`
+	Pod              *string           `json:"pod"`
+	Region           *string           `json:"region"`
+	SupportTier      *SNSupportTierRef `json:"supportTier"`
+	ArrToday         *string           `json:"arrToday"`
+	TechnicalOwner   *EntityRef        `json:"technicalOwner"`
+	Owner            *EntityRef        `json:"owner"`
+	ActivationDate   string            `json:"activationDate"`
+	DeactivationDate *string           `json:"deactivationDate"`
+	HasAgent         bool              `json:"hasAgent"`
+	HasKbReferences  bool              `json:"hasKbReferences"`
+	CreatedOn        string            `json:"createdOn"`
+	CreatedBy        *string           `json:"createdBy"`
+	UpdatedOn        string            `json:"updatedOn"`
 }
 
 // SubscriptionType classifies the subscription type of a project.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -198,11 +198,18 @@ type Account struct {
 	UpdatedOn           time.Time   `json:"updatedOn"`
 }
 
+// SearchAccountsFilters holds the optional filter criteria for an account search.
+type SearchAccountsFilters struct {
+	SearchQuery    string `json:"searchQuery,omitempty"`
+	Active         *bool  `json:"active,omitempty"`
+	Pod            string `json:"pod,omitempty"`
+	Classification string `json:"classification,omitempty"`
+}
+
 // SearchAccountsRequest is the input for an account search operation.
-// SearchQuery is matched case-insensitively against name and sf_id.
 type SearchAccountsRequest struct {
-	Pagination  Pagination `json:"pagination"`
-	SearchQuery string     `json:"searchQuery"`
+	Pagination Pagination            `json:"pagination"`
+	Filters    SearchAccountsFilters `json:"filters,omitempty"`
 }
 
 // SearchAccountsResponse is the paginated result of an account search.
@@ -215,31 +222,36 @@ type SearchAccountsResponse struct {
 	HasMore  bool      `json:"hasMore"`
 }
 
-// SNAccount is the account view returned by the ServiceNow data source.
+// SNAccountView is the account view returned by the ServiceNow data source.
 // Timestamp fields are kept as strings to accommodate empty values from ServiceNow.
-type SNAccount struct {
-	ID                  string  `json:"id"`
-	SfID                string  `json:"sfId"`
-	Name                string  `json:"name"`
-	Tier                string  `json:"tier"`
-	Region              *string `json:"region"`
-	ActivationDate      string  `json:"activationDate"`
-	DeactivationDate    *string `json:"deactivationDate"`
-	OwnerID             string  `json:"ownerId"`
-	TechnicalOwnerID    *string `json:"technicalOwnerId"`
-	AgentEnabled        bool    `json:"agentEnabled"`
-	KbReferencesEnabled bool    `json:"kbReferencesEnabled"`
-	CreatedOn           string  `json:"createdOn"`
-	UpdatedOn           string  `json:"updatedOn"`
+// SupportTier is returned as a plain label string (no ID).
+type SNAccountView struct {
+	ID               string     `json:"id"`
+	SysID            string     `json:"sysId"`
+	Name             string     `json:"name"`
+	Classification   string     `json:"classification"`
+	Pod              *string    `json:"pod"`
+	Region           *string    `json:"region"`
+	SupportTier      *string    `json:"supportTier"`
+	ArrToday         *string    `json:"arrToday"`
+	TechnicalOwner   *EntityRef `json:"technicalOwner"`
+	Owner            *EntityRef `json:"owner"`
+	ActivationDate   string     `json:"activationDate"`
+	DeactivationDate *string    `json:"deactivationDate"`
+	HasAgent         bool       `json:"hasAgent"`
+	HasKbReferences  bool       `json:"hasKbReferences"`
+	CreatedOn        string     `json:"createdOn"`
+	CreatedBy        *string    `json:"createdBy"`
+	UpdatedOn        string     `json:"updatedOn"`
 }
 
 // SearchSNAccountsResponse is the paginated result of a ServiceNow account search.
 type SearchSNAccountsResponse struct {
-	Accounts []SNAccount `json:"accounts"`
-	Total    int         `json:"total"`
-	Limit    int         `json:"limit"`
-	Offset   int         `json:"offset"`
-	HasMore  bool        `json:"hasMore"`
+	Accounts []SNAccountView `json:"accounts"`
+	Total    int             `json:"total"`
+	Limit    int             `json:"limit"`
+	Offset   int             `json:"offset"`
+	HasMore  bool            `json:"hasMore"`
 }
 
 // SubscriptionType classifies the subscription type of a project.

--- a/entity-service/internal/repository/account_repo.go
+++ b/entity-service/internal/repository/account_repo.go
@@ -56,8 +56,8 @@ func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccou
 
 	where := "WHERE 1=1"
 
-	if req.SearchQuery != "" {
-		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.SearchQuery)
+	if req.Filters.SearchQuery != "" {
+		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.Filters.SearchQuery)
 		pattern := "%" + escaped + "%"
 		where += fmt.Sprintf(" AND (name ILIKE $%d ESCAPE '\\' OR sf_id ILIKE $%d ESCAPE '\\')", argIdx, argIdx)
 		filterArgs = append(filterArgs, pattern)

--- a/entity-service/internal/service/account_service.go
+++ b/entity-service/internal/service/account_service.go
@@ -38,7 +38,7 @@ func (s *accountService) SearchAccounts(ctx context.Context, req domain.SearchAc
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchAccountsResponse{}, err
 	}
-	if err := validateSearchQuery(req.SearchQuery); err != nil {
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchAccountsResponse{}, err
 	}
 	accounts, total, err := s.repo.SearchAccounts(ctx, req)

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -64,9 +64,9 @@ type SNAccountService interface {
 	// SearchAccounts returns a paginated list of ServiceNow accounts matching the
 	// filters in req. An UnauthorizedError is returned when x-user-id-token is absent.
 	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchSNAccountsResponse, error)
-	// GetAccountByID returns the ServiceNow account for the given UUID.
+	// GetAccountByID returns the full account detail for the given UUID.
 	// An UnauthorizedError is returned when x-user-id-token is absent.
-	GetAccountByID(ctx context.Context, id string) (domain.SNAccountView, error)
+	GetAccountByID(ctx context.Context, id string) (domain.SNAccountDetail, error)
 }
 
 // ProjectService defines the operations available on the project entity.

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -66,7 +66,7 @@ type SNAccountService interface {
 	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchSNAccountsResponse, error)
 	// GetAccountByID returns the ServiceNow account for the given UUID.
 	// An UnauthorizedError is returned when x-user-id-token is absent.
-	GetAccountByID(ctx context.Context, id string) (domain.SNAccount, error)
+	GetAccountByID(ctx context.Context, id string) (domain.SNAccountView, error)
 }
 
 // ProjectService defines the operations available on the project entity.

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -133,65 +133,63 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 	}, nil
 }
 
-func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domain.SNAccountView, error) {
+func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domain.SNAccountDetail, error) {
 	if err := validateUUIDs("id", []string{id}); err != nil {
-		return domain.SNAccountView{}, err
+		return domain.SNAccountDetail{}, err
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
-		return domain.SNAccountView{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+		return domain.SNAccountDetail{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
 	raw, err := s.client.Get(ctx, "/accounts/"+uuidToSysid(id), token)
 	if err != nil {
-		return domain.SNAccountView{}, err
+		return domain.SNAccountDetail{}, err
 	}
 
 	var a snAccount
 	if err := json.Unmarshal(raw, &a); err != nil {
-		return domain.SNAccountView{}, fmt.Errorf("sn accounts: parse account response: %w", err)
+		return domain.SNAccountDetail{}, fmt.Errorf("sn accounts: parse account response: %w", err)
 	}
 
-	return snAccountToDomain(a), nil
+	return snAccountToDetail(a), nil
+}
+
+func nilIfEmpty(s *string) *string {
+	if s != nil && *s == "" {
+		return nil
+	}
+	return s
+}
+
+func snAccountCommonFields(a snAccount) (deactivationDate *string, technicalOwner, owner *domain.EntityRef) {
+	deactivationDate = nilIfEmpty(a.DeactivationDate)
+	if a.TechnicalOwner != nil && a.TechnicalOwner.ID != "" {
+		technicalOwner = &domain.EntityRef{ID: sysidToUUID(a.TechnicalOwner.ID), Name: a.TechnicalOwner.Name}
+	}
+	if a.Owner != nil && a.Owner.ID != "" {
+		owner = &domain.EntityRef{ID: sysidToUUID(a.Owner.ID), Name: a.Owner.Name}
+	}
+	return
 }
 
 func snAccountToDomain(a snAccount) domain.SNAccountView {
-	var deactivationDate *string
-	if a.DeactivationDate != nil && *a.DeactivationDate != "" {
-		deactivationDate = a.DeactivationDate
-	}
+	deactivationDate, technicalOwner, owner := snAccountCommonFields(a)
 
 	var supportTier *string
 	if a.SupportTier != nil && a.SupportTier.Label != "" {
 		supportTier = &a.SupportTier.Label
 	}
 
-	var technicalOwner *domain.EntityRef
-	if a.TechnicalOwner != nil && a.TechnicalOwner.ID != "" {
-		technicalOwner = &domain.EntityRef{
-			ID:   sysidToUUID(a.TechnicalOwner.ID),
-			Name: a.TechnicalOwner.Name,
-		}
-	}
-
-	var owner *domain.EntityRef
-	if a.Owner != nil && a.Owner.ID != "" {
-		owner = &domain.EntityRef{
-			ID:   sysidToUUID(a.Owner.ID),
-			Name: a.Owner.Name,
-		}
-	}
-
 	return domain.SNAccountView{
 		ID:               sysidToUUID(a.ID),
-		SysID:            a.ID,
 		Name:             a.Name,
 		Classification:   a.Classification,
-		Pod:              a.Pod,
-		Region:           a.Region,
+		Pod:              nilIfEmpty(a.Pod),
+		Region:           nilIfEmpty(a.Region),
 		SupportTier:      supportTier,
-		ArrToday:         a.ArrToday,
+		ArrToday:         nilIfEmpty(a.ArrToday),
 		TechnicalOwner:   technicalOwner,
 		Owner:            owner,
 		ActivationDate:   a.ActivationDate,
@@ -199,7 +197,38 @@ func snAccountToDomain(a snAccount) domain.SNAccountView {
 		HasAgent:         a.HasAgent,
 		HasKbReferences:  a.HasKbReferences,
 		CreatedOn:        a.CreatedOn,
-		CreatedBy:        a.CreatedBy,
+		CreatedBy:        nilIfEmpty(a.CreatedBy),
+		UpdatedOn:        a.UpdatedOn,
+	}
+}
+
+func snAccountToDetail(a snAccount) domain.SNAccountDetail {
+	deactivationDate, technicalOwner, owner := snAccountCommonFields(a)
+
+	var supportTier *domain.SNSupportTierRef
+	if a.SupportTier != nil && a.SupportTier.ID != "" {
+		supportTier = &domain.SNSupportTierRef{
+			ID:    sysidToUUID(a.SupportTier.ID),
+			Label: a.SupportTier.Label,
+		}
+	}
+
+	return domain.SNAccountDetail{
+		ID:               sysidToUUID(a.ID),
+		Name:             a.Name,
+		Classification:   a.Classification,
+		Pod:              nilIfEmpty(a.Pod),
+		Region:           nilIfEmpty(a.Region),
+		SupportTier:      supportTier,
+		ArrToday:         nilIfEmpty(a.ArrToday),
+		TechnicalOwner:   technicalOwner,
+		Owner:            owner,
+		ActivationDate:   a.ActivationDate,
+		DeactivationDate: deactivationDate,
+		HasAgent:         a.HasAgent,
+		HasKbReferences:  a.HasKbReferences,
+		CreatedOn:        a.CreatedOn,
+		CreatedBy:        nilIfEmpty(a.CreatedBy),
 		UpdatedOn:        a.UpdatedOn,
 	}
 }

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
@@ -36,20 +35,33 @@ type snAccountsResponse struct {
 	Limit        int         `json:"limit"`
 }
 
+type snSupportTier struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+type snPersonRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type snAccount struct {
-	ID               string  `json:"id"`
-	SfID             string  `json:"sfId"`
-	Name             string  `json:"name"`
-	SupportTier      string  `json:"supportTier"`
-	Region           *string `json:"region"`
-	ActivationDate   string  `json:"activationDate"`
-	DeactivationDate *string `json:"deactivationDate"`
-	OwnerID          string  `json:"ownerId"`
-	TechnicalOwnerID *string `json:"technicalOwnerId"`
-	HasAgent         bool    `json:"hasAgent"`
-	HasKbReferences  bool    `json:"hasKbReferences"`
-	CreatedOn        string  `json:"createdOn"`
-	UpdatedOn        string  `json:"updatedOn"`
+	ID               string         `json:"id"`
+	Name             string         `json:"name"`
+	SupportTier      *snSupportTier `json:"supportTier"`
+	Classification   string         `json:"classification"`
+	Pod              *string        `json:"pod"`
+	Region           *string        `json:"region"`
+	ArrToday         *string        `json:"arrToday"`
+	ActivationDate   string         `json:"activationDate"`
+	DeactivationDate *string        `json:"deactivationDate"`
+	TechnicalOwner   *snPersonRef   `json:"technicalOwner"`
+	Owner            *snPersonRef   `json:"owner"`
+	HasAgent         bool           `json:"hasAgent"`
+	HasKbReferences  bool           `json:"hasKbReferences"`
+	CreatedOn        string         `json:"createdOn"`
+	CreatedBy        *string        `json:"createdBy"`
+	UpdatedOn        string         `json:"updatedOn"`
 }
 
 // snAccountSearchPayload is the Choreo POST /accounts/search request body.
@@ -59,7 +71,10 @@ type snAccountSearchPayload struct {
 }
 
 type snAccountFilters struct {
-	SearchQuery string `json:"searchQuery,omitempty"`
+	SearchQuery    string `json:"searchQuery,omitempty"`
+	Active         *bool  `json:"active,omitempty"`
+	Pod            string `json:"pod,omitempty"`
+	Classification string `json:"classification,omitempty"`
 }
 
 type snAccountService struct {
@@ -75,7 +90,7 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchSNAccountsResponse{}, err
 	}
-	if err := validateSearchQuery(req.SearchQuery); err != nil {
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchSNAccountsResponse{}, err
 	}
 
@@ -85,7 +100,12 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 	}
 
 	payload := snAccountSearchPayload{
-		Filters:    snAccountFilters{SearchQuery: req.SearchQuery},
+		Filters: snAccountFilters{
+			SearchQuery:    req.Filters.SearchQuery,
+			Active:         req.Filters.Active,
+			Pod:            req.Filters.Pod,
+			Classification: req.Filters.Classification,
+		},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 
@@ -99,7 +119,7 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 		return domain.SearchSNAccountsResponse{}, fmt.Errorf("sn accounts: parse response: %w", err)
 	}
 
-	accounts := make([]domain.SNAccount, 0, len(snResp.Accounts))
+	accounts := make([]domain.SNAccountView, 0, len(snResp.Accounts))
 	for _, a := range snResp.Accounts {
 		accounts = append(accounts, snAccountToDomain(a))
 	}
@@ -113,54 +133,73 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 	}, nil
 }
 
-func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domain.SNAccount, error) {
+func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domain.SNAccountView, error) {
 	if err := validateUUIDs("id", []string{id}); err != nil {
-		return domain.SNAccount{}, err
+		return domain.SNAccountView{}, err
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 	if token == "" {
-		return domain.SNAccount{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+		return domain.SNAccountView{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
 	}
 
 	raw, err := s.client.Get(ctx, "/accounts/"+uuidToSysid(id), token)
 	if err != nil {
-		return domain.SNAccount{}, err
+		return domain.SNAccountView{}, err
 	}
 
 	var a snAccount
 	if err := json.Unmarshal(raw, &a); err != nil {
-		return domain.SNAccount{}, fmt.Errorf("sn accounts: parse account response: %w", err)
+		return domain.SNAccountView{}, fmt.Errorf("sn accounts: parse account response: %w", err)
 	}
 
 	return snAccountToDomain(a), nil
 }
 
-func snAccountToDomain(a snAccount) domain.SNAccount {
+func snAccountToDomain(a snAccount) domain.SNAccountView {
 	var deactivationDate *string
 	if a.DeactivationDate != nil && *a.DeactivationDate != "" {
 		deactivationDate = a.DeactivationDate
 	}
 
-	var technicalOwnerID *string
-	if a.TechnicalOwnerID != nil && *a.TechnicalOwnerID != "" {
-		uid := sysidToUUID(*a.TechnicalOwnerID)
-		technicalOwnerID = &uid
+	var supportTier *string
+	if a.SupportTier != nil && a.SupportTier.Label != "" {
+		supportTier = &a.SupportTier.Label
 	}
 
-	return domain.SNAccount{
-		ID:                  sysidToUUID(a.ID),
-		SfID:                a.SfID,
-		Name:                a.Name,
-		Tier:                strings.ToLower(a.SupportTier),
-		Region:              a.Region,
-		ActivationDate:      a.ActivationDate,
-		DeactivationDate:    deactivationDate,
-		OwnerID:             sysidToUUID(a.OwnerID),
-		TechnicalOwnerID:    technicalOwnerID,
-		AgentEnabled:        a.HasAgent,
-		KbReferencesEnabled: a.HasKbReferences,
-		CreatedOn:           a.CreatedOn,
-		UpdatedOn:           a.UpdatedOn,
+	var technicalOwner *domain.EntityRef
+	if a.TechnicalOwner != nil && a.TechnicalOwner.ID != "" {
+		technicalOwner = &domain.EntityRef{
+			ID:   sysidToUUID(a.TechnicalOwner.ID),
+			Name: a.TechnicalOwner.Name,
+		}
+	}
+
+	var owner *domain.EntityRef
+	if a.Owner != nil && a.Owner.ID != "" {
+		owner = &domain.EntityRef{
+			ID:   sysidToUUID(a.Owner.ID),
+			Name: a.Owner.Name,
+		}
+	}
+
+	return domain.SNAccountView{
+		ID:               sysidToUUID(a.ID),
+		SysID:            a.ID,
+		Name:             a.Name,
+		Classification:   a.Classification,
+		Pod:              a.Pod,
+		Region:           a.Region,
+		SupportTier:      supportTier,
+		ArrToday:         a.ArrToday,
+		TechnicalOwner:   technicalOwner,
+		Owner:            owner,
+		ActivationDate:   a.ActivationDate,
+		DeactivationDate: deactivationDate,
+		HasAgent:         a.HasAgent,
+		HasKbReferences:  a.HasKbReferences,
+		CreatedOn:        a.CreatedOn,
+		CreatedBy:        a.CreatedBy,
+		UpdatedOn:        a.UpdatedOn,
 	}
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -136,7 +136,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Account'
+                $ref: '#/components/schemas/SNAccountDetail'
         "400":
           description: Bad request.
           content:
@@ -2238,9 +2238,6 @@ components:
         id:
           type: string
           format: uuid
-        sysId:
-          type: string
-          description: Raw ServiceNow sysid.
         name:
           type: string
         classification:
@@ -2255,6 +2252,63 @@ components:
           type: string
           nullable: true
           description: Support tier label (e.g. Platinum).
+        arrToday:
+          type: string
+          nullable: true
+        technicalOwner:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        owner:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        activationDate:
+          type: string
+        deactivationDate:
+          type: string
+          nullable: true
+        hasAgent:
+          type: boolean
+        hasKbReferences:
+          type: boolean
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+          nullable: true
+        updatedOn:
+          type: string
+
+    SNSupportTierRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        label:
+          type: string
+
+    SNAccountDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        classification:
+          type: string
+        pod:
+          type: string
+          nullable: true
+        region:
+          type: string
+          nullable: true
+        supportTier:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/SNSupportTierRef'
         arrToday:
           type: string
           nullable: true

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2212,47 +2212,76 @@ components:
       properties:
         pagination:
           $ref: '#/components/schemas/Pagination'
+        filters:
+          $ref: '#/components/schemas/SearchAccountsFilters'
+
+    SearchAccountsFilters:
+      type: object
+      properties:
         searchQuery:
           type: string
-          description: Case-insensitive match against name and sf_id.
+          description: Case-insensitive match against account name.
+        active:
+          type: boolean
+          nullable: true
+          description: Filter by active/inactive status.
+        pod:
+          type: string
+          description: Filter by pod identifier.
+        classification:
+          type: string
+          description: Filter by account classification (e.g. enterprise).
 
     Account:
       type: object
       properties:
         id:
           type: string
-        sfId:
+          format: uuid
+        sysId:
           type: string
+          description: Raw ServiceNow sysid.
         name:
           type: string
-        tier:
+        classification:
           type: string
-          enum: [basic, enterprise]
+        pod:
+          type: string
+          nullable: true
         region:
           type: string
           nullable: true
+        supportTier:
+          type: string
+          nullable: true
+          description: Support tier label (e.g. Platinum).
+        arrToday:
+          type: string
+          nullable: true
+        technicalOwner:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        owner:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
         activationDate:
           type: string
-          format: date-time
         deactivationDate:
           type: string
-          format: date-time
           nullable: true
-        ownerId:
-          type: string
-        technicalOwnerId:
-          type: string
-          nullable: true
-        agentEnabled:
+        hasAgent:
           type: boolean
-        kbReferencesEnabled:
+        hasKbReferences:
           type: boolean
         createdOn:
           type: string
-          format: date-time
+        createdBy:
+          type: string
+          nullable: true
         updatedOn:
           type: string
-          format: date-time
 
     SearchAccountsResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2232,7 +2232,7 @@ components:
           type: string
           description: Filter by account classification (e.g. enterprise).
 
-    Account:
+    SNAccountView:
       type: object
       properties:
         id:
@@ -2343,7 +2343,7 @@ components:
         accounts:
           type: array
           items:
-            $ref: '#/components/schemas/Account'
+            $ref: '#/components/schemas/SNAccountView'
         total:
           type: integer
         limit:


### PR DESCRIPTION
## Summary

- Extends `POST /accounts/search` with additional filters (`active`, `pod`, `classification`) and restructures the response to include richer fields (`supportTier` as a label string, `owner`/`technicalOwner` as `{id, name}` objects, `arrToday`, `pod`, `classification`, `createdBy`)
- Implements `GET /accounts/{id}` for the ServiceNow data source, returning full account detail with `supportTier` as an `{id, label}` object
- Removes `sysId` from both responses; normalises empty strings from ServiceNow to `null`

## Test plan

- [ ] `POST /accounts/search` — verify filters (`active`, `pod`, `classification`, `searchQuery`) are forwarded to Choreo and results match the new response shape
- [ ] `POST /accounts/search` — verify optional fields (`pod`, `region`, `supportTier`, `arrToday`, `technicalOwner`, `createdBy`) are `null` (not `""`) when absent in the SN response
- [ ] `GET /accounts/{id}` — verify `supportTier` is returned as `{id, label}`
- [ ] `GET /accounts/{id}` — verify 404 is returned for an unknown ID
- [ ] `GET /accounts/{id}` — verify 400 is returned for a malformed UUID


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account search filters for search text, active status, pod, and classification.
  * Enhanced account search results with clearer ServiceNow account information.
  * Account details now include expanded ownership, support tier, and status information.
* **API Updates**
  * Updated account detail responses to use the enhanced account detail format.
  * Improved consistency between account search results and detailed account views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->