### PR TITLE
[CSM Portal] mark Engagements and Security Center as shipped nav sections

### DIFF
--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -50,16 +50,16 @@ export interface CsmNavItem {
  * the Quick-nav palette's "Pages" section, and "Pin this page" title/kind
  * derivation — so a new page only has to be added here once.
  *
- * Dashboard, Support, Updates and Time cards are the shipped sections; the rest
- * are flagged `wip` so a deployment can disable them via
- * `CSM_PORTAL_DISABLE_WIP_FEATURES` until they are ready.
+ * Dashboard, Support, Updates, Time cards, Engagements and Security Center are
+ * the shipped sections; the rest are flagged `wip` so a deployment can disable
+ * them via `CSM_PORTAL_DISABLE_WIP_FEATURES` until they are ready.
  */
 export const CSM_NAV_ITEMS: CsmNavItem[] = [
   { id: "dashboard", label: "Dashboard", path: "/dashboard", icon: ChartColumn },
   { id: "support", label: "Support", path: "/cases", icon: Headset },
   { id: "operations", label: "Operations", path: "/operations", icon: Cog, wip: true },
-  { id: "engagements", label: "Engagements", path: "/engagements", icon: Briefcase, wip: true },
-  { id: "security-center", label: "Security Center", path: "/security-center", icon: Shield, wip: true },
+  { id: "engagements", label: "Engagements", path: "/engagements", icon: Briefcase },
+  { id: "security-center", label: "Security Center", path: "/security-center", icon: Shield },
   { id: "updates", label: "Updates", path: "/updates", icon: RefreshCw },
   { id: "time-cards", label: "Time cards", path: "/time-cards", icon: Clock },
   { id: "announcements", label: "Announcements", path: "/announcements", icon: Megaphone },


### PR DESCRIPTION
## Purpose
The CSM portal's top-level nav (`csmNavItems.ts`) flags a section `wip: true` to gate it behind `CSM_PORTAL_DISABLE_WIP_FEATURES` until it's ready. Engagements and Security Center both already have complete page implementations (list/detail pages, create flows) but were still flagged `wip`, so a WIP-disabled deployment would show them greyed out with a "work in progress" tooltip and exclude them from quick-nav even though the features work.

## Goals
Mark Engagements and Security Center as shipped sections so they behave like the other finished nav items (Dashboard, Support, Updates, Time cards): enabled in the sidebar, included in the quick-nav palette, and reachable via direct links without being redirected by `isDisabledWipPath`.

## Approach
Removed `wip: true` from the `engagements` and `security-center` entries in `CSM_NAV_ITEMS` (`apps/csm-portal/webapp/src/config/csmNavItems.ts`) and updated the accompanying doc comment listing the shipped sections. No behavior change to `isWipDisabled`/`navigableNavItems`/`isDisabledWipPath` logic itself — only which items it applies to.

## User stories
N/A — internal config change, not a new feature.

## Release note
Engagements and Security Center are now available in the CSM portal navigation (previously gated behind the work-in-progress flag).

## Documentation
N/A — no user-facing doc impact; this only changes an internal feature-flag gate.

## Automation tests
 - Unit tests
   > No new tests; this is a data-only config change (removing two `wip: true` flags) with existing coverage on the nav helper functions.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React change; ran `pnpm lint` and `pnpm build` clean instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Test environment
Verified `pnpm lint` and `pnpm build` pass locally for `apps/csm-portal/webapp` on macOS (Node/pnpm toolchain per repo requirements).

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Engagements and Security Center are now available as fully shipped sections in the CSM Portal.
  * These sections appear in quick navigation and can be accessed directly when WIP features are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->