### PR TITLE
fix(customer-portal): make last name mandatory when adding a user

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/components/AddUserModal.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/AddUserModal.tsx
@@ -265,7 +265,10 @@ export default function AddUserModal({
     onSubmit,
   ]);
 
-  const isDetailsValid = firstName.trim().length > 0 && email.trim().length > 0;
+  const isDetailsValid =
+    firstName.trim().length > 0 &&
+    lastName.trim().length > 0 &&
+    email.trim().length > 0;
 
   return (
     <Dialog
@@ -397,7 +400,8 @@ export default function AddUserModal({
                   htmlFor="add-user-lastname"
                   sx={{ display: "block", mb: 1, fontSize: "0.875rem" }}
                 >
-                  {ADD_USER_LAST_NAME_LABEL}
+                  {ADD_USER_LAST_NAME_LABEL}{" "}
+                  <span style={{ color: "var(--oxygen-palette-error-main)" }}>*</span>
                 </InputLabel>
                 <Input
                   id="add-user-lastname"


### PR DESCRIPTION
## Problem
In the customer portal **Add User** flow, the **Last Name** field was optional. Salesforce requires a last name, so user creation fails downstream when it's left blank.

## Fix
In `AddUserModal`:
- Added the required `*` indicator to the Last Name label (matching First Name / Email).
- Included `lastName` in `isDetailsValid`, so the **Add** button stays disabled until a last name is entered.

## Validation
- `tsc --noEmit`: 0 errors
- `eslint`: clean
- Existing `AddUserModal` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)