### PR TITLE
[CSM Portal Microapp] Show resolved owner/technical owner for ServiceNow-sourced accounts

### DIFF
--- a/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
@@ -92,12 +92,12 @@ export default function AccountDetailPage() {
             />
           </MetaRow>
           <Divider />
-          <MetaRow label="Owner ID">
-            <MetaValue mono>{a.ownerId || "—"}</MetaValue>
+          <MetaRow label="Account owner">
+            <MetaValue>{a.ownerName || a.ownerId || "—"}</MetaValue>
           </MetaRow>
           <Divider />
-          <MetaRow label="Technical owner ID">
-            <MetaValue mono>{a.technicalOwnerId || "—"}</MetaValue>
+          <MetaRow label="Technical owner">
+            <MetaValue>{a.technicalOwnerName || a.technicalOwnerId || "—"}</MetaValue>
           </MetaRow>
           <Divider />
           <MetaRow label="Created">

--- a/apps/csm-portal/microapp/src/types/account.dto.ts
+++ b/apps/csm-portal/microapp/src/types/account.dto.ts
@@ -16,8 +16,23 @@
 
 export type AccountTier = "basic" | "enterprise";
 
+/** A resolved `{id, name}` reference, as returned for ServiceNow-sourced accounts —
+ * mirrors the webapp's own AccountOwnerRef (csm-accounts/types/csmAccounts.ts). */
+export interface AccountOwnerRefDto {
+  id: string;
+  name?: string | null;
+}
+
 // Same shape for both a search-result row and GET /accounts/{id} — unlike
 // Project, Account has no separate enriched detail shape.
+//
+// GET /accounts/{id} and POST /accounts/search return one of two shapes depending on the
+// account's data source: PG-native accounts send bare `ownerId`/`technicalOwnerId` strings and
+// `agentEnabled`/`kbReferencesEnabled` booleans, while ServiceNow-sourced accounts send resolved
+// `owner`/`technicalOwner` {id, name} references and `hasAgent`/`hasKbReferences` instead — none
+// of which openapi.yaml's Account schema documents. Confirmed live (a ServiceNow account's
+// response carries `owner: {id, name}` with no bare `ownerId` at all) — same class of
+// doc-vs-reality gap already caught for this endpoint on the webapp side.
 export interface AccountDto {
   id: string;
   sfId: string;
@@ -26,10 +41,14 @@ export interface AccountDto {
   region?: string | null;
   activationDate: string;
   deactivationDate?: string | null;
-  ownerId: string;
+  ownerId?: string | null;
+  owner?: AccountOwnerRefDto | null;
   technicalOwnerId?: string | null;
-  agentEnabled: boolean;
-  kbReferencesEnabled: boolean;
+  technicalOwner?: AccountOwnerRefDto | null;
+  agentEnabled?: boolean;
+  hasAgent?: boolean;
+  kbReferencesEnabled?: boolean;
+  hasKbReferences?: boolean;
   createdOn: string;
   updatedOn: string;
 }

--- a/apps/csm-portal/microapp/src/types/account.model.ts
+++ b/apps/csm-portal/microapp/src/types/account.model.ts
@@ -24,14 +24,21 @@ export interface Account {
   region: string | null;
   activationDate: string;
   deactivationDate: string | null;
-  ownerId: string;
+  ownerId: string | null;
+  /** Resolved display name for the owner, when the source is ServiceNow. Falls back to
+   * `ownerId` in the UI when this is null (a PG-native account). */
+  ownerName: string | null;
   technicalOwnerId: string | null;
+  technicalOwnerName: string | null;
   agentEnabled: boolean;
   kbReferencesEnabled: boolean;
   createdOn: string;
   updatedOn: string;
 }
 
+// Resolves the PG-native-vs-ServiceNow-sourced dual shape once here (see AccountDto's own
+// comment), so nothing downstream has to know about ownerId-vs-owner / agentEnabled-vs-hasAgent —
+// callers just get a plain Account.
 export function toAccount(dto: AccountDto): Account {
   return {
     id: dto.id,
@@ -41,10 +48,12 @@ export function toAccount(dto: AccountDto): Account {
     region: dto.region ?? null,
     activationDate: dto.activationDate,
     deactivationDate: dto.deactivationDate ?? null,
-    ownerId: dto.ownerId,
-    technicalOwnerId: dto.technicalOwnerId ?? null,
-    agentEnabled: dto.agentEnabled,
-    kbReferencesEnabled: dto.kbReferencesEnabled,
+    ownerId: dto.owner?.id ?? dto.ownerId ?? null,
+    ownerName: dto.owner?.name ?? null,
+    technicalOwnerId: dto.technicalOwner?.id ?? dto.technicalOwnerId ?? null,
+    technicalOwnerName: dto.technicalOwner?.name ?? null,
+    agentEnabled: dto.hasAgent ?? dto.agentEnabled ?? false,
+    kbReferencesEnabled: dto.hasKbReferences ?? dto.kbReferencesEnabled ?? false,
     createdOn: dto.createdOn,
     updatedOn: dto.updatedOn,
   };


### PR DESCRIPTION
## Purpose
The CSM Portal microapp's Account detail page (`More > Customers > Accounts > ...`) showed "—" for Owner ID and Technical owner ID on ServiceNow-sourced accounts, even though the data was present in the API response.

## Goals
- Show the account owner and technical owner for every account, regardless of its underlying data source.

## Approach
- `GET /accounts/{id}` and `POST /accounts/search` return one of two shapes depending on the account's data source: PG-native accounts send bare `ownerId`/`technicalOwnerId` strings and `agentEnabled`/`kbReferencesEnabled` booleans, while ServiceNow-sourced accounts send resolved `owner`/`technicalOwner: {id, name}` references and `hasAgent`/`hasKbReferences` instead — none of which `openapi.yaml` documents. Confirmed live: a ServiceNow account's response carries `owner: {id, name}` with no bare `ownerId` at all.
- This is the same class of doc-vs-reality gap the webapp already hit and fixed for this exact endpoint (`fix/csm-account-owner-details`) — this port applies the equivalent fix to the microapp.
- Widened `AccountDto` to accept both shapes, and resolve the ambiguity once in `toAccount()` (rather than pushing `??`/fallback logic into the page) — callers just get a plain `Account` with `ownerName`/`technicalOwnerName` already resolved.
- `AccountDetailPage.tsx` now shows the resolved name (falling back to the bare id for PG-native accounts), relabeled "Account owner" / "Technical owner" to match.

## User stories
As a CSM engineer, I can see who owns and who's the technical owner of an account from the mobile app, for every account regardless of its data source.

## Release note
Fixed the CSM Portal mobile app's Account detail page not showing the owner/technical owner for ServiceNow-sourced accounts.

## Documentation
N/A — internal CSM portal UI bugfix, no external doc surface affected.

## Automation tests
- No automated test runner is wired up for this app yet.
- Verified locally: `tsc -b`, `eslint`, and `vite build` all clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Local dev server (Vite), manual browser testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Account details now display account and technical owner names when available.
  * Owner identifiers are shown as a fallback when names aren’t provided.
  * Account information now supports data from multiple sources with consistent owner and feature-status values.
  * Missing owner details are displayed as “—” instead of leaving the fields unclear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->