### PR TITLE
[CSM][BE] Add PATCH /incidents/{id} passthrough endpoint

### DIFF
--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -275,6 +275,7 @@ backend/
 - `POST /incidents/search` — Search incidents; optional `filters` (`searchQuery`, `priorities`, `parentIds`) and `sortBy` (`field`: `createdOn`/`updatedOn`/`openedOn`, `order`) (ServiceNow data source only)
 - `POST /incidents` — Create an incident (`callerId`, `category`, `serviceId`, `impact`, `urgency`, `subject` required; `subcategory`, `serviceOfferingId`, `configurationItemId`, `contactType`, `assignmentGroupId`, `assignedEngineerId`, `watchList`, `additionalComments`, `workNotes`, `parentId`, `parentIncidentId`, `changeRequestId`, `problemId`, `causedById` optional) (ServiceNow data source only)
 - `GET /incidents/{id}` — Get full incident detail by ID (ServiceNow data source only)
+- `PATCH /incidents/{id}` — Partially update an incident; all fields optional but at least one required (`subject`, `priority`, `state`, `category`/`subcategory`, `contactType`, `impact`/`urgency`, `resolutionCode`/`resolutionNotes`/`incidentReport`, `parentId`/`parentIncidentId`/`assignmentGroupId`/`assignedEngineerId`/`serviceId`/`serviceOfferingId`/`configurationItemId`/`changeRequestId`/`problemId`/`causedById`/`resolvedById`, `additionalComments`, `workNotes`, `watchList`); set a reference field to `null` to clear it (ServiceNow data source only)
 
 ### Problems
 
@@ -341,6 +342,12 @@ curl -X POST http://localhost:8080/incidents \
 
 # Get an incident by ID
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/incidents/<incident-id>
+
+# Partially update an incident
+curl -X PATCH http://localhost:8080/incidents/<incident-id> \
+  -H "x-jwt-assertion: $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"state":"RESOLVED","resolutionCode":"Solved (Work Around)"}'
 
 # Search problems
 curl -X POST http://localhost:8080/problems/search \

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -153,6 +153,7 @@ func main() {
 	mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)
 	mux.HandleFunc("POST /incidents", incidentHandler.CreateIncident)
 	mux.HandleFunc("GET /incidents/{id}", incidentHandler.GetIncident)
+	mux.HandleFunc("PATCH /incidents/{id}", incidentHandler.PatchIncident)
 	mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 
 	addr := envOrDefault("PORT", ":8080")

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -138,6 +138,12 @@ func (c *Client) GetIncident(ctx context.Context, id string) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/incidents/%s", url.PathEscape(id)), nil)
 }
 
+// PatchIncident calls PATCH /incidents/{id} on the entity service to partially update an incident.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) PatchIncident(ctx context.Context, id string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/incidents/%s", url.PathEscape(id)), body)
+}
+
 // SearchProblems calls POST /problems/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *Client) SearchProblems(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -347,6 +347,7 @@ type mockEntityIncidentClient struct {
 	searchIncidentsFn func(ctx context.Context, body []byte) ([]byte, error)
 	createIncidentFn  func(ctx context.Context, body []byte) ([]byte, error)
 	getIncidentFn     func(ctx context.Context, id string) ([]byte, error)
