### PR TITLE
[CSM Portal Microapp] Implement the Engagements page

### DIFF
--- a/apps/csm-portal/microapp/src/components/engagements/EngagementFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/engagements/EngagementFiltersSheet.tsx
@@ -27,18 +27,22 @@ import {
   IconButton,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { X } from "@wso2/oxygen-ui-icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { projects } from "@src/services/projects";
-import type { CaseState, EngagementType, Project } from "@src/types";
-import { FILTERABLE_STATES, STATE_LABELS } from "@components/support/config";
+import { adminUsers } from "@src/services/adminUsers";
+import { products } from "@src/services/products";
+import type { CaseState, CaseWorkState, EngagementType, Project } from "@src/types";
+import { ALL_WORK_STATES, FILTERABLE_STATES, STATE_LABELS, WORK_STATE_LABEL } from "@components/support/config";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
 import {
   ALL_ENGAGEMENT_TYPES,
   EMPTY_ENGAGEMENT_FILTERS,
   ENGAGEMENT_TYPE_LABEL,
+  type EngagementAssignee,
   type EngagementFilters,
 } from "@utils/engagements";
 
@@ -47,6 +51,13 @@ import {
 const OPAQUE_POPUP = { sx: { backgroundColor: "background.default", backgroundImage: "none" } };
 
 function toggleState(list: CaseState[], value: CaseState): CaseState[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+function toggleWorkState(
+  list: NonNullable<CaseWorkState>[],
+  value: NonNullable<CaseWorkState>,
+): NonNullable<CaseWorkState>[] {
   return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
 }
 
@@ -85,6 +96,69 @@ function ProjectMultiSelect({ value, onChange }: { value: Project[]; onChange: (
   );
 }
 
+// Async, type-to-search multi-select of engineers (server-side `assignedUserIds`).
+// Reuses adminUsers.search's internal-roles scope (LogTimeCardDialog's approver
+// picker) — "engineer" and "eligible approver" are the same directory slice.
+// Requires at least one typed character, same as that picker.
+function AssigneeMultiSelect({
+  value,
+  onChange,
+}: {
+  value: EngagementAssignee[];
+  onChange: (assignees: EngagementAssignee[]) => void;
+}) {
+  const [input, setInput] = useState("");
+  const debounced = useDebouncedValue(input, 300);
+  const { data, isFetching } = useQuery(adminUsers.search(debounced.trim()));
+
+  const options = useMemo(() => {
+    const results = data?.users ?? [];
+    return [...value, ...results.filter((r) => !value.some((v) => v.id === r.id))];
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={options}
+      value={value}
+      loading={isFetching}
+      getOptionLabel={(o) => o.name}
+      isOptionEqualToValue={(a, b) => a.id === b.id}
+      onChange={(_, next) => onChange(next.map((o) => ({ id: o.id, name: o.name })))}
+      onInputChange={(_, next) => setInput(next)}
+      slotProps={{ paper: OPAQUE_POPUP }}
+      renderInput={(params) => <TextField {...params} label="Assignee" size="small" placeholder="Search engineers…" />}
+    />
+  );
+}
+
+// Products are a bounded catalogue, so the distinct family names are fetched
+// once (products.names()) and filtered locally as the user types — mirrors the
+// webapp's ProductNameMultiSelect/useProductNameOptions.
+function ProductMultiSelect({ value, onChange }: { value: string[]; onChange: (names: string[]) => void }) {
+  const { data, isFetching } = useQuery(products.names());
+
+  const options = useMemo(() => {
+    const merged = new Set<string>(data ?? []);
+    value.forEach((v) => merged.add(v));
+    return [...merged].sort((a, b) => a.localeCompare(b));
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={options}
+      value={value}
+      loading={isFetching}
+      onChange={(_, next) => onChange(next)}
+      slotProps={{ paper: OPAQUE_POPUP }}
+      renderInput={(params) => <TextField {...params} label="Product" size="small" />}
+    />
+  );
+}
+
 interface EngagementFiltersSheetProps {
   open: boolean;
   onClose: () => void;
@@ -92,11 +166,13 @@ interface EngagementFiltersSheetProps {
   onApply: (filters: EngagementFilters) => void;
 }
 
-// Mobile bottom-sheet filters for the engagements list: State (multi) + Engagement
-// type (multi) + Project (async multi). Search lives in the always-visible bar on
-// the page, not here. Mirrors the webapp's CsmIssuesView locked to
-// `caseTypes: ["engagement"]` with `showEngagementTypeFilter` — severity is left
-// out entirely, same as there (it's a "case"-only concept).
+// Mobile bottom-sheet filters for the engagements list: State, Work state,
+// Engagement type (all chip multi-selects) + Assignee, Project, Product
+// (async multi-selects). Search lives in the always-visible bar on the page,
+// not here. Mirrors the webapp's CasesFilterBar for a view locked to
+// `caseTypes: ["engagement"]` with `showEngagementTypeFilter` — severity and
+// case type are left out entirely, same as there (severity's a "case"-only
+// concept, and case type is fixed to "engagement" here).
 export function EngagementFiltersSheet({ open, onClose, filters, onApply }: EngagementFiltersSheetProps) {
   const [draft, setDraft] = useState<EngagementFilters>(filters);
 
@@ -106,6 +182,8 @@ export function EngagementFiltersSheet({ open, onClose, filters, onApply }: Enga
     if (open) setDraft(filters);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open, not on every filters identity change
   }, [open]);
+
+  const workInProgressSelected = draft.states.includes("work_in_progress");
 
   return (
     <Dialog
@@ -139,8 +217,47 @@ export function EngagementFiltersSheet({ open, onClose, filters, onApply }: Enga
                     aria-pressed={isSelected}
                     variant={isSelected ? "filled" : "outlined"}
                     color={isSelected ? "primary" : "default"}
-                    onClick={() => setDraft({ ...draft, states: toggleState(draft.states, state) })}
+                    onClick={() => {
+                      const states = toggleState(draft.states, state);
+                      // Work sub-state only applies to work_in_progress cases, so drop any
+                      // selected work states when that state leaves the filter — keeps a
+                      // stale, inert work-state selection from lingering.
+                      setDraft({
+                        ...draft,
+                        states,
+                        workStates: states.includes("work_in_progress") ? draft.workStates : [],
+                      });
+                    }}
                   />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Work state</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {ALL_WORK_STATES.map((workState) => {
+                const isSelected = draft.workStates.includes(workState);
+                const chip = (
+                  <Chip
+                    label={WORK_STATE_LABEL[workState]}
+                    size="small"
+                    aria-pressed={isSelected}
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    disabled={!workInProgressSelected}
+                    onClick={() => setDraft({ ...draft, workStates: toggleWorkState(draft.workStates, workState) })}
+                  />
+                );
+                // Disabled MUI chips don't fire pointer events, so the tooltip needs a
+                // span wrapper to still show on hover/focus.
+                return workInProgressSelected ? (
+                  <span key={workState}>{chip}</span>
+                ) : (
+                  <Tooltip key={workState} title={`Select "${STATE_LABELS.work_in_progress}" to filter by work state`}>
+                    <span>{chip}</span>
+                  </Tooltip>
                 );
               })}
             </Stack>
@@ -168,7 +285,14 @@ export function EngagementFiltersSheet({ open, onClose, filters, onApply }: Enga
             </Stack>
           </Stack>
 
+          <AssigneeMultiSelect value={draft.assignees} onChange={(next) => setDraft({ ...draft, assignees: next })} />
+
           <ProjectMultiSelect value={draft.projects} onChange={(next) => setDraft({ ...draft, projects: next })} />
+
+          <ProductMultiSelect
+            value={draft.productNames}
+            onChange={(next) => setDraft({ ...draft, productNames: next })}
+          />
         </Stack>
       </DialogContent>
 

--- a/apps/csm-portal/microapp/src/components/engagements/EngagementFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/engagements/EngagementFiltersSheet.tsx
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Autocomplete,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { useQuery } from "@tanstack/react-query";
+import { projects } from "@src/services/projects";
+import type { CaseState, EngagementType, Project } from "@src/types";
+import { FILTERABLE_STATES, STATE_LABELS } from "@components/support/config";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import {
+  ALL_ENGAGEMENT_TYPES,
+  EMPTY_ENGAGEMENT_FILTERS,
+  ENGAGEMENT_TYPE_LABEL,
+  type EngagementFilters,
+} from "@utils/engagements";
+
+// The Acrylic theme renders popup papers translucent, so a dropdown that opens
+// over the dialog reads as see-through — force the opaque `background.default`.
+const OPAQUE_POPUP = { sx: { backgroundColor: "background.default", backgroundImage: "none" } };
+
+function toggleState(list: CaseState[], value: CaseState): CaseState[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+function toggleEngagementType(list: EngagementType[], value: EngagementType): EngagementType[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+// Async, type-to-search multi-select of projects (server-side `projectIds`).
+// Mirrors the support ProjectSelect / announcements' own ProjectMultiSelect
+// (debounced 300ms); already-picked projects stay in the option list so their
+// chips keep their labels.
+function ProjectMultiSelect({ value, onChange }: { value: Project[]; onChange: (projects: Project[]) => void }) {
+  const [input, setInput] = useState("");
+  const debounced = useDebouncedValue(input, 300);
+  const { data, isFetching } = useQuery(projects.search(debounced.trim()));
+
+  const options = useMemo(() => {
+    const results = data ?? [];
+    return [...value, ...results.filter((r) => !value.some((v) => v.id === r.id))];
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={options}
+      value={value}
+      loading={isFetching}
+      getOptionLabel={(o) => o.name}
+      isOptionEqualToValue={(a, b) => a.id === b.id}
+      onChange={(_, next) => onChange(next)}
+      onInputChange={(_, next) => setInput(next)}
+      slotProps={{ paper: OPAQUE_POPUP }}
+      renderInput={(params) => <TextField {...params} label="Project" size="small" />}
+    />
+  );
+}
+
+interface EngagementFiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: EngagementFilters;
+  onApply: (filters: EngagementFilters) => void;
+}
+
+// Mobile bottom-sheet filters for the engagements list: State (multi) + Engagement
+// type (multi) + Project (async multi). Search lives in the always-visible bar on
+// the page, not here. Mirrors the webapp's CsmIssuesView locked to
+// `caseTypes: ["engagement"]` with `showEngagementTypeFilter` — severity is left
+// out entirely, same as there (it's a "case"-only concept).
+export function EngagementFiltersSheet({ open, onClose, filters, onApply }: EngagementFiltersSheetProps) {
+  const [draft, setDraft] = useState<EngagementFilters>(filters);
+
+  // Re-seed the draft from the last-applied filters each time the sheet opens, so reopening it
+  // doesn't show stale in-progress edits from a previous open that was dismissed without applying.
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open, not on every filters identity change
+  }, [open]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xs"
+      slotProps={{ paper: { sx: { backgroundImage: "none", backgroundColor: "background.default" } } }}
+    >
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={2.5}>
+          <Stack gap={1}>
+            <Typography variant="subtitle2">State</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {FILTERABLE_STATES.map((state) => {
+                const isSelected = draft.states.includes(state);
+                return (
+                  <Chip
+                    key={state}
+                    label={STATE_LABELS[state] ?? state}
+                    size="small"
+                    aria-pressed={isSelected}
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => setDraft({ ...draft, states: toggleState(draft.states, state) })}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Engagement type</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {ALL_ENGAGEMENT_TYPES.map((type) => {
+                const isSelected = draft.engagementTypes.includes(type);
+                return (
+                  <Chip
+                    key={type}
+                    label={ENGAGEMENT_TYPE_LABEL[type]}
+                    size="small"
+                    aria-pressed={isSelected}
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() =>
+                      setDraft({ ...draft, engagementTypes: toggleEngagementType(draft.engagementTypes, type) })
+                    }
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <ProjectMultiSelect value={draft.projects} onChange={(next) => setDraft({ ...draft, projects: next })} />
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            // Keep the current search text; only the sheet's own filters reset.
+            const cleared = { ...EMPTY_ENGAGEMENT_FILTERS, search: draft.search };
+            setDraft(cleared);
+            onApply(cleared);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/engagements/EngagementFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/engagements/EngagementFiltersSheet.tsx
@@ -35,7 +35,7 @@ import { useQuery } from "@tanstack/react-query";
 import { projects } from "@src/services/projects";
 import { adminUsers } from "@src/services/adminUsers";
 import { products } from "@src/services/products";
-import type { CaseState, CaseWorkState, EngagementType, Project } from "@src/types";
+import type { Project } from "@src/types";
 import { ALL_WORK_STATES, FILTERABLE_STATES, STATE_LABELS, WORK_STATE_LABEL } from "@components/support/config";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
 import {
@@ -50,18 +50,7 @@ import {
 // over the dialog reads as see-through — force the opaque `background.default`.
 const OPAQUE_POPUP = { sx: { backgroundColor: "background.default", backgroundImage: "none" } };
 
-function toggleState(list: CaseState[], value: CaseState): CaseState[] {
-  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
-}
-
-function toggleWorkState(
-  list: NonNullable<CaseWorkState>[],
-  value: NonNullable<CaseWorkState>,
-): NonNullable<CaseWorkState>[] {
-  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
-}
-
-function toggleEngagementType(list: EngagementType[], value: EngagementType): EngagementType[] {
+function toggle<T>(list: T[], value: T): T[] {
   return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
 }
 
@@ -218,7 +207,7 @@ export function EngagementFiltersSheet({ open, onClose, filters, onApply }: Enga
                     variant={isSelected ? "filled" : "outlined"}
                     color={isSelected ? "primary" : "default"}
                     onClick={() => {
-                      const states = toggleState(draft.states, state);
+                      const states = toggle(draft.states, state);
                       // Work sub-state only applies to work_in_progress cases, so drop any
                       // selected work states when that state leaves the filter — keeps a
                       // stale, inert work-state selection from lingering.
@@ -247,7 +236,7 @@ export function EngagementFiltersSheet({ open, onClose, filters, onApply }: Enga
                     variant={isSelected ? "filled" : "outlined"}
                     color={isSelected ? "primary" : "default"}
                     disabled={!workInProgressSelected}
-                    onClick={() => setDraft({ ...draft, workStates: toggleWorkState(draft.workStates, workState) })}
+                    onClick={() => setDraft({ ...draft, workStates: toggle(draft.workStates, workState) })}
                   />
                 );
                 // Disabled MUI chips don't fire pointer events, so the tooltip needs a
@@ -276,9 +265,7 @@ export function EngagementFiltersSheet({ open, onClose, filters, onApply }: Enga
                     aria-pressed={isSelected}
                     variant={isSelected ? "filled" : "outlined"}
                     color={isSelected ? "primary" : "default"}
-                    onClick={() =>
-                      setDraft({ ...draft, engagementTypes: toggleEngagementType(draft.engagementTypes, type) })
-                    }
+                    onClick={() => setDraft({ ...draft, engagementTypes: toggle(draft.engagementTypes, type) })}
                   />
                 );
               })}

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -40,6 +40,7 @@ export const CHANGE_REQUESTS_SEARCH_ENDPOINT = "/change-requests/search";
 export const CHANGE_REQUEST_ENDPOINT = (id: string) => `/change-requests/${id}`;
 
 export const PROJECTS_SEARCH_ENDPOINT = "/projects/search";
+export const PRODUCTS_SEARCH_ENDPOINT = "/products/search";
 export const DEPLOYMENTS_SEARCH_ENDPOINT = "/deployments/search";
 export const DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT = (deploymentId: string) =>
   `/deployments/${deploymentId}/products/search`;

--- a/apps/csm-portal/microapp/src/pages/EngagementsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/EngagementsPage.tsx
@@ -14,9 +14,122 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { ComingSoonPage } from "@components/common/ComingSoonPage";
+import { useEffect, useRef, useState } from "react";
+import { Badge, Box, IconButton, Stack, Typography } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { engagements } from "@src/services/engagements";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { countActiveEngagementFilters, EMPTY_ENGAGEMENT_FILTERS, type EngagementFilters } from "@utils/engagements";
+import { SearchBar } from "@components/support/SearchBar";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
+import { EngagementFiltersSheet } from "@components/engagements/EngagementFiltersSheet";
 
-// The webapp also marks Engagements as wip:true (apps/csm-portal/webapp/src/config/csmNavItems.ts).
+// Cross-customer engagements list (engagements are cases of type "engagement"),
+// mirroring the webapp's CsmEngagementsPage — a CsmIssuesView locked to
+// `caseTypes: ["engagement"]` with the engagement-type sub-filter shown and
+// severity hidden. Search + State + Engagement type + Project filters,
+// infinite-scrolled newest-updated first. Read-only for this pass, same as
+// AnnouncementsPage — creating an engagement isn't in scope here.
 export default function EngagementsPage() {
-  return <ComingSoonPage title="Engagements" description="Engagement tracking is still under construction." />;
+  const [filters, setFilters] = useState<EngagementFilters>(EMPTY_ENGAGEMENT_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
+  const activeFilterCount = countActiveEngagementFilters(filters);
+
+  // Search is debounced into the query so typing doesn't refetch every keystroke.
+  const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    engagements.infinite({ ...filters, search: debouncedSearch }),
+  );
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? items.length;
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Stack gap={2}>
+      <Box>
+        <Typography variant="h5">Engagements</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Ongoing engagements across projects.
+        </Typography>
+      </Box>
+
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar
+          value={filters.search}
+          onChange={(value) => setFilters((prev) => ({ ...prev, search: value }))}
+          placeholder="Search by number or subject…"
+        />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
+      {isLoading ? (
+        <ListSkeleton />
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No engagements found." />
+      ) : (
+        <Stack gap={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {items.length} of {total}
+          </Typography>
+
+          {items.map((item) => (
+            <CaseCard key={item.id} item={item} />
+          ))}
+
+          {/* IntersectionObserver can miss a zero-height target, so give the sentinel 1px to observe. */}
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <CaseCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={1}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+
+      <EngagementFiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        filters={filters}
+        onApply={setFilters}
+      />
+    </Stack>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <CaseCardSkeleton key={i} />
+      ))}
+    </Stack>
+  );
 }

--- a/apps/csm-portal/microapp/src/services/engagements.ts
+++ b/apps/csm-portal/microapp/src/services/engagements.ts
@@ -48,8 +48,11 @@ async function searchEngagements(filters: EngagementFilters, offset: number): Pr
       types: ["engagement"],
       ...(q ? { searchQuery: q } : {}),
       ...(filters.states.length ? { states: filters.states } : {}),
+      ...(filters.workStates.length ? { workStates: filters.workStates } : {}),
       ...(filters.projects.length ? { projectIds: filters.projects.map((p) => p.id) } : {}),
       ...(filters.engagementTypes.length ? { engagementTypes: filters.engagementTypes } : {}),
+      ...(filters.assignees.length ? { assignedUserIds: filters.assignees.map((a) => a.id) } : {}),
+      ...(filters.productNames.length ? { productNames: filters.productNames } : {}),
     },
   };
   const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);

--- a/apps/csm-portal/microapp/src/services/engagements.ts
+++ b/apps/csm-portal/microapp/src/services/engagements.ts
@@ -66,10 +66,11 @@ async function searchEngagements(filters: EngagementFilters, offset: number): Pr
     // getAllCases and adminUsers.ts's searchUsers, which hit the same quirk);
     // derive it from offset/total when that happens instead of treating a
     // missing/false field as "no more pages" after the first page. Also require
-    // a non-empty page: an empty page with a stale/inconsistent total should
-    // never report hasMore, or the infinite query would keep requesting
-    // further pages forever.
-    hasMore: data.hasMore ?? (data.offset + items.length < data.total && items.length > 0),
+    // a non-empty page — even when the backend *does* send an explicit
+    // hasMore: true — since an empty page with a stale/inconsistent total
+    // should never report hasMore, or the infinite query would keep
+    // requesting further pages forever.
+    hasMore: items.length > 0 && (data.hasMore ?? data.offset + items.length < data.total),
   };
 }
 

--- a/apps/csm-portal/microapp/src/services/engagements.ts
+++ b/apps/csm-portal/microapp/src/services/engagements.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Engagements are cases of `type: "engagement"`, so this is a single
+// `POST /cases/search` scoped to that type — read-only (create isn't in scope for
+// this pass, mirrors the webapp's CsmEngagementsPage which only lists/filters).
+// Paged via infinite scroll, newest-updated first, mirroring `services/cases.ts`
+// `cases.infinite` and `services/announcements.ts`'s `announcements.infinite`.
+
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { CASES_SEARCH_ENDPOINT } from "@config/endpoints";
+import type { CaseSearchPayloadDto, CaseSearchResponseDto } from "@src/types";
+import { toCaseSummary, type CaseSummary } from "@src/types";
+import type { EngagementFilters } from "@utils/engagements";
+import apiClient from "./apiClient";
+
+export interface EngagementSearchResult {
+  items: CaseSummary[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+const ENGAGEMENTS_PAGE_LIMIT = 20;
+
+// Empty filter arrays are omitted so the search defaults to every state/type
+// across all projects. `searchQuery` matches subject/number.
+async function searchEngagements(filters: EngagementFilters, offset: number): Promise<EngagementSearchResult> {
+  const q = filters.search.trim();
+  const payload: CaseSearchPayloadDto = {
+    pagination: { offset, limit: ENGAGEMENTS_PAGE_LIMIT },
+    sortBy: { field: "updatedOn", order: "desc" },
+    filters: {
+      types: ["engagement"],
+      ...(q ? { searchQuery: q } : {}),
+      ...(filters.states.length ? { states: filters.states } : {}),
+      ...(filters.projects.length ? { projectIds: filters.projects.map((p) => p.id) } : {}),
+      ...(filters.engagementTypes.length ? { engagementTypes: filters.engagementTypes } : {}),
+    },
+  };
+  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const items = data.cases.map(toCaseSummary);
+  return {
+    items,
+    total: data.total,
+    offset: data.offset,
+    limit: data.limit,
+    // Some data sources omit hasMore from the search envelope (see cases.ts's
+    // getAllCases and adminUsers.ts's searchUsers, which hit the same quirk);
+    // derive it from offset/total when that happens instead of treating a
+    // missing/false field as "no more pages" after the first page. Also require
+    // a non-empty page: an empty page with a stale/inconsistent total should
+    // never report hasMore, or the infinite query would keep requesting
+    // further pages forever.
+    hasMore: data.hasMore ?? (data.offset + items.length < data.total && items.length > 0),
+  };
+}
+
+export const engagements = {
+  infinite: (filters: EngagementFilters) =>
+    infiniteQueryOptions({
+      queryKey: ["engagements", filters],
+      queryFn: ({ pageParam }) => searchEngagements(filters, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (last) => (last.hasMore ? last.offset + last.limit : undefined),
+    }),
+};

--- a/apps/csm-portal/microapp/src/services/products.ts
+++ b/apps/csm-portal/microapp/src/services/products.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { queryOptions } from "@tanstack/react-query";
+import { PRODUCTS_SEARCH_ENDPOINT } from "@config/endpoints";
+import apiClient from "./apiClient";
+
+interface ProductDto {
+  id: string;
+  name?: string;
+}
+
+interface ProductSearchResponseDto {
+  products: ProductDto[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore?: boolean;
+}
+
+// openapi.yaml declares this endpoint's pagination.limit maximum as 100, but
+// services/cases.ts documents that the live upstream entity service actually
+// rejects 100 with a 400 for the (same-shaped) comments-search endpoint; match
+// that verified-working value instead of the doc.
+const PRODUCTS_PAGE_LIMIT = 50;
+
+/**
+ * Distinct product **family names** for the engagements product filter.
+ * `POST /products/search` returns one row per product model/version (the same
+ * short `name` repeated many times, e.g. dozens of "API Manager" variants), so
+ * this fetches the full (bounded) catalogue once and reduces it to the set of
+ * distinct, non-empty names, sorted for a stable dropdown order — mirrors the
+ * webapp's useProductNameOptions.ts.
+ */
+async function fetchProductNames(): Promise<string[]> {
+  const names = new Set<string>();
+  for (let offset = 0; ; offset += PRODUCTS_PAGE_LIMIT) {
+    const { data } = await apiClient.post<ProductSearchResponseDto>(PRODUCTS_SEARCH_ENDPOINT, {
+      pagination: { offset, limit: PRODUCTS_PAGE_LIMIT },
+    });
+    for (const p of data.products) {
+      const name = p.name?.trim();
+      if (name) names.add(name);
+    }
+    if (data.products.length < PRODUCTS_PAGE_LIMIT) break;
+  }
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+export const products = {
+  names: () =>
+    queryOptions({
+      queryKey: ["products", "family-names"],
+      queryFn: fetchProductNames,
+      staleTime: 5 * 60_000,
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -16,6 +16,8 @@
 
 export type CaseType = "case" | "service_request" | "security_report_analysis" | "engagement" | "announcement";
 
+export type EngagementType = "migration" | "consultancy" | "new_feature_improvement" | "follow_up" | "onboarding";
+
 export type CaseSeverity = "catastrophic" | "critical" | "high" | "medium" | "low";
 
 export type CaseState =
@@ -87,6 +89,8 @@ export interface CaseSearchFiltersDto {
   assignedUserIds?: string[];
   createdByMe?: boolean;
   workStates?: NonNullable<CaseWorkState>[];
+  /** Filter by engagement type; only applies when `types` includes `"engagement"`. */
+  engagementTypes?: EngagementType[];
 }
 
 export interface CaseSearchPayloadDto {

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -91,6 +91,8 @@ export interface CaseSearchFiltersDto {
   workStates?: NonNullable<CaseWorkState>[];
   /** Filter by engagement type; only applies when `types` includes `"engagement"`. */
   engagementTypes?: EngagementType[];
+  /** Product family names (e.g. "API Manager"); matches all versions of each. */
+  productNames?: string[];
 }
 
 export interface CaseSearchPayloadDto {

--- a/apps/csm-portal/microapp/src/utils/engagements.ts
+++ b/apps/csm-portal/microapp/src/utils/engagements.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CaseState, EngagementType, Project } from "@src/types";
+
+// Mirrors the webapp's ALL_ENGAGEMENT_TYPES/ENGAGEMENT_TYPE_LABEL
+// (apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx).
+export const ALL_ENGAGEMENT_TYPES: EngagementType[] = [
+  "migration",
+  "consultancy",
+  "new_feature_improvement",
+  "follow_up",
+  "onboarding",
+];
+
+export const ENGAGEMENT_TYPE_LABEL: Record<EngagementType, string> = {
+  migration: "Migration",
+  consultancy: "Consultancy",
+  new_feature_improvement: "New feature / improvement",
+  follow_up: "Follow-up",
+  onboarding: "Onboarding",
+};
+
+// UI-facing engagement filters. `search` matches subject/number (server-side
+// `searchQuery`); `states` → server-side `states`; `projects` → server-side
+// `projectIds`; `engagementTypes` → server-side `engagementTypes`. All empty by
+// default, so the list shows every state/type across all projects. (No severity —
+// engagements carry none, same as the webapp's CsmIssuesView locks it out for any
+// non-"case" type.)
+export interface EngagementFilters {
+  search: string;
+  states: CaseState[];
+  projects: Project[];
+  engagementTypes: EngagementType[];
+}
+
+export const EMPTY_ENGAGEMENT_FILTERS: EngagementFilters = {
+  search: "",
+  states: [],
+  projects: [],
+  engagementTypes: [],
+};
+
+/** Active filter groups — drives the "Filters (n)" badge. Search is excluded (it
+ * has its own always-visible box). */
+export function countActiveEngagementFilters(filters: EngagementFilters): number {
+  let count = 0;
+  if (filters.states.length > 0) count += 1;
+  if (filters.projects.length > 0) count += 1;
+  if (filters.engagementTypes.length > 0) count += 1;
+  return count;
+}

--- a/apps/csm-portal/microapp/src/utils/engagements.ts
+++ b/apps/csm-portal/microapp/src/utils/engagements.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { CaseState, EngagementType, Project } from "@src/types";
+import type { CaseState, CaseWorkState, EngagementType, Project } from "@src/types";
 
 // Mirrors the webapp's ALL_ENGAGEMENT_TYPES/ENGAGEMENT_TYPE_LABEL
 // (apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx).
@@ -34,24 +34,39 @@ export const ENGAGEMENT_TYPE_LABEL: Record<EngagementType, string> = {
   onboarding: "Onboarding",
 };
 
+/** Lightweight assignee ref for the filter chip — mirrors how `projects` stores a
+ * display-ready `Project[]` rather than bare ids. */
+export interface EngagementAssignee {
+  id: string;
+  name: string;
+}
+
 // UI-facing engagement filters. `search` matches subject/number (server-side
-// `searchQuery`); `states` → server-side `states`; `projects` → server-side
-// `projectIds`; `engagementTypes` → server-side `engagementTypes`. All empty by
-// default, so the list shows every state/type across all projects. (No severity —
-// engagements carry none, same as the webapp's CsmIssuesView locks it out for any
-// non-"case" type.)
+// `searchQuery`); `states` → server-side `states`; `workStates` → server-side
+// `workStates` (only meaningful while `states` includes "work_in_progress");
+// `projects` → server-side `projectIds`; `engagementTypes` → server-side
+// `engagementTypes`; `assignees` → server-side `assignedUserIds`; `productNames`
+// → server-side `productNames`. All empty by default, so the list shows every
+// state/type across all projects. (No severity — engagements carry none, same
+// as the webapp's CsmIssuesView locks it out for any non-"case" type.)
 export interface EngagementFilters {
   search: string;
   states: CaseState[];
+  workStates: NonNullable<CaseWorkState>[];
   projects: Project[];
   engagementTypes: EngagementType[];
+  assignees: EngagementAssignee[];
+  productNames: string[];
 }
 
 export const EMPTY_ENGAGEMENT_FILTERS: EngagementFilters = {
   search: "",
   states: [],
+  workStates: [],
   projects: [],
   engagementTypes: [],
+  assignees: [],
+  productNames: [],
 };
 
 /** Active filter groups — drives the "Filters (n)" badge. Search is excluded (it
@@ -59,7 +74,10 @@ export const EMPTY_ENGAGEMENT_FILTERS: EngagementFilters = {
 export function countActiveEngagementFilters(filters: EngagementFilters): number {
   let count = 0;
   if (filters.states.length > 0) count += 1;
+  if (filters.workStates.length > 0) count += 1;
   if (filters.projects.length > 0) count += 1;
   if (filters.engagementTypes.length > 0) count += 1;
+  if (filters.assignees.length > 0) count += 1;
+  if (filters.productNames.length > 0) count += 1;
   return count;
 }


### PR DESCRIPTION
## Purpose
The CSM Portal microapp's Engagements tab (`More > Engagements`) was a "coming soon" placeholder. Engagements are cases of type `engagement`, and the webapp already lists/filters them via the shared `CsmIssuesView` — this ports that same functionality to the microapp.

## Goals
- Implement the Engagements list: search, infinite scroll, and full filter parity with the webapp's engagements view.
- Reuse existing microapp infrastructure (generic `CaseCard`, `TYPE_CONFIG`/`TAB_CONFIG`, which were already pre-configured for `engagement`) rather than duplicating a bespoke card.

## Approach
- `services/engagements.ts` — `POST /cases/search` scoped to `type: engagement`, paged via infinite scroll, mirroring `services/announcements.ts`'s pagination/`hasMore` handling.
- `utils/engagements.ts` — filter state (`EngagementFilters`) and the engagement-type label map.
- `components/engagements/EngagementFiltersSheet.tsx` — State, Work state, Engagement type (chip multi-selects), Assignee, Project, Product (async multi-selects). This matches every filter the webapp's `CasesFilterBar` offers for a view locked to `caseTypes: ["engagement"]` (severity and case type are correctly hidden — same as the webapp does for this view). The one thing intentionally left out is "Saved views," a separate bookmarking convenience layered on top of the webapp's filter bar, not a filter itself.
- `services/products.ts` (new) + `PRODUCTS_SEARCH_ENDPOINT` — fetches the full product catalogue once and reduces it to distinct family names, mirroring the webapp's `useProductNameOptions`.
- Assignee search reuses `services/adminUsers.ts`'s existing internal-roles search (the same directory slice `LogTimeCardDialog`'s approver picker already uses).
- `pages/EngagementsPage.tsx` — rewritten from the placeholder into the real list.
- Read-only for this pass — no create/edit flow, matching the webapp's own `CsmEngagementsPage`.

## User stories
As a CSM engineer, I can browse, search, and filter engagements from the mobile app the same way I can on the web portal.

## Release note
Added the Engagements list to the CSM Portal mobile app (`More > Engagements`), with full filtering (state, work state, engagement type, assignee, project, product).

## Documentation
N/A — internal CSM portal UI change, no external doc surface affected.

## Automation tests
- No automated test runner is wired up for this app yet.
- Verified locally: `tsc -b`, `eslint`, and `vite build` all clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Local dev server (Vite), manual browser testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the engagements placeholder with a read-only, paginated engagements list.
  * Added search and filtering by state, work state, engagement type, assignee, project, and product.
  * Added filter controls with Apply and Clear all actions.
  * Added loading, error, empty, progress, and infinite-scroll states.
  * Added product and engagement data retrieval to support the new experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->