### PR TITLE
[Customer Entity] Support full field updates on PATCH /change-requests/{id} (ServiceNow)

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1628,17 +1628,35 @@ type GetCatalogItemVariablesResponse struct {
 }
 
 // PatchChangeRequestRequest is the request body for PATCH /change-requests/{id}.
+// All fields are optional, but at least one must be provided.
 type PatchChangeRequestRequest struct {
-	PlannedStartOn     *string `json:"plannedStartOn,omitempty"`
-	IsCustomerApproved *bool   `json:"isCustomerApproved,omitempty"`
-	IsCustomerReviewed *bool   `json:"isCustomerReviewed,omitempty"`
+	Title              *string              `json:"title,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	ProjectID          *string              `json:"projectId,omitempty"`
+	CaseID             *string              `json:"caseId,omitempty"`
+	DeploymentID       *string              `json:"deploymentId,omitempty"`
+	DeployedProductID  *string              `json:"deployedProductId,omitempty"`
+	AssignedEngineerID *string              `json:"assignedEngineerId,omitempty"`
+	AssignedTeamID     *string              `json:"assignedTeamId,omitempty"`
+	PlannedStartOn     *string              `json:"plannedStartOn,omitempty"`
+	PlannedEndOn       *string              `json:"plannedEndOn,omitempty"`
+	Impact             *ChangeRequestImpact `json:"impact,omitempty"`
+	State              *ChangeRequestState  `json:"state,omitempty"`
+	Type               *ChangeRequestType   `json:"type,omitempty"`
+	Justification      *string              `json:"justification,omitempty"`
+	ImpactDescription  *string              `json:"impactDescription,omitempty"`
+	ServiceOutage      *string              `json:"serviceOutage,omitempty"`
+	CommunicationPlan  *string              `json:"communicationPlan,omitempty"`
+	RollbackPlan       *string              `json:"rollbackPlan,omitempty"`
+	TestPlan           *string              `json:"testPlan,omitempty"`
+	IsCustomerApproved *bool                `json:"isCustomerApproved,omitempty"`
+	IsCustomerReviewed *bool                `json:"isCustomerReviewed,omitempty"`
 }
 
 // PatchChangeRequestResponse is the response for PATCH /change-requests/{id}.
 type PatchChangeRequestResponse struct {
-	ID        string `json:"id"`
-	UpdatedOn string `json:"updatedOn"`
-	UpdatedBy string `json:"updatedBy"`
+	Message       string        `json:"message"`
+	ChangeRequest ChangeRequest `json:"changeRequest"`
 }
 
 // TimeCardState represents the workflow state of a time card.

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -37,25 +37,25 @@ type snChangeRequestsResponse struct {
 }
 
 type snChangeRequest struct {
-	ID               string                `json:"id"`
-	Number           string                `json:"number"`
-	Title            string                `json:"title"`
-	Description      string                `json:"description"`
-	CreatedOn        string                `json:"createdOn"`
-	UpdatedOn        *string               `json:"updatedOn"`
-	Project          snCREntityRef         `json:"project"`
-	Case             *snCREntityRef        `json:"case"`
-	Deployment       *snCREntityRef        `json:"deployment"`
-	DeployedProduct  *snCREntityRef        `json:"deployedProduct"`
-	Product          *snCREntityRef        `json:"product"`
-	AssignedEngineer *snCREntityRef        `json:"assignedEngineer"`
-	AssignedTeam     *snCREntityRef        `json:"assignedTeam"`
-	PlannedStartOn   *string               `json:"plannedStartOn"`
-	PlannedEndOn     *string               `json:"plannedEndOn"`
-	Duration         *string               `json:"duration"`
-	Impact           *snCRLabel            `json:"impact"`
-	State            *snCRLabel            `json:"state"`
-	Type             *snCRLabel            `json:"type"`
+	ID               string         `json:"id"`
+	Number           string         `json:"number"`
+	Title            string         `json:"title"`
+	Description      string         `json:"description"`
+	CreatedOn        string         `json:"createdOn"`
+	UpdatedOn        *string        `json:"updatedOn"`
+	Project          snCREntityRef  `json:"project"`
+	Case             *snCREntityRef `json:"case"`
+	Deployment       *snCREntityRef `json:"deployment"`
+	DeployedProduct  *snCREntityRef `json:"deployedProduct"`
+	Product          *snCREntityRef `json:"product"`
+	AssignedEngineer *snCREntityRef `json:"assignedEngineer"`
+	AssignedTeam     *snCREntityRef `json:"assignedTeam"`
+	PlannedStartOn   *string        `json:"plannedStartOn"`
+	PlannedEndOn     *string        `json:"plannedEndOn"`
+	Duration         *string        `json:"duration"`
+	Impact           *snCRLabel     `json:"impact"`
+	State            *snCRLabel     `json:"state"`
+	Type             *snCRLabel     `json:"type"`
 }
 
 type snCREntityRef struct {
@@ -460,7 +460,6 @@ var snCRCategoryIDMap = map[domain.ChangeRequestCategory]string{
 	domain.ChangeRequestCategoryCloudComputing:       "cloud computing",
 }
 
-
 func strPtr(s string) *string { return &s }
 
 // CreateChangeRequest implements ChangeRequestService for the ServiceNow data source.
@@ -594,21 +593,50 @@ func (s *snChangeRequestService) CreateChangeRequest(ctx context.Context, req do
 	return resp, nil
 }
 
+// snCRPatchStateIDMap maps domain ChangeRequestState enums to SN numeric state IDs for PATCH.
+var snCRPatchStateIDMap = map[domain.ChangeRequestState]int{
+	domain.ChangeRequestStateNew:              -5,
+	domain.ChangeRequestStateAssess:           -4,
+	domain.ChangeRequestStateAuthorize:        -3,
+	domain.ChangeRequestStateScheduled:        -2,
+	domain.ChangeRequestStateImplement:        -1,
+	domain.ChangeRequestStateReview:           0,
+	domain.ChangeRequestStateCustomerReview:   1,
+	domain.ChangeRequestStateRollback:         2,
+	domain.ChangeRequestStateClosed:           3,
+	domain.ChangeRequestStateCanceled:         4,
+	domain.ChangeRequestStateCustomerApproval: 5,
+}
+
 // snPatchChangeRequestPayload mirrors the Choreo PATCH /change-requests/{id} request body.
 type snPatchChangeRequestPayload struct {
+	Title              *string `json:"title,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	ProjectID          *string `json:"projectId,omitempty"`
+	CaseID             *string `json:"caseId,omitempty"`
+	DeploymentID       *string `json:"deploymentId,omitempty"`
+	DeployedProductID  *string `json:"deployedProductId,omitempty"`
+	AssignedEngineerID *string `json:"assignedEngineerId,omitempty"`
+	AssignedTeamID     *string `json:"assignedTeamId,omitempty"`
 	PlannedStartOn     *string `json:"plannedStartOn,omitempty"`
+	PlannedEndOn       *string `json:"plannedEndOn,omitempty"`
+	ImpactKey          *int    `json:"impactKey,omitempty"`
+	StateKey           *int    `json:"stateKey,omitempty"`
+	TypeKey            *string `json:"typeKey,omitempty"`
+	Justification      *string `json:"justification,omitempty"`
+	ImpactDescription  *string `json:"impactDescription,omitempty"`
+	ServiceOutage      *string `json:"serviceOutage,omitempty"`
+	CommunicationPlan  *string `json:"communicationPlan,omitempty"`
+	RollbackPlan       *string `json:"rollbackPlan,omitempty"`
+	TestPlan           *string `json:"testPlan,omitempty"`
 	IsCustomerApproved *bool   `json:"isCustomerApproved,omitempty"`
 	IsCustomerReviewed *bool   `json:"isCustomerReviewed,omitempty"`
 }
 
 // snPatchChangeRequestResponse mirrors the Choreo PATCH /change-requests/{id} response.
 type snPatchChangeRequestResponse struct {
-	Message       string `json:"message"`
-	ChangeRequest struct {
-		ID        string `json:"id"`
-		UpdatedOn string `json:"updatedOn"`
-		UpdatedBy string `json:"updatedBy"`
-	} `json:"changeRequest"`
+	Message       string                `json:"message"`
+	ChangeRequest snChangeRequestDetail `json:"changeRequest"`
 }
 
 func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id string, req domain.PatchChangeRequestRequest) (domain.PatchChangeRequestResponse, error) {
@@ -621,14 +649,94 @@ func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id stri
 		return domain.PatchChangeRequestResponse{}, err
 	}
 