+	patchIncidentFn   func(ctx context.Context, id string, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityIncidentClient) SearchIncidents(ctx context.Context, body []byte) ([]byte, error) {
@@ -366,6 +367,13 @@ func (m *mockEntityIncidentClient) CreateIncident(ctx context.Context, body []by
 func (m *mockEntityIncidentClient) GetIncident(ctx context.Context, id string) ([]byte, error) {
 	if m.getIncidentFn != nil {
 		return m.getIncidentFn(ctx, id)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityIncidentClient) PatchIncident(ctx context.Context, id string, body []byte) ([]byte, error) {
+	if m.patchIncidentFn != nil {
+		return m.patchIncidentFn(ctx, id, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -32,6 +32,7 @@ type entityIncidentClient interface {
 	SearchIncidents(ctx context.Context, body []byte) ([]byte, error)
 	CreateIncident(ctx context.Context, body []byte) ([]byte, error)
 	GetIncident(ctx context.Context, id string) ([]byte, error)
+	PatchIncident(ctx context.Context, id string, body []byte) ([]byte, error)
 }
 
 // searchIncidentsRequest mirrors the enum/format-constrained fields of the documented
@@ -78,6 +79,10 @@ var (
 	}
 	validIncidentImpacts   = map[string]bool{"HIGH": true, "MEDIUM": true, "LOW": true}
 	validIncidentUrgencies = map[string]bool{"HIGH": true, "MEDIUM": true, "LOW": true}
+
+	validIncidentStates = map[string]bool{
+		"NEW": true, "IN_PROGRESS": true, "ON_HOLD": true, "RESOLVED": true, "CLOSED": true, "CANCELLED": true,
+	}
 )
 
 // createIncidentRequest mirrors the enum/format-constrained fields of the documented
@@ -167,6 +172,104 @@ func validateCreateIncidentBody(body []byte) bool {
 	}
 	if req.CausedByID != "" && !uuidRe.MatchString(req.CausedByID) {
 		return false
+	}
+	return true
+}
+
+// updateIncidentRequest mirrors the enum/format-constrained fields of the documented
+// UpdateIncidentPayload schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+type updateIncidentRequest struct {
+	Priority            string   `json:"priority"`
+	State               string   `json:"state"`
+	Category            string   `json:"category"`
+	Subcategory         string   `json:"subcategory"`
+	ContactType         string   `json:"contactType"`
+	Impact              string   `json:"impact"`
+	Urgency             string   `json:"urgency"`
+	ParentID            string   `json:"parentId"`
+	ParentIncidentID    string   `json:"parentIncidentId"`
+	AssignmentGroupID   string   `json:"assignmentGroupId"`
+	AssignedEngineerID  string   `json:"assignedEngineerId"`
+	ServiceID           string   `json:"serviceId"`
+	ServiceOfferingID   string   `json:"serviceOfferingId"`
+	ConfigurationItemID string   `json:"configurationItemId"`
+	ChangeRequestID     string   `json:"changeRequestId"`
+	ProblemID           string   `json:"problemId"`
+	CausedByID          string   `json:"causedById"`
+	ResolvedByID        string   `json:"resolvedById"`
+	WatchList           []string `json:"watchList"`
+}
+
+// validateUpdateIncidentBody checks the enum fields (priority, state, category, subcategory,
+// contactType, impact, urgency) and every UUID-formatted field with a known, fixed set of
+// valid values so obviously invalid requests are rejected before reaching the entity service.
+// An absent, null, or empty-string value for any of these optional fields is treated as
+// "leave unchanged" or "clear", matching the entity service's own PATCH semantics, and is
+// not rejected here.
+func validateUpdateIncidentBody(body []byte) bool {
+	var req updateIncidentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if req.Priority != "" && !validIncidentPriorities[req.Priority] {
+		return false
+	}
+	if req.State != "" && !validIncidentStates[req.State] {
+		return false
+	}
+	if req.Category != "" && !validIncidentCategories[req.Category] {
+		return false
+	}
+	if req.Subcategory != "" && !validIncidentSubcategories[req.Subcategory] {
+		return false
+	}
+	if req.ContactType != "" && !validIncidentContactTypes[req.ContactType] {
+		return false
+	}
+	if req.Impact != "" && !validIncidentImpacts[req.Impact] {
+		return false
+	}
+	if req.Urgency != "" && !validIncidentUrgencies[req.Urgency] {
+		return false
+	}
+	if req.ParentID != "" && !uuidRe.MatchString(req.ParentID) {
+		return false
+	}
+	if req.ParentIncidentID != "" && !uuidRe.MatchString(req.ParentIncidentID) {
+		return false
+	}
+	if req.AssignmentGroupID != "" && !uuidRe.MatchString(req.AssignmentGroupID) {
+		return false
+	}
+	if req.AssignedEngineerID != "" && !uuidRe.MatchString(req.AssignedEngineerID) {
+		return false
+	}
+	if req.ServiceID != "" && !uuidRe.MatchString(req.ServiceID) {
+		return false
+	}
+	if req.ServiceOfferingID != "" && !uuidRe.MatchString(req.ServiceOfferingID) {
+		return false
+	}
+	if req.ConfigurationItemID != "" && !uuidRe.MatchString(req.ConfigurationItemID) {
+		return false
+	}
+	if req.ChangeRequestID != "" && !uuidRe.MatchString(req.ChangeRequestID) {
+		return false
+	}
+	if req.ProblemID != "" && !uuidRe.MatchString(req.ProblemID) {
+		return false
+	}
+	if req.CausedByID != "" && !uuidRe.MatchString(req.CausedByID) {
+		return false
+	}
+	if req.ResolvedByID != "" && !uuidRe.MatchString(req.ResolvedByID) {
+		return false
+	}
+	for _, w := range req.WatchList {
+		if !uuidRe.MatchString(w) {
+			return false
+		}
 	}
 	return true
 }
@@ -308,6 +411,52 @@ func (h *IncidentHandler) GetIncident(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity GetIncident failed", "userID", user.UserID, "incidentID", id, "err", err)
 		mapUpstreamError(w, err, "Failed to retrieve incident.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// PatchIncident handles PATCH /incidents/{id}.
+func (h *IncidentHandler) PatchIncident(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validateUpdateIncidentBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.PatchIncident(r.Context(), id, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity PatchIncident failed", "userID", user.UserID, "incidentID", id, "err", err)
+		mapUpstreamError(w, err, "Failed to update incident.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/incidents.go
+++ b/apps/csm-portal/backend/internal/handler/incidents.go
@@ -201,13 +201,23 @@ type updateIncidentRequest struct {
 	WatchList           []string `json:"watchList"`
 }
 
-// validateUpdateIncidentBody checks the enum fields (priority, state, category, subcategory,
-// contactType, impact, urgency) and every UUID-formatted field with a known, fixed set of
-// valid values so obviously invalid requests are rejected before reaching the entity service.
-// An absent, null, or empty-string value for any of these optional fields is treated as
-// "leave unchanged" or "clear", matching the entity service's own PATCH semantics, and is
-// not rejected here.
+// validateUpdateIncidentBody rejects an empty JSON object (matching the documented
+// minProperties: 1 on UpdateIncidentPayload — a PATCH must change at least one field),
+// and checks the enum fields (priority, state, category, subcategory, contactType,
+// impact, urgency) and every UUID-formatted field with a known, fixed set of valid
+// values so obviously invalid requests are rejected before reaching the entity service.
+// An absent, null, or empty-string value for any individual optional field is treated
+// as "leave unchanged" or "clear", matching the entity service's own PATCH semantics,
+// and is not rejected here.
 func validateUpdateIncidentBody(body []byte) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return false
+	}
+	if len(fields) == 0 {
+		return false
+	}
+
 	var req updateIncidentRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return false

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -398,6 +398,17 @@ func TestPatchIncident(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects empty JSON object", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`{}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
 	t.Run("rejects unknown state enum value", func(t *testing.T) {
 		h := NewIncidentHandler(&mockEntityIncidentClient{})
 		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`{"state":"DONE"}`)))

--- a/apps/csm-portal/backend/internal/handler/incidents_test.go
+++ b/apps/csm-portal/backend/internal/handler/incidents_test.go
@@ -340,3 +340,149 @@ func TestGetIncident(t *testing.T) {
 		}
 	})
 }
+
+func TestPatchIncident(t *testing.T) {
+	const incidentID = "11111111-1111-1111-1111-111111111111"
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`{"subject":"Updated"}`))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty incident ID", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/", strings.NewReader(`{"subject":"Updated"}`)))
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID incident ID", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/inc-42", strings.NewReader(`{"subject":"Updated"}`)))
+		r.SetPathValue("id", "inc-42")
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`not-json`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects unknown state enum value", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`{"state":"DONE"}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID assignedEngineerId", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`{"assignedEngineerId":"not-a-uuid"}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("accepts explicit null to clear an optional reference field", func(t *testing.T) {
+		h := NewIncidentHandler(&mockEntityIncidentClient{
+			patchIncidentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{"message":"incident updated","incident":{"id":"` + incidentID + `"}}`), nil
+			},
+		})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`{"parentIncidentId":null}`)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards ID and body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"state":"RESOLVED","resolutionCode":"Solved (Work Around)"}`
+		var capturedID string
+		var capturedBody []byte
+		client := &mockEntityIncidentClient{
+			patchIncidentFn: func(_ context.Context, id string, body []byte) ([]byte, error) {
+				capturedID = id
+				capturedBody = body
+				return []byte(`{"message":"incident updated","incident":{"id":"` + incidentID + `","state":"RESOLVED"}}`), nil
+			},
+		}
+		h := NewIncidentHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(reqPayload)))
+		r.SetPathValue("id", incidentID)
+		w := httptest.NewRecorder()
+		h.PatchIncident(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != incidentID {
+			t.Errorf("upstream received id %q, want %q", capturedID, incidentID)
+		}
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["message"] != "incident updated" {
+			t.Errorf("message = %v, want %q", resp["message"], "incident updated")
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to update incident.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityIncidentClient{
+					patchIncidentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewIncidentHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/incidents/"+incidentID, strings.NewReader(`{"subject":"Updated"}`)))
+				r.SetPathValue("id", incidentID)
+				w := httptest.NewRecorder()
+				h.PatchIncident(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2850,6 +2850,61 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+    patch:
+      summary: Partially update an incident (ServiceNow data source only).
+      operationId: patchIncidentById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Incident update payload. All fields are optional, but at least one must be provided.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIncidentPayload'
+        required: true
+      responses:
+        "200":
+          description: Incident updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateIncidentResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Incident not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /problems/search:
     post:
       summary: Search problems (ServiceNow data source only).
@@ -6526,6 +6581,107 @@ components:
           type: string
           nullable: true
           description: Root-cause/incident report notes. Populated for resolved/closed ServiceNow incidents; null otherwise.
+
+    UpdateIncidentPayload:
+      type: object
+      description: All fields are optional, but at least one must be provided. Set a field to null to clear it.
+      minProperties: 1
+      properties:
+        subject:
+          type: string
+        priority:
+          type: string
+          enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
+        state:
+          type: string
+          enum: [NEW, IN_PROGRESS, ON_HOLD, RESOLVED, CLOSED, CANCELLED]
+        category:
+          type: string
+          enum: [INQUIRY, SERVICE_INTERRUPTION, SECURITY]
+        subcategory:
+          type: string
+          enum: [DHCP, ORACLE, CPU, KEYBOARD, DOS_DDOS, PRIVILEGE_ESCALATIONS, THREAT_INTELLIGENCE, SCANS_AND_PROBES, APPLICATION_SECURITY, CONFIG_CHANGE_REQUEST, IP_ADDRESS, FULL_OUTAGE, SQL_SERVER, SLOWNESS, MEMORY, MOUSE, PRIVACY, DATA_BREACH, SYSTEM_COMPROMISES, DNS, OS, DISK, VPN, MALWARE, VULNERABILITY, UNAUTHORIZED_ACCESS, IDENTITY_PROTECTION, PHISHING, IMPROPER_CONFIGURATION, INFORMATION_REQUEST, DB2, PARTIAL_OUTAGE, EMAIL, MONITOR, WIRELESS]
+        contactType:
+          type: string
+          enum: [SELF_SERVICE, EMAIL, WALK_IN, AZURE, EMAIL_INTERNAL, SITE_247, DIRECT, PHONE, SENTINEL, VIRTUAL_AGENT, CHAT, EMAIL_EXTERNAL]
+        impact:
+          type: string
+          enum: [HIGH, MEDIUM, LOW]
+        urgency:
+          type: string
+          enum: [HIGH, MEDIUM, LOW]
+        resolutionCode:
+          type: string
+          nullable: true
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        parentIncidentId:
+          type: string
+          format: uuid
+          nullable: true
+        assignmentGroupId:
+          type: string
+          format: uuid
+          nullable: true
+        assignedEngineerId:
+          type: string
+          format: uuid
+          nullable: true
+        serviceId:
+          type: string
+          format: uuid
+          nullable: true
+        serviceOfferingId:
+          type: string
+          format: uuid
+          nullable: true
+        configurationItemId:
+          type: string
+          format: uuid
+          nullable: true
+        changeRequestId:
+          type: string
+          format: uuid
+          nullable: true
+        problemId:
+          type: string
+          format: uuid
+          nullable: true
+        causedById:
+          type: string
+          format: uuid
+          nullable: true
+        resolvedById:
+          type: string
+          format: uuid
+          nullable: true
+        resolutionNotes:
+          type: string
+          nullable: true
+        incidentReport:
+          type: string
+          nullable: true
+        additionalComments:
+          type: string
+          nullable: true
+        workNotes:
+          type: string
+          nullable: true
+        watchList:
+          type: array
+          items:
+            type: string
+            format: uuid
+
+    UpdateIncidentResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        incident:
+          $ref: '#/components/schemas/IncidentDetail'
 
     ProblemSearchPayload:
       type: object


### PR DESCRIPTION
## Summary

Wires the csm-portal backend to entity-service's new `PATCH /incidents/{id}` endpoint (#1151).

- Adds `PatchIncident` client method (`internal/entity/entity.go`)
- Adds `PatchIncident` handler with `validateUpdateIncidentBody`, validating the enum fields (`priority`, `state`, `category`, `subcategory`, `contactType`, `impact`, `urgency`) and every UUID-formatted reference field before forwarding — reusing the existing validation maps from `POST /incidents`, plus a new `validIncidentStates` map
- An absent, null, or empty value for any optional field is treated as "leave unchanged" or "clear" (not rejected), matching the entity service's own PATCH semantics — only genuinely malformed values are rejected
- Registers `PATCH /incidents/{id}` in `cmd/server/main.go`
- Documents `UpdateIncidentPayload`/`UpdateIncidentResponse` and the new `patch:` operation in `openapi.yaml`, and updates `README.md`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (added `TestPatchIncident`: auth, path UUID validation, body size, invalid JSON, invalid enum, invalid UUID, explicit-null-to-clear, successful forwarding, upstream error mapping)
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] Validated `openapi.yaml` as well-formed YAML
- [x] Manually started the server locally and confirmed `GET /health` returns 200
- [ ] Manual: PATCH a ServiceNow-backed incident and confirm the update is forwarded and reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for partially updating incidents through `PATCH /incidents/{id}`.
  - Update individual incident fields, including state and resolution details, without replacing the entire record.
  - Clear supported reference fields by setting them to `null`.
  - Added validation for update values, identifiers, request size, and JSON format.
- **Documentation**
  - Updated API documentation and examples with the new incident update endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->