### PR TITLE
[Customer Entity ] Add resolution fields to case/incident GET responses (ServiceNow) and update OpenAPI specs

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6506,6 +6506,26 @@ components:
           format: date-time
         updatedBy:
           type: string
+        resolutionCode:
+          type: string
+          nullable: true
+          description: Resolution code label. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        resolutionNotes:
+          type: string
+          nullable: true
+          description: Free-text resolution notes. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        resolvedBy:
+          type: string
+          nullable: true
+          description: Email of the user who resolved the incident. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        resolved:
+          type: string
+          nullable: true
+          description: Timestamp when the incident was resolved. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        incidentReport:
+          type: string
+          nullable: true
+          description: Root-cause/incident report notes. Populated for resolved/closed ServiceNow incidents; null otherwise.
 
     ProblemSearchPayload:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -3796,6 +3796,25 @@ components:
             case may still be created as related to this one — true for a
             standard `case`-type case closed within the last 60 days, empty
             otherwise.
+        resolvedOn:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the case was resolved. Populated for resolved/closed ServiceNow cases; null otherwise.
+        resolutionCode:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CaseResolutionCode'
+          description: Resolution code. Populated for resolved/closed ServiceNow cases; null otherwise.
+        cause:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CaseCause'
+          description: Root-cause category. Populated for resolved/closed ServiceNow cases; null otherwise.
+        resolutionNotes:
+          type: string
+          nullable: true
+          description: Free-text resolution/close notes. Populated for resolved/closed ServiceNow cases; null otherwise.
 
     CaseSearchView:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6518,7 +6518,7 @@ components:
           type: string
           nullable: true
           description: Email of the user who resolved the incident. Populated for resolved/closed ServiceNow incidents; null otherwise.
-        resolved:
+        resolvedOn:
           type: string
           nullable: true
           description: Timestamp when the incident was resolved. Populated for resolved/closed ServiceNow incidents; null otherwise.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -928,6 +928,11 @@ type CaseView struct {
 	ParentCase             *CaseNumberRef       `json:"parentCase"`
 	RelatedCase            *CaseNumberRef       `json:"relatedCase"`
 	AccountDetails         *AccountRef          `json:"account"`
+	// Resolution fields — populated only for resolved/closed ServiceNow cases.
+	ResolvedOn      *time.Time          `json:"resolvedOn"`
+	ResolutionCode  *CaseResolutionCode `json:"resolutionCode"`
+	Cause           *CaseCause          `json:"cause"`
+	ResolutionNotes *string             `json:"resolutionNotes"`
 }
 
 // SearchCasesFilters holds all optional filter criteria for a case search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2425,20 +2425,20 @@ type IncidentView struct {
 	OpenedOn           *string                 `json:"openedOn"`
 	Subject            *string                 `json:"subject"`
 	Caller             *EntityRef              `json:"caller"`
-	Priority           *string    `json:"priority"`
-	State              *string    `json:"state"`
-	Category           *string    `json:"category"`
-	Subcategory        *string    `json:"subcategory"`
-	Parent             *EntityRef `json:"parent"`
-	ParentIncident     *EntityRef `json:"parentIncident"`
-	AssignmentGroup    *EntityRef `json:"assignmentGroup"`
-	AssignedTo         *EntityRef `json:"assignedTo"`
-	Service            *EntityRef `json:"service"`
-	ServiceOffering    *EntityRef `json:"serviceOffering"`
-	ConfigurationItem  *EntityRef `json:"configurationItem"`
-	ContactType        *string    `json:"contactType"`
-	Impact             *string    `json:"impact"`
-	Urgency            *string    `json:"urgency"`
+	Priority           *string                 `json:"priority"`
+	State              *string                 `json:"state"`
+	Category           *string                 `json:"category"`
+	Subcategory        *string                 `json:"subcategory"`
+	Parent             *EntityRef              `json:"parent"`
+	ParentIncident     *EntityRef              `json:"parentIncident"`
+	AssignmentGroup    *EntityRef              `json:"assignmentGroup"`
+	AssignedTo         *EntityRef              `json:"assignedTo"`
+	Service            *EntityRef              `json:"service"`
+	ServiceOffering    *EntityRef              `json:"serviceOffering"`
+	ConfigurationItem  *EntityRef              `json:"configurationItem"`
+	ContactType        *string                 `json:"contactType"`
+	Impact             *string                 `json:"impact"`
+	Urgency            *string                 `json:"urgency"`
 	ChangeRequest      *EntityRef              `json:"changeRequest"`
 	Problem            *EntityRef              `json:"problem"`
 	CausedBy           *EntityRef              `json:"causedBy"`
