### PR TITLE
[CSM Portal] Add an announcement detail page

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -315,6 +315,10 @@ export default function App(): JSX.Element {
                   />
                   <Route path="time-cards" element={<CsmTimeCardsPage />} />
                   <Route path="announcements" element={<CsmAnnouncementsPage />} />
+                  <Route
+                    path="announcements/:caseId"
+                    element={<CsmCaseDetailPage />}
+                  />
                 </Route>
               </Route>
 

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -40,8 +40,9 @@ import {
 import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import { Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useState, type ChangeEvent, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
-import SemanticChip, { type SemanticRole } from "@components/SemanticChip";
+import SemanticChip from "@components/SemanticChip";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
@@ -50,6 +51,7 @@ import {
   DEFAULT_ANNOUNCEMENT_FILTERS,
   type AnnouncementFilters,
 } from "@features/csm-announcements/types/csmAnnouncements";
+import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 
@@ -68,22 +70,6 @@ const STATE_OPTIONS: { value: CaseState; label: string }[] = (
     "closed",
   ] as CaseState[]
 ).map((s) => ({ value: s, label: STATE_LABEL[s] }));
-
-/**
- * Chip colour for an announcement's lifecycle state — announcement-specific,
- * not the case-state palette (which paints a closed case green). Here an Open
- * announcement is live/published → green, a Closed one is inactive → grey.
- */
-function announcementStateRole(state?: CaseState): SemanticRole {
-  switch (state) {
-    case "open":
-      return "success";
-    case "closed":
-      return "default";
-    default:
-      return "info";
-  }
-}
 
 function formatDate(value?: string | null): string {
   return (
@@ -260,7 +246,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
             <TableHead>
               <TableRow sx={{ bgcolor: "action.hover" }}>
                 <TableCell>Number</TableCell>
-                <TableCell>Subject</TableCell>
+                <TableCell sx={{ width: "28%" }}>Subject</TableCell>
                 <TableCell>Project</TableCell>
                 <TableCell>State</TableCell>
                 <TableCell>Created by</TableCell>
@@ -298,22 +284,55 @@ export default function CsmAnnouncementsPage(): JSX.Element {
                 </TableRow>
               ) : (
                 announcements.map((a) => (
-                  <TableRow key={a.id} hover>
+                  // A real anchor (not a click-handler row) so it supports
+                  // cmd/middle-click "open in new tab" and exposes a copyable
+                  // URL — same rationale as CasesList's row links (ISSU-031).
+                  <TableRow
+                    key={a.id}
+                    hover
+                    component={RouterLink}
+                    to={`/announcements/${a.id}`}
+                    sx={{
+                      cursor: "pointer",
+                      textDecoration: "none",
+                      color: "inherit",
+                      "&:focus-visible": {
+                        outline: (t) => `2px solid ${t.palette.primary.main}`,
+                        outlineOffset: -2,
+                      },
+                    }}
+                  >
                     <TableCell>{a.number || "—"}</TableCell>
-                    <TableCell>{a.subject}</TableCell>
+                    <TableCell sx={{ width: "28%" }}>
+                      <Typography
+                        variant="body2"
+                        title={a.subject}
+                        sx={{
+                          display: "-webkit-box",
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: "vertical",
+                          overflow: "hidden",
+                        }}
+                      >
+                        {a.subject}
+                      </Typography>
+                    </TableCell>
                     <TableCell>{a.projectName}</TableCell>
                     <TableCell>
                       {a.state ? (
                         <SemanticChip
                           role={announcementStateRole(a.state)}
                           label={STATE_LABEL[a.state] ?? a.state}
+                          variant="outlined"
                         />
                       ) : (
                         "—"
                       )}
                     </TableCell>
                     <TableCell>{a.createdBy || "—"}</TableCell>
-                    <TableCell>{formatDate(a.updatedAt)}</TableCell>
+                    <TableCell sx={{ whiteSpace: "nowrap" }}>
+                      {formatDate(a.updatedAt)}
+                    </TableCell>
                   </TableRow>
                 ))
               )}

--- a/apps/csm-portal/webapp/src/features/csm-announcements/utils/announcementState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/utils/announcementState.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { SemanticRole } from "@components/SemanticChip";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
+
+/**
+ * Chip colour for an announcement's lifecycle state — announcement-specific,
+ * not the case-state palette (which paints a closed case green). Here an Open
+ * announcement is live/published → green, a Closed one is inactive → grey.
+ * Shared by the announcements list and the announcement detail page's
+ * Overview band so the same state reads the same colour in both places.
+ */
+export function announcementStateRole(state?: CaseState): SemanticRole {
+  switch (state) {
+    case "open":
+      return "success";
+    case "closed":
+      return "default";
+    default:
+      return "info";
+  }
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -23,6 +23,8 @@ import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import SemanticChip from "@components/SemanticChip";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
 import type { BeDeploymentType } from "@api/backend/types";
+import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
+import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
@@ -33,9 +35,14 @@ interface CaseMetaBandProps {
 function Cell({
   label,
   children,
+  maxWidth,
 }: {
   label: string;
   children: ReactNode;
+  /** Caps the cell's width so long values (account/project names) still
+   * truncate via `noWrap` when the cell sizes to its content instead of
+   * stretching across a grid track — see the announcement flex row below. */
+  maxWidth?: number | string;
 }): JSX.Element {
   return (
     <Box
@@ -44,6 +51,7 @@ function Cell({
         flexDirection: "column",
         gap: 0.25,
         minWidth: 0,
+        ...(maxWidth !== undefined ? { maxWidth } : {}),
       }}
     >
       <Typography
@@ -168,6 +176,10 @@ export default function CaseMetaBand({
   const product = c.productContext;
   const tier = c.customerContext.tier;
   const [showDeployment, setShowDeployment] = useState(false);
+  // Deployment/product/assignee are support-workflow facts (which environment,
+  // who's triaging it) that don't apply to a read-only announcement broadcast —
+  // mirrors the hidden SLA/time-tracking/call-request tabs and action bar.
+  const isAnnouncement = c.caseType === "announcement";
   // Project type is encoded as the second " - "-delimited segment of the
   // project name (e.g. "Acme - Managed Cloud" → "Managed Cloud"). Temporary
   // until the backend exposes it as a first-class field.
@@ -227,25 +239,33 @@ export default function CaseMetaBand({
       </Box>
       {!collapsed && (
         <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: {
-              // `minmax(0, 1fr)` everywhere: a plain `1fr` track's implicit
-              // minimum is content-based ("auto"), so a long value in one
-              // cell pushes into its neighbour instead of truncating.
-              xs: "repeat(2, minmax(0, 1fr))",
-              sm: "repeat(3, minmax(0, 1fr))",
-              md: "repeat(4, minmax(0, 1fr))",
-            },
-            gap: 2,
-            px: 2,
-            pb: 2,
-            pt: 0.5,
-            borderTop: 1,
-            borderColor: "divider",
-          }}
+          sx={[
+            { px: 2, pb: 2, pt: 0.5, borderTop: 1, borderColor: "divider" },
+            isAnnouncement
+              ? // Announcements only ever show 5 cells (Account, Tier,
+                // Project, Project type, State). A flex row lets each cell
+                // size to its content instead of stretching across a
+                // 1/5-width grid track (which concentrated all the slack
+                // into one gap before the last cell); `space-between` then
+                // spreads that same slack evenly across the full row width,
+                // with `gap` as the floor once cells wrap on narrow screens.
+                { display: "flex", flexWrap: "wrap", justifyContent: "space-between", gap: 4 }
+              : {
+                  display: "grid",
+                  // `minmax(0, 1fr)` everywhere: a plain `1fr` track's
+                  // implicit minimum is content-based ("auto"), so a long
+                  // value in one cell pushes into its neighbour instead of
+                  // truncating.
+                  gridTemplateColumns: {
+                    xs: "repeat(2, minmax(0, 1fr))",
+                    sm: "repeat(3, minmax(0, 1fr))",
+                    md: "repeat(4, minmax(0, 1fr))",
+                  },
+                  gap: 2,
+                },
+          ]}
         >
-          <Cell label="Account">
+          <Cell label="Account" maxWidth={isAnnouncement ? 240 : undefined}>
             {c.accountId ? (
               <LinkText to={`/customers/accounts/${c.accountId}`}>
                 {c.customer}
@@ -261,7 +281,7 @@ export default function CaseMetaBand({
               <SemanticChip role={tierColor(tier)} variant="outlined" label={tierLabel(tier)} />
             </Box>
           </Cell>
-          <Cell label="Project">
+          <Cell label="Project" maxWidth={isAnnouncement ? 240 : undefined}>
             {c.projectId ? (
               <LinkText to={`/customers/projects/${c.projectId}`}>
                 {c.projectName}
@@ -277,36 +297,51 @@ export default function CaseMetaBand({
               {projectType}
             </Typography>
           </Cell>
-          <Cell label="Deployment">
-            {product.deploymentId ? (
-              <LinkButton onClick={() => setShowDeployment(true)}>
-                {product.deployment}
-              </LinkButton>
-            ) : (
-              <Typography variant="body2" noWrap>
-                {product.deployment ?? "—"}
-              </Typography>
-            )}
-          </Cell>
-          <Cell label="Product">
-            <Typography variant="body2" noWrap>
-              {product.product ?? "—"}
-            </Typography>
-          </Cell>
-          <Cell label="Created by">
-            <Typography variant="body2" noWrap>
-              {c.createdBy ?? c.customerContext.primaryContact ?? "—"}
-            </Typography>
-          </Cell>
-          <Cell label="Assignee">
-            <Typography variant="body2" noWrap>
-              {c.assigneeIsMe ? (
-                <strong>{c.assignee}</strong>
-              ) : (
-                c.assignee
-              )}
-            </Typography>
-          </Cell>
+          {isAnnouncement && (
+            <Cell label="State">
+              <Box sx={{ minWidth: 0 }}>
+                <SemanticChip
+                  role={announcementStateRole(c.state)}
+                  label={STATE_LABEL[c.state] ?? c.state}
+                  variant="outlined"
+                />
+              </Box>
+            </Cell>
+          )}
+          {!isAnnouncement && (
+            <>
+              <Cell label="Deployment">
+                {product.deploymentId ? (
+                  <LinkButton onClick={() => setShowDeployment(true)}>
+                    {product.deployment}
+                  </LinkButton>
+                ) : (
+                  <Typography variant="body2" noWrap>
+                    {product.deployment ?? "—"}
+                  </Typography>
+                )}
+              </Cell>
+              <Cell label="Product">
+                <Typography variant="body2" noWrap>
+                  {product.product ?? "—"}
+                </Typography>
+              </Cell>
+              <Cell label="Created by">
+                <Typography variant="body2" noWrap>
+                  {c.createdBy ?? c.customerContext.primaryContact ?? "—"}
+                </Typography>
+              </Cell>
+              <Cell label="Assignee">
+                <Typography variant="body2" noWrap>
+                  {c.assigneeIsMe ? (
+                    <strong>{c.assignee}</strong>
+                  ) : (
+                    c.assignee
+                  )}
+                </Typography>
+              </Cell>
+            </>
+          )}
         </Box>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -258,21 +258,28 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const location = useLocation();
   const isEngagementRoute = location.pathname.startsWith("/engagements/");
   const isServiceRequestRoute = location.pathname.startsWith("/operations/service-requests/");
+  const isAnnouncementRoute = location.pathname.startsWith("/announcements/");
   const backPath = isEngagementRoute
     ? "/engagements"
     : isServiceRequestRoute
       ? "/operations?tab=service_requests"
-      : "/cases";
+      : isAnnouncementRoute
+        ? "/announcements"
+        : "/cases";
   const backLabel = isEngagementRoute
     ? "Back to engagements"
     : isServiceRequestRoute
       ? "Back to service requests"
-      : "Back to cases";
+      : isAnnouncementRoute
+        ? "Back to announcements"
+        : "Back to cases";
   const detailPath = isEngagementRoute
     ? `/engagements/${caseId}`
     : isServiceRequestRoute
       ? `/operations/service-requests/${caseId}`
-      : `/cases/${caseId}`;
+      : isAnnouncementRoute
+        ? `/announcements/${caseId}`
+        : `/cases/${caseId}`;
   const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
   const {
     data: comments,
@@ -310,8 +317,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // Fetched unconditionally (not just while their tab is active) purely for
   // the tab-label counts below; each widget still runs its own scoped query
   // when its tab mounts, deduped against this one by react-query's cache.
-  const { data: slaList } = useGetCsmCaseSlas(caseId);
-  const { data: callRequests } = useGetCsmCaseCallRequests(caseId);
+  // Skipped for announcements (undefined caseId disables the query) since
+  // neither tab is shown there.
+  const { data: slaList } = useGetCsmCaseSlas(
+    isAnnouncementRoute ? undefined : caseId,
+  );
+  const { data: callRequests } = useGetCsmCaseCallRequests(
+    isAnnouncementRoute ? undefined : caseId,
+  );
   // Live deployment lookup for the Details tab's "Deployment info" widget —
   // only runs when the case actually has a deployment link (SN-sourced cases
   // may have none). Reuses the project's deployment list rather than a
@@ -1117,7 +1130,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               distinct from the free-form tags by a divider, so the current
               state doesn't get lost among the tag chips. */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-            {c.caseType && CASE_TYPE_LABEL[c.caseType] && (
+            {!isAnnouncementRoute && c.caseType && CASE_TYPE_LABEL[c.caseType] && (
               <Chip
                 size="small"
                 variant="outlined"
@@ -1125,9 +1138,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 sx={{ fontWeight: 600 }}
               />
             )}
-            <SeverityChip severity={c.severity} withLabel />
-            <StateChip state={c.state} />
-            {relatedCase && (
+            {!isAnnouncementRoute && <SeverityChip severity={c.severity} withLabel />}
+            {!isAnnouncementRoute && <StateChip state={c.state} />}
+            {!isAnnouncementRoute && relatedCase && (
               <Chip
                 size="small"
                 variant="outlined"
@@ -1138,7 +1151,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 sx={{ fontWeight: 600 }}
               />
             )}
-            {c.state === "work_in_progress" && c.workState && (
+            {!isAnnouncementRoute && c.state === "work_in_progress" && c.workState && (
               <Chip
                 size="small"
                 variant="outlined"
@@ -1147,24 +1160,27 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 sx={{ fontWeight: 600 }}
               />
             )}
-            {c.tags.length > 0 && (
+            {!isAnnouncementRoute && c.tags.length > 0 && (
               <Divider orientation="vertical" flexItem sx={{ mx: 0.5, my: 0.25 }} />
             )}
-            {c.tags.map((t) => (
-              <Chip
-                key={t.id}
-                size="small"
-                variant="outlined"
-                color={t.color ?? "default"}
-                label={t.label}
-              />
-            ))}
+            {!isAnnouncementRoute &&
+              c.tags.map((t) => (
+                <Chip
+                  key={t.id}
+                  size="small"
+                  variant="outlined"
+                  color={t.color ?? "default"}
+                  label={t.label}
+                />
+              ))}
           </Box>
           <Typography variant="h5">{c.subject}</Typography>
         </Box>
-        <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
-          <CaseActionBar caseDetail={c} onAction={onAction} />
-        </Box>
+        {!isAnnouncementRoute && (
+          <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
+            <CaseActionBar caseDetail={c} onAction={onAction} />
+          </Box>
+        )}
       </Box>
 
       <CaseMetaBand
@@ -1209,7 +1225,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
           variant="scrollable"
           scrollButtons="auto"
         >
-          {TAB_DEFS.map((t) => {
+          {TAB_DEFS.filter(
+            (t) =>
+              !isAnnouncementRoute ||
+              (t.id !== "sla" && t.id !== "time" && t.id !== "call-requests"),
+          ).map((t) => {
             // Counts shown only where the tab IS the list (unambiguous).
             const count =
               t.id === "sla"
@@ -1244,7 +1264,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
               The composer is always available (an internal work note can be
               added in any state); the public-reply path is gated inside it via
               `publicReplyGateReason` when the case isn't in-progress/ongoing. */}
-          {composerOpen ? (
+          {/* Announcements are read-only broadcasts — no reply/work-note
+              composer, matching the hidden CaseActionBar (no patch ops). */}
+          {isAnnouncementRoute ? null : composerOpen ? (
             <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Box
                 sx={{

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -281,6 +281,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
         ? `/announcements/${caseId}`
         : `/cases/${caseId}`;
   const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
+  // The route alone isn't a reliable signal once data has loaded: a "Related
+  // case" link always points at /cases/:id regardless of the target's actual
+  // type, so an announcement opened that way would otherwise render the full
+  // case UI. Combine the route with the loaded case's own caseType.
+  const isAnnouncement = isAnnouncementRoute || data?.caseType === "announcement";
   const {
     data: comments,
     isLoading: isCommentsLoading,
@@ -320,10 +325,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // Skipped for announcements (undefined caseId disables the query) since
   // neither tab is shown there.
   const { data: slaList } = useGetCsmCaseSlas(
-    isAnnouncementRoute ? undefined : caseId,
+    isAnnouncement ? undefined : caseId,
   );
   const { data: callRequests } = useGetCsmCaseCallRequests(
-    isAnnouncementRoute ? undefined : caseId,
+    isAnnouncement ? undefined : caseId,
   );
   // Live deployment lookup for the Details tab's "Deployment info" widget —
   // only runs when the case actually has a deployment link (SN-sourced cases
@@ -416,6 +421,18 @@ export default function CsmCaseDetailPage(): JSX.Element {
     setGithubIssueResult(null);
     setPendingDelete(null);
     setPauseConflict(null);
+  }
+
+  // isAnnouncement can only be confirmed once `data` loads (see its
+  // definition above) — if a case reached via /cases/:id turns out to be an
+  // announcement and the active tab is one hidden for announcements, fall
+  // back to Activities. Same render-time adjustment pattern as the reset
+  // above rather than an effect, to avoid an extra render pass.
+  if (
+    isAnnouncement &&
+    (activeTab === "sla" || activeTab === "time" || activeTab === "call-requests")
+  ) {
+    setActiveTab("activities");
   }
 
   // Twitter-style permalinks: when the URL has a fragment matching an entry id,
@@ -1130,7 +1147,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               distinct from the free-form tags by a divider, so the current
               state doesn't get lost among the tag chips. */}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-            {!isAnnouncementRoute && c.caseType && CASE_TYPE_LABEL[c.caseType] && (
+            {!isAnnouncement && c.caseType && CASE_TYPE_LABEL[c.caseType] && (
               <Chip
                 size="small"
                 variant="outlined"
@@ -1138,9 +1155,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 sx={{ fontWeight: 600 }}
               />
             )}
-            {!isAnnouncementRoute && <SeverityChip severity={c.severity} withLabel />}
-            {!isAnnouncementRoute && <StateChip state={c.state} />}
-            {!isAnnouncementRoute && relatedCase && (
+            {!isAnnouncement && <SeverityChip severity={c.severity} withLabel />}
+            {!isAnnouncement && <StateChip state={c.state} />}
+            {!isAnnouncement && relatedCase && (
               <Chip
                 size="small"
                 variant="outlined"
@@ -1151,7 +1168,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 sx={{ fontWeight: 600 }}
               />
             )}
-            {!isAnnouncementRoute && c.state === "work_in_progress" && c.workState && (
+            {!isAnnouncement && c.state === "work_in_progress" && c.workState && (
               <Chip
                 size="small"
                 variant="outlined"
@@ -1160,10 +1177,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 sx={{ fontWeight: 600 }}
               />
             )}
-            {!isAnnouncementRoute && c.tags.length > 0 && (
+            {!isAnnouncement && c.tags.length > 0 && (
               <Divider orientation="vertical" flexItem sx={{ mx: 0.5, my: 0.25 }} />
             )}
-            {!isAnnouncementRoute &&
+            {!isAnnouncement &&
               c.tags.map((t) => (
                 <Chip
                   key={t.id}
@@ -1176,7 +1193,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           </Box>
           <Typography variant="h5">{c.subject}</Typography>
         </Box>
-        {!isAnnouncementRoute && (
+        {!isAnnouncement && (
           <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
             <CaseActionBar caseDetail={c} onAction={onAction} />
           </Box>
@@ -1227,7 +1244,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         >
           {TAB_DEFS.filter(
             (t) =>
-              !isAnnouncementRoute ||
+              !isAnnouncement ||
               (t.id !== "sla" && t.id !== "time" && t.id !== "call-requests"),
           ).map((t) => {
             // Counts shown only where the tab IS the list (unambiguous).
@@ -1266,7 +1283,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               `publicReplyGateReason` when the case isn't in-progress/ongoing. */}
           {/* Announcements are read-only broadcasts — no reply/work-note
               composer, matching the hidden CaseActionBar (no patch ops). */}
-          {isAnnouncementRoute ? null : composerOpen ? (
+          {isAnnouncement ? null : composerOpen ? (
             <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Box
                 sx={{


### PR DESCRIPTION
## Purpose
Announcements had no detail page — the list only showed subject/state/project, with no way to view the full description, follow-up comments, or attachments on an announcement.

## Goals
Give announcements a details page similar to cases, including attachments.

## Approach
Reuse the shared `CsmCaseDetailPage` component (already reused by Engagements and Service Requests) via a new `/announcements/:caseId` route, trimmed down to a read-only view for announcements:
- Hide the SLA / Time tracking / Call requests tabs (and skip their now-unused fetches) — none apply to a broadcast.
- Hide the lifecycle action bar (no patch operations) and the reply/work-note composer (no commenting) — announcements are read-only.
- Overview band shows a State chip (green = open/live, grey = closed, matching the list) instead of the header's case-specific chips (severity, related case, work state, tags), and drops Deployment/Product/Assignee since they're support-workflow facts that don't apply. Laid out as a single full-width row for the 5 remaining fields.
- Extracted `announcementStateRole` into a shared util (`csm-announcements/utils/announcementState.ts`) so the list and the new detail page's Overview render the same state colour.

Also tidied up the Announcements list itself: rows are now clickable as real anchors (whole row, not just the subject) so cmd/middle-click "open in new tab" and copyable URLs work, same rationale as the Cases list. State chip is outlined, the Updated column stays single-line, and Subject is clamped to 2 lines with a reduced column width now that it's the click target.

## User stories
As a CSM engineer, I can click an announcement to see its full description, follow-up comments, and attachments, without patch/comment actions that don't apply to a read-only broadcast.

## Release note
Announcements now have a details page (description, activity/comments, attachments), reached by clicking a row in the Announcements list.

## Documentation
N/A — in-app UI change only, no separate product documentation impact.

## Automation tests
 - Unit tests
   > No new test file added; the detail page inherits `CsmCaseDetailPage`'s existing coverage. Pre-existing `CsmAnnouncementsPage.test.tsx` still covers the list.
 - Integration tests
   > Manually verified locally (Vite dev server against the staging backend): row navigation to the new detail route, tab visibility (SLA/Time tracking/Call requests hidden), action bar and composer hidden, Overview band layout and State chip.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React frontend change, no Java code)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Local Vite dev server against the staging backend, Chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated announcement detail pages, navigable from announcement rows to `/announcements/:caseId`.
  * Announcement details now use announcement-specific navigation and show a tailored, read-only layout (including state presentation).
* **Improvements**
  * Announcement rows are fully clickable with better keyboard navigation and focus styling.
  * Announcement table subjects are clamped for readability; state chips render with consistent outlined styling.
  * On announcement details, SLA/time/call-request tabs and related actions are hidden, and the reply/composer is suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->