### PR TITLE
[Customer Portal Webapp] Fix invisible comment text in dark mode caused by rgb() white backgrounds

### DIFF
--- a/apps/customer-portal/webapp/src/utils/common.ts
+++ b/apps/customer-portal/webapp/src/utils/common.ts
@@ -72,6 +72,8 @@ export function stripLightModeInlineStyles(html: string): string {
           )
         )
           return false;
+        if (/^background(-color)?\s*:/.test(normalized) && isNearWhiteRgb(normalized))
+          return false;
         if (/^color\s*:/.test(normalized) && isDarkColor(normalized))
           return false;
         return true;
@@ -88,6 +90,15 @@ export const DESCRIPTION_PURIFY_CONFIG = {
   FORBID_TAGS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
   FORBID_CONTENTS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
 };
+
+function isNearWhiteRgb(bgDecl: string): boolean {
+  const rgbMatch = bgDecl.match(
+    /^background(?:-color)?\s*:\s*rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/,
+  );
+  if (!rgbMatch) return false;
+  const [, r, g, b] = rgbMatch.map(Number);
+  return r > 230 && g > 230 && b > 230;
+}
 
 function isDarkColor(colorDecl: string): boolean {
   // Named dark colors


### PR DESCRIPTION
### Summary

- stripLightModeInlineStyles in [common.ts](vscode-webview://16htq1dki2c0c7hb2tm5qerlb7ptv59t3hnnoku4cti0bl7pfbqn/src/utils/common.ts) stripped dark inline color values in dark mode but only recognized white backgrounds written as hex/named colors (#fff, white, etc.) — not rgb(255, 255, 255), which is commonly emitted by external rich-text editors (e.g. ServiceNow-pasted comments).
- This left some case activity comments with a hardcoded white background surviving in dark mode while other declarations were stripped, making text unreadable.
- Added isNearWhiteRgb() to detect background/background-color: rgb(r,g,b) where all channels are >230 and strip it in dark mode, closing the gap.

### Test plan

-  Verify the previously affected comment renders with legible text in dark mode
-  Confirm light mode rendering is unaffected
-  Spot-check other comments/announcements/updates using stripLightModeInlineStyles still render correctly in both themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved light-mode styling cleanup by removing near-white RGB background declarations, in addition to existing white color formats.
  * Helps prevent unwanted light backgrounds from appearing in supported styling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->