-	if req.PlannedStartOn == nil && req.IsCustomerApproved == nil && req.IsCustomerReviewed == nil {
+	if req.Title == nil && req.Description == nil && req.ProjectID == nil && req.CaseID == nil &&
+		req.DeploymentID == nil && req.DeployedProductID == nil && req.AssignedEngineerID == nil &&
+		req.AssignedTeamID == nil && req.PlannedStartOn == nil && req.PlannedEndOn == nil &&
+		req.Impact == nil && req.State == nil && req.Type == nil && req.Justification == nil &&
+		req.ImpactDescription == nil && req.ServiceOutage == nil && req.CommunicationPlan == nil &&
+		req.RollbackPlan == nil && req.TestPlan == nil && req.IsCustomerApproved == nil &&
+		req.IsCustomerReviewed == nil {
 		return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "at least one field must be provided"}
 	}
 
+	if req.Title != nil && *req.Title == "" {
+		return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "title cannot be empty"}
+	}
+	if req.Impact != nil {
+		if _, ok := snCRImpactIDMap[*req.Impact]; !ok {
+			return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: fmt.Sprintf("invalid impact %q", *req.Impact)}
+		}
+	}
+	if req.State != nil {
+		if _, ok := snCRPatchStateIDMap[*req.State]; !ok {
+			return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: fmt.Sprintf("invalid state %q", *req.State)}
+		}
+	}
+	if req.Type != nil {
+		if _, ok := snCRCreateTypeIDMap[*req.Type]; !ok {
+			return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: fmt.Sprintf("invalid type %q", *req.Type)}
+		}
+	}
+
+	uuidFields := map[string]*string{
+		"projectId":          req.ProjectID,
+		"caseId":             req.CaseID,
+		"deploymentId":       req.DeploymentID,
+		"deployedProductId":  req.DeployedProductID,
+		"assignedEngineerId": req.AssignedEngineerID,
+		"assignedTeamId":     req.AssignedTeamID,
+	}
+	for field, val := range uuidFields {
+		if val != nil {
+			if err := validateUUIDs(field, []string{*val}); err != nil {
+				return domain.PatchChangeRequestResponse{}, err
+			}
+		}
+	}
+
 	payload := snPatchChangeRequestPayload{
+		Title:              req.Title,
+		Description:        req.Description,
 		PlannedStartOn:     req.PlannedStartOn,
+		PlannedEndOn:       req.PlannedEndOn,
+		Justification:      req.Justification,
+		ImpactDescription:  req.ImpactDescription,
+		ServiceOutage:      req.ServiceOutage,
+		CommunicationPlan:  req.CommunicationPlan,
+		RollbackPlan:       req.RollbackPlan,
+		TestPlan:           req.TestPlan,
 		IsCustomerApproved: req.IsCustomerApproved,
 		IsCustomerReviewed: req.IsCustomerReviewed,
+	}
+	if req.ProjectID != nil {
+		payload.ProjectID = strPtr(uuidToSysid(*req.ProjectID))
+	}
+	if req.CaseID != nil {
+		payload.CaseID = strPtr(uuidToSysid(*req.CaseID))
+	}
+	if req.DeploymentID != nil {
+		payload.DeploymentID = strPtr(uuidToSysid(*req.DeploymentID))
+	}
+	if req.DeployedProductID != nil {
+		payload.DeployedProductID = strPtr(uuidToSysid(*req.DeployedProductID))
+	}
+	if req.AssignedEngineerID != nil {
+		payload.AssignedEngineerID = strPtr(uuidToSysid(*req.AssignedEngineerID))
+	}
+	if req.AssignedTeamID != nil {
+		payload.AssignedTeamID = strPtr(uuidToSysid(*req.AssignedTeamID))
+	}
+	if req.Impact != nil {
+		v := snCRImpactIDMap[*req.Impact]
+		payload.ImpactKey = &v
+	}
+	if req.State != nil {
+		v := snCRPatchStateIDMap[*req.State]
+		payload.StateKey = &v
+	}
+	if req.Type != nil {
+		v := snCRCreateTypeIDMap[*req.Type]
+		payload.TypeKey = &v
 	}
 
 	raw, err := s.client.Patch(ctx, "/change-requests/"+uuidToSysid(id), token, payload)
