### PR TITLE
[Customer Entity] Add PATCH /incidents/{id} for ServiceNow

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2290,6 +2290,18 @@ type SearchIncidentsResponse struct {
 	Limit     int                  `json:"limit"`
 }
 
+// IncidentState represents the workflow state of an incident.
+type IncidentState string
+
+const (
+	IncidentStateNew        IncidentState = "NEW"
+	IncidentStateInProgress IncidentState = "IN_PROGRESS"
+	IncidentStateOnHold     IncidentState = "ON_HOLD"
+	IncidentStateResolved   IncidentState = "RESOLVED"
+	IncidentStateClosed     IncidentState = "CLOSED"
+	IncidentStateCancelled  IncidentState = "CANCELLED"
+)
+
 // IncidentCategory represents the category of an incident.
 type IncidentCategory string
 
@@ -2409,6 +2421,43 @@ type CreateIncidentResponse struct {
 		CreatedOn string `json:"createdOn"`
 		CreatedBy string `json:"createdBy"`
 	} `json:"incident"`
+}
+
+// UpdateIncidentRequest is the input for PATCH /incidents/{id}. All fields are optional,
+// but at least one must be provided.
+type UpdateIncidentRequest struct {
+	ID                  string               `json:"-"`
+	Subject             *string              `json:"subject,omitempty"`
+	Priority            *IncidentPriority    `json:"priority,omitempty"`
+	State               *IncidentState       `json:"state,omitempty"`
+	Category            *IncidentCategory    `json:"category,omitempty"`
+	Subcategory         *IncidentSubcategory `json:"subcategory,omitempty"`
+	ContactType         *IncidentContactType `json:"contactType,omitempty"`
+	Impact              *IncidentImpact      `json:"impact,omitempty"`
+	Urgency             *IncidentUrgency     `json:"urgency,omitempty"`
+	ResolutionCode      *string              `json:"resolutionCode,omitempty"`
+	ParentID            *string              `json:"parentId,omitempty"`
+	ParentIncidentID    *string              `json:"parentIncidentId,omitempty"`
+	AssignmentGroupID   *string              `json:"assignmentGroupId,omitempty"`
+	AssignedEngineerID  *string              `json:"assignedEngineerId,omitempty"`
+	ServiceID           *string              `json:"serviceId,omitempty"`
+	ServiceOfferingID   *string              `json:"serviceOfferingId,omitempty"`
+	ConfigurationItemID *string              `json:"configurationItemId,omitempty"`
+	ChangeRequestID     *string              `json:"changeRequestId,omitempty"`
+	ProblemID           *string              `json:"problemId,omitempty"`
+	CausedByID          *string              `json:"causedById,omitempty"`
+	ResolvedByID        *string              `json:"resolvedById,omitempty"`
+	ResolutionNotes     *string              `json:"resolutionNotes,omitempty"`
+	IncidentReport      *string              `json:"incidentReport,omitempty"`
+	AdditionalComments  *string              `json:"additionalComments,omitempty"`
+	WorkNotes           *string              `json:"workNotes,omitempty"`
+	WatchList           []string             `json:"watchList,omitempty"`
+}
+
+// UpdateIncidentResponse is the output for PATCH /incidents/{id}.
+type UpdateIncidentResponse struct {
+	Message  string       `json:"message"`
+	Incident IncidentView `json:"incident"`
 }
 
 // IncidentWatchListItem represents a user on the incident watch list.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2451,7 +2451,7 @@ type UpdateIncidentRequest struct {
 	IncidentReport      *string              `json:"incidentReport,omitempty"`
 	AdditionalComments  *string              `json:"additionalComments,omitempty"`
 	WorkNotes           *string              `json:"workNotes,omitempty"`
-	WatchList           []string             `json:"watchList,omitempty"`
+	WatchList           *[]string            `json:"watchList,omitempty"`
 }
 
 // UpdateIncidentResponse is the output for PATCH /incidents/{id}.

