### PR TITLE
[CSM Portal Microapp] Add the Customers page (Accounts, Projects, Deployments)

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -32,6 +32,9 @@ import TimeCardsPage from "@pages/TimeCardsPage";
 import SecurityCenterPage from "@pages/SecurityCenterPage";
 import UpdatesPage from "@pages/UpdatesPage";
 import EngagementsPage from "@pages/EngagementsPage";
+import CustomersPage from "@pages/CustomersPage";
+import AccountDetailPage from "@pages/AccountDetailPage";
+import ProjectDetailPage from "@pages/ProjectDetailPage";
 import SettingsPage from "@pages/SettingsPage";
 import ProfilePage from "@pages/ProfilePage";
 
@@ -73,6 +76,9 @@ export default function App() {
           <Route path="/more/security-center" element={<SecurityCenterPage />} />
           <Route path="/more/updates" element={<UpdatesPage />} />
           <Route path="/more/engagements" element={<EngagementsPage />} />
+          <Route path="/more/customers" element={<CustomersPage />} />
+          <Route path="/more/customers/accounts/:id" element={<AccountDetailPage />} />
+          <Route path="/more/customers/projects/:id" element={<ProjectDetailPage />} />
           <Route path="/more/settings" element={<SettingsPage />} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>

--- a/apps/csm-portal/microapp/src/components/customers/AccountsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/AccountsTab.tsx
@@ -14,13 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Card, Chip, Stack, Typography } from "@wso2/oxygen-ui";
 import { Link } from "react-router-dom";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { accounts } from "@src/services/accounts";
 import type { Account } from "@src/types";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { useInfiniteScrollSentinel } from "@utils/useInfiniteScrollSentinel";
 import { formatDateOnly } from "@utils/customers";
 import { SearchBar } from "@components/support/SearchBar";
 import { EmptyState } from "@components/support/EmptyState";
