### PR TITLE
[Entity-Service] Make x-user-id-token optional for ServiceNow-backed requests

### DIFF
--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -41,10 +41,8 @@ type SNUserService interface {
 	// error indicates an infrastructure failure.
 	SearchUsers(ctx context.Context, req domain.SearchUsersRequest) (domain.SearchSNUsersResponse, error)
 	// GetMe returns the profile of the currently authenticated user from ServiceNow.
-	// An UnauthorizedError is returned when x-user-id-token is absent.
 	GetMe(ctx context.Context) (domain.GetUserMeResponse, error)
 	// PatchMe updates mutable fields on the currently authenticated user in ServiceNow.
-	// An UnauthorizedError is returned when x-user-id-token is absent.
 	PatchMe(ctx context.Context, req domain.PatchUserMeRequest) (domain.PatchUserMeResponse, error)
 }
 
@@ -62,10 +60,9 @@ type AccountService interface {
 // SNAccountService defines the account operations backed by the ServiceNow data source.
 type SNAccountService interface {
 	// SearchAccounts returns a paginated list of ServiceNow accounts matching the
-	// filters in req. An UnauthorizedError is returned when x-user-id-token is absent.
+	// filters in req.
 	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchSNAccountsResponse, error)
 	// GetAccountByID returns the full account detail for the given UUID.
-	// An UnauthorizedError is returned when x-user-id-token is absent.
 	GetAccountByID(ctx context.Context, id string) (domain.SNAccountDetail, error)
 }
 
