### PR TITLE
[Customer Portal Webapp] Show feedback prompt on case close and display submitted feedback in case details

### DIFF
--- a/apps/customer-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/customer-portal/webapp/src/constants/apiConstants.ts
@@ -72,6 +72,7 @@ export const ApiQueryKeys = {
   DEPLOYED_PRODUCT_INSTANCE_METRICS: "deployed-product-instance-metrics",
   PROJECT_INSTANCE_USAGE_STATS: "project-instance-usage-stats",
   CASE_ESCALATIONS_SEARCH: "case-escalations-search",
+  CASE_FEEDBACK: "case-feedback",
   GLOBAL_SEARCH: "global-search",
 } as const;
 

--- a/apps/customer-portal/webapp/src/features/support/api/useGetCaseFeedback.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useGetCaseFeedback.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAsgardeo } from "@asgardeo/react";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { useLogger } from "@hooks/useLogger";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import type { CaseFeedback } from "@features/support/types/feedback";
+
+/**
+ * Fetches previously submitted feedback for a case (GET /cases/{caseId}/feedback).
+ * Returns null when no feedback has been submitted yet (backend responds 404).
+ *
+ * @param {string} caseId - The case ID.
+ * @param {boolean} [enabled] - Whether the query should run (e.g. only for closed cases).
+ * @returns {UseQueryResult<CaseFeedback | null, Error>} The query result object.
+ */
+export function useGetCaseFeedback(
+  caseId: string,
+  enabled = true,
+): UseQueryResult<CaseFeedback | null, Error> {
+  const logger = useLogger();
+  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
+  const authFetch = useAuthApiClient();
+
+  return useQuery<CaseFeedback | null, Error>({
+    queryKey: [ApiQueryKeys.CASE_FEEDBACK, caseId],
+    queryFn: async (): Promise<CaseFeedback | null> => {
+      logger.debug(`[useGetCaseFeedback] Fetching feedback for case ${caseId}`);
+
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
+      if (!baseUrl) {
+        throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
+      }
+
+      const response = await authFetch(`${baseUrl}/cases/${caseId}/feedback`, {
+        method: "GET",
+      });
+
+      if (response.status === 404) {
+        return null;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Error fetching case feedback: ${response.statusText}`);
+      }
+
+      return response.json() as Promise<CaseFeedback>;
+    },
+    enabled: enabled && !!caseId && isSignedIn && !isAuthLoading,
+    staleTime: 0,
+  });
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -39,12 +39,14 @@ import {
   FileText,
   ExternalLink,
   Pencil,
+  MessageSquare,
 } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, useState, useMemo } from "react";
 import { Link, useLocation, useParams } from "react-router";
 import useGetProjectContacts from "@features/settings/api/useGetProjectContacts";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import { usePatchCase } from "@features/support/api/usePatchCase";
+import { useGetCaseFeedback } from "@features/support/api/useGetCaseFeedback";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
 import DOMPurify from "dompurify";
@@ -114,6 +116,8 @@ export default function CaseDetailsDetailsPanel({
   const { showError } = useErrorBanner();
   const { showSuccess } = useSuccessBanner();
   const { mutate: patchCase, isPending: isPatchPending } = usePatchCase(projectId, caseId);
+  const isClosed = data?.status?.label?.toLowerCase() === "closed";
+  const { data: feedback } = useGetCaseFeedback(caseId, isClosed);
 
   const handleEditWatchList = () => {
     const current = savedWatchList ?? (data?.watchList ?? [])
@@ -541,7 +545,7 @@ export default function CaseDetailsDetailsPanel({
       )}
 
       {/* Section 4: Closed Case Details (only when case is closed) */}
-      {statusLabel?.toLowerCase() === "closed" && (
+      {isClosed && (
         <CaseDetailsCard
           title={
             isServiceRequest ? "Closed Request Details" : "Closed Case Details"
@@ -577,6 +581,49 @@ export default function CaseDetailsDetailsPanel({
               </Typography>
             </Box>
           </Box>
+        </CaseDetailsCard>
+      )}
+
+      {/* Section 4b: Customer Feedback (only when feedback has been submitted) */}
+      {isClosed && feedback && (
+        <CaseDetailsCard
+          title="Customer Feedback"
+          icon={<MessageSquare size={20} aria-hidden />}
+        >
+          <Stack direction="row" spacing={2} alignItems="flex-start">
+            <Box
+              component="img"
+              src={feedback.emoji.selectedImage}
+              alt={feedback.emoji.name}
+              sx={{ width: 40, height: 40, objectFit: "contain", flexShrink: 0 }}
+            />
+            <Box sx={{ flex: 1 }}>
+              <Typography {...valueSx} sx={{ fontWeight: 600 }}>
+                {feedback.emoji.name}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+                {formatUtcToLocal(feedback.createdOn)}
+              </Typography>
+              {feedback.chips && feedback.chips.length > 0 && (
+                <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mb: feedback.additionalComment ? 1.5 : 0 }}>
+                  {feedback.chips.map((chip) => (
+                    <Chip
+                      key={chip}
+                      label={chip}
+                      size="small"
+                      variant="outlined"
+                      sx={{ fontSize: "0.75rem" }}
+                    />
+                  ))}
+                </Stack>
+              )}
+              {feedback.additionalComment && (
+                <Typography {...valueSx} sx={{ whiteSpace: "pre-wrap" }}>
+                  {feedback.additionalComment}
+                </Typography>
+              )}
+            </Box>
+          </Stack>
         </CaseDetailsCard>
       )}
 

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -116,7 +116,7 @@ export default function CaseDetailsDetailsPanel({
   const { showError } = useErrorBanner();
   const { showSuccess } = useSuccessBanner();
   const { mutate: patchCase, isPending: isPatchPending } = usePatchCase(projectId, caseId);
-  const isClosed = data?.status?.label?.toLowerCase() === "closed";
+  const isClosed = data?.status?.label?.trim().toLowerCase() === "closed";
   const { data: feedback } = useGetCaseFeedback(caseId, isClosed);
 
   const handleEditWatchList = () => {

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -226,8 +226,8 @@ export default function CaseDetailsActionRow({
             {
               onSuccess: () => {
                 showSuccess("State updated successfully.");
-                // Prompt for feedback only when accepting a solution (Solution Proposed state).
-                if (label === "Accept Solution" && caseId) {
+                // Prompt for feedback when accepting a solution or closing the case.
+                if ((label === "Accept Solution" || label === "Closed") && caseId) {
                   setFeedbackModalOpen(true);
                 }
               },


### PR DESCRIPTION
### Summary

- Trigger the feedback modal when a user closes a case, not just when accepting a solution.
- Add a `GET /cases/{caseId}/feedback` hook and render a "Customer Feedback" card in the Details tab for closed cases that have submitted feedback (rating emoji, chips, and comment).

### Test plan

-  Close a case and confirm the feedback modal appears
-  Submit feedback, reopen the case details page, and confirm the Customer Feedback card shows the emoji, chips, and comment
-  Verify the card is hidden for closed cases with no feedback submitted, and for non-closed cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customer feedback collection when cases are marked as closed.
  * Displayed submitted feedback, including rating, selected topics, submission time, and comments, in closed case details.
  * Added feedback retrieval with appropriate handling when no feedback is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->