@@ -642,9 +750,8 @@ func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id stri
 	}
 
 	return domain.PatchChangeRequestResponse{
-		ID:        sysidToUUID(snResp.ChangeRequest.ID),
-		UpdatedOn: snResp.ChangeRequest.UpdatedOn,
-		UpdatedBy: snResp.ChangeRequest.UpdatedBy,
+		Message:       snResp.Message,
+		ChangeRequest: mapSNChangeRequestDetailToView(snResp.ChangeRequest),
 	}, nil
 }
 
@@ -684,6 +791,12 @@ func (s *snChangeRequestService) GetChangeRequest(ctx context.Context, id string
 		return domain.ChangeRequest{}, fmt.Errorf("sn get change request: parse response: %w", err)
 	}
 
+	return mapSNChangeRequestDetailToView(cr), nil
+}
+
+// mapSNChangeRequestDetailToView maps a Choreo change-request detail payload to the domain view,
+// shared by GetChangeRequest and PatchChangeRequest.
+func mapSNChangeRequestDetailToView(cr snChangeRequestDetail) domain.ChangeRequest {
 	subject := cr.Title
 	description := cr.Description
 
@@ -743,5 +856,5 @@ func (s *snChangeRequestService) GetChangeRequest(ctx context.Context, id string
 		result.ApprovedBy = &domain.EntityRef{ID: sysidToUUID(cr.ApprovedBy.ID), Name: cr.ApprovedBy.Name}
 	}
 
-	return result, nil
+	return result
 }

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
@@ -675,6 +676,16 @@ func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id stri
 	if req.Type != nil {
 		if _, ok := snCRCreateTypeIDMap[*req.Type]; !ok {
 			return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: fmt.Sprintf("invalid type %q", *req.Type)}
+		}
+	}
+	if req.PlannedStartOn != nil {
+		if _, err := time.Parse(snCreatedOnLayout, *req.PlannedStartOn); err != nil {
+			return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "plannedStartOn must follow the format: YYYY-MM-DD HH:mm:ss"}
+		}
+	}
+	if req.PlannedEndOn != nil {
+		if _, err := time.Parse(snCreatedOnLayout, *req.PlannedEndOn); err != nil {
+			return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "plannedEndOn must follow the format: YYYY-MM-DD HH:mm:ss"}
 		}
 	}
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4446,9 +4446,11 @@ components:
         plannedStartOn:
           type: string
           description: Planned start date and time (format YYYY-MM-DD HH:MM:SS).
