### PR TITLE
[CSM][Web] Rich text editors for the change-request planning fields and work log comment

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
@@ -37,6 +37,8 @@ import { useRef, useState, type JSX } from "react";
 import { useNavigate } from "react-router";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import Editor from "@components/rich-text-editor/Editor";
+import { isBlankHtml } from "@utils/sanitizeHtml";
 import { usePostChangeRequest } from "@features/csm-operations/api/usePostChangeRequest";
 import { useGetUsersMe } from "@features/settings/api/useGetUsersMe";
 import { useSearchGroups } from "@api/useSearchGroups";
@@ -65,11 +67,13 @@ const UNSET = "";
 const SELECT_PLACEHOLDER = "-- Select --";
 
 // Field limits and defaults below mirror the legacy ServiceNow "Create New
-// Change Request" form (Short description: 500 chars; the five Planning
-// journal fields: 4000 chars each; Type/Category/Impact/Risk pre-selected
-// rather than left blank).
+// Change Request" form (Short description: 500 chars; Type/Category/Impact/
+// Risk pre-selected rather than left blank). The Planning journal fields
+// (Description onward) are ServiceNow rich-text fields — no character cap
+// here, since naively truncating HTML at a fixed offset risks cutting a tag
+// in half and corrupting the markup; the backend rejects an overlong
+// submission with a real error instead (see handleSubmit's onError).
 const SUBJECT_MAX = 500;
