### PR TITLE
[Customer Portal Webapp] Hide Calls tab for Operations service requests

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -82,6 +82,7 @@ export default function CaseDetailsContent({
   const isSecurityReportAnalysisRoute = location.pathname.includes(
     "security-report-analysis",
   );
+  const isOperationsRoute = location.pathname.includes("/operations/");
 
   const statusLabel = data?.status?.label;
   const severityLabel = data?.severity?.label;
@@ -125,7 +126,7 @@ export default function CaseDetailsContent({
 
   const callsQuery = useGetCallRequests(
     resolvedProjectId,
-    caseId,
+    isOperationsRoute ? "" : caseId,
     callRequestStateKeys,
   );
   const callCount =
@@ -153,7 +154,8 @@ export default function CaseDetailsContent({
     statusLabel != null &&
     CALL_SCHEDULABLE_CASE_STATUSES.includes(statusLabel as CaseStatus);
 
-  const hideCallsTab = isSecurityReportAnalysis || !isCallSchedulingAllowed;
+  const hideCallsTab =
+    isSecurityReportAnalysis || isOperationsRoute || !isCallSchedulingAllowed;
   const hideKnowledgeBaseTab =
     isSecurityReportAnalysis || isEngagementRoute || isServiceRequest;
   const hideRelatedChangeRequestsTab =


### PR DESCRIPTION
### Summary
- The Calls (call request) tab was showing in the Operations service request view, but this feature should only be available for Support cases.
- Added an `isOperationsRoute` check in `CaseDetailsContent` and folded it into `hideCallsTab` so the tab is hidden on any `/operations/` route.
- Skipped the call requests fetch (`caseId=""`) on Operations routes to avoid the unnecessary network call.

### Test plan
- [ ] Open a service request under Operations — confirm the Calls tab is no longer shown.
- [ ] Open a case under Support — confirm the Calls tab still shows as before.
- [ ] Open an engagement / security report analysis case — confirm no regression in tab visibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated operations pages to hide the Calls tab.
  * Prevented calls-related data from being requested in operations contexts.
  * Preserved existing behavior for other case detail page types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->