--- a/entity-service/internal/handler/incident_handler.go
+++ b/entity-service/internal/handler/incident_handler.go
@@ -63,6 +63,23 @@ func (h *IncidentHandler) CreateIncident(w http.ResponseWriter, r *http.Request)
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// PatchIncident handles PATCH /incidents/{id}.
+func (h *IncidentHandler) PatchIncident(w http.ResponseWriter, r *http.Request) {
+	var req domain.UpdateIncidentRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.ID = r.PathValue("id")
+	resp, err := h.svc.UpdateIncident(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // SearchIncidents handles POST /incidents/search.
 func (h *IncidentHandler) SearchIncidents(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchIncidentsRequest

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -298,6 +298,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 
 	if incidentHandler != nil {
 		mux.HandleFunc("GET /incidents/{id}", incidentHandler.GetIncident)
+		mux.HandleFunc("PATCH /incidents/{id}", incidentHandler.PatchIncident)
 		mux.HandleFunc("POST /incidents", incidentHandler.CreateIncident)
 		mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)
 	}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -326,6 +326,10 @@ type IncidentService interface {
 	// GetIncidentByID returns the full detail of a single incident by its UUID.
 	// A NotFoundError is returned if the incident does not exist.
 	GetIncidentByID(ctx context.Context, id string) (domain.IncidentView, error)
+
+	// UpdateIncident partially updates an existing incident. At least one field must be
+	// provided. A NotFoundError is returned if the incident does not exist.
+	UpdateIncident(ctx context.Context, req domain.UpdateIncidentRequest) (domain.UpdateIncidentResponse, error)
 }
 
 // ProblemService defines the operations available on the problems entity.

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -857,31 +857,31 @@ func mapSNIncidentToView(sn snGetIncidentResponse) domain.IncidentView {
 
 // snUpdateIncidentPayload is the Choreo PATCH /incidents/{id} request body.
 type snUpdateIncidentPayload struct {
-	Subject             *string  `json:"subject,omitempty"`
-	PriorityKey         *int     `json:"priorityKey,omitempty"`
-	StateKey            *int     `json:"stateKey,omitempty"`
-	CategoryKey         *string  `json:"categoryKey,omitempty"`
-	SubcategoryKey      *string  `json:"subcategoryKey,omitempty"`
-	ContactTypeKey      *string  `json:"contactTypeKey,omitempty"`
-	ImpactKey           *int     `json:"impactKey,omitempty"`
-	UrgencyKey          *int     `json:"urgencyKey,omitempty"`
-	ResolutionCodeKey   *string  `json:"resolutionCodeKey,omitempty"`
-	ParentID            *string  `json:"parentId,omitempty"`
-	ParentIncidentID    *string  `json:"parentIncidentId,omitempty"`
-	AssignmentGroupID   *string  `json:"assignmentGroupId,omitempty"`
-	AssignedEngineerID  *string  `json:"assignedEngineerId,omitempty"`
-	ServiceID           *string  `json:"serviceId,omitempty"`
-	ServiceOfferingID   *string  `json:"serviceOfferingId,omitempty"`
-	ConfigurationItemID *string  `json:"configurationItemId,omitempty"`
-	ChangeRequestID     *string  `json:"changeRequestId,omitempty"`
-	ProblemID           *string  `json:"problemId,omitempty"`
-	CausedByID          *string  `json:"causedById,omitempty"`
-	ResolvedByID        *string  `json:"resolvedById,omitempty"`
-	ResolutionNotes     *string  `json:"resolutionNotes,omitempty"`
-	IncidentReport      *string  `json:"incidentReport,omitempty"`
-	AdditionalComments  *string  `json:"additionalComments,omitempty"`
-	WorkNotes           *string  `json:"workNotes,omitempty"`
-	WatchList           []string `json:"watchList,omitempty"`
+	Subject             *string   `json:"subject,omitempty"`
+	PriorityKey         *int      `json:"priorityKey,omitempty"`
+	StateKey            *int      `json:"stateKey,omitempty"`
+	CategoryKey         *string   `json:"categoryKey,omitempty"`
+	SubcategoryKey      *string   `json:"subcategoryKey,omitempty"`
+	ContactTypeKey      *string   `json:"contactTypeKey,omitempty"`
+	ImpactKey           *int      `json:"impactKey,omitempty"`
+	UrgencyKey          *int      `json:"urgencyKey,omitempty"`
+	ResolutionCodeKey   *string   `json:"resolutionCodeKey,omitempty"`
+	ParentID            *string   `json:"parentId,omitempty"`
+	ParentIncidentID    *string   `json:"parentIncidentId,omitempty"`
+	AssignmentGroupID   *string   `json:"assignmentGroupId,omitempty"`
+	AssignedEngineerID  *string   `json:"assignedEngineerId,omitempty"`
+	ServiceID           *string   `json:"serviceId,omitempty"`
+	ServiceOfferingID   *string   `json:"serviceOfferingId,omitempty"`
+	ConfigurationItemID *string   `json:"configurationItemId,omitempty"`
+	ChangeRequestID     *string   `json:"changeRequestId,omitempty"`
+	ProblemID           *string   `json:"problemId,omitempty"`
+	CausedByID          *string   `json:"causedById,omitempty"`
+	ResolvedByID        *string   `json:"resolvedById,omitempty"`
+	ResolutionNotes     *string   `json:"resolutionNotes,omitempty"`
+	IncidentReport      *string   `json:"incidentReport,omitempty"`
+	AdditionalComments  *string   `json:"additionalComments,omitempty"`
+	WorkNotes           *string   `json:"workNotes,omitempty"`
+	WatchList           *[]string `json:"watchList,omitempty"`
 }
 
 // snUpdateIncidentResponse mirrors the Choreo PATCH /incidents/{id} response.
@@ -902,7 +902,7 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 		req.ServiceOfferingID != nil || req.ConfigurationItemID != nil || req.ChangeRequestID != nil ||
 		req.ProblemID != nil || req.CausedByID != nil || req.ResolvedByID != nil ||
 		req.ResolutionNotes != nil || req.IncidentReport != nil || req.AdditionalComments != nil ||
-		req.WorkNotes != nil || len(req.WatchList) > 0
+		req.WorkNotes != nil || req.WatchList != nil
 	if !hasUpdate {
 		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "at least one field must be provided"}
 	}

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -122,6 +122,25 @@ var snIncidentStateLabelMap = map[int]string{
 	8: "CANCELLED",
 }
 
+// snIncidentStateKeyMap maps domain IncidentState enums to SN numeric state keys.
+var snIncidentStateKeyMap = map[domain.IncidentState]int{
+	domain.IncidentStateNew:        1,
+	domain.IncidentStateInProgress: 2,
+	domain.IncidentStateOnHold:     3,
+	domain.IncidentStateResolved:   6,
+	domain.IncidentStateClosed:     7,
+	domain.IncidentStateCancelled:  8,
+}
+
+var validIncidentState = map[domain.IncidentState]bool{
+	domain.IncidentStateNew:        true,
+	domain.IncidentStateInProgress: true,
+	domain.IncidentStateOnHold:     true,
+	domain.IncidentStateResolved:   true,
+	domain.IncidentStateClosed:     true,
+	domain.IncidentStateCancelled:  true,
+}
+
 var snIncidentCategoryLabelMap = map[string]string{
 	"inquiry":              "INQUIRY",
 	"service_interruption": "SERVICE_INTERRUPTION",
@@ -724,6 +743,12 @@ func (s *snIncidentService) GetIncidentByID(ctx context.Context, id string) (dom
 		return domain.IncidentView{}, fmt.Errorf("sn get incident: parse response: %w", err)
 	}
 
+	return mapSNIncidentToView(sn), nil
+}
+
+// mapSNIncidentToView maps a Choreo incident payload to the domain IncidentView representation.
+// Shared by GetIncidentByID and UpdateIncident since both endpoints return the full incident detail.
+func mapSNIncidentToView(sn snGetIncidentResponse) domain.IncidentView {
 	view := domain.IncidentView{
 		OpenedOn:           sn.OpenedOn,
 		Subject:            sn.Subject,
@@ -827,5 +852,205 @@ func (s *snIncidentService) GetIncidentByID(ctx context.Context, id string) (dom
 	}
 	view.WatchList = watchList
 
-	return view, nil
+	return view
+}
+
+// snUpdateIncidentPayload is the Choreo PATCH /incidents/{id} request body.
+type snUpdateIncidentPayload struct {
+	Subject             *string  `json:"subject,omitempty"`
+	PriorityKey         *int     `json:"priorityKey,omitempty"`
+	StateKey            *int     `json:"stateKey,omitempty"`
+	CategoryKey         *string  `json:"categoryKey,omitempty"`
+	SubcategoryKey      *string  `json:"subcategoryKey,omitempty"`
+	ContactTypeKey      *string  `json:"contactTypeKey,omitempty"`
+	ImpactKey           *int     `json:"impactKey,omitempty"`
+	UrgencyKey          *int     `json:"urgencyKey,omitempty"`
+	ResolutionCodeKey   *string  `json:"resolutionCodeKey,omitempty"`
+	ParentID            *string  `json:"parentId,omitempty"`
+	ParentIncidentID    *string  `json:"parentIncidentId,omitempty"`
+	AssignmentGroupID   *string  `json:"assignmentGroupId,omitempty"`
+	AssignedEngineerID  *string  `json:"assignedEngineerId,omitempty"`
+	ServiceID           *string  `json:"serviceId,omitempty"`
+	ServiceOfferingID   *string  `json:"serviceOfferingId,omitempty"`
+	ConfigurationItemID *string  `json:"configurationItemId,omitempty"`
+	ChangeRequestID     *string  `json:"changeRequestId,omitempty"`
+	ProblemID           *string  `json:"problemId,omitempty"`
+	CausedByID          *string  `json:"causedById,omitempty"`
+	ResolvedByID        *string  `json:"resolvedById,omitempty"`
+	ResolutionNotes     *string  `json:"resolutionNotes,omitempty"`
+	IncidentReport      *string  `json:"incidentReport,omitempty"`
+	AdditionalComments  *string  `json:"additionalComments,omitempty"`
+	WorkNotes           *string  `json:"workNotes,omitempty"`
+	WatchList           []string `json:"watchList,omitempty"`
+}
+
+// snUpdateIncidentResponse mirrors the Choreo PATCH /incidents/{id} response.
+type snUpdateIncidentResponse struct {
+	Message  string                `json:"message"`
+	Incident snGetIncidentResponse `json:"incident"`
+}
+
+func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.UpdateIncidentRequest) (domain.UpdateIncidentResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.UpdateIncidentResponse{}, err
+	}
+
+	hasUpdate := req.Subject != nil || req.Priority != nil || req.State != nil || req.Category != nil ||
+		req.Subcategory != nil || req.ContactType != nil || req.Impact != nil || req.Urgency != nil ||
+		req.ResolutionCode != nil || req.ParentID != nil || req.ParentIncidentID != nil ||
+		req.AssignmentGroupID != nil || req.AssignedEngineerID != nil || req.ServiceID != nil ||
+		req.ServiceOfferingID != nil || req.ConfigurationItemID != nil || req.ChangeRequestID != nil ||
+		req.ProblemID != nil || req.CausedByID != nil || req.ResolvedByID != nil ||
+		req.ResolutionNotes != nil || req.IncidentReport != nil || req.AdditionalComments != nil ||
+		req.WorkNotes != nil || len(req.WatchList) > 0
+	if !hasUpdate {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "at least one field must be provided"}
+	}
+
+	if req.Priority != nil && !validIncidentPriority[*req.Priority] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid priority: " + string(*req.Priority)}
+	}
+	if req.State != nil && !validIncidentState[*req.State] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid state: " + string(*req.State)}
+	}
+	if req.Category != nil && !validIncidentCategory[*req.Category] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid category: " + string(*req.Category)}
+	}
+	if req.Subcategory != nil && !validIncidentSubcategory[*req.Subcategory] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid subcategory: " + string(*req.Subcategory)}
+	}
+	if req.ContactType != nil && !validIncidentContactType[*req.ContactType] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid contactType: " + string(*req.ContactType)}
+	}
+	if req.Impact != nil && !validIncidentImpact[*req.Impact] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid impact: " + string(*req.Impact)}
+	}
+	if req.Urgency != nil && !validIncidentUrgency[*req.Urgency] {
+		return domain.UpdateIncidentResponse{}, &apierror.ValidationError{Msg: "invalid urgency: " + string(*req.Urgency)}
+	}
+
+	optionalUUIDs := map[string]*string{
+		"parentId":            req.ParentID,
+		"parentIncidentId":    req.ParentIncidentID,
+		"assignmentGroupId":   req.AssignmentGroupID,
+		"assignedEngineerId":  req.AssignedEngineerID,
+		"serviceId":           req.ServiceID,
+		"serviceOfferingId":   req.ServiceOfferingID,
+		"configurationItemId": req.ConfigurationItemID,
+		"changeRequestId":     req.ChangeRequestID,
+		"problemId":           req.ProblemID,
+		"causedById":          req.CausedByID,
+		"resolvedById":        req.ResolvedByID,
+	}
+	for field, val := range optionalUUIDs {
+		if val != nil {
+			if err := validateUUIDs(field, []string{*val}); err != nil {
+				return domain.UpdateIncidentResponse{}, err
+			}
+		}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.UpdateIncidentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	payload := snUpdateIncidentPayload{
+		Subject:            req.Subject,
+		ResolutionNotes:    req.ResolutionNotes,
+		IncidentReport:     req.IncidentReport,
+		AdditionalComments: req.AdditionalComments,
+		WorkNotes:          req.WorkNotes,
+		WatchList:          req.WatchList,
+	}
+	if req.Priority != nil {
+		v := snIncidentPriorityKeyMap[*req.Priority]
+		payload.PriorityKey = &v
+	}
+	if req.State != nil {
+		v := snIncidentStateKeyMap[*req.State]
+		payload.StateKey = &v
+	}
+	if req.Category != nil {
+		v := snIncidentCategoryKeyMap[*req.Category]
+		payload.CategoryKey = &v
+	}
+	if req.Subcategory != nil {
+		v := snIncidentSubcategoryKeyMap[*req.Subcategory]
+		payload.SubcategoryKey = &v
+	}
+	if req.ContactType != nil {
+		v := snIncidentContactTypeKeyMap[*req.ContactType]
+		payload.ContactTypeKey = &v
+	}
+	if req.Impact != nil {
+		v := snIncidentImpactKeyMap[*req.Impact]
+		payload.ImpactKey = &v
+	}
+	if req.Urgency != nil {
+		v := snIncidentUrgencyKeyMap[*req.Urgency]
+		payload.UrgencyKey = &v
+	}
+	if req.ResolutionCode != nil {
+		payload.ResolutionCodeKey = req.ResolutionCode
+	}
+	if req.ParentID != nil {
+		v := uuidToSysid(*req.ParentID)
+		payload.ParentID = &v
+	}
+	if req.ParentIncidentID != nil {
+		v := uuidToSysid(*req.ParentIncidentID)
+		payload.ParentIncidentID = &v
+	}
+	if req.AssignmentGroupID != nil {
+		v := uuidToSysid(*req.AssignmentGroupID)
+		payload.AssignmentGroupID = &v
+	}
+	if req.AssignedEngineerID != nil {
+		v := uuidToSysid(*req.AssignedEngineerID)
+		payload.AssignedEngineerID = &v
+	}
+	if req.ServiceID != nil {
+		v := uuidToSysid(*req.ServiceID)
+		payload.ServiceID = &v
+	}
+	if req.ServiceOfferingID != nil {
+		v := uuidToSysid(*req.ServiceOfferingID)
+		payload.ServiceOfferingID = &v
+	}
+	if req.ConfigurationItemID != nil {
+		v := uuidToSysid(*req.ConfigurationItemID)
+		payload.ConfigurationItemID = &v
+	}
+	if req.ChangeRequestID != nil {
+		v := uuidToSysid(*req.ChangeRequestID)
+		payload.ChangeRequestID = &v
+	}
+	if req.ProblemID != nil {
+		v := uuidToSysid(*req.ProblemID)
+		payload.ProblemID = &v
+	}
+	if req.CausedByID != nil {
+		v := uuidToSysid(*req.CausedByID)
+		payload.CausedByID = &v
+	}
+	if req.ResolvedByID != nil {
+		v := uuidToSysid(*req.ResolvedByID)
+		payload.ResolvedByID = &v
+	}
+
+	raw, err := s.client.Patch(ctx, "/incidents/"+uuidToSysid(req.ID), token, payload)
+	if err != nil {
+		return domain.UpdateIncidentResponse{}, err
+	}
+
+	var snResp snUpdateIncidentResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateIncidentResponse{}, fmt.Errorf("sn update incident: parse response: %w", err)
+	}
+
+	return domain.UpdateIncidentResponse{
+		Message:  snResp.Message,
+		Incident: mapSNIncidentToView(snResp.Incident),
+	}, nil
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1873,6 +1873,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+    patch:
+      summary: Partially update an incident (ServiceNow data source only).
+      operationId: updateIncident
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIncidentRequest'
+      responses:
+        "200":
+          description: Incident updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateIncidentResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Incident not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /incidents:
     post:
       summary: Create a new incident (ServiceNow data source only).
