### PR TITLE
[Customer Portal][Webapp] Usage metrics: instance view, chart layout polish, and payload fixes

### DIFF
--- a/apps/customer-portal/webapp/src/components/tab-bar/TabBar.tsx
+++ b/apps/customer-portal/webapp/src/components/tab-bar/TabBar.tsx
@@ -21,6 +21,7 @@ export interface TabOption {
   id: string;
   label: string;
   icon?: React.ElementType;
+  iconColor?: string;
   count?: number | string;
   badgeColor?: string;
 }
@@ -72,7 +73,9 @@ const TabBar = ({
             variant="outlined"
             aria-selected={isActive}
             onClick={() => onTabChange(tab.id)}
-            startIcon={Icon ? <Icon size={16} /> : undefined}
+            startIcon={
+              Icon ? <Icon size={16} color={tab.iconColor} /> : undefined
+            }
             sx={{
               position: "relative",
               flex: keepButtonWidth ? "0 0 auto" : 1,

--- a/apps/customer-portal/webapp/src/features/project-details/api/useGetDeployedProductInstancesInfinite.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useGetDeployedProductInstancesInfinite.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+import { useAsgardeo } from "@asgardeo/react";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import type {
+  DateRangeFilter,
+  InstancesResponse,
+} from "@features/project-details/types/usage";
+
+const PAGE_SIZE = 10;
+
+/**
+ * Infinite query for a deployed product's instances, loading 10 at a time.
+ * Call `fetchNextPage()` (e.g. via an IntersectionObserver sentinel) to load more.
+ */
+export default function useGetDeployedProductInstancesInfinite(
+  deployedProductId: string | undefined,
+  dateRange: DateRangeFilter,
+): UseInfiniteQueryResult<InfiniteData<InstancesResponse>, Error> {
+  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
+  const authFetch = useAuthApiClient();
+
+  return useInfiniteQuery<InstancesResponse, Error, InfiniteData<InstancesResponse>>({
+    queryKey: [
+      ApiQueryKeys.DEPLOYED_PRODUCT_INSTANCES_SEARCH,
+      deployedProductId,
+      dateRange,
+      "infinite",
+    ],
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const nextOffset = lastPage.offset + lastPage.limit;
+      return nextOffset < lastPage.totalRecords ? nextOffset : undefined;
+    },
+    queryFn: async ({ pageParam }): Promise<InstancesResponse> => {
+      const offset = pageParam as number;
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL ?? "";
+      const response = await authFetch(
+        `${baseUrl}/deployments/products/${deployedProductId}/instances/search`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            filters: dateRange,
+            pagination: { offset, limit: PAGE_SIZE },
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(
+          `Failed to search deployed product instances: ${response.status}`,
+        );
+      }
+      return response.json() as Promise<InstancesResponse>;
+    },
+    enabled: !!deployedProductId && isSignedIn && !isAuthLoading,
+    staleTime: 0,
+  });
+}

--- a/apps/customer-portal/webapp/src/features/project-details/api/useGetDeployedProductInstancesInfinite.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/api/useGetDeployedProductInstancesInfinite.ts
@@ -74,6 +74,8 @@ export default function useGetDeployedProductInstancesInfinite(
       return response.json() as Promise<InstancesResponse>;
     },
     enabled: !!deployedProductId && isSignedIn && !isAuthLoading,
-    staleTime: 0,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
@@ -31,6 +31,7 @@ import {
   resolveUsagePresetDateRange,
 } from "@features/usage-metrics/utils/usageMetricsTab";
 import { usePostProjectDeploymentsSearchAll } from "@api/usePostProjectDeploymentsSearch";
+import { getUsageOverviewAccentForTypeId } from "@features/usage-metrics/utils/usageMetricsAccent";
 
 /**
  * Usage & Metrics area: time range, inner environment tabs, overview and product drill-downs.
@@ -72,6 +73,7 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
           id: `${USAGE_METRICS_DEPLOYMENT_TAB_PREFIX}${dep.id}`,
           label: dep.name,
           icon: Server,
+          iconColor: getUsageOverviewAccentForTypeId(dep.type.id).iconColor,
           instanceCount: dep.instanceCount ?? 0,
           productCount: dep.productCount ?? 0,
         })),

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button } from "@wso2/oxygen-ui";
-import { Upload } from "@wso2/oxygen-ui-icons-react";
+import { Box, Button, Typography } from "@wso2/oxygen-ui";
+import { Server, Upload } from "@wso2/oxygen-ui-icons-react";
 import type { ReactNode } from "react";
 import type { JSX } from "react";
 import { useCallback, useMemo, useState } from "react";
@@ -69,6 +69,7 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
         .map((dep) => ({
           id: `${USAGE_METRICS_DEPLOYMENT_TAB_PREFIX}${dep.id}`,
           label: dep.name,
+          icon: Server,
           instanceCount: dep.instanceCount ?? 0,
           productCount: dep.productCount ?? 0,
         })),
@@ -82,6 +83,11 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
   const activeDeploymentId = useMemo(
     () => getActiveUsageDeploymentId(activeTab),
     [activeTab],
+  );
+
+  const activeDeployment = useMemo(
+    () => (deploymentsData ?? []).find((dep) => dep.id === activeDeploymentId),
+    [deploymentsData, activeDeploymentId],
   );
 
   const toggleProduct = useCallback((productId: string) => {
@@ -194,6 +200,13 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
         </Box>
         {uploadButton}
       </Box>
+
+      {activeDeployment && (
+        <Typography variant="body2" color="text.secondary">
+          {activeDeployment.name}
+          {activeDeployment.type?.label && ` · ${activeDeployment.type.label}`}
+        </Typography>
+      )}
 
       <DeploymentUsageUploadDialog
         open={uploadOpen}

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageAndMetricsTabContent.tsx
@@ -53,10 +53,12 @@ export default function UsageAndMetricsTabContent(): JSX.Element {
   const [appliedCustomEnd, setAppliedCustomEnd] = useState<string>("");
   const [uploadOpen, setUploadOpen] = useState<boolean>(false);
 
-  const dateRange = useMemo(
-    () => resolveUsagePresetDateRange(timeRange),
-    [timeRange],
-  );
+  const dateRange = useMemo(() => {
+    if (timeRange === UsageTimeRange.CUSTOM && appliedCustomStart && appliedCustomEnd) {
+      return { startDate: appliedCustomStart, endDate: appliedCustomEnd };
+    }
+    return resolveUsagePresetDateRange(timeRange);
+  }, [timeRange, appliedCustomStart, appliedCustomEnd]);
 
   const { data: deploymentsData } = usePostProjectDeploymentsSearchAll(
     projectId ?? "",

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -37,6 +37,7 @@ import {
   USAGE_METRICS_ENVIRONMENT_PRODUCTS_ERROR,
   USAGE_METRICS_NO_INSTANCE_DATA,
   USAGE_METRICS_NO_PRODUCTS_IN_DEPLOYMENT,
+  USAGE_METRICS_PRODUCT_DATA_UNAVAILABLE,
   USAGE_METRICS_PRODUCT_INSTANCES_SECTION,
   USAGE_METRICS_PRODUCT_INSTANCE_METRICS,
   USAGE_METRICS_PRODUCT_CORE_METRICS,
@@ -265,10 +266,16 @@ function ProductAccordionRow({
     return sorted[0]?.instances ?? [];
   }, [metricsData]);
 
+  // Nothing to show for this product if neither source has any data for this range.
+  const hasChartData =
+    (metricsData?.chartData?.length ?? 0) > 0 ||
+    (countsData?.chartData?.length ?? 0) > 0 ||
+    summaryStats.length > 0;
+
   return (
     <Accordion
-      expanded={expanded}
-      onChange={() => onToggle()}
+      expanded={hasChartData && expanded}
+      onChange={hasChartData ? () => onToggle() : undefined}
       disableGutters
       elevation={0}
       sx={{
@@ -279,19 +286,22 @@ function ProductAccordionRow({
         borderColor: "divider",
         borderRadius: 0,
         bgcolor: "background.paper",
-        "&:hover": { bgcolor: "action.hover" },
+        "&:hover": hasChartData ? { bgcolor: "action.hover" } : undefined,
         "&.Mui-expanded": { margin: 0 },
       }}
     >
       <AccordionSummary
-        expandIcon={<ChevronDown size={20} color={a.iconColor} />}
+        expandIcon={
+          hasChartData ? <ChevronDown size={20} color={a.iconColor} /> : null
+        }
         sx={{
           px: 2,
           py: 2,
           minHeight: 56,
           bgcolor: a.headerBg,
           borderRadius: 0,
-          "&:hover": { bgcolor: a.headerHoverBg },
+          cursor: hasChartData ? "pointer" : "default",
+          "&:hover": hasChartData ? { bgcolor: a.headerHoverBg } : undefined,
         }}
       >
         <Box
@@ -343,29 +353,41 @@ function ProductAccordionRow({
               gap: 5,
             }}
           >
-            {summaryStats.map((stat) => (
-              <Box key={stat.label}>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  display="block"
-                  sx={{ mb: 0.5 }}
-                >
-                  {stat.label}
-                </Typography>
-                <Typography variant="body1" sx={{ fontWeight: 700 }}>
-                  {stat.value}
-                </Typography>
-              </Box>
-            ))}
-            <CurrMinMaxBlock
-              label={USAGE_METRICS_PRODUCT_INSTANCE_METRICS}
-              summary={instanceSummary}
-            />
-            <CurrMinMaxBlock
-              label={USAGE_METRICS_PRODUCT_CORE_METRICS}
-              summary={coreSummary}
-            />
+            {!isLoading && !hasChartData ? (
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ fontStyle: "italic" }}
+              >
+                {USAGE_METRICS_PRODUCT_DATA_UNAVAILABLE}
+              </Typography>
+            ) : (
+              <>
+                {summaryStats.map((stat) => (
+                  <Box key={stat.label}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      display="block"
+                      sx={{ mb: 0.5 }}
+                    >
+                      {stat.label}
+                    </Typography>
+                    <Typography variant="body1" sx={{ fontWeight: 700 }}>
+                      {stat.value}
+                    </Typography>
+                  </Box>
+                ))}
+                <CurrMinMaxBlock
+                  label={USAGE_METRICS_PRODUCT_INSTANCE_METRICS}
+                  summary={instanceSummary}
+                />
+                <CurrMinMaxBlock
+                  label={USAGE_METRICS_PRODUCT_CORE_METRICS}
+                  summary={coreSummary}
+                />
+              </>
+            )}
           </Box>
         </Box>
       </AccordionSummary>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -192,10 +192,19 @@ function ProductAccordionRow({
 
   const countTypes = countsData?.summary?.countTypes;
 
+  // Show every count type the API actually returned, ordered by the classifier's
+  // known priority first, then any additional keys the classifier didn't anticipate.
+  const countTypeKeys = useMemo(() => {
+    if (!countTypes) return [];
+    const keys = Object.keys(countTypes);
+    const known = metricKeys.filter((key) => keys.includes(key));
+    const extra = keys.filter((key) => !metricKeys.includes(key));
+    return [...known, ...extra];
+  }, [countTypes, metricKeys]);
+
   const summaryStats = useMemo(() => {
     if (!countTypes) return [];
-    return metricKeys
-      .filter((key) => countTypes[key] != null)
+    return countTypeKeys
       .map((key) => {
         const cfg = METRIC_CHART_CONFIG[key] ?? METRIC_CHART_CONFIG_FALLBACK;
         const stat = countTypes[key];
@@ -216,7 +225,7 @@ function ProductAccordionRow({
         }
         return { label: cfg.title, value: formatUsageMetricCount(value) };
       });
-  }, [countTypes, metricKeys]);
+  }, [countTypes, countTypeKeys]);
 
   const coreTrend = useMemo(() => {
     const sorted = [...(metricsData?.chartData ?? [])].sort((x, y) =>
@@ -229,8 +238,7 @@ function ProductAccordionRow({
     const sortedCharts = [...(countsData?.chartData ?? [])].sort((x, y) =>
       x.date.localeCompare(y.date),
     );
-    return metricKeys
-      .filter((key) => countTypes?.[key] != null)
+    return countTypeKeys
       .map((key) => {
         const cfg = METRIC_CHART_CONFIG[key] ?? METRIC_CHART_CONFIG_FALLBACK;
         return {
@@ -244,7 +252,7 @@ function ProductAccordionRow({
           })),
         };
       });
-  }, [countsData, countTypes, metricKeys]);
+  }, [countsData, countTypeKeys]);
 
   const chartTrends = useMemo(
     () => [

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -28,11 +28,11 @@ import {
   alpha,
   colors,
 } from "@wso2/oxygen-ui";
-import { ChevronDown, Package, Server } from "@wso2/oxygen-ui-icons-react";
+import { ChevronDown, Code, Monitor, Package, Server } from "@wso2/oxygen-ui-icons-react";
 import EmptyState from "@components/empty-state/EmptyState";
 import { LineChart } from "@wso2/oxygen-ui-charts-react";
 import type { JSX } from "react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   USAGE_LINE_CHART_MARGIN,
   USAGE_METRICS_ENVIRONMENT_PRODUCTS_ERROR,
@@ -46,11 +46,16 @@ import {
   USAGE_METRICS_STAT_LABEL_MIN,
   USAGE_METRICS_STAT_LABEL_MAX,
   USAGE_METRICS_UNKNOWN_LABEL,
+  USAGE_METRICS_INSTANCE_OS_LABEL,
+  USAGE_METRICS_INSTANCE_JAVA_VERSION_LABEL,
+  USAGE_METRICS_INSTANCE_U2_LEVEL_LABEL,
 } from "@features/usage-metrics/constants/usageMetricsConstants";
+import type { InstanceItem } from "@features/project-details/types/usage";
 import { UsageChartSurface } from "@features/usage-metrics/components/UsageChartSurface";
 import { usePostDeploymentProductsSearchAll } from "@features/project-details/api/usePostDeploymentProductsSearch";
 import usePostDeploymentProductMetricsSearch from "@features/project-details/api/usePostDeploymentProductMetricsSearch";
 import usePostDeploymentProductUsageCountsSearch from "@features/project-details/api/usePostDeploymentProductUsageCountsSearch";
+import useGetDeployedProductInstancesInfinite from "@features/project-details/api/useGetDeployedProductInstancesInfinite";
 import { computeSeriesSummary, formatUsageMetricCount } from "@features/project-details/utils/usageMetrics";
 import type { CurrMinMaxAvg } from "@features/project-details/types/usage";
 import type {
@@ -168,6 +173,36 @@ function ProductAccordionRow({
   const { data: countsData, isLoading: countsLoading } =
     usePostDeploymentProductUsageCountsSearch(deploymentId, product.id, payload);
 
+  const {
+    data: instancesData,
+    isLoading: instancesLoading,
+    hasNextPage: hasMoreInstances,
+    isFetchingNextPage: isFetchingMoreInstances,
+    fetchNextPage: fetchMoreInstances,
+  } = useGetDeployedProductInstancesInfinite(expanded ? product.id : undefined, dateRange);
+
+  const instances = useMemo(
+    () => instancesData?.pages.flatMap((page) => page.instances) ?? [],
+    [instancesData],
+  );
+  const totalInstances = instancesData?.pages[0]?.totalRecords ?? 0;
+
+  const instancesSentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const sentinel = instancesSentinelRef.current;
+    if (!sentinel || !hasMoreInstances || isFetchingMoreInstances) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          void fetchMoreInstances();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMoreInstances, isFetchingMoreInstances, fetchMoreInstances]);
+
   const isLoading = metricsLoading || countsLoading;
 
   const metricKeys = useMemo(
@@ -267,13 +302,6 @@ function ProductAccordionRow({
     ],
     [countTrends, coreTrend],
   );
-
-  const latestInstances = useMemo(() => {
-    const sorted = [...(metricsData?.chartData ?? [])].sort((x, y) =>
-      y.date.localeCompare(x.date),
-    );
-    return sorted[0]?.instances ?? [];
-  }, [metricsData]);
 
   // Nothing to show for this product if neither source has any data for this range.
   const hasChartData =
@@ -418,7 +446,7 @@ function ProductAccordionRow({
       >
         {isLoading ? (
           <Skeleton variant="rounded" height={200} />
-        ) : latestInstances.length === 0 && chartTrends.every((t) => t.data.length === 0) ? (
+        ) : instances.length === 0 && chartTrends.every((t) => t.data.length === 0) ? (
           <Typography variant="body2" color="text.secondary">
             {USAGE_METRICS_NO_INSTANCE_DATA}
           </Typography>
@@ -470,18 +498,30 @@ function ProductAccordionRow({
               ))}
             </Grid>
 
-            {latestInstances.length > 0 && (
+            {instancesLoading ? (
+              <Box sx={{ mt: 2 }}>
+                <Skeleton variant="rounded" height={120} />
+              </Box>
+            ) : instances.length > 0 ? (
               <Box sx={{ mt: 2 }}>
                 <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>
-                  {USAGE_METRICS_PRODUCT_INSTANCES_SECTION} ({latestInstances.length})
+                  {USAGE_METRICS_PRODUCT_INSTANCES_SECTION} ({totalInstances})
                 </Typography>
                 <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-                  {latestInstances.map((inst) => (
-                    <InstanceRow key={inst.id} name={inst.name} cores={inst.cores} />
+                  {instances.map((inst) => (
+                    <InstanceRow key={inst.id} instance={inst} />
                   ))}
                 </Box>
+                {hasMoreInstances && (
+                  <Box
+                    ref={instancesSentinelRef}
+                    sx={{ display: "flex", justifyContent: "center", py: 2 }}
+                  >
+                    {isFetchingMoreInstances && <CircularProgress size={20} sx={{ color: a.iconColor }} />}
+                  </Box>
+                )}
               </Box>
-            )}
+            ) : null}
           </>
         )}
       </AccordionDetails>
@@ -491,8 +531,15 @@ function ProductAccordionRow({
 
 // ─── Flat instance row ────────────────────────────────────────────────────────
 
-function InstanceRow({ name, cores }: { name: string; cores: number }): JSX.Element {
+function InstanceRow({ instance }: { instance: InstanceItem }): JSX.Element {
   const wellBg = alpha(colors.grey?.[500] ?? "#6B7280", 0.04);
+  const dm = instance.metadata?.deploymentMetadata;
+
+  const os = dm?.os ? (dm.osVersion ? `${dm.os} ${dm.osVersion}` : dm.os) : "—";
+  const jdkVersion = dm?.jdkVersion || instance.metadata?.jdkVersion || "—";
+  const u2Level = dm?.updateLevel || "—";
+  const keyDisplay =
+    instance.key.length > 20 ? `${instance.key.slice(0, 12)}…` : instance.key;
 
   return (
     <Box
@@ -509,17 +556,29 @@ function InstanceRow({ name, cores }: { name: string; cores: number }): JSX.Elem
         bgcolor: wellBg,
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, minWidth: 0 }}>
         <Server size={18} color={colors.grey?.[500]} />
-        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-          {name}
+        <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap title={instance.key}>
+          {keyDisplay}
         </Typography>
       </Box>
-      <MetricPill
-        icon={<Package size={16} color={colors.grey?.[400]} />}
-        label={USAGE_METRICS_PRODUCT_CORE_METRICS}
-        value={String(cores)}
-      />
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
+        <MetricPill
+          icon={<Monitor size={16} color={colors.grey?.[400]} />}
+          label={USAGE_METRICS_INSTANCE_OS_LABEL}
+          value={os}
+        />
+        <MetricPill
+          icon={<Code size={16} color={colors.grey?.[400]} />}
+          label={USAGE_METRICS_INSTANCE_JAVA_VERSION_LABEL}
+          value={jdkVersion}
+        />
+        <MetricPill
+          icon={<Package size={16} color={colors.grey?.[400]} />}
+          label={USAGE_METRICS_INSTANCE_U2_LEVEL_LABEL}
+          value={u2Level}
+        />
+      </Box>
     </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -46,9 +46,9 @@ import {
   USAGE_METRICS_STAT_LABEL_MIN,
   USAGE_METRICS_STAT_LABEL_MAX,
   USAGE_METRICS_UNKNOWN_LABEL,
-  USAGE_METRICS_INSTANCE_OS_LABEL,
-  USAGE_METRICS_INSTANCE_JAVA_VERSION_LABEL,
-  USAGE_METRICS_INSTANCE_U2_LEVEL_LABEL,
+  USAGE_METRICS_INSTANCE_OS,
+  USAGE_METRICS_INSTANCE_JAVA,
+  USAGE_METRICS_INSTANCE_U2,
 } from "@features/usage-metrics/constants/usageMetricsConstants";
 import type { InstanceItem } from "@features/project-details/types/usage";
 import { UsageChartSurface } from "@features/usage-metrics/components/UsageChartSurface";
@@ -454,7 +454,7 @@ function ProductAccordionRow({
           borderRadius: 0,
         }}
       >
-        {isLoading ? (
+        {isLoading || instancesLoading ? (
           <Skeleton variant="rounded" height={200} />
         ) : instances.length === 0 && chartTrends.every((t) => t.data.length === 0) ? (
           <Typography variant="body2" color="text.secondary">
@@ -598,17 +598,17 @@ function InstanceRow({ instance }: { instance: InstanceItem }): JSX.Element {
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
         <MetricPill
           icon={<Monitor size={16} color={colors.grey?.[400]} />}
-          label={USAGE_METRICS_INSTANCE_OS_LABEL}
+          label={USAGE_METRICS_INSTANCE_OS}
           value={os}
         />
         <MetricPill
           icon={<Code size={16} color={colors.grey?.[400]} />}
-          label={USAGE_METRICS_INSTANCE_JAVA_VERSION_LABEL}
+          label={USAGE_METRICS_INSTANCE_JAVA}
           value={jdkVersion}
         />
         <MetricPill
           icon={<Package size={16} color={colors.grey?.[400]} />}
-          label={USAGE_METRICS_INSTANCE_U2_LEVEL_LABEL}
+          label={USAGE_METRICS_INSTANCE_U2}
           value={u2Level}
         />
       </Box>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -301,7 +301,6 @@ function ProductAccordionRow({
 
   const chartTrends = useMemo(
     () => [
-      ...countTrends,
       {
         key: "CORE_USAGE",
         title: CORE_CHART_CONFIG.title,
@@ -309,6 +308,7 @@ function ProductAccordionRow({
         stroke: CORE_CHART_CONFIG.stroke,
         data: coreTrend,
       },
+      ...countTrends,
     ],
     [countTrends, coreTrend],
   );

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -281,10 +281,14 @@ function ProductAccordionRow({
     (countsData?.chartData?.length ?? 0) > 0 ||
     summaryStats.length > 0;
 
+  // While a date-range change is refetching, don't force-collapse a row that was
+  // already expanded just because the in-flight data is momentarily empty.
+  const canExpand = hasChartData || isLoading;
+
   return (
     <Accordion
-      expanded={hasChartData && expanded}
-      onChange={hasChartData ? () => onToggle() : undefined}
+      expanded={canExpand && expanded}
+      onChange={canExpand ? () => onToggle() : undefined}
       disableGutters
       elevation={0}
       sx={{
@@ -295,13 +299,13 @@ function ProductAccordionRow({
         borderColor: "divider",
         borderRadius: 0,
         bgcolor: "background.paper",
-        "&:hover": hasChartData ? { bgcolor: "action.hover" } : undefined,
+        "&:hover": canExpand ? { bgcolor: "action.hover" } : undefined,
         "&.Mui-expanded": { margin: 0 },
       }}
     >
       <AccordionSummary
         expandIcon={
-          hasChartData ? <ChevronDown size={20} color={a.iconColor} /> : null
+          canExpand ? <ChevronDown size={20} color={a.iconColor} /> : null
         }
         sx={{
           px: 2,
@@ -309,8 +313,8 @@ function ProductAccordionRow({
           minHeight: 56,
           bgcolor: a.headerBg,
           borderRadius: 0,
-          cursor: hasChartData ? "pointer" : "default",
-          "&:hover": hasChartData ? { bgcolor: a.headerHoverBg } : undefined,
+          cursor: canExpand ? "pointer" : "default",
+          "&:hover": canExpand ? { bgcolor: a.headerHoverBg } : undefined,
         }}
       >
         <Box

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -485,7 +485,7 @@ function ProductAccordionRow({
                         xAxisDataKey="name"
                         height={200}
                         width="100%"
-                        margin={USAGE_LINE_CHART_MARGIN}
+                        margin={{ ...USAGE_LINE_CHART_MARGIN, top: 5, left: 0 }}
                         accessibilityLayer={false}
                         xAxis={{ show: false }}
                         yAxis={{ show: false }}
@@ -508,7 +508,8 @@ function ProductAccordionRow({
                           tick={{ fontSize: 12 }}
                         />
                         <YAxis
-                          tickMargin={8}
+                          tickMargin={4}
+                          width={36}
                           allowDecimals={false}
                           domain={[0, (max: number) => Math.max(1, Math.ceil(max * 1.2))]}
                           tick={{ fontSize: 12 }}

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -30,7 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ChevronDown, Code, Monitor, Package, Server } from "@wso2/oxygen-ui-icons-react";
 import EmptyState from "@components/empty-state/EmptyState";
-import { LineChart } from "@wso2/oxygen-ui-charts-react";
+import { LineChart, XAxis, YAxis } from "@wso2/oxygen-ui-charts-react";
 import type { JSX } from "react";
 import { useEffect, useMemo, useRef } from "react";
 import {
@@ -56,7 +56,10 @@ import { usePostDeploymentProductsSearchAll } from "@features/project-details/ap
 import usePostDeploymentProductMetricsSearch from "@features/project-details/api/usePostDeploymentProductMetricsSearch";
 import usePostDeploymentProductUsageCountsSearch from "@features/project-details/api/usePostDeploymentProductUsageCountsSearch";
 import useGetDeployedProductInstancesInfinite from "@features/project-details/api/useGetDeployedProductInstancesInfinite";
-import { computeSeriesSummary, formatUsageMetricCount } from "@features/project-details/utils/usageMetrics";
+import {
+  computeSeriesSummary,
+  formatUsageMetricCount,
+} from "@features/project-details/utils/usageMetrics";
 import type { CurrMinMaxAvg } from "@features/project-details/types/usage";
 import type {
   MetricPillProps,
@@ -76,9 +79,12 @@ const ZERO_SUMMARY: CurrMinMaxAvg = { curr: 0, avg: 0, min: 0, max: 0 };
 // list to ~5 visible rows before it becomes internally scrollable.
 const INSTANCE_ROW_HEIGHT = 64;
 
-/** Short period label (MM-DD) for chart x-axes. */
+/** Short period label ("Jul 19") for chart x-axes. */
 function formatPeriodLabel(date: string): string {
-  return date.slice(5);
+  return new Date(`${date}T00:00:00`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
 }
 
 // ─── Curr/Avg/Min/Max metric block ────────────────────────────────────────────
@@ -466,7 +472,7 @@ function ProductAccordionRow({
                   key={trend.key}
                   size={{
                     xs: 12,
-                    lg: chartTrends.length === 1 ? 12 : chartTrends.length === 3 ? 4 : 6,
+                    lg: chartTrends.length === 1 ? 12 : 4,
                   }}
                 >
                   <Card sx={{ p: 2, borderRadius: 0 }}>
@@ -481,9 +487,8 @@ function ProductAccordionRow({
                         width="100%"
                         margin={USAGE_LINE_CHART_MARGIN}
                         accessibilityLayer={false}
-                        xAxis={{
-                          interval: Math.max(0, Math.ceil(trend.data.length / 6) - 1),
-                        }}
+                        xAxis={{ show: false }}
+                        yAxis={{ show: false }}
                         legend={{ show: false }}
                         grid={{ show: true, strokeDasharray: "3 3" }}
                         lines={[
@@ -495,7 +500,21 @@ function ProductAccordionRow({
                             dot: false,
                           },
                         ]}
-                      />
+                      >
+                        <XAxis
+                          dataKey="name"
+                          tickMargin={8}
+                          interval={Math.max(0, Math.ceil(trend.data.length / 6) - 1)}
+                          tick={{ fontSize: 12 }}
+                        />
+                        <YAxis
+                          tickMargin={8}
+                          allowDecimals={false}
+                          domain={[0, (max: number) => Math.max(1, Math.ceil(max * 1.2))]}
+                          tick={{ fontSize: 12 }}
+                          tickFormatter={(value: number) => formatUsageMetricCount(value)}
+                        />
+                      </LineChart>
                     </UsageChartSurface>
                   </Card>
                 </Grid>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -21,6 +21,7 @@ import {
   Alert,
   Box,
   Card,
+  CircularProgress,
   Grid,
   Skeleton,
   Typography,
@@ -353,7 +354,9 @@ function ProductAccordionRow({
               gap: 5,
             }}
           >
-            {!isLoading && !hasChartData ? (
+            {isLoading ? (
+              <CircularProgress size={20} sx={{ color: a.iconColor }} />
+            ) : !hasChartData ? (
               <Typography
                 variant="body2"
                 color="text.secondary"

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageEnvironmentProductsPanel.tsx
@@ -72,6 +72,10 @@ import {
 
 const ZERO_SUMMARY: CurrMinMaxAvg = { curr: 0, avg: 0, min: 0, max: 0 };
 
+// Approximate height of a single instance row (px), used to cap the instances
+// list to ~5 visible rows before it becomes internally scrollable.
+const INSTANCE_ROW_HEIGHT = 64;
+
 /** Short period label (MM-DD) for chart x-axes. */
 function formatPeriodLabel(date: string): string {
   return date.slice(5);
@@ -507,19 +511,28 @@ function ProductAccordionRow({
                 <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>
                   {USAGE_METRICS_PRODUCT_INSTANCES_SECTION} ({totalInstances})
                 </Typography>
-                <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 1,
+                    maxHeight: 5 * INSTANCE_ROW_HEIGHT,
+                    overflowY: "auto",
+                    pr: 0.5,
+                  }}
+                >
                   {instances.map((inst) => (
                     <InstanceRow key={inst.id} instance={inst} />
                   ))}
+                  {hasMoreInstances && (
+                    <Box
+                      ref={instancesSentinelRef}
+                      sx={{ display: "flex", justifyContent: "center", py: 2 }}
+                    >
+                      {isFetchingMoreInstances && <CircularProgress size={20} sx={{ color: a.iconColor }} />}
+                    </Box>
+                  )}
                 </Box>
-                {hasMoreInstances && (
-                  <Box
-                    ref={instancesSentinelRef}
-                    sx={{ display: "flex", justifyContent: "center", py: 2 }}
-                  >
-                    {isFetchingMoreInstances && <CircularProgress size={20} sx={{ color: a.iconColor }} />}
-                  </Box>
-                )}
               </Box>
             ) : null}
           </>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
@@ -27,7 +27,10 @@ import {
   USAGE_METRICS_CUSTOM_RANGE_APPLY,
   USAGE_METRICS_CUSTOM_RANGE_BUTTON,
   USAGE_METRICS_CUSTOM_RANGE_CANCEL,
+  USAGE_METRICS_CUSTOM_RANGE_INVALID_ORDER,
+  USAGE_METRICS_CUSTOM_RANGE_MAX_DAYS,
   USAGE_METRICS_CUSTOM_RANGE_PLACEHOLDER,
+  USAGE_METRICS_CUSTOM_RANGE_TOO_LONG,
   USAGE_METRICS_CUSTOM_RANGE_TO,
   USAGE_METRICS_PRESET_TIME_RANGES,
   USAGE_TIME_RANGE_LABELS,
@@ -62,6 +65,16 @@ export default function UsageMetricsTimeRangeSelector({
   rightAction,
 }: UsageMetricsTimeRangeSelectorProps): JSX.Element {
   const timeLabel = USAGE_TIME_RANGE_LABELS[timeRange];
+
+  const customRangeError = (() => {
+    if (!customStart || !customEnd) return null;
+    const start = new Date(customStart);
+    const end = new Date(customEnd);
+    if (end < start) return USAGE_METRICS_CUSTOM_RANGE_INVALID_ORDER;
+    const days = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24);
+    if (days > USAGE_METRICS_CUSTOM_RANGE_MAX_DAYS) return USAGE_METRICS_CUSTOM_RANGE_TOO_LONG;
+    return null;
+  })();
 
   return (
     <Box
@@ -123,63 +136,72 @@ export default function UsageMetricsTimeRangeSelector({
           </Button>
 
           {timeRange === UsageTimeRange.CUSTOM && (
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2, ml: 1 }}>
-              <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-                <TextField
-                  type="date"
-                  size="small"
-                  value={customStart}
-                  onChange={(e) => onCustomStartChange(e.target.value)}
-                  sx={{ minWidth: 160, maxWidth: "100%" }}
-                  InputProps={{
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <Calendar size={16} />
-                      </InputAdornment>
-                    ),
-                  }}
-                />
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mx: 0.5 }}
-                >
-                  {USAGE_METRICS_CUSTOM_RANGE_TO}
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, ml: 1 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                  <TextField
+                    type="date"
+                    size="small"
+                    value={customStart}
+                    onChange={(e) => onCustomStartChange(e.target.value)}
+                    error={!!customRangeError}
+                    sx={{ minWidth: 160, maxWidth: "100%" }}
+                    InputProps={{
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <Calendar size={16} />
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mx: 0.5 }}
+                  >
+                    {USAGE_METRICS_CUSTOM_RANGE_TO}
+                  </Typography>
+                  <TextField
+                    type="date"
+                    size="small"
+                    value={customEnd}
+                    onChange={(e) => onCustomEndChange(e.target.value)}
+                    error={!!customRangeError}
+                    sx={{ minWidth: 160, maxWidth: "100%" }}
+                    InputProps={{
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <Calendar size={16} />
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                </Box>
+                <Box sx={{ display: "flex", gap: 1 }}>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    color="warning"
+                    onClick={onApplyCustom}
+                    disabled={!customStart || !customEnd || !!customRangeError}
+                  >
+                    {USAGE_METRICS_CUSTOM_RANGE_APPLY}
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    color="inherit"
+                    onClick={onCancelCustom}
+                  >
+                    {USAGE_METRICS_CUSTOM_RANGE_CANCEL}
+                  </Button>
+                </Box>
+              </Box>
+              {customRangeError && (
+                <Typography variant="caption" color="error">
+                  {customRangeError}
                 </Typography>
-                <TextField
-                  type="date"
-                  size="small"
-                  value={customEnd}
-                  onChange={(e) => onCustomEndChange(e.target.value)}
-                  sx={{ minWidth: 160, maxWidth: "100%" }}
-                  InputProps={{
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <Calendar size={16} />
-                      </InputAdornment>
-                    ),
-                  }}
-                />
-              </Box>
-              <Box sx={{ display: "flex", gap: 1 }}>
-                <Button
-                  size="small"
-                  variant="contained"
-                  color="warning"
-                  onClick={onApplyCustom}
-                  disabled={!customStart || !customEnd}
-                >
-                  {USAGE_METRICS_CUSTOM_RANGE_APPLY}
-                </Button>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="inherit"
-                  onClick={onCancelCustom}
-                >
-                  {USAGE_METRICS_CUSTOM_RANGE_CANCEL}
-                </Button>
-              </Box>
+              )}
             </Box>
           )}
         </Box>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageOverviewPanel.tsx
@@ -239,9 +239,7 @@ function DeploymentExpandedView({
   const a = getUsageOverviewAccentForTypeId(typeId);
 
   const metricsPayload = useMemo(
-    () => ({
-      filters: { startDate: dateRange.startDate, endDate: dateRange.endDate },
-    }),
+    () => ({ startDate: dateRange.startDate, endDate: dateRange.endDate }),
     [dateRange],
   );
 
@@ -370,7 +368,7 @@ function EnvironmentBreakdownAccordion({
   const fetchDeploymentId = (expanded || hasExpandedRef.current) ? row.deploymentId : undefined;
 
   const metricsPayload = useMemo(
-    () => ({ filters: { startDate: dateRange.startDate, endDate: dateRange.endDate } }),
+    () => ({ startDate: dateRange.startDate, endDate: dateRange.endDate }),
     [dateRange],
   );
 
@@ -576,9 +574,7 @@ export default function UsageOverviewPanel({
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
   const metricsPayload = useMemo(
-    () => ({
-      filters: { startDate: dateRange.startDate, endDate: dateRange.endDate },
-    }),
+    () => ({ startDate: dateRange.startDate, endDate: dateRange.endDate }),
     [dateRange],
   );
 

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/__tests__/UsageEnvironmentProductsPanel.test.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/__tests__/UsageEnvironmentProductsPanel.test.tsx
@@ -59,6 +59,16 @@ vi.mock("@features/project-details/api/usePostDeploymentProductUsageCountsSearch
   }),
 }));
 
+vi.mock("@features/project-details/api/useGetDeployedProductInstancesInfinite", () => ({
+  default: () => ({
+    data: undefined,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+
 describe("UsageEnvironmentProductsPanel", () => {
   it("renders product rows and toggles product expansion", () => {
     const onToggleProduct = vi.fn();

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -195,6 +195,12 @@ export const USAGE_METRICS_PRODUCT_INSTANCE_METRICS = "Instance Metrics";
 
 export const USAGE_METRICS_PRODUCT_CORE_METRICS = "CPU Usage";
 
+export const USAGE_METRICS_INSTANCE_OS_LABEL = "OS";
+
+export const USAGE_METRICS_INSTANCE_JAVA_VERSION_LABEL = "Java Version";
+
+export const USAGE_METRICS_INSTANCE_U2_LEVEL_LABEL = "U2 Level";
+
 export const USAGE_METRICS_STAT_LABEL_CURR = "Curr";
 
 export const USAGE_METRICS_STAT_LABEL_AVG = "Avg";

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -57,6 +57,14 @@ export const USAGE_METRICS_CUSTOM_RANGE_TO = "to";
 
 export const USAGE_METRICS_CUSTOM_RANGE_PLACEHOLDER = "Select custom range";
 
+// Backend metrics/usage-count search endpoints reject ranges longer than 1 year.
+export const USAGE_METRICS_CUSTOM_RANGE_MAX_DAYS = 366;
+
+export const USAGE_METRICS_CUSTOM_RANGE_INVALID_ORDER =
+  "End date must be on or after the start date.";
+
+export const USAGE_METRICS_CUSTOM_RANGE_TOO_LONG = `Custom range can span at most ${USAGE_METRICS_CUSTOM_RANGE_MAX_DAYS} days.`;
+
 export const USAGE_METRICS_OVERVIEW_ERROR =
   "Failed to load usage overview data. Please try again.";
 

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -71,6 +71,9 @@ export const USAGE_METRICS_NO_PRODUCTS_IN_DEPLOYMENT =
 
 export const USAGE_METRICS_NO_INSTANCE_DATA = "No instance data available.";
 
+export const USAGE_METRICS_PRODUCT_DATA_UNAVAILABLE =
+  "Usage data is not available for this product";
+
 export const USAGE_METRICS_STAT_ENVIRONMENTS = "Environments";
 
 export const USAGE_METRICS_STAT_PRODUCTS = "Products";

--- a/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/constants/usageMetricsConstants.ts
@@ -203,12 +203,6 @@ export const USAGE_METRICS_PRODUCT_INSTANCE_METRICS = "Instance Metrics";
 
 export const USAGE_METRICS_PRODUCT_CORE_METRICS = "CPU Usage";
 
-export const USAGE_METRICS_INSTANCE_OS_LABEL = "OS";
-
-export const USAGE_METRICS_INSTANCE_JAVA_VERSION_LABEL = "Java Version";
-
-export const USAGE_METRICS_INSTANCE_U2_LEVEL_LABEL = "U2 Level";
-
 export const USAGE_METRICS_STAT_LABEL_CURR = "Curr";
 
 export const USAGE_METRICS_STAT_LABEL_AVG = "Avg";


### PR DESCRIPTION
## Summary
- Add an instances view for deployments/products with correct usage data, and hide expand/stats controls when no usage data is available
- Show a loading spinner instead of zeroed-out metrics in the product header while data is fetching
- Show the deployment icon on tabs and surface the active deployment's type below the tab bar
- Render all count-type charts returned by the API instead of a hardcoded known list
- Lay out 3 trend charts per row, render Core Usage first with count-type charts after, and tighten chart title/axis spacing with proper y-axis alignment
- Fix custom date range being ignored when fetching usage metrics, and preserve the expanded usage accordion state across time range refetches
- Fix `InstanceMetricsRequest` payload shape (`startDate`/`endDate` were nested under a stray `filters` key) causing a build failure

## Test plan
- [ ] Verify usage metrics load correctly for a deployment/product with no usage data (expand/stats hidden)
- [ ] Verify product header shows a spinner (not zeroed metrics) while loading
- [ ] Verify deployment tabs show icons and correct type label
- [ ] Verify all count-type charts render, including any new/unknown types
- [ ] Verify custom date range selection actually refetches usage metrics
- [ ] Verify expanding an accordion and changing the time range keeps it expanded
- [ ] `npm run build` passes with no TypeScript errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added infinite scrolling for deployed product instances, including total counts and OS, Java, and U2 metadata.
  - Added active deployment details and server indicators to usage views.
  - Expanded charts to display all metrics returned by the service.
  - Added loading states, unavailable-data messaging, and improved instance period labels.

- **Bug Fixes**
  - Corrected custom date-range handling and usage metric filtering.
  - Prevented invalid date ranges from being applied, including reversed or overly long ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->