### PR TITLE
[CSM] Add POST /conversations/search endpoint

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -263,6 +263,7 @@ backend/
 ### Conversations
 
 - `GET /conversations/{id}/messages` — Get paginated messages for a conversation; optional query params `limit` (1–100, default 20) and `offset` (default 0) (ServiceNow data source only)
+- `POST /conversations/search` — Search conversations; optional `filters` (`projectIds`, `states` (`ACTIVE`/`RESOLVED`), `searchQuery`, `createdByMe`) and `sortBy` (`field`: `createdOn`/`updatedOn`, `order`) (ServiceNow data source only)
 
 ### Updates
 
@@ -346,4 +347,10 @@ curl -X POST http://localhost:8080/problems/search \
   -H "x-jwt-assertion: $JWT" \
   -H "Content-Type: application/json" \
   -d '{"filters":{"searchQuery":"database"},"pagination":{"limit":10,"offset":0}}'
+
+# Search conversations
+curl -X POST http://localhost:8080/conversations/search \
+  -H "x-jwt-assertion: $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"filters":{"states":["ACTIVE"]},"pagination":{"limit":10,"offset":0}}'
 ```

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -147,6 +147,7 @@ func main() {
 	mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)
 	mux.HandleFunc("GET /products/vulnerabilities/{id}", productVulnerabilityHandler.GetProductVulnerability)
 	mux.HandleFunc("GET /conversations/{id}/messages", conversationHandler.GetConversationMessages)
+	mux.HandleFunc("POST /conversations/search", conversationHandler.SearchConversations)
 	mux.HandleFunc("POST /slas/search", taskSlaHandler.SearchTaskSlas)
 	mux.HandleFunc("GET /slas/{id}", taskSlaHandler.GetTaskSla)
 	mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -325,6 +325,12 @@ func (c *Client) SearchComments(ctx context.Context, body []byte) ([]byte, error
 	return c.do(ctx, http.MethodPost, "/comments/search", body)
 }
 
+// SearchConversations calls POST /conversations/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *Client) SearchConversations(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/conversations/search", body)
+}
+
 // SearchTaskSlas calls POST /slas/search on the entity service.
 // Response is returned as raw JSON.
 func (c *Client) SearchTaskSlas(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/conversations.go
+++ b/apps/csm-portal/backend/internal/handler/conversations.go
@@ -19,6 +19,8 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -34,6 +36,54 @@ const (
 // entityConversationClient abstracts the entity service conversation operations.
 type entityConversationClient interface {
 	SearchComments(ctx context.Context, body []byte) ([]byte, error)
+	SearchConversations(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// searchConversationsRequest mirrors the enum/format-constrained fields of the documented
+// ConversationSearchPayload schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+type searchConversationsRequest struct {
+	Filters struct {
+		ProjectIDs []string `json:"projectIds"`
+		States     []string `json:"states"`
+	} `json:"filters"`
+	SortBy struct {
+		Field string `json:"field"`
+		Order string `json:"order"`
+	} `json:"sortBy"`
+}
+
+var (
+	validConversationStates     = map[string]bool{"ACTIVE": true, "RESOLVED": true}
+	validConversationSortFields = map[string]bool{"createdOn": true, "updatedOn": true}
+	validConversationSortOrders = map[string]bool{"asc": true, "desc": true}
+)
+
+// validateSearchConversationsBody checks the filter/sort fields with a known, fixed set of
+// valid values (state enums, projectIds as UUIDs, sort field/order enums) so obviously
+// invalid requests are rejected before reaching the entity service.
+func validateSearchConversationsBody(body []byte) bool {
+	var req searchConversationsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	for _, id := range req.Filters.ProjectIDs {
+		if !uuidRe.MatchString(id) {
+			return false
+		}
+	}
+	for _, st := range req.Filters.States {
+		if !validConversationStates[st] {
+			return false
+		}
+	}
+	if req.SortBy.Field != "" && !validConversationSortFields[req.SortBy.Field] {
+		return false
+	}
+	if req.SortBy.Order != "" && !validConversationSortOrders[req.SortBy.Order] {
+		return false
+	}
+	return true
 }
 
 // ConversationHandler handles HTTP requests for conversation operations.
@@ -99,6 +149,46 @@ func (h *ConversationHandler) GetConversationMessages(w http.ResponseWriter, r *
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchComments failed", "userID", user.UserID, "conversationID", id, "err", err)
 		mapUpstreamError(w, err, "Failed to retrieve conversation messages.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// SearchConversations handles POST /conversations/search.
+func (h *ConversationHandler) SearchConversations(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validateSearchConversationsBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchConversations(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchConversations failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search conversations.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/conversations_test.go
+++ b/apps/csm-portal/backend/internal/handler/conversations_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -140,6 +141,123 @@ func TestGetConversationMessages(t *testing.T) {
 				h.GetConversationMessages(w, r)
 				assertStatus(t, w, tc.wantCode)
 				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}
+
+func TestSearchConversations(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewConversationHandler(&mockEntityConversationClient{})
+		r := httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewConversationHandler(&mockEntityConversationClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewConversationHandler(&mockEntityConversationClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects unknown state enum value", func(t *testing.T) {
+		h := NewConversationHandler(&mockEntityConversationClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(`{"filters":{"states":["CLOSED"]}}`)))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID projectIds entry", func(t *testing.T) {
+		h := NewConversationHandler(&mockEntityConversationClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(`{"filters":{"projectIds":["not-a-uuid"]}}`)))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid sortBy field", func(t *testing.T) {
+		h := NewConversationHandler(&mockEntityConversationClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(`{"sortBy":{"field":"subject","order":"asc"}}`)))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid sortBy order", func(t *testing.T) {
+		h := NewConversationHandler(&mockEntityConversationClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(`{"sortBy":{"field":"createdOn","order":"sideways"}}`)))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"filters":{"searchQuery":"outage","states":["ACTIVE"]},"pagination":{"limit":10,"offset":0}}`
+		var capturedBody []byte
+		client := &mockEntityConversationClient{
+			searchConversationsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"conversations":[{"id":"11111111-1111-1111-1111-111111111111","number":"CONV0001"}],"total":1}`), nil
+			},
+		}
+		h := NewConversationHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchConversations(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search conversations.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityConversationClient{
+					searchConversationsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewConversationHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/conversations/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchConversations(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
 			})
 		}
 	})

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -557,7 +557,8 @@ func (m *mockEntityDeploymentClient) PatchDeployedProduct(ctx context.Context, d
 // ----- mock entity conversation client -----
 
 type mockEntityConversationClient struct {
-	searchCommentsFn func(ctx context.Context, body []byte) ([]byte, error)
+	searchCommentsFn      func(ctx context.Context, body []byte) ([]byte, error)
+	searchConversationsFn func(ctx context.Context, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityConversationClient) SearchComments(ctx context.Context, body []byte) ([]byte, error) {
@@ -565,6 +566,13 @@ func (m *mockEntityConversationClient) SearchComments(ctx context.Context, body 
 		return m.searchCommentsFn(ctx, body)
 	}
 	return []byte(`{"comments":[],"total":0,"limit":20,"offset":0,"hasMore":false}`), nil
+}
+
+func (m *mockEntityConversationClient) SearchConversations(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchConversationsFn != nil {
+		return m.searchConversationsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
 }
 
 // ----- mock entity task SLA client -----

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2318,6 +2318,57 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /conversations/search:
+    post:
+      summary: Search conversations (ServiceNow data source only).
+      operationId: postConversationsSearch
+      security:
+        - bearerAuth: []
+      requestBody:
+        description: Conversation search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConversationSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /slas/search:
     post:
       summary: Search task SLA records (ServiceNow data source only).
@@ -5808,6 +5859,89 @@ components:
         hasMore:
           type: boolean
           description: Whether additional pages are available.
+
+    ConversationSearchPayload:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+            states:
+              type: array
+              items:
+                type: string
+                enum: [ACTIVE, RESOLVED]
+            searchQuery:
+              type: string
+            createdByMe:
+              type: boolean
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 50
+
+    ConversationView:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        initialMessage:
+          type: string
+          nullable: true
+        messageCount:
+          type: integer
+        project:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        case:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        state:
+          type: string
+          nullable: true
+          enum: [ACTIVE, RESOLVED]
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+
+    ConversationSearchResponse:
+      type: object
+      properties:
+        conversations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConversationView'
+        total:
+          type: integer
+          description: Total number of matching conversations
+        limit:
+          type: integer
+        offset:
+          type: integer
 
     SearchTaskSlasPayload:
       type: object

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -753,24 +753,24 @@ const (
 type CaseResolutionCode string
 
 const (
-	CaseResolutionCodeSolvedFixedBySupportGuidanceProvided    CaseResolutionCode = "SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED"
-	CaseResolutionCodeSolvedFixedByClosingRelatedIncident     CaseResolutionCode = "SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT"
-	CaseResolutionCodeSolvedFixedByClosingRelatedRDTicket     CaseResolutionCode = "SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET"
-	CaseResolutionCodeSolvedWorkaroundProvided                CaseResolutionCode = "SOLVED_WORKAROUND_PROVIDED"
-	CaseResolutionCodeSolvedByCustomer                        CaseResolutionCode = "SOLVED_BY_CUSTOMER"
-	CaseResolutionCodeConsideredForRoadmap                    CaseResolutionCode = "CONSIDERED_FOR_ROADMAP"
-	CaseResolutionCodeInconclusiveOutOfScope                  CaseResolutionCode = "INCONCLUSIVE_OUT_OF_SCOPE"
-	CaseResolutionCodeInconclusiveCannotReproduce             CaseResolutionCode = "INCONCLUSIVE_CANNOT_REPRODUCE"
-	CaseResolutionCodeInconclusiveNoWorkaround                CaseResolutionCode = "INCONCLUSIVE_NO_WORKAROUND"
-	CaseResolutionCodeDuplicateIssue                          CaseResolutionCode = "DUPLICATE_ISSUE"
-	CaseResolutionCodeVoidedCanceled                          CaseResolutionCode = "VOIDED_CANCELED"
-	CaseResolutionCodeOnHold                                  CaseResolutionCode = "ON_HOLD"
-	CaseResolutionCodeConsideredForRoadmapAlt                 CaseResolutionCode = "CONSIDERED_FOR_ROADMAP_ALT"
-	CaseResolutionCodeSolvedFixedTheIssue                     CaseResolutionCode = "SOLVED_FIXED_THE_ISSUE"
-	CaseResolutionCodeSolvedWorkaroundProvidedAlt             CaseResolutionCode = "SOLVED_WORKAROUND_PROVIDED_ALT"
-	CaseResolutionCodeSolvedByContributor                     CaseResolutionCode = "SOLVED_BY_CONTRIBUTOR"
-	CaseResolutionCodeSolvedByNovera                          CaseResolutionCode = "SOLVED_BY_NOVERA"
-	CaseResolutionCodeAbruptlyClosedDueToNonResponsiveness    CaseResolutionCode = "ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS"
+	CaseResolutionCodeSolvedFixedBySupportGuidanceProvided CaseResolutionCode = "SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED"
+	CaseResolutionCodeSolvedFixedByClosingRelatedIncident  CaseResolutionCode = "SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT"
+	CaseResolutionCodeSolvedFixedByClosingRelatedRDTicket  CaseResolutionCode = "SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET"
+	CaseResolutionCodeSolvedWorkaroundProvided             CaseResolutionCode = "SOLVED_WORKAROUND_PROVIDED"
+	CaseResolutionCodeSolvedByCustomer                     CaseResolutionCode = "SOLVED_BY_CUSTOMER"
+	CaseResolutionCodeConsideredForRoadmap                 CaseResolutionCode = "CONSIDERED_FOR_ROADMAP"
+	CaseResolutionCodeInconclusiveOutOfScope               CaseResolutionCode = "INCONCLUSIVE_OUT_OF_SCOPE"
+	CaseResolutionCodeInconclusiveCannotReproduce          CaseResolutionCode = "INCONCLUSIVE_CANNOT_REPRODUCE"
+	CaseResolutionCodeInconclusiveNoWorkaround             CaseResolutionCode = "INCONCLUSIVE_NO_WORKAROUND"
+	CaseResolutionCodeDuplicateIssue                       CaseResolutionCode = "DUPLICATE_ISSUE"
+	CaseResolutionCodeVoidedCanceled                       CaseResolutionCode = "VOIDED_CANCELED"
+	CaseResolutionCodeOnHold                               CaseResolutionCode = "ON_HOLD"
+	CaseResolutionCodeConsideredForRoadmapAlt              CaseResolutionCode = "CONSIDERED_FOR_ROADMAP_ALT"
+	CaseResolutionCodeSolvedFixedTheIssue                  CaseResolutionCode = "SOLVED_FIXED_THE_ISSUE"
+	CaseResolutionCodeSolvedWorkaroundProvidedAlt          CaseResolutionCode = "SOLVED_WORKAROUND_PROVIDED_ALT"
+	CaseResolutionCodeSolvedByContributor                  CaseResolutionCode = "SOLVED_BY_CONTRIBUTOR"
+	CaseResolutionCodeSolvedByNovera                       CaseResolutionCode = "SOLVED_BY_NOVERA"
+	CaseResolutionCodeAbruptlyClosedDueToNonResponsiveness CaseResolutionCode = "ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS"
 )
 
 // CaseCause enumerates the root-cause categories for a resolved case.
@@ -1004,15 +1004,15 @@ type SearchCasesResponse struct {
 // ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
 // State is closed or solution_proposed.
 type UpdateCaseRequest struct {
-	ID             string         `json:"-"`
-	State          *CaseState     `json:"state"`
-	Severity       *CaseSeverity  `json:"severity"`
-	WorkState      *CaseWorkState `json:"workState"`
-	WatchList      []string       `json:"watchList"`
-	AssigneeEmail  *string        `json:"assigneeEmail"`
+	ID             string              `json:"-"`
+	State          *CaseState          `json:"state"`
+	Severity       *CaseSeverity       `json:"severity"`
+	WorkState      *CaseWorkState      `json:"workState"`
+	WatchList      []string            `json:"watchList"`
+	AssigneeEmail  *string             `json:"assigneeEmail"`
 	ResolutionCode *CaseResolutionCode `json:"resolutionCode"`
-	Cause          *CaseCause     `json:"cause"`
-	CloseNotes     *string        `json:"closeNotes"`
+	Cause          *CaseCause          `json:"cause"`
+	CloseNotes     *string             `json:"closeNotes"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -2259,21 +2259,21 @@ type SearchIncidentsRequest struct {
 
 // SearchIncidentView is the unified incident representation returned in search results.
 type SearchIncidentView struct {
-	ID              *string              `json:"id"`
-	Number          *string              `json:"number"`
-	OpenedOn        *string              `json:"openedOn"`
-	Subject         *string              `json:"subject"`
-	Caller          *EntityRef           `json:"caller"`
-	Priority        *string `json:"priority"`
-	State           *string `json:"state"`
-	Category        *string `json:"category"`
-	Parent          *EntityRef           `json:"parent"`
-	AssignmentGroup *EntityRef           `json:"assignmentGroup"`
-	AssignedTo      *EntityRef           `json:"assignedTo"`
-	CreatedOn       string               `json:"createdOn"`
-	CreatedBy       string               `json:"createdBy"`
-	UpdatedOn       string               `json:"updatedOn"`
-	UpdatedBy       string               `json:"updatedBy"`
+	ID              *string    `json:"id"`
+	Number          *string    `json:"number"`
+	OpenedOn        *string    `json:"openedOn"`
+	Subject         *string    `json:"subject"`
+	Caller          *EntityRef `json:"caller"`
+	Priority        *string    `json:"priority"`
+	State           *string    `json:"state"`
+	Category        *string    `json:"category"`
+	Parent          *EntityRef `json:"parent"`
+	AssignmentGroup *EntityRef `json:"assignmentGroup"`
+	AssignedTo      *EntityRef `json:"assignedTo"`
+	CreatedOn       string     `json:"createdOn"`
+	CreatedBy       string     `json:"createdBy"`
+	UpdatedOn       string     `json:"updatedOn"`
+	UpdatedBy       string     `json:"updatedBy"`
 }
 
 // SearchIncidentsResponse is the paginated result of an incident search.
@@ -2418,19 +2418,19 @@ type IncidentView struct {
 	OpenedOn           *string                 `json:"openedOn"`
 	Subject            *string                 `json:"subject"`
 	Caller             *EntityRef              `json:"caller"`
-	Priority           *string    `json:"priority"`
-	State              *string    `json:"state"`
-	Category           *string    `json:"category"`
-	Subcategory        *string    `json:"subcategory"`
-	Parent             *EntityRef `json:"parent"`
-	AssignmentGroup    *EntityRef `json:"assignmentGroup"`
-	AssignedTo         *EntityRef `json:"assignedTo"`
-	Service            *EntityRef `json:"service"`
-	ServiceOffering    *EntityRef `json:"serviceOffering"`
-	ConfigurationItem  *EntityRef `json:"configurationItem"`
-	ContactType        *string    `json:"contactType"`
-	Impact             *string    `json:"impact"`
-	Urgency            *string    `json:"urgency"`
+	Priority           *string                 `json:"priority"`
+	State              *string                 `json:"state"`
+	Category           *string                 `json:"category"`
+	Subcategory        *string                 `json:"subcategory"`
+	Parent             *EntityRef              `json:"parent"`
+	AssignmentGroup    *EntityRef              `json:"assignmentGroup"`
+	AssignedTo         *EntityRef              `json:"assignedTo"`
+	Service            *EntityRef              `json:"service"`
+	ServiceOffering    *EntityRef              `json:"serviceOffering"`
+	ConfigurationItem  *EntityRef              `json:"configurationItem"`
+	ContactType        *string                 `json:"contactType"`
+	Impact             *string                 `json:"impact"`
+	Urgency            *string                 `json:"urgency"`
 	ChangeRequest      *EntityRef              `json:"changeRequest"`
 	Problem            *EntityRef              `json:"problem"`
 	CausedBy           *EntityRef              `json:"causedBy"`
@@ -2467,4 +2467,70 @@ type SearchProblemsResponse struct {
 	Total    int                 `json:"total"`
 	Offset   int                 `json:"offset"`
 	Limit    int                 `json:"limit"`
+}
+
+// ConversationState represents the state of a conversation.
+type ConversationState string
+
+const (
+	ConversationStateActive   ConversationState = "ACTIVE"
+	ConversationStateResolved ConversationState = "RESOLVED"
+)
+
+// ConversationSortField enumerates the columns available for sorting conversation search results.
+type ConversationSortField string
+
+const (
+	ConversationSortFieldCreatedOn ConversationSortField = "createdOn"
+	ConversationSortFieldUpdatedOn ConversationSortField = "updatedOn"
+)
+
+// ConversationSortOrder controls the sort direction for conversation search.
+type ConversationSortOrder string
+
+const (
+	ConversationSortOrderAsc  ConversationSortOrder = "asc"
+	ConversationSortOrderDesc ConversationSortOrder = "desc"
+)
+
+// ConversationSort specifies the sort field and direction for conversation search results.
+type ConversationSort struct {
+	Field ConversationSortField `json:"field"`
+	Order ConversationSortOrder `json:"order"`
+}
+
+// SearchConversationsFilters holds all optional filter criteria for a conversation search.
+type SearchConversationsFilters struct {
+	ProjectIDs  []string            `json:"projectIds"`
+	States      []ConversationState `json:"states"`
+	SearchQuery string              `json:"searchQuery"`
+	CreatedByMe bool                `json:"createdByMe"`
+}
+
+// SearchConversationsRequest is the input for POST /conversations/search.
+type SearchConversationsRequest struct {
+	Filters    SearchConversationsFilters `json:"filters"`
+	SortBy     ConversationSort           `json:"sortBy"`
+	Pagination Pagination                 `json:"pagination"`
+}
+
+// SearchConversationView is the conversation representation returned in search results.
+type SearchConversationView struct {
+	ID             *string    `json:"id"`
+	Number         *string    `json:"number"`
+	InitialMessage *string    `json:"initialMessage"`
+	MessageCount   int        `json:"messageCount"`
+	Project        *EntityRef `json:"project"`
+	Case           *EntityRef `json:"case"`
+	State          *string    `json:"state"`
+	CreatedOn      string     `json:"createdOn"`
+	CreatedBy      string     `json:"createdBy"`
+}
+
+// SearchConversationsResponse is the paginated result of a conversation search.
+type SearchConversationsResponse struct {
+	Conversations []SearchConversationView `json:"conversations"`
+	Total         int                      `json:"total"`
+	Offset        int                      `json:"offset"`
+	Limit         int                      `json:"limit"`
 }

--- a/entity-service/internal/handler/conversation_handler.go
+++ b/entity-service/internal/handler/conversation_handler.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// ConversationHandler handles HTTP requests for the conversations resource.
+type ConversationHandler struct {
+	svc service.ConversationService
+}
+
+// NewConversationHandler constructs a ConversationHandler with the given service.
+func NewConversationHandler(svc service.ConversationService) *ConversationHandler {
+	return &ConversationHandler{svc: svc}
+}
+
+// SearchConversations handles POST /conversations/search.
+func (h *ConversationHandler) SearchConversations(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchConversationsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchConversations(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -152,6 +152,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		problemHandler = handler.NewProblemHandler(service.NewServiceNowProblemService(serviceNowIntegrationServiceClient))
 	}
 
+	var conversationHandler *handler.ConversationHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		conversationHandler = handler.NewConversationHandler(service.NewServiceNowConversationService(serviceNowIntegrationServiceClient))
+	}
+
 	var itServiceHandler *handler.ITServiceHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		itServiceHandler = handler.NewITServiceHandler(service.NewServiceNowITServiceService(serviceNowIntegrationServiceClient))
@@ -299,6 +304,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 
 	if problemHandler != nil {
 		mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
+	}
+
+	if conversationHandler != nil {
+		mux.HandleFunc("POST /conversations/search", conversationHandler.SearchConversations)
 	}
 
 	return middleware.CorrelationID(

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -334,3 +334,12 @@ type ProblemService interface {
 	// A ValidationError is returned for invalid input.
 	SearchProblems(ctx context.Context, req domain.SearchProblemsRequest) (domain.SearchProblemsResponse, error)
 }
+
+// ConversationService defines the operations available on the conversations entity.
+// All methods require the ServiceNow data source; there is no Postgres fallback.
+type ConversationService interface {
+	// SearchConversations returns a paginated list of conversations filtered by optional
+	// project IDs, states, search query, and createdByMe. A ValidationError is returned
+	// for invalid input.
+	SearchConversations(ctx context.Context, req domain.SearchConversationsRequest) (domain.SearchConversationsResponse, error)
+}

--- a/entity-service/internal/service/sn_conversation_service.go
+++ b/entity-service/internal/service/sn_conversation_service.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snConversationsResponse mirrors the Choreo POST /conversations/search response.
+type snConversationsResponse struct {
+	Conversations []snConversation `json:"conversations"`
+	TotalRecords  int              `json:"totalRecords"`
+	Offset        int              `json:"offset"`
+	Limit         int              `json:"limit"`
+}
+
+type snConversation struct {
+	ID             *string                  `json:"id"`
+	Number         *string                  `json:"number"`
+	InitialMessage *string                  `json:"initialMessage"`
+	MessageCount   int                      `json:"messageCount"`
+	Project        *snConversationEntityRef `json:"project"`
+	Case           *snConversationEntityRef `json:"case"`
+	State          *snConversationIntLabel  `json:"state"`
+	CreatedOn      string                   `json:"createdOn"`
+	CreatedBy      string                   `json:"createdBy"`
+}
+
+type snConversationEntityRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type snConversationIntLabel struct {
+	ID    int    `json:"id"`
+	Label string `json:"label"`
+}
+
+// snConversationSearchPayload is the Choreo POST /conversations/search request body.
+type snConversationSearchPayload struct {
+	Filters    snConversationFilters `json:"filters,omitempty"`
+	SortBy     *snConversationSort   `json:"sortBy,omitempty"`
+	Pagination snProjectPagination   `json:"pagination"`
+}
+
+type snConversationSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+type snConversationFilters struct {
+	ProjectIDs  []string `json:"projectIds,omitempty"`
+	StateKeys   []int    `json:"stateKeys,omitempty"`
+	SearchQuery string   `json:"searchQuery,omitempty"`
+	CreatedByMe bool     `json:"createdByMe,omitempty"`
+}
+
+// snConversationStateKeyMap maps domain ConversationState enums to SN numeric state keys.
+var snConversationStateKeyMap = map[domain.ConversationState]int{
+	domain.ConversationStateActive:   2,
+	domain.ConversationStateResolved: 3,
+}
+
+// snConversationStateLabelMap maps SN numeric state keys to domain enum strings.
+var snConversationStateLabelMap = map[int]string{
+	2: "ACTIVE",
+	3: "RESOLVED",
+}
+
+var validConversationState = map[domain.ConversationState]bool{
+	domain.ConversationStateActive:   true,
+	domain.ConversationStateResolved: true,
+}
+
+var validConversationSortField = map[domain.ConversationSortField]bool{
+	domain.ConversationSortFieldCreatedOn: true,
+	domain.ConversationSortFieldUpdatedOn: true,
+}
+
+var validConversationSortOrder = map[domain.ConversationSortOrder]bool{
+	domain.ConversationSortOrderAsc:  true,
+	domain.ConversationSortOrderDesc: true,
+}
+
+// conversationDefaultLimit and conversationMaxLimit mirror the ServiceNow
+// Choreo /conversations/search endpoint's own pagination bounds.
+const (
+	conversationDefaultLimit = 20
+	conversationMaxLimit     = 50
+)
+
+// normalizeConversationPagination applies conversation-search-specific defaults
+// (limit 20, max 50) matching the downstream Choreo endpoint's own constraints.
+func normalizeConversationPagination(p *domain.Pagination) error {
+	if p.Limit <= 0 {
+		p.Limit = conversationDefaultLimit
+	}
+	if p.Limit > conversationMaxLimit {
+		return &apierror.ValidationError{Msg: "limit cannot exceed 50"}
+	}
+	if p.Offset < 0 {
+		p.Offset = 0
+	}
+	return nil
+}
+
+type snConversationService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowConversationService constructs a ConversationService backed by the Choreo API.
+func NewServiceNowConversationService(client *integrationservice.Client) ConversationService {
+	return &snConversationService{client: client}
+}
+
+func (s *snConversationService) SearchConversations(ctx context.Context, req domain.SearchConversationsRequest) (domain.SearchConversationsResponse, error) {
+	if err := normalizeConversationPagination(&req.Pagination); err != nil {
+		return domain.SearchConversationsResponse{}, err
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchConversationsResponse{}, err
+	}
+	if req.SortBy.Field != "" && !validConversationSortField[req.SortBy.Field] {
+		return domain.SearchConversationsResponse{}, &apierror.ValidationError{Msg: "sortBy.field contains invalid value: " + string(req.SortBy.Field)}
+	}
+	if req.SortBy.Order != "" && !validConversationSortOrder[req.SortBy.Order] {
+		return domain.SearchConversationsResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + string(req.SortBy.Order)}
+	}
+	for _, st := range req.Filters.States {
+		if !validConversationState[st] {
+			return domain.SearchConversationsResponse{}, &apierror.ValidationError{Msg: "states contains invalid value: " + string(st)}
+		}
+	}
+	if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
+		return domain.SearchConversationsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.SearchConversationsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	var snSortBy *snConversationSort
+	if req.SortBy.Field != "" {
+		order := string(req.SortBy.Order)
+		if order == "" {
+			order = "desc"
+		}
+		snSortBy = &snConversationSort{Field: string(req.SortBy.Field), Order: order}
+	}
+
+	stateKeys := make([]int, 0, len(req.Filters.States))
+	for _, st := range req.Filters.States {
+		stateKeys = append(stateKeys, snConversationStateKeyMap[st])
+	}
+
+	payload := snConversationSearchPayload{
+		Filters: snConversationFilters{
+			ProjectIDs:  uuidsToSysids(req.Filters.ProjectIDs),
+			StateKeys:   stateKeys,
+			SearchQuery: req.Filters.SearchQuery,
+			CreatedByMe: req.Filters.CreatedByMe,
+		},
+		SortBy:     snSortBy,
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/conversations/search", token, payload)
+	if err != nil {
+		return domain.SearchConversationsResponse{}, err
+	}
+
+	var snResp snConversationsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchConversationsResponse{}, fmt.Errorf("sn conversations: parse response: %w", err)
+	}
+
+	views := make([]domain.SearchConversationView, 0, len(snResp.Conversations))
+	for _, c := range snResp.Conversations {
+		view := domain.SearchConversationView{
+			Number:         c.Number,
+			InitialMessage: c.InitialMessage,
+			MessageCount:   c.MessageCount,
+			CreatedOn:      c.CreatedOn,
+			CreatedBy:      c.CreatedBy,
+		}
+		if c.ID != nil && *c.ID != "" {
+			id := sysidToUUID(*c.ID)
+			view.ID = &id
+		}
+		if c.Project != nil {
+			view.Project = &domain.EntityRef{ID: sysidToUUID(c.Project.ID), Name: c.Project.Name}
+		}
+		if c.Case != nil {
+			view.Case = &domain.EntityRef{ID: sysidToUUID(c.Case.ID), Name: c.Case.Name}
+		}
+		if c.State != nil {
+			if label, ok := snConversationStateLabelMap[c.State.ID]; ok {
+				view.State = &label
+			}
+		}
+		views = append(views, view)
+	}
+
+	return domain.SearchConversationsResponse{
+		Conversations: views,
+		Total:         snResp.TotalRecords,
+		Limit:         req.Pagination.Limit,
+		Offset:        req.Pagination.Offset,
+	}, nil
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1987,6 +1987,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /conversations/search:
+    post:
+      summary: Search conversations (ServiceNow data source only).
+      operationId: searchConversations
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchConversationsRequest'
+      responses:
+        "200":
+          description: Paginated list of conversations matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchConversationsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     Pagination:
@@ -5804,6 +5840,81 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SearchProblemView'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    SearchConversationsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+            states:
+              type: array
+              items:
+                type: string
+                enum: [ACTIVE, RESOLVED]
+            searchQuery:
+              type: string
+            createdByMe:
+              type: boolean
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn]
+            order:
+              type: string
+              enum: [asc, desc]
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    SearchConversationView:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        initialMessage:
+          type: string
+          nullable: true
+        messageCount:
+          type: integer
+        project:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        case:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        state:
+          type: string
+          nullable: true
+          enum: [ACTIVE, RESOLVED]
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+
+    SearchConversationsResponse:
+      type: object
+      properties:
+        conversations:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchConversationView'
         total:
           type: integer
         offset:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5877,7 +5877,20 @@ components:
               type: string
               enum: [asc, desc]
         pagination:
-          $ref: '#/components/schemas/Pagination'
+          $ref: '#/components/schemas/ConversationPagination'
+
+    ConversationPagination:
+      type: object
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 20
+          description: Number of results per page. Defaults to 20, capped at 50.
+        offset:
+          type: integer
+          description: Zero-based offset into the result set.
 
     SearchConversationView:
       type: object


### PR DESCRIPTION
## Summary

Adds a Go equivalent of the Ballerina entity-service's `conversations/search` endpoint (`POST /conversations/search`), and wires the csm-portal backend to it.

### entity-service
- New `ConversationService` (ServiceNow-only, no Postgres fallback), following the same service/handler/route pattern as `incidents`/`problems`
- `SearchConversationsRequest`/`SearchConversationsResponse`/`SearchConversationView` domain types: `filters` (`projectIds`, `states` — `ACTIVE`/`RESOLVED`, `searchQuery`, `createdByMe`), `sortBy` (`createdOn`/`updatedOn`, `asc`/`desc`), pagination (default 20, capped at 50 — matching the downstream Choreo endpoint's own hard limit)
- SN response fields mapped to domain conventions: sysids → UUIDs, numeric state keys → plain `UPPER_SNAKE_CASE` strings, project/case references → `EntityRef`
- Documented in `openapi.yaml`

### csm-portal backend
- Extends the existing `ConversationHandler` (previously only `GetConversationMessages`) with `SearchConversations`
- Validates known enum/UUID fields (`states`, `projectIds`, `sortBy.field`/`sortBy.order`) at the boundary before forwarding, matching the pattern already used for `POST /incidents/search`
- Documented in `openapi.yaml` and `README.md`

## Test plan
- [x] entity-service: `go build ./...`, `go vet ./...`, `go test ./...`, `gosec -fmt=text ./...` (0 issues)
- [x] csm-portal backend: `go build ./...`, `go vet ./...`, `go test ./...`, `gosec -fmt=text ./...` (0 issues)
- [x] Both `openapi.yaml` files validated as well-formed YAML
- [x] Manually started the csm-portal backend server locally and confirmed `GET /health` returns 200
- [ ] Manual: exercise `POST /conversations/search` against a running entity-service with ServiceNow data source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new conversation search API: `POST /conversations/search`.
  * Enables filtering by `projectIds`, `states` (ACTIVE/RESOLVED), `searchQuery`, and `createdByMe`.
  * Supports sorting (`createdOn`/`updatedOn`, ascending/descending) and pagination.
  * Returns paginated results including conversation identifiers, initial message, counts, related project/case info, state, and paging fields.
* **Documentation**
  * Updated API documentation and added a local `curl` example for `POST /conversations/search`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->