### PR TITLE
feat(customer-portal): flag-gated token limit increase request in Novera chat

### DIFF
--- a/apps/customer-portal/webapp/public/config.js.example
+++ b/apps/customer-portal/webapp/public/config.js.example
@@ -123,6 +123,14 @@ window.config = {
   //   false – widget is hidden.
   CUSTOMER_PORTAL_FLOATING_NOVERA_ENABLED: false,
 
+  // ── Novera token limit increase request ────────────────────────────────────
+  //
+  // CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED  (optional — default: false)
+  //   true  – when a user hits the Novera token limit, shows a CTA to request an
+  //           increase (sends the request over the chat WebSocket).
+  //   false – feature hidden. Keep false until the backend handler is ready.
+  CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED: false,
+
   // ── Top banners ─────────────────────────────────────────────────────────────
   //
   // CUSTOMER_PORTAL_TOP_BANNERS  (optional — default: [])

--- a/apps/customer-portal/webapp/src/config/portalConfig.ts
+++ b/apps/customer-portal/webapp/src/config/portalConfig.ts
@@ -34,6 +34,8 @@ export interface CustomerPortalWindowConfig {
   CUSTOMER_PORTAL_MAINTENANCE_BANNER_ACTION_URL?: string;
   CUSTOMER_PORTAL_CHATBOT_WEBSOCKET_URL?: string;
   CUSTOMER_PORTAL_FLOATING_NOVERA_ENABLED?: boolean;
+  /** Enables the Novera chat "request a token limit increase" flow. */
+  CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED?: boolean;
   CUSTOMER_PORTAL_TOP_BANNERS?: Array<{
     enabled: boolean;
     html: string;

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -18,6 +18,7 @@ import type { ChatMessageBubbleProps } from "@features/support/types/supportComp
 import {
   Avatar,
   Box,
+  Button,
   Paper,
   Stack,
   Typography,
@@ -138,6 +139,7 @@ function MarkdownContent({ text }: { text: string }) {
  */
 export default function ChatMessageBubble({
   message,
+  onRequestTokenIncrease,
 }: ChatMessageBubbleProps): JSX.Element {
   const isUser = message.sender === ChatSender.USER;
   const isCurrentUserMessage = isUser && (message.isCurrentUser ?? true);
@@ -315,9 +317,22 @@ export default function ChatMessageBubble({
           {/* Message content */}
           <Box>
             {message.isError ? (
-              <Typography variant="body2" color="error.main">
-                {displayText}
-              </Typography>
+              <>
+                <Typography variant="body2" color="error.main">
+                  {displayText}
+                </Typography>
+                {isUsageLimitError && onRequestTokenIncrease && (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    color="warning"
+                    onClick={onRequestTokenIncrease}
+                    sx={{ mt: 1, textTransform: "none" }}
+                  >
+                    Request a token limit increase
+                  </Button>
+                )}
+              </>
             ) : showThinkingStreamFrame ? (
               <Paper
                 sx={(t) => ({

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList.tsx
@@ -37,6 +37,7 @@ export default function ChatMessageList({
   onFetchOlder,
   isFetchingOlder = false,
   onSolutionWorked,
+  onRequestTokenIncrease,
 }: ChatMessageListProps): JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const pendingPrependRef = useRef(false);
@@ -93,6 +94,7 @@ export default function ChatMessageList({
             onThumbsUp={onThumbsUp}
             onThumbsDown={onThumbsDown}
             onSolutionWorked={onSolutionWorked}
+            onRequestTokenIncrease={onRequestTokenIncrease}
           />
         ),
       )}

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -66,6 +66,7 @@ import type {
 import ChatHeader from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatHeader";
 import ChatInput from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatInput";
 import ChatMessageList from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList";
+import TokenRequestModal from "@features/support/components/novera-ai-assistant/novera-chat-page/TokenRequestModal";
 import ChatSkeleton from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatSkeleton";
 import {
   displayTextFromConversationContent,
@@ -670,6 +671,28 @@ export default function NoveraChatPage(): JSX.Element {
     void sendViaWebSocket("This Resolved My Issue");
   }, [isSending, sendViaWebSocket]);
 
+  // Feature-flagged (config.js): request a token limit increase over the chat
+  // WebSocket. Kept off until the backend handler is ready.
+  const tokenRequestEnabled =
+    window.config?.CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED ?? false;
+  const [isTokenModalOpen, setIsTokenModalOpen] = useState(false);
+
+  const handleTokenIncreaseSubmit = useCallback(
+    async (reason: string): Promise<void> => {
+      if (!projectId || !accountId) {
+        throw new Error("Unable to submit the request right now.");
+      }
+      await connect(projectId);
+      await sendUserMessage({
+        type: "token_increase_request",
+        accountId,
+        reason,
+        limitType: "session",
+      });
+    },
+    [projectId, accountId, connect, sendUserMessage],
+  );
+
   const handleSendMessage = useCallback(async (): Promise<boolean> => {
     const text = htmlToPlainText(inputValueRef.current).trim();
     if (!text || isSending || !projectId) return false;
@@ -734,6 +757,11 @@ export default function NoveraChatPage(): JSX.Element {
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
               onSolutionWorked={handleSolutionWorked}
+              onRequestTokenIncrease={
+                tokenRequestEnabled
+                  ? () => setIsTokenModalOpen(true)
+                  : undefined
+              }
               onFetchOlder={
                 urlConversationId && hasNextPage && !isFetchingNextPage
                   ? () => fetchNextPage()
@@ -760,6 +788,14 @@ export default function NoveraChatPage(): JSX.Element {
       </Box>
 
       <PiiWarningDialog {...piiGuard.dialogProps} />
+
+      {tokenRequestEnabled && (
+        <TokenRequestModal
+          open={isTokenModalOpen}
+          onClose={() => setIsTokenModalOpen(false)}
+          onSubmit={handleTokenIncreaseSubmit}
+        />
+      )}
     </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -249,7 +249,7 @@ export type ChatWebSocketPayload =
       type: "token_increase_request";
       accountId: string;
       reason: string;
-      period: "daily" | "monthly";
+      limitType: "session" | "monthly";
     };
 
 // Model type for chat WebSocket hook options.

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -524,6 +524,8 @@ export type ChatMessageListProps = {
   onFetchOlder?: () => void;
   isFetchingOlder?: boolean;
   onSolutionWorked?: () => void;
+  /** When provided, usage-limit error bubbles show a "request token increase" CTA. */
+  onRequestTokenIncrease?: () => void;
 };
 
 export type ChatMessageBubbleProps = {
@@ -532,4 +534,6 @@ export type ChatMessageBubbleProps = {
   onThumbsUp?: (messageId: string) => void;
   onThumbsDown?: (messageId: string) => void;
   onSolutionWorked?: () => void;
+  /** When provided, usage-limit error bubbles show a "request token increase" CTA. */
+  onRequestTokenIncrease?: () => void;
 };


### PR DESCRIPTION
Adds a **feature-flagged** flow for requesting a Novera token limit increase, wired into the chat but **off by default** until the backend WebSocket handler is ready.

## Feature flag
`CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED` (runtime, `config.js` / `window.config`, default **false**) — same convention as the other portal flags. Flip in `config.js` to enable; **no rebuild**. Documented in `config.js.example` and typed in `portalConfig.ts`.

## Behaviour (when enabled)
- On a Novera usage/token-limit error bubble, a **"Request a token limit increase"** CTA appears.
- Clicking it opens the existing `TokenRequestModal` (reason field).
- Submitting sends a `token_increase_request` over the **chat WebSocket**:
  ```json
  { "type": "token_increase_request", "accountId": "<accountId>", "reason": "<reason>", "limitType": "session" }
  ```
- `limitType` is always `"session"` per current requirement.

With the flag off (default), nothing renders and no callback is passed — zero behaviour change.

## Notes / open items for backend
- ⚠️ **Payload contract to confirm:** the existing `ChatWebSocketPayload` union had `period: "daily" | "monthly"`; per requirement I changed it to **`limitType: "session" | "monthly"`** and always send `"session"`. Please confirm the WS handler expects `limitType`.
- The backend WebSocket handler for `token_increase_request` is the dependency this flag is gating on.


## Summary by CodeRabbit

* **New Features**
  * Added an optional Novera chatbot flow for requesting a session token-limit increase.
  * Users encountering usage-limit errors can open a request form and submit a reason.
  * The feature is controlled by a runtime setting and remains hidden by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->