@@ -5857,6 +5905,112 @@ components:
           type: string
           nullable: true
           description: Root-cause/incident report notes. Populated for resolved/closed ServiceNow incidents; null otherwise.
+
+    UpdateIncidentRequest:
+      type: object
+      description: All fields are optional, but at least one must be provided.
+      minProperties: 1
+      properties:
+        subject:
+          type: string
+        priority:
+          type: string
+          enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
+        state:
+          type: string
+          enum: [NEW, IN_PROGRESS, ON_HOLD, RESOLVED, CLOSED, CANCELLED]
+        category:
+          type: string
+          enum: [INQUIRY, SERVICE_INTERRUPTION, SECURITY]
+        subcategory:
+          type: string
+          enum: [DHCP, ORACLE, CPU, KEYBOARD, DOS_DDOS, PRIVILEGE_ESCALATIONS, THREAT_INTELLIGENCE,
+                 SCANS_AND_PROBES, APPLICATION_SECURITY, CONFIG_CHANGE_REQUEST, IP_ADDRESS,
+                 FULL_OUTAGE, SQL_SERVER, SLOWNESS, MEMORY, MOUSE, PRIVACY, DATA_BREACH,
+                 SYSTEM_COMPROMISES, DNS, OS, DISK, VPN, MALWARE, VULNERABILITY,
+                 UNAUTHORIZED_ACCESS, IDENTITY_PROTECTION, PHISHING, IMPROPER_CONFIGURATION,
+                 INFORMATION_REQUEST, DB2, PARTIAL_OUTAGE, EMAIL, MONITOR, WIRELESS]
+        contactType:
+          type: string
+          enum: [SELF_SERVICE, EMAIL, WALK_IN, AZURE, EMAIL_INTERNAL, SITE_247, DIRECT,
+                 PHONE, SENTINEL, VIRTUAL_AGENT, CHAT, EMAIL_EXTERNAL]
+        impact:
+          type: string
+          enum: [HIGH, MEDIUM, LOW]
+        urgency:
+          type: string
+          enum: [HIGH, MEDIUM, LOW]
+        resolutionCode:
+          type: string
+          nullable: true
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        parentIncidentId:
+          type: string
+          format: uuid
+          nullable: true
+        assignmentGroupId:
+          type: string
+          format: uuid
+          nullable: true
+        assignedEngineerId:
+          type: string
+          format: uuid
+          nullable: true
+        serviceId:
+          type: string
+          format: uuid
+          nullable: true
+        serviceOfferingId:
+          type: string
+          format: uuid
+          nullable: true
+        configurationItemId:
+          type: string
+          format: uuid
+          nullable: true
+        changeRequestId:
+          type: string
+          format: uuid
+          nullable: true
+        problemId:
+          type: string
+          format: uuid
+          nullable: true
+        causedById:
+          type: string
+          format: uuid
+          nullable: true
+        resolvedById:
+          type: string
+          format: uuid
+          nullable: true
+        resolutionNotes:
+          type: string
+          nullable: true
+        incidentReport:
+          type: string
+          nullable: true
+        additionalComments:
+          type: string
+          nullable: true
+        workNotes:
+          type: string
+          nullable: true
+        watchList:
+          type: array
+          items:
+            type: string
+
+    UpdateIncidentResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        incident:
+          $ref: '#/components/schemas/IncidentView'
 
     SearchProblemsRequest:
       type: object


### PR DESCRIPTION
### Summary

- Add` PATCH /incidents/{id}` to support partial updates of ServiceNow-backed incidents (`subject`, `priority`, `state`, `category`/`subcategory`, `contact type`, `impact`/`urgency`, `resolution` fields, `assignment`/relationship references, watch list, comments/notes)
- All fields are optional but at least one must be supplied per request
- Domain enum fields (priority, state, category, subcategory, contactType, impact, urgency) are mapped to/from ServiceNow's integer/string keys in the service layer; UUID reference fields are converted to/from ServiceNow sysids
- Extracted a shared mapSNIncidentToView helper from GetIncidentByID so the SN → domain mapping isn't duplicated between GET and PATCH
- Documented the new endpoint and request/response schemas in openapi.yaml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partially updating incidents through `PATCH /incidents/{id}`.
  * Incident updates can modify details such as subject, priority, category, assignment, resolution information, watch-list status, and workflow state.
  * Added supported workflow states, including New, In Progress, On Hold, Resolved, Closed, and Cancelled.
  * Updated incidents are returned with the latest incident details and a confirmation message.
* **Documentation**
  * Documented the new incident update endpoint, request fields, responses, and error conditions in the API specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->