### PR TITLE
[CSM][Web] Redirect case details page when the case type has its own dedicated page

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/CaseDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CaseDetailsPage.tsx
@@ -20,7 +20,12 @@ import { useLoader } from "@context/linear-loader/LoaderContext";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import useGetCaseDetails from "@features/support/api/useGetCaseDetails";
 import CaseDetailsContent from "@case-details-details/CaseDetailsContent";
-import { isSecurityReportAnalysisType } from "@features/support/utils/support";
+import {
+  isAnnouncementType,
+  isEngagementType,
+  isSecurityReportAnalysisType,
+  isServiceRequestType,
+} from "@features/support/utils/support";
 import { SecurityTabId } from "@features/security/types/security";
 import { ROUTE_PREVIOUS_PAGE } from "@features/project-hub/constants/navigationConstants";
 
@@ -49,9 +54,53 @@ export default function CaseDetailsPage(): JSX.Element {
     "security-report-analysis",
   );
 
+  // Announcements and Service Requests have their own dedicated pages; Engagement and
+  // Security Report Analysis cases have dedicated routes too, though they share this same
+  // component. Redirect when a case is loaded on a route that doesn't match its actual type.
+  const isAnnouncement = isAnnouncementType(data?.type);
+  const isMisroutedEngagement = isEngagementType(data?.type) && !isEngagementRoute;
+  const isMisroutedSecurityReportAnalysis =
+    isSecurityReportAnalysisType(data?.type) && !isSecurityReportAnalysisRoute;
+  const isServiceRequest = isServiceRequestType(data?.type);
+  const isMisrouted =
+    isAnnouncement ||
+    isMisroutedEngagement ||
+    isMisroutedSecurityReportAnalysis ||
+    isServiceRequest;
+
+  useEffect(() => {
+    if (!projectId || !caseId) return;
+    if (isAnnouncement) {
+      navigate(`/projects/${projectId}/announcements/${caseId}`, {
+        replace: true,
+      });
+    } else if (isMisroutedEngagement) {
+      navigate(`/projects/${projectId}/engagements/${caseId}`, {
+        replace: true,
+      });
+    } else if (isMisroutedSecurityReportAnalysis) {
+      navigate(
+        `/projects/${projectId}/security-center/security-report-analysis/${caseId}`,
+        { replace: true },
+      );
+    } else if (isServiceRequest) {
+      navigate(`/projects/${projectId}/operations/service-requests/${caseId}`, {
+        replace: true,
+      });
+    }
+  }, [
+    isAnnouncement,
+    isMisroutedEngagement,
+    isMisroutedSecurityReportAnalysis,
+    isServiceRequest,
+    projectId,
+    caseId,
+    navigate,
+  ]);
+
   // Show skeletons immediately when no data (avoid "-" flash on refresh) and when loading/refetching.
   const showSkeletons =
-    isLoading || (data === undefined && !isError);
+    isLoading || (data === undefined && !isError) || isMisrouted;
 
   useEffect(() => {
     if (showSkeletons) {

--- a/apps/customer-portal/webapp/src/features/support/utils/support.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/support.ts
@@ -133,6 +133,108 @@ export function isSecurityReportAnalysisType(type: CaseTypeInput): boolean {
 }
 
 /**
+ * Detects whether a case type represents an Announcement.
+ * Prefers stable id matching and falls back to normalized label matching.
+ */
+export function isAnnouncementType(type: CaseTypeInput): boolean {
+  if (!type) return false;
+
+  const target = CaseType.ANNOUNCEMENT.toLowerCase().replace(/_/g, "");
+
+  const normalize = (val: string) =>
+    val
+      .toLowerCase()
+      .replace(/[\s_-]+/g, "")
+      .trim();
+
+  switch (typeof type) {
+    case "string":
+      return normalize(type) === target;
+
+    case "object":
+      switch (true) {
+        case type.id === CaseType.ANNOUNCEMENT:
+          return true;
+        case !!type.label:
+          return normalize(type.label!) === target;
+        default:
+          return false;
+      }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Detects whether a case type represents an Engagement.
+ * Prefers stable id matching and falls back to normalized label matching.
+ */
+export function isEngagementType(type: CaseTypeInput): boolean {
+  if (!type) return false;
+
+  const target = CaseType.ENGAGEMENT.toLowerCase().replace(/_/g, "");
+
+  const normalize = (val: string) =>
+    val
+      .toLowerCase()
+      .replace(/[\s_-]+/g, "")
+      .trim();
+
+  switch (typeof type) {
+    case "string":
+      return normalize(type) === target;
+
+    case "object":
+      switch (true) {
+        case type.id === CaseType.ENGAGEMENT:
+          return true;
+        case !!type.label:
+          return normalize(type.label!) === target;
+        default:
+          return false;
+      }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Detects whether a case type represents a Service Request.
+ * Prefers stable id matching and falls back to normalized label matching.
+ */
+export function isServiceRequestType(type: CaseTypeInput): boolean {
+  if (!type) return false;
+
+  const target = CaseType.SERVICE_REQUEST.toLowerCase().replace(/_/g, "");
+
+  const normalize = (val: string) =>
+    val
+      .toLowerCase()
+      .replace(/[\s_-]+/g, "")
+      .trim();
+
+  switch (typeof type) {
+    case "string":
+      return normalize(type) === target;
+
+    case "object":
+      switch (true) {
+        case type.id === CaseType.SERVICE_REQUEST:
+          return true;
+        case !!type.label:
+          return normalize(type.label!) === target;
+        default:
+          return false;
+      }
+
+    default:
+      return false;
+  }
+}
+
+/**
  * Comprehensive check to determine if a created case is a security report.
  * Consolidates multiple possible indicators into a single check.
  *


### PR DESCRIPTION
## Summary
- Announcement, Engagement, Security Report Analysis, and Service Request cases each have a dedicated route/page. Opening one of these via the generic `/support/cases/:caseId` URL (or another mismatched route) previously rendered the generic case-details page.
- `CaseDetailsPage` now checks the fetched case's type and redirects to the correct destination (`/announcements/:caseId`, `/engagements/:caseId`, `/security-center/security-report-analysis/:caseId`, or `/operations/service-requests/:caseId`) when it doesn't match the current route.

## Test plan
- [x] `tsc --noEmit` passes
- [x] ESLint clean on changed files
- [ ] Manually open a case-details URL for each type (`support/cases/:id`, `engagements/:id`, `security-report-analysis/:id`) using an ID belonging to a different type, and confirm it redirects to the correct page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support case navigation by detecting when a case is opened under the wrong route.
  * Automatically redirects cases to the correct detail view.
  * Displays loading placeholders during route correction to prevent incorrect content from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->