### PR TITLE
[CSM][BE] Add parentIncidentId support to incident create/search/get

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -273,7 +273,7 @@ backend/
 ### Incidents
 
 - `POST /incidents/search` — Search incidents; optional `filters` (`searchQuery`, `priorities`, `parentIds`) and `sortBy` (`field`: `createdOn`/`updatedOn`/`openedOn`, `order`) (ServiceNow data source only)
-- `POST /incidents` — Create an incident (`callerId`, `category`, `serviceId`, `impact`, `urgency`, `subject` required; `subcategory`, `serviceOfferingId`, `configurationItemId`, `contactType`, `assignmentGroupId`, `assignedEngineerId`, `watchList`, `additionalComments`, `workNotes`, `parentId`, `changeRequestId`, `problemId`, `causedById` optional) (ServiceNow data source only)
+- `POST /incidents` — Create an incident (`callerId`, `category`, `serviceId`, `impact`, `urgency`, `subject` required; `subcategory`, `serviceOfferingId`, `configurationItemId`, `contactType`, `assignmentGroupId`, `assignedEngineerId`, `watchList`, `additionalComments`, `workNotes`, `parentId`, `parentIncidentId`, `changeRequestId`, `problemId`, `causedById` optional) (ServiceNow data source only)
 - `GET /incidents/{id}` — Get full incident detail by ID (ServiceNow data source only)
 
 ### Problems

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -98,6 +98,7 @@ type createIncidentRequest struct {
 	Subject             string   `json:"subject"`
 	WatchList           []string `json:"watchList"`
 	ParentID            string   `json:"parentId"`
+	ParentIncidentID    string   `json:"parentIncidentId"`
 	ChangeRequestID     string   `json:"changeRequestId"`
 	ProblemID           string   `json:"problemId"`
 	CausedByID          string   `json:"causedById"`
@@ -153,6 +154,9 @@ func validateCreateIncidentBody(body []byte) bool {
 		}
 	}
 	if req.ParentID != "" && !uuidRe.MatchString(req.ParentID) {
+		return false
+	}
+	if req.ParentIncidentID != "" && !uuidRe.MatchString(req.ParentIncidentID) {
 		return false
 	}
 	if req.ChangeRequestID != "" && !uuidRe.MatchString(req.ChangeRequestID) {

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -202,6 +202,16 @@ func TestCreateIncident(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects non-UUID parentIncidentId", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incidents", strings.NewReader(`{"callerId":"11111111-1111-1111-1111-111111111111","category":"SECURITY","serviceId":"22222222-2222-2222-2222-222222222222","impact":"HIGH","urgency":"HIGH","subject":"Something broke","parentIncidentId":"not-a-uuid"}`)))
+		w := httptest.NewRecorder()
+		h.CreateIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
 	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
 		const reqPayload = `{"callerId":"11111111-1111-1111-1111-111111111111","category":"SECURITY","serviceId":"22222222-2222-2222-2222-222222222222","impact":"HIGH","urgency":"HIGH","subject":"Something broke"}`
 		var capturedBody []byte

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6263,6 +6263,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/EntityRef'
+        parentIncident:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
         assignmentGroup:
           nullable: true
           allOf:
@@ -6331,6 +6335,9 @@ components:
         workNotes:
           type: string
         parentId:
+          type: string
+          format: uuid
+        parentIncidentId:
           type: string
           format: uuid
         changeRequestId:
@@ -6409,6 +6416,10 @@ components:
           nullable: true
           enum: [DHCP, ORACLE, CPU, KEYBOARD, DOS_DDOS, PRIVILEGE_ESCALATIONS, THREAT_INTELLIGENCE, SCANS_AND_PROBES, APPLICATION_SECURITY, CONFIG_CHANGE_REQUEST, IP_ADDRESS, FULL_OUTAGE, SQL_SERVER, SLOWNESS, MEMORY, MOUSE, PRIVACY, DATA_BREACH, SYSTEM_COMPROMISES, DNS, OS, DISK, VPN, MALWARE, VULNERABILITY, UNAUTHORIZED_ACCESS, IDENTITY_PROTECTION, PHISHING, IMPROPER_CONFIGURATION, INFORMATION_REQUEST, DB2, PARTIAL_OUTAGE, EMAIL, MONITOR, WIRELESS]
         parent:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EntityRef'
+        parentIncident:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/EntityRef'


### PR DESCRIPTION
## Summary

Wires the csm-portal backend to entity-service's new `parentIncidentId` field (#1147).

- Adds `parentIncidentId` to the request-validation struct in `POST /incidents`, validated as an optional UUID alongside the other reference fields (`parentId`, `changeRequestId`, `problemId`, `causedById`)
- Documents the new nullable `parentIncident` reference (`EntityRef`) in both the `Incident` (search) and `IncidentDetail` (get-by-id) response schemas
- Documents `parentIncidentId` in `CreateIncidentPayload` and the README's `POST /incidents` field list

Both endpoints are raw passthrough, so no other code changes were needed for the response side — the new `parentIncident` field already flows through automatically.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (added a test case rejecting a non-UUID `parentIncidentId`)
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] Validated `openapi.yaml` as well-formed YAML
- [ ] Manual: create an incident with `parentIncidentId` set and confirm it's forwarded; search/get an incident with a parent incident set in ServiceNow and confirm `parentIncident` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for linking an incident to a parent incident.
  * Parent incident references are now available when creating incidents and in incident details.

* **Bug Fixes**
  * Invalid parent incident identifiers are now rejected with a clear bad-request response.

* **Documentation**
  * Updated the incident API documentation to describe the new parent incident field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->