### PR TITLE
[CSM][Web] QuickNav follow-ups: sanitize stored text, header layout fixes

### DIFF
--- a/apps/csm-portal/webapp/src/components/header/Brand.tsx
+++ b/apps/csm-portal/webapp/src/components/header/Brand.tsx
@@ -61,7 +61,15 @@ export default function Brand({
         !isNavigationDisabled &&
         navigate("/", { state: { fromHeader: true } })
       }
-      sx={{ cursor: isNavigationDisabled ? "default" : "pointer" }}
+      sx={{
+        cursor: isNavigationDisabled ? "default" : "pointer",
+        // Never let the row's flex layout shrink the brand — with several
+        // pinned tabs plus the search bar, there isn't always room for
+        // everything, and without this "CSM Portal" would wrap onto a
+        // second line instead of PinnedTabs (already horizontally
+        // scrollable) absorbing the squeeze.
+        flexShrink: 0,
+      }}
     >
       {/* brand logo */}
       <HeaderUI.BrandLogo>
@@ -73,7 +81,9 @@ export default function Brand({
         />
       </HeaderUI.BrandLogo>
       {/* brand title */}
-      <HeaderUI.BrandTitle>CSM Portal</HeaderUI.BrandTitle>
+      <HeaderUI.BrandTitle sx={{ whiteSpace: "nowrap" }}>
+        CSM Portal
+      </HeaderUI.BrandTitle>
     </HeaderUI.Brand>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -67,6 +67,10 @@ export default function QuickNav(): JSX.Element | null {
   const { isSignedIn } = useAsgardeo();
   const navigate = useNavTransition();
   const recents = useRecentViews();
+  // Shrink the closed trigger (not the open palette) once something is
+  // pinned, so PinnedTabs — which shares the header's flexible middle slot —
+  // has room to actually show the pinned chips instead of getting squeezed.
+  const hasPinned = recents.some((e) => e.pinned);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
@@ -245,7 +249,9 @@ export default function QuickNav(): JSX.Element | null {
           alignItems: "center",
           gap: 1,
           height: 36,
-          width: { xs: 40, sm: 340, md: 460, lg: 600 },
+          width: hasPinned
+            ? { xs: 40, sm: 260, md: 340, lg: 420 }
+            : { xs: 40, sm: 340, md: 460, lg: 600 },
           px: { xs: 0, sm: 1.25 },
           justifyContent: { xs: "center", sm: "flex-start" },
           borderRadius: 1,

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
@@ -66,6 +66,33 @@ describe("useRecentViews + useRecordRecentView", () => {
     expect(reader.result.current[0].visitedAt).toBeTruthy();
   });
 
+  it("strips HTML tags from title/subtitle/caseHit text before storing", () => {
+    const reader = renderHook(() => useRecentViews());
+    const recorder = renderHook(() => useRecordRecentView());
+
+    act(() =>
+      recorder.result.current({
+        kind: "case",
+        id: "1",
+        title: "<b>Case</b> 1 <script>alert(1)</script>",
+        subtitle: "Acme <i>Corp</i>",
+        href: "/cases/1",
+        caseHit: {
+          subject: "<img src=x onerror=alert(1)>Urgent",
+          severity: "S3",
+          state: "open",
+          assigneeName: "<b>Jane</b> Doe",
+        },
+      }),
+    );
+
+    const stored = reader.result.current[0];
+    expect(stored.title).toBe("Case 1 alert(1)");
+    expect(stored.subtitle).toBe("Acme Corp");
+    expect(stored.caseHit?.subject).toBe("Urgent");
+    expect(stored.caseHit?.assigneeName).toBe("Jane Doe");
+  });
+
   it("de-dupes by kind+id and bumps the entry to the top", () => {
     const reader = renderHook(() => useRecentViews());
     const recorder = renderHook(() => useRecordRecentView());

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
@@ -87,10 +87,26 @@ describe("useRecentViews + useRecordRecentView", () => {
     );
 
     const stored = reader.result.current[0];
-    expect(stored.title).toBe("Case 1 alert(1)");
+    // DOMPurify drops a <script> element's content along with its tags,
+    // not just the tag markup.
+    expect(stored.title).toBe("Case 1 ");
     expect(stored.subtitle).toBe("Acme Corp");
     expect(stored.caseHit?.subject).toBe("Urgent");
     expect(stored.caseHit?.assigneeName).toBe("Jane Doe");
+  });
+
+  it("preserves plain text with angle brackets that aren't HTML tags", () => {
+    const reader = renderHook(() => useRecentViews());
+    const recorder = renderHook(() => useRecordRecentView());
+
+    act(() =>
+      recorder.result.current({
+        ...entry("1"),
+        title: "Error when x < y > z",
+      }),
+    );
+
+    expect(reader.result.current[0].title).toBe("Error when x < y > z");
   });
 
   it("de-dupes by kind+id and bumps the entry to the top", () => {

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
@@ -16,6 +16,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import { stripHtmlTags } from "@utils/sanitizeHtml";
 import type { QuickCaseHit } from "@features/csm-cases/api/useQuickCaseSearch";
 
 export type RecentViewKind =
@@ -318,17 +319,36 @@ export function useRecordRecentView(): (
   useSyncActiveUserKey();
   return useCallback((entry: Omit<RecentView, "visitedAt" | "pinned">) => {
     const now = new Date().toISOString();
+    // Title/subtitle/case-hit text ultimately come from backend/customer
+    // free text (case subject, account/project name, assignee name) — not
+    // sanitized before render (JSX text interpolation already escapes it
+    // safely), but strip tag-like markup before it's persisted so it can't
+    // do anything if a future change ever renders it somewhere less safe.
+    const sanitized: Omit<RecentView, "visitedAt" | "pinned"> = {
+      ...entry,
+      title: stripHtmlTags(entry.title),
+      subtitle: entry.subtitle ? stripHtmlTags(entry.subtitle) : entry.subtitle,
+      caseHit: entry.caseHit
+        ? {
+            ...entry.caseHit,
+            subject: stripHtmlTags(entry.caseHit.subject),
+            assigneeName: entry.caseHit.assigneeName
+              ? stripHtmlTags(entry.caseHit.assigneeName)
+              : entry.caseHit.assigneeName,
+          }
+        : entry.caseHit,
+    };
     const current = readStorage();
     const existing = current.find(
-      (e) => e.kind === entry.kind && e.id === entry.id,
+      (e) => e.kind === sanitized.kind && e.id === sanitized.id,
     );
     const filtered = current.filter(
-      (e) => !(e.kind === entry.kind && e.id === entry.id),
+      (e) => !(e.kind === sanitized.kind && e.id === sanitized.id),
     );
     // Re-visiting an entry must preserve its pinned state — a pin is not lost
     // just because the case was opened again.
     const next: RecentView[] = capUnpinned([
-      { ...entry, visitedAt: now, pinned: existing?.pinned },
+      { ...sanitized, visitedAt: now, pinned: existing?.pinned },
       ...filtered,
     ]);
     writeStorage(next);

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -33,7 +33,10 @@ export function sanitizeRichTextHtml(html: string): string {
 
 /** True when an HTML string has no visible content (e.g. `<p></p>`, `&nbsp;`). */
 export function isBlankHtml(html: string): boolean {
-  return stripHtmlTags(html).replace(/&nbsp;/g, " ").trim().length === 0;
+  // stripHtmlTags decodes entities (see below), so a blank `&nbsp;`-only
+  // paragraph comes back as an actual U+00A0 character, not the literal
+  // string "&nbsp;" — match that character, not the entity text.
+  return stripHtmlTags(html).replace(/\u00A0/g, " ").trim().length === 0;
 }
 
 /**
@@ -44,7 +47,28 @@ export function isBlankHtml(html: string): boolean {
  * appropriate before persisting a plain-text label so a stray `<script>`
  * a customer typed into a case subject can't do anything if a future
  * change ever renders it somewhere less safe than JSX text interpolation.
+ *
+ * Goes through DOMPurify (real HTML parsing) rather than a `<[^>]*>` regex —
+ * that regex treats any `<...>` run as a tag, so plain text like
+ * `x < y > z` (comparison operators, not markup) would lose everything
+ * between the angle brackets; DOMPurify's parser only removes what the
+ * browser would actually treat as an element.
+ *
+ * `DOMPurify.sanitize` alone isn't quite enough on its own, though: its
+ * output is meant to be re-inserted as HTML, so a stray `<`/`>` that
+ * *isn't* part of a real tag comes back HTML-entity-encoded (`&lt;`/`&gt;`)
+ * rather than as the literal character — which would then render as the
+ * literal text "&lt;" once put through plain JSX interpolation instead of
+ * a decoded `<`. Round-tripping through a detached element's `innerHTML` →
+ * `textContent` decodes those entities back to plain characters. This is
+ * safe specifically because the input to that second `innerHTML` assign is
+ * already fully tag-stripped by DOMPurify — there's nothing left to parse
+ * into a live element, and even if there were, `textContent` never
+ * executes anything and strips whatever tags it reads back out anyway.
  */
 export function stripHtmlTags(text: string): string {
-  return text.replace(/<[^>]*>/g, "");
+  const withoutTags = DOMPurify.sanitize(text, { ALLOWED_TAGS: [] });
+  const container = document.createElement("div");
+  container.innerHTML = withoutTags;
+  return container.textContent ?? "";
 }

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -33,5 +33,18 @@ export function sanitizeRichTextHtml(html: string): string {
 
 /** True when an HTML string has no visible content (e.g. `<p></p>`, `&nbsp;`). */
 export function isBlankHtml(html: string): boolean {
-  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
+  return stripHtmlTags(html).replace(/&nbsp;/g, " ").trim().length === 0;
+}
+
+/**
+ * Strip HTML tags from free text that's meant to be rendered as plain text
+ * (e.g. a case subject stored for later display), not treated as HTML.
+ * Unlike {@link sanitizeRichTextHtml} (which sanitizes-but-keeps safe HTML
+ * for `dangerouslySetInnerHTML`), this removes tag-like markup outright —
+ * appropriate before persisting a plain-text label so a stray `<script>`
+ * a customer typed into a case subject can't do anything if a future
+ * change ever renders it somewhere less safe than JSX text interpolation.
+ */
+export function stripHtmlTags(text: string): string {
+  return text.replace(/<[^>]*>/g, "");
 }


### PR DESCRIPTION
## Summary
Follow-up to #1174 / #1175 (both merged) — the QuickNav search palette rework and its recent-views storage fix.

- **Sanitize before storing**: `title`/`subtitle`/case-hit text recorded into the recent-views `localStorage` cache come from backend/customer free text (case subject, account/project name, assignee name). Every current render site uses plain JSX text interpolation, which React already escapes safely — but added `stripHtmlTags` (`src/utils/sanitizeHtml.ts`) and apply it in `useRecordRecentView` as defense-in-depth, so stored text can't do anything if a future change ever renders it less safely (e.g. `dangerouslySetInnerHTML`).
- **Search trigger shrinks when something's pinned**: the QuickNav trigger button now uses a narrower width once the user has pinned at least one item, freeing horizontal space for `PinnedTabs` (which shares the header's flexible middle slot) to actually show the pinned chips instead of getting squeezed.
- **Fix "CSM Portal" wrapping to two lines**: with several pinned tabs plus the search bar, the header row could run out of width and the flex layout would shrink/wrap the brand text instead of the (already horizontally-scrollable) `PinnedTabs` row. `Header.Brand` now has `flexShrink: 0` and `Header.BrandTitle` has `whiteSpace: "nowrap"`, so the brand never wraps.

## Test plan
- [x] `tsc -b --noEmit` passes
- [x] `eslint` passes on all touched files
- [x] `vitest run` passes, including a new regression test asserting HTML tags are stripped from title/subtitle/case-hit text before storage
- [x] `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the CSM Portal brand title from wrapping and preserved its layout.
  * Improved Quick Nav sizing when pinned items are present.
  * Removed HTML tags from recent-view details before saving them.
  * Improved detection of empty HTML content.

* **Tests**
  * Added coverage verifying HTML sanitization in recent-view history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->