### PR TITLE
[CSM][Web] Route search results to their correct page by case type

### DIFF
--- a/apps/customer-portal/webapp/src/components/header/SearchBar.tsx
+++ b/apps/customer-portal/webapp/src/components/header/SearchBar.tsx
@@ -55,6 +55,33 @@ const SEARCH_DEBOUNCE_MS = 300;
 const SEARCH_RESULTS_DROPDOWN_MIN_WIDTH_PX = 320;
 const SEARCH_RESULTS_DROPDOWN_VIEWPORT_PADDING_PX = 16;
 
+// Strips whitespace, underscores, and hyphens for label comparison.
+function normalizeTypeLabel(val: string): string {
+  return val.toLowerCase().replace(/[\s_-]+/g, "").trim();
+}
+
+/**
+ * Resolves the in-app path for a case search result based on its type label.
+ * Mirrors the route mapping in globalSearchNavigation.ts.
+ */
+function getCaseSearchResultPath(projectId: string, caseItem: CaseListItem): string {
+  const typeLabel = normalizeTypeLabel(caseItem.type?.label ?? "");
+
+  if (typeLabel === "announcement") {
+    return `/projects/${projectId}/announcements/${caseItem.id}`;
+  }
+  if (typeLabel === "engagement") {
+    return `/projects/${projectId}/engagements/${caseItem.id}`;
+  }
+  if (typeLabel === "servicerequest") {
+    return `/projects/${projectId}/operations/service-requests/${caseItem.id}`;
+  }
+  if (typeLabel === "securityreportanalysis") {
+    return `/projects/${projectId}/security-center/security-report-analysis/${caseItem.id}`;
+  }
+  return `/projects/${projectId}/support/cases/${caseItem.id}`;
+}
+
 /**
  * Resolves dropdown size and position from the search field anchor rect.
  * Width matches the search bar when wide; uses a minimum width when the input is narrow.
@@ -189,9 +216,7 @@ export default function SearchBar({
   const handleCaseClick = useCallback(
     (caseItem: CaseListItem) => {
       if (effectiveProjectId) {
-        navigate(
-          `/projects/${effectiveProjectId}/support/cases/${caseItem.id}`,
-        );
+        navigate(getCaseSearchResultPath(effectiveProjectId, caseItem));
         setSearchValue("");
         setIsDropdownOpen(false);
       }
@@ -253,8 +278,6 @@ export default function SearchBar({
         window.removeEventListener("scroll", updateRect, true);
         window.removeEventListener("resize", updateRect);
       };
-    } else {
-      setDropdownRect(null);
     }
   }, [showDropdown]);
 

--- a/apps/customer-portal/webapp/src/features/project-hub/utils/globalSearchNavigation.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/utils/globalSearchNavigation.ts
@@ -51,6 +51,9 @@ export function getCaseTypeChipProps(label: string | null | undefined): {
   if (normalized === "changerequest") {
     return { color: colors.blue?.[500] ?? "#3B82F6", displayLabel: "Change Request" };
   }
+  if (normalized === "announcement") {
+    return { color: colors.indigo?.[500] ?? "#6366F1", displayLabel: "Announcement" };
+  }
   return { color: colors.grey?.[500] ?? "#6B7280", displayLabel: label?.trim() ?? "--" };
 }
 
@@ -59,12 +62,13 @@ export function getCaseTypeChipProps(label: string | null | undefined): {
  * Returns null when the case has no project (navigation not possible).
  *
  * We match on the normalized label because caseType.id is a ServiceNow GUID, not a constant.
- * Known labels from the API: "Engagement", "Service Request", "Security Report Analysis", "Query".
+ * Known labels from the API: "Engagement", "Service Request", "Security Report Analysis", "Query", "Announcement".
  *
  * Route mapping:
  *   engagement              → /projects/:id/engagements/:caseId
  *   service request         → /projects/:id/operations/service-requests/:caseId
  *   security report analysis → /projects/:id/security-center/security-report-analysis/:caseId
+ *   announcement            → /projects/:id/announcements/:caseId
  *   default case / unknown  → /projects/:id/support/cases/:caseId
  */
 export function getCaseNavigationPath(c: GlobalSearchCase): string | null {
@@ -81,6 +85,9 @@ export function getCaseNavigationPath(c: GlobalSearchCase): string | null {
   }
   if (typeLabel === "securityreportanalysis") {
     return `/projects/${projectId}/security-center/security-report-analysis/${c.id}`;
+  }
+  if (typeLabel === "announcement") {
+    return `/projects/${projectId}/announcements/${c.id}`;
   }
   return `/projects/${projectId}/support/cases/${c.id}`;
 }


### PR DESCRIPTION
## Summary
- Project Hub global search now navigates announcement results to the Announcements page instead of the Cases tab, using the result's case type label.
- Header search bar (used within a project) now applies the same type-based routing — announcements, engagements, service requests, and security report analysis cases each open their dedicated page; everything else keeps opening the Cases tab.

## Test plan
- [x] `tsc --noEmit` passes
- [x] ESLint clean on changed files
- [x] Manually search for an announcement, engagement, service request, and security report analysis case ID from both the Project Hub search and the in-project header search bar, and confirm each opens its correct page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global search now directs case results to the appropriate destination based on case type.
  * Added support for navigating Announcement cases to their dedicated project route.
  * Announcement case results now display a distinct indigo label and styling.

* **Bug Fixes**
  * Improved navigation for Engagement, Service Request, and Security Report Analysis cases while preserving a default route for unrecognized types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->