### PR TITLE
[Customer Portal Webapp] Remove misleading sign-in redirect fallback from attachment downloads

### DIFF
--- a/apps/customer-portal/webapp/src/api/__tests__/useGetAttachment.test.tsx
+++ b/apps/customer-portal/webapp/src/api/__tests__/useGetAttachment.test.tsx
@@ -109,7 +109,7 @@ describe("useGetAttachment", () => {
     clickSpy.mockRestore();
   });
 
-  it("should open downloadUrl when GET fails and URL is set", async () => {
+  it("should reject when GET fails even if downloadUrl is set", async () => {
     mockAuthFetch.mockResolvedValue({
       ok: false,
       status: 500,
@@ -120,18 +120,16 @@ describe("useGetAttachment", () => {
     const { result } = renderHook(() => useGetAttachment(), { wrapper });
 
     await act(async () => {
-      await result.current.downloadAttachment({
-        id: "att-1",
-        name: "x",
-        downloadUrl: "https://sn.example/file",
-      });
+      await expect(
+        result.current.downloadAttachment({
+          id: "att-1",
+          name: "x",
+          downloadUrl: "https://sn.example/file",
+        }),
+      ).rejects.toThrow(/Error/);
     });
 
-    expect(openSpy).toHaveBeenCalledWith(
-      "https://sn.example/file",
-      "_blank",
-      "noopener,noreferrer",
-    );
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it("should reject when GET fails and no downloadUrl", async () => {

--- a/apps/customer-portal/webapp/src/api/useGetAttachment.ts
+++ b/apps/customer-portal/webapp/src/api/useGetAttachment.ts
@@ -54,10 +54,6 @@ function triggerDownloadFromContentField(
   link.click();
 }
 
-function openExternalDownload(url: string): void {
-  window.open(url, "_blank", "noopener,noreferrer");
-}
-
 async function downloadAttachmentThroughBackend(
   authFetch: (
     input: RequestInfo | URL,
@@ -76,28 +72,16 @@ async function downloadAttachmentThroughBackend(
   try {
     response = await authFetch(url, { method: "GET" });
   } catch {
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
     throw new Error("Network error while downloading attachment");
   }
 
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
     throw new Error(parseApiResponseMessage(detail, response.status, response.statusText));
   }
 
   const data = (await response.json()) as AttachmentDownloadResponse;
   if (!data?.content || typeof data.content !== "string") {
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
     throw new Error("Attachment response did not include file content");
   }
 
@@ -118,8 +102,8 @@ export interface UseGetAttachmentResult {
 }
 
 /**
- * Authenticated attachment download via GET /attachments/:id, with optional
- * inline content shortcut and ServiceNow URL fallback.
+ * Authenticated attachment download via GET /attachments/:id, with an
+ * optional inline content shortcut.
  *
  * @returns {UseGetAttachmentResult} mutateAsync, loading flag, and active id.
  */

--- a/apps/customer-portal/webapp/src/api/useGetAttachmentContent.ts
+++ b/apps/customer-portal/webapp/src/api/useGetAttachmentContent.ts
@@ -36,10 +36,6 @@ function getBackendBaseUrl(): string {
   return baseUrl.replace(/\/$/, "");
 }
 
-function openExternalDownload(url: string): void {
-  window.open(url, "_blank", "noopener,noreferrer");
-}
-
 function getFilenameFromContentDisposition(
   contentDisposition: string | null,
 ): string | null {
@@ -107,19 +103,11 @@ async function downloadAttachmentContentThroughBackend(
   try {
     response = await authFetch(url, { method: "GET" });
   } catch {
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
     throw new Error("Network error while downloading attachment");
   }
 
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
     throw new Error(
       parseApiResponseMessage(detail, response.status, response.statusText),
     );
@@ -140,10 +128,6 @@ async function downloadAttachmentContentThroughBackend(
       return;
     }
 
-    if (input.downloadUrl) {
-      openExternalDownload(input.downloadUrl);
-      return;
-    }
     throw new Error("Attachment response did not include file content");
   }
 


### PR DESCRIPTION
### Description
Removes the downloadUrl fallback (`openExternalDownload` → `window.open`) from `useGetAttachmentContent.ts `and `useGetAttachment.ts`. On download failure (network error, non-OK response, or missing/malformed content), these hooks now throw an error instead of opening a new tab pointed at an unauthenticated URL.

That fallback URL isn't a real download endpoint — opening it just redirects the user to the sign-in page. On any download failure, users saw an unexpected new tab asking them to log in again, with no indication the download had actually failed.

### Test plan

-  `useGetAttachment.test.tsx` — all 5 tests pass
-  `useGetAttachmentContent.test.tsx `— 1 pre-existing failure, unrelated to this change (confirmed via git stash)
-  Manually verify in-browser: trigger a failed case-attachment download and a failed deployment-document download, confirm no new tab opens and an error banner is shown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment downloads now report clear errors when backend requests fail or responses are incomplete.
  * Prevented opening external download links after failed or invalid attachment responses.
  * Preserved successful downloads for valid file and inline-content responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->