+          pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$'
         plannedEndOn:
           type: string
           description: Planned end date and time (format YYYY-MM-DD HH:MM:SS).
+          pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$'
         impact:
           type: string
           enum:
@@ -4497,6 +4499,9 @@ components:
 
     PatchChangeRequestResponse:
       type: object
+      required:
+        - message
+        - changeRequest
       properties:
         message:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1171,7 +1171,7 @@ paths:
               $ref: '#/components/schemas/PatchChangeRequestRequest'
       responses:
         "200":
-          description: Updated change request identifiers.
+          description: The updated change request.
           content:
             application/json:
               schema:
@@ -4417,10 +4417,79 @@ components:
     PatchChangeRequestRequest:
       type: object
       minProperties: 1
+      description: >
+        Any combination of fields may be supplied; at least one is required.
+        Omitted fields are left unchanged.
       properties:
+        title:
+          type: string
+        description:
+          type: string
+        projectId:
+          type: string
+          format: uuid
+        caseId:
+          type: string
+          format: uuid
+        deploymentId:
+          type: string
+          format: uuid
+        deployedProductId:
+          type: string
+          format: uuid
+        assignedEngineerId:
+          type: string
+          format: uuid
+        assignedTeamId:
+          type: string
+          format: uuid
         plannedStartOn:
           type: string
           description: Planned start date and time (format YYYY-MM-DD HH:MM:SS).
