### PR TITLE
[CSM Portal] Include endDate in project search results

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -433,8 +433,10 @@ type ProjectView struct {
 	Name             string           `json:"name"`
 	Key              string           `json:"key"`
 	SubscriptionType SubscriptionType `json:"subscriptionType"`
-	EndDate          time.Time        `json:"endDate"`
-	CreatedOn        time.Time        `json:"createdOn"`
+	// EndDate is nil when the backing data source has no end date recorded
+	// for this project (e.g. ServiceNow leaves it blank).
+	EndDate   *time.Time `json:"endDate"`
+	CreatedOn time.Time  `json:"createdOn"`
 	ProjectClosureFields
 }
 

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -433,6 +433,7 @@ type ProjectView struct {
 	Name             string           `json:"name"`
 	Key              string           `json:"key"`
 	SubscriptionType SubscriptionType `json:"subscriptionType"`
+	EndDate          time.Time        `json:"endDate"`
 	CreatedOn        time.Time        `json:"createdOn"`
 	ProjectClosureFields
 }

--- a/entity-service/internal/service/project_service.go
+++ b/entity-service/internal/service/project_service.go
@@ -54,6 +54,7 @@ func (s *projectService) SearchProjects(ctx context.Context, req domain.SearchPr
 			Name:             p.Name,
 			Key:              p.Key,
 			SubscriptionType: p.SubscriptionType,
+			EndDate:          p.EndDate,
 			CreatedOn:        p.CreatedOn,
 		}
 	}

--- a/entity-service/internal/service/project_service.go
+++ b/entity-service/internal/service/project_service.go
@@ -49,12 +49,13 @@ func (s *projectService) SearchProjects(ctx context.Context, req domain.SearchPr
 
 	views := make([]domain.ProjectView, len(projects))
 	for i, p := range projects {
+		endDate := p.EndDate
 		views[i] = domain.ProjectView{
 			ID:               p.ID,
 			Name:             p.Name,
 			Key:              p.Key,
 			SubscriptionType: p.SubscriptionType,
-			EndDate:          p.EndDate,
+			EndDate:          &endDate,
 			CreatedOn:        p.CreatedOn,
 		}
 	}

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -150,12 +150,13 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 		if err != nil {
 			return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: project %q: %w", p.ID, err)
 		}
-		var endDate time.Time
+		var endDate *time.Time
 		if p.EndDate != "" {
-			endDate, err = time.Parse(snDateLayout, p.EndDate)
+			parsed, err := time.Parse(snDateLayout, p.EndDate)
 			if err != nil {
 				return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: parse endDate %q: %w", p.EndDate, err)
 			}
+			endDate = &parsed
 		}
 		views = append(views, domain.ProjectView{
 			ID:               sysidToUUID(p.ID),

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -54,6 +54,7 @@ type snProject struct {
 	Name      string        `json:"name"`
 	Key       string        `json:"key"`
 	Type      snProjectType `json:"type"`
+	EndDate   string        `json:"endDate"`
 	CreatedOn string        `json:"createdOn"`
 	snProjectClosureFields
 }
@@ -149,11 +150,19 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 		if err != nil {
 			return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: project %q: %w", p.ID, err)
 		}
+		var endDate time.Time
+		if p.EndDate != "" {
+			endDate, err = time.Parse(snDateLayout, p.EndDate)
+			if err != nil {
+				return domain.SearchProjectsResponse{}, fmt.Errorf("sn projects: parse endDate %q: %w", p.EndDate, err)
+			}
+		}
 		views = append(views, domain.ProjectView{
 			ID:               sysidToUUID(p.ID),
 			Name:             p.Name,
 			Key:              p.Key,
 			SubscriptionType: subType,
+			EndDate:          endDate,
 			CreatedOn:        createdOn,
 			ProjectClosureFields: domain.ProjectClosureFields{
 				ClosureState:                    p.ClosureState,

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2682,6 +2682,21 @@ components:
         updatedOn:
           type: string
           format: date-time
+        closureState:
+          type: string
+          nullable: true
+        endDateClosureState:
+          type: string
+          nullable: true
+        invoiceDueDateClosureState:
+          type: string
+          nullable: true
+        complianceViolationClosureState:
+          type: string
+          nullable: true
+        complianceViolationDate:
+          type: string
+          nullable: true
 
     ProjectView:
       type: object
@@ -2704,9 +2719,27 @@ components:
             - platformer_subscription
             - cloud_support
             - professional_services
+        endDate:
+          type: string
+          format: date-time
         createdOn:
           type: string
           format: date-time
+        closureState:
+          type: string
+          nullable: true
+        endDateClosureState:
+          type: string
+          nullable: true
+        invoiceDueDateClosureState:
+          type: string
+          nullable: true
+        complianceViolationClosureState:
+          type: string
+          nullable: true
+        complianceViolationDate:
+          type: string
+          nullable: true
 
     SearchProjectsResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2722,6 +2722,7 @@ components:
         endDate:
           type: string
           format: date-time
+          nullable: true
         createdOn:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- Adds `endDate` to `ProjectView`, the unified shape returned by `POST /projects/search` for both data sources.
- Both backends already had the value: the Postgres query already selects `end_date`, and ServiceNow's search response already returns `endDate` per project — it just wasn't carried through the mapping into the search response, even though `endDate` is already a supported filter/sort key on the same endpoint.
- Needed to compute account-closure notice-window buckets (90/60/30/15/7/0 days) client-side from the sorted, `Open`-filtered result set without an extra per-project detail fetch.
- Also documented the closure-state fields (`closureState`, `endDateClosureState`, `invoiceDueDateClosureState`, `complianceViolationClosureState`, `complianceViolationDate`) on `ProjectView`/`ProjectDetailsView` in `openapi.yaml` — these are already present in the real response from earlier project/account contact work, but were missing from the spec.

## Goals
- Surface `endDate` on project search results for both `postgres` and `servicenow` data sources.
- Bring `openapi.yaml` in line with the actual response shape.

## Approach
- `domain.ProjectView` gains an `EndDate time.Time` field.
- Postgres path (`project_service.go`): populate it from the already-selected `domain.Project.EndDate`.
- ServiceNow path (`sn_project_service.go`): add `endDate` to the `snProject` unmarshal target and parse it (guarded on non-empty, since the field is nullable upstream) alongside the existing `createdOn` parse.
- No changes needed in the Ballerina entity-service or ServiceNow — the field was already returned there, just dropped in this layer's mapping.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l` on changed files (clean)

## Release note
`GET /projects/search` results now include each project's `endDate`.

## Documentation
Updated `entity-service/openapi.yaml` (`ProjectView`, `ProjectDetailsView`).

## Security checks
- Secure coding standards followed: yes
- FindSecurityBugs/static analysis: N/A for Go — `go vet` ran clean, no new external calls or inputs introduced
- No secrets committed: yes

## Related PRs
Builds on #1191 (project/account contact search, closure fields, project update).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project search and detail responses now include an optional (nullable) project end date; it’s omitted when no end date is available.
  * Added nullable closure and compliance-related properties (including closure states, invoice due date closure state, and compliance violation date information) to project API responses.
  * ServiceNow-sourced project search results now populate the end date whenever it is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->