### PR TITLE
[CSM Portal] Add incident editing (classification, state, assignment)

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1715,6 +1715,51 @@ export interface BeCreateIncidentResponse {
   };
 }
 
+/**
+ * `PATCH /incidents/{id}` body (ServiceNow data source only,
+ * `minProperties: 1`). Covers the in-scope subset the Edit dialog sends —
+ * the full `UpdateIncidentPayload` schema also documents `incidentReport` /
+ * `resolvedById`, deliberately left out here since there's no read-side
+ * model for them yet either (see {@link BeIncidentDetail}). `resolutionCode`
+ * / `resolutionNotes` ARE included (write-only, same as `incidentReport` —
+ * `IncidentDetail` never echoes them back on read) since ServiceNow requires
+ * them to move an incident to `RESOLVED`/`CLOSED` (confirmed live: those two
+ * state values 500 without them).
+ */
+export interface BeUpdateIncidentPayload {
+  subject?: string;
+  category?: BeIncidentCategory;
+  subcategory?: BeIncidentSubcategory;
+  contactType?: BeIncidentContactType;
+  impact?: BeIncidentImpact;
+  urgency?: BeIncidentUrgency;
+  state?: BeIncidentState;
+  resolutionCode?: string;
+  resolutionNotes?: string;
+  // Reference/note fields are `nullable: true` on the documented schema — the
+  // portal sends an explicit `null` to clear one (e.g. unassign an engineer),
+  // as distinct from omitting the field entirely, which the BE treats as
+  // "leave unchanged".
+  serviceId?: string | null;
+  serviceOfferingId?: string | null;
+  configurationItemId?: string | null;
+  assignmentGroupId?: string | null;
+  assignedEngineerId?: string | null;
+  watchList?: string[];
+  workNotes?: string | null;
+  additionalComments?: string | null;
+  parentId?: string | null;
+  changeRequestId?: string | null;
+  problemId?: string | null;
+  causedById?: string | null;
+}
+
+/** `PATCH /incidents/{id}` response — the full updated incident. */
+export interface BePatchIncidentResponse {
+  message: string;
+  incident: BeIncidentDetail;
+}
+
 export interface BeIncidentSearchPayload {
   filters?: {
     searchQuery?: string;

--- a/apps/csm-portal/webapp/src/components/AsyncEntityMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/components/AsyncEntityMultiSelect.tsx
@@ -41,6 +41,11 @@ export interface AsyncEntityMultiSelectProps<T> {
   };
   getId: (item: T) => string;
   getLabel: (item: T) => string;
+  /** Labels for `values` that didn't come from a search this component ran
+   * itself (e.g. pre-filled from another source, like an incident's existing
+   * watch list) — shown until a real search result for the same id replaces
+   * them. Same purpose as `AsyncEntitySelect`'s `knownLabel`, plural. */
+  knownLabels?: Record<string, string>;
 }
 
 /**
@@ -61,6 +66,7 @@ export default function AsyncEntityMultiSelect<T>({
   useSearch,
   getId,
   getLabel,
+  knownLabels,
 }: AsyncEntityMultiSelectProps<T>): JSX.Element {
   const [searchTerm, setSearchTerm] = useState("");
   const [open, setOpen] = useState(false);
@@ -70,7 +76,7 @@ export default function AsyncEntityMultiSelect<T>({
   const { data, isFetching, isError } = useSearch(query, open);
   const items = useMemo(() => data ?? [], [data]);
 
-  const [labelById, setLabelById] = useState<Record<string, string>>({});
+  const [labelById, setLabelById] = useState<Record<string, string>>(() => knownLabels ?? {});
 
   const selectedOptions = useMemo<AsyncEntityMultiSelectOption[]>(
     () =>

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchIncident.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchIncident.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BePatchIncidentResponse,
+  BeUpdateIncidentPayload,
+} from "@api/backend/types";
+
+export interface PatchIncidentInput {
+  id: string;
+  patch: BeUpdateIncidentPayload;
+}
+
+/**
+ * Update an incident via `PATCH /incidents/{id}` (ServiceNow data source
+ * only). The BE requires at least one field in `patch`. On success the
+ * detail and any cached list/search are invalidated so the new values show.
+ */
+export function usePatchIncident(): UseMutationResult<
+  BePatchIncidentResponse,
+  Error,
+  PatchIncidentInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BePatchIncidentResponse, Error, PatchIncidentInput>({
+    mutationFn: (input): Promise<BePatchIncidentResponse> =>
+      api.patch<BeUpdateIncidentPayload, BePatchIncidentResponse>(
+        `/incidents/${encodeURIComponent(input.id)}`,
+        input.patch,
+      ),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.INCIDENT_DETAILS, variables.id],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.INCIDENTS],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
@@ -1,0 +1,514 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import { useSearchGroups } from "@api/useSearchGroups";
+import { useSearchItServices } from "@api/useSearchItServices";
+import { useSearchServiceOfferings } from "@api/useSearchServiceOfferings";
+import { useSearchConfigurationItems } from "@api/useSearchConfigurationItems";
+import { useSearchUsersByName } from "@api/useSearchUsersByName";
+import AsyncEntitySelect from "@components/AsyncEntitySelect";
+import AsyncEntityMultiSelect from "@components/AsyncEntityMultiSelect";
+import {
+  CATEGORY_OPTIONS,
+  CONTACT_TYPE_OPTIONS,
+  IMPACT_OPTIONS,
+  SUBCATEGORY_OPTIONS_BY_CATEGORY,
+  URGENCY_OPTIONS,
+  configurationItemLabel,
+  itServiceLabel,
+  userLabel,
+} from "@features/csm-operations/utils/incidentFormOptions";
+import { computeIncidentPriority } from "@features/csm-operations/utils/incidentPriorityMatrix";
+import { INCIDENT_STATES, incidentStateLabel } from "@features/csm-operations/utils/incidents";
+import type {
+  BeIncidentCategory,
+  BeIncidentContactType,
+  BeIncidentDetail,
+  BeIncidentImpact,
+  BeIncidentState,
+  BeIncidentSubcategory,
+  BeIncidentUrgency,
+  BeUpdateIncidentPayload,
+  BeConfigurationItem,
+  BeGroup,
+  BeItService,
+  BeServiceOffering,
+  BeUser,
+} from "@api/backend/types";
+
+const UNSET = "" as const;
+const SELECT_PLACEHOLDER = "-- Select --";
+
+interface EditIncidentDialogProps {
+  incident: BeIncidentDetail;
+  /** True while the PATCH is in flight; disables the actions. */
+  isSaving: boolean;
+  onClose: () => void;
+  /** Submit only the changed fields (`PATCH /incidents/{id}`). */
+  onSave: (patch: BeUpdateIncidentPayload) => void;
+}
+
+/** Local editable copy of the fields this dialog covers, derived once from `incident`. */
+interface EditState {
+  subject: string;
+  category: BeIncidentCategory | "";
+  subcategory: BeIncidentSubcategory | "";
+  contactType: BeIncidentContactType | "";
+  impact: BeIncidentImpact | "";
+  urgency: BeIncidentUrgency | "";
+  state: BeIncidentState | "";
+  /** Write-only (see `BeUpdateIncidentPayload`) — `IncidentDetail` never
+   * echoes these back, so they always start blank, unlike every other field
+   * here. Required by ServiceNow to move `state` to `RESOLVED`/`CLOSED`. */
+  resolutionCode: string;
+  resolutionNotes: string;
+  serviceId: string;
+  serviceOfferingId: string;
+  configurationItemId: string;
+  assignmentGroupId: string;
+  assignedEngineerId: string;
+  watchList: string[];
+  workNotes: string;
+  additionalComments: string;
+  parentId: string;
+  changeRequestId: string;
+  problemId: string;
+  causedById: string;
+}
+
+function toEditState(incident: BeIncidentDetail): EditState {
+  return {
+    subject: incident.subject ?? "",
+    category: incident.category ?? UNSET,
+    subcategory: incident.subcategory ?? UNSET,
+    contactType: incident.contactType ?? UNSET,
+    impact: incident.impact ?? UNSET,
+    urgency: incident.urgency ?? UNSET,
+    state: incident.state ?? UNSET,
+    resolutionCode: "",
+    resolutionNotes: "",
+    serviceId: incident.service?.id ?? "",
+    serviceOfferingId: incident.serviceOffering?.id ?? "",
+    configurationItemId: incident.configurationItem?.id ?? "",
+    assignmentGroupId: incident.assignmentGroup?.id ?? "",
+    assignedEngineerId: incident.assignedTo?.id ?? "",
+    watchList: (incident.watchList ?? []).map((w) => w.id),
+    workNotes: incident.workNotes ?? "",
+    additionalComments: incident.additionalComments ?? "",
+    parentId: incident.parent?.id ?? "",
+    changeRequestId: incident.changeRequest?.id ?? "",
+    problemId: incident.problem?.id ?? "",
+    causedById: incident.causedBy?.id ?? "",
+  };
+}
+
+function sameIds(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((id, i) => id === sortedB[i]);
+}
+
+/**
+ * Diff `next` against `initial` so only changed fields are sent. Reference
+ * and note fields send an explicit `null` when cleared (distinct from
+ * omitting the field, which the BE treats as "leave unchanged" — see
+ * {@link BeUpdateIncidentPayload}); the fixed-enum fields (category, impact,
+ * etc.) never clear to null, only to a different value.
+ *
+ * `resolutionCode`/`resolutionNotes` don't fit that diff pattern — they're
+ * write-only (no `initial` value exists to diff against), so they're sent
+ * whenever filled in, regardless of whether anything else changed.
+ */
+function buildPatch(initial: EditState, next: EditState): BeUpdateIncidentPayload {
+  const patch: BeUpdateIncidentPayload = {};
+  if (next.subject.trim() !== initial.subject && next.subject.trim()) patch.subject = next.subject.trim();
+  if (next.category !== initial.category && next.category) patch.category = next.category;
+  if (next.subcategory !== initial.subcategory && next.subcategory) patch.subcategory = next.subcategory;
+  if (next.contactType !== initial.contactType && next.contactType) patch.contactType = next.contactType;
+  if (next.impact !== initial.impact && next.impact) patch.impact = next.impact;
+  if (next.urgency !== initial.urgency && next.urgency) patch.urgency = next.urgency;
+  if (next.state !== initial.state && next.state) patch.state = next.state;
+  if (next.resolutionCode.trim()) patch.resolutionCode = next.resolutionCode.trim();
+  if (next.resolutionNotes.trim()) patch.resolutionNotes = next.resolutionNotes.trim();
+  if (next.serviceId !== initial.serviceId) patch.serviceId = next.serviceId || null;
+  if (next.serviceOfferingId !== initial.serviceOfferingId) patch.serviceOfferingId = next.serviceOfferingId || null;
+  if (next.configurationItemId !== initial.configurationItemId)
+    patch.configurationItemId = next.configurationItemId || null;
+  if (next.assignmentGroupId !== initial.assignmentGroupId) patch.assignmentGroupId = next.assignmentGroupId || null;
+  if (next.assignedEngineerId !== initial.assignedEngineerId)
+    patch.assignedEngineerId = next.assignedEngineerId || null;
+  if (!sameIds(next.watchList, initial.watchList)) patch.watchList = next.watchList;
+  if (next.workNotes.trim() !== initial.workNotes) patch.workNotes = next.workNotes.trim() || null;
+  if (next.additionalComments.trim() !== initial.additionalComments)
+    patch.additionalComments = next.additionalComments.trim() || null;
+  if (next.parentId.trim() !== initial.parentId) patch.parentId = next.parentId.trim() || null;
+  if (next.changeRequestId.trim() !== initial.changeRequestId)
+    patch.changeRequestId = next.changeRequestId.trim() || null;
+  if (next.problemId.trim() !== initial.problemId) patch.problemId = next.problemId.trim() || null;
+  if (next.causedById.trim() !== initial.causedById) patch.causedById = next.causedById.trim() || null;
+  return patch;
+}
+
+/**
+ * Edit dialog for an incident's classification, state, assignment, watch
+ * list, notes, and linked-record ids — mirrors `CreateIncidentPage.tsx`'s
+ * fields (same option lists, same async pickers) plus a State select, which
+ * only makes sense once an incident already exists. Priority is never sent
+ * directly here either — ServiceNow computes it from impact × urgency, same
+ * rule as create.
+ */
+export default function EditIncidentDialog({
+  incident,
+  isSaving,
+  onClose,
+  onSave,
+}: EditIncidentDialogProps): JSX.Element {
+  const initial = useMemo(() => toEditState(incident), [incident]);
+  const [state, setState] = useState<EditState>(initial);
+
+  const knownWatchListLabels = useMemo(
+    () => Object.fromEntries((incident.watchList ?? []).map((w) => [w.id, w.name])),
+    [incident.watchList],
+  );
+
+  const subcategoryOptions = state.category ? SUBCATEGORY_OPTIONS_BY_CATEGORY[state.category] : [];
+  const priority = computeIncidentPriority(state.impact || "", state.urgency || "");
+
+  const patch = useMemo(() => buildPatch(initial, state), [initial, state]);
+  const hasChanges = Object.keys(patch).length > 0;
+
+  const set = <K extends keyof EditState>(key: K, value: EditState[K]): void =>
+    setState((prev) => ({ ...prev, [key]: value }));
+
+  const handleCategoryChange = (next: string): void => {
+    set("category", next as BeIncidentCategory | "");
+    // A subcategory only makes sense under its own category — drop it rather
+    // than leave a stale pairing, same rule as CreateIncidentPage.
+    set("subcategory", UNSET);
+  };
+
+  const handleServiceChange = (next: string): void => {
+    set("serviceId", next);
+    set("serviceOfferingId", "");
+  };
+
+  const renderSelect = (
+    label: string,
+    value: string,
+    onChange: (v: string) => void,
+    options: Array<{ value: string; label: string }>,
+    opts?: { disabled?: boolean; helperText?: string },
+  ): JSX.Element => (
+    <FormControl fullWidth size="small" disabled={isSaving || opts?.disabled}>
+      <InputLabel id={`${label}-label`} shrink>
+        {label}
+      </InputLabel>
+      <Select
+        labelId={`${label}-label`}
+        label={label}
+        value={value}
+        displayEmpty
+        onChange={(e) => onChange(String(e.target.value))}
+      >
+        <MenuItem value={UNSET}>
+          <Typography component="span" color="text.secondary">
+            {SELECT_PLACEHOLDER}
+          </Typography>
+        </MenuItem>
+        {options.map((o) => (
+          <MenuItem key={o.value} value={o.value}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Edit incident</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <TextField
+            label="Subject"
+            value={state.subject}
+            onChange={(e) => set("subject", e.target.value)}
+            fullWidth
+            disabled={isSaving}
+          />
+
+          <Divider />
+          <Typography variant="subtitle2">Classification</Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <Box sx={{ flex: "1 1 220px" }}>
+              {renderSelect("Category", state.category, handleCategoryChange, CATEGORY_OPTIONS)}
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              {renderSelect(
+                "Subcategory",
+                state.subcategory,
+                (v) => set("subcategory", v as BeIncidentSubcategory | ""),
+                subcategoryOptions,
+                { disabled: !state.category, helperText: state.category ? undefined : "Pick a category first." },
+              )}
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              {renderSelect("Contact type", state.contactType, (v) => set("contactType", v as BeIncidentContactType | ""), CONTACT_TYPE_OPTIONS)}
+            </Box>
+          </Box>
+
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <Box sx={{ flex: "1 1 220px" }}>
+              {renderSelect("Impact", state.impact, (v) => set("impact", v as BeIncidentImpact | ""), IMPACT_OPTIONS)}
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              {renderSelect("Urgency", state.urgency, (v) => set("urgency", v as BeIncidentUrgency | ""), URGENCY_OPTIONS)}
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              {renderSelect(
+                "State",
+                state.state,
+                (v) => set("state", v as BeIncidentState | ""),
+                INCIDENT_STATES.map((s) => ({ value: s, label: incidentStateLabel(s) })),
+              )}
+            </Box>
+          </Box>
+
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              Priority
+            </Typography>
+            {priority ? (
+              <Chip
+                size="small"
+                label={`${priority.label} (${priority.code})`}
+                sx={{ bgcolor: priority.bg, color: priority.fg, fontWeight: 600 }}
+              />
+            ) : (
+              <Chip size="small" label="Set impact & urgency" variant="outlined" disabled />
+            )}
+          </Box>
+
+          {(state.state === "RESOLVED" || state.state === "CLOSED") && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              <Typography variant="caption" color="text.secondary">
+                ServiceNow requires a resolution to move this incident to {incidentStateLabel(state.state)}.
+              </Typography>
+              <TextField
+                label="Resolution code"
+                value={state.resolutionCode}
+                onChange={(e) => set("resolutionCode", e.target.value)}
+                disabled={isSaving}
+                fullWidth
+                size="small"
+              />
+              <TextField
+                label="Resolution notes"
+                value={state.resolutionNotes}
+                onChange={(e) => set("resolutionNotes", e.target.value)}
+                disabled={isSaving}
+                multiline
+                minRows={2}
+                fullWidth
+              />
+            </Box>
+          )}
+
+          <Divider />
+          <Typography variant="subtitle2">Service &amp; assignment</Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeItService>
+                id="edit-incident-service"
+                label="Service"
+                placeholder="Search services…"
+                value={state.serviceId}
+                onChange={handleServiceChange}
+                disabled={isSaving}
+                useSearch={useSearchItServices}
+                getId={(s) => s.id}
+                getLabel={itServiceLabel}
+                knownLabel={incident.service?.name}
+              />
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeServiceOffering>
+                id="edit-incident-service-offering"
+                label="Service offering"
+                placeholder="Search service offerings…"
+                value={state.serviceOfferingId}
+                onChange={(v) => set("serviceOfferingId", v)}
+                disabled={isSaving}
+                useSearch={useSearchServiceOfferings}
+                searchExtra={state.serviceId || undefined}
+                getId={(o) => o.id}
+                getLabel={(o) => o.name}
+                knownLabel={incident.serviceOffering?.name}
+                helperText={state.serviceId ? undefined : "Narrows to a Service once one is picked."}
+              />
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeConfigurationItem>
+                id="edit-incident-configuration-item"
+                label="Configuration item"
+                placeholder="Search configuration items…"
+                value={state.configurationItemId}
+                onChange={(v) => set("configurationItemId", v)}
+                disabled={isSaving}
+                useSearch={useSearchConfigurationItems}
+                getId={(ci) => ci.id}
+                getLabel={configurationItemLabel}
+                knownLabel={incident.configurationItem?.name}
+              />
+            </Box>
+          </Box>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeGroup>
+                id="edit-incident-assignment-group"
+                label="Assignment group"
+                placeholder="Search groups…"
+                value={state.assignmentGroupId}
+                onChange={(v) => set("assignmentGroupId", v)}
+                disabled={isSaving}
+                useSearch={useSearchGroups}
+                getId={(g) => g.id}
+                getLabel={(g) => g.name}
+                knownLabel={incident.assignmentGroup?.name}
+              />
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeUser>
+                id="edit-incident-assigned-engineer"
+                label="Assigned to"
+                placeholder="Search people…"
+                value={state.assignedEngineerId}
+                onChange={(v) => set("assignedEngineerId", v)}
+                disabled={isSaving}
+                useSearch={useSearchUsersByName}
+                getId={(u) => u.id!}
+                getLabel={userLabel}
+                knownLabel={incident.assignedTo?.name}
+              />
+            </Box>
+          </Box>
+
+          <AsyncEntityMultiSelect<BeUser>
+            id="edit-incident-watch-list"
+            label="Watch list"
+            placeholder="Search people…"
+            values={state.watchList}
+            onChange={(v) => set("watchList", v)}
+            disabled={isSaving}
+            useSearch={useSearchUsersByName}
+            getId={(u) => u.id!}
+            getLabel={userLabel}
+            knownLabels={knownWatchListLabels}
+            helperText="Notified on updates to this incident."
+          />
+
+          <Divider />
+          <Typography variant="subtitle2">Notes</Typography>
+          <TextField
+            label="Additional comments"
+            multiline
+            minRows={2}
+            value={state.additionalComments}
+            onChange={(e) => set("additionalComments", e.target.value)}
+            disabled={isSaving}
+            fullWidth
+            helperText="Visible to the customer."
+          />
+          <TextField
+            label="Internal work note"
+            multiline
+            minRows={2}
+            value={state.workNotes}
+            onChange={(e) => set("workNotes", e.target.value)}
+            disabled={isSaving}
+            fullWidth
+            helperText="Internal only — never shown to the customer."
+          />
+
+          <Divider />
+          <Typography variant="caption" color="text.secondary">
+            Advanced linking (portal UUIDs — no lookup available for these yet)
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <TextField
+              label="Parent incident ID"
+              size="small"
+              value={state.parentId}
+              onChange={(e) => set("parentId", e.target.value)}
+              disabled={isSaving}
+              sx={{ flex: "1 1 220px" }}
+            />
+            <TextField
+              label="Change request ID"
+              size="small"
+              value={state.changeRequestId}
+              onChange={(e) => set("changeRequestId", e.target.value)}
+              disabled={isSaving}
+              sx={{ flex: "1 1 220px" }}
+            />
+            <TextField
+              label="Problem ID"
+              size="small"
+              value={state.problemId}
+              onChange={(e) => set("problemId", e.target.value)}
+              disabled={isSaving}
+              sx={{ flex: "1 1 220px" }}
+            />
+            <TextField
+              label="Caused by ID"
+              size="small"
+              value={state.causedById}
+              onChange={(e) => set("causedById", e.target.value)}
+              disabled={isSaving}
+              sx={{ flex: "1 1 220px" }}
+            />
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={() => onSave(patch)} disabled={isSaving || !hasChanges}>
+          {isSaving ? "Saving…" : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
@@ -202,11 +202,46 @@ export default function EditIncidentDialog({
     [incident.watchList],
   );
 
-  const subcategoryOptions = state.category ? SUBCATEGORY_OPTIONS_BY_CATEGORY[state.category] : [];
+  // The curated map (see its own doc comment) intentionally omits ~16
+  // backend-valid subcategories that don't have an obvious curated home.
+  // An existing incident can already carry one of those — inject it back in
+  // (only while the category hasn't changed, since a new category drops the
+  // old subcategory anyway) so it still displays and remains selectable
+  // rather than showing as blank.
+  const subcategoryOptions = useMemo(() => {
+    const base = state.category ? SUBCATEGORY_OPTIONS_BY_CATEGORY[state.category] : [];
+    if (
+      state.category === initial.category &&
+      initial.subcategory &&
+      !base.some((o) => o.value === initial.subcategory)
+    ) {
+      return [{ value: initial.subcategory, label: initial.subcategory.replace(/_/g, " ") }, ...base];
+    }
+    return base;
+  }, [state.category, initial.category, initial.subcategory]);
   const priority = computeIncidentPriority(state.impact || "", state.urgency || "");
 
   const patch = useMemo(() => buildPatch(initial, state), [initial, state]);
   const hasChanges = Object.keys(patch).length > 0;
+  // hasChanges alone isn't enough: clearing Subject or a fixed-enum field is
+  // silently dropped by buildPatch's diff (not sent, not blocked); changing
+  // Category resets Subcategory to blank, which the diff also drops instead
+  // of submitting; and a transition into Resolved/Closed can submit without
+  // the resolution fields ServiceNow requires for that transition (a live
+  // 500 — see the comment above buildPatch). Block Save until all of that is
+  // actually valid, rather than letting any of it silently no-op or 500.
+  const isTransitioningToResolved =
+    state.state !== initial.state && (state.state === "RESOLVED" || state.state === "CLOSED");
+  const isValid =
+    state.subject.trim().length > 0 &&
+    !!state.category &&
+    !!state.subcategory &&
+    !!state.contactType &&
+    !!state.impact &&
+    !!state.urgency &&
+    !!state.state &&
+    (!isTransitioningToResolved ||
+      (!!state.resolutionCode.trim() && !!state.resolutionNotes.trim()));
 
   const set = <K extends keyof EditState>(key: K, value: EditState[K]): void =>
     setState((prev) => ({ ...prev, [key]: value }));
@@ -505,7 +540,11 @@ export default function EditIncidentDialog({
         <Button color="inherit" onClick={onClose} disabled={isSaving}>
           Cancel
         </Button>
-        <Button variant="contained" onClick={() => onSave(patch)} disabled={isSaving || !hasChanges}>
+        <Button
+          variant="contained"
+          onClick={() => onSave(patch)}
+          disabled={isSaving || !hasChanges || !isValid}
+        >
           {isSaving ? "Saving…" : "Save"}
         </Button>
       </DialogActions>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateIncidentPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateIncidentPage.tsx
@@ -46,6 +46,16 @@ import { useSearchUsersByName } from "@api/useSearchUsersByName";
 import AsyncEntitySelect from "@components/AsyncEntitySelect";
 import AsyncEntityMultiSelect from "@components/AsyncEntityMultiSelect";
 import { computeIncidentPriority } from "@features/csm-operations/utils/incidentPriorityMatrix";
+import {
+  CATEGORY_OPTIONS,
+  CONTACT_TYPE_OPTIONS,
+  IMPACT_OPTIONS,
+  SUBCATEGORY_OPTIONS_BY_CATEGORY,
+  URGENCY_OPTIONS,
+  configurationItemLabel,
+  itServiceLabel,
+  userLabel,
+} from "@features/csm-operations/utils/incidentFormOptions";
 import type {
   BeIncidentCategory,
   BeIncidentContactType,
@@ -62,90 +72,6 @@ import type {
 
 const UNSET = "" as const;
 const SELECT_PLACEHOLDER = "-- Select --";
-
-const CATEGORY_OPTIONS: Array<{ value: BeIncidentCategory; label: string }> = [
-  { value: "INQUIRY", label: "Inquiry / Help" },
-  { value: "SERVICE_INTERRUPTION", label: "Service Interruption" },
-  { value: "SECURITY", label: "Security" },
-];
-
-const IMPACT_OPTIONS: Array<{ value: BeIncidentImpact; label: string }> = [
-  { value: "HIGH", label: "High" },
-  { value: "MEDIUM", label: "Medium" },
-  { value: "LOW", label: "Low" },
-];
-
-const URGENCY_OPTIONS: Array<{ value: BeIncidentUrgency; label: string }> = [
-  { value: "HIGH", label: "High" },
-  { value: "MEDIUM", label: "Medium" },
-  { value: "LOW", label: "Low" },
-];
-
-const CONTACT_TYPE_OPTIONS: Array<{ value: BeIncidentContactType; label: string }> = [
-  { value: "SELF_SERVICE", label: "Self-service" },
-  { value: "EMAIL", label: "Email" },
-  { value: "WALK_IN", label: "Walk-in" },
-  { value: "AZURE", label: "Azure" },
-  { value: "EMAIL_INTERNAL", label: "Email Internal" },
-  { value: "SITE_247", label: "Site 24/7" },
-  { value: "DIRECT", label: "Direct" },
-  { value: "PHONE", label: "Phone" },
-  { value: "SENTINEL", label: "Sentinel" },
-  { value: "VIRTUAL_AGENT", label: "Virtual Agent" },
-  { value: "CHAT", label: "Chat" },
-  { value: "EMAIL_EXTERNAL", label: "Email External" },
-];
-
-/**
- * Subcategory options, curated per category rather than offered as one flat
- * 35-value list. The backend's `validIncidentSubcategories` enum has 16 more
- * values than appear here (DHCP, DNS, OS, VPN, disk/memory/CPU-type hardware
- * values, etc.) — they're still valid on the wire, they just don't have an
- * obvious home in Inquiry/Help, Service Interruption, or Security, so this
- * curated picker doesn't surface them.
- */
-const SUBCATEGORY_OPTIONS_BY_CATEGORY: Record<
-  BeIncidentCategory,
-  Array<{ value: BeIncidentSubcategory; label: string }>
-> = {
-  INQUIRY: [
-    { value: "CONFIG_CHANGE_REQUEST", label: "Config Change Request" },
-    { value: "INFORMATION_REQUEST", label: "Information Request" },
-  ],
-  SERVICE_INTERRUPTION: [
-    { value: "FULL_OUTAGE", label: "Full Outage" },
-    { value: "PARTIAL_OUTAGE", label: "Partial Outage" },
-    { value: "SLOWNESS", label: "Slowness" },
-  ],
-  SECURITY: [
-    { value: "DOS_DDOS", label: "DOS/DDOS" },
-    { value: "PRIVILEGE_ESCALATIONS", label: "Privilege Escalations" },
-    { value: "THREAT_INTELLIGENCE", label: "Threat Intelligence" },
-    { value: "SCANS_AND_PROBES", label: "Scans and Probes" },
-    { value: "APPLICATION_SECURITY", label: "Application Security" },
-    { value: "PRIVACY", label: "Privacy" },
-    { value: "DATA_BREACH", label: "Data Breach" },
-    { value: "SYSTEM_COMPROMISES", label: "System Compromises" },
-    { value: "MALWARE", label: "Malware" },
-    { value: "VULNERABILITY", label: "Vulnerability" },
-    { value: "UNAUTHORIZED_ACCESS", label: "Unauthorized Access" },
-    { value: "IDENTITY_PROTECTION", label: "Identity Protection" },
-    { value: "PHISHING", label: "Phishing" },
-    { value: "IMPROPER_CONFIGURATION", label: "Improper Configuration" },
-  ],
-};
-
-function userLabel(u: BeUser): string {
-  return [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.email || u.id || "";
-}
-
-function itServiceLabel(s: BeItService): string {
-  return s.name ?? s.id;
-}
-
-function configurationItemLabel(ci: BeConfigurationItem): string {
-  return ci.name ?? ci.id;
-}
 
 const REQUIRED_HELPER = "Required";
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -15,21 +15,56 @@
 // under the License.
 
 import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
-import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode } from "react";
+import { ArrowLeft, Pencil } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode, useState } from "react";
 import { useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { BackendApiError } from "@api/backend/client";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useGetIncident } from "@features/csm-operations/api/useGetIncident";
+import { usePatchIncident } from "@features/csm-operations/api/usePatchIncident";
+import EditIncidentDialog from "@features/csm-operations/components/EditIncidentDialog";
 import {
   incidentPriorityColor,
   incidentPriorityLabel,
   incidentStateColor,
   incidentStateLabel,
 } from "@features/csm-operations/utils/incidents";
-import type { BeEntityRef } from "@api/backend/types";
+import type { BeEntityRef, BeIncidentDetail, BeUpdateIncidentPayload } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 
 const OPERATIONS_INCIDENTS_PATH = "/operations?tab=incidents";
+
+/**
+ * Two confirmed-live upstream limitations of `PATCH /incidents/{id}`
+ * (entity-service/ServiceNow, not this BFF or the FE) — a third,
+ * `state: RESOLVED`/`CLOSED` 500ing without a resolution, was fixed by
+ * having `EditIncidentDialog` collect `resolutionCode`/`resolutionNotes`
+ * (write-only fields, no read-side model — see `BeUpdateIncidentPayload`)
+ * once the target state is one of those two:
+ *  - `watchList` 404s ("The requested resource was not found!") for *any*
+ *    id — confirmed with both an anonymous service account and a real, named
+ *    person, so it isn't a bad-id problem on our side.
+ *  - `additionalComments` (and, defensively, `workNotes` — same ServiceNow
+ *    journal-field shape, not independently confirmed) is the dangerous one:
+ *    the PATCH returns 200, but the response's own echoed value comes back
+ *    `null` even though we just set it — a silent no-op dressed as success.
+ * `watchList` already surfaces as a real error (see `onError` below) — this
+ * is correct, if unfortunate, behavior. `checkSilentlyDroppedNotes` exists so
+ * the notes case doesn't: it catches a 200 that didn't actually persist what
+ * it claims to and treats it like the failure it is, rather than closing the
+ * dialog on a false positive.
+ */
+function checkSilentlyDroppedNotes(patch: BeUpdateIncidentPayload, saved: BeIncidentDetail): string[] {
+  const dropped: string[] = [];
+  if ("additionalComments" in patch && (saved.additionalComments ?? null) !== patch.additionalComments) {
+    dropped.push("Additional comments");
+  }
+  if ("workNotes" in patch && (saved.workNotes ?? null) !== patch.workNotes) {
+    dropped.push("Internal work note");
+  }
+  return dropped;
+}
 
 function formatDateTime(value?: string | null): string {
   return (
@@ -60,15 +95,17 @@ function RefText({ value }: { value?: BeEntityRef | null }): JSX.Element {
 }
 
 /**
- * Read-only detail for a single incident (`GET /incidents/{id}`). No edit
- * flow — the backend only exposes search/create/get for incidents, no
- * PATCH — so unlike the change-request detail page, there's nothing to
- * open an edit dialog against.
+ * Detail for a single incident (`GET /incidents/{id}`), with an Edit dialog
+ * (`PATCH /incidents/{id}`) mirroring the change-request detail page's
+ * pattern.
  */
 export default function CsmIncidentDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
   const { data, isLoading, isError } = useGetIncident(id);
+  const { showError } = useErrorBanner();
+  const patchIncident = usePatchIncident();
+  const [editOpen, setEditOpen] = useState(false);
 
   const back = (): void => {
     navigate(OPERATIONS_INCIDENTS_PATH);
@@ -144,6 +181,15 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               label={incidentPriorityLabel(incident.priority)}
             />
           )}
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Pencil size={14} />}
+            onClick={() => setEditOpen(true)}
+            sx={{ ml: "auto", flexShrink: 0 }}
+          >
+            Edit
+          </Button>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
           {incident.number || incident.id}
@@ -246,6 +292,43 @@ export default function CsmIncidentDetailPage(): JSX.Element {
             ))}
           </Box>
         </Card>
+      )}
+
+      {editOpen && (
+        <EditIncidentDialog
+          incident={incident}
+          isSaving={patchIncident.isPending}
+          onClose={() => {
+            if (!patchIncident.isPending) setEditOpen(false);
+          }}
+          onSave={(patch) =>
+            patchIncident.mutate(
+              { id: incident.id as string, patch },
+              {
+                onSuccess: (data) => {
+                  const droppedFields = checkSilentlyDroppedNotes(patch, data.incident);
+                  if (droppedFields.length > 0) {
+                    showError(
+                      `${droppedFields.join(" and ")} didn't save — ServiceNow accepted the request but ` +
+                        "silently dropped that change. Any other fields in this edit were saved; please retry the note separately.",
+                    );
+                    return;
+                  }
+                  setEditOpen(false);
+                },
+                onError: (err) => {
+                  // Real validation messages (e.g. an invalid UUID in one of the
+                  // linking fields) are worth surfacing, same as CreateIncidentPage.
+                  const msg =
+                    err instanceof BackendApiError && err.status < 500 && err.message
+                      ? err.message
+                      : "Could not update the incident. Please try again.";
+                  showError(msg, err);
+                },
+              },
+            )
+          }
+        />
       )}
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -309,8 +309,8 @@ export default function CsmIncidentDetailPage(): JSX.Element {
                   const droppedFields = checkSilentlyDroppedNotes(patch, data.incident);
                   if (droppedFields.length > 0) {
                     showError(
-                      `${droppedFields.join(" and ")} didn't save — ServiceNow accepted the request but ` +
-                        "silently dropped that change. Any other fields in this edit were saved; please retry the note separately.",
+                      `${droppedFields.join(" and ")} didn't save — the request was accepted but that ` +
+                        "change wasn't actually persisted. Any other fields in this edit were saved; please retry the note separately.",
                     );
                     return;
                   }

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentFormOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidentFormOptions.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type {
+  BeConfigurationItem,
+  BeIncidentCategory,
+  BeIncidentContactType,
+  BeIncidentImpact,
+  BeIncidentSubcategory,
+  BeIncidentUrgency,
+  BeItService,
+  BeUser,
+} from "@api/backend/types";
+
+// Shared between CreateIncidentPage and EditIncidentDialog so their dropdown
+// option sets can't drift apart.
+
+export const CATEGORY_OPTIONS: Array<{ value: BeIncidentCategory; label: string }> = [
+  { value: "INQUIRY", label: "Inquiry / Help" },
+  { value: "SERVICE_INTERRUPTION", label: "Service Interruption" },
+  { value: "SECURITY", label: "Security" },
+];
+
+export const IMPACT_OPTIONS: Array<{ value: BeIncidentImpact; label: string }> = [
+  { value: "HIGH", label: "High" },
+  { value: "MEDIUM", label: "Medium" },
+  { value: "LOW", label: "Low" },
+];
+
+export const URGENCY_OPTIONS: Array<{ value: BeIncidentUrgency; label: string }> = [
+  { value: "HIGH", label: "High" },
+  { value: "MEDIUM", label: "Medium" },
+  { value: "LOW", label: "Low" },
+];
+
+export const CONTACT_TYPE_OPTIONS: Array<{ value: BeIncidentContactType; label: string }> = [
+  { value: "SELF_SERVICE", label: "Self-service" },
+  { value: "EMAIL", label: "Email" },
+  { value: "WALK_IN", label: "Walk-in" },
+  { value: "AZURE", label: "Azure" },
+  { value: "EMAIL_INTERNAL", label: "Email Internal" },
+  { value: "SITE_247", label: "Site 24/7" },
+  { value: "DIRECT", label: "Direct" },
+  { value: "PHONE", label: "Phone" },
+  { value: "SENTINEL", label: "Sentinel" },
+  { value: "VIRTUAL_AGENT", label: "Virtual Agent" },
+  { value: "CHAT", label: "Chat" },
+  { value: "EMAIL_EXTERNAL", label: "Email External" },
+];
+
+/**
+ * Subcategory options, curated per category rather than offered as one flat
+ * 35-value list. The backend's `validIncidentSubcategories` enum has 16 more
+ * values than appear here (DHCP, DNS, OS, VPN, disk/memory/CPU-type hardware
+ * values, etc.) — they're still valid on the wire, they just don't have an
+ * obvious home in Inquiry/Help, Service Interruption, or Security, so this
+ * curated picker doesn't surface them.
+ */
+export const SUBCATEGORY_OPTIONS_BY_CATEGORY: Record<
+  BeIncidentCategory,
+  Array<{ value: BeIncidentSubcategory; label: string }>
+> = {
+  INQUIRY: [
+    { value: "CONFIG_CHANGE_REQUEST", label: "Config Change Request" },
+    { value: "INFORMATION_REQUEST", label: "Information Request" },
+  ],
+  SERVICE_INTERRUPTION: [
+    { value: "FULL_OUTAGE", label: "Full Outage" },
+    { value: "PARTIAL_OUTAGE", label: "Partial Outage" },
+    { value: "SLOWNESS", label: "Slowness" },
+  ],
+  SECURITY: [
+    { value: "DOS_DDOS", label: "DOS/DDOS" },
+    { value: "PRIVILEGE_ESCALATIONS", label: "Privilege Escalations" },
+    { value: "THREAT_INTELLIGENCE", label: "Threat Intelligence" },
+    { value: "SCANS_AND_PROBES", label: "Scans and Probes" },
+    { value: "APPLICATION_SECURITY", label: "Application Security" },
+    { value: "PRIVACY", label: "Privacy" },
+    { value: "DATA_BREACH", label: "Data Breach" },
+    { value: "SYSTEM_COMPROMISES", label: "System Compromises" },
+    { value: "MALWARE", label: "Malware" },
+    { value: "VULNERABILITY", label: "Vulnerability" },
+    { value: "UNAUTHORIZED_ACCESS", label: "Unauthorized Access" },
+    { value: "IDENTITY_PROTECTION", label: "Identity Protection" },
+    { value: "PHISHING", label: "Phishing" },
+    { value: "IMPROPER_CONFIGURATION", label: "Improper Configuration" },
+  ],
+};
+
+export function userLabel(u: BeUser): string {
+  return [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.email || u.id || "";
+}
+
+export function itServiceLabel(s: BeItService): string {
+  return s.name ?? s.id;
+}
+
+export function configurationItemLabel(ci: BeConfigurationItem): string {
+  return ci.name ?? ci.id;
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/incidents.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/incidents.ts
@@ -57,6 +57,9 @@ const PRIORITY_COLOR: Record<BeIncidentPriority, ChipColor> = {
 /** All incident priorities, for a filter control. */
 export const INCIDENT_PRIORITIES = Object.keys(PRIORITY_LABEL) as BeIncidentPriority[];
 
+/** All incident states, for the Edit dialog's State select. */
+export const INCIDENT_STATES = Object.keys(STATE_LABEL) as BeIncidentState[];
+
 function humanize(value: string): string {
   return value.replace(/_/g, " ");
 }


### PR DESCRIPTION
## Purpose
Incidents had no way to be edited after creation — no classification changes, no state transitions, no assignment, and no way to resolve/close one.

## Goals
Add an edit flow for incidents mirroring the change-request detail page's pattern: a dialog covering classification, state, service/assignment, watch list, notes, and linked-record ids, submitted as a diffed `PATCH /incidents/{id}`.

## Approach
- `usePatchIncident` — `PATCH /incidents/{id}` hook; `BeUpdateIncidentPayload`/`BePatchIncidentResponse` types.
- `EditIncidentDialog` — collects classification (category/subcategory/contact type/impact/urgency), state, service & assignment (service/service offering/configuration item/assignment group/assigned engineer), watch list, notes (additional comments/work notes), and advanced linking ids (parent/change request/problem/caused-by). Only changed fields are sent (diffed against the incident's initial state).
- `resolutionCode`/`resolutionNotes` are collected whenever the target state is Resolved/Closed — ServiceNow rejects that transition without them (a live-tested 500, not documented anywhere beforehand). These are write-only (no read-side field on `IncidentDetail`), so they're always sent when filled in rather than diffed.
- Wired into `CsmIncidentDetailPage.tsx` behind an "Edit" button. `checkSilentlyDroppedNotes` guards a separate confirmed-live ServiceNow quirk: a `PATCH` touching `additionalComments`/`workNotes` can return 200 while the echoed value doesn't actually reflect what was sent — this is caught and surfaced as an error instead of a false-positive success.
- Extracted `incidentFormOptions.ts` so `CreateIncidentPage.tsx` and `EditIncidentDialog.tsx` share the same category/subcategory/impact/urgency/contact-type option lists rather than duplicating them.
- `AsyncEntityMultiSelect` gained a `knownLabels` prop so the watch list picker can show names for ids that didn't come from a search this session (pre-filled from the incident itself).

## User stories
As a CSM engineer, I can edit an incident's classification, reassign it, update its watch list and notes, and move it through its lifecycle (including to Resolved/Closed with a resolution) — all from its detail page.

## Release note
Incidents can now be edited from their detail page — classification, state (including resolution), service & assignment, watch list, and notes.

## Documentation
N/A — in-app UI change only, no separate product documentation impact.

## Automation tests
 - Unit tests
   > No new test file added for the dialog itself; relies on the existing type-check/lint gate. `incidentFormOptions.ts` is a pure data/label module shared with the already-covered create flow.
 - Integration tests
   > Manually verified live against the staging backend across every field group: classification, watch list, assigned engineer, additional comments, work notes, and state → Resolved with resolution code/notes. All persist correctly except watch list, which returns a 404 from ServiceNow for any user id — confirmed as a ServiceNow-side issue, not something fixable in this codebase.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React frontend change, no Java code)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Local Vite dev server against the staging backend, Chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added incident editing from the incident details page with an “Edit” modal.
  - Save updates classification/state, service & assignment, watch list, notes, linked-record IDs, and resolution fields (including required-field checks).
- **Improvements**
  - Patch updates now refetch incident details and the incident list to keep the UI in sync.
  - Detects and surfaces cases where certain note changes appear to be silently dropped.
  - Preserves labels for preselected async multi-select items using known values.
  - Centralized incident form option lists and labeling for consistent rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->