@@ -2449,6 +2449,12 @@ type IncidentView struct {
 	CreatedBy          string                  `json:"createdBy"`
 	UpdatedOn          string                  `json:"updatedOn"`
 	UpdatedBy          string                  `json:"updatedBy"`
+	// Resolution fields — populated only for resolved/closed ServiceNow incidents.
+	ResolutionCode  *string `json:"resolutionCode"`
+	ResolutionNotes *string `json:"resolutionNotes"`
+	ResolvedBy      *string `json:"resolvedBy"`
+	Resolved        *string `json:"resolved"`
+	IncidentReport  *string `json:"incidentReport"`
 }
 
 // SearchProblemsFilters holds all optional filter criteria for a problem search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2453,7 +2453,7 @@ type IncidentView struct {
 	ResolutionCode  *string `json:"resolutionCode"`
 	ResolutionNotes *string `json:"resolutionNotes"`
 	ResolvedBy      *string `json:"resolvedBy"`
-	Resolved        *string `json:"resolved"`
+	ResolvedOn      *string `json:"resolvedOn"`
 	IncidentReport  *string `json:"incidentReport"`
 }
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -65,6 +65,16 @@ type snCase struct {
 	ParentCase       *snCaseRef             `json:"parentCase"`
 	RelatedCase      *snCaseRef             `json:"relatedCase"`
 	Account          *snCaseAccount         `json:"account"`
+	ResolutionCode   *struct {
+		ID    json.Number `json:"id"`
+		Label string      `json:"label"`
+	} `json:"resolutionCode"`
+	Cause *struct {
+		ID    string `json:"id"`
+		Label string `json:"label"`
+	} `json:"cause"`
+	ResolutionNotes *string `json:"resolutionNotes"`
+	ResolvedOn      *string `json:"resolvedOn"`
 }
 
 type snCaseEntityRef struct {
@@ -566,6 +576,24 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	}
 	if c.Account != nil {
 		cv.AccountDetails = &domain.AccountRef{ID: sysidToUUID(c.Account.ID), Name: c.Account.Name, Type: c.Account.Type}
+	}
+	if c.ResolutionCode != nil {
+		if rc, ok := snResolutionCodeByID[c.ResolutionCode.ID.String()]; ok {
+			cv.ResolutionCode = &rc
+		}
+	}
+	if c.Cause != nil {
+		if cause, ok := snCauseLabelToEnum[c.Cause.Label]; ok {
+			cv.Cause = &cause
+		}
+	}
+	cv.ResolutionNotes = c.ResolutionNotes
+	if c.ResolvedOn != nil && *c.ResolvedOn != "" {
+		resolvedOn, err := time.Parse(snCreatedOnLayout, *c.ResolvedOn)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse resolvedOn %q: %w", *c.ResolvedOn, err)
+		}
+		cv.ResolvedOn = &resolvedOn
 	}
 
 	return cv, nil

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -36,10 +36,10 @@ type snIncidentsResponse struct {
 }
 
 type snIncident struct {
-	ID              *string             `json:"id"`
-	Number          *string             `json:"number"`
-	OpenedOn        *string             `json:"openedOn"`
-	Subject         *string             `json:"subject"`
+	ID              *string              `json:"id"`
+	Number          *string              `json:"number"`
+	OpenedOn        *string              `json:"openedOn"`
+	Subject         *string              `json:"subject"`
 	Caller          *snIncidentEntityRef `json:"caller"`
 	Priority        *snIncidentIntLabel  `json:"priority"`
 	State           *snIncidentIntLabel  `json:"state"`
@@ -518,13 +518,13 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 	}
 
 	payload := snCreateIncidentPayload{
-		CallerID:    uuidToSysid(req.CallerID),
-		CategoryKey: snIncidentCategoryKeyMap[req.Category],
-		ServiceID:   uuidToSysid(req.ServiceID),
-		ImpactKey:   snIncidentImpactKeyMap[req.Impact],
-		UrgencyKey:  snIncidentUrgencyKeyMap[req.Urgency],
-		Subject:     req.Subject,
-		WatchList:   req.WatchList,
+		CallerID:           uuidToSysid(req.CallerID),
+		CategoryKey:        snIncidentCategoryKeyMap[req.Category],
+		ServiceID:          uuidToSysid(req.ServiceID),
+		ImpactKey:          snIncidentImpactKeyMap[req.Impact],
+		UrgencyKey:         snIncidentUrgencyKeyMap[req.Urgency],
+		Subject:            req.Subject,
+		WatchList:          req.WatchList,
 		AdditionalComments: req.AdditionalComments,
 		WorkNotes:          req.WorkNotes,
 	}
