### PR TITLE
[Customer Portal Webapp] Show comments on announcement details page

### DIFF
--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementActivityPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementActivityPanel.tsx
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Avatar,
+  Box,
+  Button,
+  Divider,
+  Paper,
+  Skeleton,
+  Stack,
+  Typography,
+  alpha,
+  useTheme,
+} from "@wso2/oxygen-ui";
+import DOMPurify from "dompurify";
+import { useMemo, type JSX } from "react";
+import useGetCaseCommentsInfinite from "@features/support/api/useGetCaseCommentsInfinite";
+import type { CaseComment } from "@features/support/types/cases";
+import {
+  compareByCreatedOnThenId,
+  convertCodeTagsToHtml,
+  formatCommentDate,
+  getInitials,
+  hasDisplayableContent,
+  hasSingleCodeWrapper,
+  INLINE_COMMENT_HTML_PURIFY,
+  stripAllCodeBlocks,
+  stripCodeWrapper,
+  stripCustomerCommentAddedLabel,
+  trimLeadingBr,
+} from "@features/support/utils/support";
+import ApiErrorState from "@components/error/ApiErrorState";
+import { stripLightModeInlineStyles } from "@/utils/common";
+import { useDarkMode } from "@utils/useDarkMode";
+import {
+  ANNOUNCEMENT_COMMENTS_ERROR_MESSAGE,
+  ANNOUNCEMENT_COMMENTS_LOADING_LABEL,
+  ANNOUNCEMENT_COMMENTS_LOAD_MORE_LABEL,
+} from "@features/announcements/constants/announcementsConstants";
+
+type AnnouncementActivityPanelProps = {
+  projectId: string;
+  caseId: string;
+};
+
+function commentAuthorDisplayName(comment: CaseComment): string {
+  if (comment.createdByFullName?.trim()) {
+    return comment.createdByFullName.trim();
+  }
+  return comment.createdBy?.trim() || "Unknown";
+}
+
+function sanitizeCommentContent(content: string, isDarkMode: boolean): string {
+  const rawContent = content ?? "";
+  const isFullCodeWrap = hasSingleCodeWrapper(rawContent);
+  const codeBlockCount = (rawContent.match(/\[code\]/gi) ?? []).length;
+  const afterCode = isFullCodeWrap
+    ? stripCodeWrapper(rawContent)
+    : codeBlockCount > 1
+      ? stripAllCodeBlocks(rawContent)
+      : convertCodeTagsToHtml(rawContent);
+  const trimmedBr = trimLeadingBr(afterCode);
+  const withoutLabel = stripCustomerCommentAddedLabel(trimmedBr);
+  const darkModeHtml = isDarkMode
+    ? stripLightModeInlineStyles(withoutLabel)
+    : withoutLabel;
+  return DOMPurify.sanitize(darkModeHtml, INLINE_COMMENT_HTML_PURIFY);
+}
+
+/**
+ * AnnouncementActivityPanel shows the latest comments for an announcement (case),
+ * newest first, with each comment rendered as its own card matching the description card style.
+ *
+ * @param props - projectId and caseId of the announcement to fetch comments for.
+ * @returns {JSX.Element | null} The rendered comments section, or null when there is nothing to show.
+ */
+export default function AnnouncementActivityPanel({
+  projectId,
+  caseId,
+}: AnnouncementActivityPanelProps): JSX.Element | null {
+  const isDarkMode = useDarkMode();
+  const theme = useTheme();
+
+  const {
+    data: commentsData,
+    isLoading,
+    isError,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useGetCaseCommentsInfinite(projectId, caseId);
+
+  const commentsToShow = useMemo(() => {
+    const comments = commentsData?.pages?.flatMap((page) => page.comments) ?? [];
+    return comments
+      .filter((comment) => comment.type?.toLowerCase() !== "attachment")
+      .filter(hasDisplayableContent)
+      .sort((a, b) => -compareByCreatedOnThenId(a, b));
+  }, [commentsData?.pages]);
+
+  if (!isLoading && !isError && commentsToShow.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {isLoading ? (
+        <Stack spacing={2}>
+          {[1, 2].map((i) => (
+            <Paper
+              key={i}
+              variant="outlined"
+              elevation={0}
+              sx={{ p: 4, display: "flex", flexDirection: "column", gap: 1 }}
+            >
+              <Skeleton width="30%" height={20} />
+              <Skeleton width="100%" height={48} sx={{ mt: 1 }} variant="rounded" />
+            </Paper>
+          ))}
+        </Stack>
+      ) : isError ? (
+        <ApiErrorState
+          error={error}
+          fallbackMessage={ANNOUNCEMENT_COMMENTS_ERROR_MESSAGE}
+        />
+      ) : (
+        <Stack divider={<Divider />} spacing={2}>
+          {commentsToShow.map((comment) => (
+            <Stack
+              key={comment.id}
+              direction="row"
+              alignItems="flex-start"
+              spacing={1.5}
+            >
+              <Avatar
+                sx={{
+                  width: 28,
+                  height: 28,
+                  fontSize: "0.7rem",
+                  flexShrink: 0,
+                  bgcolor: alpha(theme.palette.info?.light ?? "#0288d1", 0.2),
+                  color: theme.palette.info?.main ?? "#0288d1",
+                }}
+              >
+                {getInitials(commentAuthorDisplayName(comment))}
+              </Avatar>
+              <Stack sx={{ minWidth: 0, flex: 1, gap: 1 }}>
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  flexWrap="wrap"
+                  sx={{ gap: 1 }}
+                >
+                  <Typography variant="body2" color="text.primary" fontWeight={500}>
+                    {commentAuthorDisplayName(comment)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatCommentDate(comment.createdOn)}
+                  </Typography>
+                </Stack>
+                <Paper
+                  variant="outlined"
+                  elevation={0}
+                  component="div"
+                  sx={{
+                    typography: "body2",
+                    color: "text.primary",
+                    bgcolor: "background.paper",
+                    borderRadius: 1,
+                    p: 1.5,
+                    maxWidth: "100%",
+                    overflowX: "auto",
+                    "& p": { mb: 0.5 },
+                    "& p:last-child": { mb: 0 },
+                    "& img": {
+                      maxWidth: "100%",
+                      height: "auto",
+                      borderRadius: 1,
+                      display: "block",
+                    },
+                  }}
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized with DOMPurify
+                  dangerouslySetInnerHTML={{
+                    __html: sanitizeCommentContent(comment.content, isDarkMode),
+                  }}
+                />
+              </Stack>
+            </Stack>
+          ))}
+        </Stack>
+      )}
+
+      {hasNextPage && (
+        <Button
+          variant="text"
+          size="small"
+          onClick={() => void fetchNextPage()}
+          disabled={isFetchingNextPage}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          {isFetchingNextPage
+            ? ANNOUNCEMENT_COMMENTS_LOADING_LABEL
+            : ANNOUNCEMENT_COMMENTS_LOAD_MORE_LABEL}
+        </Button>
+      )}
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementActivityPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementActivityPanel.tsx
@@ -113,7 +113,12 @@ export default function AnnouncementActivityPanel({
       .sort((a, b) => -compareByCreatedOnThenId(a, b));
   }, [commentsData?.pages]);
 
-  if (!isLoading && !isError && commentsToShow.length === 0) {
+  if (
+    !isLoading &&
+    !isError &&
+    commentsToShow.length === 0 &&
+    !hasNextPage
+  ) {
     return null;
   }
 

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -33,6 +33,7 @@ import {
   resolveColorFromTheme,
 } from "@features/support/utils/support";
 import ApiErrorState from "@components/error/ApiErrorState";
+import AnnouncementActivityPanel from "@features/announcements/components/AnnouncementActivityPanel";
 import type { AnnouncementDetailsPanelProps } from "@features/announcements/types/announcements";
 import {
   ANNOUNCEMENT_DETAILS_BODY_EMPTY,
@@ -241,6 +242,11 @@ export default function AnnouncementDetailsPanel({
           )}
         </Stack>
       </Paper>
+
+      {projectId && caseId && (
+        <AnnouncementActivityPanel projectId={projectId} caseId={caseId} />
+      )}
+
       <Paper
         variant="outlined"
         elevation={0}

--- a/apps/customer-portal/webapp/src/features/announcements/constants/announcementsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/announcements/constants/announcementsConstants.ts
@@ -99,3 +99,15 @@ export const ANNOUNCEMENTS_EMPTY_STATE_ICON_MAX_WIDTH_PX = 200;
 
 /** Empty-state illustration bottom margin (px). */
 export const ANNOUNCEMENTS_EMPTY_STATE_ICON_MARGIN_BOTTOM_PX = 16;
+
+/** Comments panel: section heading. */
+export const ANNOUNCEMENT_COMMENTS_HEADING = "Comments";
+
+/** Comments panel: error fallback message. */
+export const ANNOUNCEMENT_COMMENTS_ERROR_MESSAGE = "Could not load comments.";
+
+/** Comments panel: label shown on "load more" button while fetching. */
+export const ANNOUNCEMENT_COMMENTS_LOADING_LABEL = "Loading...";
+
+/** Comments panel: "load more" button label. */
+export const ANNOUNCEMENT_COMMENTS_LOAD_MORE_LABEL = "Load more";


### PR DESCRIPTION
### Summary

- Wires up `AnnouncementActivityPanel` on the announcement details view, displaying the latest comments for an announcement fetched via the existing `useGetCaseCommentsInfinite` hook (reusing the cases/comments API — no new endpoint needed).
- Comments are shown above the Description card, newest first, with pagination via a "Load more" button.
- Added missing `ANNOUNCEMENT_COMMENTS_* ` label constants required by the panel.
- Restyled comment rows to a flatter layout (small avatar, name + date inline, thin-bordered content box, divider-separated) instead of heavy bordered cards, and removed the "Comments" section heading per feedback.

### Test plan

-  Open an announcement with existing comments and confirm they render above the description, newest first
-  Confirm loading skeleton and error states display correctly
-  Confirm "Load more" pagination works for announcements with >10 comments
-  Confirm the panel hides entirely when there are no comments
-  Verify layout in both light and dark mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Comments” section to the announcement details view.
  - Fetches and displays case comments in a clean, newest-first list with author and timestamp.
  - Includes loading and error states, plus a “Load more” control for additional comments.
  - Excludes attachment-only entries and safely renders comment content with sanitized HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->