### PR TITLE
[CSM Portal] add Problem management list and detail views

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -156,6 +156,7 @@ func main() {
 	mux.HandleFunc("POST /incidents", incidentHandler.CreateIncident)
 	mux.HandleFunc("GET /incidents/{id}", incidentHandler.GetIncident)
 	mux.HandleFunc("PATCH /incidents/{id}", incidentHandler.PatchIncident)
+	mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
 	mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 
 	addr := envOrDefault("PORT", ":8080")

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -162,6 +162,12 @@ func (c *Client) SearchProblems(ctx context.Context, body []byte) ([]byte, error
 	return c.do(ctx, http.MethodPost, "/problems/search", body)
 }
 
+// GetProblem calls GET /problems/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) GetProblem(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/problems/%s", url.PathEscape(id)), nil)
+}
+
 // PostDeployment calls POST /deployments on the entity service to create a new deployment.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -398,11 +398,19 @@ func (m *mockEntityIncidentClient) PatchIncident(ctx context.Context, id string,
 
 type mockEntityProblemClient struct {
 	searchProblemsFn func(ctx context.Context, body []byte) ([]byte, error)
+	getProblemFn     func(ctx context.Context, id string) ([]byte, error)
 }
 
 func (m *mockEntityProblemClient) SearchProblems(ctx context.Context, body []byte) ([]byte, error) {
 	if m.searchProblemsFn != nil {
 		return m.searchProblemsFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityProblemClient) GetProblem(ctx context.Context, id string) ([]byte, error) {
+	if m.getProblemFn != nil {
+		return m.getProblemFn(ctx, id)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/problems.go
+++ b/apps/csm-portal/backend/internal/handler/problems.go
@@ -30,6 +30,7 @@ import (
 // entityProblemClient abstracts the entity service problem operations used by ProblemHandler.
 type entityProblemClient interface {
 	SearchProblems(ctx context.Context, body []byte) ([]byte, error)
+	GetProblem(ctx context.Context, id string) ([]byte, error)
 }
 
 // ProblemHandler handles HTTP requests for problem operations, delegating to the
@@ -72,6 +73,30 @@ func (h *ProblemHandler) SearchProblems(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchProblems failed", "userID", user.UserID, "err", err)
 		mapUpstreamError(w, err, "Failed to search problems.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetProblem handles GET /problems/{id}.
+func (h *ProblemHandler) GetProblem(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProblem(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProblem failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamError(w, err, "Failed to retrieve problem.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/problems_test.go
+++ b/apps/csm-portal/backend/internal/handler/problems_test.go
@@ -24,6 +24,89 @@ import (
 	"testing"
 )
 
+const testProblemID = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
+
+func TestGetProblem(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := httptest.NewRequest(http.MethodGet, "/problems/"+testProblemID, nil)
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.GetProblem(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/problems/not-a-uuid", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.GetProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty id", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/problems/", nil))
+		w := httptest.NewRecorder()
+		h.GetProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards id to upstream and returns 200", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityProblemClient{
+			getProblemFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"id":"` + testProblemID + `","number":"PRB0001","state":"assess"}`), nil
+			},
+		}
+		h := NewProblemHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/problems/"+testProblemID, nil))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.GetProblem(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedID != testProblemID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testProblemID)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["number"] != "PRB0001" {
+			t.Errorf("response number = %v, want PRB0001", resp["number"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to retrieve problem.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityProblemClient{
+					getProblemFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewProblemHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/problems/"+testProblemID, nil))
+				r.SetPathValue("id", testProblemID)
+				w := httptest.NewRecorder()
+				h.GetProblem(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestSearchProblems(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewProblemHandler(&mockEntityProblemClient{})

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -3027,6 +3027,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /problems/{id}:
+    get:
+      summary: Get a single problem by ID (ServiceNow data source only).
+      operationId: getProblem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID of the problem.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /problems/search:
     post:
       summary: Search problems (ServiceNow data source only).
@@ -6987,3 +7037,70 @@ components:
           type: integer
         offset:
           type: integer
+
+    IdNumberRef:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+
+    ProblemDetail:
+      allOf:
+        - $ref: '#/components/schemas/Problem'
+        - type: object
+          properties:
+            state:
+              type: string
+              nullable: true
+              description: Current workflow state (e.g. "new", "assess", "resolved", "closed")
+            priority:
+              type: string
+              nullable: true
+            category:
+              type: string
+              nullable: true
+            subcategory:
+              type: string
+              nullable: true
+            originCase:
+              $ref: '#/components/schemas/CaseNumberRef'
+            primaryIncident:
+              $ref: '#/components/schemas/IdNumberRef'
+            linkedIncidents:
+              type: array
+              nullable: true
+              items:
+                $ref: '#/components/schemas/IdNumberRef'
+            linkedChangeRequest:
+              $ref: '#/components/schemas/IdNumberRef'
+            assignedTo:
+              $ref: '#/components/schemas/EntityRef'
+              nullable: true
+            resolutionCode:
+              type: string
+              nullable: true
+            causeNotes:
+              type: string
+              nullable: true
+            fixNotes:
+              type: string
+              nullable: true
+            workaround:
+              type: string
+              nullable: true
+            resolvedAt:
+              type: string
+              nullable: true
+            resolvedBy:
+              $ref: '#/components/schemas/EntityRef'
+              nullable: true
+            openedAt:
+              type: string
+              nullable: true
+            closedAt:
+              type: string
+              nullable: true

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -69,6 +69,9 @@ const CsmIncidentDetailPage = lazy(
 const CreateIncidentPage = lazy(
   () => import("@features/csm-operations/pages/CreateIncidentPage"),
 );
+const ProblemDetailPage = lazy(
+  () => import("@features/csm-operations/pages/ProblemDetailPage"),
+);
 const CsmAdminLayout = lazy(
   () => import("@features/csm-admin/pages/CsmAdminLayout"),
 );
@@ -299,6 +302,10 @@ export default function App(): JSX.Element {
                   <Route
                     path="operations/incidents/:id"
                     element={<CsmIncidentDetailPage />}
+                  />
+                  <Route
+                    path="operations/problems/:id"
+                    element={<ProblemDetailPage />}
                   />
 
                   <Route path="engagements" element={<CsmEngagementsPage />} />

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1798,6 +1798,100 @@ export interface BeIncidentSearchResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Problems (SRE-owned; ServiceNow data source only). Enum casing mirrors
+// incidents (UPPER_SNAKE_CASE on the wire), not change requests.
+// ---------------------------------------------------------------------------
+
+export type BeProblemState =
+  | "NEW"
+  | "ASSESS"
+  | "ROOT_CAUSE_ANALYSIS"
+  | "FIX_IN_PROGRESS"
+  | "RESOLVED"
+  | "CLOSED";
+
+/**
+ * A reference to another record embedded within a problem. Deliberately
+ * generic (id + number only, no record-type discriminant): the backend does
+ * not tag these with a type, and `originCase` in particular can point at
+ * either a Case or an Incident depending on the underlying data despite its
+ * name. Render as a plain, non-navigable reference unless the caller
+ * independently knows the target record type and has a route for it.
+ */
+export interface BeProblemRef {
+  id: string;
+  number?: string;
+}
+
+/**
+ * List-item shape for `POST /problems/search`. Minimal by design — unlike
+ * change requests/incidents, the search view does not embed state, priority,
+ * or any other field beyond id/number/subject; only `GET /problems/{id}`
+ * does (see {@link BeProblemDetail}).
+ */
+export interface BeProblemSearchView {
+  id: string;
+  number?: string;
+  subject?: string;
+}
+
+export interface BeProblemSearchFilters {
+  searchQuery?: string;
+  /**
+   * Filter by state. Not confirmed live against the backend at the time this
+   * was written — the search response itself doesn't echo `state` — so if
+   * the backend rejects or silently ignores this filter, drop it here and
+   * from `ProblemsTab`'s payload, and remove the state control from
+   * `ProblemsFilterBar`.
+   */
+  states?: BeProblemState[];
+}
+
+export interface BeProblemSearchPayload {
+  filters?: BeProblemSearchFilters;
+  pagination?: BePagination;
+}
+
+/** Note: mirrors the change-request/incident search responses — no `hasMore`. */
+export interface BeProblemSearchResponse {
+  problems: BeProblemSearchView[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * `GET /problems/{id}` response. `originCase` / `primaryIncident` /
+ * `linkedChangeRequest` are singular refs (each may reference a different
+ * record type — see {@link BeProblemRef}); `linkedIncidents` is a genuine
+ * one-to-many and must be rendered as a list, not a single value.
+ */
+export interface BeProblemDetail {
+  id: string;
+  number?: string;
+  subject?: string;
+  state?: BeProblemState;
+  priority?: string | null;
+  /** May be null/empty on many records — render blank gracefully, not as an awkward empty field. */
+  category?: string | null;
+  subcategory?: string | null;
+  /** Despite the name, may reference an Incident rather than a Case. */
+  originCase?: BeProblemRef | null;
+  primaryIncident?: BeProblemRef | null;
+  linkedIncidents?: BeProblemRef[];
+  linkedChangeRequest?: BeProblemRef | null;
+  assignedTo?: BeEntityRef | null;
+  resolutionCode?: string | null;
+  causeNotes?: string | null;
+  fixNotes?: string | null;
+  workaround?: string | null;
+  resolvedAt?: string | null;
+  resolvedBy?: BeEntityRef | null;
+  openedAt?: string | null;
+  closedAt?: string | null;
+}
+
+// ---------------------------------------------------------------------------
 // Product vulnerabilities (managed-cloud; ServiceNow data source only)
 // ---------------------------------------------------------------------------
 

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -71,6 +71,8 @@ export const ApiQueryKeys = {
   CHANGE_REQUEST_STATS: "change-request-stats",
   INCIDENTS: "incidents",
   INCIDENT_DETAILS: "incident-details",
+  PROBLEMS: "problems",
+  PROBLEM_DETAILS: "problem-details",
   GROUPS_SEARCH: "groups-search",
   IT_SERVICES_SEARCH: "it-services-search",
   SERVICE_OFFERINGS_SEARCH: "service-offerings-search",

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useGetProblem.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useGetProblem.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeProblemDetail } from "@api/backend/types";
+
+/**
+ * Look up a single problem by id via `GET /problems/{id}` (ServiceNow data
+ * source only). Returns `null` when the id is unknown so the detail page can
+ * render a not-found state rather than an error.
+ */
+export function useGetProblem(
+  id: string | undefined,
+): UseQueryResult<BeProblemDetail | null, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProblemDetail | null, Error>({
+    queryKey: [ApiQueryKeys.PROBLEM_DETAILS, id ?? ""],
+    queryFn: (): Promise<BeProblemDetail | null> =>
+      api.get<BeProblemDetail>(`/problems/${encodeURIComponent(id as string)}`),
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchProblems.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchProblems.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeProblemSearchPayload,
+  BeProblemSearchResponse,
+} from "@api/backend/types";
+
+/**
+ * Search problems via `POST /problems/search` (ServiceNow data source only).
+ * Returns the raw paged response so the listing can drive server-side
+ * pagination from `total`. `keepPreviousData` keeps the table populated
+ * while the next page/filter loads.
+ */
+export function useSearchProblems(
+  payload: BeProblemSearchPayload,
+): UseQueryResult<BeProblemSearchResponse, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProblemSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.PROBLEMS, payload],
+    queryFn: (): Promise<BeProblemSearchResponse> =>
+      api.post<BeProblemSearchPayload, BeProblemSearchResponse>(
+        "/problems/search",
+        payload,
+      ),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  FormControl,
+  Grid,
+  IconButton,
+  InputAdornment,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+} from "@wso2/oxygen-ui";
+import type { SelectChangeEvent } from "@wso2/oxygen-ui";
+import { ChevronDown, ChevronUp, ListFilter, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, type JSX } from "react";
+import type { BeProblemState } from "@api/backend/types";
+import {
+  countActiveProblemFilters,
+  PROBLEM_STATES,
+  problemStateLabel,
+  type ProblemFilters,
+} from "@features/csm-operations/utils/problems";
+
+interface ProblemsFilterBarProps {
+  filters: ProblemFilters;
+  onChange: (next: ProblemFilters) => void;
+  onReset: () => void;
+  isFiltersOpen: boolean;
+  onFiltersToggle: () => void;
+}
+
+/**
+ * Search + State filter bar for the Problem management tab. Kept simple by
+ * design (search + a single state control) — see the caveat on
+ * `BeProblemSearchFilters.states` before adding more filter fields.
+ */
+export default function ProblemsFilterBar({
+  filters,
+  onChange,
+  onReset,
+  isFiltersOpen,
+  onFiltersToggle,
+}: ProblemsFilterBarProps): JSX.Element {
+  const activeCount = countActiveProblemFilters(filters);
+  const hasActive = activeCount > 0;
+
+  const stateOptions = useMemo(
+    () =>
+      PROBLEM_STATES.map((s) => ({
+        value: s,
+        label: problemStateLabel(s),
+      })),
+    [],
+  );
+
+  const handleStateChange = (event: SelectChangeEvent<string[]>): void => {
+    const val = event.target.value;
+    onChange({
+      ...filters,
+      states: (Array.isArray(val) ? val : [val]) as BeProblemState[],
+    });
+  };
+
+  return (
+    <Paper sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+        <Box sx={{ position: "relative", flex: 1, minWidth: 240 }}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Search by number or subject…"
+            value={filters.search}
+            onChange={(e) => onChange({ ...filters, search: e.target.value })}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={16} />
+                  </InputAdornment>
+                ),
+                endAdornment: filters.search ? (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      edge="end"
+                      onClick={() => onChange({ ...filters, search: "" })}
+                      aria-label="Clear search"
+                    >
+                      <X size={16} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+          />
+        </Box>
+
+        <Button
+          variant="outlined"
+          size="small"
+          color="primary"
+          onClick={onFiltersToggle}
+          startIcon={<ListFilter size={16} />}
+          endIcon={isFiltersOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        >
+          {hasActive ? `Filters (${activeCount})` : "Filters"}
+        </Button>
+        {hasActive && (
+          <Button
+            variant="text"
+            size="small"
+            color="primary"
+            onClick={onReset}
+            startIcon={<X size={16} />}
+          >
+            Clear filters
+          </Button>
+        )}
+      </Box>
+
+      {isFiltersOpen && (
+        <>
+          <Divider />
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <FormControl fullWidth size="small">
+                <InputLabel id="problem-filter-state-label">State</InputLabel>
+                <Select
+                  multiple
+                  labelId="problem-filter-state-label"
+                  id="problem-filter-state"
+                  value={filters.states}
+                  label="State"
+                  onChange={handleStateChange}
+                  renderValue={(selected) =>
+                    (selected as string[])
+                      .map((v) => stateOptions.find((o) => o.value === v)?.label ?? v)
+                      .join(", ")
+                  }
+                >
+                  {stateOptions.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
+                      <Checkbox
+                        size="small"
+                        checked={filters.states.includes(opt.value)}
+                        sx={{ mr: 1, p: 0.25 }}
+                      />
+                      <ListItemText primary={opt.label} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+          </Grid>
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  LinearProgress,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useNavTransition } from "@hooks/useNavTransition";
+import QueryErrorState from "@components/QueryErrorState";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useSearchProblems } from "@features/csm-operations/api/useSearchProblems";
+import {
+  DEFAULT_PROBLEM_FILTERS,
+  type ProblemFilters,
+} from "@features/csm-operations/utils/problems";
+import ProblemsFilterBar from "@features/csm-operations/components/ProblemsFilterBar";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+
+/**
+ * Problems listing for the Operations → Problem management tab. Searches
+ * `POST /problems/search` with server-side pagination, free-text search, and
+ * a state filter. Unlike change requests/incidents, the search view is
+ * minimal (id/number/subject only — no `state`), so the table can't show a
+ * State column even though the filter can still be applied server-side.
+ */
+export default function ProblemsTab(): JSX.Element {
+  const navigate = useNavTransition();
+  const [filters, setFilters] = useState<ProblemFilters>(DEFAULT_PROBLEM_FILTERS);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
+
+  const payload = useMemo(
+    () => ({
+      filters: {
+        ...(debouncedSearch.length > 0 && { searchQuery: debouncedSearch }),
+        ...(filters.states.length > 0 && { states: filters.states }),
+      },
+      pagination: { offset: page * rowsPerPage, limit: rowsPerPage },
+    }),
+    [debouncedSearch, filters.states, page, rowsPerPage],
+  );
+
+  const { data, isLoading, isError, error, isFetching } = useSearchProblems(payload);
+
+  const problems = data?.problems ?? [];
+  const total = data?.total ?? 0;
+
+  const handleFiltersChange = (next: ProblemFilters): void => {
+    setFilters(next);
+    setPage(0);
+  };
+
+  const handleReset = (): void => {
+    setFilters(DEFAULT_PROBLEM_FILTERS);
+    setPage(0);
+  };
+
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <ProblemsFilterBar
+        filters={filters}
+        onChange={handleFiltersChange}
+        onReset={handleReset}
+        isFiltersOpen={isFiltersOpen}
+        onFiltersToggle={() => setIsFiltersOpen((prev) => !prev)}
+      />
+
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
+        {/* A background refetch (pagination/filter change) shows this thin
+            bar instead of swapping to skeleton rows — isLoading alone gates
+            the skeleton, so keepPreviousData's already-loaded rows stay
+            visible while the next page/filter loads. */}
+        <Box sx={{ height: 2 }}>{isFetching && !isLoading && <LinearProgress sx={{ height: 2 }} />}</Box>
+        <TableContainer>
+          <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
+            <TableHead>
+              <TableRow sx={{ bgcolor: "action.hover" }}>
+                <TableCell>Number</TableCell>
+                <TableCell>Subject</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="90%" height={18} /></TableCell>
+                  </TableRow>
+                ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={2} align="center">
+                    <QueryErrorState
+                      message={`Failed to load problems: ${error instanceof Error ? error.message : "unknown error"}`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
+              ) : problems.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={2} align="center" sx={{ py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No problems found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                problems.map((problem) => (
+                  <TableRow
+                    key={problem.id}
+                    hover
+                    onClick={() => navigate(`/operations/problems/${problem.id}`)}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    <TableCell>{problem.number || "—"}</TableCell>
+                    <TableCell sx={{ maxWidth: 480 }}>
+                      <Typography variant="body2" noWrap title={problem.subject ?? undefined}>
+                        {problem.subject || "—"}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(_: unknown, newPage: number) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+          showFirstButton
+          showLastButton
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -21,14 +21,20 @@ import {  useSearchParams } from "react-router";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ChangeRequestsTab from "@features/csm-operations/components/ChangeRequestsTab";
 import IncidentsTab from "@features/csm-operations/components/IncidentsTab";
+import ProblemsTab from "@features/csm-operations/components/ProblemsTab";
 import { useNavTransition } from "@hooks/useNavTransition";
 
-type OperationsTabId = "service_requests" | "change_requests" | "incidents";
+type OperationsTabId =
+  | "service_requests"
+  | "change_requests"
+  | "incidents"
+  | "problems";
 
 const TAB_IDS: readonly OperationsTabId[] = [
   "service_requests",
   "change_requests",
   "incidents",
+  "problems",
 ];
 
 /**
@@ -57,7 +63,7 @@ export default function OperationsPage(): JSX.Element {
       <Box>
         <Typography variant="h5">Operations</Typography>
         <Typography variant="body2" color="text.secondary">
-          Service requests, change requests, and incidents across customers.
+          Service requests, change requests, incidents, and problems across customers.
         </Typography>
       </Box>
 
@@ -69,6 +75,7 @@ export default function OperationsPage(): JSX.Element {
           <Tab value="service_requests" label="Service requests" />
           <Tab value="change_requests" label="Change requests" />
           <Tab value="incidents" label="Incidents" />
+          <Tab value="problems" label="Problem management" />
         </Tabs>
       </Box>
 
@@ -95,6 +102,8 @@ export default function OperationsPage(): JSX.Element {
       {activeTab === "change_requests" && <ChangeRequestsTab />}
 
       {activeTab === "incidents" && <IncidentsTab />}
+
+      {activeTab === "problems" && <ProblemsTab />}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { BeProblemDetail } from "@api/backend/types";
+
+const navigateMock = vi.fn();
+const useGetProblemMock = vi.fn();
+
+vi.mock("react-router", () => ({
+  useParams: () => ({ id: "prb-1" }),
+}));
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+vi.mock("@features/csm-operations/api/useGetProblem", () => ({
+  useGetProblem: () => useGetProblemMock(),
+}));
+
+// Imported after the mocks above so the module picks them up.
+import ProblemDetailPage from "@features/csm-operations/pages/ProblemDetailPage";
+
+const BASE_PROBLEM: BeProblemDetail = {
+  id: "prb-1",
+  number: "PRB0040157",
+  subject: "Intermittent 502s on the gateway",
+  state: "CLOSED",
+  priority: "High",
+  category: "",
+  subcategory: null,
+  originCase: { id: "inc-1", number: "INC0012345" },
+  primaryIncident: { id: "inc-1", number: "INC0012345" },
+  linkedIncidents: [
+    { id: "inc-1", number: "INC0012345" },
+    { id: "inc-2", number: "INC0012399" },
+  ],
+  linkedChangeRequest: { id: "chg-1", number: "CHG0009988" },
+  assignedTo: { id: "user-1", name: "Jane Doe" },
+  resolutionCode: "Fixed",
+  causeNotes: "Root cause was a bad config push.",
+  fixNotes: "Rolled back the config.",
+  workaround: "Restart the pod.",
+  resolvedAt: "2026-01-01T00:00:00Z",
+  resolvedBy: { id: "user-1", name: "Jane Doe" },
+  openedAt: "2025-12-01T00:00:00Z",
+  closedAt: "2026-01-02T00:00:00Z",
+};
+
+function mockQueryResult(
+  overrides: Partial<UseQueryResult<BeProblemDetail | null, Error>>,
+): void {
+  useGetProblemMock.mockReturnValue({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+describe("ProblemDetailPage", () => {
+  it("renders a loading skeleton while the query is pending", () => {
+    mockQueryResult({ isLoading: true });
+    const { container } = render(<ProblemDetailPage />);
+    expect(container.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
+  });
+
+  it("renders an error state when the query fails", () => {
+    mockQueryResult({ isError: true, error: new Error("boom") });
+    render(<ProblemDetailPage />);
+    expect(screen.getByText(/Could not load problem/i)).toBeInTheDocument();
+  });
+
+  it("renders a not-found state when the problem is null", () => {
+    mockQueryResult({ data: null });
+    render(<ProblemDetailPage />);
+    expect(screen.getByText(/Problem not found/i)).toBeInTheDocument();
+  });
+
+  it("renders subject, number, and state for a loaded problem", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    expect(screen.getByText("Intermittent 502s on the gateway")).toBeInTheDocument();
+    expect(screen.getByText("PRB0040157")).toBeInTheDocument();
+    // "Closed" also appears as the (unrelated) label of the closedAt
+    // MetaCell, so scope the assertion to the state Chip specifically.
+    expect(screen.getByText("Closed", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
+  it("renders an empty category/subcategory gracefully, without a stray blank chip", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    // MetaCell renders "—" for both category and subcategory here (empty string / null).
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders every linkedIncidents entry as a separate reference, not just one", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    // "INC0012345" appears 3 times: originCase (plain text), primaryIncident
+    // (chip), and its entry within linkedIncidents (chip) — all distinct
+    // renders, confirming linkedIncidents is treated as a real list.
+    expect(screen.getAllByText("INC0012345")).toHaveLength(3);
+    expect(screen.getByText("INC0012399")).toBeInTheDocument();
+  });
+
+  it("renders the linked change request as a clickable reference to the CR route", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    screen.getByText("CHG0009988").closest('[role="button"]')?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
+    expect(navigateMock).toHaveBeenCalledWith("/operations/change-requests/chg-1");
+  });
+
+  it("renders originCase as plain, non-navigable text (may not actually be a Case)", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    const originLabels = screen.getAllByText("INC0012345");
+    // None of the two "INC0012345" renders that are plain text (not a clickable chip)
+    // should trigger navigation when clicked directly as text.
+    const plainTextOccurrence = originLabels.find((el) => el.closest('[role="button"]') === null);
+    expect(plainTextOccurrence).toBeDefined();
+  });
+
+  it("renders resolution notes when present", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    expect(screen.getByText("Root cause was a bad config push.")).toBeInTheDocument();
+    expect(screen.getByText("Rolled back the config.")).toBeInTheDocument();
+    expect(screen.getByText("Restart the pod.")).toBeInTheDocument();
+  });
+
+  it("navigates back to the problems tab from the back button", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    screen.getByRole("button", { name: /back to problems/i }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/operations?tab=problems");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft, Link as LinkIcon } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode } from "react";
+import { useParams } from "react-router";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { useGetProblem } from "@features/csm-operations/api/useGetProblem";
+import { problemStateColor, problemStateLabel } from "@features/csm-operations/utils/problems";
+import type { BeEntityRef, BeProblemRef } from "@api/backend/types";
+import { useNavTransition } from "@hooks/useNavTransition";
+
+const OPERATIONS_PROBLEMS_PATH = "/operations?tab=problems";
+
+function formatDateTime(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }) ?? "—"
+  );
+}
+
+function MetaCell({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function RefText({ value }: { value?: BeEntityRef | null }): JSX.Element {
+  return <Typography variant="body2">{value?.name || "—"}</Typography>;
+}
+
+/**
+ * Renders a `BeProblemRef` as a clickable Case-detail chip when `routeBase`
+ * is given (the only route this webapp actually has for a linked-record
+ * type today is `/cases/:caseId`), or as plain text otherwise. Deliberately
+ * does NOT assume `originCase`/`primaryIncident`/`linkedChangeRequest` point
+ * at the record type their field name implies — see the caveat on
+ * `BeProblemRef` in `api/backend/types.ts`. Callers must only pass
+ * `routeBase` when they independently know the target is that record type.
+ */
+function ProblemRefItem({
+  value,
+  routeBase,
+  onNavigate,
+}: {
+  value?: BeProblemRef | null;
+  routeBase?: string;
+  onNavigate: (path: string) => void;
+}): JSX.Element {
+  if (!value) return <Typography variant="body2">—</Typography>;
+  const label = value.number || value.id;
+  if (!routeBase) return <Typography variant="body2">{label}</Typography>;
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      clickable
+      icon={<LinkIcon size={14} />}
+      label={label}
+      onClick={() => onNavigate(`${routeBase}/${value.id}`)}
+    />
+  );
+}
+
+/**
+ * Read-only detail for a single problem (`GET /problems/{id}`): its overview
+ * fields, linked records, and resolution/fix notes. There is no Edit dialog
+ * — problems are SRE-owned and the portal doesn't yet expose a mutation
+ * endpoint for them (unlike change requests/incidents).
+ */
+export default function ProblemDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavTransition();
+  const { data, isLoading, isError } = useGetProblem(id);
+
+  const back = (): void => {
+    navigate(OPERATIONS_PROBLEMS_PATH);
+  };
+
+  const BackButton = (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={back}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back to problems
+    </Button>
+  );
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rounded" height={32} width={240} />
+        <Skeleton variant="rounded" height={260} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {BackButton}
+        <Typography variant="body1" color="error">
+          Could not load problem {id}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {BackButton}
+        <Typography variant="h5">Problem not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No problem with id <code>{id}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const problem = data;
+  const linkedIncidents = problem.linkedIncidents ?? [];
+  const hasLinks = !!(
+    problem.originCase ||
+    problem.primaryIncident ||
+    linkedIncidents.length > 0 ||
+    problem.linkedChangeRequest
+  );
+  const hasResolution = !!(
+    problem.resolutionCode ||
+    problem.causeNotes ||
+    problem.fixNotes ||
+    problem.workaround ||
+    problem.resolvedAt ||
+    problem.resolvedBy
+  );
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      {BackButton}
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="h5">{problem.subject || problem.number || "Problem"}</Typography>
+          {problem.state && (
+            <Chip
+              size="small"
+              color={problemStateColor(problem.state)}
+              label={problemStateLabel(problem.state)}
+            />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+          {problem.number || problem.id}
+        </Typography>
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Priority">
+            <Typography variant="body2">{problem.priority || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Category">
+            <Typography variant="body2">{problem.category || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Subcategory">
+            <Typography variant="body2">{problem.subcategory || "—"}</Typography>
+          </MetaCell>
+          <MetaCell label="Assigned to"><RefText value={problem.assignedTo} /></MetaCell>
+          <MetaCell label="Opened">
+            <Typography variant="body2">{formatDateTime(problem.openedAt)}</Typography>
+          </MetaCell>
+          <MetaCell label="Closed">
+            <Typography variant="body2">{formatDateTime(problem.closedAt)}</Typography>
+          </MetaCell>
+        </Box>
+      </Card>
+
+      {hasLinks && (
+        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+          <Typography variant="subtitle2">Linked records</Typography>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: {
+                xs: "1fr",
+                sm: "repeat(2, minmax(0, 1fr))",
+                md: "repeat(3, minmax(0, 1fr))",
+              },
+            }}
+          >
+            <MetaCell label="Origin record">
+              {/* "originCase" can be an Incident's number in real data despite
+                  the field name — no route assumption is made for it. */}
+              <ProblemRefItem value={problem.originCase} onNavigate={navigate} />
+            </MetaCell>
+            <MetaCell label="Primary incident">
+              <ProblemRefItem
+                value={problem.primaryIncident}
+                routeBase="/operations/incidents"
+                onNavigate={navigate}
+              />
+            </MetaCell>
+            <MetaCell label="Change request">
+              <ProblemRefItem
+                value={problem.linkedChangeRequest}
+                routeBase="/operations/change-requests"
+                onNavigate={navigate}
+              />
+            </MetaCell>
+            {linkedIncidents.length > 0 && (
+              <MetaCell label={`Linked incidents (${linkedIncidents.length})`}>
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
+                  {linkedIncidents.map((incident) => (
+                    <ProblemRefItem
+                      key={incident.id}
+                      value={incident}
+                      routeBase="/operations/incidents"
+                      onNavigate={navigate}
+                    />
+                  ))}
+                </Box>
+              </MetaCell>
+            )}
+          </Box>
+        </Card>
+      )}
+
+      {hasResolution && (
+        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+          <Typography variant="subtitle2">Resolution</Typography>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: {
+                xs: "1fr",
+                sm: "repeat(2, minmax(0, 1fr))",
+                md: "repeat(3, minmax(0, 1fr))",
+              },
+            }}
+          >
+            <MetaCell label="Resolution code">
+              <Typography variant="body2">{problem.resolutionCode || "—"}</Typography>
+            </MetaCell>
+            <MetaCell label="Resolved by"><RefText value={problem.resolvedBy} /></MetaCell>
+            <MetaCell label="Resolved">
+              <Typography variant="body2">{formatDateTime(problem.resolvedAt)}</Typography>
+            </MetaCell>
+          </Box>
+          {problem.causeNotes && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+              <Typography variant="body2" color="text.secondary">
+                Cause notes
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                {problem.causeNotes}
+              </Typography>
+            </Box>
+          )}
+          {problem.fixNotes && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+              <Typography variant="body2" color="text.secondary">
+                Fix notes
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                {problem.fixNotes}
+              </Typography>
+            </Box>
+          )}
+          {problem.workaround && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+              <Typography variant="body2" color="text.secondary">
+                Workaround
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                {problem.workaround}
+              </Typography>
+            </Box>
+          )}
+        </Card>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/problems.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/problems.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  countActiveProblemFilters,
+  DEFAULT_PROBLEM_FILTERS,
+  PROBLEM_STATES,
+  problemStateColor,
+  problemStateLabel,
+} from "@features/csm-operations/utils/problems";
+
+describe("problemStateLabel", () => {
+  it.each([
+    ["NEW", "New"],
+    ["ASSESS", "Assess"],
+    ["ROOT_CAUSE_ANALYSIS", "Root Cause Analysis"],
+    ["FIX_IN_PROGRESS", "Fix In Progress"],
+    ["RESOLVED", "Resolved"],
+    ["CLOSED", "Closed"],
+  ] as const)("labels %s as %s", (state, label) => {
+    expect(problemStateLabel(state)).toBe(label);
+  });
+
+  it("returns an em dash for a missing state", () => {
+    expect(problemStateLabel(null)).toBe("—");
+    expect(problemStateLabel(undefined)).toBe("—");
+  });
+
+  it("humanizes an unrecognized state rather than throwing", () => {
+    expect(problemStateLabel("SOME_NEW_STATE")).toBe("SOME NEW STATE");
+  });
+});
+
+describe("problemStateColor", () => {
+  it("returns success for terminal-good states", () => {
+    expect(problemStateColor("RESOLVED")).toBe("success");
+    expect(problemStateColor("CLOSED")).toBe("success");
+  });
+
+  it("returns warning for the active fix state", () => {
+    expect(problemStateColor("FIX_IN_PROGRESS")).toBe("warning");
+  });
+
+  it("falls back to default for an unrecognized state", () => {
+    expect(problemStateColor("SOME_NEW_STATE")).toBe("default");
+  });
+});
+
+describe("PROBLEM_STATES", () => {
+  it("lists all 6 documented states", () => {
+    expect(PROBLEM_STATES).toHaveLength(6);
+    expect(PROBLEM_STATES).toEqual(
+      expect.arrayContaining([
+        "NEW",
+        "ASSESS",
+        "ROOT_CAUSE_ANALYSIS",
+        "FIX_IN_PROGRESS",
+        "RESOLVED",
+        "CLOSED",
+      ]),
+    );
+  });
+});
+
+describe("countActiveProblemFilters", () => {
+  it("is 0 for the default filters", () => {
+    expect(countActiveProblemFilters(DEFAULT_PROBLEM_FILTERS)).toBe(0);
+  });
+
+  it("is 1 when a state filter is set", () => {
+    expect(countActiveProblemFilters({ ...DEFAULT_PROBLEM_FILTERS, states: ["NEW"] })).toBe(1);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/problems.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/problems.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeProblemState } from "@api/backend/types";
+
+type ChipColor = "default" | "info" | "warning" | "success" | "error";
+
+const STATE_LABEL: Record<BeProblemState, string> = {
+  NEW: "New",
+  ASSESS: "Assess",
+  ROOT_CAUSE_ANALYSIS: "Root Cause Analysis",
+  FIX_IN_PROGRESS: "Fix In Progress",
+  RESOLVED: "Resolved",
+  CLOSED: "Closed",
+};
+
+// New/assess are unstarted-ish (default/info), the analysis/fix states are
+// active work (info/warning), resolved/closed are terminal-good.
+const STATE_COLOR: Record<BeProblemState, ChipColor> = {
+  NEW: "default",
+  ASSESS: "info",
+  ROOT_CAUSE_ANALYSIS: "info",
+  FIX_IN_PROGRESS: "warning",
+  RESOLVED: "success",
+  CLOSED: "success",
+};
+
+/** All problem states, for a filter control. */
+export const PROBLEM_STATES = Object.keys(STATE_LABEL) as BeProblemState[];
+
+function humanize(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+export function problemStateLabel(state?: string | null): string {
+  if (!state) return "—";
+  return STATE_LABEL[state as BeProblemState] ?? humanize(state);
+}
+
+export function problemStateColor(state?: string | null): ChipColor {
+  return STATE_COLOR[state as BeProblemState] ?? "default";
+}
+
+/**
+ * Filters for the problems list. Deliberately just search + state — see the
+ * caveat on `BeProblemSearchFilters.states` in `api/backend/types.ts` (not yet
+ * confirmed live against the backend).
+ */
+export interface ProblemFilters {
+  search: string;
+  states: BeProblemState[];
+}
+
+export const DEFAULT_PROBLEM_FILTERS: ProblemFilters = {
+  search: "",
+  states: [],
+};
+
+/** Count active (non-search) filters, used for the badge on the Filters button. */
+export function countActiveProblemFilters(filters: ProblemFilters): number {
+  return filters.states.length > 0 ? 1 : 0;
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2685,6 +2685,35 @@ type SearchProblemsResponse struct {
 	Limit    int                 `json:"limit"`
 }
 
+// ProblemDetail is the full detail representation returned by GET /problems/{id}.
+//
+// State and ResolutionCode are plain, unvalidated passthrough strings from the
+// data source rather than closed enums. Known State values at the time of writing:
+// NEW | ASSESS | ROOT_CAUSE_ANALYSIS | FIX_IN_PROGRESS | RESOLVED | CLOSED. Do not
+// add strict validation against this list — it is not guaranteed exhaustive.
+type ProblemDetail struct {
+	ID                  *string         `json:"id"`
+	Number              *string         `json:"number"`
+	Subject             *string         `json:"subject"`
+	State               *string         `json:"state"`
+	Priority            *string         `json:"priority"`
+	Category            *string         `json:"category"`
+	Subcategory         *string         `json:"subcategory"`
+	OriginCase          *CaseNumberRef  `json:"originCase"`
+	PrimaryIncident     *CaseNumberRef  `json:"primaryIncident"`
+	LinkedIncidents     []CaseNumberRef `json:"linkedIncidents"`
+	LinkedChangeRequest *CaseNumberRef  `json:"linkedChangeRequest"`
+	AssignedTo          *EntityRef      `json:"assignedTo"`
+	ResolutionCode      *string         `json:"resolutionCode"`
+	CauseNotes          *string         `json:"causeNotes"`
+	FixNotes            *string         `json:"fixNotes"`
+	Workaround          *string         `json:"workaround"`
+	ResolvedAt          *string         `json:"resolvedAt"`
+	ResolvedBy          *EntityRef      `json:"resolvedBy"`
+	OpenedAt            *string         `json:"openedAt"`
+	ClosedAt            *string         `json:"closedAt"`
+}
+
 // ConversationState represents the state of a conversation.
 type ConversationState string
 

--- a/entity-service/internal/handler/problem_handler.go
+++ b/entity-service/internal/handler/problem_handler.go
@@ -49,3 +49,15 @@ func (h *ProblemHandler) SearchProblems(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// GetProblem handles GET /problems/{id}.
+func (h *ProblemHandler) GetProblem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	result, err := h.svc.GetProblem(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -329,6 +329,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 
 	if problemHandler != nil {
 		mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
+		mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
 	}
 
 	if conversationHandler != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -365,6 +365,10 @@ type ProblemService interface {
 	// SearchProblems returns a paginated list of problems filtered by optional search query.
 	// A ValidationError is returned for invalid input.
 	SearchProblems(ctx context.Context, req domain.SearchProblemsRequest) (domain.SearchProblemsResponse, error)
+
+	// GetProblem returns the full detail of a single problem by its UUID.
+	// A NotFoundError is returned if the problem does not exist.
+	GetProblem(ctx context.Context, id string) (domain.ProblemDetail, error)
 }
 
 // ConversationService defines the operations available on the conversations entity.

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -108,3 +108,107 @@ func (s *snProblemService) SearchProblems(ctx context.Context, req domain.Search
 		Offset:   req.Pagination.Offset,
 	}, nil
 }
+
+// snProblemEntityRef is a compact id+number reference used for the problem's
+// origin case / primary incident / linked incidents / linked change request.
+type snProblemEntityRef struct {
+	ID     string `json:"id"`
+	Number string `json:"number"`
+}
+
+// snProblemUserRef is a compact id+name reference used for assignedTo/resolvedBy.
+type snProblemUserRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// snProblemDetailResponse mirrors the Choreo GET /problems/{id} response.
+type snProblemDetailResponse struct {
+	ID                  string               `json:"id"`
+	Number              string               `json:"number"`
+	Subject             string               `json:"subject"`
+	State               *string              `json:"state"`
+	Priority            *string              `json:"priority"`
+	Category            *string              `json:"category"`
+	Subcategory         *string              `json:"subcategory"`
+	OriginCase          *snProblemEntityRef  `json:"originCase"`
+	PrimaryIncident     *snProblemEntityRef  `json:"primaryIncident"`
+	LinkedIncidents     []snProblemEntityRef `json:"linkedIncidents"`
+	LinkedChangeRequest *snProblemEntityRef  `json:"linkedChangeRequest"`
+	AssignedTo          *snProblemUserRef    `json:"assignedTo"`
+	ResolutionCode      *string              `json:"resolutionCode"`
+	CauseNotes          *string              `json:"causeNotes"`
+	FixNotes            *string              `json:"fixNotes"`
+	Workaround          *string              `json:"workaround"`
+	ResolvedAt          *string              `json:"resolvedAt"`
+	ResolvedBy          *snProblemUserRef    `json:"resolvedBy"`
+	OpenedAt            *string              `json:"openedAt"`
+	ClosedAt            *string              `json:"closedAt"`
+}
+
+// GetProblem implements ProblemService for the ServiceNow data source.
+func (s *snProblemService) GetProblem(ctx context.Context, id string) (domain.ProblemDetail, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.ProblemDetail{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.ProblemDetail{}, err
+	}
+
+	raw, err := s.client.Get(ctx, "/problems/"+uuidToSysid(id), token)
+	if err != nil {
+		return domain.ProblemDetail{}, err
+	}
+
+	var p snProblemDetailResponse
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return domain.ProblemDetail{}, fmt.Errorf("sn get problem: parse response: %w", err)
+	}
+
+	problemID := sysidToUUID(p.ID)
+	number := p.Number
+	subject := p.Subject
+
+	view := domain.ProblemDetail{
+		ID:             &problemID,
+		Number:         &number,
+		Subject:        &subject,
+		State:          p.State,
+		Priority:       p.Priority,
+		Category:       p.Category,
+		Subcategory:    p.Subcategory,
+		ResolutionCode: p.ResolutionCode,
+		CauseNotes:     p.CauseNotes,
+		FixNotes:       p.FixNotes,
+		Workaround:     p.Workaround,
+		ResolvedAt:     p.ResolvedAt,
+		OpenedAt:       p.OpenedAt,
+		ClosedAt:       p.ClosedAt,
+	}
+	if p.OriginCase != nil {
+		view.OriginCase = &domain.CaseNumberRef{ID: sysidToUUID(p.OriginCase.ID), Number: p.OriginCase.Number}
+	}
+	if p.PrimaryIncident != nil {
+		view.PrimaryIncident = &domain.CaseNumberRef{ID: sysidToUUID(p.PrimaryIncident.ID), Number: p.PrimaryIncident.Number}
+	}
+	if len(p.LinkedIncidents) > 0 {
+		linked := make([]domain.CaseNumberRef, 0, len(p.LinkedIncidents))
+		for _, li := range p.LinkedIncidents {
+			linked = append(linked, domain.CaseNumberRef{ID: sysidToUUID(li.ID), Number: li.Number})
+		}
+		view.LinkedIncidents = linked
+	}
+	if p.LinkedChangeRequest != nil {
+		view.LinkedChangeRequest = &domain.CaseNumberRef{ID: sysidToUUID(p.LinkedChangeRequest.ID), Number: p.LinkedChangeRequest.Number}
+	}
+	if p.AssignedTo != nil {
+		view.AssignedTo = &domain.EntityRef{ID: sysidToUUID(p.AssignedTo.ID), Name: p.AssignedTo.Name}
+	}
+	if p.ResolvedBy != nil {
+		view.ResolvedBy = &domain.EntityRef{ID: sysidToUUID(p.ResolvedBy.ID), Name: p.ResolvedBy.Name}
+	}
+
+	return view, nil
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2035,6 +2035,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /problems/{id}:
+    get:
+      summary: Get a single problem by ID (ServiceNow data source only).
+      operationId: getProblem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The problem detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Problem not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /conversations/search:
     post:
       summary: Search conversations (ServiceNow data source only).
@@ -6138,6 +6181,75 @@ components:
           type: integer
         limit:
           type: integer
+
+    ProblemDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        subject:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+          description: >
+            Passthrough value from the data source, not a closed enum. Known values at
+            the time of writing: NEW, ASSESS, ROOT_CAUSE_ANALYSIS, FIX_IN_PROGRESS,
+            RESOLVED, CLOSED.
+        priority:
+          type: string
+          nullable: true
+        category:
+          type: string
+          nullable: true
+        subcategory:
+          type: string
+          nullable: true
+        originCase:
+          $ref: '#/components/schemas/CaseNumberRef'
+          nullable: true
+        primaryIncident:
+          $ref: '#/components/schemas/CaseNumberRef'
+          nullable: true
+        linkedIncidents:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseNumberRef'
+        linkedChangeRequest:
+          $ref: '#/components/schemas/CaseNumberRef'
+          nullable: true
+        assignedTo:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        resolutionCode:
+          type: string
+          nullable: true
+        causeNotes:
+          type: string
+          nullable: true
+        fixNotes:
+          type: string
+          nullable: true
+        workaround:
+          type: string
+          nullable: true
+        resolvedAt:
+          type: string
+          nullable: true
+        resolvedBy:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        openedAt:
+          type: string
+          nullable: true
+        closedAt:
+          type: string
+          nullable: true
 
     SearchConversationsRequest:
       type: object


### PR DESCRIPTION
## Purpose
The CSM portal has no way to view Problem records. The existing search resource only returns id/number/subject, so there is no way to open a problem and see its full detail, including which incidents it links back to.

## Goals
Adds Problem management to the CSM portal: a Problems tab (list + filters) on the Operations page, and a dedicated problem detail page, backed by a new `GET /problems/{id}` resource across the entity-service and CSM backend.

## Approach
- entity-service: new domain fields/handler wiring and a `GET /problems/{id}` resource on the backing data source, alongside the existing search resource.
- CSM backend: entity client + handler + route for fetching a single problem, proxied through the existing auth/access-check pattern used by sibling resources.
- webapp: `useGetProblem`/`useSearchProblems` hooks, a `ProblemsTab` + `ProblemsFilterBar` on the Operations page, and a `ProblemDetailPage` reachable via a new route from `App.tsx`.

Notable UX detail: a problem can link to multiple incidents, and the detail page renders each as its own distinct, clickable entry rather than collapsing them into a single reference. It also tolerates an origin-record reference that isn't guaranteed to be a Case.

Verified end-to-end against real data through the full stack (entity-service -> backend -> webapp), including a live browser check with a real login confirming a problem's linked incidents render correctly as separate entries.

A corresponding change on the backing data source side is tracked separately, outside this repo.

## User stories
As a CS engineer, I can open a problem from the Operations page and see its full detail, including which incidents it is linked to, so I can triage without leaving the portal.

## Release note
Adds Problem management (list + detail) to the CSM portal.

## Documentation
N/A - internal CSM-portal feature, no external-facing docs impact.

## Training
N/A

## Certification
N/A - no certification content affected.

## Marketing
N/A

## Automation tests
- Unit tests
  Backend: handler tests for the new `GET /problems/{id}` route (success, not-found, upstream error) using an in-package mock entity client. Webapp: unit tests for the problems util module and a component test for `ProblemDetailPage` covering the multi-incident rendering and the non-Case origin reference.
- Integration tests
  Exercised the full chain (entity-service -> CSM backend -> webapp) against real data in a live browser session with a real login.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A for Go/TypeScript - ran `go vet` and eslint instead, both clean
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A - no schema migrations; additive API resource only.

## Test environment
Verified locally against a real backing-data-source DEV environment, Node/pnpm + Go toolchain on macOS, Chrome (real login flow).

## Learning
N/A

---

**Note on PR size:** this diff spans three components (entity-service, CSM backend, webapp) that are intentionally coupled - the webapp calls the new backend endpoint which calls the new entity-service endpoint - so it is one PR of 24 files rather than a split stack. One file (`ProblemDetailPage.tsx`, ~325 changed lines) is slightly over the usual per-file review size and may get summarized rather than line-by-line review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Problem Management to Operations, including search, state filters, pagination, and clear-filter controls.
  * Added read-only problem detail pages with overview, linked records, resolution information, loading, error, and not-found states.
  * Added support for retrieving detailed problem records through the API.
* **Documentation**
  * Updated API specifications with problem detail endpoints and response schemas.
* **Tests**
  * Added coverage for problem search, detail views, validation, error handling, and filter utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->