@@ -662,35 +662,40 @@ var snIncidentUrgencyLabelMap = map[int]string{
 
 // snGetIncidentResponse mirrors the Choreo GET /incidents/{id} response.
 type snGetIncidentResponse struct {
-	ID                 *string                  `json:"id"`
-	Number             *string                  `json:"number"`
-	OpenedOn           *string                  `json:"openedOn"`
-	Subject            *string                  `json:"subject"`
-	Caller             *snIncidentEntityRef     `json:"caller"`
-	Priority           *snIncidentIntLabel      `json:"priority"`
-	State              *snIncidentIntLabel      `json:"state"`
-	Category           *snIncidentStrLabel      `json:"category"`
-	Subcategory        *snIncidentStrLabel      `json:"subcategory"`
-	Parent             *snIncidentEntityRef     `json:"parent"`
-	ParentIncident     *snIncidentEntityRef     `json:"parentIncident"`
-	AssignmentGroup    *snIncidentEntityRef     `json:"assignmentGroup"`
-	AssignedTo         *snIncidentEntityRef     `json:"assignedTo"`
-	Service            *snIncidentEntityRef     `json:"service"`
-	ServiceOffering    *snIncidentEntityRef     `json:"serviceOffering"`
-	ConfigurationItem  *snIncidentEntityRef     `json:"configurationItem"`
-	ContactType        *snIncidentStrLabel      `json:"contactType"`
-	Impact             *snIncidentIntLabel      `json:"impact"`
-	Urgency            *snIncidentIntLabel      `json:"urgency"`
-	ChangeRequest      *snIncidentEntityRef     `json:"changeRequest"`
-	Problem            *snIncidentEntityRef     `json:"problem"`
-	CausedBy           *snIncidentEntityRef     `json:"causedBy"`
-	AdditionalComments *string                  `json:"additionalComments"`
-	WorkNotes          *string                  `json:"workNotes"`
+	ID                 *string                   `json:"id"`
+	Number             *string                   `json:"number"`
+	OpenedOn           *string                   `json:"openedOn"`
+	Subject            *string                   `json:"subject"`
+	Caller             *snIncidentEntityRef      `json:"caller"`
+	Priority           *snIncidentIntLabel       `json:"priority"`
+	State              *snIncidentIntLabel       `json:"state"`
+	Category           *snIncidentStrLabel       `json:"category"`
+	Subcategory        *snIncidentStrLabel       `json:"subcategory"`
+	Parent             *snIncidentEntityRef      `json:"parent"`
+	ParentIncident     *snIncidentEntityRef      `json:"parentIncident"`
+	AssignmentGroup    *snIncidentEntityRef      `json:"assignmentGroup"`
+	AssignedTo         *snIncidentEntityRef      `json:"assignedTo"`
+	Service            *snIncidentEntityRef      `json:"service"`
+	ServiceOffering    *snIncidentEntityRef      `json:"serviceOffering"`
+	ConfigurationItem  *snIncidentEntityRef      `json:"configurationItem"`
+	ContactType        *snIncidentStrLabel       `json:"contactType"`
+	Impact             *snIncidentIntLabel       `json:"impact"`
+	Urgency            *snIncidentIntLabel       `json:"urgency"`
+	ChangeRequest      *snIncidentEntityRef      `json:"changeRequest"`
+	Problem            *snIncidentEntityRef      `json:"problem"`
+	CausedBy           *snIncidentEntityRef      `json:"causedBy"`
+	AdditionalComments *string                   `json:"additionalComments"`
+	WorkNotes          *string                   `json:"workNotes"`
 	WatchList          []snIncidentWatchListItem `json:"watchList"`
-	CreatedOn          string                   `json:"createdOn"`
-	CreatedBy          string                   `json:"createdBy"`
-	UpdatedOn          string                   `json:"updatedOn"`
-	UpdatedBy          string                   `json:"updatedBy"`
+	CreatedOn          string                    `json:"createdOn"`
+	CreatedBy          string                    `json:"createdBy"`
+	UpdatedOn          string                    `json:"updatedOn"`
+	UpdatedBy          string                    `json:"updatedBy"`
+	ResolutionCode     *snIncidentStrLabel       `json:"resolutionCode"`
+	ResolutionNotes    *string                   `json:"resolutionNotes"`
+	ResolvedBy         *string                   `json:"resolvedBy"`
+	Resolved           *string                   `json:"resolved"`
+	IncidentReport     *string                   `json:"incidentReport"`
 }
 
 type snIncidentWatchListItem struct {
@@ -728,6 +733,13 @@ func (s *snIncidentService) GetIncidentByID(ctx context.Context, id string) (dom
 		CreatedBy:          sn.CreatedBy,
 		UpdatedOn:          sn.UpdatedOn,
 		UpdatedBy:          sn.UpdatedBy,
+		ResolutionNotes:    sn.ResolutionNotes,
+		ResolvedBy:         sn.ResolvedBy,
+		Resolved:           sn.Resolved,
+		IncidentReport:     sn.IncidentReport,
+	}
+	if sn.ResolutionCode != nil {
+		view.ResolutionCode = &sn.ResolutionCode.Label
 	}
 	if sn.ID != nil && *sn.ID != "" {
 		v := sysidToUUID(*sn.ID)

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -694,7 +694,7 @@ type snGetIncidentResponse struct {
 	ResolutionCode     *snIncidentStrLabel       `json:"resolutionCode"`
 	ResolutionNotes    *string                   `json:"resolutionNotes"`
 	ResolvedBy         *string                   `json:"resolvedBy"`
-	Resolved           *string                   `json:"resolved"`
+	ResolvedOn         *string                   `json:"resolved"`
 	IncidentReport     *string                   `json:"incidentReport"`
 }
 
@@ -735,7 +735,7 @@ func (s *snIncidentService) GetIncidentByID(ctx context.Context, id string) (dom
 		UpdatedBy:          sn.UpdatedBy,
 		ResolutionNotes:    sn.ResolutionNotes,
 		ResolvedBy:         sn.ResolvedBy,
-		Resolved:           sn.Resolved,
+		ResolvedOn:         sn.ResolvedOn,
 		IncidentReport:     sn.IncidentReport,
 	}
 	if sn.ResolutionCode != nil {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5837,6 +5837,26 @@ components:
           type: string
         updatedBy:
           type: string
+        resolutionCode:
+          type: string
+          nullable: true
+          description: Resolution code label. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        resolutionNotes:
+          type: string
+          nullable: true
+          description: Free-text resolution notes. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        resolvedBy:
+          type: string
+          nullable: true
+          description: Email of the user who resolved the incident. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        resolved:
+          type: string
+          nullable: true
+          description: Timestamp when the incident was resolved. Populated for resolved/closed ServiceNow incidents; null otherwise.
+        incidentReport:
+          type: string
+          nullable: true
+          description: Root-cause/incident report notes. Populated for resolved/closed ServiceNow incidents; null otherwise.
 
     SearchProblemsRequest:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3586,6 +3586,25 @@ components:
         account:
           nullable: true
           $ref: '#/components/schemas/AccountRef'
+        resolvedOn:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the case was resolved. Populated for resolved/closed ServiceNow cases; null otherwise.
+        resolutionCode:
+          type: string
+          nullable: true
+          enum: [SOLVED_FIXED_BY_SUPPORT_GUIDANCE_PROVIDED, SOLVED_FIXED_BY_CLOSING_RELATED_INCIDENT, SOLVED_FIXED_BY_CLOSING_RELATED_RD_TICKET, SOLVED_WORKAROUND_PROVIDED, SOLVED_BY_CUSTOMER, CONSIDERED_FOR_ROADMAP, INCONCLUSIVE_OUT_OF_SCOPE, INCONCLUSIVE_CANNOT_REPRODUCE, INCONCLUSIVE_NO_WORKAROUND, DUPLICATE_ISSUE, VOIDED_CANCELED, ON_HOLD, CONSIDERED_FOR_ROADMAP_ALT, SOLVED_FIXED_THE_ISSUE, SOLVED_WORKAROUND_PROVIDED_ALT, SOLVED_BY_CONTRIBUTOR, SOLVED_BY_NOVERA, ABRUPTLY_CLOSED_DUE_TO_NON_RESPONSIVENESS]
+          description: Resolution code. Populated for resolved/closed ServiceNow cases; null otherwise.
+        cause:
+          type: string
+          nullable: true
+          enum: [USER_MISUNDERSTANDING_CONCEPTS, USER_MISUNDERSTANDING_DOCUMENTATION, USER_NOT_FOLLOWING_DOCUMENTATION, USER_MISTAKE, SOLUTION_PROBLEMATIC_SOLUTION_ARCHITECTURE, SOLUTION_PROBLEMATIC_CODE, APPLICATION_BUG, APPLICATION_MISLEADING_UX_UI, APPLICATION_LIMITATION, APPLICATION_MISSING_FEATURE, APPLICATION_DOCUMENTATION_GAP, APPLICATION_DOCUMENTATION_ERROR, INFRASTRUCTURE_CUSTOMERS_SIDE, INFRASTRUCTURE_SAAS_SIDE_NOT_ENOUGH, INFRASTRUCTURE_SAAS_SIDE_OTHER, UNKNOWN]
+          description: Root-cause category. Populated for resolved/closed ServiceNow cases; null otherwise.
+        resolutionNotes:
+          type: string
+          nullable: true
+          description: Free-text resolution/close notes. Populated for resolved/closed ServiceNow cases; null otherwise.
 
     CaseSearchView:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5849,7 +5849,7 @@ components:
           type: string
           nullable: true
           description: Email of the user who resolved the incident. Populated for resolved/closed ServiceNow incidents; null otherwise.
-        resolved:
+        resolvedOn:
           type: string
           nullable: true
           description: Timestamp when the incident was resolved. Populated for resolved/closed ServiceNow incidents; null otherwise.


### PR DESCRIPTION
## Summary
- entity-service: add `resolvedOn`, `resolutionCode`, `cause`, `resolutionNotes` to `CaseView` (GET /cases/{id}), populated only for resolved/closed ServiceNow cases
- entity-service: add `resolutionCode`, `resolutionNotes`, `resolvedBy`, `resolved`, `incidentReport` to `IncidentView` (GET /incidents/{id}), populated only for resolved/closed ServiceNow incidents
- Case resolution fields reuse the existing `CaseResolutionCode`/`CaseCause` domain enums; incident `resolutionCode` is flattened to its label string per the ServiceNow response contract
- Fields are `nil`/omitted for non-ServiceNow (Postgres) cases; incidents are ServiceNow-only
- csm-portal/backend: update `CaseView` and `IncidentDetail` schemas in openapi.yaml to document the new fields — no Go code changes needed there since `GetCase`/`GetIncident` are raw passthroughs, so the fields already flow to the frontend

## Test plan
- [x] `go build ./...` and `go vet ./...` in entity-service
- [ ] Manual GET against a resolved ServiceNow case and incident to confirm field population
- [ ] Confirm frontend can read the new fields from a resolved case/incident response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case details now include resolution date, resolution code, cause, and resolution notes when available.
  * Incident details now include resolution code, resolution notes, resolver, resolution status, and incident report information.
  * API responses expose these additional nullable resolution fields for case and incident records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->