### PR TITLE
feat(customer-portal): PII notification on chat, case creation, and comments

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -29,6 +29,9 @@ import { usePostAttachments } from "@features/support/api/usePostAttachments";
 import { useAsgardeo } from "@asgardeo/react";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { hasSubmittableEditorContent } from "@features/support/utils/support";
+import { htmlToPlainText } from "@features/support/utils/richTextEditor";
+import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
+import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import Editor from "@components/rich-text-editor/Editor";
 import UploadAttachmentModal from "@case-details-attachments/UploadAttachmentModal";
 import type { JSX } from "react";
@@ -55,6 +58,7 @@ export default function ActivityCommentInput({
   const postAttachments = usePostAttachments();
   const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
   const { showError } = useErrorBanner();
+  const piiGuard = usePiiGuard();
 
   // Attachment state
   type AttachmentItem = { id: string; file: File };
@@ -183,47 +187,57 @@ export default function ActivityCommentInput({
       attachmentNamesRef.current.clear();
     };
 
-    // Attachment-only: skip comment endpoint, upload directly
-    if (!hasText && hasAttachments) {
-      const ok = await uploadAttachmentsFromSnapshot(
-        attachmentsSnapshot,
-        attachmentNamesSnapshot,
-      );
-      if (ok) {
-        clearUI();
-        window.location.reload();
-      }
-      return;
-    }
-
-    // Text (with or without attachments): post comment first, then upload attachments
-    postComment.mutate(
-      {
-        caseId,
-        body: { content: currentValue.trim(), type: CommentType.COMMENT },
-      },
-      {
-        onSuccess: async () => {
+    const performSend = async () => {
+      // Attachment-only: skip comment endpoint, upload directly
+      if (!hasText && hasAttachments) {
+        const ok = await uploadAttachmentsFromSnapshot(
+          attachmentsSnapshot,
+          attachmentNamesSnapshot,
+        );
+        if (ok) {
           clearUI();
-          if (attachmentsSnapshot.length > 0) {
-            const ok = await uploadAttachmentsFromSnapshot(
-              attachmentsSnapshot,
-              attachmentNamesSnapshot,
-            );
-            if (ok) {
-              window.location.reload();
+          window.location.reload();
+        }
+        return;
+      }
+
+      // Text (with or without attachments): post comment first, then upload attachments
+      postComment.mutate(
+        {
+          caseId,
+          body: { content: currentValue.trim(), type: CommentType.COMMENT },
+        },
+        {
+          onSuccess: async () => {
+            clearUI();
+            if (attachmentsSnapshot.length > 0) {
+              const ok = await uploadAttachmentsFromSnapshot(
+                attachmentsSnapshot,
+                attachmentNamesSnapshot,
+              );
+              if (ok) {
+                window.location.reload();
+              }
             }
-          }
+          },
+          onError: (error: unknown) => {
+            const message =
+              error instanceof Error && error.message
+                ? error.message
+                : "Failed to post comment. Please try again.";
+            showError(message);
+          },
         },
-        onError: (error: unknown) => {
-          const message =
-            error instanceof Error && error.message
-              ? error.message
-              : "Failed to post comment. Please try again.";
-          showError(message);
-        },
-      },
-    );
+      );
+    };
+
+    // Warn about PII in the comment text before posting. Attachment-only
+    // sends have no text to scan, so they proceed directly.
+    if (hasText) {
+      piiGuard.checkBeforeSubmit(htmlToPlainText(currentValue), performSend);
+    } else {
+      performSend();
+    }
   };
 
   return (
@@ -293,6 +307,8 @@ export default function ActivityCommentInput({
         onClose={() => setIsAttachmentModalOpen(false)}
         onSelect={handleSelectAttachment}
       />
+
+      <PiiWarningDialog {...piiGuard.dialogProps} />
     </>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/activity-tab/ActivityCommentInput.tsx
@@ -29,7 +29,6 @@ import { usePostAttachments } from "@features/support/api/usePostAttachments";
 import { useAsgardeo } from "@asgardeo/react";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { hasSubmittableEditorContent } from "@features/support/utils/support";
-import { htmlToPlainText } from "@features/support/utils/richTextEditor";
 import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
 import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import Editor from "@components/rich-text-editor/Editor";
@@ -234,7 +233,7 @@ export default function ActivityCommentInput({
     // Warn about PII in the comment text before posting. Attachment-only
     // sends have no text to scan, so they proceed directly.
     if (hasText) {
-      piiGuard.checkBeforeSubmit(htmlToPlainText(currentValue), performSend);
+      piiGuard.checkBeforeSubmit(currentValue, performSend);
     } else {
       performSend();
     }

--- a/apps/customer-portal/webapp/src/features/support/components/dialogs/PiiWarningDialog.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/dialogs/PiiWarningDialog.tsx
@@ -41,7 +41,7 @@ export interface PiiWarningDialogProps {
 const TITLE = "Possible sensitive information detected";
 const DESCRIPTION =
   "Your text appears to contain personal or sensitive information. " +
-  "For your security, review and remove it before posting — or continue if " +
+  "For your security, review and remove it before posting or continue if " +
   "this information is necessary.";
 
 export default function PiiWarningDialog({

--- a/apps/customer-portal/webapp/src/features/support/components/dialogs/PiiWarningDialog.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/dialogs/PiiWarningDialog.tsx
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type JSX } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Stack,
+} from "@wso2/oxygen-ui";
+import { ShieldAlert, X } from "@wso2/oxygen-ui-icons-react";
+
+export interface PiiWarningDialogProps {
+  open: boolean;
+  /** Distinct human-readable labels of the PII types detected. */
+  detectedLabels: string[];
+  /** Close the dialog and let the user edit their text (submission cancelled). */
+  onEdit: () => void;
+  /** Proceed with the original submission despite the warning. */
+  onProceed: () => void;
+}
+
+const TITLE = "Possible sensitive information detected";
+const DESCRIPTION =
+  "Your text appears to contain personal or sensitive information. " +
+  "For your security, review and remove it before posting — or continue if " +
+  "this information is necessary.";
+
+export default function PiiWarningDialog({
+  open,
+  detectedLabels,
+  onEdit,
+  onProceed,
+}: PiiWarningDialogProps): JSX.Element {
+  return (
+    <Dialog open={open} onClose={onEdit} maxWidth="xs" fullWidth>
+      <DialogTitle
+        sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <ShieldAlert size={20} />
+          {TITLE}
+        </Box>
+        <IconButton size="small" onClick={onEdit} aria-label="close">
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>{DESCRIPTION}</DialogContentText>
+        {detectedLabels.length > 0 && (
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            {detectedLabels.map((label) => (
+              <Chip key={label} label={label} color="warning" size="small" />
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button variant="contained" onClick={onEdit} autoFocus>
+          Edit text
+        </Button>
+        <Button color="warning" onClick={onProceed}>
+          Post anyway
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/hooks/usePiiGuard.ts
+++ b/apps/customer-portal/webapp/src/features/support/hooks/usePiiGuard.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback, useRef, useState } from "react";
+import { detectPii } from "@features/support/utils/piiDetection";
+import type { PiiWarningDialogProps } from "@features/support/components/dialogs/PiiWarningDialog";
+
+export interface UsePiiGuardResult {
+  /**
+   * Scans `text` for PII before running `onProceed`.
+   *
+   * - No PII found: `onProceed` runs immediately.
+   * - PII found: the warning dialog opens and `onProceed` is deferred until the
+   *   user chooses "Post anyway".
+   */
+  checkBeforeSubmit: (text: string, onProceed: () => void) => void;
+  /** Spread onto {@link PiiWarningDialog}. */
+  dialogProps: PiiWarningDialogProps;
+}
+
+/**
+ * Reusable PII interception for submit handlers (chat, case creation, comments).
+ * Keeps the warning dialog state and the deferred submission action, so a call
+ * site only needs to wrap its send logic and render the dialog.
+ */
+export const usePiiGuard = (): UsePiiGuardResult => {
+  const [open, setOpen] = useState(false);
+  const [detectedLabels, setDetectedLabels] = useState<string[]>([]);
+  // The submission to run if the user proceeds despite the warning.
+  const pendingActionRef = useRef<(() => void) | null>(null);
+
+  const checkBeforeSubmit = useCallback(
+    (text: string, onProceed: () => void) => {
+      const matches = detectPii(text);
+      if (matches.length === 0) {
+        onProceed();
+        return;
+      }
+      // Distinct labels, preserving detection order.
+      setDetectedLabels([...new Set(matches.map((match) => match.label))]);
+      pendingActionRef.current = onProceed;
+      setOpen(true);
+    },
+    []
+  );
+
+  const onEdit = useCallback(() => {
+    pendingActionRef.current = null;
+    setOpen(false);
+  }, []);
+
+  const onProceed = useCallback(() => {
+    const action = pendingActionRef.current;
+    pendingActionRef.current = null;
+    setOpen(false);
+    action?.();
+  }, []);
+
+  return {
+    checkBeforeSubmit,
+    dialogProps: { open, detectedLabels, onEdit, onProceed },
+  };
+};

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -900,7 +900,7 @@ export default function CreateCasePage(): JSX.Element {
     // found the guard proceeds immediately; otherwise the dialog opens and
     // "Post anyway" re-runs the submit with the check bypassed.
     if (!bypassPii) {
-      piiGuard.checkBeforeSubmit(`${titlePlain}\n${descriptionPlain}`, () => {
+      piiGuard.checkBeforeSubmit(`${title}\n${description}`, () => {
         void handleSubmit(undefined, true);
       });
       return;

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -84,6 +84,8 @@ import {
   escapeHtml,
   htmlToPlainText,
 } from "@features/support/utils/richTextEditor";
+import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
+import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import UploadAttachmentModal from "@features/support/components/case-details/attachments-tab/UploadAttachmentModal";
 import type {
   ProductCategory,
@@ -238,6 +240,7 @@ export default function CreateCasePage(): JSX.Element {
   }, [baseProductOptions]);
 
   const { showError } = useErrorBanner();
+  const piiGuard = usePiiGuard();
   const { showSuccess } = useSuccessBanner();
   const { mutate: postCase, isPending: isCreatePending } = usePostCase();
   const [isNavigatingAfterCreate, setIsNavigatingAfterCreate] = useState(false);
@@ -874,8 +877,8 @@ export default function CreateCasePage(): JSX.Element {
       reader.readAsDataURL(file);
     });
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e?: FormEvent, bypassPii = false) => {
+    e?.preventDefault();
     if (!projectId || isNavigatingAfterCreate) return;
     if (isProjectLoading || isProjectFeaturesLoading) return;
 
@@ -890,6 +893,16 @@ export default function CreateCasePage(): JSX.Element {
     }
     if (!descriptionPlain) {
       showError("Please enter a description.");
+      return;
+    }
+
+    // Warn about PII in the title/description before submitting. When none is
+    // found the guard proceeds immediately; otherwise the dialog opens and
+    // "Post anyway" re-runs the submit with the check bypassed.
+    if (!bypassPii) {
+      piiGuard.checkBeforeSubmit(`${titlePlain}\n${descriptionPlain}`, () => {
+        void handleSubmit(undefined, true);
+      });
       return;
     }
 
@@ -1280,6 +1293,8 @@ export default function CreateCasePage(): JSX.Element {
         onClose={() => setIsAttachmentModalOpen(false)}
         onSelect={handleSelectAttachment}
       />
+
+      <PiiWarningDialog {...piiGuard.dialogProps} />
     </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/pages/DescribeIssuePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/DescribeIssuePage.tsx
@@ -32,6 +32,8 @@ import { useAllDeploymentProducts } from "@features/support/hooks/useAllDeployme
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { buildEnvProducts } from "@features/support/utils/caseCreation";
 import { filterDeploymentsForCaseCreation } from "@utils/permission";
+import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
+import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import type { ChatNavState } from "@features/support/types/conversations";
 import { CHAT_MAX_CHARS } from "@features/support/constants/chatConstants";
 
@@ -50,6 +52,7 @@ export default function DescribeIssuePage(): JSX.Element {
   const location = useLocation();
   const { projectId } = useParams<{ projectId: string }>();
   const { showError } = useErrorBanner();
+  const piiGuard = usePiiGuard();
   const [value, setValue] = useState("");
   const [isLoadingAfterClick, setIsLoadingAfterClick] = useState(false);
 
@@ -90,25 +93,32 @@ export default function DescribeIssuePage(): JSX.Element {
   const handleSubmit = useCallback(async () => {
     if (!plainText.trim() || !projectId) return;
     if (submittingRef.current) return;
-    submittingRef.current = true;
-    setIsLoadingAfterClick(true);
 
-    try {
-      const accountId = projectDetails?.account?.id ?? projectId;
-      const state: ChatNavState = {
-        initialUserMessage: plainText.trim(),
-        initialEnvProducts: envProducts,
-        accountId,
-      };
-      navigate(`/projects/${projectId}/support/chat`, { state });
-    } catch {
-      showError(
-        "Could not get help. Please try again or create a support case.",
-      );
-    } finally {
-      submittingRef.current = false;
-      setIsLoadingAfterClick(false);
-    }
+    const startChat = () => {
+      submittingRef.current = true;
+      setIsLoadingAfterClick(true);
+
+      try {
+        const accountId = projectDetails?.account?.id ?? projectId;
+        const state: ChatNavState = {
+          initialUserMessage: plainText.trim(),
+          initialEnvProducts: envProducts,
+          accountId,
+        };
+        navigate(`/projects/${projectId}/support/chat`, { state });
+      } catch {
+        showError(
+          "Could not get help. Please try again or create a support case.",
+        );
+      } finally {
+        submittingRef.current = false;
+        setIsLoadingAfterClick(false);
+      }
+    };
+
+    // Warn about PII before starting the chat. "Edit" keeps the text so the
+    // user can revise it; "Post anyway" proceeds.
+    piiGuard.checkBeforeSubmit(plainText.trim(), startChat);
   }, [
     plainText,
     projectId,
@@ -116,6 +126,7 @@ export default function DescribeIssuePage(): JSX.Element {
     projectDetails?.account?.id,
     navigate,
     showError,
+    piiGuard,
   ]);
 
   const isMessageTooLong = value.length > CHAT_MAX_CHARS;
@@ -273,6 +284,8 @@ export default function DescribeIssuePage(): JSX.Element {
           </Box>
         </CardContent>
       </Card>
+
+      <PiiWarningDialog {...piiGuard.dialogProps} />
     </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -56,6 +56,8 @@ import {
 } from "@features/support/utils/caseCreation";
 import { filterDeploymentsForCaseCreation } from "@utils/permission";
 import { htmlToPlainText } from "@features/support/utils/richTextEditor";
+import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
+import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import { ChatSender } from "@features/support/types/conversations";
 import type {
   ChatNavState,
@@ -348,6 +350,7 @@ export default function NoveraChatPage(): JSX.Element {
   const [isInputDisabled, setIsInputDisabled] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputValueRef = useRef("");
+  const piiGuard = usePiiGuard();
   const [resetTrigger, setResetTrigger] = useState(0);
   const [isSending, setIsSending] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -670,10 +673,16 @@ export default function NoveraChatPage(): JSX.Element {
   const handleSendMessage = useCallback(async (): Promise<boolean> => {
     const text = htmlToPlainText(inputValueRef.current).trim();
     if (!text || isSending || !projectId) return false;
-    setInputValueAndRef("");
-    setResetTrigger((prev) => prev + 1);
-    return sendViaWebSocket(text);
-  }, [isSending, projectId, sendViaWebSocket, setInputValueAndRef]);
+
+    // Warn about PII before sending. The input is only cleared once the send
+    // actually proceeds, so choosing "Edit" preserves the user's text.
+    piiGuard.checkBeforeSubmit(text, () => {
+      setInputValueAndRef("");
+      setResetTrigger((prev) => prev + 1);
+      void sendViaWebSocket(text);
+    });
+    return true;
+  }, [isSending, projectId, sendViaWebSocket, setInputValueAndRef, piiGuard]);
 
   useEffect(() => {
     if (!initialUserMessage?.trim()) return;
@@ -750,6 +759,7 @@ export default function NoveraChatPage(): JSX.Element {
         </Paper>
       </Box>
 
+      <PiiWarningDialog {...piiGuard.dialogProps} />
     </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
@@ -180,6 +180,25 @@ describe("piiDetection", () => {
     });
   });
 
+  describe("detectPii - rich-text HTML input", () => {
+    it("detects PII in link attributes that plain-text extraction would drop", () => {
+      const emailMatches = detectPii(
+        '<p><a href="mailto:john@example.com">contact us</a></p>',
+      );
+      expect(emailMatches.some((m) => m.type === PiiType.EMAIL)).toBe(true);
+
+      const credMatches = detectPii(
+        '<a href="https://user:token123@github.com/org/repo">clone</a>',
+      );
+      expect(credMatches.some((m) => m.type === PiiType.CREDENTIALS_IN_URI)).toBe(true);
+    });
+
+    it("detects visible PII inside markup", () => {
+      const matches = detectPii("<p>My card is 4242 4242 4242 4242</p>");
+      expect(matches.some((m) => m.type === PiiType.CREDIT_CARD)).toBe(true);
+    });
+  });
+
   describe("detectPii - clean input", () => {
     it("returns no matches for benign text", () => {
       expect(detectPii("The deployment failed with a 500 error on startup.")).toEqual([]);

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  PiiType,
+  passesLuhn,
+  detectPii,
+  containsPii,
+  getDetectedPiiLabels,
+} from "@features/support/utils/piiDetection";
+
+describe("piiDetection", () => {
+  describe("passesLuhn", () => {
+    it("accepts valid card numbers", () => {
+      expect(passesLuhn("4242424242424242")).toBe(true); // Visa test number
+      expect(passesLuhn("5555555555554444")).toBe(true); // Mastercard test number
+      expect(passesLuhn("4242 4242 4242 4242")).toBe(true); // with spaces
+    });
+
+    it("rejects numbers that fail the checksum", () => {
+      expect(passesLuhn("4242424242424241")).toBe(false);
+      expect(passesLuhn("1234567890123456")).toBe(false);
+    });
+
+    it("rejects sequences of the wrong length", () => {
+      expect(passesLuhn("42424242")).toBe(false); // too short
+      expect(passesLuhn("42424242424242424242")).toBe(false); // too long
+    });
+  });
+
+  describe("detectPii - credit cards", () => {
+    it("detects a Luhn-valid card number", () => {
+      const matches = detectPii("My card is 4242 4242 4242 4242 please charge it");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].type).toBe(PiiType.CREDIT_CARD);
+    });
+
+    it("does not flag a random long digit string that fails Luhn", () => {
+      const matches = detectPii("Order reference 1234567890123456 shipped today");
+      expect(matches.some((m) => m.type === PiiType.CREDIT_CARD)).toBe(false);
+    });
+  });
+
+  describe("detectPii - Danish CPR", () => {
+    it("detects a CPR number with hyphen", () => {
+      const matches = detectPii("My CPR is 010203-1234");
+      expect(matches.some((m) => m.type === PiiType.DANISH_CPR)).toBe(true);
+    });
+
+    it("detects a CPR number without hyphen", () => {
+      const matches = detectPii("CPR 0102031234 on file");
+      expect(matches.some((m) => m.type === PiiType.DANISH_CPR)).toBe(true);
+    });
+
+    it("does not flag an invalid day/month", () => {
+      const matches = detectPii("Ticket 991399-1234 raised");
+      expect(matches.some((m) => m.type === PiiType.DANISH_CPR)).toBe(false);
+    });
+  });
+
+  describe("detectPii - email and phone", () => {
+    it("detects an email address", () => {
+      const matches = detectPii("Reach me at john.doe@example.com anytime");
+      expect(matches.some((m) => m.type === PiiType.EMAIL)).toBe(true);
+    });
+
+    it("detects a phone number", () => {
+      const matches = detectPii("Call +45 12 34 56 78 for support");
+      expect(matches.some((m) => m.type === PiiType.PHONE)).toBe(true);
+    });
+
+    it("does not flag a short number as a phone", () => {
+      const matches = detectPii("There are 42 open cases");
+      expect(matches.some((m) => m.type === PiiType.PHONE)).toBe(false);
+    });
+  });
+
+  describe("detectPii - IBAN", () => {
+    it("detects an IBAN", () => {
+      const matches = detectPii("Transfer to DK5000400440116243 today");
+      expect(matches.some((m) => m.type === PiiType.IBAN)).toBe(true);
+    });
+  });
+
+  describe("detectPii - clean input", () => {
+    it("returns no matches for benign text", () => {
+      expect(detectPii("The deployment failed with a 500 error on startup.")).toEqual([]);
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(detectPii("")).toEqual([]);
+    });
+  });
+
+  describe("detectPii - multiple and ordering", () => {
+    it("returns matches sorted by position", () => {
+      const text = "Email john@example.com then card 4242 4242 4242 4242";
+      const matches = detectPii(text);
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+      for (let i = 1; i < matches.length; i += 1) {
+        expect(matches[i].index).toBeGreaterThanOrEqual(matches[i - 1].index);
+      }
+    });
+  });
+
+  describe("containsPii", () => {
+    it("returns true when PII is present", () => {
+      expect(containsPii("card 4242 4242 4242 4242")).toBe(true);
+    });
+
+    it("returns false for clean text", () => {
+      expect(containsPii("no sensitive data here")).toBe(false);
+    });
+  });
+
+  describe("getDetectedPiiLabels", () => {
+    it("returns distinct labels", () => {
+      const labels = getDetectedPiiLabels(
+        "a@b.com and c@d.com and card 4242 4242 4242 4242"
+      );
+      expect(labels).toContain("Email address");
+      expect(labels).toContain("Credit card number");
+      // Two emails collapse to a single label.
+      expect(labels.filter((l) => l === "Email address")).toHaveLength(1);
+    });
+  });
+});

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
@@ -95,6 +95,55 @@ describe("piiDetection", () => {
     });
   });
 
+  describe("detectPii - secrets and credentials", () => {
+    it("detects a PEM private key header", () => {
+      const matches = detectPii(
+        "Here is my key:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEow...",
+      );
+      expect(matches.some((m) => m.type === PiiType.PRIVATE_KEY)).toBe(true);
+    });
+
+    it("detects credentials in a JDBC connection string", () => {
+      const matches = detectPii("jdbc:mysql://admin:s3cretPw@db.internal:3306/wso2");
+      expect(matches.some((m) => m.type === PiiType.CREDENTIALS_IN_URI)).toBe(true);
+    });
+
+    it("detects credentials in an https URL without also flagging an email", () => {
+      const matches = detectPii("clone from https://user:token@github.com/org/repo");
+      expect(matches.some((m) => m.type === PiiType.CREDENTIALS_IN_URI)).toBe(true);
+      expect(matches.some((m) => m.type === PiiType.EMAIL)).toBe(false);
+    });
+
+    it("detects an AWS access key id", () => {
+      const matches = detectPii("key AKIAIOSFODNN7EXAMPLE in the config");
+      expect(matches.some((m) => m.type === PiiType.ACCESS_TOKEN)).toBe(true);
+    });
+
+    it("detects a GitHub token", () => {
+      const matches = detectPii(
+        "token ghp_1234567890abcdefghijklmnopqrstuvwxyz set",
+      );
+      expect(matches.some((m) => m.type === PiiType.ACCESS_TOKEN)).toBe(true);
+    });
+
+    it("detects a JWT", () => {
+      const matches = detectPii(
+        "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.abc123-_",
+      );
+      expect(matches.some((m) => m.type === PiiType.JWT)).toBe(true);
+    });
+
+    it("detects a password assigned in a config line", () => {
+      const matches = detectPii('keystore password="wso2carbon123"');
+      expect(matches.some((m) => m.type === PiiType.PASSWORD)).toBe(true);
+    });
+
+    it("does not flag prose mentioning a password with no value", () => {
+      const matches = detectPii("The user forgot their password and cannot log in");
+      expect(matches.some((m) => m.type === PiiType.PASSWORD)).toBe(false);
+    });
+  });
+
   describe("detectPii - clean input", () => {
     it("returns no matches for benign text", () => {
       expect(detectPii("The deployment failed with a 500 error on startup.")).toEqual([]);

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
@@ -142,6 +142,42 @@ describe("piiDetection", () => {
       const matches = detectPii("The user forgot their password and cannot log in");
       expect(matches.some((m) => m.type === PiiType.PASSWORD)).toBe(false);
     });
+
+    it("detects short secret keyword variants (pass, pin, token)", () => {
+      expect(detectPii("pass: hunter2").some((m) => m.type === PiiType.PASSWORD)).toBe(
+        true,
+      );
+      expect(detectPii("pin=4821").some((m) => m.type === PiiType.PASSWORD)).toBe(true);
+      expect(
+        detectPii("token: Xk9223LmQpR8vTnW4bLz").some(
+          (m) => m.type === PiiType.PASSWORD,
+        ),
+      ).toBe(true);
+    });
+
+    it("detects an Azure-style AccountKey", () => {
+      const matches = detectPii(
+        "DefaultEndpointsProtocol=https;AccountKey=abc123def456==",
+      );
+      expect(matches.some((m) => m.type === PiiType.PASSWORD)).toBe(true);
+    });
+  });
+
+  describe("detectPii - national identifiers", () => {
+    it("detects a UK National Insurance number", () => {
+      const matches = detectPii("My NINO is QQ 12 34 56 C");
+      expect(matches.some((m) => m.type === PiiType.UK_NINO)).toBe(true);
+    });
+
+    it("detects a passport number when labelled", () => {
+      const matches = detectPii("German passport: C01X00T47");
+      expect(matches.some((m) => m.type === PiiType.PASSPORT)).toBe(true);
+    });
+
+    it("does not flag a bare alphanumeric code without the word passport", () => {
+      const matches = detectPii("Build artifact C01X00T47 completed");
+      expect(matches.some((m) => m.type === PiiType.PASSPORT)).toBe(false);
+    });
   });
 
   describe("detectPii - clean input", () => {

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -26,6 +26,14 @@
  */
 
 export enum PiiType {
+  // Secrets / credentials — the highest-value category for a technical
+  // support tool, where customers paste logs and config snippets.
+  PRIVATE_KEY = "PRIVATE_KEY",
+  CREDENTIALS_IN_URI = "CREDENTIALS_IN_URI",
+  ACCESS_TOKEN = "ACCESS_TOKEN",
+  JWT = "JWT",
+  PASSWORD = "PASSWORD",
+  // Classic personal data.
   CREDIT_CARD = "CREDIT_CARD",
   DANISH_CPR = "DANISH_CPR",
   NATIONAL_ID = "NATIONAL_ID",
@@ -90,6 +98,41 @@ export const passesLuhn = (value: string): boolean => {
  * and wins. See {@link detectPii}.
  */
 export const PII_PATTERNS: readonly PiiPattern[] = [
+  {
+    // PEM-encoded private keys (RSA/EC/OpenSSH/PGP/DSA). Near-zero false rate.
+    type: PiiType.PRIVATE_KEY,
+    label: "Private key",
+    regex: /-----BEGIN (?:[A-Z0-9]+ )?PRIVATE KEY-----/g,
+  },
+  {
+    // Credentials embedded in a URL or DB connection string, e.g.
+    // https://user:pass@host or jdbc:mysql://user:pass@host. Kept above EMAIL
+    // so "pass@host.com" isn't mis-reported as an email address.
+    type: PiiType.CREDENTIALS_IN_URI,
+    label: "Credentials in a URL or connection string",
+    regex: /\b(?:jdbc:)?[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s:@/]+@[^\s/]+/g,
+  },
+  {
+    // Well-known service/cloud access tokens with distinctive prefixes.
+    type: PiiType.ACCESS_TOKEN,
+    label: "API key or access token",
+    regex:
+      /\b(?:AKIA[0-9A-Z]{16}|gh[posru]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{35}|[sr]k_(?:live|test)_[A-Za-z0-9]{16,}|npm_[A-Za-z0-9]{36})\b/g,
+  },
+  {
+    // JSON Web Tokens (header.payload.signature, base64url).
+    type: PiiType.JWT,
+    label: "Authentication token",
+    regex: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+  },
+  {
+    // A password/secret assigned in a config or log line, e.g.
+    // password="s3cret", clientSecret: abc123, api_key=xxxx.
+    type: PiiType.PASSWORD,
+    label: "Password or secret",
+    regex:
+      /\b(?:password|passwd|pwd|secret|client[_-]?secret|api[_-]?key|access[_-]?key|auth[_-]?token)\b\s*[:=]\s*["']?[^\s"'<>{}]{4,}["']?/gi,
+  },
   {
     type: PiiType.CREDIT_CARD,
     label: "Credit card number",

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Client-side PII (Personally Identifiable Information) detection.
+ *
+ * Scans plain text for structured sensitive data (credit cards, national IDs,
+ * email, phone, IBAN) so the UI can warn a customer before their input is
+ * posted. Runs synchronously in the browser — no network call, no data leaves
+ * the client before the warning is shown.
+ *
+ * Out of scope: unstructured PII such as names and postal addresses, which
+ * regex cannot reliably detect. Those would require a backend/DLP service.
+ */
+
+export enum PiiType {
+  CREDIT_CARD = "CREDIT_CARD",
+  DANISH_CPR = "DANISH_CPR",
+  NATIONAL_ID = "NATIONAL_ID",
+  EMAIL = "EMAIL",
+  PHONE = "PHONE",
+  IBAN = "IBAN",
+}
+
+export interface PiiMatch {
+  /** The category of PII detected. */
+  type: PiiType;
+  /** Human-readable label for the detected type (used in the warning dialog). */
+  label: string;
+  /** The matched substring. */
+  snippet: string;
+  /** Start index of the match within the scanned text. */
+  index: number;
+}
+
+interface PiiPattern {
+  type: PiiType;
+  label: string;
+  regex: RegExp;
+  /**
+   * Optional extra check to confirm a raw regex match is really PII.
+   * Returning false drops the candidate (e.g. Luhn check for card numbers).
+   */
+  validate?: (match: string) => boolean;
+}
+
+/**
+ * Luhn checksum — validates credit-card-like digit sequences and filters out
+ * most random numbers (order IDs, reference numbers) that merely look like cards.
+ */
+export const passesLuhn = (value: string): boolean => {
+  const digits = value.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) {
+    return false;
+  }
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let digit = digits.charCodeAt(i) - 48;
+    if (double) {
+      digit *= 2;
+      if (digit > 9) {
+        digit -= 9;
+      }
+    }
+    sum += digit;
+    double = !double;
+  }
+  return sum % 10 === 0;
+};
+
+/**
+ * Detection patterns. Kept as a single exported config so the rule set can be
+ * tuned (added to / relaxed) as false-positive feedback comes in.
+ *
+ * Order matters: it defines priority when two patterns match the same span
+ * (e.g. a card number also looks like a phone number). Earlier = more specific,
+ * and wins. See {@link detectPii}.
+ */
+export const PII_PATTERNS: readonly PiiPattern[] = [
+  {
+    type: PiiType.CREDIT_CARD,
+    label: "Credit card number",
+    // 13-19 digits allowing spaces or hyphens between groups.
+    regex: /\b(?:\d[ -]*?){13,19}\b/g,
+    validate: passesLuhn,
+  },
+  {
+    type: PiiType.IBAN,
+    label: "IBAN",
+    regex: /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g,
+  },
+  {
+    type: PiiType.DANISH_CPR,
+    label: "Danish CPR number",
+    // DDMMYY-XXXX (optionally without the hyphen).
+    regex: /\b(0[1-9]|[12]\d|3[01])(0[1-9]|1[0-2])\d{2}-?\d{4}\b/g,
+  },
+  {
+    type: PiiType.NATIONAL_ID,
+    label: "National ID / SSN",
+    // US SSN style: 3-2-4 with separators.
+    regex: /\b\d{3}-\d{2}-\d{4}\b/g,
+  },
+  {
+    type: PiiType.EMAIL,
+    label: "Email address",
+    regex: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+  },
+  {
+    // Most generic numeric pattern — kept last so more specific matches
+    // (card, IBAN, CPR, SSN) win any overlap.
+    type: PiiType.PHONE,
+    label: "Phone number",
+    // International/local numbers, 9-15 digits with common separators.
+    regex: /(?:\+?\d[\d ().-]{7,}\d)/g,
+    validate: (match) => match.replace(/\D/g, "").length >= 9,
+  },
+];
+
+/**
+ * Scans text for potential PII and returns all matches.
+ *
+ * @param text Plain text to scan (convert rich-text/HTML to plain text first).
+ * @returns Matches sorted by position; empty array when nothing is found.
+ */
+export const detectPii = (text: string): PiiMatch[] => {
+  if (!text) {
+    return [];
+  }
+
+  // Collect every candidate, tagged with its pattern priority (array order).
+  const candidates: (PiiMatch & { priority: number; end: number })[] = [];
+
+  PII_PATTERNS.forEach((pattern, priority) => {
+    // Fresh regex per scan to avoid shared lastIndex state on the /g flag.
+    const regex = new RegExp(pattern.regex.source, pattern.regex.flags);
+    let result: RegExpExecArray | null = regex.exec(text);
+    while (result !== null) {
+      const snippet = result[0];
+      if (!pattern.validate || pattern.validate(snippet)) {
+        candidates.push({
+          type: pattern.type,
+          label: pattern.label,
+          snippet,
+          index: result.index,
+          end: result.index + snippet.length,
+          priority,
+        });
+      }
+      // Guard against zero-length matches causing an infinite loop.
+      if (result.index === regex.lastIndex) {
+        regex.lastIndex += 1;
+      }
+      result = regex.exec(text);
+    }
+  });
+
+  // Resolve overlaps: when spans intersect, the higher-priority (more specific)
+  // pattern wins, so a card number is not also reported as a phone number.
+  const kept: typeof candidates = [];
+  candidates
+    .sort((a, b) => a.priority - b.priority)
+    .forEach((candidate) => {
+      const overlaps = kept.some(
+        (k) => candidate.index < k.end && k.index < candidate.end
+      );
+      if (!overlaps) {
+        kept.push(candidate);
+      }
+    });
+
+  return kept
+    .sort((a, b) => a.index - b.index)
+    .map(({ type, label, snippet, index }) => ({ type, label, snippet, index }));
+};
+
+/**
+ * Convenience predicate for submit handlers that only need a yes/no.
+ */
+export const containsPii = (text: string): boolean => detectPii(text).length > 0;
+
+/**
+ * Distinct PII type labels present in the text, for display in the warning.
+ */
+export const getDetectedPiiLabels = (text: string): string[] => {
+  const labels = new Set<string>();
+  for (const match of detectPii(text)) {
+    labels.add(match.label);
+  }
+  return [...labels];
+};

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -206,7 +206,12 @@ export const detectPii = (text: string): PiiMatch[] => {
 
   PII_PATTERNS.forEach((pattern, priority) => {
     // Fresh regex per scan to avoid shared lastIndex state on the /g flag.
-    const regex = new RegExp(pattern.regex.source, pattern.regex.flags);
+    // Force the global flag so exec() advances lastIndex and the loop below
+    // terminates even if a pattern was defined without /g.
+    const flags = pattern.regex.flags.includes("g")
+      ? pattern.regex.flags
+      : `${pattern.regex.flags}g`;
+    const regex = new RegExp(pattern.regex.source, flags);
     let result: RegExpExecArray | null = regex.exec(text);
     while (result !== null) {
       const snippet = result[0];

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -37,6 +37,8 @@ export enum PiiType {
   CREDIT_CARD = "CREDIT_CARD",
   DANISH_CPR = "DANISH_CPR",
   NATIONAL_ID = "NATIONAL_ID",
+  UK_NINO = "UK_NINO",
+  PASSPORT = "PASSPORT",
   EMAIL = "EMAIL",
   PHONE = "PHONE",
   IBAN = "IBAN",
@@ -127,11 +129,13 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
   },
   {
     // A password/secret assigned in a config or log line, e.g.
-    // password="s3cret", clientSecret: abc123, api_key=xxxx.
+    // password="s3cret", clientSecret: abc123, api_key=xxxx, pass: hunter2,
+    // AccountKey=... (Azure). The keyword must be followed by ':' or '=' and a
+    // value, so prose like "forgot their password" is not flagged.
     type: PiiType.PASSWORD,
     label: "Password or secret",
     regex:
-      /\b(?:password|passwd|pwd|secret|client[_-]?secret|api[_-]?key|access[_-]?key|auth[_-]?token)\b\s*[:=]\s*["']?[^\s"'<>{}]{4,}["']?/gi,
+      /\b(?:passphrase|password|passwd|pwd|pass|pin|secret|credential|token|bearer|client[_-]?secret|api[_-]?key|access[_-]?key|account[_-]?key|shared[_-]?access[_-]?key|auth[_-]?token)\b\s*[:=]\s*["']?[^\s"'<>{}]{4,}["']?/gi,
   },
   {
     type: PiiType.CREDIT_CARD,
@@ -156,6 +160,19 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     label: "National ID / SSN",
     // US SSN style: 3-2-4 with separators.
     regex: /\b\d{3}-\d{2}-\d{4}\b/g,
+  },
+  {
+    // UK National Insurance number: 2 letters, 6 digits, 1 suffix letter.
+    type: PiiType.UK_NINO,
+    label: "UK National Insurance number",
+    regex: /\b[A-Z]{2} ?\d{2} ?\d{2} ?\d{2} ?[A-D]\b/g,
+  },
+  {
+    // Passport number — only when the word "passport" is present, since a bare
+    // 6-9 char alphanumeric alone is indistinguishable from an ID/order code.
+    type: PiiType.PASSPORT,
+    label: "Passport number",
+    regex: /\bpassport\s*(?:no\.?|number|#|id)?\s*[:=-]?\s*[A-Z0-9]{6,9}\b/gi,
   },
   {
     type: PiiType.EMAIL,


### PR DESCRIPTION
## What & why

JYSK requires a proactive warning when a customer's text contains Personally Identifiable Information (PII), so they can review it before it's posted. This adds a client-side PII check to every customer text-submission point in the support flow.

Related issues (in `wso2-enterprise/digiops-cs`, cross-repo — close manually):
- Epic: wso2-enterprise/digiops-cs#2352
- wso2-enterprise/digiops-cs#2379 · wso2-enterprise/digiops-cs#2380 · wso2-enterprise/digiops-cs#2381 · wso2-enterprise/digiops-cs#2382 · wso2-enterprise/digiops-cs#2383

## Approach

- **Frontend regex detection** — runs synchronously in the browser, so no round-trip and the text is scanned *before* it leaves the client. Structured PII only (cards, IDs, email, phone, IBAN); unstructured PII (names, addresses) is out of scope for this iteration.
- **Warn, don't block** — matches the AC: the user can edit the text, or post anyway if the info is necessary.

## Changes

**Foundation**
- `utils/piiDetection.ts` — `detectPii(text)` with a tunable pattern config. Credit cards are Luhn-checked; overlapping matches resolve to the most specific type (a card isn't also flagged as a phone number). Unit-tested (18 cases).
- `components/dialogs/PiiWarningDialog.tsx` — lists detected PII types as chips; **Edit text** / **Post anyway**.
- `hooks/usePiiGuard.ts` — `checkBeforeSubmit(text, onProceed)` + `dialogProps`; defers the submission until the user proceeds.

**Integrations** (scan plain text, clear/submit only on proceed)
- `DescribeIssuePage` — initial chat message
- `NoveraChatPage` — in-chat message send
- `CreateCasePage` — case **title + description**
- `ActivityCommentInput` — case comment

## Testing

- `piiDetection` unit tests: 18/18 pass (Luhn valid/invalid, CPR, email/phone, IBAN, false positives, ordering).
- `tsc --noEmit`: 0 errors across the app.
- `eslint`: clean on all changed files.
- Note: `CreateCasePage.test.tsx` fails on `main` too (pre-existing, unrelated query-hook setup issue) — not introduced here.

## Notes for reviewers

- **False positives are the main risk**, not misses — patterns live in an exported config (`PII_PATTERNS`) so they're easy to tune; the "Post anyway" escape hatch keeps over-flagging low-friction.
- Danish **CPR** is included since the customer is JYSK (DK).
- No i18n framework exists in this codebase; dialog copy follows the existing inline-string convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when support submissions contain possible sensitive information.
  * Users can review detected information before posting, or choose to continue.
  * Protection now covers case creation, issue descriptions, chat messages, and case comments.
  * Attachment-only comments continue without an unnecessary warning.

* **Tests**
  * Added coverage for detecting common sensitive information, including payment details, identification numbers, email addresses, phone numbers, and IBANs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->