### PR TITLE
[Customer Portal] Populate updatedOn for cases and stop falling back to createdOn

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -379,6 +379,8 @@ public type Case record {|
     string number;
     # Created date and time
     string createdOn;
+    # Updated date and time
+    string updatedOn;
     # Created by (User email)
     string createdBy;
     # Case title

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -136,6 +136,8 @@ public type Case record {|
     string number;
     # Created date and time
     string createdOn;
+    # Updated date and time
+    string updatedOn;
     # Created by (User email)
     string createdBy;
     # Case title

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -3581,6 +3581,7 @@ components:
       - assignedTeam
       - createdBy
       - createdOn
+      - updatedOn
       - description
       - duration
       - id
@@ -3605,6 +3606,9 @@ components:
         createdOn:
           type: string
           description: Created date and time
+        updatedOn:
+          type: string
+          description: Updated date and time
         createdBy:
           type: string
           description: Created by (User email)

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -100,6 +100,7 @@ public isolated function searchCases(string idToken, string projectId, types:Cas
             number: case.number,
             title: case.title,
             createdOn: case.createdOn,
+            updatedOn: case.updatedOn,
             createdBy: case.createdBy,
             description: case.description,
             duration: case.duration,

--- a/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
+++ b/apps/customer-portal/webapp/src/components/list-view/ListCard.tsx
@@ -213,7 +213,7 @@ export default function ListCard({
               color="text.secondary"
               sx={{ lineHeight: 1, overflowWrap: "anywhere" }}
             >
-              Updated {formatDateTime(caseItem.updatedOn ?? caseItem.createdOn) || "--"}
+              Updated {formatDateTime(caseItem.updatedOn) || "--"}
             </Typography>
           </Box>
           {caseItem.createdBy && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementDetailsPanel.tsx
@@ -114,9 +114,7 @@ export default function AnnouncementDetailsPanel({
   const statusLabel = data.status?.label;
   const statusColorPath = getStatusColor(statusLabel ?? undefined);
   const resolvedStatusColor = resolveColorFromTheme(statusColorPath, theme);
-  const updatedOnLabel = formatAnnouncementDateDisplay(
-    data.updatedOn ?? data.createdOn,
-  );
+  const updatedOnLabel = formatAnnouncementDateDisplay(data.updatedOn);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -225,7 +223,7 @@ export default function AnnouncementDetailsPanel({
               aria-hidden
             />
             <Typography variant="body2" color="text.secondary">
-              {updatedOnLabel}
+              {updatedOnLabel || "--"}
             </Typography>
           </Stack>
           {data.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
+++ b/apps/customer-portal/webapp/src/features/announcements/components/AnnouncementList.tsx
@@ -97,7 +97,7 @@ export default function AnnouncementList({
         const statusColor = getStatusColor(statusLabel);
         const resolvedStatusColor = resolveColorFromTheme(statusColor, theme);
         const updatedOnLabel = formatAnnouncementDateDisplay(
-          caseItem.updatedOn ?? caseItem.createdOn,
+          caseItem.updatedOn,
         );
 
         const cardContent = (
@@ -195,7 +195,7 @@ export default function AnnouncementList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    Updated {updatedOnLabel}
+                    Updated {updatedOnLabel || "--"}
                   </Typography>
                 </Box>
                 {caseItem.issueType?.label && (

--- a/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/dashboard/components/cases-table/CasesList.tsx
@@ -163,7 +163,7 @@ const CasesList = ({
                           <Box>
                             <Typography variant="body2" color="text.primary">
                               {formatBackendTimestampForDisplay(
-                                row.updatedOn ?? row.createdOn,
+                                row.updatedOn,
                                 {
                                   month: "short",
                                   day: "numeric",
@@ -176,7 +176,7 @@ const CasesList = ({
                               color="text.secondary"
                             >
                               {formatBackendTimestampForDisplay(
-                                row.updatedOn ?? row.createdOn,
+                                row.updatedOn,
                                 {
                                   hour: "numeric",
                                   minute: "2-digit",

--- a/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/change-requests/ChangeRequestsList.tsx
@@ -319,7 +319,7 @@ export default function ChangeRequestsList({
                     </Typography>
                   </Box>
                 )}
-                {(item.updatedOn ?? item.createdOn) && (
+                {item.updatedOn && (
                   <Box
                     sx={{
                       display: "flex",
@@ -331,11 +331,11 @@ export default function ChangeRequestsList({
                       {CHANGE_REQUESTS_LIST_UPDATED_PREFIX}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {formatDateTime(item.updatedOn ?? item.createdOn)}
+                      {formatDateTime(item.updatedOn)}
                     </Typography>
                   </Box>
                 )}
-                {(item.updatedOn ?? item.createdOn) && (item.startDate || item.endDate) && (
+                {item.updatedOn && (item.startDate || item.endDate) && (
                   <Typography variant="body2" color="text.disabled">
                     |
                   </Typography>

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/ServiceRequestsList.tsx
@@ -232,7 +232,7 @@ export default function ServiceRequestsList({
                     color="text.secondary"
                     sx={{ lineHeight: 1 }}
                   >
-                    {formatDateTime(sr.updatedOn ?? sr.createdOn) || NULL_PLACEHOLDER}
+                    {formatDateTime(sr.updatedOn) || NULL_PLACEHOLDER}
                   </Typography>
                 </Box>
                 {environmentLabel && (

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/OutstandingCasesList.tsx
@@ -260,7 +260,7 @@ export default function OutstandingCasesList({
                   color="text.secondary"
                   sx={{ flexShrink: 0 }}
                 >
-                  {formatRelativeTime(c.updatedOn ?? c.createdOn ?? undefined)}
+                  {formatRelativeTime(c.updatedOn ?? undefined)}
                 </Typography>
               </Box>
             </Form.CardActions>


### PR DESCRIPTION
## Summary
- The `/cases/search` response never populated `updatedOn` — the entity and portal `Case` types only declared `createdOn`, so the Dashboard and Support case lists showed the created date labeled as "Updated."
- Added `updatedOn` to the entity (`entity/types.bal`) and portal (`types/types.bal`) `Case` records, mapped it in `searchCases` (`utils.bal`), and updated `openapi.yaml` to mark it as a required field on the `Case` schema.
- With `updatedOn` now guaranteed by the backend, removed the `?? createdOn` fallbacks in the frontend (cases, announcements, change requests, service requests, outstanding cases lists) that were masking the missing field, so "Updated" labels now reflect the real update time and fall back to a placeholder only when genuinely absent.

## Changes

**Backend**
- `modules/entity/types.bal` — add `updatedOn` to `Case`
- `modules/types/types.bal` — add `updatedOn` to `Case`
- `utils.bal` — map `updatedOn` in `searchCases`
- `openapi.yaml` — add `updatedOn` to `Case` schema, mark required

**Frontend**
- `components/list-view/ListCard.tsx`
- `features/announcements/components/AnnouncementDetailsPanel.tsx`
- `features/announcements/components/AnnouncementList.tsx`
- `features/dashboard/components/cases-table/CasesList.tsx`
- `features/operations/components/change-requests/ChangeRequestsList.tsx`
- `features/operations/components/service-requests/ServiceRequestsList.tsx`
- `features/support/components/support-overview-cards/OutstandingCasesList.tsx`

Each drops the `updatedOn ?? createdOn` fallback now that the backend always returns `updatedOn`.

## Test plan
- [x] `bal build` compiles cleanly with the type/mapper changes
- [ ] Verify Dashboard "Updated" column shows the correct last-updated timestamp (not created date) for cases
- [ ] Verify Support case list "Updated" label matches case-details "Last Updated"
- [ ] Verify announcements, change requests, service requests, and outstanding cases lists still render correctly when `updatedOn` is present/absent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added updated date and time information to case records and API responses.
  * Case and announcement views now display the latest update timestamp consistently.
* **Bug Fixes**
  * Removed fallback to creation dates when updated timestamps are unavailable.
  * Added clear placeholders where update information is missing.
  * Standardized “Updated” labels across lists, cards, tables, and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->