### PR TITLE
fix(customer-portal): show token-request CTA on limit notice messages

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -159,6 +159,21 @@ export default function ChatMessageBubble({
       : "Something went wrong"
     : message.text;
 
+  /**
+   * Token-limit signal that warrants offering a "request an increase" CTA.
+   * The limit is often delivered as a normal assistant notice (e.g. "you've
+   * reached your session token limit"), not an error bubble — so we detect it
+   * on regular messages too. The narrower pattern (no bare credit/billing/quota)
+   * avoids false positives on normal messages that merely mention those words.
+   */
+  const isTokenLimitNotice =
+    !!message.text && /token limit|usage limit|rate limit/i.test(message.text);
+  const showTokenRequestCta =
+    !!onRequestTokenIncrease &&
+    !message.isStreaming &&
+    ((message.isError && isUsageLimitError) ||
+      (!message.isError && isTokenLimitNotice));
+
   /** Until the final assistant message, hide thumbs and timestamp only (header stays). */
   const hideFeedbackRow =
     !message.isError &&
@@ -317,22 +332,9 @@ export default function ChatMessageBubble({
           {/* Message content */}
           <Box>
             {message.isError ? (
-              <>
-                <Typography variant="body2" color="error.main">
-                  {displayText}
-                </Typography>
-                {isUsageLimitError && onRequestTokenIncrease && (
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    color="warning"
-                    onClick={onRequestTokenIncrease}
-                    sx={{ mt: 1, textTransform: "none" }}
-                  >
-                    Request a token limit increase
-                  </Button>
-                )}
-              </>
+              <Typography variant="body2" color="error.main">
+                {displayText}
+              </Typography>
             ) : showThinkingStreamFrame ? (
               <Paper
                 sx={(t) => ({
@@ -423,6 +425,20 @@ export default function ChatMessageBubble({
               </Box>
             )}
           </Box>
+
+          {showTokenRequestCta && (
+            <Box sx={{ mt: 1 }}>
+              <Button
+                size="small"
+                variant="outlined"
+                color="warning"
+                onClick={onRequestTokenIncrease}
+                sx={{ textTransform: "none" }}
+              >
+                Request a token limit increase
+              </Button>
+            </Box>
+          )}
         </Stack>
       </Stack>
 


### PR DESCRIPTION
Follow-up to the token-request feature (#1163, now merged).

## Problem
The session-token-limit message from Novera arrives as a **normal assistant message** (`isError: false`) — e.g. *"I'm sorry, it seems you've reached your session token limit for today…"* — not a red error bubble. The "Request a token limit increase" CTA was gated on `message.isError`, so it never appeared on the exact message that signals the limit.

## Fix
In `ChatMessageBubble`:
- Detect the token-limit **notice** on normal messages too (`/token limit|usage limit|rate limit/i`), deliberately excluding bare `credit/billing/quota` to avoid false positives on normal messages mentioning those words.
- Render a single **"Request a token limit increase"** CTA below the message content for both the notice (normal) and error cases (`showTokenRequestCta`), instead of only inside the error branch.

Still behind the `CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED` flag (default off).

## Validation
- `tsc --noEmit`: 0 errors
- `eslint`: clean
- Verified locally: the CTA now renders under the "reached your session token limit" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Request a token limit increase” option to applicable assistant messages, including usage-limit notices and regular token or rate-limit notifications.
  * The request option is hidden while a message is still streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->