### PR TITLE
[Customer Portal][Backend] Fix and align deployed-product usage-count metrics types with the entity service

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2829,6 +2829,37 @@ public type DeployedProductMetricsUsageCountsSummary record {|
     json...;
 |};
 
+# A single instance's contribution to a count-type entry.
+public type UsageCountInstance record {|
+    # System ID of the instance
+    string id;
+    # Instance name or key
+    string name;
+    # Count value contributed by this instance
+    decimal value;
+    json...;
+|};
+
+# Aggregated value for a single count type on a single date.
+public type UsageCountEntry record {|
+    # Aggregated value across instances
+    decimal value;
+    # Aggregation function applied (e.g. sum, max)
+    string aggregation;
+    # Per-instance breakdown
+    UsageCountInstance[] instances;
+    json...;
+|};
+
+# A single chart data entry for deployed product usage counts grouped by date.
+public type DeployedProductUsageCountsChartEntry record {|
+    # Date of the chart entry (format: YYYY-MM-DD)
+    string date;
+    # Pivoted counts keyed by count type
+    map<UsageCountEntry> counts;
+    json...;
+|};
+
 # Response for deployed product metrics usage counts search.
 public type DeployedProductMetricsUsageCountsResponse record {|
     # The deployed product reference
@@ -2842,6 +2873,6 @@ public type DeployedProductMetricsUsageCountsResponse record {|
     # Summary statistics for the queried range
     DeployedProductMetricsUsageCountsSummary summary;
     # Chart data points ordered by date
-    json[] chartData;
+    DeployedProductUsageCountsChartEntry[] chartData;
     json...;
 |};

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -2220,6 +2220,34 @@ public type DeployedProductMetricsUsageCountsSummary record {|
     map<CountTypeAggregation> countTypes;
 |};
 
+# A single instance's contribution to a count-type entry.
+public type UsageCountInstance record {|
+    # System ID of the instance
+    string id;
+    # Instance name or key
+    string name;
+    # Count value contributed by this instance
+    decimal value;
+|};
+
+# Aggregated value for a single count type on a single date.
+public type UsageCountEntry record {|
+    # Aggregated value across instances
+    decimal value;
+    # Aggregation function applied (e.g. sum, max)
+    string aggregation;
+    # Per-instance breakdown
+    UsageCountInstance[] instances;
+|};
+
+# A single chart data entry for deployed product usage counts grouped by date.
+public type DeployedProductUsageCountsChartEntry record {|
+    # Date of the chart entry (format: YYYY-MM-DD)
+    string date;
+    # Pivoted counts keyed by count type
+    map<UsageCountEntry> counts;
+|};
+
 # Response for deployed product metrics usage counts search.
 public type DeployedProductMetricsUsageCountsResponse record {|
     # The deployed product reference
@@ -2232,5 +2260,5 @@ public type DeployedProductMetricsUsageCountsResponse record {|
     # Summary statistics for the queried range
     DeployedProductMetricsUsageCountsSummary summary;
     # Chart data points ordered by date
-    json[] chartData;
+    DeployedProductUsageCountsChartEntry[] chartData;
 |};

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -5206,7 +5206,57 @@ components:
           type: array
           description: Chart data points ordered by date
           items:
-            type: object
+            $ref: '#/components/schemas/DeployedProductUsageCountsChartEntry'
+    UsageCountInstance:
+      required:
+      - id
+      - name
+      - value
+      type: object
+      properties:
+        id:
+          type: string
+          description: System ID of the instance
+        name:
+          type: string
+          description: Instance name or key
+        value:
+          type: number
+          format: double
+          description: Count value contributed by this instance
+    UsageCountEntry:
+      required:
+      - value
+      - aggregation
+      - instances
+      type: object
+      properties:
+        value:
+          type: number
+          format: double
+          description: Aggregated value across instances
+        aggregation:
+          type: string
+          description: Aggregation function applied (e.g. sum, max)
+        instances:
+          type: array
+          description: Per-instance breakdown
+          items:
+            $ref: '#/components/schemas/UsageCountInstance'
+    DeployedProductUsageCountsChartEntry:
+      required:
+      - date
+      - counts
+      type: object
+      properties:
+        date:
+          type: string
+          description: "Date of the chart entry (format: YYYY-MM-DD)"
+        counts:
+          type: object
+          description: Pivoted counts keyed by count type
+          additionalProperties:
+            $ref: '#/components/schemas/UsageCountEntry'
     DeployedProductUpdatePayload:
       type: object
       properties:

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1437,39 +1437,25 @@ public isolated function mapDeployedProductMetricsUsageCounts(
         entity:DeployedProductMetricsUsageCountsResponse response)
         returns types:DeployedProductMetricsUsageCountsResponse {
 
-    map<types:CountTypeAggregation> countTypes = {};
-    foreach [string, entity:CountTypeAggregation] [key, value] in response.summary.countTypes.entries() {
-        countTypes[key] = {
-            aggregation: value.aggregation,
-            min: value.min,
-            max: value.max,
-            avg: value.avg
-        };
-    }
+    map<types:CountTypeAggregation> countTypes = response.summary.countTypes.map(value => {
+        aggregation: value.aggregation,
+        min: value.min,
+        max: value.max,
+        avg: value.avg
+    });
 
-    types:DeployedProductUsageCountsChartEntry[] chartData = [];
-    foreach entity:DeployedProductUsageCountsChartEntry entry in response.chartData {
-        map<types:UsageCountEntry> counts = {};
-        foreach [string, entity:UsageCountEntry] [countKey, countEntry] in entry.counts.entries() {
-            types:UsageCountInstance[] instances = [];
-            foreach entity:UsageCountInstance inst in countEntry.instances {
-                instances.push({
-                    id: inst.id,
-                    name: inst.name,
-                    value: inst.value
-                });
-            }
-            counts[countKey] = {
-                value: countEntry.value,
-                aggregation: countEntry.aggregation,
-                instances
-            };
-        }
-        chartData.push({
-            date: entry.date,
-            counts
-        });
-    }
+    types:DeployedProductUsageCountsChartEntry[] chartData = response.chartData.map(entry => {
+        date: entry.date,
+        counts: entry.counts.map(countEntry => {
+            value: countEntry.value,
+            aggregation: countEntry.aggregation,
+            instances: countEntry.instances.map(inst => {
+                id: inst.id,
+                name: inst.name,
+                value: inst.value
+            })
+        })
+    });
 
     return {
         product: {

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1447,6 +1447,30 @@ public isolated function mapDeployedProductMetricsUsageCounts(
         };
     }
 
+    types:DeployedProductUsageCountsChartEntry[] chartData = [];
+    foreach entity:DeployedProductUsageCountsChartEntry entry in response.chartData {
+        map<types:UsageCountEntry> counts = {};
+        foreach [string, entity:UsageCountEntry] [countKey, countEntry] in entry.counts.entries() {
+            types:UsageCountInstance[] instances = [];
+            foreach entity:UsageCountInstance inst in countEntry.instances {
+                instances.push({
+                    id: inst.id,
+                    name: inst.name,
+                    value: inst.value
+                });
+            }
+            counts[countKey] = {
+                value: countEntry.value,
+                aggregation: countEntry.aggregation,
+                instances
+            };
+        }
+        chartData.push({
+            date: entry.date,
+            counts
+        });
+    }
+
     return {
         product: {
             id: response.deployedProduct.id,
@@ -1459,6 +1483,6 @@ public isolated function mapDeployedProductMetricsUsageCounts(
             },
             countTypes
         },
-        chartData: response.chartData
+        chartData
     };
 }


### PR DESCRIPTION
## Summary

- Fix a 500 payload-binding error on `.../metrics/usage-counts/search`: `countTypes` was typed as `map<int>`, but the entity service returns per-count-type aggregate objects (`{aggregation, min, max, avg}`). Added a `CountTypeAggregation` record and used it in both the entity client and portal-facing types.
- Type `chartData[].counts` as `UsageCountEntry`/`UsageCountInstance` (`{value, aggregation, instances}`) instead of an untyped `json[]`/`json` placeholder, matching the entity service's actual per-date, per-instance breakdown.
- Convert between the entity-service types and the portal-facing response types explicitly in `utils.bal`, since Ballerina doesn't implicitly assign across distinct named record types even when structurally identical. Nested `map from`/`from` query expressions crashed the Ballerina compiler (`ClosureDesugar` `IllegalStateException`), so the conversions use plain `foreach` loops instead.
- Document `CountTypeAggregation`, `UsageCountInstance`, `UsageCountEntry`, and `DeployedProductUsageCountsChartEntry` in `openapi.yaml`.

## Test plan

- [ ] `bal build` compiles cleanly
- [ ] Verify `.../metrics/usage-counts/search` returns 200 (no more `[SERVICENOW_ERROR]`/binding-failed 500s) and per-instance chart breakdowns render correctly in Usage & Metrics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed deployed-product usage metrics, including per-instance, per-count-type, and per-date breakdowns.
  * Usage chart data now provides structured counts and instance contributions for clearer reporting.

* **Bug Fixes**
  * Improved usage metrics response handling to consistently transform and present chart data in the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->