@@ -85,22 +86,7 @@ export function AccountsTab() {
   const items = data?.pages.flatMap((p) => p.items) ?? [];
   const total = data?.pages[0]?.total ?? items.length;
 
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          void fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
     <Stack gap={2}>

--- a/apps/csm-portal/microapp/src/components/customers/AccountsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/AccountsTab.tsx
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { Card, Chip, Stack, Typography } from "@wso2/oxygen-ui";
+import { Link } from "react-router-dom";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { accounts } from "@src/services/accounts";
+import type { Account } from "@src/types";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { formatDateOnly } from "@utils/customers";
+import { SearchBar } from "@components/support/SearchBar";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+
+function AccountCard({ item }: { item: Account }) {
+  return (
+    <Card
+      component={Link}
+      to={`/more/customers/accounts/${item.id}`}
+      variant="outlined"
+      sx={{ p: 2, textDecoration: "none", display: "block" }}
+    >
+      <Stack gap={1}>
+        <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
+          <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
+            {item.name}
+          </Typography>
+          <Chip
+            size="small"
+            label={item.tier}
+            color={item.tier === "enterprise" ? "primary" : "default"}
+            variant="outlined"
+            sx={{ textTransform: "capitalize" }}
+          />
+        </Stack>
+        <Typography variant="caption" color="text.secondary" noWrap sx={{ fontFamily: "monospace" }}>
+          {item.sfId}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {item.region ?? "—"} · Activated {formatDateOnly(item.activationDate)}
+          {item.deactivationDate ? ` · Deactivated ${formatDateOnly(item.deactivationDate)}` : ""}
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+function AccountCardSkeleton() {
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Stack gap={1}>
+        <Typography variant="body2" color="text.secondary">
+          &nbsp;
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+// Read-only accounts list (search across name + Salesforce ID), infinite-scrolled — mirrors the
+// webapp's CsmAccountsPage's search, minus its Table/TablePagination (this app's list pages are
+// all infinite-scrolled, not classically paginated).
+export function AccountsTab() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    accounts.infinite(debouncedSearch),
+  );
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? items.length;
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Stack gap={2}>
+      <SearchBar value={search} onChange={setSearch} placeholder="Search by name or SF ID…" />
+
+      {isLoading ? (
+        <Stack gap={1.5}>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <AccountCardSkeleton key={i} />
+          ))}
+        </Stack>
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No accounts found." />
+      ) : (
+        <Stack gap={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {items.length} of {total}
+          </Typography>
+
+          {items.map((item) => (
+            <AccountCard key={item.id} item={item} />
+          ))}
+
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <AccountCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={1}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/customers/DeployedProductsList.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/DeployedProductsList.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery } from "@tanstack/react-query";
+import { Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { deployments } from "@src/services/deployments";
+import { formatDateOnly } from "@utils/customers";
+import { ErrorState } from "@components/support/ErrorState";
+
+/** SN sizing fields arrive as strings; treat null/blank uniformly as "—" — mirrors the webapp's
+ * DeployedProductsPanel sizingValue. */
+function sizingValue(value: string | null): string {
+  return value?.trim() ? value : "—";
+}
+
+// Read-only list of a deployment's deployed products — the mobile card-list equivalent of the
+// webapp's DeployedProductsPanel table (Product / Version / Support EOL / Cores / TPS / Category),
+// minus its write actions (add/edit/deactivate are deliberately out of scope for this pass).
+export function DeployedProductsList({ deploymentId }: { deploymentId: string }) {
+  const { data, isLoading, isError, refetch } = useQuery(deployments.productsList(deploymentId));
+
+  if (isLoading) {
+    return (
+      <Stack gap={1}>
+        {[0, 1].map((i) => (
+          <Skeleton key={i} variant="rounded" height={56} />
+        ))}
+      </Stack>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => void refetch()} />;
+  }
+
+  const products = data ?? [];
+
+  if (products.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No products deployed in this deployment.
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack gap={1.5}>
+      {products.map((p) => (
+        <Stack key={p.id} gap={0.5} sx={{ p: 1.5, border: 1, borderColor: "divider", borderRadius: 1 }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
+            <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
+              {p.productName}
+            </Typography>
+            {p.versionName && <Chip size="small" variant="outlined" label={p.versionName} />}
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            Support EOL {formatDateOnly(p.supportEoLDate)}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Cores {sizingValue(p.cores)} · TPS {sizingValue(p.tps)} · {p.category ?? "—"}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/customers/DeploymentDetailDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/DeploymentDetailDialog.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Chip, Dialog, DialogContent, DialogTitle, Divider, IconButton, Stack, Typography } from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import type { Deployment } from "@src/types";
+import { formatDateOnly, formatEnumLabel } from "@utils/customers";
+import { DialogPaper } from "@components/common/DialogPaper";
+import { MetaRow, MetaValue } from "@components/customers/MetaRow";
+import { DeployedProductsList } from "@components/customers/DeployedProductsList";
+
+interface DeploymentDetailDialogProps {
+  deployment: Deployment | null;
+  onClose: () => void;
+}
+
+// Read-only deployment detail (name/type/description/dates) + its Deployed Products list —
+// the mobile dialog equivalent of the webapp's DeploymentDetailsDialog, with
+// DeployedProductsPanel folded in underneath rather than needing its own expand/click.
+export function DeploymentDetailDialog({ deployment, onClose }: DeploymentDetailDialogProps) {
+  return (
+    <Dialog open={!!deployment} onClose={onClose} fullWidth maxWidth="xs" slots={{ paper: DialogPaper }}>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        {deployment?.name || "Deployment"}
+        <IconButton size="small" aria-label="Close" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      {deployment && (
+        <DialogContent>
+          <Stack gap={2}>
+            <Stack gap={1.5}>
+              <MetaRow label="Type">
+                <Chip size="small" variant="outlined" label={formatEnumLabel(deployment.type)} />
+              </MetaRow>
+              <Divider />
+              <MetaRow label="Description">
+                <MetaValue>{deployment.description || "—"}</MetaValue>
+              </MetaRow>
+              <Divider />
+              <MetaRow label="Created">
+                <MetaValue>{formatDateOnly(deployment.createdOn)}</MetaValue>
+              </MetaRow>
+              <Divider />
+              <MetaRow label="Updated">
+                <MetaValue>{formatDateOnly(deployment.updatedOn)}</MetaValue>
+              </MetaRow>
+            </Stack>
+
+            <Stack gap={1}>
+              <Typography variant="subtitle2">Deployed products</Typography>
+              <DeployedProductsList deploymentId={deployment.id} />
+            </Stack>
+          </Stack>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/customers/DeploymentsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/DeploymentsTab.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { ChevronRight } from "@wso2/oxygen-ui-icons-react";
+import { deployments } from "@src/services/deployments";
+import type { Deployment } from "@src/types";
+import { formatDateOnly, formatEnumLabel } from "@utils/customers";
+import { ErrorState } from "@components/support/ErrorState";
+import { DeploymentDetailDialog } from "@components/customers/DeploymentDetailDialog";
+
+// A project's deployments — the mobile card-list equivalent of the webapp's DeploymentsTab table
+// (Name / Type / Description / Created / Updated), minus its write actions/create button
+// (deliberately out of scope for this pass). Tapping a card opens its detail + deployed products,
+// same role the webapp's row-click / "View details" menu item plays.
+export function DeploymentsTab({ projectId }: { projectId: string }) {
+  const { data, isLoading, isError, refetch } = useQuery(deployments.list(projectId));
+  const [viewing, setViewing] = useState<Deployment | null>(null);
+
+  if (isLoading) {
+    return (
+      <Stack gap={1.5}>
+        {[0, 1].map((i) => (
+          <Skeleton key={i} variant="rounded" height={72} />
+        ))}
+      </Stack>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => void refetch()} />;
+  }
+
+  const items = data ?? [];
+
+  if (items.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No deployments for this project.
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack gap={1.5}>
+      {items.map((d) => (
+        <Card key={d.id} variant="outlined" sx={{ p: 2, cursor: "pointer" }} onClick={() => setViewing(d)}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
+            <Stack gap={0.5} sx={{ minWidth: 0 }}>
+              <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+                <Typography variant="body2" noWrap>
+                  {d.name || "—"}
+                </Typography>
+                <Chip size="small" variant="outlined" label={formatEnumLabel(d.type)} />
+              </Stack>
+              {d.description && (
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {d.description}
+                </Typography>
+              )}
+              <Typography variant="caption" color="text.secondary">
+                Updated {formatDateOnly(d.updatedOn)}
+              </Typography>
+            </Stack>
+            <ChevronRight size={18} />
+          </Stack>
+        </Card>
+      ))}
+
+      <DeploymentDetailDialog deployment={viewing} onClose={() => setViewing(null)} />
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/customers/MetaRow.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/MetaRow.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Stack, Typography, type TypographyProps } from "@wso2/oxygen-ui";
+import type { ReactNode } from "react";
+
+/** One "label / value" row in an Account/Project overview card — the mobile
+ * equivalent of the webapp's grid-cell MetaCell (a single narrow column reads
+ * better as stacked rows than as a multi-column grid). */
+export function MetaRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={2}>
+      <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}>
+        {label}
+      </Typography>
+      <Stack alignItems="flex-end" sx={{ minWidth: 0 }}>
+        {children}
+      </Stack>
+    </Stack>
+  );
+}
+
+export function MetaValue({ mono, children, ...rest }: TypographyProps & { mono?: boolean }) {
+  return (
+    <Typography
+      variant="body2"
+      align="right"
+      sx={{ wordBreak: "break-word", ...(mono && { fontFamily: "monospace" }) }}
+      {...rest}
+    >
+      {children}
+    </Typography>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/customers/ProjectIssuesTab.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/ProjectIssuesTab.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { Stack, Typography } from "@wso2/oxygen-ui";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { cases } from "@src/services/cases";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { SearchBar } from "@components/support/SearchBar";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
+
+// A project's issues across every case type (support cases, service requests, engagements,
+// security reports, announcements) — the mobile equivalent of the webapp's CsmIssuesView locked
+// to `projects: [id]`. Search-only for this pass; no filter sheet (the webapp's full
+// severity/state/assignee/product filter set isn't warranted for a single project's issue list,
+// same reasoning Announcements/Engagements started from before Engagements later grew filters).
+export function ProjectIssuesTab({ projectId }: { projectId: string }) {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    cases.infinite({
+      projectIds: [projectId],
+      ...(debouncedSearch.trim() && { searchQuery: debouncedSearch.trim() }),
+    }),
+  );
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Stack gap={2}>
+      <SearchBar value={search} onChange={setSearch} placeholder="Search by number, subject…" />
+
+      {isLoading ? (
+        <Stack gap={1.5}>
+          {[0, 1, 2].map((i) => (
+            <CaseCardSkeleton key={i} />
+          ))}
+        </Stack>
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No issues for this project." />
+      ) : (
+        <Stack gap={1.5}>
+          {items.map((item) => (
+            <CaseCard key={item.id} item={item} />
+          ))}
+
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <CaseCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={1}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/customers/ProjectIssuesTab.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/ProjectIssuesTab.tsx
@@ -14,11 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Stack, Typography } from "@wso2/oxygen-ui";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { useInfiniteScrollSentinel } from "@utils/useInfiniteScrollSentinel";
 import { SearchBar } from "@components/support/SearchBar";
 import { EmptyState } from "@components/support/EmptyState";
 import { ErrorState } from "@components/support/ErrorState";
@@ -42,22 +43,7 @@ export function ProjectIssuesTab({ projectId }: { projectId: string }) {
 
   const items = data?.pages.flatMap((p) => p.items) ?? [];
 
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          void fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
     <Stack gap={2}>

--- a/apps/csm-portal/microapp/src/components/customers/ProjectsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/ProjectsTab.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { Card, Chip, Stack, Typography } from "@wso2/oxygen-ui";
+import { Link } from "react-router-dom";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { projects } from "@src/services/projects";
+import type { ProjectSummary } from "@src/types";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { formatDateOnly, formatEnumLabel } from "@utils/customers";
+import { SearchBar } from "@components/support/SearchBar";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+
+function ProjectCard({ item }: { item: ProjectSummary }) {
+  return (
+    <Card
+      component={Link}
+      to={`/more/customers/projects/${item.id}`}
+      variant="outlined"
+      sx={{ p: 2, textDecoration: "none", display: "block" }}
+    >
+      <Stack gap={1}>
+        <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
+          <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
+            {item.name}
+          </Typography>
+          <Chip size="small" label={formatEnumLabel(item.subscriptionType)} variant="outlined" />
+        </Stack>
+        <Typography variant="caption" color="text.secondary" noWrap sx={{ fontFamily: "monospace" }}>
+          {item.key ?? "—"}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {formatDateOnly(item.startDate)} – {formatDateOnly(item.endDate)}
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+function ProjectCardSkeleton() {
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Stack gap={1}>
+        <Typography variant="body2" color="text.secondary">
+          &nbsp;
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+// Read-only projects list (search across name, project key, subscription), infinite-scrolled —
+// mirrors the webapp's CsmProjectsPage's search, minus its Table/TablePagination.
+export function ProjectsTab() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    projects.list(debouncedSearch),
+  );
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? items.length;
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Stack gap={2}>
+      <SearchBar value={search} onChange={setSearch} placeholder="Search by name, key, or subscription…" />
+
+      {isLoading ? (
+        <Stack gap={1.5}>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <ProjectCardSkeleton key={i} />
+          ))}
+        </Stack>
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No projects found." />
+      ) : (
+        <Stack gap={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {items.length} of {total}
+          </Typography>
+
+          {items.map((item) => (
+            <ProjectCard key={item.id} item={item} />
+          ))}
+
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <ProjectCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={1}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/customers/ProjectsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/ProjectsTab.tsx
@@ -14,13 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Card, Chip, Stack, Typography } from "@wso2/oxygen-ui";
 import { Link } from "react-router-dom";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { projects } from "@src/services/projects";
 import type { ProjectSummary } from "@src/types";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { useInfiniteScrollSentinel } from "@utils/useInfiniteScrollSentinel";
 import { formatDateOnly, formatEnumLabel } from "@utils/customers";
 import { SearchBar } from "@components/support/SearchBar";
 import { EmptyState } from "@components/support/EmptyState";
@@ -77,22 +78,7 @@ export function ProjectsTab() {
   const items = data?.pages.flatMap((p) => p.items) ?? [];
   const total = data?.pages[0]?.total ?? items.length;
 
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          void fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
     <Stack gap={2}>

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -39,7 +39,11 @@ export const SLAS_SEARCH_ENDPOINT = "/slas/search";
 export const CHANGE_REQUESTS_SEARCH_ENDPOINT = "/change-requests/search";
 export const CHANGE_REQUEST_ENDPOINT = (id: string) => `/change-requests/${id}`;
 
+export const ACCOUNTS_SEARCH_ENDPOINT = "/accounts/search";
+export const ACCOUNT_ENDPOINT = (id: string) => `/accounts/${id}`;
+
 export const PROJECTS_SEARCH_ENDPOINT = "/projects/search";
+export const PROJECT_ENDPOINT = (id: string) => `/projects/${id}`;
 export const PRODUCTS_SEARCH_ENDPOINT = "/products/search";
 export const DEPLOYMENTS_SEARCH_ENDPOINT = "/deployments/search";
 export const DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT = (deploymentId: string) =>

--- a/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Chip, Divider, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { accounts } from "@src/services/accounts";
+import { formatDateOnly } from "@utils/customers";
+import { MetaRow, MetaValue } from "@components/customers/MetaRow";
+import { ErrorState } from "@components/support/ErrorState";
+
+export default function AccountDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data, isLoading, isError, refetch } = useQuery(accounts.get(id ?? ""));
+
+  if (isLoading) {
+    return (
+      <Stack gap={2}>
+        <Skeleton variant="rounded" height={28} width="60%" />
+        <Skeleton variant="rounded" height={260} />
+      </Stack>
+    );
+  }
+
+  if (isError || !data) {
+    return <ErrorState onRetry={() => void refetch()} />;
+  }
+
+  const a = data;
+
+  return (
+    <Stack gap={2}>
+      <Stack gap={0.5}>
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+          <Typography variant="h6">{a.name}</Typography>
+          <Chip
+            size="small"
+            label={a.tier}
+            color={a.tier === "enterprise" ? "primary" : "default"}
+            variant="outlined"
+            sx={{ textTransform: "capitalize" }}
+          />
+          {a.deactivationDate && <Chip size="small" label="Deactivated" variant="outlined" />}
+        </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+          {a.sfId}
+        </Typography>
+      </Stack>
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Stack gap={1.5}>
+          <MetaRow label="Region">
+            <MetaValue>{a.region ?? "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Activated">
+            <MetaValue>{formatDateOnly(a.activationDate)}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Deactivated">
+            <MetaValue>{formatDateOnly(a.deactivationDate)}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="AI agent">
+            <Chip
+              size="small"
+              variant="outlined"
+              color={a.agentEnabled ? "success" : "default"}
+              label={a.agentEnabled ? "Enabled" : "Disabled"}
+            />
+          </MetaRow>
+          <Divider />
+          <MetaRow label="KB references">
+            <Chip
+              size="small"
+              variant="outlined"
+              color={a.kbReferencesEnabled ? "success" : "default"}
+              label={a.kbReferencesEnabled ? "Enabled" : "Disabled"}
+            />
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Owner ID">
+            <MetaValue mono>{a.ownerId || "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Technical owner ID">
+            <MetaValue mono>{a.technicalOwnerId || "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Created">
+            <MetaValue>{formatDateOnly(a.createdOn)}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Updated">
+            <MetaValue>{formatDateOnly(a.updatedOn)}</MetaValue>
+          </MetaRow>
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/CustomersPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CustomersPage.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState } from "react";
+import { Stack, Tab, Tabs } from "@wso2/oxygen-ui";
+import { AccountsTab } from "@components/customers/AccountsTab";
+import { ProjectsTab } from "@components/customers/ProjectsTab";
+
+type CustomersTabId = "accounts" | "projects";
+
+const TABS: { id: CustomersTabId; label: string }[] = [
+  { id: "accounts", label: "Accounts" },
+  { id: "projects", label: "Projects" },
+];
+
+// Mirrors the webapp's CsmCustomersLayout: a thin tab shell (Accounts | Projects) over two
+// pre-existing, fully-built search pages — read-only browse only for this pass, no
+// create/edit/deactivate (that's several more dialogs with cascading pickers, deliberately
+// deferred, same call the webapp's own Operations "Create SR/CR" and this app's Engagements made).
+export default function CustomersPage() {
+  const [activeTab, setActiveTab] = useState<CustomersTabId>("accounts");
+
+  return (
+    <Stack gap={2}>
+      <Tabs variant="scrollable" value={activeTab} onChange={(_, value: CustomersTabId) => setActiveTab(value)}>
+        {TABS.map((tab) => (
+          <Tab key={tab.id} label={tab.label} value={tab.id} disableRipple />
+        ))}
+      </Tabs>
+
+      {activeTab === "accounts" && <AccountsTab />}
+      {activeTab === "projects" && <ProjectsTab />}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/MorePage.tsx
+++ b/apps/csm-portal/microapp/src/pages/MorePage.tsx
@@ -18,6 +18,7 @@ import { Link } from "react-router-dom";
 import { List, ListItemButton, ListItemIcon, ListItemText, Stack } from "@wso2/oxygen-ui";
 import {
   Briefcase,
+  Building2,
   ChevronRight,
   Clock,
   Megaphone,
@@ -35,15 +36,17 @@ interface MoreItem {
 }
 
 // Secondary sections that don't get their own tab, mirroring a subset of the webapp's
-// CSM_NAV_ITEMS (apps/csm-portal/webapp/src/config/csmNavItems.ts) — Customers is deliberately
-// left out here. Settings is last, same position it has in CSM_NAV_ITEMS. Profile comes after
-// Settings — it moved here from the TopBar's avatar shortcut.
+// CSM_NAV_ITEMS (apps/csm-portal/webapp/src/config/csmNavItems.ts). Settings is last, same
+// position it has in CSM_NAV_ITEMS. Profile comes after Settings — it moved here from the
+// TopBar's avatar shortcut. Customers sits right before Settings, same relative order as the
+// webapp's own customers/admin pairing.
 const MORE_ITEMS: MoreItem[] = [
   { label: "Announcements", path: "/more/announcements", icon: Megaphone },
   { label: "Time Cards", path: "/more/time-cards", icon: Clock },
   { label: "Security Center", path: "/more/security-center", icon: Shield },
   { label: "Updates", path: "/more/updates", icon: RefreshCw },
   { label: "Engagements", path: "/more/engagements", icon: Briefcase },
+  { label: "Customers", path: "/more/customers", icon: Building2 },
   { label: "Settings", path: "/more/settings", icon: Settings },
   { label: "Profile", path: "/profile", icon: User },
 ];

--- a/apps/csm-portal/microapp/src/pages/ProjectDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Chip, Divider, Skeleton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { projects } from "@src/services/projects";
+import { formatDateOnly, formatEnumLabel } from "@utils/customers";
+import { MetaRow, MetaValue } from "@components/customers/MetaRow";
+import { ProjectIssuesTab } from "@components/customers/ProjectIssuesTab";
+import { DeploymentsTab } from "@components/customers/DeploymentsTab";
+import { ErrorState } from "@components/support/ErrorState";
+
+type ProjectTabId = "overview" | "issues" | "deployments";
+
+const TABS: { id: ProjectTabId; label: string }[] = [
+  { id: "overview", label: "Overview" },
+  { id: "issues", label: "Issues" },
+  { id: "deployments", label: "Deployments" },
+];
+
+export default function ProjectDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data, isLoading, isError, refetch } = useQuery(projects.get(id ?? ""));
+  const [activeTab, setActiveTab] = useState<ProjectTabId>("overview");
+
+  if (isLoading) {
+    return (
+      <Stack gap={2}>
+        <Skeleton variant="rounded" height={28} width="60%" />
+        <Skeleton variant="rounded" height={260} />
+      </Stack>
+    );
+  }
+
+  if (isError || !data) {
+    return <ErrorState onRetry={() => void refetch()} />;
+  }
+
+  const p = data;
+
+  return (
+    <Stack gap={2}>
+      <Stack gap={0.5}>
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+          <Typography variant="h6">{p.name}</Typography>
+          <Chip size="small" variant="outlined" label={formatEnumLabel(p.subscriptionType)} />
+        </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+          {p.key ?? "—"}
+        </Typography>
+      </Stack>
+
+      <Tabs variant="scrollable" value={activeTab} onChange={(_, value: ProjectTabId) => setActiveTab(value)}>
+        {TABS.map((tab) => (
+          <Tab key={tab.id} label={tab.label} value={tab.id} disableRipple />
+        ))}
+      </Tabs>
+
+      {activeTab === "overview" && (
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Stack gap={1.5}>
+            <MetaRow label="Project key">
+              <MetaValue mono>{p.key ?? "—"}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Subscription">
+              <MetaValue>{formatEnumLabel(p.subscriptionType)}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Account">
+              {p.account ? (
+                <Typography
+                  component={Link}
+                  to={`/more/customers/accounts/${p.account.id}`}
+                  variant="body2"
+                  align="right"
+                  sx={{ color: "primary.main", textDecoration: "none" }}
+                >
+                  {p.account.name || p.account.id}
+                </Typography>
+              ) : (
+                <MetaValue>—</MetaValue>
+              )}
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Account tier">
+              <MetaValue sx={{ textTransform: "capitalize" }}>{p.account?.tier || "—"}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Start date">
+              <MetaValue>{formatDateOnly(p.startDate)}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="End date">
+              <MetaValue>{formatDateOnly(p.endDate)}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Salesforce ID">
+              <MetaValue mono>{p.sfId || "—"}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Created">
+              <MetaValue>{formatDateOnly(p.createdOn)}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Last updated">
+              <MetaValue>{formatDateOnly(p.updatedOn)}</MetaValue>
+            </MetaRow>
+            <Divider />
+            <MetaRow label="Project ID">
+              <MetaValue mono>{p.id}</MetaValue>
+            </MetaRow>
+          </Stack>
+        </Card>
+      )}
+
+      {activeTab === "issues" && <ProjectIssuesTab projectId={p.id} />}
+
+      {activeTab === "deployments" && <DeploymentsTab projectId={p.id} />}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/services/accounts.ts
+++ b/apps/csm-portal/microapp/src/services/accounts.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Read-only Accounts browsing (Customers > Accounts). Paged via infinite
+// scroll, mirroring services/announcements.ts and services/engagements.ts —
+// the webapp's own CsmAccountsPage uses classic offset pagination, but every
+// other list page in this app is infinite-scrolled, so this follows the
+// mobile convention instead of the desktop one.
+
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { ACCOUNTS_SEARCH_ENDPOINT, ACCOUNT_ENDPOINT } from "@config/endpoints";
+import type { AccountDto, AccountSearchPayloadDto, AccountSearchResponseDto } from "@src/types";
+import { toAccount, type Account } from "@src/types";
+import apiClient from "./apiClient";
+
+export interface AccountSearchResult {
+  items: Account[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+const ACCOUNTS_PAGE_LIMIT = 20;
+
+async function searchAccounts(searchQuery: string, offset: number): Promise<AccountSearchResult> {
+  const q = searchQuery.trim();
+  const payload: AccountSearchPayloadDto = {
+    pagination: { offset, limit: ACCOUNTS_PAGE_LIMIT },
+    ...(q ? { searchQuery: q } : {}),
+  };
+  const { data } = await apiClient.post<AccountSearchResponseDto>(ACCOUNTS_SEARCH_ENDPOINT, payload);
+  const items = data.accounts.map(toAccount);
+  return {
+    items,
+    total: data.total,
+    offset: data.offset,
+    limit: data.limit,
+    // Some data sources omit hasMore from the search envelope (see cases.ts's getAllCases and
+    // adminUsers.ts's searchUsers); derive it from offset/total when that happens, and never
+    // report hasMore on an empty page (see services/engagements.ts's own fix for this).
+    hasMore: items.length > 0 && (data.hasMore ?? data.offset + items.length < data.total),
+  };
+}
+
+const getAccount = async (id: string): Promise<Account> => {
+  const { data } = await apiClient.get<AccountDto>(ACCOUNT_ENDPOINT(id));
+  return toAccount(data);
+};
+
+export const accounts = {
+  infinite: (searchQuery: string) =>
+    infiniteQueryOptions({
+      queryKey: ["accounts", "infinite", searchQuery],
+      queryFn: ({ pageParam }) => searchAccounts(searchQuery, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (last) => (last.hasMore ? last.offset + last.limit : undefined),
+    }),
+
+  get: (id: string) =>
+    queryOptions({
+      queryKey: ["account", id],
+      queryFn: () => getAccount(id),
+    }),
+};

--- a/apps/csm-portal/microapp/src/services/deployments.ts
+++ b/apps/csm-portal/microapp/src/services/deployments.ts
@@ -20,12 +20,20 @@ import type { DeploymentSearchResponseDto, DeployedProductSearchResponseDto } fr
 import {
   toDeploymentOption,
   toDeployedProductOption,
+  toDeployment,
+  toDeployedProduct,
   type DeploymentOption,
   type DeployedProductOption,
+  type Deployment,
+  type DeployedProduct,
 } from "@src/types";
 import apiClient from "./apiClient";
 
-const SEARCH_PAGE_LIMIT = 100;
+// openapi.yaml declares both endpoints' pagination.limit maximum as 100, but the live upstream
+// entity service actually rejects 100 with a 400 — the same documented discrepancy
+// services/cases.ts's COMMENTS_PAGE_LIMIT and services/products.ts's PRODUCTS_PAGE_LIMIT already
+// caught for their own endpoints; match that real, working value instead of the doc.
+const SEARCH_PAGE_LIMIT = 50;
 
 const searchDeployments = async (projectId: string): Promise<DeploymentOption[]> => {
   const { data } = await apiClient.post<DeploymentSearchResponseDto>(DEPLOYMENTS_SEARCH_ENDPOINT, {
@@ -43,6 +51,25 @@ const searchDeployedProducts = async (deploymentId: string): Promise<DeployedPro
   return data.deployedProducts.map(toDeployedProductOption);
 };
 
+// Richer variants of the two searches above, for the Customers > Project > Deployments tab
+// (read-only browsing) rather than the case-create cascading picker. Same requests, same bounded
+// page size — only the mapper (and so the cached shape) differs, hence the separate query keys.
+const listDeployments = async (projectId: string): Promise<Deployment[]> => {
+  const { data } = await apiClient.post<DeploymentSearchResponseDto>(DEPLOYMENTS_SEARCH_ENDPOINT, {
+    pagination: { offset: 0, limit: SEARCH_PAGE_LIMIT },
+    projectIds: [projectId],
+  });
+  return data.deployments.map(toDeployment);
+};
+
+const listDeployedProducts = async (deploymentId: string): Promise<DeployedProduct[]> => {
+  const { data } = await apiClient.post<DeployedProductSearchResponseDto>(
+    DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT(deploymentId),
+    { pagination: { offset: 0, limit: SEARCH_PAGE_LIMIT } },
+  );
+  return data.deployedProducts.map(toDeployedProduct);
+};
+
 export const deployments = {
   byProject: (projectId: string) =>
     queryOptions({
@@ -55,6 +82,20 @@ export const deployments = {
     queryOptions({
       queryKey: ["deployment-products", deploymentId],
       queryFn: () => searchDeployedProducts(deploymentId),
+      enabled: !!deploymentId,
+    }),
+
+  list: (projectId: string) =>
+    queryOptions({
+      queryKey: ["deployments", "list", projectId],
+      queryFn: () => listDeployments(projectId),
+      enabled: !!projectId,
+    }),
+
+  productsList: (deploymentId: string) =>
+    queryOptions({
+      queryKey: ["deployment-products", "list", deploymentId],
+      queryFn: () => listDeployedProducts(deploymentId),
       enabled: !!deploymentId,
     }),
 };

--- a/apps/csm-portal/microapp/src/services/deployments.ts
+++ b/apps/csm-portal/microapp/src/services/deployments.ts
@@ -16,7 +16,12 @@
 
 import { queryOptions } from "@tanstack/react-query";
 import { DEPLOYMENTS_SEARCH_ENDPOINT, DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT } from "@config/endpoints";
-import type { DeploymentSearchResponseDto, DeployedProductSearchResponseDto } from "@src/types";
+import type {
+  DeploymentDto,
+  DeploymentSearchResponseDto,
+  DeployedProductSearchItemDto,
+  DeployedProductSearchResponseDto,
+} from "@src/types";
 import {
   toDeploymentOption,
   toDeployedProductOption,
@@ -52,22 +57,35 @@ const searchDeployedProducts = async (deploymentId: string): Promise<DeployedPro
 };
 
 // Richer variants of the two searches above, for the Customers > Project > Deployments tab
-// (read-only browsing) rather than the case-create cascading picker. Same requests, same bounded
-// page size — only the mapper (and so the cached shape) differs, hence the separate query keys.
+// (read-only browsing) rather than the case-create cascading picker. Unlike those, these fetch
+// every page rather than just the first — a project's deployments (or a deployment's products)
+// can exceed SEARCH_PAGE_LIMIT, and this tab has no pagination/infinite-scroll UI of its own, so
+// the query itself has to return the complete list. Loop terminates on a short page (fewer rows
+// than requested), same technique as services/products.ts's fetchProductNames.
 const listDeployments = async (projectId: string): Promise<Deployment[]> => {
-  const { data } = await apiClient.post<DeploymentSearchResponseDto>(DEPLOYMENTS_SEARCH_ENDPOINT, {
-    pagination: { offset: 0, limit: SEARCH_PAGE_LIMIT },
-    projectIds: [projectId],
-  });
-  return data.deployments.map(toDeployment);
+  const all: DeploymentDto[] = [];
+  for (let offset = 0; ; offset += SEARCH_PAGE_LIMIT) {
+    const { data } = await apiClient.post<DeploymentSearchResponseDto>(DEPLOYMENTS_SEARCH_ENDPOINT, {
+      pagination: { offset, limit: SEARCH_PAGE_LIMIT },
+      projectIds: [projectId],
+    });
+    all.push(...data.deployments);
+    if (data.deployments.length < SEARCH_PAGE_LIMIT) break;
+  }
+  return all.map(toDeployment);
 };
 
 const listDeployedProducts = async (deploymentId: string): Promise<DeployedProduct[]> => {
-  const { data } = await apiClient.post<DeployedProductSearchResponseDto>(
-    DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT(deploymentId),
-    { pagination: { offset: 0, limit: SEARCH_PAGE_LIMIT } },
-  );
-  return data.deployedProducts.map(toDeployedProduct);
+  const all: DeployedProductSearchItemDto[] = [];
+  for (let offset = 0; ; offset += SEARCH_PAGE_LIMIT) {
+    const { data } = await apiClient.post<DeployedProductSearchResponseDto>(
+      DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT(deploymentId),
+      { pagination: { offset, limit: SEARCH_PAGE_LIMIT } },
+    );
+    all.push(...data.deployedProducts);
+    if (data.deployedProducts.length < SEARCH_PAGE_LIMIT) break;
+  }
+  return all.map(toDeployedProduct);
 };
 
 export const deployments = {

--- a/apps/csm-portal/microapp/src/services/projects.ts
+++ b/apps/csm-portal/microapp/src/services/projects.ts
@@ -14,10 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { queryOptions } from "@tanstack/react-query";
-import { PROJECTS_SEARCH_ENDPOINT } from "@config/endpoints";
-import type { ProjectSearchResponseDto } from "@src/types";
-import { toProject, type Project } from "@src/types";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { PROJECTS_SEARCH_ENDPOINT, PROJECT_ENDPOINT } from "@config/endpoints";
+import type { ProjectDetailDto, ProjectSearchResponseDto } from "@src/types";
+import {
+  toProject,
+  toProjectDetail,
+  toProjectSummary,
+  type Project,
+  type ProjectDetail,
+  type ProjectSummary,
+} from "@src/types";
 import apiClient from "./apiClient";
 
 const PROJECTS_PAGE_LIMIT = 20;
@@ -30,10 +37,56 @@ const searchProjects = async (searchQuery: string): Promise<Project[]> => {
   return data.projects.map(toProject);
 };
 
+export interface ProjectListResult {
+  items: ProjectSummary[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+// Full, richer list for the Customers > Projects page — distinct from `search` above (which
+// stays a lean one-shot type-ahead for filter pickers). Paged via infinite scroll, mirroring
+// services/accounts.ts.
+async function listProjects(searchQuery: string, offset: number): Promise<ProjectListResult> {
+  const q = searchQuery.trim();
+  const { data } = await apiClient.post<ProjectSearchResponseDto>(PROJECTS_SEARCH_ENDPOINT, {
+    pagination: { offset, limit: PROJECTS_PAGE_LIMIT },
+    ...(q ? { searchQuery: q } : {}),
+  });
+  const items = data.projects.map(toProjectSummary);
+  return {
+    items,
+    total: data.total,
+    offset: data.offset,
+    limit: data.limit,
+    hasMore: items.length > 0 && (data.hasMore ?? data.offset + items.length < data.total),
+  };
+}
+
+const getProject = async (id: string): Promise<ProjectDetail> => {
+  const { data } = await apiClient.get<ProjectDetailDto>(PROJECT_ENDPOINT(id));
+  return toProjectDetail(data);
+};
+
 export const projects = {
   search: (searchQuery: string) =>
     queryOptions({
       queryKey: ["projects", "search", searchQuery],
       queryFn: () => searchProjects(searchQuery),
+    }),
+
+  list: (searchQuery: string) =>
+    infiniteQueryOptions({
+      queryKey: ["projects", "list", searchQuery],
+      queryFn: ({ pageParam }) => listProjects(searchQuery, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (last) => (last.hasMore ? last.offset + last.limit : undefined),
+    }),
+
+  get: (id: string) =>
+    queryOptions({
+      queryKey: ["project", id],
+      queryFn: () => getProject(id),
     }),
 };

--- a/apps/csm-portal/microapp/src/types/account.dto.ts
+++ b/apps/csm-portal/microapp/src/types/account.dto.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export type AccountTier = "basic" | "enterprise";
+
+// Same shape for both a search-result row and GET /accounts/{id} — unlike
+// Project, Account has no separate enriched detail shape.
+export interface AccountDto {
+  id: string;
+  sfId: string;
+  name: string;
+  tier: AccountTier;
+  region?: string | null;
+  activationDate: string;
+  deactivationDate?: string | null;
+  ownerId: string;
+  technicalOwnerId?: string | null;
+  agentEnabled: boolean;
+  kbReferencesEnabled: boolean;
+  createdOn: string;
+  updatedOn: string;
+}
+
+export interface AccountSearchPayloadDto {
+  pagination?: { offset?: number; limit?: number };
+  searchQuery?: string;
+}
+
+export interface AccountSearchResponseDto {
+  accounts: AccountDto[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore?: boolean;
+}

--- a/apps/csm-portal/microapp/src/types/account.model.ts
+++ b/apps/csm-portal/microapp/src/types/account.model.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { AccountDto, AccountTier } from "./account.dto";
+
+export interface Account {
+  id: string;
+  sfId: string;
+  name: string;
+  tier: AccountTier;
+  region: string | null;
+  activationDate: string;
+  deactivationDate: string | null;
+  ownerId: string;
+  technicalOwnerId: string | null;
+  agentEnabled: boolean;
+  kbReferencesEnabled: boolean;
+  createdOn: string;
+  updatedOn: string;
+}
+
+export function toAccount(dto: AccountDto): Account {
+  return {
+    id: dto.id,
+    sfId: dto.sfId,
+    name: dto.name,
+    tier: dto.tier,
+    region: dto.region ?? null,
+    activationDate: dto.activationDate,
+    deactivationDate: dto.deactivationDate ?? null,
+    ownerId: dto.ownerId,
+    technicalOwnerId: dto.technicalOwnerId ?? null,
+    agentEnabled: dto.agentEnabled,
+    kbReferencesEnabled: dto.kbReferencesEnabled,
+    createdOn: dto.createdOn,
+    updatedOn: dto.updatedOn,
+  };
+}

--- a/apps/csm-portal/microapp/src/types/deployment.dto.ts
+++ b/apps/csm-portal/microapp/src/types/deployment.dto.ts
@@ -21,6 +21,9 @@ export interface DeploymentDto {
   projectId: string;
   name: string;
   type: DeploymentType;
+  description?: string;
+  createdOn?: string;
+  updatedOn?: string;
 }
 
 export interface DeploymentSearchPayloadDto {
@@ -43,6 +46,10 @@ export interface DeployedProductEntityRefDto {
   name: string;
 }
 
+export interface DeployedProductVersionRefDto extends DeployedProductEntityRefDto {
+  supportEoLDate?: string | null;
+}
+
 // The search response embeds the resolved product + version objects (not just their raw ids —
 // unlike what the OpenAPI doc's DeployedProduct schema documents), so the human-readable label
 // can be built straight from this without a second lookup, matching the webapp's
@@ -50,7 +57,14 @@ export interface DeployedProductEntityRefDto {
 export interface DeployedProductSearchItemDto {
   id: string;
   product?: DeployedProductEntityRefDto;
-  version?: DeployedProductEntityRefDto | null;
+  version?: DeployedProductVersionRefDto | null;
+  // SN-only sizing fields; the entity service returns them as strings (and always null for the
+  // Postgres data source) — mirrors the webapp's BeDeployedProduct.
+  cores?: string | null;
+  tps?: string | null;
+  category?: string | null;
+  createdOn?: string;
+  updatedOn?: string;
 }
 
 export interface DeployedProductSearchPayloadDto {

--- a/apps/csm-portal/microapp/src/types/deployment.model.ts
+++ b/apps/csm-portal/microapp/src/types/deployment.model.ts
@@ -36,3 +36,49 @@ export function toDeployedProductOption(dto: DeployedProductSearchItemDto): Depl
   const version = dto.version?.name ?? "";
   return { id: dto.id, label: version ? `${name} ${version}` : name };
 }
+
+/** Richer shape for the Customers > Project > Deployments list — a superset of
+ * {@link DeploymentOption} (which stays deliberately minimal for the case-create picker). */
+export interface Deployment {
+  id: string;
+  name: string;
+  type: DeploymentType;
+  description: string | null;
+  createdOn: string | null;
+  updatedOn: string | null;
+}
+
+export function toDeployment(dto: DeploymentDto): Deployment {
+  return {
+    id: dto.id,
+    name: dto.name,
+    type: dto.type,
+    description: dto.description ?? null,
+    createdOn: dto.createdOn ?? null,
+    updatedOn: dto.updatedOn ?? null,
+  };
+}
+
+/** Richer shape for a deployment's Deployed Products list — a superset of
+ * {@link DeployedProductOption} (which stays deliberately minimal for the case-create picker). */
+export interface DeployedProduct {
+  id: string;
+  productName: string;
+  versionName: string | null;
+  supportEoLDate: string | null;
+  cores: string | null;
+  tps: string | null;
+  category: string | null;
+}
+
+export function toDeployedProduct(dto: DeployedProductSearchItemDto): DeployedProduct {
+  return {
+    id: dto.id,
+    productName: dto.product?.name || dto.product?.id || "—",
+    versionName: dto.version?.name ?? null,
+    supportEoLDate: dto.version?.supportEoLDate ?? null,
+    cores: dto.cores ?? null,
+    tps: dto.tps ?? null,
+    category: dto.category ?? null,
+  };
+}

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -16,6 +16,8 @@
 
 export * from "./case.dto";
 export * from "./case.model";
+export * from "./account.dto";
+export * from "./account.model";
 export * from "./activity.dto";
 export * from "./activity.model";
 export * from "./attachment.dto";

--- a/apps/csm-portal/microapp/src/types/project.dto.ts
+++ b/apps/csm-portal/microapp/src/types/project.dto.ts
@@ -27,8 +27,18 @@ export type ProjectSubscriptionType =
 
 export interface ProjectDto {
   id: string;
+  accountId?: string;
+  sfId?: string;
   name: string;
+  // openapi.yaml documents this field as `projectKey`, but the live search
+  // endpoint actually returns `key` — verified in practice, matching the
+  // webapp's own csmProjects.ts, which carries the same correction.
+  key?: string;
   subscriptionType: ProjectSubscriptionType;
+  startDate?: string;
+  endDate?: string;
+  createdOn?: string;
+  updatedOn?: string;
 }
 
 export interface ProjectSearchPayloadDto {
@@ -42,4 +52,33 @@ export interface ProjectSearchResponseDto {
   limit: number;
   offset: number;
   hasMore: boolean;
+}
+
+/** Parent-account reference embedded in GET /projects/{id} — the entity
+ * service JOINs the account, so the project detail view gets the account
+ * name (and a few account facts) with no extra call. `tier` is a free-form
+ * label here (e.g. "Enterprise"), not the lowercase AccountTier enum. */
+export interface ProjectAccountRefDto {
+  id: string;
+  name: string;
+  activationDate?: string | null;
+  tier?: string;
+  region?: string | null;
+  agentEnabled?: boolean;
+  kbReferencesEnabled?: boolean;
+}
+
+/** GET /projects/{id} — enriched single-project shape, distinct from the
+ * search-result row: embeds the parent `account` instead of a bare `accountId`. */
+export interface ProjectDetailDto {
+  id: string;
+  sfId?: string;
+  name: string;
+  key?: string;
+  subscriptionType: ProjectSubscriptionType;
+  startDate?: string;
+  endDate?: string;
+  createdOn?: string;
+  updatedOn?: string;
+  account?: ProjectAccountRefDto;
 }

--- a/apps/csm-portal/microapp/src/types/project.model.ts
+++ b/apps/csm-portal/microapp/src/types/project.model.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { ProjectDto, ProjectSubscriptionType } from "./project.dto";
+import type { ProjectAccountRefDto, ProjectDetailDto, ProjectDto, ProjectSubscriptionType } from "./project.dto";
 
 export interface Project {
   id: string;
@@ -33,4 +33,64 @@ export function isCloudSupportProject(project: Project): boolean {
 
 export function toProject(dto: ProjectDto): Project {
   return { id: dto.id, name: dto.name, subscriptionType: dto.subscriptionType };
+}
+
+/** Richer search-row shape for the Customers > Projects list — a superset of
+ * {@link Project} (which stays deliberately minimal for its picker call sites). */
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  key: string | null;
+  subscriptionType: ProjectSubscriptionType;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+export function toProjectSummary(dto: ProjectDto): ProjectSummary {
+  return {
+    id: dto.id,
+    name: dto.name,
+    key: dto.key ?? null,
+    subscriptionType: dto.subscriptionType,
+    startDate: dto.startDate ?? null,
+    endDate: dto.endDate ?? null,
+  };
+}
+
+export interface ProjectAccountRef {
+  id: string;
+  name: string;
+  tier: string | null;
+}
+
+export interface ProjectDetail {
+  id: string;
+  name: string;
+  key: string | null;
+  sfId: string | null;
+  subscriptionType: ProjectSubscriptionType;
+  startDate: string | null;
+  endDate: string | null;
+  createdOn: string | null;
+  updatedOn: string | null;
+  account: ProjectAccountRef | null;
+}
+
+function toProjectAccountRef(dto: ProjectAccountRefDto): ProjectAccountRef {
+  return { id: dto.id, name: dto.name, tier: dto.tier ?? null };
+}
+
+export function toProjectDetail(dto: ProjectDetailDto): ProjectDetail {
+  return {
+    id: dto.id,
+    name: dto.name,
+    key: dto.key ?? null,
+    sfId: dto.sfId ?? null,
+    subscriptionType: dto.subscriptionType,
+    startDate: dto.startDate ?? null,
+    endDate: dto.endDate ?? null,
+    createdOn: dto.createdOn ?? null,
+    updatedOn: dto.updatedOn ?? null,
+    account: dto.account ? toProjectAccountRef(dto.account) : null,
+  };
 }

--- a/apps/csm-portal/microapp/src/utils/customers.ts
+++ b/apps/csm-portal/microapp/src/utils/customers.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { formatDate, parseOptionalBackendTimestamp } from "./dateTime";
+
+/** Shared across Accounts/Projects/Deployments: a raw backend timestamp
+ * (or null/undefined) to a display string, "—" when absent/unparseable. */
+export function formatDateOnly(raw: string | null | undefined): string {
+  const parsed = parseOptionalBackendTimestamp(raw);
+  return parsed ? formatDate(parsed) : "—";
+}
+
+/** "cloud_support" -> "cloud support" — matches the webapp's formatSubscriptionType/
+ * deploymentTypeLabel treatment of these underscore-separated enum values. */
+export function formatEnumLabel(value: string): string {
+  return value.replace(/_/g, " ");
+}

--- a/apps/csm-portal/microapp/src/utils/useInfiniteScrollSentinel.ts
+++ b/apps/csm-portal/microapp/src/utils/useInfiniteScrollSentinel.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef } from "react";
+
+interface UseInfiniteScrollSentinelParams {
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+}
+
+/**
+ * A 1px sentinel ref to place at the end of an infinite-scrolled list: observes its own
+ * intersection with the viewport and calls `fetchNextPage` once it scrolls into view, guarded
+ * against firing while a page is already loading or none remain.
+ */
+export function useInfiniteScrollSentinel({
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: UseInfiniteScrollSentinelParams) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return sentinelRef;
+}


### PR DESCRIPTION
## Purpose
The CSM Portal microapp had no "Customers" section at all — `MorePage.tsx` explicitly left it out. This adds a read-only port of the webapp's Customers area (Accounts, Projects, Deployments/Deployed Products), so engineers can look up account and project data from the mobile app.

## Goals
- Browse Accounts (search, list, detail).
- Browse Projects (search, list, detail with Overview/Issues/Deployments).
- Browse a project's Deployments and each deployment's Deployed Products.
- Reuse existing infrastructure wherever it already fit (the generic `cases.infinite` service for the Issues tab, the shared `DialogPaper` for the deployment dialog) rather than duplicating it.

## Approach
- `CustomersPage.tsx` — thin tab shell (Accounts | Projects), mirroring the webapp's `CsmCustomersLayout`.
- **Accounts**: search + infinite-scrolled list (name, SF ID, tier, region, activation dates) → detail page with the full metadata card (AI agent/KB toggles, owner IDs, timestamps).
- **Projects**: search + infinite-scrolled list (name, key, subscription, dates) → a 3-tab detail page:
  - **Overview** — metadata card, with a link through to the parent account.
  - **Issues** — reuses the existing generic `cases.infinite` service, scoped to `projectIds: [id]` with no case-type lock (search only, no filter sheet — kept lean for a single project's view).
  - **Deployments** — card list; tapping one opens a dialog with the deployment's metadata plus its Deployed Products (product, version, support EOL, cores, TPS, category).
- Extended `Project`/`Deployment`/`DeployedProduct` DTOs+models additively — the existing lean picker shapes (`Project`, `DeploymentOption`, `DeployedProductOption`) used by the case-create cascading pickers are untouched; new richer `ProjectSummary`/`ProjectDetail`/`Deployment`/`DeployedProduct` types sit alongside them.
- New `Account` domain type + `services/accounts.ts` (search infinite scroll + get-by-id).
- Found and fixed a live bug along the way: `services/deployments.ts`'s page-size constant was `100`, matching what `openapi.yaml` claims is the max for `/deployments/search` and `/deployments/{id}/products/search` — but the live entity service actually rejects `100` with a 400. Same documented discrepancy `services/cases.ts`'s `COMMENTS_PAGE_LIMIT` and `services/products.ts`'s `PRODUCTS_PAGE_LIMIT` already caught for their own endpoints; dropped to `50` to match.
- **Deliberately out of scope**: create/edit/deactivate for deployments and deployed products — read-only browse only for this pass, same call the webapp's own Operations "Create SR/CR" and this app's Engagements made.

## User stories
As a CSM engineer, I can look up an account's or project's details, and see a project's deployments and deployed products, from the mobile app.

## Release note
Added a Customers section to the CSM Portal mobile app (`More > Customers`): browse Accounts and Projects, including a project's Issues and Deployments.

## Documentation
N/A — internal CSM portal UI change, no external doc surface affected.

## Automation tests
- No automated test runner is wired up for this app yet.
- Verified locally: `tsc -b`, `eslint`, and `vite build` all clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Local dev server (Vite), manual browser testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Customers area with Accounts and Projects tabs, plus debounced search, infinite scrolling, and navigation to account/project details.
  * Introduced an Account Details page and a Project Details page with Overview, Issues, and Deployments tabs.
  * Added deployment detail dialogs showing deployed products with version, support EOL, and capacity metadata.
  * Updated “More” navigation to include Customers.
* **Bug Fixes**
  * Improved loading, error/retry, empty, and missing-data presentation across these views.
  * Standardized display formatting for dates and enum labels, with clear fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->