+        plannedEndOn:
+          type: string
+          description: Planned end date and time (format YYYY-MM-DD HH:MM:SS).
+        impact:
+          type: string
+          enum:
+            - high
+            - medium
+            - low
+        state:
+          type: string
+          enum:
+            - new
+            - assess
+            - authorize
+            - customer_approval
+            - scheduled
+            - implement
+            - review
+            - customer_review
+            - rollback
+            - closed
+            - canceled
+        type:
+          type: string
+          enum:
+            - standard
+            - normal
+            - emergency
+            - model
+            - site_reliability_ops
+            - azure
+        justification:
+          type: string
+        impactDescription:
+          type: string
+        serviceOutage:
+          type: string
+        communicationPlan:
+          type: string
+        rollbackPlan:
+          type: string
+        testPlan:
+          type: string
         isCustomerApproved:
           type: boolean
         isCustomerReviewed:
@@ -4429,13 +4498,10 @@ components:
     PatchChangeRequestResponse:
       type: object
       properties:
-        id:
+        message:
           type: string
-          format: uuid
-        updatedOn:
-          type: string
-        updatedBy:
-          type: string
+        changeRequest:
+          $ref: '#/components/schemas/ChangeRequest'
 
     TimeCardState:
       type: string


### PR DESCRIPTION
## Summary
- Extend `PatchChangeRequestRequest`/`PatchChangeRequestResponse` to support the full ServiceNow change-request update payload (title, description, project/case/deployment/deployed-product/engineer/team refs, planned start/end, impact, state, type, justification, and the free-text plan/description fields), instead of the previous 3-field subset.
- Response now returns the full updated `ChangeRequest` view (`{message, changeRequest}`), matching the pattern already used by `UpdateIncidentResponse`.
- Extract `mapSNChangeRequestDetailToView` out of `GetChangeRequest` so it's shared with `PatchChangeRequest`, mirroring the existing `mapSNIncidentToView` extraction for incidents.
- Add `snCRPatchStateIDMap` (int-keyed, covers `new`/`assess`/`authorize` in addition to the existing search-only states) to match the ServiceNow `stateKey` values used by this endpoint.
- Document the expanded request/response schemas in `openapi.yaml`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Manual smoke test against a ServiceNow-backed environment: PATCH with a full payload and a partial payload, confirm 200 with the expected `changeRequest` view, and confirm 400s for invalid `impact`/`state`/`type`/UUID values and empty `title`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded change-request PATCH updates to include descriptions, assignments, planned dates, impact/workflow state/type, and implementation planning fields.
  * Added support for creating change requests in the Cloud Computing category.
  * PATCH responses now return a confirmation message plus the full updated change request.
* **Bug Fixes**
  * Added stricter validation for empty titles, malformed identifiers, invalid impact/state/type values, and empty PATCH payloads.
* **Documentation**
  * Updated API documentation to reflect partial-update behavior and the revised request/response schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->