### PR TITLE
[Customer Portal Webapp] Improve PII detection and Customer Feedback card display

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsDetailsPanel.tsx
@@ -21,6 +21,7 @@ import {
   Button,
   Checkbox,
   Chip,
+  Divider,
   Stack,
   TextField,
   Typography,
@@ -590,39 +591,43 @@ export default function CaseDetailsDetailsPanel({
           title="Customer Feedback"
           icon={<MessageSquare size={20} aria-hidden />}
         >
-          <Stack direction="row" spacing={2} alignItems="flex-start">
-            <Box
-              component="img"
-              src={feedback.emoji.selectedImage}
-              alt={feedback.emoji.name}
-              sx={{ width: 40, height: 40, objectFit: "contain", flexShrink: 0 }}
-            />
-            <Box sx={{ flex: 1 }}>
-              <Typography {...valueSx} sx={{ fontWeight: 600 }}>
+          <Stack spacing={1.5}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Box
+                component="img"
+                src={feedback.emoji.selectedImage}
+                alt={feedback.emoji.name}
+                sx={{ width: 40, height: 40, objectFit: "contain", flexShrink: 0 }}
+              />
+              <Typography variant="body1" color="text.primary" sx={{ fontWeight: 600 }}>
                 {feedback.emoji.name}
               </Typography>
-              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
-                {formatUtcToLocal(feedback.createdOn)}
-              </Typography>
-              {feedback.chips && feedback.chips.length > 0 && (
-                <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mb: feedback.additionalComment ? 1.5 : 0 }}>
-                  {feedback.chips.map((chip) => (
-                    <Chip
-                      key={chip}
-                      label={chip}
-                      size="small"
-                      variant="outlined"
-                      sx={{ fontSize: "0.75rem" }}
-                    />
-                  ))}
-                </Stack>
-              )}
-              {feedback.additionalComment && (
-                <Typography {...valueSx} sx={{ whiteSpace: "pre-wrap" }}>
-                  {feedback.additionalComment}
+            </Stack>
+            {feedback.chips && feedback.chips.length > 0 && (
+              <Stack direction="row" flexWrap="wrap" gap={1} sx={{ ml: 7 }}>
+                {feedback.chips.map((chip) => (
+                  <Chip
+                    key={chip}
+                    label={chip}
+                    size="small"
+                    variant="outlined"
+                    sx={{ fontSize: "0.75rem" }}
+                  />
+                ))}
+              </Stack>
+            )}
+            {feedback.additionalComment && (
+              <Typography {...valueSx} sx={{ whiteSpace: "pre-wrap", ml: 7 }}>
+                <Typography component="span" color="text.secondary" sx={{ fontWeight: 500 }}>
+                  Details:{" "}
                 </Typography>
-              )}
-            </Box>
+                {feedback.additionalComment}
+              </Typography>
+            )}
+            <Divider sx={{ my: 0.5 }} />
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+              Submitted by {feedback.createdBy} on {formatUtcToLocal(feedback.createdOn)}
+            </Typography>
           </Stack>
         </CaseDetailsCard>
       )}

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -237,6 +237,19 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     regex: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
   },
   {
+    // One-time passcodes / verification codes sent for login or MFA, e.g.
+    // "your OTP is 483920", "verification code: 719283", "2FA code 552011".
+    // Same shape as PASSWORD (keyword + filler + separator + digit-bearing
+    // value) but kept as a distinct type/label since these are short-lived
+    // codes rather than long-term credentials. Checked before PASSWORD so
+    // phrases like "one time password 918273" resolve as OTP rather than
+    // being shadowed by the broader "password" match.
+    type: PiiType.OTP,
+    label: "One-time passcode",
+    regex:
+      /\b(?:otp|one[\s-]?time[\s-]?(?:passcode|password|code|pin)|verification[\s-]?code|security[\s-]?code|confirmation[\s-]?code|access[\s-]?code|auth(?:entication)?[\s-]?code|login[\s-]?code|2fa[\s-]?code|mfa[\s-]?code)\b(?:\s+[A-Za-z][A-Za-z'-]*){0,6}\s*[:=-]?\s*["']?(?=[^\s"'<>{}]*\d)[^\s"'<>{}]{3,}["']?/gi,
+  },
+  {
     // A password/secret assigned in a config/log line or stated in prose, e.g.
     // password="s3cret", clientSecret: abc123, api_key=xxxx, pass: hunter2,
     // AccountKey=... (Azure), "my password is admin123", "password 3221211sdts",
@@ -248,17 +261,6 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     label: "Password or secret",
     regex:
       /\b(?:passphrase|password|passwd|pwd|pass|pin|secret|credential|token|bearer|client[_-]?secret|api[_-]?key|access[_-]?key|account[_-]?key|shared[_-]?access[_-]?key|shared[_-]?access[_-]?signature|auth[_-]?token)\b(?:\s+[A-Za-z][A-Za-z'-]*){0,6}\s*[:=-]?\s*["']?(?=[^\s"'<>{}]*\d)[^\s"'<>{}]{3,}["']?/gi,
-  },
-  {
-    // One-time passcodes / verification codes sent for login or MFA, e.g.
-    // "your OTP is 483920", "verification code: 719283", "2FA code 552011".
-    // Same shape as PASSWORD (keyword + filler + separator + digit-bearing
-    // value) but kept as a distinct type/label since these are short-lived
-    // codes rather than long-term credentials.
-    type: PiiType.OTP,
-    label: "One-time passcode",
-    regex:
-      /\b(?:otp|one[\s-]?time[\s-]?(?:passcode|password|code|pin)|verification[\s-]?code|security[\s-]?code|confirmation[\s-]?code|access[\s-]?code|auth(?:entication)?[\s-]?code|login[\s-]?code|2fa[\s-]?code|mfa[\s-]?code)\b(?:\s+[A-Za-z][A-Za-z'-]*){0,6}\s*[:=-]?\s*["']?(?=[^\s"'<>{}]*\d)[^\s"'<>{}]{3,}["']?/gi,
   },
   {
     type: PiiType.CREDIT_CARD,

--- a/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/piiDetection.ts
@@ -33,6 +33,7 @@ export enum PiiType {
   ACCESS_TOKEN = "ACCESS_TOKEN",
   JWT = "JWT",
   PASSWORD = "PASSWORD",
+  OTP = "OTP",
   // Classic personal data.
   CREDIT_CARD = "CREDIT_CARD",
   DANISH_CPR = "DANISH_CPR",
@@ -236,14 +237,28 @@ export const PII_PATTERNS: readonly PiiPattern[] = [
     regex: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
   },
   {
-    // A password/secret assigned in a config or log line, e.g.
+    // A password/secret assigned in a config/log line or stated in prose, e.g.
     // password="s3cret", clientSecret: abc123, api_key=xxxx, pass: hunter2,
-    // AccountKey=... (Azure). The keyword must be followed by ':' or '=' and a
-    // value, so prose like "forgot their password" is not flagged.
+    // AccountKey=... (Azure), "my password is admin123", "password 3221211sdts",
+    // "check the password below - 879338". The keyword may be followed by up to
+    // three filler words (is/was/below/for/etc.) and/or a ':'/'='/'-' separator
+    // before the value. The value is required to contain a digit so plain prose
+    // like "reset your password soon" or "forgot their password" isn't flagged.
     type: PiiType.PASSWORD,
     label: "Password or secret",
     regex:
-      /\b(?:passphrase|password|passwd|pwd|pass|pin|secret|credential|token|bearer|client[_-]?secret|api[_-]?key|access[_-]?key|account[_-]?key|shared[_-]?access[_-]?key|shared[_-]?access[_-]?signature|auth[_-]?token)\b\s*[:=]\s*["']?[^\s"'<>{}]{4,}["']?/gi,
+      /\b(?:passphrase|password|passwd|pwd|pass|pin|secret|credential|token|bearer|client[_-]?secret|api[_-]?key|access[_-]?key|account[_-]?key|shared[_-]?access[_-]?key|shared[_-]?access[_-]?signature|auth[_-]?token)\b(?:\s+[A-Za-z][A-Za-z'-]*){0,6}\s*[:=-]?\s*["']?(?=[^\s"'<>{}]*\d)[^\s"'<>{}]{3,}["']?/gi,
+  },
+  {
+    // One-time passcodes / verification codes sent for login or MFA, e.g.
+    // "your OTP is 483920", "verification code: 719283", "2FA code 552011".
+    // Same shape as PASSWORD (keyword + filler + separator + digit-bearing
+    // value) but kept as a distinct type/label since these are short-lived
+    // codes rather than long-term credentials.
+    type: PiiType.OTP,
+    label: "One-time passcode",
+    regex:
+      /\b(?:otp|one[\s-]?time[\s-]?(?:passcode|password|code|pin)|verification[\s-]?code|security[\s-]?code|confirmation[\s-]?code|access[\s-]?code|auth(?:entication)?[\s-]?code|login[\s-]?code|2fa[\s-]?code|mfa[\s-]?code)\b(?:\s+[A-Za-z][A-Za-z'-]*){0,6}\s*[:=-]?\s*["']?(?=[^\s"'<>{}]*\d)[^\s"'<>{}]{3,}["']?/gi,
   },
   {
     type: PiiType.CREDIT_CARD,


### PR DESCRIPTION
## Summary
- Widen the PII PASSWORD detection regex to catch prose-style disclosures (e.g. "My password is admin123", "check the password below - 879338") that previously slipped past the warning dialog, which only matched strict `key:value`/`key=value` assignments.
- Add a new OTP/verification-code PII category (otp, verification code, security code, 2FA/MFA code, etc.) — a secret type that wasn't detected at all before.
- In the Customer Feedback card on the case details page, label the free-text comment as "Details:" and add a divider-separated footer showing who submitted the feedback and when.

## Test plan
- [ ] In a case comment/feedback box, verify these now trigger the PII warning dialog: "My password is admin123.", "check the password below - 879338", "use this password for = 123", "your OTP is 483920", "verification code: 719283"
- [ ] Verify these do NOT trigger a false positive: "I forgot my password", "password requirements are strict", "the OTP field accepts 6 digits"
- [ ] Open a closed case with submitted feedback and confirm the Customer Feedback card shows "Details: <comment>" and a "Submitted by <name> on <date>" footer below a divider


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for one-time passcodes as a distinct type of sensitive information.
  * Improved password and secret detection across more formatting variations.

* **UI Improvements**
  * Updated the closed-case customer feedback layout for clearer organization.
  * Added visual separation and consolidated submission details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->