-const PLAN_FIELD_MAX = 4000;
 
 const TYPE_OPTIONS: Array<{ value: BeChangeRequestType; label: string }> = [
   { value: "standard", label: "Standard" },
@@ -239,12 +243,17 @@ export default function CreateChangeRequestPage(): JSX.Element {
     if (state) payload.state = state as BeChangeRequestState;
     if (plannedStartDate) payload.plannedStartDate = toBackendDateTime(plannedStartDate);
     if (plannedEndDate) payload.plannedEndDate = toBackendDateTime(plannedEndDate);
-    if (description.trim()) payload.description = description.trim();
-    if (justification.trim()) payload.justification = justification.trim();
-    if (implementationPlan.trim()) payload.implementationPlan = implementationPlan.trim();
-    if (riskImpactAnalysis.trim()) payload.riskImpactAnalysis = riskImpactAnalysis.trim();
-    if (backoutPlan.trim()) payload.backoutPlan = backoutPlan.trim();
-    if (testPlan.trim()) payload.testPlan = testPlan.trim();
+    // These six are rich-text HTML from Editor, not plain strings — an
+    // untouched editor still produces non-empty-looking HTML (e.g.
+    // "<p><br></p>"), so `.trim()` truthiness would send blank content as
+    // if it were real. isBlankHtml is the same check the detail page uses
+    // to decide whether to render a plan section at all.
+    if (!isBlankHtml(description)) payload.description = description;
+    if (!isBlankHtml(justification)) payload.justification = justification;
+    if (!isBlankHtml(implementationPlan)) payload.implementationPlan = implementationPlan;
+    if (!isBlankHtml(riskImpactAnalysis)) payload.riskImpactAnalysis = riskImpactAnalysis;
+    if (!isBlankHtml(backoutPlan)) payload.backoutPlan = backoutPlan;
+    if (!isBlankHtml(testPlan)) payload.testPlan = testPlan;
     if (serviceId.trim()) payload.serviceId = serviceId.trim();
     if (serviceOfferingId.trim()) payload.serviceOfferingId = serviceOfferingId.trim();
     if (configurationItemId.trim()) payload.configurationItemId = configurationItemId.trim();
@@ -303,24 +312,41 @@ export default function CreateChangeRequestPage(): JSX.Element {
     </FormControl>
   );
 
-  // Shared renderer for a 4000-char-capped Planning textarea.
-  const renderPlanField = (
+  // Shared renderer for a Planning rich-text field. Editor doesn't accept an
+  // `id`/native label association, so the visible label is a separate
+  // Typography and the pair is tied together via role="group" +
+  // aria-labelledby for assistive tech (matches CsmCaseCreatePage's own
+  // Description field, the other place this editor is used for a form
+  // field rather than a comment box).
+  const renderEditorField = (
+    id: string,
     label: string,
     value: string,
     onChange: (v: string) => void,
     placeholder?: string,
   ): JSX.Element => (
-    <TextField
-      label={label}
-      multiline
-      minRows={3}
-      value={value}
-      onChange={(e) => onChange(e.target.value.slice(0, PLAN_FIELD_MAX))}
-      fullWidth
-      disabled={postChangeRequest.isPending}
-      placeholder={placeholder}
-      helperText={charsLeftHelper(value, PLAN_FIELD_MAX)}
-    />
+    <Box>
+      <Typography
+        id={`${id}-label`}
+        component="label"
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: "block", mb: 0.5 }}
+      >
+        {label}
+      </Typography>
+      <Box role="group" aria-labelledby={`${id}-label`}>
+        <Editor
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          minHeight={100}
+          maxHeight={300}
+          toolbarVariant="full"
+          disabled={postChangeRequest.isPending}
+        />
+      </Box>
+    </Box>
   );
 
   return (
@@ -377,26 +403,28 @@ export default function CreateChangeRequestPage(): JSX.Element {
             Planning
           </Typography>
 
-          <TextField
-            label="Description"
-            multiline
-            minRows={3}
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            fullWidth
-            disabled={postChangeRequest.isPending}
-            placeholder="What is changing?"
-          />
-          {renderPlanField(
+          {renderEditorField("cr-description", "Description", description, setDescription, "What is changing?")}
+          {renderEditorField(
+            "cr-justification",
             "Justification",
             justification,
             setJustification,
             "Why is this change needed?",
           )}
-          {renderPlanField("Implementation plan", implementationPlan, setImplementationPlan)}
-          {renderPlanField("Risk and impact analysis", riskImpactAnalysis, setRiskImpactAnalysis)}
-          {renderPlanField("Backout plan", backoutPlan, setBackoutPlan)}
-          {renderPlanField("Test plan", testPlan, setTestPlan)}
+          {renderEditorField(
+            "cr-implementation-plan",
+            "Implementation plan",
+            implementationPlan,
+            setImplementationPlan,
+          )}
+          {renderEditorField(
+            "cr-risk-impact-analysis",
+            "Risk and impact analysis",
+            riskImpactAnalysis,
+            setRiskImpactAnalysis,
+          )}
+          {renderEditorField("cr-backout-plan", "Backout plan", backoutPlan, setBackoutPlan)}
+          {renderEditorField("cr-test-plan", "Test plan", testPlan, setTestPlan)}
 
           <Typography variant="subtitle2" sx={{ mt: 1 }}>
             Schedule

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
@@ -328,7 +328,6 @@ export default function CreateChangeRequestPage(): JSX.Element {
     <Box>
       <Typography
         id={`${id}-label`}
-        component="label"
         variant="caption"
         color="text.secondary"
         sx={{ display: "block", mb: 0.5 }}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -247,12 +247,16 @@ export default function LogTimeCardDialog({
     });
   };
 
-  /** Submit on Enter, except inside the multiline work-log (where Enter = newline). */
+  /** Submit on Enter, except inside a multiline field (where Enter = newline)
+   * — the plain-textarea case (TEXTAREA) and the rich-text work log comment
+   * (a contenteditable div, not a TEXTAREA, so it needs its own check). */
   const handleKeyDown = (e: KeyboardEvent): void => {
+    const target = e.target as HTMLElement;
     if (
       e.key === "Enter" &&
       !e.shiftKey &&
-      (e.target as HTMLElement).tagName !== "TEXTAREA"
+      target.tagName !== "TEXTAREA" &&
+      !target.isContentEditable
     ) {
       e.preventDefault();
       handleSubmit();
@@ -399,7 +403,6 @@ export default function LogTimeCardDialog({
           <Box>
             <Typography
               id="work-log-comment-label"
-              component="label"
               variant="caption"
               color={
                 isTouched("workLogComment") && errors.workLogComment

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -41,6 +41,7 @@ import {
 // below the sm breakpoint, on this desktop-only portal page.
 const { DesktopDatePicker: DatePicker, LocalizationProvider } = DatePickers;
 import { Clock, Search, X } from "@wso2/oxygen-ui-icons-react";
+import Editor from "@components/rich-text-editor/Editor";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { initialsOf, resolveUserInfo } from "@utils/userClaims";
@@ -389,24 +390,51 @@ export default function LogTimeCardDialog({
             />
           </Box>
 
-          {/* Work log */}
-          <TextField
-            label="Work log comment"
-            required
-            multiline
-            minRows={3}
-            value={workLogComment}
-            onChange={(e) =>
-              setWorkLogComment(e.target.value.slice(0, WORK_LOG_MAX))
-            }
-            onBlur={() => touch("workLogComment")}
-            error={isTouched("workLogComment") && !!errors.workLogComment}
-            helperText={
-              isTouched("workLogComment") && errors.workLogComment
+          {/* Work log — rich text, matching ServiceNow's own work-notes
+              convention. Never truncated on input (unlike the old plain
+              TextField's live .slice()): naively cutting HTML at a fixed
+              offset risks slicing a tag in half and corrupting the markup.
+              The WORK_LOG_MAX cap is still enforced (see
+              timeCardDraftErrors), just not by mid-typing truncation. */}
+          <Box>
+            <Typography
+              id="work-log-comment-label"
+              component="label"
+              variant="caption"
+              color={
+                isTouched("workLogComment") && errors.workLogComment
+                  ? "error"
+                  : "text.secondary"
+              }
+              sx={{ display: "block", mb: 0.5 }}
+            >
+              Work log comment *
+            </Typography>
+            <Box role="group" aria-labelledby="work-log-comment-label">
+              <Editor
+                value={workLogComment}
+                onChange={setWorkLogComment}
+                onBlur={() => touch("workLogComment")}
+                placeholder="What did you work on?"
+                minHeight={80}
+                maxHeight={240}
+                toolbarVariant="full"
+              />
+            </Box>
+            <Typography
+              variant="caption"
+              color={
+                isTouched("workLogComment") && errors.workLogComment
+                  ? "error"
+                  : "text.secondary"
+              }
+              sx={{ display: "block", mt: 0.5 }}
+            >
+              {isTouched("workLogComment") && errors.workLogComment
                 ? errors.workLogComment
-                : `${WORK_LOG_MAX - workLogComment.length} characters left`
-            }
-          />
+                : `${WORK_LOG_MAX - workLogComment.length} characters left`}
+            </Typography>
+          </Box>
 
           {/* Approver */}
           <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardTotals.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardTotals.test.ts
@@ -77,5 +77,21 @@ describe("timeCardTotals", () => {
       });
       expect(errors.workLogComment).toBeDefined();
     });
+
+    it("flags an untouched rich-text editor's empty-looking HTML as blank", () => {
+      const errors = timeCardDraftErrors({
+        ...valid,
+        workLogComment: "<p><br></p>",
+      });
+      expect(errors.workLogComment).toBeDefined();
+    });
+
+    it("accepts real HTML content from the rich-text editor", () => {
+      const errors = timeCardDraftErrors({
+        ...valid,
+        workLogComment: "<p>Investigated <strong>root cause</strong>.</p>",
+      });
+      expect(errors.workLogComment).toBeUndefined();
+    });
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardTotals.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardTotals.ts
@@ -19,6 +19,7 @@ import {
   type ActivityBreakdown,
 } from "@features/csm-timecards/types/timeCards";
 import { WORK_LOG_MAX } from "@features/csm-timecards/constants/timeCardConstants";
+import { isBlankHtml } from "@utils/sanitizeHtml";
 
 /** A fresh breakdown with every activity at zero minutes. */
 export function emptyBreakdown(): ActivityBreakdown {
@@ -67,7 +68,12 @@ export function timeCardDraftErrors(draft: TimeCardDraft): TimeCardDraftErrors {
   if (!hasLoggedTime(draft.breakdown)) {
     errors.minutes = "Log time against at least one activity.";
   }
-  if (!draft.workLogComment.trim()) {
+  // workLogComment is rich-text HTML from Editor, not a plain string — an
+  // untouched editor still outputs non-empty-looking HTML (e.g.
+  // "<p><br></p>"), so `.trim()` truthiness would treat an empty comment as
+  // filled in. isBlankHtml is the same check used wherever else the app
+  // decides whether HTML content is really empty.
+  if (isBlankHtml(draft.workLogComment)) {
     errors.workLogComment = "Add a work log comment.";
   } else if (draft.workLogComment.length > WORK_LOG_MAX) {
     errors.workLogComment = `Comment must be ${WORK_LOG_MAX} characters or fewer.`;


### PR DESCRIPTION
## Purpose
Adds the existing Lexical rich text editor to form fields that ServiceNow itself treats as rich text, but this portal only offered as plain textareas — matching ServiceNow's own form behavior for these fields.

> **Scope note:** Scoped to fields where there's real evidence the backend expects/renders HTML (or, for one write-only field, no risk either way) — not a blanket sweep. See Approach for exactly what was checked and excluded.

## Goals
- Let users actually produce formatted (bold/italic/lists/links) content for change-request planning fields that the detail page already renders as HTML
- Match ServiceNow's own work-notes convention for the time card work log comment
- Avoid corrupting rich text content via naive character-limit truncation
- Avoid silently accepting a "blank" rich text field as filled in

## Approach
- `CreateChangeRequestPage.tsx`: Description, Justification, Implementation plan, Risk and impact analysis, Backout plan, and Test plan now use `Editor` (`@components/rich-text-editor`, Lexical-based, already used elsewhere for case descriptions/comments and security reports) instead of plain `TextField`s. `CsmChangeRequestDetailPage.tsx` already sanitizes and renders these via `dangerouslySetInnerHTML` — the create side just had no way to produce real formatting for it to render. "Additional comments"/"Internal work note" on the same form are deliberately left plain — they're write-only fields, absent from the detail schema entirely, so there's no evidence the backend treats them as HTML.
- `LogTimeCardDialog.tsx`: the "Work log comment" field now uses the same editor. This field is write-only (accepted on create, never read back or displayed anywhere in the portal), so there's no direct evidence either way, but also no risk of a broken display. By contrast, `TimeCardReviewDialog`'s "Lead's comment" is deliberately **not** touched — it comes back as `rejectionReason` and is rendered via plain `Typography` elsewhere, so making it rich text would send HTML that then displays as literal tags.
- Dropped the old live character-limit truncation (`.slice(0, MAX)` on every keystroke) on all of these fields: safe for a plain string, but truncating HTML at a fixed offset risks cutting a tag in half and corrupting the markup. The backend still returns a real validation error on submit if a field is too long.
- Switched the "is this field empty" check from `.trim()` truthiness to `isBlankHtml` (existing utility, already used by the detail page for the same purpose) on every affected field. An untouched Lexical editor's HTML output (e.g. `<p><br></p>`) is non-empty as a *string*, so `.trim()` would have treated a genuinely blank field as filled in.
- Also audited every other `multiline` field in the app (call-request dialogs, case resolution notes, GitHub issue body, deployment/deployed-product descriptions, catalog variables) against how each is actually rendered downstream. All confirmed genuinely plain text (or, for the GitHub issue body, Markdown — a different format entirely) — no other gaps found.

## User stories
As a CS engineer filling out a change request, I can format the planning fields (bold, lists, links) the same way I would in ServiceNow directly.
As a CS engineer logging time, I can format my work log comment the same way.

## Release note
Change request creation and the time card "Log time" dialog now support rich text formatting (bold, italic, lists, links) in their long-form fields, matching ServiceNow's own form behavior.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: added 2 new tests for `timeCardDraftErrors`' HTML-blank detection (`timeCardTotals.test.ts`, 8/8 passing); full webapp suite 223 passed / 2 failed, and those 2 (`CaseActionBar.test.tsx`) are pre-existing failures unrelated to this change.
- Verified against staging: yes, live. Opened `/operations/change-requests/new`, confirmed all 6 editors render with their toolbars, typed into two independent fields to confirm no cross-talk, confirmed the Create button's gating is unaffected. Opened a real case's Time tracking tab → Log time dialog, typed into the work log comment editor, confirmed clean text (no corruption), the character counter updating correctly, and no console errors.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `./node_modules/.bin/tsc -b`, `./node_modules/.bin/eslint src`, `./node_modules/.bin/vitest run`, and `./node_modules/.bin/vite build` all passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rich-text editing for change request planning fields (description, justification, implementation plan, risk/impact, backout, and test plan).
  - Added rich-text editing for the timecard “Work log comment” field.
- **Bug Fixes**
  - Improved validation to treat rich-text placeholders/empty HTML as blank (so they aren’t submitted).
  - Prevented rich-text markup from being truncated while typing; updated Enter-to-submit to work correctly with editor contenteditable elements.
- **Tests**
  - Added test coverage for rich-text blank vs. populated work log comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->