### PR TITLE
[CSM Portal Microapp] Build out the Updates page

### DIFF
--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -48,3 +48,6 @@ export const ATTACHMENTS_SEARCH_ENDPOINT = "/attachments/search";
 export const TIME_CARDS_ENDPOINT = "/time-cards";
 export const TIME_CARDS_SEARCH_ENDPOINT = "/time-cards/search";
 export const TIME_CARD_ENDPOINT = (id: string) => `/time-cards/${id}`;
+
+export const PRODUCT_UPDATE_LEVELS_ENDPOINT = "/updates/product-update-levels";
+export const UPDATE_LEVELS_SEARCH_ENDPOINT = "/updates/levels/search";

--- a/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
@@ -14,8 +14,438 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { ComingSoonPage } from "@components/common/ComingSoonPage";
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  CircularProgress,
+  Dialog,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useQuery } from "@tanstack/react-query";
+import DOMPurify from "dompurify";
+import { DialogPaper } from "@components/common/DialogPaper";
+import { updates } from "@src/services/updates";
+import type { ProductUpdateLevel, SearchUpdatesInput, UpdateDescription, UpdateLevelGroup } from "@src/types";
+
+// The Acrylic theme renders popup papers translucent, so a dropdown reads as
+// see-through unless forced opaque — same fix as TimeCardFiltersSheet /
+// AnnouncementFiltersSheet / LogTimeCardDialog.
+const OPAQUE_POPUP = { sx: { backgroundColor: "background.default", backgroundImage: "none" } };
+
+interface FilterState {
+  productName: string;
+  productVersion: string;
+  startLevel: string;
+  endLevel: string;
+}
+
+const INITIAL_FILTER: FilterState = { productName: "", productVersion: "", startLevel: "", endLevel: "" };
+
+// Real HTML tags that warrant sanitized HTML rendering vs a plain-text fallback
+// — update descriptions come back as HTML sometimes and plain text other
+// times, from the same upstream field (see the webapp's identical gotcha).
+const HTML_FORMAT_RE = /<\/?(p|span|div|ul|ol|li|strong|em|b|i|br|h[1-6]|a[\s>]|table|tr|td|th|code|pre|blockquote)\b/i;
+
+function HtmlOrText({ content }: { content: string }) {
+  if (HTML_FORMAT_RE.test(content)) {
+    return (
+      <Box
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
+        sx={{ fontSize: "0.875rem", lineHeight: 1.6, color: "text.secondary", "& p": { m: "0 0 0.4em 0" } }}
+      />
+    );
+  }
+  return (
+    <Box
+      component="pre"
+      sx={{
+        fontSize: "0.875rem",
+        lineHeight: 1.6,
+        color: "text.secondary",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+        m: 0,
+        fontFamily: "inherit",
+      }}
+    >
+      {content}
+    </Box>
+  );
+}
+
+function isMeaningful(value: string | undefined): boolean {
+  const t = (value ?? "").trim().toLowerCase();
+  return t !== "" && t !== "n/a" && t !== "na";
+}
+
+function updateTypeChipColor(updateType: string): "error" | "warning" | "primary" {
+  const t = updateType.toLowerCase();
+  if (t === "security") return "error";
+  if (t === "regular") return "warning";
+  return "primary";
+}
+
+function getProductNames(data: ProductUpdateLevel[] | undefined): string[] {
+  if (!data) return [];
+  return Array.from(new Set(data.map((p) => p.productName))).sort();
+}
+
+function getVersionsForProduct(data: ProductUpdateLevel[] | undefined, productName: string): string[] {
+  const product = data?.find((p) => p.productName === productName);
+  if (!product) return [];
+  return Array.from(new Set(product.productUpdateLevels.map((v) => v.productBaseVersion))).sort();
+}
+
+function getLevelsForVersion(
+  data: ProductUpdateLevel[] | undefined,
+  productName: string,
+  productVersion: string,
+): number[] {
+  const product = data?.find((p) => p.productName === productName);
+  const version = product?.productUpdateLevels.find((v) => v.productBaseVersion === productVersion);
+  return version ? [...version.updateLevels].sort((a, b) => a - b) : [];
+}
 
 export default function UpdatesPage() {
-  return <ComingSoonPage title="Updates" description="Product update announcements on mobile are on the way." />;
+  const [filter, setFilter] = useState<FilterState>(INITIAL_FILTER);
+  const [search, setSearch] = useState<SearchUpdatesInput | null>(null);
+  const [openGroup, setOpenGroup] = useState<UpdateLevelGroup | null>(null);
+
+  const productLevels = useQuery(updates.productLevels());
+  const searchResult = useQuery(updates.search(search));
+
+  const productNames = useMemo(() => getProductNames(productLevels.data), [productLevels.data]);
+  const versionOptions = useMemo(
+    () => getVersionsForProduct(productLevels.data, filter.productName),
+    [productLevels.data, filter.productName],
+  );
+  const rawLevels = useMemo(
+    () => getLevelsForVersion(productLevels.data, filter.productName, filter.productVersion),
+    [productLevels.data, filter.productName, filter.productVersion],
+  );
+  const startLevelOptions = useMemo(
+    () => (rawLevels.length === 0 ? [] : rawLevels[0] === 0 ? rawLevels : [0, ...rawLevels]),
+    [rawLevels],
+  );
+  const endLevelOptions = useMemo(() => {
+    if (!filter.startLevel || rawLevels.length === 0) return [];
+    const start = Number(filter.startLevel);
+    return rawLevels.filter((l) => l > start);
+  }, [rawLevels, filter.startLevel]);
+
+  const setField = (field: keyof FilterState, value: string) => {
+    setFilter((prev) => {
+      const next = { ...prev, [field]: value };
+      if (field === "productName") {
+        next.productVersion = "";
+        next.startLevel = "";
+        next.endLevel = "";
+      } else if (field === "productVersion") {
+        next.startLevel = "";
+        next.endLevel = "";
+      } else if (field === "startLevel") {
+        next.endLevel = "";
+      }
+      return next;
+    });
+  };
+
+  const canSearch =
+    filter.productName !== "" &&
+    filter.productVersion !== "" &&
+    filter.startLevel !== "" &&
+    filter.endLevel !== "" &&
+    Number(filter.endLevel) > Number(filter.startLevel);
+
+  const handleSearch = () => {
+    if (!canSearch) return;
+    setSearch({
+      productName: filter.productName,
+      productVersion: filter.productVersion,
+      startingUpdateLevel: Number(filter.startLevel),
+      endingUpdateLevel: Number(filter.endLevel),
+    });
+  };
+
+  const handleClear = () => {
+    setFilter(INITIAL_FILTER);
+    setSearch(null);
+  };
+
+  return (
+    <Stack gap={2}>
+      <Box>
+        <Typography variant="h6">Updates</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Check release notes between two update levels of a product version.
+        </Typography>
+      </Box>
+
+      <Card sx={{ p: 2 }}>
+        {productLevels.isError ? (
+          <Typography variant="body2" color="error.main">
+            Could not load the product catalog. Please try again.
+          </Typography>
+        ) : productLevels.isLoading ? (
+          <Stack gap={1.5}>
+            {[1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} variant="rounded" height={40} />
+            ))}
+          </Stack>
+        ) : (
+          <Stack gap={1.5}>
+            <FormControl size="small" fullWidth>
+              <InputLabel id="upd-product">Product</InputLabel>
+              <Select
+                labelId="upd-product"
+                label="Product"
+                value={filter.productName}
+                onChange={(e) => setField("productName", String(e.target.value))}
+                MenuProps={{ slotProps: { paper: OPAQUE_POPUP } }}
+              >
+                {productNames.map((n) => (
+                  <MenuItem key={n} value={n}>
+                    {n}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" fullWidth disabled={!filter.productName}>
+              <InputLabel id="upd-version">Version</InputLabel>
+              <Select
+                labelId="upd-version"
+                label="Version"
+                value={filter.productVersion}
+                onChange={(e) => setField("productVersion", String(e.target.value))}
+                MenuProps={{ slotProps: { paper: OPAQUE_POPUP } }}
+              >
+                {versionOptions.map((v) => (
+                  <MenuItem key={v} value={v}>
+                    {v}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Stack direction="row" gap={1.5}>
+              <FormControl size="small" fullWidth disabled={!filter.productVersion}>
+                <InputLabel id="upd-start">Start level</InputLabel>
+                <Select
+                  labelId="upd-start"
+                  label="Start level"
+                  value={filter.startLevel}
+                  onChange={(e) => setField("startLevel", String(e.target.value))}
+                  MenuProps={{ slotProps: { paper: OPAQUE_POPUP } }}
+                >
+                  {startLevelOptions.map((l) => (
+                    <MenuItem key={l} value={String(l)}>
+                      {l}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl size="small" fullWidth disabled={!filter.startLevel}>
+                <InputLabel id="upd-end">End level</InputLabel>
+                <Select
+                  labelId="upd-end"
+                  label="End level"
+                  value={filter.endLevel}
+                  onChange={(e) => setField("endLevel", String(e.target.value))}
+                  MenuProps={{ slotProps: { paper: OPAQUE_POPUP } }}
+                >
+                  {endLevelOptions.map((l) => (
+                    <MenuItem key={l} value={String(l)}>
+                      {l}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+
+            <Stack direction="row" gap={1}>
+              <Button variant="contained" size="small" onClick={handleSearch} disabled={!canSearch}>
+                Search
+              </Button>
+              <Button variant="text" size="small" onClick={handleClear}>
+                Clear
+              </Button>
+            </Stack>
+          </Stack>
+        )}
+      </Card>
+
+      {search && (
+        <Box>
+          {searchResult.isLoading ? (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+              <CircularProgress size={28} />
+            </Box>
+          ) : searchResult.isError ? (
+            <Typography variant="body2" color="error.main" textAlign="center" sx={{ py: 2 }}>
+              Could not load updates. Please try again.
+            </Typography>
+          ) : !searchResult.data || searchResult.data.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" textAlign="center" sx={{ py: 2 }}>
+              No updates found between level {search.startingUpdateLevel} and {search.endingUpdateLevel}.
+            </Typography>
+          ) : (
+            <Stack gap={1}>
+              <Typography variant="body2" color="text.secondary">
+                {searchResult.data.length} update level(s) found.
+              </Typography>
+              {searchResult.data.map((group) => (
+                <Stack
+                  key={group.levelKey}
+                  direction="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  gap={1}
+                  sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
+                >
+                  <Stack direction="row" alignItems="center" gap={1}>
+                    <Typography variant="body2" fontWeight={500}>
+                      Level {group.levelKey}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={group.updateType.charAt(0).toUpperCase() + group.updateType.slice(1)}
+                      color={updateTypeChipColor(group.updateType)}
+                    />
+                  </Stack>
+                  <Button size="small" variant="text" onClick={() => setOpenGroup(group)}>
+                    View
+                  </Button>
+                </Stack>
+              ))}
+            </Stack>
+          )}
+        </Box>
+      )}
+
+      {openGroup && <UpdateLevelDialog group={openGroup} onClose={() => setOpenGroup(null)} />}
+    </Stack>
+  );
+}
+
+function UpdateLevelDialog({ group, onClose }: { group: UpdateLevelGroup; onClose: () => void }) {
+  return (
+    <DialogPaperWrapper onClose={onClose}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Typography variant="h6" fontWeight={650}>
+          Update level {group.levelKey}
+        </Typography>
+        <Chip
+          size="small"
+          label={group.updateType.charAt(0).toUpperCase() + group.updateType.slice(1)}
+          color={updateTypeChipColor(group.updateType)}
+        />
+      </Stack>
+
+      <Stack gap={2.5}>
+        {group.updateDescriptionLevels.map((desc) => (
+          <UpdateDescriptionBlock key={desc.updateNumber} desc={desc} />
+        ))}
+      </Stack>
+
+      <Button variant="outlined" onClick={onClose} sx={{ alignSelf: "end" }}>
+        Close
+      </Button>
+    </DialogPaperWrapper>
+  );
+}
+
+function UpdateDescriptionBlock({ desc }: { desc: UpdateDescription }) {
+  return (
+    <Stack gap={1.5}>
+      <Typography variant="subtitle2" fontWeight={600}>
+        Update number: {desc.updateNumber}
+      </Typography>
+
+      {desc.description && <UpdateSection title="Description" content={desc.description} />}
+      {isMeaningful(desc.instructions) && <UpdateSection title="Instructions" content={desc.instructions!} />}
+      <FileList title="Bug fixes" items={desc.bugFixes} />
+      <FileList title="Files added" items={desc.filesAdded} />
+      <FileList title="Files modified" items={desc.filesModified} />
+      <FileList title="Files removed" items={desc.filesRemoved} />
+
+      {desc.securityAdvisories.length > 0 && (
+        <Box>
+          <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 0.75 }}>
+            Security advisories
+          </Typography>
+          <Stack gap={1}>
+            {desc.securityAdvisories.map((a) => (
+              <Box key={a.id} sx={{ p: 1.25, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                <Stack direction="row" gap={1} alignItems="center" sx={{ mb: 0.5 }}>
+                  <Typography variant="body2" fontWeight={600}>
+                    {a.id}
+                  </Typography>
+                  <Chip size="small" label={a.severity} color="error" variant="outlined" />
+                </Stack>
+                {a.overview && <HtmlOrText content={a.overview} />}
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+      )}
+    </Stack>
+  );
+}
+
+function UpdateSection({ title, content }: { title: string; content: string }) {
+  return (
+    <Box>
+      <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 0.75 }}>
+        {title}
+      </Typography>
+      <HtmlOrText content={content} />
+    </Box>
+  );
+}
+
+function FileList({ title, items }: { title: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <Box>
+      <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 0.75 }}>
+        {title}
+      </Typography>
+      <Box component="ul" sx={{ pl: 2.5, m: 0 }}>
+        {items.map((f) => (
+          <Typography key={f} component="li" variant="body2" color="text.secondary">
+            {f}
+          </Typography>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+// Thin wrapper so UpdateLevelDialog's JSX doesn't need to repeat the
+// Dialog/slots/slotProps boilerplate — mirrors the microapp's other
+// full-content dialogs (Card component={Stack} via the shared DialogPaper).
+function DialogPaperWrapper({ children, onClose }: { children: ReactNode; onClose: () => void }) {
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      slots={{ paper: DialogPaper }}
+      slotProps={{
+        paper: { sx: { bgcolor: "background.default", p: 2, gap: 2, m: 2, maxHeight: "85vh", overflowY: "auto" } },
+      }}
+    >
+      {children}
+    </Dialog>
+  );
 }

--- a/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
@@ -372,7 +372,7 @@ function UpdateDescriptionBlock({ desc }: { desc: UpdateDescription }) {
         Update number: {desc.updateNumber}
       </Typography>
 
-      {desc.description && <UpdateSection title="Description" content={desc.description} />}
+      {isMeaningful(desc.description) && <UpdateSection title="Description" content={desc.description!} />}
       {isMeaningful(desc.instructions) && <UpdateSection title="Instructions" content={desc.instructions!} />}
       <FileList title="Bug fixes" items={desc.bugFixes} />
       <FileList title="Files added" items={desc.filesAdded} />

--- a/apps/csm-portal/microapp/src/services/updates.ts
+++ b/apps/csm-portal/microapp/src/services/updates.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { queryOptions } from "@tanstack/react-query";
+import { PRODUCT_UPDATE_LEVELS_ENDPOINT, UPDATE_LEVELS_SEARCH_ENDPOINT } from "@config/endpoints";
+import type {
+  ProductUpdateLevelDto,
+  SearchUpdatesInput,
+  UpdateLevelGroup,
+  UpdateLevelsSearchResponseDto,
+} from "@src/types";
+import { toUpdateLevelGroups, type ProductUpdateLevel } from "@src/types";
+import apiClient from "./apiClient";
+
+const getProductUpdateLevels = async (): Promise<ProductUpdateLevel[]> => {
+  const { data } = await apiClient.get<ProductUpdateLevelDto[]>(PRODUCT_UPDATE_LEVELS_ENDPOINT);
+  return data;
+};
+
+const searchUpdateLevels = async (input: SearchUpdatesInput): Promise<UpdateLevelGroup[]> => {
+  const { data } = await apiClient.post<UpdateLevelsSearchResponseDto>(UPDATE_LEVELS_SEARCH_ENDPOINT, input);
+  return toUpdateLevelGroups(data);
+};
+
+export const updates = {
+  productLevels: () =>
+    queryOptions({
+      queryKey: ["updates", "product-update-levels"],
+      queryFn: () => getProductUpdateLevels(),
+      staleTime: 5 * 60_000,
+    }),
+
+  search: (input: SearchUpdatesInput | null) =>
+    queryOptions({
+      queryKey: ["updates", "levels-search", input],
+      queryFn: () => searchUpdateLevels(input!),
+      enabled: input !== null,
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -36,3 +36,5 @@ export * from "./timecard.dto";
 export * from "./timecard.model";
 export * from "./changeRequest.dto";
 export * from "./changeRequest.model";
+export * from "./updates.dto";
+export * from "./updates.model";

--- a/apps/csm-portal/microapp/src/types/updates.dto.ts
+++ b/apps/csm-portal/microapp/src/types/updates.dto.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Mirrors csm-portal-backend/internal/updates/types.go (portal camelCase) —
+// same contract the webapp's features/updates/types/updates.ts uses.
+
+export interface UpdateLevelDto {
+  productBaseVersion: string;
+  channel: string;
+  updateLevels: number[];
+}
+
+export interface ProductUpdateLevelDto {
+  productName: string;
+  productUpdateLevels: UpdateLevelDto[];
+}
+
+export interface SearchUpdatesPayloadDto {
+  productName: string;
+  productVersion: string;
+  startingUpdateLevel: number;
+  endingUpdateLevel: number;
+}
+
+export interface SecurityAdvisoryDto {
+  id: string;
+  overview: string;
+  severity: string;
+  description: string;
+  impact: string;
+  solution: string;
+  notes: string;
+  credits: string;
+}
+
+export interface DependantReleaseDto {
+  repository: string;
+  releaseVersion: string;
+}
+
+export interface UpdateDescriptionDto {
+  updateLevel: number;
+  productName: string;
+  productVersion: string;
+  channel: string;
+  updateType: string;
+  updateNumber: number;
+  description?: string;
+  instructions?: string;
+  bugFixes?: string;
+  filesAdded?: string;
+  filesModified?: string;
+  filesRemoved?: string;
+  bundlesInfoChanges?: string;
+  dependantReleases?: DependantReleaseDto[];
+  /** Epoch milliseconds. */
+  timestamp: number;
+  securityAdvisories: SecurityAdvisoryDto[];
+}
+
+export interface UpdateLevelGroupDto {
+  updateType: string;
+  updateDescriptionLevels: UpdateDescriptionDto[];
+}
+
+/** POST /updates/levels/search response: map of level key -> group. */
+export type UpdateLevelsSearchResponseDto = Record<string, UpdateLevelGroupDto>;

--- a/apps/csm-portal/microapp/src/types/updates.model.ts
+++ b/apps/csm-portal/microapp/src/types/updates.model.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { UpdateDescriptionDto, UpdateLevelsSearchResponseDto } from "./updates.dto";
+
+export interface UpdateLevel {
+  productBaseVersion: string;
+  channel: string;
+  updateLevels: number[];
+}
+
+export interface ProductUpdateLevel {
+  productName: string;
+  productUpdateLevels: UpdateLevel[];
+}
+
+export interface SearchUpdatesInput {
+  productName: string;
+  productVersion: string;
+  startingUpdateLevel: number;
+  endingUpdateLevel: number;
+}
+
+export interface SecurityAdvisory {
+  id: string;
+  overview: string;
+  severity: string;
+  description: string;
+  impact: string;
+  solution: string;
+  notes: string;
+  credits: string;
+}
+
+export interface DependantRelease {
+  repository: string;
+  releaseVersion: string;
+}
+
+export interface UpdateDescription {
+  updateLevel: number;
+  productName: string;
+  productVersion: string;
+  channel: string;
+  updateType: string;
+  updateNumber: number;
+  description?: string;
+  instructions?: string;
+  bugFixes: string[];
+  filesAdded: string[];
+  filesModified: string[];
+  filesRemoved: string[];
+  dependantReleases: DependantRelease[];
+  releasedOn: Date | null;
+  securityAdvisories: SecurityAdvisory[];
+}
+
+export interface UpdateLevelGroup {
+  levelKey: string;
+  updateType: string;
+  updateDescriptionLevels: UpdateDescription[];
+}
+
+// The upstream sometimes JSON-encodes these list fields as a string
+// (e.g. '["Foo.java","Bar.java"]') rather than sending a real array —
+// normalized here once so components never see the raw encoded form.
+function parseJsonStringArray(raw: string | undefined | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function toUpdateDescription(dto: UpdateDescriptionDto): UpdateDescription {
+  return {
+    updateLevel: dto.updateLevel,
+    productName: dto.productName,
+    productVersion: dto.productVersion,
+    channel: dto.channel,
+    updateType: dto.updateType,
+    updateNumber: dto.updateNumber,
+    description: dto.description,
+    instructions: dto.instructions,
+    bugFixes: parseJsonStringArray(dto.bugFixes),
+    filesAdded: parseJsonStringArray(dto.filesAdded),
+    filesModified: parseJsonStringArray(dto.filesModified),
+    filesRemoved: parseJsonStringArray(dto.filesRemoved),
+    dependantReleases: dto.dependantReleases ?? [],
+    releasedOn: Number.isFinite(dto.timestamp) && dto.timestamp > 0 ? new Date(dto.timestamp) : null,
+    securityAdvisories: dto.securityAdvisories ?? [],
+  };
+}
+
+/** Level-key-sorted groups, ready to render — components never see the raw response map. */
+export function toUpdateLevelGroups(dto: UpdateLevelsSearchResponseDto): UpdateLevelGroup[] {
+  return Object.entries(dto)
+    .map(([levelKey, group]) => ({
+      levelKey,
+      updateType: group.updateType,
+      updateDescriptionLevels: group.updateDescriptionLevels.map(toUpdateDescription),
+    }))
+    .sort((a, b) => Number(a.levelKey) - Number(b.levelKey));
+}


### PR DESCRIPTION
## Purpose
The Updates page in the CSM microapp was a `ComingSoonPage` placeholder — no way to check release notes between two update levels of a product version on mobile, even though the webapp has had this for a while.

## Goals
- Let an agent pick a product, version, and an update-level range, and see every update level in that range with its type (security/regular/mixed).
- Show the full detail for a level on demand: description, instructions, bug fixes, added/modified/removed files, and security advisories.
- Handle the upstream's "description is sometimes HTML, sometimes plain text" quirk correctly either way.

## Approach
- Ported the webapp's `features/updates/` contract into the microapp's `types/`, `services/`, `pages/` layout: `updates.dto.ts`/`updates.model.ts` mirror `GET /updates/product-update-levels` and `POST /updates/levels/search`, with the model layer normalizing the upstream's sometimes-JSON-encoded-as-string list fields into real arrays and pre-sorting search results by level key.
- `UpdatesPage.tsx` replaces the placeholder: cascading Product → Version → Start level → End level selects, a result list, and a per-level detail dialog. Reuses the shared `DialogPaper` (stable paper-slot component) and the `OPAQUE_POPUP` pattern already established in `TimeCardFiltersSheet`/`AnnouncementFiltersSheet` for this theme's translucent dropdowns.
- Trimmed from the webapp's version for a single-column mobile layout: no PDF export or report-preview dialog (a print/download flow doesn't suit a WebView well and wasn't asked for), and a single preferred date/time instead of the webapp's up-to-3-slot picker.
- While wiring dialogs for this, noticed the call-requests feature's five dialogs (a separate, already-open PR) had the same paper-slot focus-loss bug as an earlier customer-portal fix — turned out this microapp already has a shared `DialogPaper` for exactly that reason. Fixed those to use it too, included here since it was found in the course of this work.

## User stories
As an agent, I can look up what changed between two update levels of a product version from my phone, including security advisories, without needing the desktop webapp.

## Release note
Added the Updates page (product/version/update-level range search) to the CSM Portal mobile app.

## Documentation
N/A — internal CSM portal UI change, no external doc surface affected.

## Automation tests
- No automated test runner is wired up for this app yet.
- Verified locally: `tsc -b`, `eslint`, and `npm run build` all clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Local dev server (Vite), manual browser testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full “Updates” search page with product/version and update-level selection.
  * Added range validation so searches only run when the selected start/end levels are valid.
  * Added search results with per-level “View” dialogs showing update details (descriptions, bug fixes, file changes, security advisories, and related releases).
  * Added safe rendering for formatted update content and structured detail sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->