### PR TITLE
[Customer Portal MicroApp] Remove the comment bar entirely on closed cases

### DIFF
--- a/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/customer-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -72,7 +72,7 @@ export default function CaseDetailPage() {
   const isSendingComment = mutation.status !== "idle" && mutation.isPending && isCommentsRefetching;
 
   const handleSend = () => {
-    if (!comment.trim()) return;
+    if (!comment.trim() || isClosed) return;
 
     mutation.mutate({
       content: comment,
@@ -195,7 +195,7 @@ export default function CaseDetailPage() {
 
   return (
     <>
-      <Stack gap={2} mb={10}>
+      <Stack gap={2} mb={isClosed ? 2 : 10}>
         <Typography ref={ref} variant="h5" fontWeight="medium">
           {data?.title}
         </Typography>
@@ -339,13 +339,15 @@ export default function CaseDetailPage() {
           </Stack>
         </SectionCard>
       </Stack>
-      <StickyCommentBar
-        placeholder="Add Comment"
-        value={comment}
-        onChange={setComment}
-        onSend={handleSend}
-        loading={isSendingComment}
-      />
+      {!isClosed && (
+        <StickyCommentBar
+          placeholder="Add Comment"
+          value={comment}
+          onChange={setComment}
+          onSend={handleSend}
+          loading={isSendingComment}
+        />
+      )}
 
       <AttachmentPreviewDialog
         key={previewAttachment?.id}


### PR DESCRIPTION
## Purpose
A closed case could still take new comments through the UI in the Customer Portal microapp — the comment bar had no closed-case gating at all.

## Goals
- Match the read-only expectation a closed case already has everywhere else in this page (case actions, feedback prompt): no new comments once closed.

## Approach
- `isClosed` was already computed in `CaseDetailPage.tsx` (used for the feedback prompt and the case-actions menu) but never applied to the comment composer — `StickyCommentBar` was rendered unconditionally, with no `disabled` prop passed even though the component already supports one.
- Went with removing the bar outright for a closed case rather than just disabling its inputs, and dropped the reserved bottom margin (`mb`) to match — same treatment `ChatDetailPage` already gives its own read-only state (`isReadOnly`).
- Added a defensive guard in `handleSend` itself too, so nothing can post while closed even if some other path reaches it.

## User stories
As a customer, once my case is closed, I no longer see a way to add a comment on it.

## Release note
Closed cases no longer show a comment box in the Customer Portal mobile app.

## Documentation
N/A — internal customer portal UI change, no external doc surface affected.

## Automation tests
- No automated test runner is wired up for this app yet.
- Verified locally: `tsc -b`, `eslint`, and `vite build` all clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Local dev server (Vite), manual browser testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from submitting new comments on closed cases.
  * Hid the comment entry bar when a case is closed.
  * Improved spacing around the Activity Timeline for closed cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->