### PR TITLE
[CSM Portal Microapp] Add Operations page: Service Requests, Change Requests, Incidents

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -25,6 +25,7 @@ import SupportPage from "@pages/SupportPage";
 import CaseDetailPage from "@pages/CaseDetailPage";
 import NewCasePage from "@pages/NewCasePage";
 import OperationsPage from "@pages/OperationsPage";
+import ChangeRequestDetailPage from "@pages/ChangeRequestDetailPage";
 import MorePage from "@pages/MorePage";
 import AnnouncementsPage from "@pages/AnnouncementsPage";
 import TimeCardsPage from "@pages/TimeCardsPage";
@@ -65,6 +66,7 @@ export default function App() {
           <Route path="/cases/new" element={<NewCasePage />} />
           <Route path="/cases/:id" element={<CaseDetailPage />} />
           <Route path="/operations" element={<OperationsPage />} />
+          <Route path="/operations/change-requests/:id" element={<ChangeRequestDetailPage />} />
           <Route path="/more" element={<MorePage />} />
           <Route path="/more/announcements" element={<AnnouncementsPage />} />
           <Route path="/more/time-cards" element={<TimeCardsPage />} />

--- a/apps/csm-portal/microapp/src/components/case-detail/SectionCard.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/SectionCard.tsx
@@ -14,18 +14,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-export * from "./case.dto";
-export * from "./case.model";
-export * from "./attachment.dto";
-export * from "./project.dto";
-export * from "./project.model";
-export * from "./deployment.dto";
-export * from "./deployment.model";
-export * from "./user.dto";
-export * from "./user.model";
-export * from "./adminUser.dto";
-export * from "./adminUser.model";
-export * from "./timecard.dto";
-export * from "./timecard.model";
-export * from "./changeRequest.dto";
-export * from "./changeRequest.model";
+import type { ReactNode } from "react";
+import { Card, Stack, Typography } from "@wso2/oxygen-ui";
+
+// Mirrors the customer-portal microapp's own SectionCard
+// (apps/customer-portal/microapp/src/components/shared/SectionCard.tsx).
+export function SectionCard({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <Card component={Stack} p={1.5} gap={1.5} sx={{ bgcolor: "background.paper" }}>
+      {title && (
+        <Typography variant="h6" fontWeight="medium">
+          {title}
+        </Typography>
+      )}
+      {children}
+    </Card>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/ChangeRequestCard.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ChangeRequestCard.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Card, Chip, Skeleton, Stack, Typography, pxToRem, useTheme } from "@wso2/oxygen-ui";
+import { ChevronRight, Clock4 } from "@wso2/oxygen-ui-icons-react";
+import { Link } from "react-router-dom";
+import type { ChangeRequestSummary } from "@src/types";
+import { fromNow } from "@utils/dateTime";
+import {
+  changeRequestImpactColor,
+  changeRequestImpactLabel,
+  changeRequestStateColor,
+  changeRequestStateLabel,
+} from "./config";
+
+export function ChangeRequestCard({ item }: { item: ChangeRequestSummary }) {
+  const theme = useTheme();
+
+  return (
+    <Card
+      component={Link}
+      to={`/operations/change-requests/${item.id}`}
+      sx={{ textDecoration: "none", p: 1.5, display: "block" }}
+    >
+      <Stack gap={0.75}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="subtitle2" color="text.secondary">
+            {item.number}
+          </Typography>
+          <ChevronRight size={pxToRem(18)} color={theme.palette.text.secondary} />
+        </Stack>
+
+        <Typography variant="body1" color="text.primary" noWrap>
+          {item.subject}
+        </Typography>
+
+        <Typography variant="subtitle2" color="text.secondary" noWrap>
+          {item.project?.name}
+        </Typography>
+
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+          {item.state && (
+            <Chip
+              size="small"
+              label={changeRequestStateLabel(item.state)}
+              color={changeRequestStateColor(item.state)}
+            />
+          )}
+          {item.impact && (
+            <Chip
+              size="small"
+              label={changeRequestImpactLabel(item.impact)}
+              color={changeRequestImpactColor(item.impact)}
+            />
+          )}
+        </Stack>
+
+        <Stack direction="row" alignItems="center" gap={0.5}>
+          <Clock4 size={pxToRem(13)} color={theme.palette.text.secondary} />
+          <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: pxToRem(12) }}>
+            Updated {fromNow(item.updatedOn)}
+          </Typography>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}
+
+export function ChangeRequestCardSkeleton() {
+  return (
+    <Card sx={{ p: 1.5 }}>
+      <Stack gap={0.75}>
+        <Stack direction="row" justifyContent="space-between">
+          <Skeleton variant="text" width={60} height={20} />
+          <Skeleton variant="circular" width={pxToRem(18)} height={pxToRem(18)} />
+        </Stack>
+        <Skeleton variant="text" width="80%" height={26} />
+        <Skeleton variant="text" width="40%" height={18} />
+        <Stack direction="row" gap={1}>
+          <Skeleton variant="rounded" width={70} height={24} sx={{ borderRadius: 1 }} />
+          <Skeleton variant="rounded" width={70} height={24} sx={{ borderRadius: 1 }} />
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/ChangeRequestsFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ChangeRequestsFiltersSheet.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import {
+  AdapterDateFns,
+  Button,
+  Chip,
+  DatePickers,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { format, parse } from "date-fns";
+import {
+  CHANGE_REQUEST_FILTERABLE_STATES,
+  CHANGE_REQUEST_IMPACTS,
+  CHANGE_REQUEST_IMPACT_LABELS,
+  CHANGE_REQUEST_STATE_LABELS,
+} from "./config";
+import { EMPTY_CR_FILTERS, type ChangeRequestFilters } from "./changeRequestFilters";
+
+const { LocalizationProvider, DatePicker } = DatePickers;
+const ISO_DATE = "yyyy-MM-dd";
+
+function fromIsoDate(iso: string): Date | null {
+  if (!iso) return null;
+  const d = parse(iso, ISO_DATE, new Date());
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function toIsoDate(date: Date | null): string {
+  return date && !Number.isNaN(date.getTime()) ? format(date, ISO_DATE) : "";
+}
+
+function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+interface ChangeRequestsFiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: ChangeRequestFilters;
+  onApply: (filters: ChangeRequestFilters) => void;
+}
+
+// Mirrors the support FiltersSheet's bottom-sheet pattern (src/components/support/FiltersSheet.tsx).
+export function ChangeRequestsFiltersSheet({ open, onClose, filters, onApply }: ChangeRequestsFiltersSheetProps) {
+  const [draft, setDraft] = useState<ChangeRequestFilters>(filters);
+
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={2.5}>
+          <Stack gap={1}>
+            <Typography variant="subtitle2">State</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {CHANGE_REQUEST_FILTERABLE_STATES.map((state) => {
+                const isSelected = draft.states.includes(state);
+                return (
+                  <Chip
+                    key={state}
+                    label={CHANGE_REQUEST_STATE_LABELS[state]}
+                    size="small"
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => setDraft({ ...draft, states: toggle(draft.states, state) })}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Impact</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {CHANGE_REQUEST_IMPACTS.map((impact) => {
+                const isSelected = draft.impacts.includes(impact);
+                return (
+                  <Chip
+                    key={impact}
+                    label={CHANGE_REQUEST_IMPACT_LABELS[impact]}
+                    size="small"
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => setDraft({ ...draft, impacts: toggle(draft.impacts, impact) })}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Closed date range</Typography>
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <Stack direction="row" gap={1}>
+                <DatePicker
+                  label="From"
+                  value={fromIsoDate(draft.closedStartDate)}
+                  onChange={(date: Date | null) => setDraft({ ...draft, closedStartDate: toIsoDate(date) })}
+                  maxDate={fromIsoDate(draft.closedEndDate) ?? undefined}
+                  slotProps={{ textField: { size: "small", fullWidth: true }, field: { clearable: true } }}
+                />
+                <DatePicker
+                  label="To"
+                  value={fromIsoDate(draft.closedEndDate)}
+                  onChange={(date: Date | null) => setDraft({ ...draft, closedEndDate: toIsoDate(date) })}
+                  minDate={fromIsoDate(draft.closedStartDate) ?? undefined}
+                  slotProps={{ textField: { size: "small", fullWidth: true }, field: { clearable: true } }}
+                />
+              </Stack>
+            </LocalizationProvider>
+          </Stack>
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            setDraft(EMPTY_CR_FILTERS);
+            onApply(EMPTY_CR_FILTERS);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ChangeRequestsTab.tsx
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { Badge, Chip, IconButton, Stack } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { changeRequests } from "@src/services/changeRequests";
+import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { SearchBar } from "@components/support/SearchBar";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { formatDate } from "@utils/dateTime";
+import { ChangeRequestCard, ChangeRequestCardSkeleton } from "./ChangeRequestCard";
+import { ChangeRequestsFiltersSheet } from "./ChangeRequestsFiltersSheet";
+import { CHANGE_REQUEST_IMPACT_LABELS, CHANGE_REQUEST_STATE_LABELS } from "./config";
+import {
+  countActiveCRFilters,
+  EMPTY_CR_FILTERS,
+  toChangeRequestSearchFilters,
+  type ChangeRequestFilters,
+} from "./changeRequestFilters";
+
+// Mirrors the shape of SupportPage's own list content (search + filter sheet + infinite scroll),
+// scoped to change requests instead of cases.
+export function ChangeRequestsTab() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [filters, setFilters] = useState<ChangeRequestFilters>(EMPTY_CR_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const activeFilterCount = countActiveCRFilters(filters);
+
+  return (
+    <Stack gap={2}>
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar value={search} onChange={setSearch} placeholder="Search by CR #, subject…" />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
+      {activeFilterCount > 0 && <ActiveFiltersRow filters={filters} onChange={setFilters} />}
+
+      <ChangeRequestListErrorBoundary>
+        <Suspense fallback={<ChangeRequestListSkeleton />}>
+          <ChangeRequestListContent search={debouncedSearch} filters={filters} />
+        </Suspense>
+      </ChangeRequestListErrorBoundary>
+
+      <ChangeRequestsFiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        filters={filters}
+        onApply={setFilters}
+      />
+    </Stack>
+  );
+}
+
+// One removable chip per active filter — mirrors SupportPage's own ActiveFiltersRow, letting a
+// filter picked in the sheet be removed individually instead of only via "Clear all".
+function ActiveFiltersRow({
+  filters,
+  onChange,
+}: {
+  filters: ChangeRequestFilters;
+  onChange: (filters: ChangeRequestFilters) => void;
+}) {
+  return (
+    <Stack direction="row" gap={1} flexWrap="wrap">
+      {filters.states.map((state) => (
+        <Chip
+          key={`state-${state}`}
+          label={CHANGE_REQUEST_STATE_LABELS[state]}
+          size="small"
+          onDelete={() => onChange({ ...filters, states: filters.states.filter((s) => s !== state) })}
+        />
+      ))}
+      {filters.impacts.map((impact) => (
+        <Chip
+          key={`impact-${impact}`}
+          label={CHANGE_REQUEST_IMPACT_LABELS[impact]}
+          size="small"
+          onDelete={() => onChange({ ...filters, impacts: filters.impacts.filter((i) => i !== impact) })}
+        />
+      ))}
+      {filters.closedStartDate && (
+        <Chip
+          label={`From ${formatDate(new Date(filters.closedStartDate))}`}
+          size="small"
+          onDelete={() => onChange({ ...filters, closedStartDate: "" })}
+        />
+      )}
+      {filters.closedEndDate && (
+        <Chip
+          label={`To ${formatDate(new Date(filters.closedEndDate))}`}
+          size="small"
+          onDelete={() => onChange({ ...filters, closedEndDate: "" })}
+        />
+      )}
+    </Stack>
+  );
+}
+
+function ChangeRequestListContent({ search, filters }: { search: string; filters: ChangeRequestFilters }) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfiniteQuery(
+    changeRequests.infinite({ filters: toChangeRequestSearchFilters(search, filters) }),
+  );
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const items = data.pages.flatMap((page) => page.items);
+
+  if (items.length === 0) return <EmptyState message="No change requests found." />;
+
+  return (
+    <Stack gap={1.5}>
+      {items.map((item) => (
+        <ChangeRequestCard key={item.id} item={item} />
+      ))}
+
+      <div ref={sentinelRef} style={{ height: 1 }} />
+
+      {isFetchingNextPage && <ChangeRequestCardSkeleton />}
+    </Stack>
+  );
+}
+
+function ChangeRequestListSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {[0, 1, 2].map((i) => (
+        <ChangeRequestCardSkeleton key={i} />
+      ))}
+    </Stack>
+  );
+}
+
+function ChangeRequestListErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/EditChangeRequestDialog.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState } from "react";
+import { AdapterDateFns, Button, Card, DatePickers, Dialog, Stack, Switch, Typography } from "@wso2/oxygen-ui";
+import { format } from "date-fns";
+import type { ChangeRequestDetail } from "@src/types";
+
+const { LocalizationProvider, DateTimePicker } = DatePickers;
+const WIRE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+interface EditChangeRequestDialogProps {
+  changeRequest: ChangeRequestDetail;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (fields: { plannedStartOn?: string; isCustomerApproved?: boolean; isCustomerReviewed?: boolean }) => void;
+}
+
+// Mirrors the webapp's EditChangeRequestDialog: only 3 fields are editable, matching exactly what
+// the backend's PatchChangeRequestPayload accepts (minProperties: 1) — Planned start, Customer
+// approved, Customer reviewed. Save is disabled until something actually differs.
+export function EditChangeRequestDialog({
+  changeRequest,
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: EditChangeRequestDialogProps) {
+  const initialPlannedStart = changeRequest.plannedStartOn ? new Date(changeRequest.plannedStartOn) : null;
+  const [plannedStart, setPlannedStart] = useState<Date | null>(initialPlannedStart);
+  const [customerApproved, setCustomerApproved] = useState(changeRequest.hasCustomerApproved);
+  const [customerReviewed, setCustomerReviewed] = useState(changeRequest.hasCustomerReviewed);
+
+  const plannedStartChanged = (plannedStart?.getTime() ?? null) !== (initialPlannedStart?.getTime() ?? null);
+  const hasChanges =
+    plannedStartChanged ||
+    customerApproved !== changeRequest.hasCustomerApproved ||
+    customerReviewed !== changeRequest.hasCustomerReviewed;
+
+  const handleSave = () => {
+    onSubmit({
+      ...(plannedStartChanged && plannedStart && { plannedStartOn: format(plannedStart, WIRE_FORMAT) }),
+      ...(customerApproved !== changeRequest.hasCustomerApproved && { isCustomerApproved: customerApproved }),
+      ...(customerReviewed !== changeRequest.hasCustomerReviewed && { isCustomerReviewed: customerReviewed }),
+    });
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
+    >
+      <Typography variant="h6" fontWeight={650}>
+        Edit change request
+      </Typography>
+
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DateTimePicker
+          label="Planned start"
+          value={plannedStart}
+          onChange={setPlannedStart}
+          slotProps={{ textField: { size: "small", fullWidth: true }, field: { clearable: true } }}
+        />
+      </LocalizationProvider>
+
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Typography variant="body2">Customer approved</Typography>
+        <Switch checked={customerApproved} onChange={(e) => setCustomerApproved(e.target.checked)} />
+      </Stack>
+
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Typography variant="body2">Customer reviewed</Typography>
+        <Switch checked={customerReviewed} onChange={(e) => setCustomerReviewed(e.target.checked)} />
+      </Stack>
+
+      <Stack direction="row" justifyContent="end" gap={1}>
+        <Button variant="outlined" onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!hasChanges || isSubmitting} onClick={handleSave}>
+          Save
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/EditChangeRequestDialog.tsx
@@ -26,7 +26,11 @@ interface EditChangeRequestDialogProps {
   changeRequest: ChangeRequestDetail;
   isSubmitting: boolean;
   onClose: () => void;
-  onSubmit: (fields: { plannedStartOn?: string; isCustomerApproved?: boolean; isCustomerReviewed?: boolean }) => void;
+  onSubmit: (fields: {
+    plannedStartOn?: string | null;
+    isCustomerApproved?: boolean;
+    isCustomerReviewed?: boolean;
+  }) => void;
 }
 
 // Mirrors the webapp's EditChangeRequestDialog: only 3 fields are editable, matching exactly what
@@ -51,7 +55,9 @@ export function EditChangeRequestDialog({
 
   const handleSave = () => {
     onSubmit({
-      ...(plannedStartChanged && plannedStart && { plannedStartOn: format(plannedStart, WIRE_FORMAT) }),
+      ...(plannedStartChanged && {
+        plannedStartOn: plannedStart ? format(plannedStart, WIRE_FORMAT) : null,
+      }),
       ...(customerApproved !== changeRequest.hasCustomerApproved && { isCustomerApproved: customerApproved }),
       ...(customerReviewed !== changeRequest.hasCustomerReviewed && { isCustomerReviewed: customerReviewed }),
     });

--- a/apps/csm-portal/microapp/src/components/operations/ServiceRequestsFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ServiceRequestsFiltersSheet.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Switch,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { ALL_WORK_STATES, WORK_STATE_LABEL } from "@components/support/config";
+import { EMPTY_FILTERS, type CaseFilters } from "@components/support/filters";
+
+function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+interface ServiceRequestsFiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: CaseFilters;
+  onApply: (filters: CaseFilters) => void;
+}
+
+// Mirrors the support FiltersSheet (src/components/support/FiltersSheet.tsx), minus the Severity
+// section — severity is case-type-only, and the webapp's own CsmIssuesView explicitly hides its
+// severity filter when locked to a non-"case" type (showSeverityFilter derives from the locked
+// type). Work state stays, disabled until "Work in progress" is selected, same as the webapp.
+export function ServiceRequestsFiltersSheet({ open, onClose, filters, onApply }: ServiceRequestsFiltersSheetProps) {
+  const [draft, setDraft] = useState<CaseFilters>(filters);
+
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open
+  }, [open]);
+
+  const workStateDisabled = !draft.states.includes("work_in_progress");
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={2.5}>
+          <Stack gap={1}>
+            <Typography variant="subtitle2" color={workStateDisabled ? "text.disabled" : "text.primary"}>
+              Work state
+            </Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {ALL_WORK_STATES.map((workState) => {
+                const isSelected = draft.workStates.includes(workState);
+                return (
+                  <Chip
+                    key={workState}
+                    label={WORK_STATE_LABEL[workState]}
+                    size="small"
+                    disabled={workStateDisabled}
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => setDraft({ ...draft, workStates: toggle(draft.workStates, workState) })}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Divider />
+
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="body2">Assigned to me</Typography>
+            <Switch
+              checked={draft.assignedToMe}
+              onChange={(event) => setDraft({ ...draft, assignedToMe: event.target.checked })}
+            />
+          </Stack>
+
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="body2">Created by me</Typography>
+            <Switch
+              checked={draft.createdByMe}
+              onChange={(event) => setDraft({ ...draft, createdByMe: event.target.checked })}
+            />
+          </Stack>
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            setDraft(EMPTY_FILTERS);
+            onApply(EMPTY_FILTERS);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { Badge, Chip, IconButton, Stack, Tab, Tabs } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useQuery, useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { cases } from "@src/services/cases";
+import { currentUser } from "@src/services/currentUser";
+import type { CaseState } from "@src/types";
+import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { SearchBar } from "@components/support/SearchBar";
+import { FILTERABLE_STATES, STATE_LABELS, TAB_CONFIG, WORK_STATE_LABEL } from "@components/support/config";
+import { countActiveFilters, EMPTY_FILTERS, toCaseSearchFilters, type CaseFilters } from "@components/support/filters";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { ServiceRequestsFiltersSheet } from "./ServiceRequestsFiltersSheet";
+
+const ALL_STATES_TAB = "all" as const;
+type StateTabValue = CaseState | typeof ALL_STATES_TAB;
+
+// Reuses the exact same list/pagination infra as SupportPage's case list, just scoped to
+// type: "service_request". Severity is dropped (case-type-only — the webapp's own CsmIssuesView
+// hides its severity filter the same way when locked to a non-"case" type); work state stays,
+// same as the webapp.
+export function ServiceRequestsTab() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [filters, setFilters] = useState<CaseFilters>(EMPTY_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const activeFilterCount = countActiveFilters(filters);
+  const { data: currentUserId } = useQuery(currentUser.id());
+
+  const stateTab: StateTabValue = filters.states[0] ?? ALL_STATES_TAB;
+  const handleStateTabChange = (value: StateTabValue) => {
+    const states = value === ALL_STATES_TAB ? [] : [value];
+    const workStates = value === "work_in_progress" ? filters.workStates : [];
+    setFilters({ ...filters, states, workStates });
+  };
+
+  return (
+    <Stack gap={2}>
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar value={search} onChange={setSearch} placeholder="Search by request #, subject…" />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
+      {activeFilterCount > 0 && <ActiveFiltersRow filters={filters} onChange={setFilters} />}
+
+      <Tabs variant="scrollable" value={stateTab} onChange={(_, value: StateTabValue) => handleStateTabChange(value)}>
+        <Tab label="All" value={ALL_STATES_TAB} disableRipple />
+        {FILTERABLE_STATES.map((state) => (
+          <Tab key={state} label={STATE_LABELS[state]} value={state} disableRipple />
+        ))}
+      </Tabs>
+
+      <ServiceRequestListErrorBoundary>
+        <Suspense fallback={<ServiceRequestListSkeleton />}>
+          <ServiceRequestListContent search={debouncedSearch} filters={filters} currentUserId={currentUserId ?? null} />
+        </Suspense>
+      </ServiceRequestListErrorBoundary>
+
+      <ServiceRequestsFiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        filters={filters}
+        onApply={setFilters}
+      />
+    </Stack>
+  );
+}
+
+// Mirrors SupportPage's own ActiveFiltersRow, minus severity (not applicable to service requests).
+function ActiveFiltersRow({ filters, onChange }: { filters: CaseFilters; onChange: (filters: CaseFilters) => void }) {
+  return (
+    <Stack direction="row" gap={1} flexWrap="wrap">
+      {filters.workStates.map((workState) => (
+        <Chip
+          key={`work-state-${workState}`}
+          label={WORK_STATE_LABEL[workState]}
+          size="small"
+          onDelete={() => onChange({ ...filters, workStates: filters.workStates.filter((w) => w !== workState) })}
+        />
+      ))}
+      {filters.assignedToMe && (
+        <Chip label="Assigned to me" size="small" onDelete={() => onChange({ ...filters, assignedToMe: false })} />
+      )}
+      {filters.createdByMe && (
+        <Chip label="Created by me" size="small" onDelete={() => onChange({ ...filters, createdByMe: false })} />
+      )}
+    </Stack>
+  );
+}
+
+function ServiceRequestListContent({
+  search,
+  filters,
+  currentUserId,
+}: {
+  search: string;
+  filters: CaseFilters;
+  currentUserId: string | null;
+}) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfiniteQuery(
+    cases.infinite(toCaseSearchFilters("service_request", search, filters, currentUserId)),
+  );
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const items = data.pages.flatMap((page) => page.items);
+
+  if (items.length === 0) return <EmptyState message={TAB_CONFIG.service_request.emptyMessage} />;
+
+  return (
+    <Stack gap={1.5}>
+      {items.map((item) => (
+        <CaseCard key={item.id} item={item} />
+      ))}
+
+      <div ref={sentinelRef} style={{ height: 1 }} />
+
+      {isFetchingNextPage && <CaseCardSkeleton />}
+    </Stack>
+  );
+}
+
+function ServiceRequestListSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {[0, 1, 2].map((i) => (
+        <CaseCardSkeleton key={i} />
+      ))}
+    </Stack>
+  );
+}
+
+function ServiceRequestListErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/changeRequestFilters.ts
+++ b/apps/csm-portal/microapp/src/components/operations/changeRequestFilters.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ChangeRequestFilterableState, ChangeRequestImpact, ChangeRequestSearchPayloadDto } from "@src/types";
+
+export interface ChangeRequestFilters {
+  states: ChangeRequestFilterableState[];
+  impacts: ChangeRequestImpact[];
+  /** YYYY-MM-DD, or empty. */
+  closedStartDate: string;
+  /** YYYY-MM-DD, or empty. */
+  closedEndDate: string;
+}
+
+export const EMPTY_CR_FILTERS: ChangeRequestFilters = {
+  states: [],
+  impacts: [],
+  closedStartDate: "",
+  closedEndDate: "",
+};
+
+export function countActiveCRFilters(filters: ChangeRequestFilters): number {
+  return (
+    (filters.states.length > 0 ? 1 : 0) +
+    (filters.impacts.length > 0 ? 1 : 0) +
+    (filters.closedStartDate ? 1 : 0) +
+    (filters.closedEndDate ? 1 : 0)
+  );
+}
+
+export function toChangeRequestSearchFilters(
+  search: string,
+  filters: ChangeRequestFilters,
+): ChangeRequestSearchPayloadDto["filters"] {
+  return {
+    ...(search.length > 0 && { searchQuery: search }),
+    ...(filters.states.length > 0 && { states: filters.states }),
+    ...(filters.impacts.length > 0 && { impacts: filters.impacts }),
+    // Closed-date filters are UTC datetimes on the wire; a plain YYYY-MM-DD local date is widened
+    // to cover the whole day in UTC, mirroring the webapp's toISOStart/toISOEnd.
+    ...(filters.closedStartDate && { closedStartDate: `${filters.closedStartDate}T00:00:00.000Z` }),
+    ...(filters.closedEndDate && { closedEndDate: `${filters.closedEndDate}T23:59:59.999Z` }),
+  };
+}

--- a/apps/csm-portal/microapp/src/components/operations/config.ts
+++ b/apps/csm-portal/microapp/src/components/operations/config.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ChipProps } from "@wso2/oxygen-ui";
+import type { ChangeRequestFilterableState, ChangeRequestImpact, ChangeRequestState } from "@src/types";
+
+// Direct port of the webapp's utils/changeRequests.ts label/color maps
+// (apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts).
+
+export const CHANGE_REQUEST_STATE_LABELS: Record<ChangeRequestState, string> = {
+  new: "New",
+  assess: "Assess",
+  authorize: "Authorize",
+  customer_approval: "Customer Approval",
+  scheduled: "Scheduled",
+  implement: "Implement",
+  review: "Review",
+  customer_review: "Customer Review",
+  rollback: "Rollback",
+  closed: "Closed",
+  canceled: "Canceled",
+};
+
+export const CHANGE_REQUEST_STATE_COLORS: Record<ChangeRequestState, NonNullable<ChipProps["color"]>> = {
+  new: "default",
+  assess: "info",
+  authorize: "info",
+  customer_approval: "info",
+  scheduled: "info",
+  implement: "warning",
+  review: "info",
+  customer_review: "info",
+  rollback: "error",
+  closed: "success",
+  canceled: "error",
+};
+
+export const CHANGE_REQUEST_IMPACT_LABELS: Record<ChangeRequestImpact, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+export const CHANGE_REQUEST_IMPACT_COLORS: Record<ChangeRequestImpact, NonNullable<ChipProps["color"]>> = {
+  high: "error",
+  medium: "warning",
+  low: "default",
+};
+
+// The backend documents `state`/`impact` on the search response as loose strings (not a strict
+// enum, unlike the search *filter*'s enum) — a value that doesn't match the maps above (different
+// casing, a value not in our list) would otherwise render as a blank Chip. Falls back to a
+// humanized version of the raw value instead, mirroring the webapp's own
+// changeRequestStateLabel/changeRequestImpactLabel.
+function humanize(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+export function changeRequestStateLabel(state?: string | null): string {
+  if (!state) return "—";
+  return CHANGE_REQUEST_STATE_LABELS[state as ChangeRequestState] ?? humanize(state);
+}
+
+export function changeRequestStateColor(state?: string | null): NonNullable<ChipProps["color"]> {
+  if (!state) return "default";
+  return CHANGE_REQUEST_STATE_COLORS[state as ChangeRequestState] ?? "default";
+}
+
+export function changeRequestImpactLabel(impact?: string | null): string {
+  if (!impact) return "—";
+  return CHANGE_REQUEST_IMPACT_LABELS[impact as ChangeRequestImpact] ?? humanize(impact);
+}
+
+export function changeRequestImpactColor(impact?: string | null): NonNullable<ChipProps["color"]> {
+  if (!impact) return "default";
+  return CHANGE_REQUEST_IMPACT_COLORS[impact as ChangeRequestImpact] ?? "default";
+}
+
+// Only the 8 states the backend's search filter actually accepts (new/assess/authorize are
+// returnable but not filterable — see changeRequest.dto.ts).
+export const CHANGE_REQUEST_FILTERABLE_STATES: ChangeRequestFilterableState[] = [
+  "customer_approval",
+  "scheduled",
+  "implement",
+  "review",
+  "customer_review",
+  "rollback",
+  "closed",
+  "canceled",
+];
+
+export const CHANGE_REQUEST_IMPACTS: ChangeRequestImpact[] = ["high", "medium", "low"];

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -28,6 +28,9 @@ export const CASES_SEARCH_ENDPOINT = "/cases/search";
 export const CASE_DETAILS_ENDPOINT = (id: string) => `/cases/${id}`;
 export const CASE_COMMENTS_SEARCH_ENDPOINT = (id: string) => `/cases/${id}/comments/search`;
 
+export const CHANGE_REQUESTS_SEARCH_ENDPOINT = "/change-requests/search";
+export const CHANGE_REQUEST_ENDPOINT = (id: string) => `/change-requests/${id}`;
+
 export const PROJECTS_SEARCH_ENDPOINT = "/projects/search";
 export const DEPLOYMENTS_SEARCH_ENDPOINT = "/deployments/search";
 export const DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT = (deploymentId: string) =>

--- a/apps/csm-portal/microapp/src/pages/ChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/ChangeRequestDetailPage.tsx
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Suspense, useState, type ReactNode } from "react";
+import { useParams } from "react-router-dom";
+import { Button, Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { changeRequests } from "@src/services/changeRequests";
+import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { ErrorState } from "@components/support/ErrorState";
+import { SectionCard } from "@components/case-detail/SectionCard";
+import {
+  changeRequestImpactColor,
+  changeRequestImpactLabel,
+  changeRequestStateColor,
+  changeRequestStateLabel,
+} from "@components/operations/config";
+import { EditChangeRequestDialog } from "@components/operations/EditChangeRequestDialog";
+import { formatDate } from "@utils/dateTime";
+
+export default function ChangeRequestDetailPage() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <Stack gap={2} sx={{ mb: 10 }}>
+      <ChangeRequestDetailErrorBoundary>
+        <Suspense fallback={<ChangeRequestDetailSkeleton />}>
+          <ChangeRequestDetailContent id={id ?? ""} />
+        </Suspense>
+      </ChangeRequestDetailErrorBoundary>
+    </Stack>
+  );
+}
+
+function ChangeRequestDetailContent({ id }: { id: string }) {
+  const queryClient = useQueryClient();
+  const { data: cr } = useSuspenseQuery(changeRequests.get(id));
+  const [editOpen, setEditOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit: Parameters<typeof EditChangeRequestDialog>[0]["onSubmit"] = (fields) => {
+    setIsSubmitting(true);
+    setError(null);
+    changeRequests
+      .patch(id, fields)
+      .then(() => {
+        setEditOpen(false);
+        void queryClient.invalidateQueries({ queryKey: ["change-request", id] });
+        void queryClient.invalidateQueries({ queryKey: ["change-requests", "infinite"] });
+      })
+      .catch(() => setError("Could not save changes. Please try again."))
+      .finally(() => setIsSubmitting(false));
+  };
+
+  const hasPlans = [
+    cr.description,
+    cr.justification,
+    cr.impactDescription,
+    cr.serviceOutage,
+    cr.communicationPlan,
+    cr.rollbackPlan,
+    cr.testPlan,
+  ].some((v) => v && v.trim().length > 0);
+
+  return (
+    <>
+      <Stack gap={1}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1}>
+          <Typography variant="subtitle2" color="text.secondary" noWrap>
+            {cr.number}
+          </Typography>
+          <Button size="small" variant="outlined" onClick={() => setEditOpen(true)}>
+            Edit
+          </Button>
+        </Stack>
+
+        <Typography variant="h6">{cr.subject}</Typography>
+
+        <Stack direction="row" gap={1} flexWrap="wrap">
+          {cr.state && (
+            <Chip size="small" label={changeRequestStateLabel(cr.state)} color={changeRequestStateColor(cr.state)} />
+          )}
+          {cr.impact && (
+            <Chip
+              size="small"
+              label={changeRequestImpactLabel(cr.impact)}
+              color={changeRequestImpactColor(cr.impact)}
+            />
+          )}
+        </Stack>
+
+        {error && (
+          <Typography variant="caption" color="error.main">
+            {error}
+          </Typography>
+        )}
+      </Stack>
+
+      <SectionCard title="Overview">
+        <Stack gap={1}>
+          <DetailRow label="Project" value={cr.project?.name} />
+          <DetailRow label="Linked case" value={cr.case?.name} />
+          <DetailRow label="Deployment" value={cr.deployment?.name} />
+          <DetailRow label="Product" value={cr.product?.name} />
+          <DetailRow label="Assigned Engineer" value={cr.assignedEngineer?.name} />
+          <DetailRow label="Assigned Team" value={cr.assignedTeam?.name} />
+          <DetailRow label="Duration" value={cr.duration} />
+          <DetailRow
+            label="Planned Start"
+            value={cr.plannedStartOn ? formatDate(new Date(cr.plannedStartOn)) : undefined}
+          />
+          <DetailRow label="Planned End" value={cr.plannedEndOn ? formatDate(new Date(cr.plannedEndOn)) : undefined} />
+          <DetailRow label="Created By" value={cr.createdBy} />
+          <DetailRow label="Created On" value={formatDate(cr.createdOn)} />
+          <DetailRow label="Updated On" value={formatDate(cr.updatedOn)} />
+        </Stack>
+      </SectionCard>
+
+      <SectionCard title="Approval">
+        <Stack gap={1}>
+          <DetailRow label="Customer Approved" value={cr.hasCustomerApproved ? "Yes" : "No"} />
+          <DetailRow label="Customer Reviewed" value={cr.hasCustomerReviewed ? "Yes" : "No"} />
+          <DetailRow label="Approved By" value={cr.approvedBy?.name} />
+          <DetailRow label="Approved On" value={cr.approvedOn ? formatDate(cr.approvedOn) : undefined} />
+        </Stack>
+      </SectionCard>
+
+      {hasPlans && (
+        <SectionCard title="Details & plans">
+          <Stack gap={1.5}>
+            <TextBlock label="Description" value={cr.description} />
+            <TextBlock label="Justification" value={cr.justification} />
+            <TextBlock label="Impact description" value={cr.impactDescription} />
+            <TextBlock label="Service outage" value={cr.serviceOutage} />
+            <TextBlock label="Communication plan" value={cr.communicationPlan} />
+            <TextBlock label="Rollback plan" value={cr.rollbackPlan} />
+            <TextBlock label="Test plan" value={cr.testPlan} />
+          </Stack>
+        </SectionCard>
+      )}
+
+      {editOpen && (
+        <EditChangeRequestDialog
+          changeRequest={cr}
+          isSubmitting={isSubmitting}
+          onClose={() => setEditOpen(false)}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+
+  return (
+    <Stack direction="row" justifyContent="space-between" gap={2}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.primary" textAlign="right">
+        {value}
+      </Typography>
+    </Stack>
+  );
+}
+
+function TextBlock({ label, value }: { label: string; value?: string | null }) {
+  if (!value || value.trim().length === 0) return null;
+
+  return (
+    <Stack gap={0.25}>
+      <Typography variant="subtitle2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.primary" sx={{ whiteSpace: "pre-wrap" }}>
+        {value}
+      </Typography>
+    </Stack>
+  );
+}
+
+function ChangeRequestDetailSkeleton() {
+  return (
+    <Stack gap={2}>
+      <Skeleton variant="text" width="40%" height={24} />
+      <Skeleton variant="text" width="80%" height={32} />
+      <Skeleton variant="rounded" height={200} />
+      <Skeleton variant="rounded" height={120} />
+    </Stack>
+  );
+}
+
+function ChangeRequestDetailErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
@@ -14,16 +14,47 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { useState } from "react";
+import { Stack, Tab, Tabs } from "@wso2/oxygen-ui";
 import { ComingSoonPage } from "@components/common/ComingSoonPage";
+import { ServiceRequestsTab } from "@components/operations/ServiceRequestsTab";
+import { ChangeRequestsTab } from "@components/operations/ChangeRequestsTab";
 
-// The webapp itself marks Operations as wip:true (apps/csm-portal/webapp/src/config/csmNavItems.ts)
-// and shows its own coming-soon page — mirroring that here rather than building ahead of it.
+type OperationsTabId = "service_requests" | "change_requests" | "incidents";
+
+const TABS: { id: OperationsTabId; label: string }[] = [
+  { id: "service_requests", label: "Service Requests" },
+  { id: "change_requests", label: "Change Requests" },
+  { id: "incidents", label: "Incidents" },
+];
+
+// Mirrors the webapp's OperationsPage (apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx):
+// three tabs — Service requests (cases with type=service_request, reusing the Support page's own
+// list/pagination/filter infra), Change requests (its own list/detail/edit), and Incidents (no
+// backend endpoint exists yet, in this repo or the webapp's — kept as a placeholder like the
+// webapp's own IssuesListUnavailable). "Create service request"/"Create change request" are
+// deliberately out of scope for this pass — each is its own large form (cascading
+// project/deployment/catalog selects with dynamic variables, or a 15+ field change-request form).
 export default function OperationsPage() {
+  const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
+
   return (
-    <ComingSoonPage
-      title="Operations"
-      description="Operations tooling is still under construction."
-      showTitle={false}
-    />
+    <Stack gap={2}>
+      <Tabs variant="scrollable" value={activeTab} onChange={(_, value: OperationsTabId) => setActiveTab(value)}>
+        {TABS.map((tab) => (
+          <Tab key={tab.id} label={tab.label} value={tab.id} disableRipple />
+        ))}
+      </Tabs>
+
+      {activeTab === "service_requests" && <ServiceRequestsTab />}
+      {activeTab === "change_requests" && <ChangeRequestsTab />}
+      {activeTab === "incidents" && (
+        <ComingSoonPage
+          title="Incidents"
+          description="Incident tracking is still under construction."
+          showTitle={false}
+        />
+      )}
+    </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -47,12 +47,16 @@ export interface CaseSearchResult {
 // api client directly for the same reason.
 export const getAllCases = async (payload: CaseSearchPayloadDto = {}): Promise<CaseSearchResult> => {
   const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const items = data.cases.map(toCaseSummary);
   return {
-    items: data.cases.map(toCaseSummary),
+    items,
     total: data.total,
     limit: data.limit,
     offset: data.offset,
-    hasMore: data.hasMore,
+    // Some data sources omit hasMore from the search envelope (see adminUsers.ts's searchUsers,
+    // which hits the same quirk on /users/search); derive it from offset/total when that happens
+    // instead of treating a missing field as "no more pages".
+    hasMore: data.hasMore ?? data.offset + items.length < data.total,
   };
 };
 

--- a/apps/csm-portal/microapp/src/services/changeRequests.ts
+++ b/apps/csm-portal/microapp/src/services/changeRequests.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { CHANGE_REQUESTS_SEARCH_ENDPOINT, CHANGE_REQUEST_ENDPOINT } from "@config/endpoints";
+import type {
+  ChangeRequestDetailDto,
+  ChangeRequestSearchPayloadDto,
+  ChangeRequestSearchResponseDto,
+  PatchChangeRequestPayloadDto,
+  PatchChangeRequestResponseDto,
+} from "@src/types";
+import { toChangeRequestDetail, toChangeRequestSummary, type ChangeRequestSummary } from "@src/types";
+import apiClient from "./apiClient";
+
+export interface ChangeRequestSearchResult {
+  items: ChangeRequestSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+// The search response has no `hasMore` field (unlike /cases/search) — derive it from offset/total,
+// same defensive pattern as adminUsers.ts's searchUsers for the same reason.
+const searchChangeRequests = async (
+  payload: ChangeRequestSearchPayloadDto = {},
+): Promise<ChangeRequestSearchResult> => {
+  const { data } = await apiClient.post<ChangeRequestSearchResponseDto>(CHANGE_REQUESTS_SEARCH_ENDPOINT, payload);
+  const items = data.changeRequests.map(toChangeRequestSummary);
+  return {
+    items,
+    total: data.total,
+    limit: data.limit,
+    offset: data.offset,
+    hasMore: data.offset + items.length < data.total,
+  };
+};
+
+const getChangeRequest = async (id: string) => {
+  const { data } = await apiClient.get<ChangeRequestDetailDto>(CHANGE_REQUEST_ENDPOINT(id));
+  return toChangeRequestDetail(data);
+};
+
+const patchChangeRequest = async (id: string, payload: PatchChangeRequestPayloadDto) => {
+  const { data } = await apiClient.patch<PatchChangeRequestResponseDto>(CHANGE_REQUEST_ENDPOINT(id), payload);
+  return data;
+};
+
+const CHANGE_REQUEST_PAGE_LIMIT = 20;
+
+export const changeRequests = {
+  infinite: (payload: Omit<ChangeRequestSearchPayloadDto, "pagination"> = {}) =>
+    infiniteQueryOptions({
+      queryKey: ["change-requests", "infinite", payload],
+      queryFn: ({ pageParam }) =>
+        searchChangeRequests({ ...payload, pagination: { offset: pageParam, limit: CHANGE_REQUEST_PAGE_LIMIT } }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
+    }),
+
+  get: (id: string) =>
+    queryOptions({
+      queryKey: ["change-request", id],
+      queryFn: () => getChangeRequest(id),
+    }),
+
+  patch: patchChangeRequest,
+};

--- a/apps/csm-portal/microapp/src/services/changeRequests.ts
+++ b/apps/csm-portal/microapp/src/services/changeRequests.ts
@@ -46,7 +46,9 @@ const searchChangeRequests = async (
     total: data.total,
     limit: data.limit,
     offset: data.offset,
-    hasMore: data.offset + items.length < data.total,
+    // Guard against an empty page still reporting hasMore (e.g. a stale/inconsistent total) —
+    // an empty page always means there's nothing further to fetch, regardless of total.
+    hasMore: items.length > 0 && data.offset + items.length < data.total,
   };
 };
 

--- a/apps/csm-portal/microapp/src/types/changeRequest.dto.ts
+++ b/apps/csm-portal/microapp/src/types/changeRequest.dto.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { EntityRefDto } from "./case.dto";
+
+// The backend's /change-requests/search filter only accepts these 8 (documented gap: `new`,
+// `assess`, `authorize` — the pre-workflow states — aren't filterable, only returnable).
+export type ChangeRequestFilterableState =
+  | "customer_approval"
+  | "scheduled"
+  | "implement"
+  | "review"
+  | "customer_review"
+  | "rollback"
+  | "closed"
+  | "canceled";
+
+// The full state set a change request can actually be in (search/detail responses), including the
+// 3 pre-workflow states the search filter can't target.
+export type ChangeRequestState = ChangeRequestFilterableState | "new" | "assess" | "authorize";
+
+export type ChangeRequestImpact = "high" | "medium" | "low";
+
+export interface ChangeRequestSearchViewDto {
+  id: string;
+  number: string;
+  subject: string | null;
+  description: string | null;
+  project: EntityRefDto;
+  case: EntityRefDto | null;
+  deployment: EntityRefDto | null;
+  deployedProduct: EntityRefDto | null;
+  product: EntityRefDto | null;
+  assignedEngineer: EntityRefDto | null;
+  assignedTeam: EntityRefDto | null;
+  plannedStartOn: string | null;
+  plannedEndOn: string | null;
+  duration: string | null;
+  impact: ChangeRequestImpact | null;
+  state: ChangeRequestState | null;
+  type: string | null;
+  createdOn: string;
+  updatedOn: string;
+}
+
+export interface ChangeRequestDetailDto extends ChangeRequestSearchViewDto {
+  createdBy: string;
+  justification: string | null;
+  impactDescription: string | null;
+  serviceOutage: string | null;
+  communicationPlan: string | null;
+  rollbackPlan: string | null;
+  testPlan: string | null;
+  hasCustomerApproved: boolean;
+  hasCustomerReviewed: boolean;
+  approvedBy: EntityRefDto | null;
+  approvedOn: string | null;
+}
+
+export interface ChangeRequestSearchPayloadDto {
+  filters?: {
+    projectIds?: string[];
+    searchQuery?: string;
+    states?: ChangeRequestFilterableState[];
+    impacts?: ChangeRequestImpact[];
+    closedStartDate?: string;
+    closedEndDate?: string;
+  };
+  sortBy?: {
+    field?: "createdOn" | "updatedOn";
+    order?: "asc" | "desc";
+  };
+  pagination?: {
+    offset?: number;
+    limit?: number;
+  };
+}
+
+export interface ChangeRequestSearchResponseDto {
+  changeRequests: ChangeRequestSearchViewDto[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// minProperties: 1 on the backend — caller must send at least one field.
+export interface PatchChangeRequestPayloadDto {
+  /** "YYYY-MM-DD HH:MM:SS" */
+  plannedStartOn?: string;
+  isCustomerApproved?: boolean;
+  isCustomerReviewed?: boolean;
+}
+
+export interface PatchChangeRequestResponseDto {
+  id: string;
+  updatedOn?: string;
+  updatedBy?: string;
+}

--- a/apps/csm-portal/microapp/src/types/changeRequest.dto.ts
+++ b/apps/csm-portal/microapp/src/types/changeRequest.dto.ts
@@ -98,8 +98,8 @@ export interface ChangeRequestSearchResponseDto {
 
 // minProperties: 1 on the backend — caller must send at least one field.
 export interface PatchChangeRequestPayloadDto {
-  /** "YYYY-MM-DD HH:MM:SS" */
-  plannedStartOn?: string;
+  /** "YYYY-MM-DD HH:MM:SS", or null to clear a previously-set planned start. */
+  plannedStartOn?: string | null;
   isCustomerApproved?: boolean;
   isCustomerReviewed?: boolean;
 }

--- a/apps/csm-portal/microapp/src/types/changeRequest.model.ts
+++ b/apps/csm-portal/microapp/src/types/changeRequest.model.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { EntityRefDto } from "./case.dto";
+import type {
+  ChangeRequestDetailDto,
+  ChangeRequestImpact,
+  ChangeRequestSearchViewDto,
+  ChangeRequestState,
+} from "./changeRequest.dto";
+import { parseOptionalBackendTimestamp } from "@utils/dateTime";
+
+export interface ChangeRequestSummary {
+  id: string;
+  number: string;
+  subject: string;
+  project: EntityRefDto;
+  case: EntityRefDto | null;
+  deployment: EntityRefDto | null;
+  product: EntityRefDto | null;
+  assignedEngineer: EntityRefDto | null;
+  assignedTeam: EntityRefDto | null;
+  plannedStartOn: string | null;
+  plannedEndOn: string | null;
+  duration: string | null;
+  impact: ChangeRequestImpact | null;
+  state: ChangeRequestState | null;
+  createdOn: Date;
+  updatedOn: Date;
+}
+
+export interface ChangeRequestDetail extends ChangeRequestSummary {
+  description: string | null;
+  createdBy: string;
+  justification: string | null;
+  impactDescription: string | null;
+  serviceOutage: string | null;
+  communicationPlan: string | null;
+  rollbackPlan: string | null;
+  testPlan: string | null;
+  hasCustomerApproved: boolean;
+  hasCustomerReviewed: boolean;
+  approvedBy: EntityRefDto | null;
+  approvedOn: Date | null;
+}
+
+export function toChangeRequestSummary(dto: ChangeRequestSearchViewDto): ChangeRequestSummary {
+  return {
+    id: dto.id,
+    number: dto.number,
+    subject: dto.subject ?? "(No subject)",
+    project: dto.project,
+    case: dto.case,
+    deployment: dto.deployment,
+    product: dto.product,
+    assignedEngineer: dto.assignedEngineer,
+    assignedTeam: dto.assignedTeam,
+    plannedStartOn: dto.plannedStartOn,
+    plannedEndOn: dto.plannedEndOn,
+    duration: dto.duration,
+    impact: dto.impact,
+    state: dto.state,
+    createdOn: parseOptionalBackendTimestamp(dto.createdOn) ?? new Date(NaN),
+    updatedOn: parseOptionalBackendTimestamp(dto.updatedOn) ?? new Date(NaN),
+  };
+}
+
+export function toChangeRequestDetail(dto: ChangeRequestDetailDto): ChangeRequestDetail {
+  return {
+    ...toChangeRequestSummary(dto),
+    description: dto.description,
+    createdBy: dto.createdBy,
+    justification: dto.justification,
+    impactDescription: dto.impactDescription,
+    serviceOutage: dto.serviceOutage,
+    communicationPlan: dto.communicationPlan,
+    rollbackPlan: dto.rollbackPlan,
+    testPlan: dto.testPlan,
+    hasCustomerApproved: dto.hasCustomerApproved,
+    hasCustomerReviewed: dto.hasCustomerReviewed,
+    approvedBy: dto.approvedBy,
+    approvedOn: parseOptionalBackendTimestamp(dto.approvedOn),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the Operations page (previously a "Coming soon" placeholder) with three tabs, mirroring the webapp's own Operations feature:
  - **Service Requests** — reuses the Support page's own case-list/pagination/filter infrastructure, scoped to `type: service_request`. Severity is dropped (case-type-only, matches the webapp's `CsmIssuesView` behavior when locked to a non-`case` type); Work state is kept, disabled until "Work in progress" is selected (also matches the webapp).
  - **Change Requests** — new end-to-end feature: search/list with a filter sheet (state, impact, closed-date range) mirroring the Support page's own filter-sheet pattern, an infinite-scroll list, a detail page (Overview / Approval / Details & plans), and an edit dialog limited to exactly the 3 fields the backend allows (`plannedStartOn`, `isCustomerApproved`, `isCustomerReviewed`).
  - **Incidents** — stays a placeholder; confirmed no backend endpoint exists for it anywhere (this repo's `openapi.yaml` or the webapp's own `IssuesListUnavailable`).
- Includes a `getAllCases` `hasMore` fallback fix (derives `hasMore` from `offset`/`total` when the search response omits it, mirroring the same fix already in `adminUsers.ts`'s `searchUsers`) — needed for the Service Requests list to paginate past the first page.
- "Create service request" and "Create change request" are deliberately out of scope for this PR — each is its own large form (cascading project/deployment/catalog selects with dynamic variables, or a 15+ field change-request form).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vite build` clean
- [x] Verified the committed changes build standalone in isolation (staged-only snapshot, apart from unrelated in-progress work on the same branch)
- [ ] Manual verification in the simulator: Service Requests list/filters, Change Requests list/filters/detail/edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Operations tabs for Service Requests, Change Requests, and Incidents.
  * Added searchable, filterable service-request and change-request lists with infinite scrolling.
  * Added change-request detail pages with state, impact, planning information, and editable fields.
  * Added loading, empty, error, retry, and skeleton states for operations views.
* **Bug Fixes**
  * Improved pagination handling when result counts omit continuation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->