@@ -85,8 +82,8 @@ type ProjectService interface {
 type ProjectUpdateService interface {
 	// UpdateProject applies the given field changes to the project identified by
 	// id. A ValidationError is returned for a malformed UUID or an empty request;
-	// a NotFoundError if no project matches; an UnauthorizedError when
-	// x-user-id-token is absent or the caller lacks the required SN role.
+	// a NotFoundError if no project matches; an UnauthorizedError if the caller
+	// lacks the required SN role.
 	UpdateProject(ctx context.Context, id string, req domain.ProjectUpdateRequest) (domain.ProjectUpdateResponse, error)
 }
 
@@ -94,8 +91,7 @@ type ProjectUpdateService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type ProjectContactService interface {
 	// SearchProjectContacts returns a paginated list of contacts associated with
-	// the project identified by projectID. An UnauthorizedError is returned when
-	// x-user-id-token is absent.
+	// the project identified by projectID.
 	SearchProjectContacts(ctx context.Context, projectID string, req domain.SearchProjectContactsRequest) (domain.SearchProjectContactsResponse, error)
 }
 
@@ -103,8 +99,7 @@ type ProjectContactService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type AccountContactService interface {
 	// SearchAccountContacts returns a paginated list of contacts associated with
-	// the account identified by accountID. An UnauthorizedError is returned when
-	// x-user-id-token is absent.
+	// the account identified by accountID.
 	SearchAccountContacts(ctx context.Context, accountID string, req domain.SearchAccountContactsRequest) (domain.SearchAccountContactsResponse, error)
 }
 
@@ -119,7 +114,7 @@ type ProductService interface {
 // SNProductService defines the product operations backed by the ServiceNow data source.
 type SNProductService interface {
 	// SearchProducts returns a paginated list of ServiceNow products matching the
-	// search query. An UnauthorizedError is returned when x-user-id-token is absent.
+	// search query.
 	SearchProducts(ctx context.Context, req domain.SearchProductsRequest) (domain.SearchSNProductsResponse, error)
 }
 
@@ -284,7 +279,7 @@ type TimeCardService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type ConfigurationItemService interface {
 	// SearchConfigurationItems returns a paginated list of CMDB configuration items filtered by
-	// optional search query. An UnauthorizedError is returned when x-user-id-token is absent.
+	// optional search query.
 	SearchConfigurationItems(ctx context.Context, req domain.SearchConfigurationItemsRequest) (domain.SearchConfigurationItemsResponse, error)
 }
 
@@ -292,7 +287,6 @@ type ConfigurationItemService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type GroupService interface {
 	// SearchGroups returns a paginated list of groups filtered by optional search query.
-	// An UnauthorizedError is returned when x-user-id-token is absent.
 	SearchGroups(ctx context.Context, req domain.SearchGroupsRequest) (domain.SearchGroupsResponse, error)
 }
 
@@ -300,7 +294,7 @@ type GroupService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type ServiceOfferingService interface {
 	// SearchServiceOfferings returns a paginated list of service offerings filtered by
-	// optional service IDs. An UnauthorizedError is returned when x-user-id-token is absent.
+	// optional service IDs.
 	SearchServiceOfferings(ctx context.Context, req domain.SearchServiceOfferingsRequest) (domain.SearchServiceOfferingsResponse, error)
 }
 
@@ -308,7 +302,6 @@ type ServiceOfferingService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type ITServiceService interface {
 	// SearchITServices returns a paginated list of CMDB services from ServiceNow.
-	// An UnauthorizedError is returned when x-user-id-token is absent.
 	SearchITServices(ctx context.Context, req domain.SearchITServicesRequest) (domain.SearchITServicesResponse, error)
 }
 
@@ -317,7 +310,6 @@ type ITServiceService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type CommentService interface {
 	// SearchComments returns a paginated list of comments for the given reference entity.
-	// An UnauthorizedError is returned when x-user-id-token is absent.
 	SearchComments(ctx context.Context, req domain.SearchCommentsRequest) (domain.SearchCommentsResponse, error)
 }
 
@@ -325,7 +317,6 @@ type CommentService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type TaskSlaService interface {
 	// SearchTaskSlas returns a paginated list of task SLA records filtered by optional task IDs.
-	// An UnauthorizedError is returned when x-user-id-token is absent.
 	SearchTaskSlas(ctx context.Context, req domain.SearchTaskSlasRequest) (domain.SearchTaskSlasResponse, error)
 	// GetTaskSla returns the full detail of a single task SLA record by its UUID.
 	// A NotFoundError is returned if the record does not exist.
@@ -336,8 +327,7 @@ type TaskSlaService interface {
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type TaskService interface {
 	// SearchCaseTasks returns a paginated list of tasks for the case identified by
-	// caseID. A ValidationError is returned for invalid input (e.g. malformed UUID);
-	// an UnauthorizedError is returned when x-user-id-token is absent.
+	// caseID. A ValidationError is returned for invalid input (e.g. malformed UUID).
 	SearchCaseTasks(ctx context.Context, caseID string, req domain.SearchCaseTasksRequest) (domain.SearchCaseTasksResponse, error)
 	// GetTask returns the full detail of a single task by its UUID.
 	// A NotFoundError is returned if the task does not exist.

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -95,9 +94,6 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchSNAccountsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snAccountSearchPayload{
 		Filters: snAccountFilters{
@@ -139,9 +135,6 @@ func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domai
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SNAccountDetail{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	raw, err := s.client.Get(ctx, "/accounts/"+uuidToSysid(id), token)
 	if err != nil {
@@ -270,9 +263,6 @@ func (s *snAccountContactService) SearchAccountContacts(ctx context.Context, acc
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchAccountContactsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snContactSearchPayload{
 		Filters:    snContactFilters{SearchQuery: req.Filters.SearchQuery},

--- a/entity-service/internal/service/sn_call_request_service.go
+++ b/entity-service/internal/service/sn_call_request_service.go
@@ -201,9 +201,6 @@ func NewServiceNowCallRequestService(client *integrationservice.Client) CallRequ
 // CreateCallRequest implements CallRequestService.
 func (s *snCallRequestService) CreateCallRequest(ctx context.Context, req domain.CreateCallRequestRequest) (domain.CreateCallRequestResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateCallRequestResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if req.CaseID == "" {
 		return domain.CreateCallRequestResponse{}, &apierror.ValidationError{Msg: "caseId is required"}
@@ -253,9 +250,6 @@ func (s *snCallRequestService) SearchCallRequests(ctx context.Context, req domai
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchCallRequestsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if req.CaseID == "" {
 		return domain.SearchCallRequestsResponse{}, &apierror.ValidationError{Msg: "caseId is required"}
@@ -329,9 +323,6 @@ func (s *snCallRequestService) SearchCallRequests(ctx context.Context, req domai
 // UpdateCallRequest implements CallRequestService.
 func (s *snCallRequestService) UpdateCallRequest(ctx context.Context, req domain.UpdateCallRequestRequest) (domain.UpdateCallRequestResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.UpdateCallRequestResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCallRequestResponse{}, err

--- a/entity-service/internal/service/sn_call_request_service_test.go
+++ b/entity-service/internal/service/sn_call_request_service_test.go
@@ -56,12 +56,6 @@ func TestSNCallRequestService_UpdateCallRequest_Validation(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "missing token",
-			ctx:     context.Background(),
-			req:     domain.UpdateCallRequestRequest{ID: validID, State: domain.CallRequestStateScheduled},
-			wantErr: &apierror.UnauthorizedError{},
-		},
-		{
 			name:    "invalid id format",
 			ctx:     contextWithUserIDToken("token"),
 			req:     domain.UpdateCallRequestRequest{ID: "not-a-uuid", State: domain.CallRequestStateScheduled},

--- a/entity-service/internal/service/sn_case_github_issue_service.go
+++ b/entity-service/internal/service/sn_case_github_issue_service.go
@@ -76,9 +76,6 @@ func NewServiceNowCaseGithubIssueService(client *integrationservice.Client) Case
 // CreateCaseGithubIssue implements CaseGithubIssueService.
 func (s *snCaseGithubIssueService) CreateCaseGithubIssue(ctx context.Context, req domain.CreateCaseGithubIssueRequest) (domain.CreateCaseGithubIssueResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateCaseGithubIssueResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if req.CaseID == "" {
 		return domain.CreateCaseGithubIssueResponse{}, &apierror.ValidationError{Msg: "case ID is required"}

--- a/entity-service/internal/service/sn_case_github_issue_service_test.go
+++ b/entity-service/internal/service/sn_case_github_issue_service_test.go
@@ -52,17 +52,6 @@ func TestSNCaseGithubIssueService_CreateCaseGithubIssue_Validation(t *testing.T)
 		wantErr any // pointer type to assert via errors.As-style type switch below
 	}{
 		{
-			name: "missing token",
-			ctx:  context.Background(),
-			req: domain.CreateCaseGithubIssueRequest{
-				CaseID:      validCaseID,
-				Reason:      domain.CaseGithubIssueReasonDefault,
-				Title:       "t",
-				Description: "d",
-			},
-			wantErr: &apierror.UnauthorizedError{},
-		},
-		{
 			name: "empty case ID",
 			ctx:  contextWithUserIDToken("token"),
 			req: domain.CreateCaseGithubIssueRequest{
@@ -160,10 +149,6 @@ func TestSNCaseGithubIssueService_CreateCaseGithubIssue_Validation(t *testing.T)
 				t.Fatalf("expected error, got nil")
 			}
 			switch tt.wantErr.(type) {
-			case *apierror.UnauthorizedError:
-				if _, ok := err.(*apierror.UnauthorizedError); !ok {
-					t.Fatalf("expected *apierror.UnauthorizedError, got %T: %v", err, err)
-				}
 			case *apierror.ValidationError:
 				if _, ok := err.(*apierror.ValidationError); !ok {
 					t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -367,9 +367,6 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	snType, ok := snCaseTypeMap[req.Type]
 	if !ok {
@@ -481,9 +478,6 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 
 func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.CaseView, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CaseView{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	raw, err := s.client.Get(ctx, "/cases/"+uuidToSysid(id), token)
 	if err != nil {
@@ -628,9 +622,6 @@ func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.Create
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateCaseCommentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	snType := snCommentTypeMap[req.Type]
 
@@ -714,9 +705,6 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchCaseCommentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snSearchCommentsPayload{
 		ReferenceID:   uuidToSysid(req.CaseID),
@@ -791,7 +779,7 @@ type snUpdateCasePayload struct {
 	WorkStateKey   *int     `json:"workStateKey,omitempty"`
 	WatchList      []string `json:"watchList,omitempty"`
 	AssigneeEmail  *string  `json:"assigneeEmail,omitempty"`
-	ResolutionCode *int    `json:"resolutionCode,omitempty"`
+	ResolutionCode *int     `json:"resolutionCode,omitempty"`
 	Cause          *string  `json:"cause,omitempty"`
 	CloseNotes     *string  `json:"closeNotes,omitempty"`
 }
@@ -890,13 +878,13 @@ var snWorkStateIDMap = map[domain.CaseWorkState]int{
 type snUpdateCaseResponse struct {
 	Message string `json:"message"`
 	Case    struct {
-		ID             string       `json:"id"`
-		UpdatedOn      string       `json:"updatedOn"`
-		UpdatedBy      string       `json:"updatedBy"`
-		State          *snCaseState `json:"state"`
-		Severity       *snCaseLabel `json:"severity"`
-		WorkState      *snCaseLabel `json:"workState"`
-		WatchList      []struct {
+		ID        string       `json:"id"`
+		UpdatedOn string       `json:"updatedOn"`
+		UpdatedBy string       `json:"updatedBy"`
+		State     *snCaseState `json:"state"`
+		Severity  *snCaseLabel `json:"severity"`
+		WorkState *snCaseLabel `json:"workState"`
+		WatchList []struct {
 			ID       string `json:"id"`
 			UserName string `json:"userName"`
 			Name     string `json:"name"`
@@ -953,9 +941,6 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.UpdateCaseResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snUpdateCasePayload{}
 	if req.State != nil {
@@ -1151,9 +1136,6 @@ func (s *snCaseService) CreateCaseAttachment(ctx context.Context, req domain.Cre
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateAttachmentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
 		return domain.CreateAttachmentResponse{}, err
@@ -1237,9 +1219,6 @@ func (s *snCaseService) SearchCaseAttachments(ctx context.Context, req domain.Se
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchAttachmentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
 		return domain.SearchAttachmentsResponse{}, err
@@ -1337,9 +1316,6 @@ func (s *snCaseService) SearchCaseActivities(ctx context.Context, req domain.Sea
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchCaseActivitiesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{req.CaseID}); err != nil {
 		return domain.SearchCaseActivitiesResponse{}, err
@@ -1422,9 +1398,6 @@ func (s *snCaseService) SearchCaseActivities(ctx context.Context, req domain.Sea
 
 func (s *snCaseService) GetCaseAttachmentContent(ctx context.Context, attachmentID string) ([]byte, string, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return nil, "", &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	resp, err := s.client.GetBinary(ctx, "/attachments/"+uuidToSysid(attachmentID)+"/content", token)
 	if err != nil {
@@ -1436,9 +1409,6 @@ func (s *snCaseService) GetCaseAttachmentContent(ctx context.Context, attachment
 
 func (s *snCaseService) DeleteCaseAttachment(ctx context.Context, req domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.DeleteAttachmentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	raw, err := s.client.Delete(ctx, "/attachments/"+uuidToSysid(req.AttachmentID), token)
 	if err != nil {
@@ -1487,9 +1457,6 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchCasesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var snSortBy *snCaseSort
 	if req.SortBy.Field != "" {

--- a/entity-service/internal/service/sn_catalog_service.go
+++ b/entity-service/internal/service/sn_catalog_service.go
@@ -88,9 +88,6 @@ func (s *snCatalogService) SearchCatalogs(ctx context.Context, req domain.Search
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchCatalogsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snSearchCatalogsPayload{
 		DeployedProductID: uuidToSysid(req.DeployedProductID),
@@ -146,9 +143,6 @@ func (s *snCatalogService) GetCatalogItemVariables(ctx context.Context, catalogI
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.GetCatalogItemVariablesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	path := "/catalogs/" + uuidToSysid(catalogID) + "/items/" + uuidToSysid(catalogItemID) + "/variables"
 	raw, err := s.client.Get(ctx, path, token)

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -268,9 +268,6 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchChangeRequestsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var snSortBy *snCRSort
 	if req.SortBy.Field != "" {
@@ -516,9 +513,6 @@ func (s *snChangeRequestService) CreateChangeRequest(ctx context.Context, req do
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateChangeRequestResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snCreateChangeRequestPayload{
 		Subject:            req.Subject,
@@ -642,9 +636,6 @@ type snPatchChangeRequestResponse struct {
 
 func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id string, req domain.PatchChangeRequestRequest) (domain.PatchChangeRequestResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.PatchChangeRequestResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.PatchChangeRequestResponse{}, err
@@ -784,9 +775,6 @@ type snChangeRequestDetail struct {
 
 func (s *snChangeRequestService) GetChangeRequest(ctx context.Context, id string) (domain.ChangeRequest, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.ChangeRequest{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.ChangeRequest{}, err
@@ -829,9 +817,6 @@ type snChangeRequestApprover struct {
 // single change request identified by UUID.
 func (s *snChangeRequestService) GetChangeRequestApprovals(ctx context.Context, id string) (domain.ChangeRequestApprovals, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.ChangeRequestApprovals{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.ChangeRequestApprovals{}, err

--- a/entity-service/internal/service/sn_comment_service.go
+++ b/entity-service/internal/service/sn_comment_service.go
@@ -51,9 +51,6 @@ func (s *snCommentSearchService) SearchComments(ctx context.Context, req domain.
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchCommentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snSearchCommentsPayload{
 		ReferenceID:   uuidToSysid(req.ReferenceID),

--- a/entity-service/internal/service/sn_configuration_item_service.go
+++ b/entity-service/internal/service/sn_configuration_item_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -68,9 +67,6 @@ func (s *snConfigurationItemService) SearchConfigurationItems(ctx context.Contex
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchConfigurationItemsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var filters snConfigurationItemFilters
 	if req.Filters != nil {

--- a/entity-service/internal/service/sn_conversation_service.go
+++ b/entity-service/internal/service/sn_conversation_service.go
@@ -157,9 +157,6 @@ func (s *snConversationService) SearchConversations(ctx context.Context, req dom
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchConversationsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var snSortBy *snConversationSort
 	if req.SortBy.Field != "" {

--- a/entity-service/internal/service/sn_deployed_product_service.go
+++ b/entity-service/internal/service/sn_deployed_product_service.go
@@ -133,9 +133,6 @@ func (s *snDeployedProductService) CreateDeployedProduct(ctx context.Context, re
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateDeployedProductResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snCreateDeployedProductPayload{
 		ProjectID:    uuidToSysid(req.ProjectID),
@@ -195,9 +192,6 @@ func (s *snDeployedProductService) UpdateDeployedProduct(ctx context.Context, re
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.UpdateDeployedProductResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	// When deploymentId is provided, verify the product belongs to that deployment
 	// before mutating it to prevent cross-deployment modification (IDOR).
@@ -277,9 +271,6 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchDeployedProductsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snDeployedProductSearchPayload{
 		Filters:    snDeployedProductFilters{DeploymentIDs: uuidsToSysids(req.DeploymentIDs)},

--- a/entity-service/internal/service/sn_deployment_service.go
+++ b/entity-service/internal/service/sn_deployment_service.go
@@ -59,8 +59,8 @@ type snDeployType struct {
 
 // snDeploymentSearchPayload is the Choreo POST /deployments/search request body.
 type snDeploymentSearchPayload struct {
-	Filters    snDeploymentFilters    `json:"filters"`
-	Pagination snProjectPagination    `json:"pagination"`
+	Filters    snDeploymentFilters `json:"filters"`
+	Pagination snProjectPagination `json:"pagination"`
 }
 
 type snDeploymentFilters struct {
@@ -87,9 +87,6 @@ func (s *snDeploymentService) SearchDeployments(ctx context.Context, req domain.
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchDeploymentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snDeploymentSearchPayload{
 		Filters: snDeploymentFilters{
@@ -181,9 +178,6 @@ func (s *snDeploymentService) CreateDeployment(ctx context.Context, req domain.C
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateDeploymentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snCreateDeploymentPayload{
 		ProjectID:   uuidToSysid(req.ProjectID),
@@ -259,9 +253,6 @@ func (s *snDeploymentService) UpdateDeployment(ctx context.Context, req domain.U
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.UpdateDeploymentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snUpdateDeploymentPayload{
 		Name:   req.Name,

--- a/entity-service/internal/service/sn_group_service.go
+++ b/entity-service/internal/service/sn_group_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -73,9 +72,6 @@ func (s *snGroupService) SearchGroups(ctx context.Context, req domain.SearchGrou
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchGroupsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var filters snGroupFilters
 	if req.Filters != nil {

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -190,9 +190,6 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchIncidentsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var snSortBy *snIncidentSort
 	if req.SortBy.Field != "" {
@@ -532,9 +529,6 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.CreateIncidentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snCreateIncidentPayload{
 		CallerID:           uuidToSysid(req.CallerID),
@@ -729,9 +723,6 @@ func (s *snIncidentService) GetIncidentByID(ctx context.Context, id string) (dom
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.IncidentView{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	raw, err := s.client.Get(ctx, "/incidents/"+uuidToSysid(id), token)
 	if err != nil {
@@ -951,9 +942,6 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.UpdateIncidentResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snUpdateIncidentPayload{
 		Subject:            req.Subject,

--- a/entity-service/internal/service/sn_it_service_service.go
+++ b/entity-service/internal/service/sn_it_service_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -74,9 +73,6 @@ func (s *snITServiceService) SearchITServices(ctx context.Context, req domain.Se
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchITServicesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var filters snITServiceFilters
 	if req.Filters != nil {

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -69,9 +68,6 @@ func (s *snProblemService) SearchProblems(ctx context.Context, req domain.Search
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchProblemsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snProblemSearchPayload{
 		Filters:    snProblemFilters{SearchQuery: req.Filters.SearchQuery},
@@ -149,9 +145,6 @@ type snProblemDetailResponse struct {
 // GetProblem implements ProblemService for the ServiceNow data source.
 func (s *snProblemService) GetProblem(ctx context.Context, id string) (domain.ProblemDetail, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.ProblemDetail{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.ProblemDetail{}, err

--- a/entity-service/internal/service/sn_product_service.go
+++ b/entity-service/internal/service/sn_product_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -69,9 +68,6 @@ func (s *snProductService) SearchProducts(ctx context.Context, req domain.Search
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchSNProductsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snProductSearchPayload{
 		Filters:    snProductFilters{SearchQuery: req.SearchQuery},

--- a/entity-service/internal/service/sn_product_version_service.go
+++ b/entity-service/internal/service/sn_product_version_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -72,9 +71,6 @@ func (s *snProductVersionService) SearchProductVersions(ctx context.Context, req
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchSNProductVersionsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	productSysid := uuidToSysid(req.ProductID)
 	path := fmt.Sprintf("/products/%s/versions/search", productSysid)

--- a/entity-service/internal/service/sn_product_vulnerability_service.go
+++ b/entity-service/internal/service/sn_product_vulnerability_service.go
@@ -91,7 +91,6 @@ type snChoiceListItem struct {
 	Label string `json:"label"`
 }
 
-
 func snVulnerabilityToView(v snVulnerability) domain.ProductVulnerabilityView {
 	return domain.ProductVulnerabilityView{
 		ID:              sysidToUUID(v.ID),
@@ -126,9 +125,6 @@ func (s *snProductVulnerabilityService) SearchProductVulnerabilities(ctx context
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchProductVulnerabilitiesResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snVulnerabilitySearchPayload{
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
@@ -172,9 +168,6 @@ func (s *snProductVulnerabilityService) SearchProductVulnerabilities(ctx context
 
 func (s *snProductVulnerabilityService) GetProductVulnerability(ctx context.Context, id string) (domain.ProductVulnerabilityView, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.ProductVulnerabilityView{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.ProductVulnerabilityView{}, err
@@ -192,4 +185,3 @@ func (s *snProductVulnerabilityService) GetProductVulnerability(ctx context.Cont
 
 	return snVulnerabilityToView(v), nil
 }
-

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -114,9 +114,6 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchProjectsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snSearchProjectsPayload{
 		Filters: snProjectFilters{
@@ -202,9 +199,6 @@ type snProjectAccount struct {
 // GetProjectByID implements ProjectService by calling the Choreo GET /projects/{id} endpoint.
 func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domain.ProjectDetailsView, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.ProjectDetailsView{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	raw, err := s.client.Get(ctx, "/projects/"+uuidToSysid(id), token)
 	if err != nil {
@@ -328,9 +322,6 @@ func (s *snProjectUpdateService) UpdateProject(ctx context.Context, id string, r
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.ProjectUpdateResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snProjectUpdatePayload{
 		HasAgent:                        req.HasAgent,
@@ -488,9 +479,6 @@ func (s *snProjectContactService) SearchProjectContacts(ctx context.Context, pro
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchProjectContactsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	payload := snContactSearchPayload{
 		Filters:    snContactFilters{SearchQuery: req.Filters.SearchQuery},

--- a/entity-service/internal/service/sn_service_offering_service.go
+++ b/entity-service/internal/service/sn_service_offering_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -73,9 +72,6 @@ func (s *snServiceOfferingService) SearchServiceOfferings(ctx context.Context, r
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchServiceOfferingsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var filters snServiceOfferingFilters
 	if req.Filters != nil {

--- a/entity-service/internal/service/sn_task_service.go
+++ b/entity-service/internal/service/sn_task_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -111,9 +110,6 @@ func NewServiceNowTaskService(client *integrationservice.Client) TaskService {
 
 func (s *snTaskService) SearchCaseTasks(ctx context.Context, caseID string, req domain.SearchCaseTasksRequest) (domain.SearchCaseTasksResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchCaseTasksResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{caseID}); err != nil {
 		return domain.SearchCaseTasksResponse{}, err
@@ -165,9 +161,6 @@ func (s *snTaskService) SearchCaseTasks(ctx context.Context, caseID string, req 
 
 func (s *snTaskService) GetTask(ctx context.Context, id string) (domain.TaskDetail, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.TaskDetail{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.TaskDetail{}, err

--- a/entity-service/internal/service/sn_task_sla_service.go
+++ b/entity-service/internal/service/sn_task_sla_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -74,17 +73,17 @@ type snTaskSlaStage struct {
 }
 
 type snTaskSlaDetail struct {
-	ID                        string                    `json:"id"`
-	Task                      *snTaskSlaTaskRef         `json:"task"`
+	ID                        string                     `json:"id"`
+	Task                      *snTaskSlaTaskRef          `json:"task"`
 	SlaDefinition             *snTaskSlaDefinitionDetail `json:"slaDefinition"`
-	Stage                     *snTaskSlaStage           `json:"stage"`
-	BusinessTimeLeft          *string                   `json:"businessTimeLeft"`
-	BusinessElapsedTime       *string                   `json:"businessElapsedTime"`
-	BusinessElapsedPercentage *float64                  `json:"businessElapsedPercentage"`
-	StartTime                 *string                   `json:"startTime"`
-	EndTime                   *string                   `json:"endTime"`
-	Active                    *bool                     `json:"active"`
-	Schedule                  *snTaskSlaScheduleRef     `json:"schedule"`
+	Stage                     *snTaskSlaStage            `json:"stage"`
+	BusinessTimeLeft          *string                    `json:"businessTimeLeft"`
+	BusinessElapsedTime       *string                    `json:"businessElapsedTime"`
+	BusinessElapsedPercentage *float64                   `json:"businessElapsedPercentage"`
+	StartTime                 *string                    `json:"startTime"`
+	EndTime                   *string                    `json:"endTime"`
+	Active                    *bool                      `json:"active"`
+	Schedule                  *snTaskSlaScheduleRef      `json:"schedule"`
 }
 
 type snTaskSlaDefinitionDetail struct {
@@ -195,28 +194,28 @@ func snTaskSlaToDetailView(t snTaskSlaDetail) domain.TaskSlaDetail {
 
 	if t.SlaDefinition != nil {
 		def := &domain.TaskSlaDefinitionDetail{
-			Name:             t.SlaDefinition.Name,
-			Type:             t.SlaDefinition.Type,
-			Target:           t.SlaDefinition.Target,
-			Flow:             t.SlaDefinition.Flow,
-			Workflow:         t.SlaDefinition.Workflow,
-			IsEnableLogging:  t.SlaDefinition.EnableLogging,
-			DurationType:     t.SlaDefinition.DurationType,
-			Duration:         t.SlaDefinition.Duration,
-			ScheduleSource:   t.SlaDefinition.ScheduleSource,
-			Schedule:         t.SlaDefinition.Schedule,
-			TimezoneSource:   t.SlaDefinition.TimezoneSource,
-			Timezone:         t.SlaDefinition.Timezone,
-			StartCondition:   t.SlaDefinition.StartCondition,
+			Name:               t.SlaDefinition.Name,
+			Type:               t.SlaDefinition.Type,
+			Target:             t.SlaDefinition.Target,
+			Flow:               t.SlaDefinition.Flow,
+			Workflow:           t.SlaDefinition.Workflow,
+			IsEnableLogging:    t.SlaDefinition.EnableLogging,
+			DurationType:       t.SlaDefinition.DurationType,
+			Duration:           t.SlaDefinition.Duration,
+			ScheduleSource:     t.SlaDefinition.ScheduleSource,
+			Schedule:           t.SlaDefinition.Schedule,
+			TimezoneSource:     t.SlaDefinition.TimezoneSource,
+			Timezone:           t.SlaDefinition.Timezone,
+			StartCondition:     t.SlaDefinition.StartCondition,
 			IsRetroactiveStart: t.SlaDefinition.RetroactiveStart,
 			IsRetroactivePause: t.SlaDefinition.RetroactivePause,
-			WhenToCancel:     t.SlaDefinition.WhenToCancel,
-			CancelCondition:  t.SlaDefinition.CancelCondition,
-			PauseCondition:   t.SlaDefinition.PauseCondition,
-			WhenToResume:     t.SlaDefinition.WhenToResume,
-			StopCondition:    t.SlaDefinition.StopCondition,
-			ResetCondition:   t.SlaDefinition.ResetCondition,
-			ResetAction:      t.SlaDefinition.ResetAction,
+			WhenToCancel:       t.SlaDefinition.WhenToCancel,
+			CancelCondition:    t.SlaDefinition.CancelCondition,
+			PauseCondition:     t.SlaDefinition.PauseCondition,
+			WhenToResume:       t.SlaDefinition.WhenToResume,
+			StopCondition:      t.SlaDefinition.StopCondition,
+			ResetCondition:     t.SlaDefinition.ResetCondition,
+			ResetAction:        t.SlaDefinition.ResetAction,
 		}
 		if t.SlaDefinition.ID != nil {
 			id := sysidToUUID(*t.SlaDefinition.ID)
@@ -246,9 +245,6 @@ func snTaskSlaToDetailView(t snTaskSlaDetail) domain.TaskSlaDetail {
 
 func (s *snTaskSlaService) GetTaskSla(ctx context.Context, id string) (domain.TaskSlaDetail, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.TaskSlaDetail{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.TaskSlaDetail{}, err
@@ -269,9 +265,6 @@ func (s *snTaskSlaService) GetTaskSla(ctx context.Context, id string) (domain.Ta
 
 func (s *snTaskSlaService) SearchTaskSlas(ctx context.Context, req domain.SearchTaskSlasRequest) (domain.SearchTaskSlasResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchTaskSlasResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchTaskSlasResponse{}, err

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -199,9 +199,6 @@ func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.Sear
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchTimeCardsResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	var snSortBy *snTimeCardSort
 	if req.SortBy.Field != "" {
@@ -369,9 +366,6 @@ func nonNegativeMinutes(field string, v int) error {
 
 func (s *snTimeCardService) CreateTimeCard(ctx context.Context, req domain.CreateTimeCardRequest) (domain.TimeCardMutationResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.TimeCardMutationResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if req.CaseID == "" {
 		return domain.TimeCardMutationResponse{}, &apierror.ValidationError{Msg: "caseId is required"}
@@ -432,9 +426,6 @@ func (s *snTimeCardService) CreateTimeCard(ctx context.Context, req domain.Creat
 
 func (s *snTimeCardService) UpdateTimeCard(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardMutationResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.TimeCardMutationResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.TimeCardMutationResponse{}, err
 	}

--- a/entity-service/internal/service/sn_user_service.go
+++ b/entity-service/internal/service/sn_user_service.go
@@ -159,9 +159,6 @@ func (s *snUserService) SearchUsers(ctx context.Context, req domain.SearchUsersR
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.SearchSNUsersResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	roles := make([]string, len(req.Filters.Roles))
 	for i, r := range req.Filters.Roles {
@@ -228,9 +225,6 @@ func (s *snUserService) SearchUsers(ctx context.Context, req domain.SearchUsersR
 
 func (s *snUserService) GetMe(ctx context.Context) (domain.GetUserMeResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.GetUserMeResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	raw, err := s.client.Get(ctx, "/users/me", token)
 	if err != nil {
@@ -259,9 +253,6 @@ func (s *snUserService) GetMe(ctx context.Context) (domain.GetUserMeResponse, er
 
 func (s *snUserService) PatchMe(ctx context.Context, req domain.PatchUserMeRequest) (domain.PatchUserMeResponse, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
-	if token == "" {
-		return domain.PatchUserMeResponse{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
-	}
 
 	if req.TimeZone == "" {
 		return domain.PatchUserMeResponse{}, &apierror.ValidationError{Msg: "timeZone is required"}

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -151,7 +151,9 @@ func (c *Client) Get(ctx context.Context, path string, userIDToken string) (json
 		return nil, fmt.Errorf("snclient: build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("x-user-id-token", userIDToken)
+	if userIDToken != "" {
+		req.Header.Set("x-user-id-token", userIDToken)
+	}
 
 	return c.do(req, path)
 }
@@ -176,7 +178,9 @@ func (c *Client) GetBinary(ctx context.Context, path string, userIDToken string)
 		return BinaryResponse{}, fmt.Errorf("snclient: build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("x-user-id-token", userIDToken)
+	if userIDToken != "" {
+		req.Header.Set("x-user-id-token", userIDToken)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -236,7 +240,9 @@ func (c *Client) Patch(ctx context.Context, path string, userIDToken string, pay
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("x-user-id-token", userIDToken)
+	if userIDToken != "" {
+		req.Header.Set("x-user-id-token", userIDToken)
+	}
 
 	return c.do(req, path)
 }
@@ -255,7 +261,9 @@ func (c *Client) Delete(ctx context.Context, path string, userIDToken string) (j
 		return nil, fmt.Errorf("snclient: build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("x-user-id-token", userIDToken)
+	if userIDToken != "" {
+		req.Header.Set("x-user-id-token", userIDToken)
+	}
 
 	return c.do(req, path)
 }
@@ -280,7 +288,9 @@ func (c *Client) Post(ctx context.Context, path string, userIDToken string, payl
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("x-user-id-token", userIDToken)
+	if userIDToken != "" {
+		req.Header.Set("x-user-id-token", userIDToken)
+	}
 
 	return c.do(req, path)
 }


### PR DESCRIPTION
## Summary
- Entity service's ServiceNow-backed (`sn_*`) service methods previously returned a 401 whenever `x-user-id-token` was absent, before the request ever reached the ServiceNow integration client.
- Removed that guard across all `sn_*_service.go` files so requests without the header are still forwarded downstream, rather than rejected in entity-service.
- Updated `internal/servicenow-integration-service/client.go` so the outgoing `x-user-id-token` header is only set when the token is non-empty, instead of always forwarding it (even blank).
- Left `case_service.go`'s token checks untouched — those decode the JWT to derive `CreatedBy`'s email for Postgres-backed case/comment creation and are unrelated to SN forwarding.
- Cleaned up stale doc comments in `interfaces.go` that claimed an `UnauthorizedError` is always returned when the header is absent.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gosec -fmt=text ./...` (0 issues)
- [x] Updated existing unit tests that asserted the old "missing token → 401" contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests without a user identity token are no longer rejected prematurely across entity, case, task, project, and ServiceNow-related operations.
  * Empty identity-token headers are omitted from downstream requests, allowing authentication handling to occur consistently by the receiving service.
  * Existing request validation and downstream authorization behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->