### PR TITLE
[CSM Portal Microapp] Add the announcement detail view

### DIFF
--- a/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
+++ b/apps/csm-portal/microapp/src/components/announcements/AnnouncementCard.tsx
@@ -15,16 +15,23 @@
 // under the License.
 
 import { Card, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { Link } from "react-router-dom";
 import type { CaseSummary } from "@src/types";
 import { fromNow } from "@utils/dateTime";
 import { AnnouncementStateChip } from "./AnnouncementStateChip";
 
-// Read-only announcement card (not tappable — mirrors the webapp's read-only
-// list). Announcements are cases of type "announcement", so `item` is a
-// `CaseSummary`; only the fields the list shows are rendered.
+// Announcements are cases of type "announcement", so `item` is a
+// `CaseSummary`; only the fields the list shows are rendered. Taps through to
+// the shared case detail page (/cases/:id), same as the webapp's
+// CsmCaseDetailPage reuse — it renders a read-only view for this case type.
 export function AnnouncementCard({ item }: { item: CaseSummary }) {
   return (
-    <Card variant="outlined" sx={{ p: 2 }}>
+    <Card
+      component={Link}
+      to={`/cases/${item.id}`}
+      variant="outlined"
+      sx={{ p: 2, textDecoration: "none", display: "block" }}
+    >
       <Stack gap={1}>
         <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
           <Typography variant="subtitle2" noWrap sx={{ minWidth: 0 }}>

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -109,12 +109,27 @@ function CaseDetailContent({ id }: { id: string }) {
   const { data: currentUserId } = useSuspenseQuery(currentUser.id());
   const currentUserEmail = useUserStore((s) => s.user?.email);
 
+  // Announcements are cases of type "announcement" — read-only, and the
+  // SLA/time-tracking/call-request tabs don't apply. Mirrors the webapp's
+  // CsmCaseDetailPage, minus its route-based check: this page is always
+  // reached via /cases/:id regardless of case type, so the loaded case's own
+  // type is the only signal needed.
+  const isAnnouncement = caseDetail.type === "announcement";
+
   const [isMutating, setIsMutating] = useState(false);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [resolutionTarget, setResolutionTarget] = useState<"closed" | "solution_proposed" | null>(null);
   const [isPostingComment, setIsPostingComment] = useState(false);
   const [activeTab, setActiveTab] = useState<CaseTabId>("activities");
   const [pauseConflict, setPauseConflict] = useState<MyOngoingCase[] | null>(null);
+
+  const visibleTabDefs = isAnnouncement
+    ? TAB_DEFS.filter((tab) => tab.id !== "sla" && tab.id !== "time" && tab.id !== "call-requests")
+    : TAB_DEFS;
+  // If a case turns out to be an announcement (only knowable once caseDetail
+  // loads) while a tab hidden for announcements is active, fall back to
+  // Activities rather than rendering a tab no longer in the visible list.
+  const effectiveTab = visibleTabDefs.some((tab) => tab.id === activeTab) ? activeTab : "activities";
 
   const invalidateCase = (): void => {
     void queryClient.invalidateQueries({ queryKey: ["case", id] });
@@ -367,6 +382,7 @@ function CaseDetailContent({ id }: { id: string }) {
       <CaseSummarySection
         caseDetail={caseDetail}
         currentUserId={currentUserId}
+        isAnnouncement={isAnnouncement}
         isMutating={isMutating}
         mutationError={mutationError}
         onTransition={handleTransition}
@@ -375,34 +391,35 @@ function CaseDetailContent({ id }: { id: string }) {
         onChangeSeverity={handleSeveritySubmit}
       />
 
-      <Tabs value={activeTab} variant="scrollable" onChange={(_, value: CaseTabId) => setActiveTab(value)}>
-        {TAB_DEFS.map((tab) => (
+      <Tabs value={effectiveTab} variant="scrollable" onChange={(_, value: CaseTabId) => setActiveTab(value)}>
+        {visibleTabDefs.map((tab) => (
           <Tab key={tab.id} value={tab.id} label={tab.label} />
         ))}
       </Tabs>
 
-      {activeTab === "activities" && (
+      {effectiveTab === "activities" && (
         <CaseCommentsSection
           caseId={id}
           comments={comments}
           caseState={caseDetail.state}
           workState={caseDetail.workState}
           isPostingComment={isPostingComment}
+          isAnnouncement={isAnnouncement}
           onSubmitComment={handleCommentSubmit}
         />
       )}
 
-      {activeTab === "details" && (
+      {effectiveTab === "details" && (
         <Stack gap={2}>
           <CaseMetadataSection caseDetail={caseDetail} />
         </Stack>
       )}
 
-      {activeTab === "sla" && <SlaTab caseId={id} />}
+      {effectiveTab === "sla" && <SlaTab caseId={id} />}
 
-      {activeTab === "attachments" && <AttachmentsTab caseId={id} />}
+      {effectiveTab === "attachments" && <AttachmentsTab caseId={id} />}
 
-      {activeTab === "time" && (
+      {effectiveTab === "time" && (
         <TimeTrackingTab
           caseId={id}
           caseNumber={caseDetail.number}
@@ -436,6 +453,7 @@ function CaseDetailContent({ id }: { id: string }) {
 function CaseSummarySection({
   caseDetail,
   currentUserId,
+  isAnnouncement,
   isMutating,
   mutationError,
   onTransition,
@@ -445,6 +463,7 @@ function CaseSummarySection({
 }: {
   caseDetail: CaseDetail;
   currentUserId: string | null;
+  isAnnouncement: boolean;
   isMutating: boolean;
   mutationError: string | null;
   onTransition: (target: CaseState) => void;
@@ -453,7 +472,7 @@ function CaseSummarySection({
   onChangeSeverity: (next: CaseSeverity) => void;
 }) {
   const { icon: Icon, color } = TYPE_CONFIG[caseDetail.type ?? "case"] ?? TYPE_CONFIG.case;
-  const canChangeSeverity = caseDetail.severity && caseDetail.state !== "closed";
+  const canChangeSeverity = !isAnnouncement && caseDetail.severity && caseDetail.state !== "closed";
 
   return (
     <Stack gap={1.5}>
@@ -468,16 +487,19 @@ function CaseSummarySection({
 
         <Typography variant="h6">{caseDetail.subject}</Typography>
 
-        <Stack direction="row" gap={1} flexWrap="wrap" alignItems="center">
-          <StatusChip state={caseDetail.state} />
-          {/* Only "case"-type items carry a severity; service requests/security reports/etc. don't. */}
-          {caseDetail.severity && <SeverityChip severity={caseDetail.severity} />}
-        </Stack>
+        {/* Announcements are read-only and carry no meaningful state/severity of their own. */}
+        {!isAnnouncement && (
+          <Stack direction="row" gap={1} flexWrap="wrap" alignItems="center">
+            <StatusChip state={caseDetail.state} />
+            {/* Only "case"-type items carry a severity; service requests/security reports/etc. don't. */}
+            {caseDetail.severity && <SeverityChip severity={caseDetail.severity} />}
+          </Stack>
+        )}
       </Stack>
 
       {/* Actions live in their own row, visually separated from the identity block above so the
        * primary "what can I do" affordance isn't read as part of the case's own metadata. */}
-      {(caseDetail.nextStates.length > 0 || canChangeSeverity) && (
+      {!isAnnouncement && (caseDetail.nextStates.length > 0 || canChangeSeverity) && (
         <Stack
           direction="row"
           gap={1}
@@ -639,6 +661,7 @@ function CaseCommentsSection({
   caseState,
   workState,
   isPostingComment,
+  isAnnouncement,
   onSubmitComment,
 }: {
   caseId: string;
@@ -646,6 +669,7 @@ function CaseCommentsSection({
   caseState: CaseState;
   workState: CaseWorkState;
   isPostingComment: boolean;
+  isAnnouncement: boolean;
   onSubmitComment: (fields: {
     type: CaseCommentType;
     content: string;
@@ -654,14 +678,19 @@ function CaseCommentsSection({
 }) {
   return (
     <Stack gap={1.5}>
-      <CommentComposer
-        caseState={caseState}
-        workState={workState}
-        isSubmitting={isPostingComment}
-        onSubmit={onSubmitComment}
-      />
+      {/* Announcements are read-only — no commenting. */}
+      {!isAnnouncement && (
+        <>
+          <CommentComposer
+            caseState={caseState}
+            workState={workState}
+            isSubmitting={isPostingComment}
+            onSubmit={onSubmitComment}
+          />
 
-      <Divider />
+          <Divider />
+        </>
+      )}
 
       <CaseActivitiesTab caseId={caseId} comments={comments} />
     </Stack>

--- a/apps/csm-portal/microapp/src/services/announcements.ts
+++ b/apps/csm-portal/microapp/src/services/announcements.ts
@@ -53,12 +53,17 @@ async function searchAnnouncements(filters: AnnouncementFilters, offset: number)
     },
   };
   const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const items = data.cases.map(toCaseSummary);
   return {
-    items: data.cases.map(toCaseSummary),
+    items,
     total: data.total,
     offset: data.offset,
     limit: data.limit,
-    hasMore: data.hasMore,
+    // Some data sources omit hasMore from the search envelope (see cases.ts's
+    // getAllCases and adminUsers.ts's searchUsers, which hit the same quirk);
+    // derive it from offset/total when that happens instead of treating a
+    // missing/false field as "no more pages" after the first 20.
+    hasMore: data.hasMore ?? data.offset + items.length < data.total,
   };
 }
 

--- a/apps/csm-portal/microapp/src/services/announcements.ts
+++ b/apps/csm-portal/microapp/src/services/announcements.ts
@@ -62,8 +62,11 @@ async function searchAnnouncements(filters: AnnouncementFilters, offset: number)
     // Some data sources omit hasMore from the search envelope (see cases.ts's
     // getAllCases and adminUsers.ts's searchUsers, which hit the same quirk);
     // derive it from offset/total when that happens instead of treating a
-    // missing/false field as "no more pages" after the first 20.
-    hasMore: data.hasMore ?? data.offset + items.length < data.total,
+    // missing/false field as "no more pages" after the first 20. Also require
+    // a non-empty page: an empty page with a stale/inconsistent total should
+    // never report hasMore, or the infinite query would keep requesting
+    // further pages forever.
+    hasMore: data.hasMore ?? (data.offset + items.length < data.total && items.length > 0),
   };
 }
 


### PR DESCRIPTION
## Purpose
Announcement cards in the CSM microapp weren't tappable — there was no way to open one to read its full content, even though the webapp added this a while back.

## Goals
- Let an agent tap an announcement to see its full detail (description/activity, attachments) on mobile.
- Don't expose actions that don't apply to announcements: state transitions, severity changes, commenting, SLAs, time tracking, call requests.

## Approach
- The webapp doesn't have a dedicated announcement detail page — `announcements/:caseId` just routes to the same `CsmCaseDetailPage` used for regular cases and engagements, gated down by `caseType === "announcement"`. Mirrored that here rather than building a new page.
- `AnnouncementCard` is now a `Link` to the existing `/cases/:id` route (the same `CaseCard` pattern already used for the main case list) — no new route needed, since this microapp doesn't do the webapp's per-type route aliasing.
- `CaseDetailPage` now computes `isAnnouncement` from the loaded case's own `type` and hides what doesn't apply: status/severity chips, the action bar, the severity-change control, the comment composer, and the SLA/Time tracking/Call requests tabs. Activities (read-only), Details, and Attachments stay visible. Simpler than the webapp's version, which also needs a route-based check (`/announcements/` vs `/cases/`) since it exposes both URL shapes — this page is always reached via `/cases/:id` regardless of case type, so the loaded case's own type is the only signal needed.

## User stories
As an agent, I can tap an announcement from the list and read its full content and attachments on my phone, without seeing case actions that don't apply to it.

## Release note
Announcements are now tappable in the CSM Portal mobile app, opening a read-only detail view.

## Documentation
N/A — internal CSM portal UI change, no external doc surface affected.

## Automation tests
- No automated test runner is wired up for this app yet.
- Verified locally: `tsc -b`, `eslint`, and `npm run build` all clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Local dev server (Vite), manual browser testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Announcement cards are now clickable and navigate to the related case.
  * Announcement case pages open in read-only mode, focusing on the activities feed.

* **Bug Fixes**
  * Announcement pages now hide SLA/time tracking and call-request tabs and fall back to “activities” when needed.
  * Comment composing and case actions (status/severity changes) are disabled for announcements.
  * Improved announcement search pagination by deriving “has more” when it’s not provided by the backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->