### PR TITLE
[CSM Portal Microapp] Add log time and per-case time card list

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
@@ -1,0 +1,336 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState } from "react";
+import {
+  AdapterDateFns,
+  Autocomplete,
+  Button,
+  Chip,
+  DatePickers,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useQuery } from "@tanstack/react-query";
+import { format, parse } from "date-fns";
+import { adminUsers } from "@src/services/adminUsers";
+import { useUserStore } from "@src/store/user";
+import type {
+  ActivityBreakdown,
+  ActivityKey,
+  CreateTimeCardInput,
+  IssueComplexity,
+  TimeCardApprover,
+} from "@src/types";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import {
+  ACTIVITY_BUCKETS,
+  DEFAULT_BILLABLE,
+  DEFAULT_ISSUE_COMPLEXITY,
+  ISSUE_COMPLEXITY_OPTIONS,
+  WORK_LOG_MAX,
+  emptyBreakdown,
+  timeCardDraftErrors,
+  totalMinutes,
+} from "@utils/timecard";
+
+const { LocalizationProvider, DatePicker } = DatePickers;
+
+const ISO_DATE = "yyyy-MM-dd";
+
+// The Acrylic theme renders popup papers translucent — force an opaque surface
+// so a picker/dropdown opening over the dialog is actually readable. Mirrors
+// TimeCardFiltersSheet's OPAQUE_POPUP.
+const OPAQUE_POPUP = { sx: { backgroundColor: "background.default", backgroundImage: "none" } };
+
+function todayIso(): string {
+  return format(new Date(), ISO_DATE);
+}
+
+function fromIsoDate(iso: string): Date | null {
+  if (!iso) return null;
+  const d = parse(iso, ISO_DATE, new Date());
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+interface ApproverOption {
+  id: string;
+  name: string;
+  email?: string;
+}
+
+interface LogTimeCardDialogProps {
+  /** The case the time was spent on — always known, this dialog only opens
+   * from a case's Time Tracking tab. */
+  caseId: string;
+  caseNumber: string;
+  projectId: string;
+  projectName: string;
+  /** True while the create mutation is in flight. */
+  isSubmitting: boolean;
+  /** Set when the last submit attempt failed — cleared by the caller on retry. */
+  error?: string | null;
+  onClose: () => void;
+  onSubmit: (input: CreateTimeCardInput) => void;
+}
+
+/**
+ * "Log time" form. Mirrors the webapp's LogTimeCardDialog (same fields: date,
+ * the five activity buckets, work-log comment, issue complexity, approver),
+ * adapted to this microapp's single-column mobile layout and conventions.
+ * Creating a card submits it immediately — the backend has no draft step.
+ */
+export function LogTimeCardDialog({
+  caseId,
+  caseNumber,
+  projectId,
+  projectName,
+  isSubmitting,
+  error,
+  onClose,
+  onSubmit,
+}: LogTimeCardDialogProps) {
+  const me = useUserStore((s) => s.user);
+
+  const [date, setDate] = useState(todayIso());
+  const [issueComplexity, setIssueComplexity] = useState<IssueComplexity>(DEFAULT_ISSUE_COMPLEXITY);
+  const [billable, setBillable] = useState<boolean>(DEFAULT_BILLABLE);
+  const [breakdown, setBreakdown] = useState<ActivityBreakdown>(emptyBreakdown());
+  const [workLogComment, setWorkLogComment] = useState("");
+  const [approver, setApprover] = useState<TimeCardApprover | null>(null);
+  const [approverInput, setApproverInput] = useState("");
+  const [touched, setTouched] = useState<Set<string>>(new Set());
+  const touch = (field: string): void => setTouched((prev) => new Set(prev).add(field));
+  const isTouched = (field: string): boolean => touched.has(field);
+
+  const total = totalMinutes(breakdown);
+  const errors = timeCardDraftErrors({
+    date,
+    breakdown,
+    workLogComment,
+    approverId: approver?.id,
+  });
+  const isValid = Object.keys(errors).length === 0;
+
+  const debouncedApproverInput = useDebouncedValue(approverInput.trim(), 300);
+  const { data, isFetching } = useQuery(adminUsers.search(debouncedApproverInput));
+  const hasApproverInput = approverInput.trim().length > 0;
+  // Approvers must be real internal accounts, and never the signed-in user —
+  // nothing server-side stops picking yourself, which would let a submitter
+  // approve their own time. Mirrors the webapp's LogTimeCardDialog.
+  const candidates: ApproverOption[] = useMemo(() => {
+    if (!hasApproverInput) return [];
+    const myEmail = (me?.email ?? "").toLowerCase();
+    return (data?.users ?? [])
+      .filter((u) => !!u.email && u.email.toLowerCase() !== myEmail && u.active !== false)
+      .map((u) => ({ id: u.id, name: u.name || u.userName, email: u.email }));
+  }, [data, hasApproverInput, me?.email]);
+
+  const setActivity = (key: ActivityKey, next: number): void => setBreakdown((prev) => ({ ...prev, [key]: next }));
+
+  const ALL_FIELDS = ["date", "minutes", "workLogComment", "approver"];
+  const handleSubmit = (): void => {
+    if (!isValid || !approver) {
+      setTouched(new Set(ALL_FIELDS));
+      return;
+    }
+    onSubmit({
+      caseId,
+      caseNumber,
+      projectId,
+      projectName,
+      date,
+      breakdown,
+      billable,
+      workLogComment: workLogComment.trim(),
+      issueComplexity,
+      approver,
+    });
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={isSubmitting ? undefined : onClose}
+      fullWidth
+      maxWidth="xs"
+      slotProps={{ paper: { sx: { backgroundImage: "none", backgroundColor: "background.default" } } }}
+    >
+      <DialogTitle>Log time · {caseNumber}</DialogTitle>
+      <DialogContent dividers>
+        <Stack gap={2}>
+          <Typography variant="body2" color="text.secondary">
+            {projectName || "—"}
+          </Typography>
+
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DatePicker
+              label="Date"
+              value={fromIsoDate(date)}
+              onChange={(next) => {
+                setDate(next instanceof Date && !Number.isNaN(next.getTime()) ? format(next, ISO_DATE) : "");
+                touch("date");
+              }}
+              slotProps={{
+                textField: {
+                  size: "small",
+                  fullWidth: true,
+                  required: true,
+                  error: isTouched("date") && !!errors.date,
+                  helperText: isTouched("date") ? errors.date : undefined,
+                },
+                field: { clearable: true },
+                desktopPaper: OPAQUE_POPUP,
+                mobilePaper: OPAQUE_POPUP,
+              }}
+            />
+          </LocalizationProvider>
+
+          <Divider />
+
+          <Stack direction="row" alignItems="baseline" justifyContent="space-between">
+            <Typography variant="subtitle2">Time breakdown (minutes)</Typography>
+            <Typography variant="subtitle2" color="primary">
+              {total} min total
+            </Typography>
+          </Stack>
+          {isTouched("minutes") && errors.minutes && (
+            <Typography variant="caption" color="error">
+              {errors.minutes}
+            </Typography>
+          )}
+          <Stack gap={1.25}>
+            {ACTIVITY_BUCKETS.map((b) => (
+              <Stack key={b.key} direction="row" alignItems="center" justifyContent="space-between" gap={1.5}>
+                <Typography variant="body2">{b.label}</Typography>
+                <TextField
+                  type="number"
+                  size="small"
+                  value={Number.isFinite(breakdown[b.key]) ? breakdown[b.key] : 0}
+                  onChange={(e) => setActivity(b.key, Math.max(0, Math.round(Number(e.target.value) || 0)))}
+                  onBlur={() => touch("minutes")}
+                  slotProps={{ htmlInput: { min: 0, step: 1, "aria-label": b.label } }}
+                  sx={{ width: 96 }}
+                />
+              </Stack>
+            ))}
+          </Stack>
+
+          <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
+            <TextField
+              select
+              label="Issue complexity"
+              size="small"
+              value={issueComplexity}
+              onChange={(e) => setIssueComplexity(e.target.value as IssueComplexity)}
+              sx={{ minWidth: 140 }}
+              slotProps={{ select: { MenuProps: { slotProps: { paper: OPAQUE_POPUP } } } }}
+            >
+              {ISSUE_COMPLEXITY_OPTIONS.map((o) => (
+                <MenuItem key={o} value={o}>
+                  {o}
+                </MenuItem>
+              ))}
+            </TextField>
+            <FormControlLabel
+              control={<Switch checked={billable} onChange={(e) => setBillable(e.target.checked)} />}
+              label={billable ? "Billable" : "Non-billable"}
+              labelPlacement="start"
+              sx={{ ml: 0 }}
+            />
+          </Stack>
+
+          <TextField
+            label="Work log comment"
+            required
+            multiline
+            minRows={3}
+            fullWidth
+            value={workLogComment}
+            onChange={(e) => setWorkLogComment(e.target.value.slice(0, WORK_LOG_MAX))}
+            onBlur={() => touch("workLogComment")}
+            error={isTouched("workLogComment") && !!errors.workLogComment}
+            helperText={
+              isTouched("workLogComment") && errors.workLogComment
+                ? errors.workLogComment
+                : `${WORK_LOG_MAX - workLogComment.length} characters left`
+            }
+          />
+
+          <Stack gap={0.75}>
+            <Typography variant="subtitle2">Approver (team lead)</Typography>
+            {approver ? (
+              <Chip label={approver.name} onDelete={() => setApprover(null)} sx={{ alignSelf: "flex-start" }} />
+            ) : (
+              <Autocomplete
+                size="small"
+                options={candidates}
+                loading={isFetching}
+                getOptionLabel={(o) => o.name}
+                isOptionEqualToValue={(a, b) => a.id === b.id}
+                filterOptions={(opts) => opts}
+                noOptionsText={!hasApproverInput ? "Type to search for an approver…" : "No matching engineers."}
+                onChange={(_, next) => {
+                  if (next) {
+                    setApprover({ id: next.id, name: next.name });
+                    setApproverInput("");
+                  }
+                }}
+                onInputChange={(_, next, reason) => {
+                  if (reason === "input") setApproverInput(next);
+                  else if (reason === "clear") setApproverInput("");
+                }}
+                onBlur={() => touch("approver")}
+                slotProps={{ paper: OPAQUE_POPUP }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    placeholder="Search engineers by name or email…"
+                    error={isTouched("approver") && !!errors.approver}
+                    helperText={isTouched("approver") ? errors.approver : undefined}
+                  />
+                )}
+              />
+            )}
+          </Stack>
+
+          {error && (
+            <Typography variant="body2" color="error">
+              {error}
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleSubmit} disabled={isSubmitting || (touched.size > 0 && !isValid)}>
+          {isSubmitting ? "Submitting…" : "Submit for review"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
@@ -50,6 +50,7 @@ import {
   DEFAULT_BILLABLE,
   DEFAULT_ISSUE_COMPLEXITY,
   ISSUE_COMPLEXITY_OPTIONS,
+  MAX_MINUTES_PER_DAY,
   WORK_LOG_MAX,
   emptyBreakdown,
   timeCardDraftErrors,
@@ -229,9 +230,14 @@ export function LogTimeCardDialog({
                   type="number"
                   size="small"
                   value={Number.isFinite(breakdown[b.key]) ? breakdown[b.key] : 0}
-                  onChange={(e) => setActivity(b.key, Math.max(0, Math.round(Number(e.target.value) || 0)))}
+                  onChange={(e) =>
+                    setActivity(
+                      b.key,
+                      Math.min(MAX_MINUTES_PER_DAY, Math.max(0, Math.round(Number(e.target.value) || 0))),
+                    )
+                  }
                   onBlur={() => touch("minutes")}
-                  slotProps={{ htmlInput: { min: 0, step: 1, "aria-label": b.label } }}
+                  slotProps={{ htmlInput: { min: 0, max: MAX_MINUTES_PER_DAY, step: 1, "aria-label": b.label } }}
                   sx={{ width: 96 }}
                 />
               </Stack>
@@ -327,7 +333,7 @@ export function LogTimeCardDialog({
         <Button color="inherit" onClick={onClose} disabled={isSubmitting}>
           Cancel
         </Button>
-        <Button variant="contained" onClick={handleSubmit} disabled={isSubmitting || (touched.size > 0 && !isValid)}>
+        <Button variant="contained" onClick={handleSubmit} disabled={isSubmitting}>
           {isSubmitting ? "Submitting…" : "Submit for review"}
         </Button>
       </DialogActions>

--- a/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
@@ -14,26 +14,140 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Button, Stack, Typography } from "@wso2/oxygen-ui";
+import { useState } from "react";
+import { Box, Button, Divider, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useNavigate } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { timecards } from "@src/services/timecards";
+import type { CreateTimeCardInput, CsmTimeCard } from "@src/types";
+import { cardDateLabel, formatMinutes } from "@utils/timecard";
+import { TimeCardStateChip } from "@components/timecards/TimeCardStateChip";
+import { LogTimeCardDialog } from "./LogTimeCardDialog";
+
+interface TimeTrackingTabProps {
+  caseId: string;
+  caseNumber: string;
+  projectId: string;
+  projectName: string;
+}
+
+function TimeCardRow({ card }: { card: CsmTimeCard }) {
+  return (
+    <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
+      <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
+        {card.userName}
+      </Typography>
+      <Stack alignItems="flex-end" gap={0.5} flexShrink={0}>
+        <TimeCardStateChip state={card.state} />
+        <Typography variant="caption" color="text.secondary">
+          {cardDateLabel(card.createdOn)} · {formatMinutes(card.totalMinutes)}
+          {card.billable ? "" : " · Non-billable"}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+}
 
 /**
- * The time-cards search endpoint has no working case-scoping (see services/timecards.ts —
- * `caseId` is "non-functional live"), so this can't show a genuine per-case time list yet. Rather
- * than fake a filtered view, this links out to the full Time Cards page instead.
+ * `caseId` is confirmed non-functional live as a `/time-cards/search` filter (see
+ * services/timecards.ts's fetchCaseTimeCards), so this list is scoped to the case's
+ * project server-side and filtered to the case client-side, same workaround the
+ * webapp's CaseTimeCardsPanel uses. Only the first page of the project's cards is
+ * fetched — a single case logging more than a page's worth of time isn't expected —
+ * so a truncated notice covers the rare case where it does.
  */
-export function TimeTrackingTab({ caseNumber }: { caseNumber: string }) {
+export function TimeTrackingTab({ caseId, caseNumber, projectId, projectName }: TimeTrackingTabProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [logTimeOpen, setLogTimeOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data, isLoading, isError } = useQuery(timecards.forCase(caseId, projectId));
+  const cards = data?.cards ?? [];
+  const total = cards.reduce((sum, c) => sum + c.totalMinutes, 0);
+
+  const handleSubmit = (input: CreateTimeCardInput) => {
+    setIsSubmitting(true);
+    setError(null);
+    timecards
+      .create(input)
+      .then(() => {
+        setLogTimeOpen(false);
+        // Root key — one invalidate refreshes every time-cards view (My sheets,
+        // All, Approvals, and this case's own list) after this write, per
+        // services/timecards.ts's convention.
+        void queryClient.invalidateQueries({ queryKey: ["timecards"] });
+      })
+      .catch(() => setError("Could not log time. Please try again."))
+      .finally(() => setIsSubmitting(false));
+  };
 
   return (
-    <Stack gap={1.5} alignItems="start">
-      <Typography variant="body2" color="text.secondary">
-        Per-case time tracking isn&apos;t available here yet. Log or review time for {caseNumber} from the full Time
-        Cards page.
-      </Typography>
-      <Button variant="outlined" size="small" onClick={() => navigate("/more/time-cards")}>
+    <Stack gap={1.5}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
+        <Box>
+          <Typography variant="h6" sx={{ lineHeight: 1 }}>
+            {formatMinutes(total)}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Across {cards.length} {cards.length === 1 ? "entry" : "entries"}
+          </Typography>
+        </Box>
+        <Button variant="contained" size="small" startIcon={<Plus size={14} />} onClick={() => setLogTimeOpen(true)}>
+          Log time
+        </Button>
+      </Stack>
+
+      <Divider />
+
+      {!isError && data?.truncated && (
+        <Typography variant="caption" color="text.secondary">
+          Some entries on this case may not be shown.
+        </Typography>
+      )}
+
+      {isLoading ? (
+        <Stack gap={1}>
+          {[0, 1].map((i) => (
+            <Skeleton key={i} variant="rounded" height={48} />
+          ))}
+        </Stack>
+      ) : isError ? (
+        <Typography variant="body2" color="error">
+          Could not load time cards.
+        </Typography>
+      ) : cards.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No time logged on this case yet.
+        </Typography>
+      ) : (
+        <Stack gap={1.5}>
+          {cards.map((c) => (
+            <TimeCardRow key={c.id} card={c} />
+          ))}
+        </Stack>
+      )}
+
+      <Button variant="outlined" size="small" onClick={() => navigate("/more/time-cards")} sx={{ alignSelf: "start" }}>
         Open Time Cards
       </Button>
+
+      {logTimeOpen && (
+        <LogTimeCardDialog
+          caseId={caseId}
+          caseNumber={caseNumber}
+          projectId={projectId}
+          projectName={projectName}
+          isSubmitting={isSubmitting}
+          error={error}
+          onClose={() => {
+            if (!isSubmitting) setLogTimeOpen(false);
+          }}
+          onSubmit={handleSubmit}
+        />
+      )}
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
@@ -143,7 +143,10 @@ export function TimeTrackingTab({ caseId, caseNumber, projectId, projectName }: 
           isSubmitting={isSubmitting}
           error={error}
           onClose={() => {
-            if (!isSubmitting) setLogTimeOpen(false);
+            if (!isSubmitting) {
+              setLogTimeOpen(false);
+              setError(null);
+            }
           }}
           onSubmit={handleSubmit}
         />

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -402,7 +402,14 @@ function CaseDetailContent({ id }: { id: string }) {
 
       {activeTab === "attachments" && <AttachmentsTab caseId={id} />}
 
-      {activeTab === "time" && <TimeTrackingTab caseNumber={caseDetail.number} />}
+      {activeTab === "time" && (
+        <TimeTrackingTab
+          caseId={id}
+          caseNumber={caseDetail.number}
+          projectId={caseDetail.project.id}
+          projectName={caseDetail.project.name}
+        />
+      )}
 
       {activeTab === "call-requests" && <CallRequestsTab caseId={id} />}
 

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -406,8 +406,8 @@ function CaseDetailContent({ id }: { id: string }) {
         <TimeTrackingTab
           caseId={id}
           caseNumber={caseDetail.number}
-          projectId={caseDetail.project.id}
-          projectName={caseDetail.project.name}
+          projectId={caseDetail.project?.id ?? ""}
+          projectName={caseDetail.project?.name ?? ""}
         />
       )}
 

--- a/apps/csm-portal/microapp/src/services/adminUsers.ts
+++ b/apps/csm-portal/microapp/src/services/adminUsers.ts
@@ -71,5 +71,6 @@ export const adminUsers = {
           filters: { searchQuery, roles: APPROVER_ROLES, active: true },
           pagination: { offset: 0, limit: APPROVER_SEARCH_LIMIT },
         }),
+      enabled: searchQuery.trim().length > 0,
     }),
 };

--- a/apps/csm-portal/microapp/src/services/adminUsers.ts
+++ b/apps/csm-portal/microapp/src/services/adminUsers.ts
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { infiniteQueryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { USERS_SEARCH_ENDPOINT } from "@config/endpoints";
-import type { UserSearchFiltersDto, UserSearchPayloadDto, UserSearchResponseDto } from "@src/types";
+import type { AdminUserRole, UserSearchFiltersDto, UserSearchPayloadDto, UserSearchResponseDto } from "@src/types";
 import { toAdminUser, type AdminUser } from "@src/types";
 import apiClient from "./apiClient";
 
@@ -39,6 +39,11 @@ const searchUsers = async (payload: UserSearchPayloadDto = {}): Promise<AdminUse
 
 const ADMIN_USERS_PAGE_LIMIT = 20;
 
+// Eligible time-card approvers — mirrors the webapp's INTERNAL_USER_ROLES
+// (csmUsers.ts). A customer account can't approve internal time cards.
+const APPROVER_ROLES: AdminUserRole[] = ["internal", "agent", "admin"];
+const APPROVER_SEARCH_LIMIT = 6;
+
 export const adminUsers = {
   // Mirrors the webapp's useSearchUsers.ts (POST /users/search), paged via infinite scroll —
   // the mobile equivalent of CsmUsersPage's TablePagination.
@@ -53,5 +58,18 @@ export const adminUsers = {
         }),
       initialPageParam: 0,
       getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
+    }),
+
+  // One-shot type-ahead search for a single-pick field (LogTimeCardDialog's
+  // approver picker) — mirrors projects.ts's `search`, not the paged `infinite`
+  // list above. Scoped to internal accounts only.
+  search: (searchQuery: string) =>
+    queryOptions({
+      queryKey: ["admin-users", "search", searchQuery],
+      queryFn: () =>
+        searchUsers({
+          filters: { searchQuery, roles: APPROVER_ROLES, active: true },
+          pagination: { offset: 0, limit: APPROVER_SEARCH_LIMIT },
+        }),
     }),
 };

--- a/apps/csm-portal/microapp/src/services/timecards.ts
+++ b/apps/csm-portal/microapp/src/services/timecards.ts
@@ -18,6 +18,7 @@
 // by the real csm-portal-backend endpoints:
 //
 //   POST  /time-cards/search   my sheets / all / approval queue (paged, client-grouped into weeks)
+//   POST  /time-cards          create (already `submitted` — no draft step)
 //   PATCH /time-cards/{id}     approve / reject a card
 //
 // The backend has no "sheet" concept and no bulk endpoint — weekly sheets are a
@@ -29,14 +30,16 @@
 // flattened, then grouped into weekly sheets in one pass — so a week that spans a
 // page boundary stays a single sheet, rather than being split per page.
 
-import { infiniteQueryOptions, type InfiniteData } from "@tanstack/react-query";
-import { TIME_CARDS_SEARCH_ENDPOINT, TIME_CARD_ENDPOINT } from "@config/endpoints";
+import { infiniteQueryOptions, queryOptions, type InfiniteData } from "@tanstack/react-query";
+import { TIME_CARDS_ENDPOINT, TIME_CARDS_SEARCH_ENDPOINT, TIME_CARD_ENDPOINT } from "@config/endpoints";
 import type {
+  BeCreateTimeCardPayload,
   BeSearchTimeCardsPayload,
   BeSearchTimeCardsResponse,
   BeTimeCardMutationResponse,
   BeTimeCardState,
   BeUpdateTimeCardPayload,
+  CreateTimeCardInput,
   CsmTimeCard,
   CsmTimeSheet,
   TimeCardDecisionInput,
@@ -112,6 +115,26 @@ async function searchTimeCardsPage(filters: TimeCardSearchFilters, offset: numbe
   return { cards, total: data.total, nextOffset, hasMore: raw.length > 0 && nextOffset < data.total };
 }
 
+// A case's time cards from the first TIME_CARD_MAX_PAGE_LIMIT cards in its
+// project, plus whether that one page fell short of the project's full
+// `total` — some of the case's cards may not have been fetched if so. No
+// pagination UI (a single case logging more than a page's worth of time is
+// not expected). Mirrors the webapp's useCaseTimeCards: `caseId` itself is
+// non-functional as a search filter (see the interface note above), so this
+// scopes to the case's own project instead and filters client-side.
+export interface CaseTimeCardsResult {
+  cards: CsmTimeCard[];
+  truncated: boolean;
+}
+
+async function fetchCaseTimeCards(caseId: string, projectId: string): Promise<CaseTimeCardsResult> {
+  const { cards, total } = await searchTimeCardsPage({ projectIds: [projectId] }, 0);
+  return {
+    cards: cards.filter((c) => c.caseId === caseId),
+    truncated: cards.length < total,
+  };
+}
+
 // Flatten every loaded page's cards, derive the client-filter option lists from
 // them, apply the client-side work-item / engineer filters, then group what's
 // left once. `group` builds the weekly sheets appropriately for the tab (own
@@ -161,6 +184,29 @@ async function decideCard(decision: TimeCardDecisionInput): Promise<CsmTimeCard>
     TIME_CARD_ENDPOINT(encodeURIComponent(decision.cardId)),
     payload,
   );
+  return toTimeCard(data.timeCard);
+}
+
+// Create a time card on the signed-in engineer's behalf. The card is created
+// already `submitted` — the backend has no draft/pending step.
+async function createCard(input: CreateTimeCardInput): Promise<CsmTimeCard> {
+  const payload: BeCreateTimeCardPayload = {
+    caseId: input.caseId,
+    projectId: input.projectId,
+    date: input.date,
+    approverIds: [input.approver.id],
+    isBillable: input.billable,
+    issueComplexity: input.issueComplexity,
+    workLogComment: input.workLogComment,
+    // Whole minutes on the wire — the form already collects minutes
+    // directly, so this is a defensive round only, not a unit conversion.
+    timeAnalyzing: Math.round(input.breakdown.analysisDebugging),
+    timeSettingUp: Math.round(input.breakdown.settingUp),
+    timeReproducingDebugging: Math.round(input.breakdown.reproduce),
+    timeProvidingSolution: Math.round(input.breakdown.providingSolution),
+    timePatching: Math.round(input.breakdown.answering),
+  };
+  const { data } = await apiClient.post<BeTimeCardMutationResponse>(TIME_CARDS_ENDPOINT, payload);
   return toTimeCard(data.timeCard);
 }
 
@@ -245,4 +291,18 @@ export const timecards = {
     }),
 
   decide: decideCard,
+  create: createCard,
+
+  // A single case's logged time cards (Time Tracking tab). See fetchCaseTimeCards
+  // for the projectIds-scoped + client-filtered workaround this relies on.
+  forCase: (caseId: string | undefined, projectId: string | undefined) =>
+    queryOptions({
+      queryKey: ["timecards", "case", caseId ?? "", projectId ?? ""],
+      queryFn: () =>
+        caseId && projectId
+          ? fetchCaseTimeCards(caseId, projectId)
+          : Promise.resolve<CaseTimeCardsResult>({ cards: [], truncated: false }),
+      enabled: !!caseId && !!projectId,
+      staleTime: 5_000,
+    }),
 };

--- a/apps/csm-portal/microapp/src/types/timecard.dto.ts
+++ b/apps/csm-portal/microapp/src/types/timecard.dto.ts
@@ -95,3 +95,23 @@ export interface BeTimeCardMutationResponse {
   message?: string;
   timeCard: BeTimeCardView;
 }
+
+// Create payload — mirrors the webapp's BeCreateTimeCardPayload exactly. The
+// backend never echoes these fields back on read (see BeTimeCardView's own
+// comment), so there's nothing to diff against; every field is sent as-is.
+export interface BeCreateTimeCardPayload {
+  caseId: string;
+  projectId: string;
+  /** ISO 8601 date (YYYY-MM-DD). */
+  date: string;
+  /** Eligible approvers (approver_list). Must be non-empty. */
+  approverIds: string[];
+  isBillable?: boolean;
+  issueComplexity?: string;
+  workLogComment?: string;
+  timeAnalyzing?: number;
+  timeSettingUp?: number;
+  timeReproducingDebugging?: number;
+  timeProvidingSolution?: number;
+  timePatching?: number;
+}

--- a/apps/csm-portal/microapp/src/types/timecard.model.ts
+++ b/apps/csm-portal/microapp/src/types/timecard.model.ts
@@ -75,6 +75,39 @@ export interface TimeCardDecisionInput {
   leadComment?: string;
 }
 
+// The five fixed activity categories a time card's minutes are broken down
+// into (the Time Management requirement, ISSU-009). Write-only: the backend
+// accepts these on create but never returns them on read.
+export type ActivityKey = "analysisDebugging" | "reproduce" | "settingUp" | "providingSolution" | "answering";
+
+export type ActivityBreakdown = Record<ActivityKey, number>;
+
+// The ServiceNow "Issue Complexity" field. Write-only, like the activity breakdown.
+export type IssueComplexity = "N/A" | "Low" | "Medium" | "High";
+
+// An approver candidate picked from the search box — just enough to render a
+// chip and submit the id.
+export interface TimeCardApprover {
+  id: string;
+  name: string;
+}
+
+// Draft state submitted by LogTimeCardDialog. `caseNumber`/`projectName` are
+// carried through only for the dialog's own header text, not sent on the wire.
+export interface CreateTimeCardInput {
+  caseId: string;
+  caseNumber: string;
+  projectId: string;
+  projectName: string;
+  /** ISO 8601 date (YYYY-MM-DD). */
+  date: string;
+  breakdown: ActivityBreakdown;
+  billable: boolean;
+  workLogComment: string;
+  issueComplexity: IssueComplexity;
+  approver: TimeCardApprover;
+}
+
 // Map the backend's `TimeCardView` to the portal's `CsmTimeCard`. `totalTime`
 // is already whole minutes on the wire, which is also the unit shown — a direct
 // passthrough, no conversion.

--- a/apps/csm-portal/microapp/src/utils/timecard.ts
+++ b/apps/csm-portal/microapp/src/utils/timecard.ts
@@ -15,7 +15,16 @@
 // under the License.
 
 import type { ChipProps } from "@wso2/oxygen-ui";
-import type { CsmTimeCard, CsmTimeSheet, Project, TimeCardState, TimeSheetState } from "@src/types";
+import type {
+  ActivityBreakdown,
+  ActivityKey,
+  CsmTimeCard,
+  CsmTimeSheet,
+  IssueComplexity,
+  Project,
+  TimeCardState,
+  TimeSheetState,
+} from "@src/types";
 
 /** A selectable engineer for the (client-side) engineer filter — derived from
  * the cards currently loaded, since there's no engineer-search endpoint. */
@@ -218,4 +227,93 @@ export function groupCardsByUserIntoSheets(cards: CsmTimeCard[]): CsmTimeSheet[]
   return [...byUser.entries()].flatMap(([userId, userCards]) =>
     groupIntoSheets(userCards, userId, userCards[0]?.userName ?? "—"),
   );
+}
+
+// --- Log-time (create) form support --------------------------------------
+// Ported from the webapp's timeCardConstants.ts + timeCardTotals.ts, merged
+// into this file's single-utils-file convention rather than split across
+// separate constants/ and utils/ modules.
+
+/** A labelled activity row in the time-breakdown editor (log-time form only). */
+export interface ActivityBucket {
+  key: ActivityKey;
+  label: string;
+}
+
+/** The five fixed activity categories, in display order (ISSU-009). */
+export const ACTIVITY_BUCKETS: ActivityBucket[] = [
+  { key: "analysisDebugging", label: "Analysis and debugging" },
+  { key: "reproduce", label: "Reproduce" },
+  { key: "settingUp", label: "Setting up" },
+  { key: "providingSolution", label: "Providing solution" },
+  { key: "answering", label: "Answering" },
+];
+
+const ACTIVITY_KEYS: ActivityKey[] = ACTIVITY_BUCKETS.map((b) => b.key);
+
+/** Issue-complexity options (the ServiceNow "Issue Complexity" field). Write-only. */
+export const ISSUE_COMPLEXITY_OPTIONS: readonly IssueComplexity[] = ["N/A", "Low", "Medium", "High"];
+export const DEFAULT_ISSUE_COMPLEXITY: IssueComplexity = "N/A";
+
+/** Whether logged time is billable to the customer by default. Most support work is
+ * billable; the engineer can flip it per card. */
+export const DEFAULT_BILLABLE = true;
+
+/** Character cap mirroring the ServiceNow work-log field. */
+export const WORK_LOG_MAX = 4000;
+
+/** A fresh breakdown with every activity at zero minutes. */
+export function emptyBreakdown(): ActivityBreakdown {
+  return {
+    analysisDebugging: 0,
+    reproduce: 0,
+    settingUp: 0,
+    providingSolution: 0,
+    answering: 0,
+  };
+}
+
+/** Total whole minutes across all activity buckets. */
+export function totalMinutes(breakdown: ActivityBreakdown): number {
+  return ACTIVITY_KEYS.reduce((sum, key) => sum + (breakdown[key] || 0), 0);
+}
+
+/** True when at least one activity bucket has logged time. */
+export function hasLoggedTime(breakdown: ActivityBreakdown): boolean {
+  return ACTIVITY_KEYS.some((key) => (breakdown[key] || 0) > 0);
+}
+
+/** Field-level validation errors for the log dialog, keyed by field name. */
+export interface TimeCardDraftErrors {
+  date?: string;
+  minutes?: string;
+  workLogComment?: string;
+  approver?: string;
+}
+
+export interface TimeCardDraft {
+  date: string;
+  breakdown: ActivityBreakdown;
+  workLogComment: string;
+  approverId?: string;
+}
+
+/**
+ * Validate a log-time draft. Returns an errors object; an empty object means the
+ * draft is submittable. Mirrors the ServiceNow required fields (Date, Task —
+ * preset from the case, Work Log Comment, Approver) plus a "log some time" rule.
+ */
+export function timeCardDraftErrors(draft: TimeCardDraft): TimeCardDraftErrors {
+  const errors: TimeCardDraftErrors = {};
+  if (!draft.date) errors.date = "Pick a date.";
+  if (!hasLoggedTime(draft.breakdown)) {
+    errors.minutes = "Log time against at least one activity.";
+  }
+  if (!draft.workLogComment.trim()) {
+    errors.workLogComment = "Add a work log comment.";
+  } else if (draft.workLogComment.length > WORK_LOG_MAX) {
+    errors.workLogComment = `Comment must be ${WORK_LOG_MAX} characters or fewer.`;
+  }
+  if (!draft.approverId) errors.approver = "Choose an approver.";
+  return errors;
 }

--- a/apps/csm-portal/microapp/src/utils/timecard.ts
+++ b/apps/csm-portal/microapp/src/utils/timecard.ts
@@ -262,6 +262,11 @@ export const DEFAULT_BILLABLE = true;
 /** Character cap mirroring the ServiceNow work-log field. */
 export const WORK_LOG_MAX = 4000;
 
+/** A hard sanity ceiling — nobody logs more than a full day in one bucket or
+ * in total, not a business-hours rule. Shared by the draft validator and the
+ * activity inputs' own `max` attribute. */
+export const MAX_MINUTES_PER_DAY = 1440;
+
 /** A fresh breakdown with every activity at zero minutes. */
 export function emptyBreakdown(): ActivityBreakdown {
   return {
@@ -308,6 +313,11 @@ export function timeCardDraftErrors(draft: TimeCardDraft): TimeCardDraftErrors {
   if (!draft.date) errors.date = "Pick a date.";
   if (!hasLoggedTime(draft.breakdown)) {
     errors.minutes = "Log time against at least one activity.";
+  } else if (
+    ACTIVITY_KEYS.some((key) => (draft.breakdown[key] || 0) > MAX_MINUTES_PER_DAY) ||
+    totalMinutes(draft.breakdown) > MAX_MINUTES_PER_DAY
+  ) {
+    errors.minutes = `Logged time can't exceed ${MAX_MINUTES_PER_DAY} minutes (24h) in a day.`;
   }
   if (!draft.workLogComment.trim()) {
     errors.workLogComment = "Add a work log comment.";


### PR DESCRIPTION
## Purpose
The microapp's Time Cards listing (My sheets / All / Approvals) and decide (approve/reject) flow were done, but there was no way to log time from a case, and a case's Time Tracking tab was a placeholder deep-linking to the full Time Cards page.

## Goals
Let an engineer log time against a case directly from its Time Tracking tab, and show that case's logged time cards there instead of just a placeholder.

## Approach
- `LogTimeCardDialog` — the log-time form (date, five activity-minute buckets with a running total, issue complexity, billable switch, work log comment, approver search), ported from the webapp's `LogTimeCardDialog` and adapted to this microapp's mobile conventions (`OPAQUE_POPUP`, `DatePickers`/`AdapterDateFns`, debounced `Autocomplete` search — same patterns already used by `TimeCardFiltersSheet`).
- `services/timecards.ts` — added `create()` (`POST /time-cards`, hitting the already-defined-but-previously-unused `TIME_CARDS_ENDPOINT`) and `forCase()`. `caseId` is confirmed non-functional as a `/time-cards/search` filter (documented in this file already), so `forCase` uses the same workaround the webapp's `useCaseTimeCards` relies on: scope the search by the case's `projectId` server-side, then filter to the case client-side.
- `services/adminUsers.ts` — added a one-shot `search()` for the approver type-ahead, reusing the *already-complete* `/users/search` normalization layer built for the admin Users page (`UserDto`/`SnUserDto` → `AdminUser`) rather than building new search infrastructure.
- `TimeTrackingTab.tsx` — now shows the case's logged time cards (engineer, state, date, minutes, billable) with loading/error/empty states, plus the "Log time" button and dialog. The create flow follows this microapp's established local-state-plus-promise-chain pattern (mirrors `CallRequestsTab`'s `CreateCallRequestDialog`), not `useMutation`.
- `CaseDetailPage.tsx` — passes `caseId`/`projectId`/`projectName` through to the tab.

## User stories
As a CSM engineer, I can log time against a case from its Time Tracking tab (date, activity breakdown, work log, approver), and see the time already logged on that case without leaving it.

## Release note
The CSM microapp's case detail page can now log time and shows the case's logged time cards directly in its Time Tracking tab.

## Documentation
N/A — in-app UI change only, no documentation impact.

## Automation tests
 - Unit tests
   > No new test files; this follows the existing untested-component convention already in this feature area (timecards components have no unit tests today).
 - Integration tests
   > Manually verified live against the staging backend: opened a real case, logged time with a real searched approver, confirmed `POST /time-cards` returned 201 with the correct case/project/approver/minutes/comment, dialog closed with no errors, and the new card then appeared in the case's Time Tracking list. Validation (required fields, at-least-one-activity, approver required) confirmed blocking submit until satisfied.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React frontend change, no Java code)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Local Vite dev server against the staging backend, Chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a case-scoped Time Tracking tab showing logged-time totals and entry counts, with loading/empty/error states and “Open Time Cards” navigation.
  - Added a “Log time” dialog to record activity minute buckets, date, work-log comment, issue complexity, billable status, and approver.
  - Added approver type-ahead search with eligible active candidates and form validation (including comment length and per-day limits).
  - Added the ability to create time-card entries from the case view and refresh the displayed results after submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->