### PR TITLE
[Customer Entity] Add parentIncidentId support to incident create/search/get

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2268,6 +2268,7 @@ type SearchIncidentView struct {
 	State           *string    `json:"state"`
 	Category        *string    `json:"category"`
 	Parent          *EntityRef `json:"parent"`
+	ParentIncident  *EntityRef `json:"parentIncident"`
 	AssignmentGroup *EntityRef `json:"assignmentGroup"`
 	AssignedTo      *EntityRef `json:"assignedTo"`
 	CreatedOn       string     `json:"createdOn"`
@@ -2388,6 +2389,7 @@ type CreateIncidentRequest struct {
 	AdditionalComments  *string              `json:"additionalComments,omitempty"`
 	WorkNotes           *string              `json:"workNotes,omitempty"`
 	ParentID            *string              `json:"parentId,omitempty"`
+	ParentIncidentID    *string              `json:"parentIncidentId,omitempty"`
 	ChangeRequestID     *string              `json:"changeRequestId,omitempty"`
 	ProblemID           *string              `json:"problemId,omitempty"`
 	CausedByID          *string              `json:"causedById,omitempty"`
@@ -2418,19 +2420,20 @@ type IncidentView struct {
 	OpenedOn           *string                 `json:"openedOn"`
 	Subject            *string                 `json:"subject"`
 	Caller             *EntityRef              `json:"caller"`
-	Priority           *string                 `json:"priority"`
-	State              *string                 `json:"state"`
-	Category           *string                 `json:"category"`
-	Subcategory        *string                 `json:"subcategory"`
-	Parent             *EntityRef              `json:"parent"`
-	AssignmentGroup    *EntityRef              `json:"assignmentGroup"`
-	AssignedTo         *EntityRef              `json:"assignedTo"`
-	Service            *EntityRef              `json:"service"`
-	ServiceOffering    *EntityRef              `json:"serviceOffering"`
-	ConfigurationItem  *EntityRef              `json:"configurationItem"`
-	ContactType        *string                 `json:"contactType"`
-	Impact             *string                 `json:"impact"`
-	Urgency            *string                 `json:"urgency"`
+	Priority           *string    `json:"priority"`
+	State              *string    `json:"state"`
+	Category           *string    `json:"category"`
+	Subcategory        *string    `json:"subcategory"`
+	Parent             *EntityRef `json:"parent"`
+	ParentIncident     *EntityRef `json:"parentIncident"`
+	AssignmentGroup    *EntityRef `json:"assignmentGroup"`
+	AssignedTo         *EntityRef `json:"assignedTo"`
+	Service            *EntityRef `json:"service"`
+	ServiceOffering    *EntityRef `json:"serviceOffering"`
+	ConfigurationItem  *EntityRef `json:"configurationItem"`
+	ContactType        *string    `json:"contactType"`
+	Impact             *string    `json:"impact"`
+	Urgency            *string    `json:"urgency"`
 	ChangeRequest      *EntityRef              `json:"changeRequest"`
 	Problem            *EntityRef              `json:"problem"`
 	CausedBy           *EntityRef              `json:"causedBy"`

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -45,6 +45,7 @@ type snIncident struct {
 	State           *snIncidentIntLabel  `json:"state"`
 	Category        *snIncidentStrLabel  `json:"category"`
 	Parent          *snIncidentEntityRef `json:"parent"`
+	ParentIncident  *snIncidentEntityRef `json:"parentIncident"`
 	AssignmentGroup *snIncidentEntityRef `json:"assignmentGroup"`
 	AssignedTo      *snIncidentEntityRef `json:"assignedTo"`
 	CreatedOn       string               `json:"createdOn"`
@@ -246,6 +247,9 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 		if inc.Parent != nil {
 			view.Parent = &domain.EntityRef{ID: sysidToUUID(inc.Parent.ID), Name: inc.Parent.Name}
 		}
+		if inc.ParentIncident != nil {
+			view.ParentIncident = &domain.EntityRef{ID: sysidToUUID(inc.ParentIncident.ID), Name: inc.ParentIncident.Name}
+		}
 		if inc.AssignmentGroup != nil {
 			view.AssignmentGroup = &domain.EntityRef{ID: sysidToUUID(inc.AssignmentGroup.ID), Name: inc.AssignmentGroup.Name}
 		}
@@ -428,6 +432,7 @@ type snCreateIncidentPayload struct {
 	AdditionalComments  *string  `json:"additionalComments,omitempty"`
 	WorkNotes           *string  `json:"workNotes,omitempty"`
 	ParentID            *string  `json:"parentId,omitempty"`
+	ParentIncidentID    *string  `json:"parentIncidentId,omitempty"`
 	ChangeRequestID     *string  `json:"changeRequestId,omitempty"`
 	ProblemID           *string  `json:"problemId,omitempty"`
 	CausedByID          *string  `json:"causedById,omitempty"`
@@ -494,6 +499,7 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 		"assignmentGroupId":   req.AssignmentGroupID,
 		"assignedEngineerId":  req.AssignedEngineerID,
 		"parentId":            req.ParentID,
+		"parentIncidentId":    req.ParentIncidentID,
 		"changeRequestId":     req.ChangeRequestID,
 		"problemId":           req.ProblemID,
 		"causedById":          req.CausedByID,
@@ -549,6 +555,10 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 	if req.ParentID != nil {
 		v := uuidToSysid(*req.ParentID)
 		payload.ParentID = &v
+	}
+	if req.ParentIncidentID != nil {
+		v := uuidToSysid(*req.ParentIncidentID)
+		payload.ParentIncidentID = &v
 	}
 	if req.ChangeRequestID != nil {
 		v := uuidToSysid(*req.ChangeRequestID)
@@ -662,6 +672,7 @@ type snGetIncidentResponse struct {
 	Category           *snIncidentStrLabel      `json:"category"`
 	Subcategory        *snIncidentStrLabel      `json:"subcategory"`
 	Parent             *snIncidentEntityRef     `json:"parent"`
+	ParentIncident     *snIncidentEntityRef     `json:"parentIncident"`
 	AssignmentGroup    *snIncidentEntityRef     `json:"assignmentGroup"`
 	AssignedTo         *snIncidentEntityRef     `json:"assignedTo"`
 	Service            *snIncidentEntityRef     `json:"service"`
@@ -750,6 +761,9 @@ func (s *snIncidentService) GetIncidentByID(ctx context.Context, id string) (dom
 	}
 	if sn.Parent != nil {
 		view.Parent = &domain.EntityRef{ID: sysidToUUID(sn.Parent.ID), Name: sn.Parent.Name}
+	}
+	if sn.ParentIncident != nil {
+		view.ParentIncident = &domain.EntityRef{ID: sysidToUUID(sn.ParentIncident.ID), Name: sn.ParentIncident.Name}
 	}
 	if sn.AssignmentGroup != nil {
 		view.AssignmentGroup = &domain.EntityRef{ID: sysidToUUID(sn.AssignmentGroup.ID), Name: sn.AssignmentGroup.Name}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5587,6 +5587,9 @@ components:
         parent:
           $ref: '#/components/schemas/EntityRef'
           nullable: true
+        parentIncident:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
         assignmentGroup:
           $ref: '#/components/schemas/EntityRef'
           nullable: true
@@ -5681,6 +5684,10 @@ components:
           type: string
           format: uuid
           nullable: true
+        parentIncidentId:
+          type: string
+          format: uuid
+          nullable: true
         changeRequestId:
           type: string
           format: uuid
@@ -5745,6 +5752,9 @@ components:
           type: string
           nullable: true
         parent:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        parentIncident:
           $ref: '#/components/schemas/EntityRef'
           nullable: true
         assignmentGroup:


### PR DESCRIPTION
## Summary
- Add optional `parentIncidentId` field to `POST /incidents` (mapped to sysid, sent as `parentIncidentId` in the SN payload)
- Add nullable `parentIncident` reference (`EntityRef`) to the `POST /incidents/search` and `GET /incidents/{id}` responses, converting the SN sys_id back to a UUID
- Document the new fields in `openapi.yaml`

## Test plan
- [ ] `go build ./...`
- [ ] Create an incident with `parentIncidentId` set and confirm it's accepted and forwarded
- [ ] Search/get an incident that has a parent incident set in ServiceNow and confirm `parentIncident` is populated with `{id, name}`
- [ ] Confirm `parentIncident` is `null` when no parent incident is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for linking incidents to an optional parent incident when creating a new incident.
  * Parent incident details are now shown in incident search results and incident details.
  * Updated API field names to clearly identify parent incident relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->