### PR TITLE
[CSM Portal Microapp] Add call request lifecycle actions

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
@@ -18,7 +18,6 @@ import { Suspense, useState, type ReactNode } from "react";
 import {
   AdapterDateFns,
   Button,
-  Card,
   Chip,
   DatePickers,
   Dialog,
@@ -30,6 +29,7 @@ import {
 import { useMutation, useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import { callRequests } from "@src/services/callRequests";
 import type { CallRequest, CallRequestUpdateInput, CaseSeverity } from "@src/types";
+import { DialogPaper } from "@components/common/DialogPaper";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { formatDate } from "@utils/dateTime";
@@ -329,7 +329,7 @@ function CreateCallRequestDialog({
     <Dialog
       open
       onClose={onClose}
-      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slots={{ paper: DialogPaper }}
       slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
     >
       <Typography variant="h6" fontWeight={650}>
@@ -441,7 +441,7 @@ function ScheduleCallDialog({
     <Dialog
       open={!!callRequest}
       onClose={onClose}
-      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slots={{ paper: DialogPaper }}
       slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
     >
       <Typography variant="h6" fontWeight={650}>
@@ -528,7 +528,7 @@ function RejectCallDialog({
     <Dialog
       open={!!callRequest}
       onClose={onClose}
-      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slots={{ paper: DialogPaper }}
       slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
     >
       <Typography variant="h6" fontWeight={650}>
@@ -598,7 +598,7 @@ function CancelCallDialog({
     <Dialog
       open={!!callRequest}
       onClose={onClose}
-      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slots={{ paper: DialogPaper }}
       slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
     >
       <Typography variant="h6" fontWeight={650}>
@@ -689,7 +689,7 @@ function SendCallNotesDialog({
     <Dialog
       open={!!callRequest}
       onClose={onClose}
-      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slots={{ paper: DialogPaper }}
       slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
     >
       <Typography variant="h6" fontWeight={650}>

--- a/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
@@ -467,6 +467,7 @@ function ScheduleCallDialog({
           value={meetingTime}
           onChange={setMeetingTime}
           disabled={submitting}
+          minDateTime={new Date()}
           slotProps={{ textField: { size: "small", fullWidth: true } }}
         />
       </LocalizationProvider>

--- a/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
@@ -27,12 +27,19 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import { callRequests } from "@src/services/callRequests";
-import type { CallRequest } from "@src/types";
+import type { CallRequest, CallRequestUpdateInput } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { formatDate } from "@utils/dateTime";
+import {
+  CALL_REQUEST_ACTION_LABEL,
+  CALL_REQUEST_AGENT_ACTIONS,
+  CALL_REQUEST_STATE_COLOR,
+  resolveCallRequestStateKey,
+  type CallRequestAgentAction,
+} from "@utils/callRequestState";
 
 const { LocalizationProvider, DateTimePicker } = DatePickers;
 
@@ -51,6 +58,83 @@ function CallRequestsTabContent({ caseId }: { caseId: string }) {
   const { data: requests } = useSuspenseQuery(callRequests.forCase(caseId));
   const [createOpen, setCreateOpen] = useState(false);
 
+  const invalidate = () => void queryClient.invalidateQueries({ queryKey: ["case", caseId, "call-requests"] });
+
+  const updateMutation = useMutation({
+    mutationFn: (input: CallRequestUpdateInput) => callRequests.update(input),
+  });
+
+  // Only one action dialog is ever open at a time, driven by which action was clicked on a row.
+  const [scheduleTarget, setScheduleTarget] = useState<CallRequest | null>(null);
+  const [rejectTarget, setRejectTarget] = useState<CallRequest | null>(null);
+  const [notesTarget, setNotesTarget] = useState<CallRequest | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<CallRequest | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const isReschedule = resolveCallRequestStateKey(scheduleTarget?.state) === "scheduled";
+
+  const handleAction = (action: CallRequestAgentAction, cr: CallRequest) => {
+    setActionError(null);
+    switch (action) {
+      case "schedule":
+      case "reschedule":
+        setScheduleTarget(cr);
+        break;
+      case "reject":
+        setRejectTarget(cr);
+        break;
+      case "sendNotes":
+        setNotesTarget(cr);
+        break;
+      case "cancel":
+        setCancelTarget(cr);
+        break;
+    }
+  };
+
+  const runUpdate = (input: CallRequestUpdateInput, onDone: () => void) => {
+    setActionError(null);
+    updateMutation.mutate(input, {
+      onSuccess: () => {
+        onDone();
+        invalidate();
+      },
+      onError: () => setActionError("Could not update the call request. Please try again."),
+    });
+  };
+
+  const handleSchedule = (input: { meetingDate: string; durationInMinutes: number; assignee?: string }) => {
+    if (!scheduleTarget) return;
+    runUpdate({ caseId, callRequestId: scheduleTarget.id, state: "scheduled", ...input }, () =>
+      setScheduleTarget(null),
+    );
+  };
+
+  const handleReject = (reason?: string) => {
+    if (!rejectTarget) return;
+    runUpdate({ caseId, callRequestId: rejectTarget.id, state: "wso2_rejected", cancellationReason: reason }, () =>
+      setRejectTarget(null),
+    );
+  };
+
+  const handleCancel = (cancellationReason: string) => {
+    if (!cancelTarget) return;
+    runUpdate({ caseId, callRequestId: cancelTarget.id, state: "canceled", cancellationReason }, () =>
+      setCancelTarget(null),
+    );
+  };
+
+  const handleSendNotes = (input: {
+    notes: string;
+    plan?: string;
+    attendees?: string;
+    actionItems?: string;
+    actualDurationMin?: number;
+  }) => {
+    if (!notesTarget) return;
+    runUpdate({ caseId, callRequestId: notesTarget.id, state: "concluded", ...input }, () => setNotesTarget(null));
+  };
+
   return (
     <Stack gap={2}>
       <Button variant="contained" size="small" onClick={() => setCreateOpen(true)} sx={{ alignSelf: "start" }}>
@@ -64,7 +148,7 @@ function CallRequestsTabContent({ caseId }: { caseId: string }) {
       ) : (
         <Stack gap={1}>
           {requests.map((cr) => (
-            <CallRequestRow key={cr.id} callRequest={cr} />
+            <CallRequestRow key={cr.id} callRequest={cr} onAction={handleAction} />
           ))}
         </Stack>
       )}
@@ -75,22 +159,80 @@ function CallRequestsTabContent({ caseId }: { caseId: string }) {
           onClose={() => setCreateOpen(false)}
           onCreated={() => {
             setCreateOpen(false);
-            void queryClient.invalidateQueries({ queryKey: ["case", caseId, "call-requests"] });
+            invalidate();
           }}
         />
       )}
+
+      <ScheduleCallDialog
+        callRequest={scheduleTarget}
+        isReschedule={isReschedule}
+        submitting={updateMutation.isPending}
+        error={actionError}
+        onClose={() => {
+          setScheduleTarget(null);
+          setActionError(null);
+        }}
+        onSubmit={handleSchedule}
+      />
+
+      <RejectCallDialog
+        callRequest={rejectTarget}
+        submitting={updateMutation.isPending}
+        error={actionError}
+        onClose={() => {
+          setRejectTarget(null);
+          setActionError(null);
+        }}
+        onSubmit={handleReject}
+      />
+
+      <CancelCallDialog
+        callRequest={cancelTarget}
+        submitting={updateMutation.isPending}
+        error={actionError}
+        onClose={() => {
+          setCancelTarget(null);
+          setActionError(null);
+        }}
+        onSubmit={handleCancel}
+      />
+
+      <SendCallNotesDialog
+        callRequest={notesTarget}
+        submitting={updateMutation.isPending}
+        error={actionError}
+        onClose={() => {
+          setNotesTarget(null);
+          setActionError(null);
+        }}
+        onSubmit={handleSendNotes}
+      />
     </Stack>
   );
 }
 
-function CallRequestRow({ callRequest }: { callRequest: CallRequest }) {
+function CallRequestRow({
+  callRequest,
+  onAction,
+}: {
+  callRequest: CallRequest;
+  onAction: (action: CallRequestAgentAction, cr: CallRequest) => void;
+}) {
+  const stateKey = resolveCallRequestStateKey(callRequest.state);
+  const actions = stateKey ? CALL_REQUEST_AGENT_ACTIONS[stateKey] : [];
+
   return (
     <Stack gap={0.5} sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
         <Typography variant="body2" fontWeight={500} noWrap sx={{ minWidth: 0 }}>
           {callRequest.number}
         </Typography>
-        <Chip size="small" label={callRequest.stateLabel} />
+        <Chip
+          size="small"
+          label={callRequest.stateLabel}
+          color={stateKey ? CALL_REQUEST_STATE_COLOR[stateKey] : "default"}
+        />
       </Stack>
       <Typography variant="body2" color="text.primary">
         {callRequest.reason}
@@ -99,10 +241,35 @@ function CallRequestRow({ callRequest }: { callRequest: CallRequest }) {
         {callRequest.durationMin} min
         {callRequest.scheduleTime ? ` · Scheduled ${formatDate(callRequest.scheduleTime)}` : ""}
       </Typography>
+      {callRequest.assignee && (
+        <Typography variant="caption" color="text.secondary">
+          Assignee: {callRequest.assignee}
+        </Typography>
+      )}
       {callRequest.meetingLink && (
         <Typography variant="caption" color="primary.main" noWrap>
           {callRequest.meetingLink}
         </Typography>
+      )}
+      {callRequest.notes && (
+        <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "pre-line" }}>
+          Notes: {callRequest.notes}
+        </Typography>
+      )}
+      {actions.length > 0 && (
+        <Stack direction="row" gap={1} flexWrap="wrap" pt={0.5}>
+          {actions.map((action) => (
+            <Button
+              key={action}
+              size="small"
+              variant="outlined"
+              color={action === "reject" || action === "cancel" ? "error" : "primary"}
+              onClick={() => onAction(action, callRequest)}
+            >
+              {CALL_REQUEST_ACTION_LABEL[action]}
+            </Button>
+          ))}
+        </Stack>
       )}
     </Stack>
   );
@@ -199,6 +366,387 @@ function CreateCallRequestDialog({
         </Button>
         <Button variant="contained" disabled={!canSubmit} onClick={handleSubmit}>
           Send
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}
+
+function ScheduleCallDialog({
+  callRequest,
+  isReschedule,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: {
+  callRequest: CallRequest | null;
+  isReschedule: boolean;
+  submitting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (input: { meetingDate: string; durationInMinutes: number; assignee?: string }) => void;
+}) {
+  const [meetingTime, setMeetingTime] = useState<Date | null>(null);
+  const [durationInput, setDurationInput] = useState("30");
+  const [assignee, setAssignee] = useState("");
+
+  // Reset local state whenever the target call request changes (render-time state
+  // adjustment, not an effect — matches the pattern already used in CreateCallRequestDialog's
+  // sibling dialogs on the webapp).
+  const [prevTargetId, setPrevTargetId] = useState(callRequest?.id);
+  if (callRequest?.id !== prevTargetId) {
+    setPrevTargetId(callRequest?.id);
+    setMeetingTime(null);
+    setDurationInput(callRequest?.durationMin ? String(callRequest.durationMin) : "30");
+    setAssignee(callRequest?.assignee ?? "");
+  }
+
+  const durationMinutes = Number(durationInput);
+  const isDurationValid = durationInput.trim().length > 0 && Number.isFinite(durationMinutes) && durationMinutes > 0;
+  const canSubmit = meetingTime !== null && isDurationValid && !submitting;
+
+  const handleSubmit = () => {
+    if (!canSubmit || !meetingTime) return;
+    onSubmit({
+      meetingDate: meetingTime.toISOString(),
+      durationInMinutes: durationMinutes,
+      ...(assignee.trim() ? { assignee: assignee.trim() } : {}),
+    });
+  };
+
+  const preferredTimes = callRequest?.preferredTimes ?? [];
+
+  return (
+    <Dialog
+      open={!!callRequest}
+      onClose={onClose}
+      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
+    >
+      <Typography variant="h6" fontWeight={650}>
+        {isReschedule ? "Reschedule call" : "Schedule call"}
+      </Typography>
+
+      {preferredTimes.length > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          Customer's preferred times: {preferredTimes.map((t) => formatDate(new Date(t))).join(", ")}
+        </Typography>
+      )}
+
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DateTimePicker
+          label="Meeting time"
+          value={meetingTime}
+          onChange={setMeetingTime}
+          disabled={submitting}
+          slotProps={{ textField: { size: "small", fullWidth: true } }}
+        />
+      </LocalizationProvider>
+
+      <TextField
+        label="Duration (minutes)"
+        type="number"
+        size="small"
+        fullWidth
+        value={durationInput}
+        onChange={(e) => setDurationInput(e.target.value)}
+        disabled={submitting}
+        error={durationInput.trim().length > 0 && !isDurationValid}
+        slotProps={{ htmlInput: { min: 1 } }}
+      />
+
+      <TextField
+        label="Assignee (optional)"
+        placeholder="engineer@example.com"
+        size="small"
+        fullWidth
+        value={assignee}
+        onChange={(e) => setAssignee(e.target.value)}
+        disabled={submitting}
+      />
+
+      {error && (
+        <Typography variant="caption" color="error.main">
+          {error}
+        </Typography>
+      )}
+
+      <Stack direction="row" justifyContent="end" gap={1}>
+        <Button variant="outlined" onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!canSubmit} onClick={handleSubmit}>
+          {isReschedule ? "Reschedule" : "Schedule"}
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}
+
+function RejectCallDialog({
+  callRequest,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: {
+  callRequest: CallRequest | null;
+  submitting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (reason?: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [prevTargetId, setPrevTargetId] = useState(callRequest?.id);
+  if (callRequest?.id !== prevTargetId) {
+    setPrevTargetId(callRequest?.id);
+    setReason("");
+  }
+
+  return (
+    <Dialog
+      open={!!callRequest}
+      onClose={onClose}
+      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
+    >
+      <Typography variant="h6" fontWeight={650}>
+        Reject call request
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        This declines the request on behalf of the team. The customer will see it as rejected.
+      </Typography>
+
+      <TextField
+        label="Reason (optional)"
+        multiline
+        minRows={2}
+        fullWidth
+        size="small"
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        disabled={submitting}
+      />
+
+      {error && (
+        <Typography variant="caption" color="error.main">
+          {error}
+        </Typography>
+      )}
+
+      <Stack direction="row" justifyContent="end" gap={1}>
+        <Button variant="outlined" onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          disabled={submitting}
+          onClick={() => onSubmit(reason.trim() ? reason.trim() : undefined)}
+        >
+          Reject
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}
+
+function CancelCallDialog({
+  callRequest,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: {
+  callRequest: CallRequest | null;
+  submitting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (cancellationReason: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [prevTargetId, setPrevTargetId] = useState(callRequest?.id);
+  if (callRequest?.id !== prevTargetId) {
+    setPrevTargetId(callRequest?.id);
+    setReason("");
+  }
+
+  const canSubmit = reason.trim().length > 0 && !submitting;
+
+  return (
+    <Dialog
+      open={!!callRequest}
+      onClose={onClose}
+      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
+    >
+      <Typography variant="h6" fontWeight={650}>
+        Cancel call request
+      </Typography>
+
+      <TextField
+        label="Cancellation reason"
+        multiline
+        minRows={2}
+        fullWidth
+        size="small"
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        disabled={submitting}
+      />
+
+      {error && (
+        <Typography variant="caption" color="error.main">
+          {error}
+        </Typography>
+      )}
+
+      <Stack direction="row" justifyContent="end" gap={1}>
+        <Button variant="outlined" onClick={onClose} disabled={submitting}>
+          Back
+        </Button>
+        <Button variant="contained" color="error" disabled={!canSubmit} onClick={() => onSubmit(reason.trim())}>
+          Cancel request
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}
+
+function SendCallNotesDialog({
+  callRequest,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: {
+  callRequest: CallRequest | null;
+  submitting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (input: {
+    notes: string;
+    plan?: string;
+    attendees?: string;
+    actionItems?: string;
+    actualDurationMin?: number;
+  }) => void;
+}) {
+  const [notes, setNotes] = useState("");
+  const [actionItems, setActionItems] = useState("");
+  const [plan, setPlan] = useState("");
+  const [attendees, setAttendees] = useState("");
+  const [actualDurationInput, setActualDurationInput] = useState("");
+
+  const [prevTargetId, setPrevTargetId] = useState(callRequest?.id);
+  if (callRequest?.id !== prevTargetId) {
+    setPrevTargetId(callRequest?.id);
+    setNotes("");
+    setActionItems("");
+    setPlan("");
+    setAttendees("");
+    setActualDurationInput(callRequest?.durationMin ? String(callRequest.durationMin) : "");
+  }
+
+  const actualDurationMin = actualDurationInput.trim() === "" ? undefined : Number(actualDurationInput);
+  const isDurationValid =
+    actualDurationMin === undefined || (Number.isFinite(actualDurationMin) && actualDurationMin > 0);
+  const canSubmit = notes.trim().length > 0 && isDurationValid && !submitting;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit({
+      notes: notes.trim(),
+      ...(plan.trim() ? { plan: plan.trim() } : {}),
+      ...(attendees.trim() ? { attendees: attendees.trim() } : {}),
+      ...(actionItems.trim() ? { actionItems: actionItems.trim() } : {}),
+      ...(actualDurationMin !== undefined ? { actualDurationMin } : {}),
+    });
+  };
+
+  return (
+    <Dialog
+      open={!!callRequest}
+      onClose={onClose}
+      slots={{ paper: (props) => <Card component={Stack} {...props} /> }}
+      slotProps={{ paper: { sx: { bgcolor: "background.paper", p: 1.5, gap: 2, m: 2 } } }}
+    >
+      <Typography variant="h6" fontWeight={650}>
+        Send call notes
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Submitting notes concludes this call request.
+      </Typography>
+
+      <TextField
+        label="Notes"
+        multiline
+        minRows={3}
+        fullWidth
+        size="small"
+        placeholder="Summary of what was discussed..."
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        disabled={submitting}
+      />
+
+      <TextField
+        label="Action items (optional)"
+        multiline
+        minRows={2}
+        fullWidth
+        size="small"
+        value={actionItems}
+        onChange={(e) => setActionItems(e.target.value)}
+        disabled={submitting}
+      />
+
+      <TextField
+        label="Plan (optional)"
+        multiline
+        minRows={2}
+        fullWidth
+        size="small"
+        value={plan}
+        onChange={(e) => setPlan(e.target.value)}
+        disabled={submitting}
+      />
+
+      <TextField
+        label="Attendees (optional)"
+        placeholder="Comma-separated names or emails"
+        fullWidth
+        size="small"
+        value={attendees}
+        onChange={(e) => setAttendees(e.target.value)}
+        disabled={submitting}
+      />
+
+      <TextField
+        label="Actual duration (minutes, optional)"
+        type="number"
+        fullWidth
+        size="small"
+        value={actualDurationInput}
+        onChange={(e) => setActualDurationInput(e.target.value)}
+        disabled={submitting}
+        error={actualDurationInput.trim().length > 0 && !isDurationValid}
+        slotProps={{ htmlInput: { min: 1 } }}
+      />
+
+      {error && (
+        <Typography variant="caption" color="error.main">
+          {error}
+        </Typography>
+      )}
+
+      <Stack direction="row" justifyContent="end" gap={1}>
+        <Button variant="outlined" onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button variant="contained" disabled={!canSubmit} onClick={handleSubmit}>
+          Send notes
         </Button>
       </Stack>
     </Dialog>

--- a/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
@@ -29,7 +29,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { useMutation, useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import { callRequests } from "@src/services/callRequests";
-import type { CallRequest, CallRequestUpdateInput } from "@src/types";
+import type { CallRequest, CallRequestUpdateInput, CaseSeverity } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { formatDate } from "@utils/dateTime";
@@ -37,23 +37,25 @@ import {
   CALL_REQUEST_ACTION_LABEL,
   CALL_REQUEST_AGENT_ACTIONS,
   CALL_REQUEST_STATE_COLOR,
+  callRequestLeadTimeMinutes,
+  formatCallRequestLeadTime,
   resolveCallRequestStateKey,
   type CallRequestAgentAction,
 } from "@utils/callRequestState";
 
 const { LocalizationProvider, DateTimePicker } = DatePickers;
 
-export function CallRequestsTab({ caseId }: { caseId: string }) {
+export function CallRequestsTab({ caseId, severity }: { caseId: string; severity: CaseSeverity | null }) {
   return (
     <CallRequestsTabErrorBoundary>
       <Suspense fallback={<CallRequestsTabSkeleton />}>
-        <CallRequestsTabContent caseId={caseId} />
+        <CallRequestsTabContent caseId={caseId} severity={severity} />
       </Suspense>
     </CallRequestsTabErrorBoundary>
   );
 }
 
-function CallRequestsTabContent({ caseId }: { caseId: string }) {
+function CallRequestsTabContent({ caseId, severity }: { caseId: string; severity: CaseSeverity | null }) {
   const queryClient = useQueryClient();
   const { data: requests } = useSuspenseQuery(callRequests.forCase(caseId));
   const [createOpen, setCreateOpen] = useState(false);
@@ -156,6 +158,7 @@ function CallRequestsTabContent({ caseId }: { caseId: string }) {
       {createOpen && (
         <CreateCallRequestDialog
           caseId={caseId}
+          severity={severity}
           onClose={() => setCreateOpen(false)}
           onCreated={() => {
             setCreateOpen(false);
@@ -277,10 +280,12 @@ function CallRequestRow({
 
 function CreateCallRequestDialog({
   caseId,
+  severity,
   onClose,
   onCreated,
 }: {
   caseId: string;
+  severity: CaseSeverity | null;
   onClose: () => void;
   onCreated: () => void;
 }) {
@@ -294,9 +299,16 @@ function CreateCallRequestDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // ServiceNow rejects a preferred time that's too soon, with a plain 400 the
+  // backend genericizes to "Invalid request payload." — pre-validate the same
+  // lead-time rule the webapp does so this fails in the dialog instead.
+  const leadMinutes = callRequestLeadTimeMinutes(severity);
+  const minAllowedTime = new Date(Date.now() + leadMinutes * 60_000);
+  const isTimeValid = preferredTime !== null && preferredTime.getTime() >= minAllowedTime.getTime();
+
   const durationMinutes = Number(durationInput);
   const isDurationValid = durationInput.trim().length > 0 && Number.isFinite(durationMinutes) && durationMinutes > 0;
-  const canSubmit = reason.trim().length > 0 && preferredTime !== null && isDurationValid && !isSubmitting;
+  const canSubmit = reason.trim().length > 0 && isTimeValid && isDurationValid && !isSubmitting;
 
   const handleSubmit = () => {
     if (!canSubmit || !preferredTime) return;
@@ -339,7 +351,15 @@ function CreateCallRequestDialog({
           label="Preferred time"
           value={preferredTime}
           onChange={setPreferredTime}
-          slotProps={{ textField: { size: "small", fullWidth: true } }}
+          minDateTime={minAllowedTime}
+          slotProps={{
+            textField: {
+              size: "small",
+              fullWidth: true,
+              error: preferredTime !== null && !isTimeValid,
+              helperText: `Must be at least ${formatCallRequestLeadTime(leadMinutes)} from now.`,
+            },
+          }}
         />
       </LocalizationProvider>
 

--- a/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CallRequestsTab.tsx
@@ -31,6 +31,7 @@ import { callRequests } from "@src/services/callRequests";
 import type { CallRequest, CallRequestUpdateInput, CaseSeverity } from "@src/types";
 import { DialogPaper } from "@components/common/DialogPaper";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { openUrl } from "@components/microapp-bridge";
 import { ErrorState } from "@components/support/ErrorState";
 import { formatDate } from "@utils/dateTime";
 import {
@@ -250,7 +251,13 @@ function CallRequestRow({
         </Typography>
       )}
       {callRequest.meetingLink && (
-        <Typography variant="caption" color="primary.main" noWrap>
+        <Typography
+          variant="caption"
+          color="primary.main"
+          noWrap
+          onClick={() => openUrl({ url: callRequest.meetingLink as string, presentationStyle: "fullScreen" })}
+          sx={{ cursor: "pointer" }}
+        >
           {callRequest.meetingLink}
         </Typography>
       )}

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -30,6 +30,8 @@ export const CASE_COMMENTS_SEARCH_ENDPOINT = (id: string) => `/cases/${id}/comme
 export const CASE_COMMENTS_ENDPOINT = (id: string) => `/cases/${id}/comments`;
 export const CASE_CALL_REQUESTS_ENDPOINT = (id: string) => `/cases/${id}/call-requests`;
 export const CASE_CALL_REQUESTS_SEARCH_ENDPOINT = (id: string) => `/cases/${id}/call-requests/search`;
+export const CASE_CALL_REQUEST_ENDPOINT = (caseId: string, callRequestId: string) =>
+  `/cases/${caseId}/call-requests/${callRequestId}`;
 export const CASE_ACTIVITIES_SEARCH_ENDPOINT = (id: string) => `/cases/${id}/activities/search`;
 
 export const SLAS_SEARCH_ENDPOINT = "/slas/search";

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -428,7 +428,7 @@ function CaseDetailContent({ id }: { id: string }) {
         />
       )}
 
-      {activeTab === "call-requests" && <CallRequestsTab caseId={id} />}
+      {activeTab === "call-requests" && <CallRequestsTab caseId={id} severity={caseDetail.severity} />}
 
       {resolutionTarget && (
         <ResolutionDialog

--- a/apps/csm-portal/microapp/src/services/callRequests.ts
+++ b/apps/csm-portal/microapp/src/services/callRequests.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { queryOptions } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions } from "@tanstack/react-query";
 import {
   CASE_CALL_REQUEST_ENDPOINT,
   CASE_CALL_REQUESTS_ENDPOINT,
@@ -78,6 +78,13 @@ export const callRequests = {
     queryOptions({
       queryKey: ["case", caseId, "call-requests"],
       queryFn: () => getCallRequests(caseId),
+      // CallRequestsTab reads this via useSuspenseQuery. Without
+      // placeholderData, an update's post-mutation invalidateQueries
+      // re-suspends the tab back to its skeleton on every refetch instead of
+      // just swapping the list in place once the new data lands — same
+      // network time as the webapp's plain useQuery, but it visibly blanks
+      // out first, reading as slower even though it isn't.
+      placeholderData: keepPreviousData,
     }),
   create: createCallRequest,
   update: updateCallRequest,

--- a/apps/csm-portal/microapp/src/services/callRequests.ts
+++ b/apps/csm-portal/microapp/src/services/callRequests.ts
@@ -15,10 +15,17 @@
 // under the License.
 
 import { queryOptions } from "@tanstack/react-query";
-import { CASE_CALL_REQUESTS_ENDPOINT, CASE_CALL_REQUESTS_SEARCH_ENDPOINT } from "@config/endpoints";
+import {
+  CASE_CALL_REQUEST_ENDPOINT,
+  CASE_CALL_REQUESTS_ENDPOINT,
+  CASE_CALL_REQUESTS_SEARCH_ENDPOINT,
+} from "@config/endpoints";
 import type {
+  CallRequestUpdateInput,
   CreateCallRequestPayloadDto,
   CreateCallRequestResponseDto,
+  UpdateCallRequestPayloadDto,
+  UpdateCallRequestResponseDto,
   SearchCallRequestsResponseDto,
 } from "@src/types";
 import { toCallRequest, type CallRequest } from "@src/types";
@@ -40,6 +47,32 @@ const createCallRequest = async (
   return data;
 };
 
+// Agent-side lifecycle actions on a call request (schedule, reject, cancel,
+// send notes, or reschedule a request back to the customer) — all funnel
+// through this one state-transition PATCH, same as the webapp's
+// usePatchCsmCaseCallRequest. Which optional fields matter depends on the
+// target `state`; see UpdateCallRequestPayloadDto.
+const updateCallRequest = async (input: CallRequestUpdateInput): Promise<UpdateCallRequestResponseDto> => {
+  const payload: UpdateCallRequestPayloadDto = {
+    state: input.state,
+    cancellationReason: input.cancellationReason,
+    utcTimes: input.utcTimes,
+    durationInMinutes: input.durationInMinutes,
+    meetingDate: input.meetingDate,
+    assignee: input.assignee,
+    notes: input.notes,
+    plan: input.plan,
+    attendees: input.attendees,
+    actionItems: input.actionItems,
+    actualDurationMin: input.actualDurationMin,
+  };
+  const { data } = await apiClient.patch<UpdateCallRequestResponseDto>(
+    CASE_CALL_REQUEST_ENDPOINT(input.caseId, input.callRequestId),
+    payload,
+  );
+  return data;
+};
+
 export const callRequests = {
   forCase: (caseId: string) =>
     queryOptions({
@@ -47,4 +80,5 @@ export const callRequests = {
       queryFn: () => getCallRequests(caseId),
     }),
   create: createCallRequest,
+  update: updateCallRequest,
 };

--- a/apps/csm-portal/microapp/src/types/callRequest.dto.ts
+++ b/apps/csm-portal/microapp/src/types/callRequest.dto.ts
@@ -41,6 +41,10 @@ export interface CallRequestViewDto {
   updatedOn: string | null;
   state: CallRequestStateDto | null;
   cancellationReason: string | null;
+  /** Agent (or team) assigned to run the call, once scheduled. */
+  assignee: string | null;
+  /** Call notes recorded after the call concludes. */
+  notes: string | null;
 }
 
 export interface SearchCallRequestsPayloadDto {

--- a/apps/csm-portal/microapp/src/types/callRequest.dto.ts
+++ b/apps/csm-portal/microapp/src/types/callRequest.dto.ts
@@ -76,3 +76,55 @@ export interface CreateCallRequestResponseDto {
     state: CallRequestStateDto;
   };
 }
+
+// The 8 state keys PATCH /cases/{caseId}/call-requests/{callRequestId} accepts
+// as `state`, selecting which of the optional fields below apply:
+//  - "scheduled" (agent schedule/reschedule): meetingDate + durationInMinutes
+//    required, assignee optional.
+//  - "wso2_rejected" (agent reject) / "canceled": cancellationReason optional.
+//  - "concluded" (agent send notes): notes required, plan/attendees/
+//    actionItems/actualDurationMin optional.
+//  - "pending_on_wso2" (reschedule request back to the customer): utcTimes +
+//    durationInMinutes.
+export type CallRequestStateKeyDto =
+  | "pending_on_customer"
+  | "pending_on_wso2"
+  | "scheduled"
+  | "customer_rejected"
+  | "wso2_rejected"
+  | "canceled"
+  | "notes_pending"
+  | "concluded";
+
+export interface UpdateCallRequestPayloadDto {
+  state: CallRequestStateKeyDto;
+  /** Reject/cancellation reason for "wso2_rejected"/"canceled". */
+  cancellationReason?: string;
+  /** Updated preferred UTC datetimes; used for "pending_on_wso2". */
+  utcTimes?: string[];
+  /** Updated duration in minutes (min 1); used for "pending_on_wso2"/"scheduled". */
+  durationInMinutes?: number;
+  /** UTC datetime the call is scheduled for; required for "scheduled". */
+  meetingDate?: string;
+  /** Agent (or team) assigned to run the call; used for "scheduled". */
+  assignee?: string;
+  /** Call notes; required for "concluded". */
+  notes?: string;
+  /** Follow-up plan; used for "concluded". */
+  plan?: string;
+  /** Attendee list; used for "concluded". */
+  attendees?: string;
+  /** Action items; used for "concluded". */
+  actionItems?: string;
+  /** Actual call duration in minutes; used for "concluded". */
+  actualDurationMin?: number;
+}
+
+export interface UpdateCallRequestResponseDto {
+  message?: string;
+  callRequest?: {
+    id: string;
+    updatedOn?: string;
+    updatedBy?: string;
+  };
+}

--- a/apps/csm-portal/microapp/src/types/callRequest.model.ts
+++ b/apps/csm-portal/microapp/src/types/callRequest.model.ts
@@ -14,8 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { CallRequestViewDto } from "./callRequest.dto";
+import type { CallRequestStateKeyDto, CallRequestViewDto } from "./callRequest.dto";
 import { parseBackendTimestamp, parseOptionalBackendTimestamp } from "@utils/dateTime";
+
+export type CallRequestStateKey = CallRequestStateKeyDto;
 
 export interface CallRequest {
   id: string;
@@ -28,6 +30,22 @@ export interface CallRequest {
   createdOn: Date;
   stateLabel: string;
   cancellationReason: string | null;
+}
+
+export interface CallRequestUpdateInput {
+  caseId: string;
+  callRequestId: string;
+  state: CallRequestStateKey;
+  cancellationReason?: string;
+  utcTimes?: string[];
+  durationInMinutes?: number;
+  meetingDate?: string;
+  assignee?: string;
+  notes?: string;
+  plan?: string;
+  attendees?: string;
+  actionItems?: string;
+  actualDurationMin?: number;
 }
 
 export function toCallRequest(dto: CallRequestViewDto): CallRequest {

--- a/apps/csm-portal/microapp/src/types/callRequest.model.ts
+++ b/apps/csm-portal/microapp/src/types/callRequest.model.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { CallRequestStateKeyDto, CallRequestViewDto } from "./callRequest.dto";
+import type { CallRequestStateDto, CallRequestStateKeyDto, CallRequestViewDto } from "./callRequest.dto";
 import { parseBackendTimestamp, parseOptionalBackendTimestamp } from "@utils/dateTime";
 
 export type CallRequestStateKey = CallRequestStateKeyDto;
@@ -28,8 +28,20 @@ export interface CallRequest {
   scheduleTime: Date | null;
   meetingLink: string | null;
   createdOn: Date;
+  updatedOn: Date | null;
   stateLabel: string;
+  /**
+   * Raw state {id, label} — resolve to a CallRequestStateKey with
+   * resolveCallRequestStateKey (in @utils/callRequestState) at the point of
+   * use, e.g. to decide which agent actions are available. Kept raw here
+   * rather than pre-resolved to avoid a model -> utils -> types import cycle.
+   */
+  state: CallRequestStateDto | null;
   cancellationReason: string | null;
+  /** Agent (or team) assigned to run the call, once scheduled. */
+  assignee: string | null;
+  /** Call notes recorded after the call concludes. */
+  notes: string | null;
 }
 
 export interface CallRequestUpdateInput {
@@ -58,7 +70,11 @@ export function toCallRequest(dto: CallRequestViewDto): CallRequest {
     scheduleTime: parseOptionalBackendTimestamp(dto.scheduleTime),
     meetingLink: dto.meetingLink,
     createdOn: parseBackendTimestamp(dto.createdOn),
+    updatedOn: parseOptionalBackendTimestamp(dto.updatedOn),
     stateLabel: dto.state?.label || "Unknown",
+    state: dto.state,
     cancellationReason: dto.cancellationReason,
+    assignee: dto.assignee,
+    notes: dto.notes,
   };
 }

--- a/apps/csm-portal/microapp/src/utils/callRequestState.ts
+++ b/apps/csm-portal/microapp/src/utils/callRequestState.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { CallRequestStateKey } from "@src/types";
+import type { CallRequestStateKey, CaseSeverity } from "@src/types";
 
 /** Human-readable label for each call request state key. */
 export const CALL_REQUEST_STATE_LABEL: Record<CallRequestStateKey, string> = {
@@ -108,3 +108,38 @@ export const CALL_REQUEST_ACTION_LABEL: Record<CallRequestAgentAction, string> =
   sendNotes: "Send call notes",
   cancel: "Cancel",
 };
+
+/**
+ * Minimum lead time (minutes) a proposed call time must be in the future,
+ * keyed by case severity. ServiceNow enforces this server-side (SN
+ * CallRequestUtils._PRIORITY_TIME_OFFSETS, keyed by SN priority id) and
+ * rejects a too-soon utcTimes entry with a plain 400 that the CSM backend
+ * then genericizes to "Invalid request payload." — mirrored here (same
+ * table the webapp's CreateCallRequestDialog uses) so the dialog fails
+ * with a clear message instead of round-tripping to that generic 400.
+ * If the SN offsets change, this table must change with them.
+ */
+export const CALL_REQUEST_LEAD_TIME_MINUTES_BY_SEVERITY: Record<CaseSeverity, number> = {
+  catastrophic: 15,
+  critical: 30,
+  high: 60,
+  medium: 90,
+  low: 120,
+};
+
+/** Used when the case's severity isn't known — the SN default offset. */
+export const DEFAULT_CALL_REQUEST_LEAD_TIME_MINUTES = 300;
+
+/** Minimum lead time (minutes) for a case of the given severity (or the conservative default). */
+export function callRequestLeadTimeMinutes(severity: CaseSeverity | null | undefined): number {
+  return severity ? CALL_REQUEST_LEAD_TIME_MINUTES_BY_SEVERITY[severity] : DEFAULT_CALL_REQUEST_LEAD_TIME_MINUTES;
+}
+
+/** Human-readable lead time, e.g. 300 -> "5 hours", 90 -> "90 minutes". */
+export function formatCallRequestLeadTime(minutes: number): string {
+  if (minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  return `${minutes} minutes`;
+}

--- a/apps/csm-portal/microapp/src/utils/callRequestState.ts
+++ b/apps/csm-portal/microapp/src/utils/callRequestState.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CallRequestStateKey } from "@src/types";
+
+/** Human-readable label for each call request state key. */
+export const CALL_REQUEST_STATE_LABEL: Record<CallRequestStateKey, string> = {
+  pending_on_customer: "Pending on customer",
+  pending_on_wso2: "Pending on WSO2",
+  scheduled: "Scheduled",
+  customer_rejected: "Rejected by customer",
+  wso2_rejected: "Rejected by WSO2",
+  canceled: "Canceled",
+  notes_pending: "Notes pending",
+  concluded: "Concluded",
+};
+
+/** Chip `color` for each state — terminal states are muted, active ones use the action palette. */
+export const CALL_REQUEST_STATE_COLOR: Record<
+  CallRequestStateKey,
+  "default" | "primary" | "secondary" | "error" | "info" | "success" | "warning"
+> = {
+  pending_on_customer: "warning",
+  pending_on_wso2: "info",
+  scheduled: "primary",
+  customer_rejected: "error",
+  wso2_rejected: "error",
+  canceled: "default",
+  notes_pending: "warning",
+  concluded: "success",
+};
+
+// Integer choice keys the backing data source may return for `state.id`,
+// mapped to our enum keys (mirrors the webapp's callRequestState.ts).
+const NUMERIC_STATE_KEY: Record<string, CallRequestStateKey> = {
+  "1": "pending_on_customer",
+  "2": "pending_on_wso2",
+  "3": "scheduled",
+  "4": "customer_rejected",
+  "5": "wso2_rejected",
+  "6": "canceled",
+  "7": "notes_pending",
+  "8": "concluded",
+};
+
+/**
+ * Resolve a backend call-request state to one of our enum keys from `state.id`,
+ * which arrives either as our string enum key or as the data source's integer
+ * choice key. Returns null otherwise — callers must handle that case rather
+ * than indexing a lookup table with the raw id.
+ */
+export function resolveCallRequestStateKey(
+  state: { id: string | number; label?: string } | null | undefined,
+): CallRequestStateKey | null {
+  if (!state) return null;
+  const raw = String(state.id);
+  if (raw in CALL_REQUEST_STATE_LABEL) return raw as CallRequestStateKey;
+  if (raw in NUMERIC_STATE_KEY) return NUMERIC_STATE_KEY[raw];
+  return null;
+}
+
+/**
+ * Agent-facing actions available on a call request, keyed by its current
+ * state — mirrors the webapp's CALL_REQUEST_AGENT_ACTIONS exactly (same
+ * backend, same contract). Do not add an action here unless there is a
+ * corresponding backend transition, otherwise the UI offers one that fails.
+ *
+ * - `pending_on_wso2`: agent can schedule the call or reject it.
+ * - `scheduled`: agent can reschedule or cancel. Sending notes from here is
+ *   gated by the backend's post-due automation moving the request to
+ *   `notes_pending` first, so it isn't offered directly from `scheduled`.
+ * - `notes_pending`: agent can send call notes (concludes the request).
+ * - `pending_on_customer`: the customer owns scheduling/rejecting; the agent
+ *   can only cancel on their behalf.
+ * - Terminal states (`customer_rejected`, `wso2_rejected`, `canceled`,
+ *   `concluded`): no actions.
+ */
+export type CallRequestAgentAction = "schedule" | "reschedule" | "reject" | "sendNotes" | "cancel";
+
+export const CALL_REQUEST_AGENT_ACTIONS: Record<CallRequestStateKey, CallRequestAgentAction[]> = {
+  pending_on_customer: ["cancel"],
+  pending_on_wso2: ["schedule", "reject"],
+  scheduled: ["reschedule", "cancel"],
+  customer_rejected: [],
+  wso2_rejected: [],
+  canceled: [],
+  notes_pending: ["sendNotes"],
+  concluded: [],
+};
+
+export const CALL_REQUEST_ACTION_LABEL: Record<CallRequestAgentAction, string> = {
+  schedule: "Schedule",
+  reschedule: "Reschedule",
+  reject: "Reject",
+  sendNotes: "Send call notes",
+  cancel: "Cancel",
+};


### PR DESCRIPTION
## Purpose
The CSM microapp's call requests could only be listed and created — there was no way to actually act on one (schedule, reject, cancel, send call notes, or reschedule back to the customer), even though the webapp has had this for a while.

## Goals
- Let an agent run the full call-request lifecycle from the microapp: schedule/reschedule, reject, cancel, and send call notes.
- Only show an action when it's actually valid for the request's current state.
- Prevent a known class of submission failure (a preferred time too soon for ServiceNow's lead-time rule) before it round-trips to a generic, unhelpful 400.

## Approach
- `callRequests.update()` is the new PATCH counterpart to the existing `create()`/`forCase()`, mirroring the webapp's `usePatchCsmCaseCallRequest` — one state-transition endpoint (`PATCH /cases/{caseId}/call-requests/{callRequestId}`) drives all five actions.
- `utils/callRequestState.ts` ports the webapp's state machine: labels, chip colors, the numeric-vs-string `state.id` resolver, and `CALL_REQUEST_AGENT_ACTIONS` (which actions are valid from which state — schedule/reject from `pending_on_wso2`, reschedule/cancel from `scheduled`, send notes from `notes_pending`, cancel-only from `pending_on_customer`, nothing from terminal states).
- `CallRequestsTab` gained four new dialogs (Schedule, Reject, Cancel, Send Notes) alongside the existing Create dialog, each shown as a per-row action button gated by the state machine above. Simplified from the webapp's version for a single-column mobile layout (e.g. one date/time value instead of the webapp's preferred-times radio group).
- Also ported the webapp's severity-based lead-time table (15–120 min depending on case severity, 300 min default) into the Create dialog, matching a real gap found while testing: ServiceNow rejects a too-soon preferred time with a plain 400 that the CSM backend genericizes to `"Invalid request payload."` with no detail — this validates client-side before it ever reaches that wall.
- Fixed a focus-loss bug found while building this: all five dialogs defined their `Dialog` paper slot inline (`slots={{ paper: (props) => <Card component={Stack} {...props} /> }}`), redefined on every render, so MUI remounted the whole subtree — dropping focus — on every keystroke in a text field. Switched to the shared, stable `DialogPaper` the codebase already has for exactly this reason.

## User stories
As an agent, I can schedule a pending call request, reject one I can't take, cancel one that's no longer needed, and log notes after a call concludes — all from my phone.

## Release note
Added call request lifecycle actions (schedule, reject, cancel, send notes) to the CSM Portal mobile app.

## Documentation
N/A — internal CSM portal UI change, no external doc surface affected.

## Automation tests
- No automated test runner is wired up for this app yet.
- Verified locally: `tsc -b` and `eslint` clean. Exercised the read path (list + case lookup) and the create flow's lead-time validation against the real staging API; schedule/cancel/send-notes were verified working end-to-end, reject is still being investigated (works when called directly with a minimal payload, not yet reproduced as broken through the UI — see PR comments).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Local dev server (Vite), manual browser testing against staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added severity-aware call request actions and display within case details.
  - Enhanced request creation with severity-based preferred-time lead-time validation and inline guidance.
  - Introduced a dedicated update flow for individual call requests (with refined payload handling) and refreshed action/dialog behaviors.

- **Bug Fixes**
  - Improved call request loading using suspense-based fetching with smoother tab data preservation.
  - Centralized success/error handling for updates, including automatic query refresh after successful changes.
  - Refined dialogs to consistently reset when switching targets and to disable submission on invalid input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->