### PR TITLE
[CSM Portal] add change request approval-stage visibility

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -135,6 +135,7 @@ func main() {
 	mux.HandleFunc("PATCH /deployments/{deploymentId}/products/{productId}", deploymentHandler.PatchDeployedProduct)
 	mux.HandleFunc("POST /change-requests", changeRequestHandler.CreateChangeRequest)
 	mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
+	mux.HandleFunc("GET /change-requests/{id}/approvals", changeRequestHandler.GetChangeRequestApprovals)
 	mux.HandleFunc("PATCH /change-requests/{id}", changeRequestHandler.PatchChangeRequest)
 	mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
 	mux.HandleFunc("POST /services/search", itServiceHandler.SearchITServices)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -216,6 +216,12 @@ func (c *Client) PatchChangeRequest(ctx context.Context, id string, body []byte)
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/change-requests/%s", url.PathEscape(id)), body)
 }
 
+// GetChangeRequestApprovals calls GET /change-requests/{id}/approvals on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) GetChangeRequestApprovals(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/change-requests/%s/approvals", url.PathEscape(id)), nil)
+}
+
 // SearchTimeCards calls POST /time-cards/search on the entity service.
 // Response is returned as raw JSON.
 func (c *Client) SearchTimeCards(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/change_requests.go
+++ b/apps/csm-portal/backend/internal/handler/change_requests.go
@@ -33,6 +33,7 @@ type entityChangeRequestClient interface {
 	SearchChangeRequests(ctx context.Context, body []byte) ([]byte, error)
 	GetChangeRequest(ctx context.Context, id string) ([]byte, error)
 	PatchChangeRequest(ctx context.Context, id string, body []byte) ([]byte, error)
+	GetChangeRequestApprovals(ctx context.Context, id string) ([]byte, error)
 }
 
 // ChangeRequestHandler handles HTTP requests for change-request operations.
@@ -139,6 +140,30 @@ func (h *ChangeRequestHandler) GetChangeRequest(w http.ResponseWriter, r *http.R
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity GetChangeRequest failed", "userID", user.UserID, "id", id, "err", err)
 		mapUpstreamError(w, err, "Failed to retrieve change request.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetChangeRequestApprovals handles GET /change-requests/{id}/approvals.
+func (h *ChangeRequestHandler) GetChangeRequestApprovals(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetChangeRequestApprovals(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetChangeRequestApprovals failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamError(w, err, "Failed to retrieve change request approvals.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/change_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/change_requests_test.go
@@ -180,6 +180,88 @@ func TestGetChangeRequest(t *testing.T) {
 	})
 }
 
+func TestGetChangeRequestApprovals(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := httptest.NewRequest(http.MethodGet, "/change-requests/"+testCRID+"/approvals", nil)
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.GetChangeRequestApprovals(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests/not-a-uuid/approvals", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.GetChangeRequestApprovals(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty id", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests//approvals", nil))
+		w := httptest.NewRecorder()
+		h.GetChangeRequestApprovals(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards id to upstream and returns 200", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityChangeRequestClient{
+			getChangeRequestApprovalsFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"approvals":[{"stage":"Assess","approverType":"STATIC_GROUP","approverName":"Devops Approval","status":"APPROVED","approvers":[{"id":"11111111-1111-1111-1111-111111111111","name":"Thenuka Keerthibandara","status":"APPROVED","respondedOn":"2026-07-08 06:02:56"}]}]}`), nil
+			},
+		}
+		h := NewChangeRequestHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests/"+testCRID+"/approvals", nil))
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.GetChangeRequestApprovals(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedID != testCRID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testCRID)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		approvals, ok := resp["approvals"].([]any)
+		if !ok || len(approvals) != 1 {
+			t.Fatalf("approvals = %v, want 1 entry", resp["approvals"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to retrieve change request approvals.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityChangeRequestClient{
+					getChangeRequestApprovalsFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewChangeRequestHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/change-requests/"+testCRID+"/approvals", nil))
+				r.SetPathValue("id", testCRID)
+				w := httptest.NewRecorder()
+				h.GetChangeRequestApprovals(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestSearchChangeRequests(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
@@ -257,4 +339,3 @@ func TestSearchChangeRequests(t *testing.T) {
 		}
 	})
 }
-

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -410,10 +410,11 @@ func (m *mockEntityProblemClient) SearchProblems(ctx context.Context, body []byt
 // ----- mock entity change request client -----
 
 type mockEntityChangeRequestClient struct {
-	createChangeRequestFn  func(ctx context.Context, body []byte) ([]byte, error)
-	searchChangeRequestsFn func(ctx context.Context, body []byte) ([]byte, error)
-	getChangeRequestFn     func(ctx context.Context, id string) ([]byte, error)
-	patchChangeRequestFn   func(ctx context.Context, id string, body []byte) ([]byte, error)
+	createChangeRequestFn       func(ctx context.Context, body []byte) ([]byte, error)
+	searchChangeRequestsFn      func(ctx context.Context, body []byte) ([]byte, error)
+	getChangeRequestFn          func(ctx context.Context, id string) ([]byte, error)
+	patchChangeRequestFn        func(ctx context.Context, id string, body []byte) ([]byte, error)
+	getChangeRequestApprovalsFn func(ctx context.Context, id string) ([]byte, error)
 }
 
 func (m *mockEntityChangeRequestClient) CreateChangeRequest(ctx context.Context, body []byte) ([]byte, error) {
@@ -442,6 +443,13 @@ func (m *mockEntityChangeRequestClient) PatchChangeRequest(ctx context.Context, 
 		return m.patchChangeRequestFn(ctx, id, body)
 	}
 	return []byte(`{"id":"11111111-1111-1111-1111-111111111111","updatedOn":"2026-01-01T00:00:00Z","updatedBy":"user@example.com"}`), nil
+}
+
+func (m *mockEntityChangeRequestClient) GetChangeRequestApprovals(ctx context.Context, id string) ([]byte, error) {
+	if m.getChangeRequestApprovalsFn != nil {
+		return m.getChangeRequestApprovalsFn(ctx, id)
+	}
+	return []byte(`{"approvals":[]}`), nil
 }
 
 // ----- mock entity IT service client -----

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1926,6 +1926,58 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /change-requests/{id}/approvals:
+    get:
+      summary: Get the approval stages for a change request (ServiceNow data source only).
+      operationId: getChangeRequestApprovals
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID of the change request.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestApprovalsView'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /change-requests:
     post:
       summary: Create a change request (ServiceNow data source only).
@@ -5683,6 +5735,51 @@ components:
             approvedOn:
               type: string
               nullable: true
+
+    ChangeRequestApprover:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        status:
+          type: string
+          description: >-
+            Approver-level status as reported by the backing data source
+            (e.g. "APPROVED", "NOT_REQUIRED", "REQUESTED"); open string set,
+            not a fixed enum.
+        respondedOn:
+          type: string
+          nullable: true
+
+    ChangeRequestApproval:
+      type: object
+      properties:
+        stage:
+          type: string
+          enum: [Assess, Authorize, Customer Approval]
+        approverType:
+          type: string
+          enum: [STATIC_GROUP, DYNAMIC_CONTACT]
+        approverName:
+          type: string
+        status:
+          type: string
+          enum: [APPROVED, REJECTED, PENDING]
+        approvers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestApprover'
+
+    ChangeRequestApprovalsView:
+      type: object
+      properties:
+        approvals:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestApproval'
 
     CaseVariable:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1396,6 +1396,40 @@ export interface BeChangeRequestDetail extends BeChangeRequestSearchView {
   approvedOn?: string | null;
 }
 
+/** An approval stage seen on a change request, e.g. Assess, Authorize. */
+export type BeChangeRequestApprovalStage = "Assess" | "Authorize" | "Customer Approval";
+
+/** Who a change-request approval stage is assigned to. */
+export type BeChangeRequestApproverType = "STATIC_GROUP" | "DYNAMIC_CONTACT";
+
+/**
+ * An individual approver's response within an approval stage
+ * (`GET /change-requests/{id}/approvals`). `status` is an open, backend-passthrough
+ * string (seen live: `APPROVED`, `NOT_REQUIRED`, `REQUESTED`; also possible:
+ * `REJECTED`, `CANCELLED`, `NO_CONSENSUS`, or an unrecognized value) — the backend
+ * does not validate/whitelist it, so render with a fallback rather than a closed union.
+ */
+export interface BeChangeRequestApprover {
+  id: string;
+  name?: string | null;
+  status: string;
+  respondedOn?: string | null;
+}
+
+/** One approval stage on a change request, with its individual approvers. */
+export interface BeChangeRequestApproval {
+  stage: string;
+  approverType: BeChangeRequestApproverType | string;
+  approverName?: string | null;
+  status: string;
+  approvers: BeChangeRequestApprover[];
+}
+
+/** `GET /change-requests/{id}/approvals` response. */
+export interface BeChangeRequestApprovalsView {
+  approvals: BeChangeRequestApproval[];
+}
+
 /**
  * `POST /change-requests` body (ServiceNow data source only). `subject` is
  * the only required field; every ID field (`serviceId`, `serviceOfferingId`,

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -67,6 +67,7 @@ export const ApiQueryKeys = {
   UPDATE_LEVELS_SEARCH: "update-levels-search",
   CHANGE_REQUESTS: "change-requests",
   CHANGE_REQUEST_DETAILS: "change-request-details",
+  CHANGE_REQUEST_APPROVALS: "change-request-approvals",
   CHANGE_REQUEST_COMMENTS: "change-request-comments",
   CHANGE_REQUEST_STATS: "change-request-stats",
   INCIDENTS: "incidents",

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useGetChangeRequestApprovals.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useGetChangeRequestApprovals.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeChangeRequestApprovalsView } from "@api/backend/types";
+
+/**
+ * Look up the approval-stage records for a change request via
+ * `GET /change-requests/{id}/approvals` (ServiceNow data source only). Returns
+ * `null` when the id is unknown so callers can render an empty/not-found state
+ * rather than an error.
+ */
+export function useGetChangeRequestApprovals(
+  id: string | undefined,
+): UseQueryResult<BeChangeRequestApprovalsView | null, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeChangeRequestApprovalsView | null, Error>({
+    queryKey: [ApiQueryKeys.CHANGE_REQUEST_APPROVALS, id ?? ""],
+    queryFn: (): Promise<BeChangeRequestApprovalsView | null> =>
+      api.get<BeChangeRequestApprovalsView>(
+        `/change-requests/${encodeURIComponent(id as string)}/approvals`,
+      ),
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestApprovals.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestApprovals.tsx
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Card,
+  Chip,
+  Divider,
+  Skeleton,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import QueryErrorState from "@components/QueryErrorState";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { useGetChangeRequestApprovals } from "@features/csm-operations/api/useGetChangeRequestApprovals";
+import {
+  approvalStatusColor,
+  approvalStatusLabel,
+} from "@features/csm-operations/utils/changeRequests";
+import type { BeChangeRequestApproval } from "@api/backend/types";
+
+function formatDateTime(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }) ?? "—"
+  );
+}
+
+/** "Devops Approval" (STATIC_GROUP) or a named customer contact (DYNAMIC_CONTACT). */
+function approverDisplayName(approval: BeChangeRequestApproval): string {
+  return approval.approverName || (approval.approverType === "DYNAMIC_CONTACT" ? "Customer contact" : "Approval group");
+}
+
+function ApprovalStage({ approval }: { approval: BeChangeRequestApproval }): JSX.Element {
+  return (
+    <Accordion disableGutters sx={{ "&:before": { display: "none" } }}>
+      <AccordionSummary expandIcon={<ChevronDown size={16} />}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap", minWidth: 0 }}>
+          <Typography variant="body2" fontWeight={600} sx={{ minWidth: 100 }}>
+            {approval.stage}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {approverDisplayName(approval)}
+          </Typography>
+          <Chip
+            size="small"
+            color={approvalStatusColor(approval.status)}
+            label={approvalStatusLabel(approval.status)}
+            sx={{ ml: "auto" }}
+          />
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        {approval.approvers.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No individual approvers listed for this stage.
+          </Typography>
+        ) : (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            {approval.approvers.map((approver) => (
+              <Box
+                key={approver.id}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1.5,
+                  flexWrap: "wrap",
+                  py: 0.5,
+                }}
+              >
+                <Typography variant="body2" sx={{ minWidth: 200 }}>
+                  {approver.name || "Unknown approver"}
+                </Typography>
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  color={approvalStatusColor(approver.status)}
+                  label={approvalStatusLabel(approver.status)}
+                />
+                <Typography variant="caption" color="text.secondary" sx={{ ml: "auto" }}>
+                  {approver.respondedOn ? formatDateTime(approver.respondedOn) : "—"}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+/**
+ * Approval-stage records for a change request (`GET /change-requests/{id}/approvals`):
+ * who specifically needs to approve at each stage (Assess/Authorize/Customer
+ * Approval, however many currently exist) and each approver's individual
+ * status. Distinct from the flat `hasCustomerApproved`/`hasCustomerReviewed`
+ * toggle shown in the Approval card above, which is a different, already-built
+ * concept.
+ */
+export default function ChangeRequestApprovals({ id }: { id: string | undefined }): JSX.Element | null {
+  const { data, isLoading, isError, error } = useGetChangeRequestApprovals(id);
+
+  if (isLoading) {
+    return (
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Approvals</Typography>
+        <Skeleton variant="rounded" height={48} />
+        <Skeleton variant="rounded" height={48} />
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Approvals</Typography>
+        <QueryErrorState message="Could not load the approval stages for this change request." error={error} />
+      </Card>
+    );
+  }
+
+  const approvals = data?.approvals ?? [];
+
+  if (approvals.length === 0) {
+    return (
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Approvals</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No approval stages recorded for this change request.
+        </Typography>
+      </Card>
+    );
+  }
+
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Typography variant="subtitle2">Approvals</Typography>
+      <Box sx={{ display: "flex", flexDirection: "column" }}>
+        {approvals.map((approval, index) => (
+          <Box key={`${approval.stage}-${index}`}>
+            {index > 0 && <Divider />}
+            <ApprovalStage approval={approval} />
+          </Box>
+        ))}
+      </Box>
+    </Card>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -30,6 +30,7 @@ import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
 import { usePatchChangeRequest } from "@features/csm-operations/api/usePatchChangeRequest";
+import ChangeRequestApprovals from "@features/csm-operations/components/ChangeRequestApprovals";
 import EditChangeRequestDialog from "@features/csm-operations/components/EditChangeRequestDialog";
 import {
   changeRequestImpactColor,
@@ -276,6 +277,8 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
           </MetaCell>
         </Box>
       </Card>
+
+      <ChangeRequestApprovals id={cr.id} />
 
       {[
         cr.description,

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -91,6 +91,41 @@ export function changeRequestImpactColor(impact?: string | null): ChipColor {
   return IMPACT_COLOR[impact as BeChangeRequestImpact] ?? "default";
 }
 
+// Approval-stage / approver status labels and colours. The backend passes
+// these through from the data source without validating them (see
+// `BeChangeRequestApprover.status`), so both maps are deliberately partial —
+// unrecognized values fall back to a humanized version of the raw string
+// rather than crashing or rendering nothing.
+const APPROVAL_STATUS_LABEL: Record<string, string> = {
+  APPROVED: "Approved",
+  REJECTED: "Rejected",
+  PENDING: "Pending",
+  REQUESTED: "Requested",
+  NOT_REQUIRED: "Not required",
+  CANCELLED: "Cancelled",
+  NO_CONSENSUS: "No consensus",
+};
+
+const APPROVAL_STATUS_COLOR: Record<string, ChipColor> = {
+  APPROVED: "success",
+  REJECTED: "error",
+  PENDING: "warning",
+  REQUESTED: "warning",
+  NOT_REQUIRED: "default",
+  CANCELLED: "default",
+  NO_CONSENSUS: "error",
+};
+
+export function approvalStatusLabel(status?: string | null): string {
+  if (!status) return "—";
+  return APPROVAL_STATUS_LABEL[status.toUpperCase()] ?? humanize(status.toLowerCase());
+}
+
+export function approvalStatusColor(status?: string | null): ChipColor {
+  if (!status) return "default";
+  return APPROVAL_STATUS_COLOR[status.toUpperCase()] ?? "default";
+}
+
 export interface ChangeRequestFilters {
   search: string;
   states: BeChangeRequestState[];

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1955,6 +1955,52 @@ type ChangeRequest struct {
 	ApprovedOn          *string    `json:"approvedOn"`
 }
 
+// ChangeRequestApproverType is a string enum for the kind of approver assigned to an
+// approval stage: a static ServiceNow group, or the change request's dynamic customer contact.
+type ChangeRequestApproverType string
+
+const (
+	ChangeRequestApproverTypeStaticGroup    ChangeRequestApproverType = "STATIC_GROUP"
+	ChangeRequestApproverTypeDynamicContact ChangeRequestApproverType = "DYNAMIC_CONTACT"
+)
+
+// ChangeRequestApprovalStatus is a string enum for the overall status of an approval stage.
+type ChangeRequestApprovalStatus string
+
+const (
+	ChangeRequestApprovalStatusApproved ChangeRequestApprovalStatus = "APPROVED"
+	ChangeRequestApprovalStatusRejected ChangeRequestApprovalStatus = "REJECTED"
+	ChangeRequestApprovalStatusPending  ChangeRequestApprovalStatus = "PENDING"
+)
+
+// ChangeRequestApprover is a single approver's response within an approval stage.
+// Status is an open string set (e.g. APPROVED, NOT_REQUIRED, REQUESTED, REJECTED,
+// CANCELLED, NO_CONSENSUS, or an unrecognized value uppercased) rather than a fixed
+// enum, so it is passed through as-is rather than validated against a closed list.
+type ChangeRequestApprover struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	RespondedOn *string `json:"respondedOn"`
+}
+
+// ChangeRequestApproval represents a single approval stage (e.g. Assess, Authorize,
+// Customer Approval) on a change request, along with the individual approvers within
+// that stage. A change request may have zero to several stages depending on its
+// current state.
+type ChangeRequestApproval struct {
+	Stage        string                      `json:"stage"`
+	ApproverType ChangeRequestApproverType   `json:"approverType"`
+	ApproverName string                      `json:"approverName"`
+	Status       ChangeRequestApprovalStatus `json:"status"`
+	Approvers    []ChangeRequestApprover     `json:"approvers"`
+}
+
+// ChangeRequestApprovals is the response for GET /change-requests/{id}/approvals.
+type ChangeRequestApprovals struct {
+	Approvals []ChangeRequestApproval `json:"approvals"`
+}
+
 // VulnerabilityPriority is a string enum for the priority (severity) of a product vulnerability.
 type VulnerabilityPriority string
 

--- a/entity-service/internal/handler/change_request_handler.go
+++ b/entity-service/internal/handler/change_request_handler.go
@@ -93,3 +93,14 @@ func (h *ChangeRequestHandler) GetChangeRequest(w http.ResponseWriter, r *http.R
 	_ = json.NewEncoder(w).Encode(result)
 }
 
+// GetChangeRequestApprovals handles GET /change-requests/{id}/approvals.
+func (h *ChangeRequestHandler) GetChangeRequestApprovals(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	result, err := h.svc.GetChangeRequestApprovals(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -277,6 +277,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
 		mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
 		mux.HandleFunc("PATCH /change-requests/{id}", changeRequestHandler.PatchChangeRequest)
+		mux.HandleFunc("GET /change-requests/{id}/approvals", changeRequestHandler.GetChangeRequestApprovals)
 	}
 
 	if timeCardHandler != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -262,6 +262,10 @@ type ChangeRequestService interface {
 
 	// PatchChangeRequest updates mutable fields on a change request identified by UUID.
 	PatchChangeRequest(ctx context.Context, id string, req domain.PatchChangeRequestRequest) (domain.PatchChangeRequestResponse, error)
+
+	// GetChangeRequestApprovals returns the approval stages and per-approver status
+	// for a single change request identified by UUID.
+	GetChangeRequestApprovals(ctx context.Context, id string) (domain.ChangeRequestApprovals, error)
 }
 
 // TimeCardService defines the operations available on the time-cards entity.

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -805,6 +805,71 @@ func (s *snChangeRequestService) GetChangeRequest(ctx context.Context, id string
 	return mapSNChangeRequestDetailToView(cr), nil
 }
 
+// snChangeRequestApprovalsResponse mirrors the Choreo GET /change-requests/{id}/approvals response.
+type snChangeRequestApprovalsResponse struct {
+	Approvals []snChangeRequestApproval `json:"approvals"`
+}
+
+type snChangeRequestApproval struct {
+	Stage        string                    `json:"stage"`
+	ApproverType string                    `json:"approverType"`
+	ApproverName string                    `json:"approverName"`
+	Status       string                    `json:"status"`
+	Approvers    []snChangeRequestApprover `json:"approvers"`
+}
+
+type snChangeRequestApprover struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	RespondedOn *string `json:"respondedOn"`
+}
+
+// GetChangeRequestApprovals returns the approval stages and per-approver status for a
+// single change request identified by UUID.
+func (s *snChangeRequestService) GetChangeRequestApprovals(ctx context.Context, id string) (domain.ChangeRequestApprovals, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.ChangeRequestApprovals{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.ChangeRequestApprovals{}, err
+	}
+
+	raw, err := s.client.Get(ctx, "/change-requests/"+uuidToSysid(id)+"/approvals", token)
+	if err != nil {
+		return domain.ChangeRequestApprovals{}, err
+	}
+
+	var snResp snChangeRequestApprovalsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ChangeRequestApprovals{}, fmt.Errorf("sn get change request approvals: parse response: %w", err)
+	}
+
+	approvals := make([]domain.ChangeRequestApproval, 0, len(snResp.Approvals))
+	for _, a := range snResp.Approvals {
+		approvers := make([]domain.ChangeRequestApprover, 0, len(a.Approvers))
+		for _, ap := range a.Approvers {
+			approvers = append(approvers, domain.ChangeRequestApprover{
+				ID:          sysidToUUID(ap.ID),
+				Name:        ap.Name,
+				Status:      ap.Status,
+				RespondedOn: ap.RespondedOn,
+			})
+		}
+		approvals = append(approvals, domain.ChangeRequestApproval{
+			Stage:        a.Stage,
+			ApproverType: domain.ChangeRequestApproverType(a.ApproverType),
+			ApproverName: a.ApproverName,
+			Status:       domain.ChangeRequestApprovalStatus(a.Status),
+			Approvers:    approvers,
+		})
+	}
+
+	return domain.ChangeRequestApprovals{Approvals: approvals}, nil
+}
+
 // mapSNChangeRequestDetailToView maps a Choreo change-request detail payload to the domain view,
 // shared by GetChangeRequest and PatchChangeRequest.
 func mapSNChangeRequestDetailToView(cr snChangeRequestDetail) domain.ChangeRequest {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1242,6 +1242,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /change-requests/{id}/approvals:
+    get:
+      summary: Get the approval stages for a change request (ServiceNow data source only).
+      operationId: getChangeRequestApprovals
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The change request's approval stages.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestApprovals'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Change request not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /catalogs/search:
     post:
       summary: Search service catalogs by deployed product (ServiceNow data source only).
@@ -4214,6 +4257,51 @@ components:
             approvedOn:
               type: string
               nullable: true
+
+    ChangeRequestApprover:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        status:
+          type: string
+          description: >-
+            Approver response status. Open string set (e.g. APPROVED, NOT_REQUIRED,
+            REQUESTED, REJECTED, CANCELLED, NO_CONSENSUS); not a fixed enum.
+        respondedOn:
+          type: string
+          nullable: true
+
+    ChangeRequestApproval:
+      type: object
+      properties:
+        stage:
+          type: string
+          description: Approval stage name (e.g. Assess, Authorize, Customer Approval).
+        approverType:
+          type: string
+          enum: [STATIC_GROUP, DYNAMIC_CONTACT]
+        approverName:
+          type: string
+          description: Group name (STATIC_GROUP) or the per-CR customer contact's name (DYNAMIC_CONTACT).
+        status:
+          type: string
+          enum: [APPROVED, REJECTED, PENDING]
+        approvers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestApprover'
+
+    ChangeRequestApprovals:
+      type: object
+      properties:
+        approvals:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestApproval'
 
     Variable:
       type: object


### PR DESCRIPTION
## Purpose
CS engineers reviewing a change request in the CSM portal have no visibility into where the request stands in its approval workflow. They have to leave the portal and check the backing system directly to see who has approved, rejected, or is still pending. This PR adds that visibility natively in the CSM portal.

## Goals
- Surface the change request's approval-stage data (approver, state, and comments per stage) on the change request detail page.
- Expose a new endpoint through the CSM backend so the webapp can fetch approval stages for a given change request.
- Model the approval-stage data in the entity-service so it can be sourced from the backing data source and returned in a stable, generic shape.

## Approach
End-to-end addition across three layers:
- **entity-service**: new domain type for a change request's approval stage, a service method to fetch the stages from the backing data source, and a route/handler exposing them.
- **CSM backend**: new handler + entity type consuming the entity-service response and exposing it through the CSM backend's own API (documented in `openapi.yaml`).
- **webapp**: a new `useGetChangeRequestApprovals` hook and a `ChangeRequestApprovals` component rendering the approval stages (approver, status, comments) on the change request detail page.

A corresponding change on the backing data source side (to surface the approval-stage records this reads) is tracked separately, outside this repo.

## User stories
As a CS engineer, when I open a change request in the CSM portal, I can see its approval stages (who needs to approve, current status, and any comments) without leaving the portal.

## Release note
Added change request approval-stage visibility to the CSM portal's change request detail page.

## Documentation
N/A — internal CS-engineer portal feature, no external product documentation impact.

## Automation tests
- Unit tests
  - Backend: extended `change_requests_test.go` and `helpers_test.go` with coverage for the new approval-stage handling.
- Integration tests
  - Verified end-to-end against real data through the full local stack (entity-service, CSM backend, webapp), including a live browser check with a real login, confirming approval stages render correctly on the change request detail page.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A for Go/TypeScript — `go vet` and `eslint` ran clean instead
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema/data migrations required.

## Test environment
Local full stack (entity-service, CSM backend, webapp) with a local Postgres-backed setup; verified in Chrome via a live browser session with real login.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval-stage details to change request detail pages.
  * Display approval stages, approver names or groups, statuses, and response timestamps.
  * Added loading, error, and empty states when approval information is unavailable.
  * Added an API endpoint for retrieving change request approvals with authentication and validation.
* **Documentation**
  * Documented the approvals endpoint and response models in the API specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->