### PR TITLE
fix(customer-portal): harden PII detection (false positives, checksums, token coverage) + warning dialog polish

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/dialogs/PiiWarningDialog.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/dialogs/PiiWarningDialog.tsx
@@ -17,7 +17,6 @@ import { type JSX } from "react";
 import {
   Box,
   Button,
-  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -41,9 +40,9 @@ export interface PiiWarningDialogProps {
 
 const TITLE = "Sensitive Information Detected";
 const DESCRIPTION =
-  "We found information in your message that's usually private, like ID " +
-  "numbers or passwords. Anyone with access to this ticket will be able to " +
-  "see it. If it's not needed to resolve your issue, we recommend removing it.";
+  "Information that's usually private, like ID numbers or passwords, was " +
+  "found in your message. It will be visible to anyone with access to this " +
+  "ticket. If it isn't needed to resolve your issue, removing it is recommended.";
 
 export default function PiiWarningDialog({
   open,
@@ -71,9 +70,26 @@ export default function PiiWarningDialog({
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
               Detected:
             </Typography>
-            <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
-              {detectedLabels.map((label) => (
-                <Chip key={label} label={label} color="warning" size="small" />
+            <Stack
+              component="ol"
+              spacing={0.5}
+              sx={{ m: 0, pl: 0, listStyle: "none" }}
+            >
+              {detectedLabels.map((label, index) => (
+                <Box
+                  component="li"
+                  key={label}
+                  sx={{ display: "flex", alignItems: "baseline", gap: 1 }}
+                >
+                  <Typography
+                    variant="body2"
+                    color="warning.main"
+                    sx={{ fontWeight: 600, minWidth: 16, textAlign: "right" }}
+                  >
+                    {index + 1}.
+                  </Typography>
+                  <Typography variant="body2">{label}</Typography>
+                </Box>
               ))}
             </Stack>
           </>

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
@@ -86,6 +86,11 @@ describe("piiDetection", () => {
       const matches = detectPii("There are 42 open cases");
       expect(matches.some((m) => m.type === PiiType.PHONE)).toBe(false);
     });
+
+    it("does not flag a long generic number (>15 digits) as a phone", () => {
+      const matches = detectPii("Reference 20260415123456789012 was logged");
+      expect(matches.some((m) => m.type === PiiType.PHONE)).toBe(false);
+    });
   });
 
   describe("detectPii - IBAN", () => {

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/piiDetection.test.ts
@@ -56,17 +56,22 @@ describe("piiDetection", () => {
 
   describe("detectPii - Danish CPR", () => {
     it("detects a CPR number with hyphen", () => {
-      const matches = detectPii("My CPR is 010203-1234");
+      const matches = detectPii("My CPR is 010203-0001");
       expect(matches.some((m) => m.type === PiiType.DANISH_CPR)).toBe(true);
     });
 
     it("detects a CPR number without hyphen", () => {
-      const matches = detectPii("CPR 0102031234 on file");
+      const matches = detectPii("CPR 0102030001 on file");
       expect(matches.some((m) => m.type === PiiType.DANISH_CPR)).toBe(true);
     });
 
     it("does not flag an invalid day/month", () => {
       const matches = detectPii("Ticket 991399-1234 raised");
+      expect(matches.some((m) => m.type === PiiType.DANISH_CPR)).toBe(false);
+    });
+
+    it("does not flag a date-shaped order ref that fails the mod-11 check", () => {
+      const matches = detectPii("Order 100200-3004 was created");
       expect(matches.some((m) => m.type === PiiType.DANISH_CPR)).toBe(false);
     });
   });
@@ -91,12 +96,37 @@ describe("piiDetection", () => {
       const matches = detectPii("Reference 20260415123456789012 was logged");
       expect(matches.some((m) => m.type === PiiType.PHONE)).toBe(false);
     });
+
+    it("does not flag an IPv4 address as a phone", () => {
+      const matches = detectPii("Client connected from 192.168.1.100 at startup");
+      expect(matches.some((m) => m.type === PiiType.PHONE)).toBe(false);
+    });
+
+    it("does not flag a unix timestamp or bare id as a phone", () => {
+      expect(
+        detectPii("event at 1737382920 UTC").some((m) => m.type === PiiType.PHONE),
+      ).toBe(false);
+      expect(
+        detectPii("Order 1002003004 refunded").some((m) => m.type === PiiType.PHONE),
+      ).toBe(false);
+    });
+
+    it("still detects a formatted phone number with grouping", () => {
+      expect(
+        detectPii("call (415) 555-2671").some((m) => m.type === PiiType.PHONE),
+      ).toBe(true);
+    });
   });
 
   describe("detectPii - IBAN", () => {
     it("detects an IBAN", () => {
       const matches = detectPii("Transfer to DK5000400440116243 today");
       expect(matches.some((m) => m.type === PiiType.IBAN)).toBe(true);
+    });
+
+    it("does not flag a two-letter-prefixed code that fails the mod-97 check", () => {
+      const matches = detectPii("part number GB01ACME00012345678 shipped");
+      expect(matches.some((m) => m.type === PiiType.IBAN)).toBe(false);
     });
   });
 
@@ -166,12 +196,60 @@ describe("piiDetection", () => {
       );
       expect(matches.some((m) => m.type === PiiType.PASSWORD)).toBe(true);
     });
+
+    it("detects Anthropic, OpenAI and Google OAuth tokens", () => {
+      expect(
+        detectPii("ANTHROPIC_API_KEY=sk-ant-api03-AbC123dEf456GhI789xyz").some(
+          (m) => m.type === PiiType.ACCESS_TOKEN,
+        ),
+      ).toBe(true);
+      expect(
+        detectPii("OPENAI_API_KEY=sk-proj-AbC123dEf456GhI789jkl012mno").some(
+          (m) => m.type === PiiType.ACCESS_TOKEN,
+        ),
+      ).toBe(true);
+      expect(
+        detectPii("token ya29.a0Af_longvalueherexyz12345").some(
+          (m) => m.type === PiiType.ACCESS_TOKEN,
+        ),
+      ).toBe(true);
+    });
+
+    it("detects an opaque Authorization header token", () => {
+      const matches = detectPii("Authorization: Bearer abc123def456ghi789jkl");
+      expect(matches.some((m) => m.type === PiiType.ACCESS_TOKEN)).toBe(true);
+    });
   });
 
   describe("detectPii - national identifiers", () => {
     it("detects a UK National Insurance number", () => {
-      const matches = detectPii("My NINO is QQ 12 34 56 C");
+      const matches = detectPii("My NINO is AB 12 34 56 C");
       expect(matches.some((m) => m.type === PiiType.UK_NINO)).toBe(true);
+    });
+
+    it("does not flag a NINO with an administratively invalid prefix", () => {
+      // "QQ" is HMRC's reserved test prefix; "BG" is never allocated.
+      expect(
+        detectPii("code QQ 12 34 56 C").some((m) => m.type === PiiType.UK_NINO),
+      ).toBe(false);
+      expect(
+        detectPii("code BG 12 34 56 C").some((m) => m.type === PiiType.UK_NINO),
+      ).toBe(false);
+    });
+
+    it("does not flag an SSN with an invalid area number", () => {
+      expect(
+        detectPii("id 000-45-6789").some((m) => m.type === PiiType.NATIONAL_ID),
+      ).toBe(false);
+      expect(
+        detectPii("id 666-45-6789").some((m) => m.type === PiiType.NATIONAL_ID),
+      ).toBe(false);
+    });
+
+    it("detects a valid SSN", () => {
+      expect(
+        detectPii("ssn 123-45-6789").some((m) => m.type === PiiType.NATIONAL_ID),
+      ).toBe(true);
     });
 
     it("detects a passport number when labelled", () => {

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -92,6 +92,100 @@ export const passesLuhn = (value: string): boolean => {
 };
 
 /**
+ * IBAN mod-97 checksum (ISO 13616). Filters two-letter-prefixed codes — product
+ * SKUs, container numbers, hashes — that merely look like an IBAN.
+ */
+export const passesIbanCheck = (value: string): boolean => {
+  const s = value.replace(/\s/g, "").toUpperCase();
+  if (s.length < 15 || s.length > 34) {
+    return false;
+  }
+  // Move the 4-char country/check prefix to the end, then map letters to
+  // numbers (A=10 … Z=35) and take the running remainder mod 97.
+  const rearranged = s.slice(4) + s.slice(0, 4);
+  const numeric = rearranged.replace(/[A-Z]/g, (c) =>
+    (c.charCodeAt(0) - 55).toString()
+  );
+  let remainder = 0;
+  for (const ch of numeric) {
+    remainder = (remainder * 10 + Number(ch)) % 97;
+  }
+  return remainder === 1;
+};
+
+/**
+ * Danish CPR modulus-11 check. NOTE: only CPR numbers issued before 2007 carry
+ * a valid mod-11 digit; the check was abandoned afterwards, so this rejects some
+ * genuine (post-2007) CPRs. That trade-off is acceptable here: the goal is to
+ * stop date-shaped order/reference numbers from being flagged, and CPR is a rare
+ * category in a technical support tool.
+ */
+export const passesDanishCpr = (value: string): boolean => {
+  const digits = value.replace(/\D/g, "");
+  if (digits.length !== 10) {
+    return false;
+  }
+  const weights = [4, 3, 2, 7, 6, 5, 4, 3, 2, 1];
+  let sum = 0;
+  for (let i = 0; i < 10; i += 1) {
+    sum += (digits.charCodeAt(i) - 48) * weights[i];
+  }
+  return sum % 11 === 0;
+};
+
+/** US SSN area/group/serial numbers that are never issued. */
+const isValidSsn = (value: string): boolean => {
+  const [area, group, serial] = value.split("-").map(Number);
+  if (area === 0 || area === 666 || area >= 900) {
+    return false;
+  }
+  return group !== 0 && serial !== 0;
+};
+
+// UK NINO prefixes that are administratively invalid.
+const INVALID_NINO_PREFIXES = new Set(["BG", "GB", "NK", "KN", "TN", "ZZ"]);
+
+/**
+ * UK National Insurance number structural rules: the first letter cannot be
+ * D, F, I, Q, U or V; the second cannot be D, F, I, O, Q, U or V; and a handful
+ * of two-letter prefixes are never allocated.
+ */
+const isValidNino = (value: string): boolean => {
+  const prefix = value.replace(/\s/g, "").toUpperCase().slice(0, 2);
+  if (!/[ABCEGHJ-PRSTW-Z]/.test(prefix[0])) {
+    return false;
+  }
+  if (!/[ABCEGHJ-NPRSTW-Z]/.test(prefix[1])) {
+    return false;
+  }
+  return !INVALID_NINO_PREFIXES.has(prefix);
+};
+
+/**
+ * Phone-number shape check. A bare run of digits (timestamps, order IDs, PIDs)
+ * is NOT treated as a phone number: we require either an explicit country-code
+ * prefix ("+…") or grouping separators where every group is phone-sized (≤4
+ * digits). This is what keeps IP addresses and long reference numbers from being
+ * flagged. The regex already drops "." so dotted-quads never reach here.
+ */
+const isPhoneShaped = (match: string): boolean => {
+  const digitCount = match.replace(/\D/g, "").length;
+  if (digitCount < 9 || digitCount > 15) {
+    return false;
+  }
+  // A string in the exact SSN mask (3-2-4) has already been considered — and
+  // rejected — by the higher-priority SSN rule; don't relabel it as a phone.
+  if (/^\d{3}-\d{2}-\d{4}$/.test(match.trim())) {
+    return false;
+  }
+  if (match.trimStart().startsWith("+")) {
+    return true;
+  }
+  const groups = match.split(/\D+/).filter(Boolean);
+  return groups.length >= 2 && groups.every((group) => group.length <= 4);
+};
+
+/**
  * Detection patterns. Kept as a single exported config so the rule set can be
  * tuned (added to / relaxed) as false-positive feedback comes in.
  *
@@ -115,11 +209,25 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     regex: /\b(?:jdbc:)?[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s:@/]+@[^\s/]+/g,
   },
   {
-    // Well-known service/cloud access tokens with distinctive prefixes.
+    // Well-known service/cloud access tokens with distinctive prefixes:
+    // AWS, GitHub, Slack (incl. xoxe- refresh), Google API key + OAuth (ya29.),
+    // Stripe, npm, OpenAI (sk-/sk-proj-), Anthropic (sk-ant-), Twilio
+    // (AC…/SK… SIDs), SendGrid (SG.…). Note the hyphenated OpenAI/Anthropic
+    // prefixes are distinct from Stripe's underscore form.
     type: PiiType.ACCESS_TOKEN,
     label: "API key or access token",
     regex:
-      /\b(?:AKIA[0-9A-Z]{16}|gh[posru]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{35}|[sr]k_(?:live|test)_[A-Za-z0-9]{16,}|npm_[A-Za-z0-9]{36})\b/g,
+      /\b(?:AKIA[0-9A-Z]{16}|gh[posru]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}|xox[baprse]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{35}|ya29\.[A-Za-z0-9_-]{20,}|[sr]k_(?:live|test)_[A-Za-z0-9]{16,}|sk-ant-[A-Za-z0-9_-]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9]{32,}|npm_[A-Za-z0-9]{36}|AC[a-f0-9]{32}|SK[a-f0-9]{32}|SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43})\b/g,
+  },
+  {
+    // Authorization header captured from a pasted request/log, e.g.
+    // "Authorization: Bearer <opaque>" or "Authorization: Basic <base64>".
+    // The (?!eyJ) guard leaves Bearer JWTs to the dedicated JWT rule so they
+    // keep their more specific label; this covers opaque tokens.
+    type: PiiType.ACCESS_TOKEN,
+    label: "API key or access token",
+    regex:
+      /\bAuthorization\s*:\s*(?:Bearer|Basic)\s+(?!eyJ)[A-Za-z0-9._~+/=-]{8,}/gi,
   },
   {
     // JSON Web Tokens (header.payload.signature, base64url).
@@ -135,7 +243,7 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     type: PiiType.PASSWORD,
     label: "Password or secret",
     regex:
-      /\b(?:passphrase|password|passwd|pwd|pass|pin|secret|credential|token|bearer|client[_-]?secret|api[_-]?key|access[_-]?key|account[_-]?key|shared[_-]?access[_-]?key|auth[_-]?token)\b\s*[:=]\s*["']?[^\s"'<>{}]{4,}["']?/gi,
+      /\b(?:passphrase|password|passwd|pwd|pass|pin|secret|credential|token|bearer|client[_-]?secret|api[_-]?key|access[_-]?key|account[_-]?key|shared[_-]?access[_-]?key|shared[_-]?access[_-]?signature|auth[_-]?token)\b\s*[:=]\s*["']?[^\s"'<>{}]{4,}["']?/gi,
   },
   {
     type: PiiType.CREDIT_CARD,
@@ -148,24 +256,28 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     type: PiiType.IBAN,
     label: "IBAN",
     regex: /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g,
+    validate: passesIbanCheck,
   },
   {
     type: PiiType.DANISH_CPR,
     label: "Danish CPR number",
     // DDMMYY-XXXX (optionally without the hyphen).
     regex: /\b(0[1-9]|[12]\d|3[01])(0[1-9]|1[0-2])\d{2}-?\d{4}\b/g,
+    validate: passesDanishCpr,
   },
   {
     type: PiiType.NATIONAL_ID,
     label: "National ID / SSN",
     // US SSN style: 3-2-4 with separators.
     regex: /\b\d{3}-\d{2}-\d{4}\b/g,
+    validate: isValidSsn,
   },
   {
     // UK National Insurance number: 2 letters, 6 digits, 1 suffix letter.
     type: PiiType.UK_NINO,
     label: "UK National Insurance number",
     regex: /\b[A-Z]{2} ?\d{2} ?\d{2} ?\d{2} ?[A-D]\b/g,
+    validate: isValidNino,
   },
   {
     // Passport number — only when the word "passport" is present, since a bare
@@ -184,14 +296,12 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     // (card, IBAN, CPR, SSN) win any overlap.
     type: PiiType.PHONE,
     label: "Phone number",
-    // International/local numbers, 9-15 digits with common separators.
-    // Upper bound follows E.164 (max 15 digits) so long generic numbers —
-    // order IDs, timestamps, reference codes — aren't mis-flagged as phones.
-    regex: /(?:\+?\d[\d ().-]{7,}\d)/g,
-    validate: (match) => {
-      const digitCount = match.replace(/\D/g, "").length;
-      return digitCount >= 9 && digitCount <= 15;
-    },
+    // International/local numbers with common grouping separators. "." is
+    // deliberately excluded so dotted-quad IPs and version strings never match;
+    // {@link isPhoneShaped} then enforces a "+"-prefix or phone-sized grouping
+    // so bare digit runs (timestamps, order IDs) aren't flagged.
+    regex: /(?:\+?\d[\d ()-]{7,}\d)/g,
+    validate: isPhoneShaped,
   },
 ];
 

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -185,8 +185,13 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     type: PiiType.PHONE,
     label: "Phone number",
     // International/local numbers, 9-15 digits with common separators.
+    // Upper bound follows E.164 (max 15 digits) so long generic numbers —
+    // order IDs, timestamps, reference codes — aren't mis-flagged as phones.
     regex: /(?:\+?\d[\d ().-]{7,}\d)/g,
-    validate: (match) => match.replace(/\D/g, "").length >= 9,
+    validate: (match) => {
+      const digitCount = match.replace(/\D/g, "").length;
+      return digitCount >= 9 && digitCount <= 15;
+    },
   },
 ];
 


### PR DESCRIPTION
## Summary

Hardening pass on client-side PII detection plus warning-dialog polish. Addresses review feedback that the rule set was too regex-only for a support tool where customers paste logs and config.

### False-positive reduction
- **Phone** — replaced the length-only check with a *shape* check: dropped `.` from the separator class (kills dotted-quad IPs and version strings) and now require either a `+` prefix or phone-sized grouping. IPv4 addresses, unix timestamps, PIDs, and long reference/order numbers are no longer flagged as phone numbers.
- **IBAN** — added ISO 13616 mod-97 checksum; two-letter-prefixed SKUs/container numbers/hashes no longer match.
- **Danish CPR** — added modulus-11 checksum; date-shaped order refs no longer match. (Only validates pre-2007 numbers — an accepted trade-off for a rare category.)
- **US SSN** — reject never-issued area numbers (`000`, `666`, `900-999`) and `00`/`0000` groups.
- **UK NINO** — reject invalid first/second letters and unallocated prefixes (`BG`, `GB`, `NK`, `KN`, `TN`, `ZZ`, and HMRC's `QQ` test prefix).

### Token coverage
- Added Anthropic (`sk-ant-`), OpenAI (`sk-`/`sk-proj-`), Google OAuth (`ya29.`), Slack refresh (`xoxe-`), Twilio (`AC…`/`SK…`), SendGrid (`SG.…`).
- Added an `Authorization: Bearer/Basic` header rule for opaque tokens (Bearer JWTs are left to the dedicated JWT rule so they keep the more specific label).
- Added Azure shared-access-signature to the password keyword set.

### Warning dialog
- Reworded the copy to passive voice.
- Replaced the detected-type chips with a numbered list.

### Deliberately *not* included
- IP / MAC address detection — despite the GDPR angle, IPs appear in nearly every pasted support log; flagging them would make the dialog cry wolf and train users to dismiss it. The priority here is the opposite: stop PHONE from matching IPs.
- Crypto wallet addresses — YAGNI for this tool.

## Test plan
- `vitest` — **44/44 pass**, including new regression tests for every change (IP/timestamp/order-ref not phone; SKU not IBAN; order-ref not CPR; invalid SSN ranges; invalid NINO prefixes; new token providers).
- Verified end-to-end against the real `detectPii`: all reviewer-reported false positives now clean; valid phones/IBAN/SSN/NINO still detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)