### PR TITLE
[CSM Portal] Add change request approval action and problem creation

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -160,6 +160,7 @@ func main() {
 	mux.HandleFunc("POST /incidents", incidentHandler.CreateIncident)
 	mux.HandleFunc("GET /incidents/{id}", incidentHandler.GetIncident)
 	mux.HandleFunc("PATCH /incidents/{id}", incidentHandler.PatchIncident)
+	mux.HandleFunc("POST /problems", problemHandler.CreateProblem)
 	mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
 	mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -162,6 +162,12 @@ func (c *Client) SearchProblems(ctx context.Context, body []byte) ([]byte, error
 	return c.do(ctx, http.MethodPost, "/problems/search", body)
 }
 
+// CreateProblem calls POST /problems on the entity service to create a new problem.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) CreateProblem(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/problems", body)
+}
+
 // GetProblem calls GET /problems/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *Client) GetProblem(ctx context.Context, id string) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/change_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/change_requests_test.go
@@ -137,7 +137,7 @@ func TestGetChangeRequest(t *testing.T) {
 		client := &mockEntityChangeRequestClient{
 			getChangeRequestFn: func(_ context.Context, id string) ([]byte, error) {
 				capturedID = id
-				return []byte(`{"id":"` + testCRID + `","number":"CHG001","state":"scheduled"}`), nil
+				return []byte(`{"id":"` + testCRID + `","number":"CHG001","state":"scheduled","legalNextStates":["implement","canceled"]}`), nil
 			},
 		}
 		h := NewChangeRequestHandler(client)
@@ -156,6 +156,10 @@ func TestGetChangeRequest(t *testing.T) {
 		if resp["number"] != "CHG001" {
 			t.Errorf("response number = %v, want CHG001", resp["number"])
 		}
+		legalNextStates, ok := resp["legalNextStates"].([]any)
+		if !ok || len(legalNextStates) != 2 {
+			t.Fatalf("legalNextStates = %v, want 2 entries", resp["legalNextStates"])
+		}
 	})
 
 	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
@@ -172,6 +176,117 @@ func TestGetChangeRequest(t *testing.T) {
 				r.SetPathValue("id", testCRID)
 				w := httptest.NewRecorder()
 				h.GetChangeRequest(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestPatchChangeRequest(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := httptest.NewRequest(http.MethodPatch, "/change-requests/"+testCRID, strings.NewReader(`{"requestApproval":true}`))
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.PatchChangeRequest(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/change-requests/not-a-uuid", strings.NewReader(`{"requestApproval":true}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.PatchChangeRequest(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty id", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/change-requests/", strings.NewReader(`{"requestApproval":true}`)))
+		w := httptest.NewRecorder()
+		h.PatchChangeRequest(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/change-requests/"+testCRID, strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.PatchChangeRequest(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewChangeRequestHandler(&mockEntityChangeRequestClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/change-requests/"+testCRID, strings.NewReader(`not-json`)))
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.PatchChangeRequest(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards requestApproval to upstream and returns 200 with legalNextStates", func(t *testing.T) {
+		const reqPayload = `{"requestApproval":true}`
+		var capturedID string
+		var capturedBody []byte
+		client := &mockEntityChangeRequestClient{
+			patchChangeRequestFn: func(_ context.Context, id string, body []byte) ([]byte, error) {
+				capturedID = id
+				capturedBody = body
+				return []byte(`{"id":"` + testCRID + `","number":"CHG0001","state":"assess","legalNextStates":["authorize","canceled"]}`), nil
+			},
+		}
+		h := NewChangeRequestHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/change-requests/"+testCRID, strings.NewReader(reqPayload)))
+		r.SetPathValue("id", testCRID)
+		w := httptest.NewRecorder()
+		h.PatchChangeRequest(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedID != testCRID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testCRID)
+		}
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+
+		resp := decodeJSON[map[string]any](t, w)
+		legalNextStates, ok := resp["legalNextStates"].([]any)
+		if !ok || len(legalNextStates) != 2 {
+			t.Fatalf("legalNextStates = %v, want 2 entries", resp["legalNextStates"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to update change request.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityChangeRequestClient{
+					patchChangeRequestFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewChangeRequestHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/change-requests/"+testCRID, strings.NewReader(`{"requestApproval":true}`)))
+				r.SetPathValue("id", testCRID)
+				w := httptest.NewRecorder()
+				h.PatchChangeRequest(w, r)
 				assertStatus(t, w, tc.wantCode)
 				assertErrorMessage(t, w, tc.wantMsg)
 				assertContentType(t, w, "application/json")

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -399,6 +399,7 @@ func (m *mockEntityIncidentClient) PatchIncident(ctx context.Context, id string,
 type mockEntityProblemClient struct {
 	searchProblemsFn func(ctx context.Context, body []byte) ([]byte, error)
 	getProblemFn     func(ctx context.Context, id string) ([]byte, error)
+	createProblemFn  func(ctx context.Context, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityProblemClient) SearchProblems(ctx context.Context, body []byte) ([]byte, error) {
@@ -411,6 +412,13 @@ func (m *mockEntityProblemClient) SearchProblems(ctx context.Context, body []byt
 func (m *mockEntityProblemClient) GetProblem(ctx context.Context, id string) ([]byte, error) {
 	if m.getProblemFn != nil {
 		return m.getProblemFn(ctx, id)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityProblemClient) CreateProblem(ctx context.Context, body []byte) ([]byte, error) {
+	if m.createProblemFn != nil {
+		return m.createProblemFn(ctx, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/problems.go
+++ b/apps/csm-portal/backend/internal/handler/problems.go
@@ -17,12 +17,14 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 )
@@ -32,6 +34,43 @@ type entityProblemClient interface {
 	SearchProblems(ctx context.Context, body []byte) ([]byte, error)
 	GetProblem(ctx context.Context, id string) ([]byte, error)
 	CreateProblem(ctx context.Context, body []byte) ([]byte, error)
+}
+
+// createProblemRequest mirrors the enum/format-constrained fields of the documented
+// CreateProblemPayload schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+type createProblemRequest struct {
+	Subject           string `json:"subject"`
+	Category          string `json:"category"`
+	Subcategory       string `json:"subcategory"`
+	OriginCaseID      string `json:"originCaseId"`
+	PrimaryIncidentID string `json:"primaryIncidentId"`
+}
+
+// validateCreateProblemBody checks that the body decodes as a JSON object with no
+// unknown fields, that the required subject is present and non-blank, and that any
+// optional UUID-formatted linking fields are well-formed, so obviously invalid
+// requests are rejected before reaching the entity service.
+func validateCreateProblemBody(body []byte) bool {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	var req createProblemRequest
+	if err := dec.Decode(&req); err != nil {
+		return false
+	}
+	if dec.More() {
+		return false
+	}
+	if strings.TrimSpace(req.Subject) == "" {
+		return false
+	}
+	if req.OriginCaseID != "" && !uuidRe.MatchString(req.OriginCaseID) {
+		return false
+	}
+	if req.PrimaryIncidentID != "" && !uuidRe.MatchString(req.PrimaryIncidentID) {
+		return false
+	}
+	return true
 }
 
 // ProblemHandler handles HTTP requests for problem operations, delegating to the
@@ -101,6 +140,11 @@ func (h *ProblemHandler) CreateProblem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validateCreateProblemBody(body) {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/problems.go
+++ b/apps/csm-portal/backend/internal/handler/problems.go
@@ -31,6 +31,7 @@ import (
 type entityProblemClient interface {
 	SearchProblems(ctx context.Context, body []byte) ([]byte, error)
 	GetProblem(ctx context.Context, id string) ([]byte, error)
+	CreateProblem(ctx context.Context, body []byte) ([]byte, error)
 }
 
 // ProblemHandler handles HTTP requests for problem operations, delegating to the
@@ -77,6 +78,41 @@ func (h *ProblemHandler) SearchProblems(w http.ResponseWriter, r *http.Request) 
 	}
 
 	writeJSON(w, http.StatusOK, result)
+}
+
+// CreateProblem handles POST /problems.
+func (h *ProblemHandler) CreateProblem(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateProblem(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateProblem failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to create problem.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
 }
 
 // GetProblem handles GET /problems/{id}.

--- a/apps/csm-portal/backend/internal/handler/problems_test.go
+++ b/apps/csm-portal/backend/internal/handler/problems_test.go
@@ -26,6 +26,83 @@ import (
 
 const testProblemID = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
 
+func TestCreateProblem(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := httptest.NewRequest(http.MethodPost, "/problems", strings.NewReader(`{"subject":"Recurring outage"}`))
+		w := httptest.NewRecorder()
+		h.CreateProblem(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/problems", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.CreateProblem(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/problems", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.CreateProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 201 with response", func(t *testing.T) {
+		const reqPayload = `{"subject":"Recurring outage"}`
+		var capturedBody []byte
+		client := &mockEntityProblemClient{
+			createProblemFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"id":"` + testProblemID + `","number":"PRB0001","subject":"Recurring outage","state":"new"}`), nil
+			},
+		}
+		h := NewProblemHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/problems", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.CreateProblem(w, r)
+
+		assertStatus(t, w, http.StatusCreated)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["number"] != "PRB0001" {
+			t.Errorf("response number = %v, want PRB0001", resp["number"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to create problem.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityProblemClient{
+					createProblemFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewProblemHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/problems", strings.NewReader(`{"subject":"Recurring outage"}`)))
+				w := httptest.NewRecorder()
+				h.CreateProblem(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestGetProblem(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewProblemHandler(&mockEntityProblemClient{})

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -3434,7 +3434,15 @@ components:
       additionalProperties: false
       description: >
         Any combination of fields may be supplied; at least one is required.
-        Omitted fields are left unchanged.
+        Omitted fields are left unchanged. isCustomerApproved, isCustomerReviewed,
+        and requestApproval are mutually exclusive: at most one may be set.
+      allOf:
+        - not:
+            required: [isCustomerApproved, isCustomerReviewed]
+        - not:
+            required: [isCustomerApproved, requestApproval]
+        - not:
+            required: [isCustomerReviewed, requestApproval]
       properties:
         title:
           type: string

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -3199,6 +3199,57 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /problems:
+    post:
+      summary: Create a new problem (ServiceNow data source only).
+      operationId: postProblems
+      security:
+        - bearerAuth: []
+      requestBody:
+        description: Problem create payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateProblemPayload'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /problems/{id}:
     get:
       summary: Get a single problem by ID (ServiceNow data source only).
@@ -3370,6 +3421,22 @@ components:
           type: string
         testPlan:
           type: string
+        isCustomerApproved:
+          type: boolean
+          description: >-
+            Records the customer's approval decision on the change request.
+            Mutually exclusive with isCustomerReviewed and requestApproval.
+        isCustomerReviewed:
+          type: boolean
+          description: >-
+            Records the customer's post-implementation review decision.
+            Mutually exclusive with isCustomerApproved and requestApproval.
+        requestApproval:
+          type: boolean
+          description: >-
+            Transitions the change request from New to Assess and requests
+            approval. Mutually exclusive with isCustomerApproved and
+            isCustomerReviewed.
 
     PatchChangeRequestResponse:
       type: object
@@ -5905,6 +5972,13 @@ components:
             approvedOn:
               type: string
               nullable: true
+            legalNextStates:
+              type: array
+              items:
+                type: string
+              description: >-
+                States the change request can legally transition to from its
+                current state, given its type and workflow position.
 
     TaskSummary:
       type: object
@@ -7319,6 +7393,23 @@ components:
         subject:
           type: string
           nullable: true
+
+    CreateProblemPayload:
+      type: object
+      required: [subject]
+      properties:
+        subject:
+          type: string
+        category:
+          type: string
+        subcategory:
+          type: string
+        originCaseId:
+          type: string
+          format: uuid
+        primaryIncidentId:
+          type: string
+          format: uuid
 
     ProblemSearchResponse:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -7518,6 +7518,16 @@ components:
         subject:
           type: string
           nullable: true
+        state:
+          type: string
+          nullable: true
+          description: Current workflow state (e.g. "new", "assess", "resolved", "closed")
+        assignmentGroup:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTo:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
 
     CreateProblemPayload:
       type: object
@@ -7566,10 +7576,6 @@ components:
         - $ref: '#/components/schemas/Problem'
         - type: object
           properties:
-            state:
-              type: string
-              nullable: true
-              description: Current workflow state (e.g. "new", "assess", "resolved", "closed")
             priority:
               type: string
               nullable: true
@@ -7590,9 +7596,6 @@ components:
                 $ref: '#/components/schemas/IdNumberRef'
             linkedChangeRequest:
               $ref: '#/components/schemas/IdNumberRef'
-            assignedTo:
-              $ref: '#/components/schemas/EntityRef'
-              nullable: true
             resolutionCode:
               type: string
               nullable: true

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -72,6 +72,9 @@ const CreateIncidentPage = lazy(
 const ProblemDetailPage = lazy(
   () => import("@features/csm-operations/pages/ProblemDetailPage"),
 );
+const CreateProblemPage = lazy(
+  () => import("@features/csm-operations/pages/CreateProblemPage"),
+);
 const CsmAdminLayout = lazy(
   () => import("@features/csm-admin/pages/CsmAdminLayout"),
 );
@@ -302,6 +305,10 @@ export default function App(): JSX.Element {
                   <Route
                     path="operations/incidents/:id"
                     element={<CsmIncidentDetailPage />}
+                  />
+                  <Route
+                    path="operations/problems/new"
+                    element={<CreateProblemPage />}
                   />
                   <Route
                     path="operations/problems/:id"

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1450,6 +1450,14 @@ export interface BeChangeRequestDetail extends BeChangeRequestSearchView {
   hasCustomerReviewed?: boolean;
   approvedBy?: BeEntityRef | null;
   approvedOn?: string | null;
+  /**
+   * Backend-supplied legal transitions out of the CR's current state, mirroring
+   * `nextStates` on a case (`CaseActionBar.tsx`) — render one action per entry
+   * rather than hardcoding a `state === 'new'` check. Intentionally narrow today:
+   * the only transition modeled so far is New -> Assess, so this is only ever
+   * `["assess"]` or `[]`.
+   */
+  legalNextStates?: string[];
 }
 
 /** An approval stage seen on a change request, e.g. Assess, Authorize. */
@@ -1622,12 +1630,15 @@ export interface BeConfigurationItemSearchResponse {
 /**
  * `PATCH /change-requests/{id}` body (ServiceNow data source only). At least
  * one field is required by the BE (`minProperties: 1`). `plannedStartOn` is a
- * `YYYY-MM-DD HH:MM:SS` string.
+ * `YYYY-MM-DD HH:MM:SS` string. `requestApproval` is mutually exclusive with
+ * the other fields here — it drives the New -> Assess transition (see
+ * `legalNextStates` on {@link BeChangeRequestDetail}) rather than editing a value.
  */
 export interface BePatchChangeRequestPayload {
   plannedStartOn?: string;
   isCustomerApproved?: boolean;
   isCustomerReviewed?: boolean;
+  requestApproval?: true;
 }
 
 /** `PATCH /change-requests/{id}` response — the touched identifiers. */
@@ -1979,6 +1990,20 @@ export interface BeProblemDetail {
   resolvedBy?: BeEntityRef | null;
   openedOn?: string | null;
   closedOn?: string | null;
+}
+
+/**
+ * `POST /problems` body (ServiceNow data source only). `subject` is the only
+ * required field. There is no `priority` field — priority is not settable on
+ * create (SN computes/defaults it server-side, confirmed by live testing), so
+ * it's deliberately omitted here and from the create form.
+ */
+export interface BeCreateProblemPayload {
+  subject: string;
+  category?: string;
+  subcategory?: string;
+  originCaseId?: string;
+  primaryIncidentId?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1925,25 +1925,27 @@ export interface BeProblemRef {
 }
 
 /**
- * List-item shape for `POST /problems/search`. Minimal by design — unlike
- * change requests/incidents, the search view does not embed state, priority,
- * or any other field beyond id/number/subject; only `GET /problems/{id}`
- * does (see {@link BeProblemDetail}).
+ * List-item shape for `POST /problems/search`. Includes `state` plus the
+ * assignment refs alongside id/number/subject; full record detail (priority,
+ * category, resolution fields, etc.) is still only on `GET /problems/{id}`
+ * (see {@link BeProblemDetail}).
  */
 export interface BeProblemSearchView {
   id: string;
   number?: string;
   subject?: string;
+  state?: BeProblemState;
+  assignmentGroup?: BeEntityRef | null;
+  assignedTo?: BeEntityRef | null;
 }
 
 export interface BeProblemSearchFilters {
   searchQuery?: string;
   /**
    * Filter by state. Not confirmed live against the backend at the time this
-   * was written — the search response itself doesn't echo `state` — so if
-   * the backend rejects or silently ignores this filter, drop it here and
-   * from `ProblemsTab`'s payload, and remove the state control from
-   * `ProblemsFilterBar`.
+   * was written, so if the backend rejects or silently ignores this filter,
+   * drop it here and from `ProblemsTab`'s payload, and remove the state
+   * control from `ProblemsFilterBar`.
    */
   states?: BeProblemState[];
 }

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -81,6 +81,8 @@ export const ApiQueryKeys = {
   SERVICE_OFFERINGS_SEARCH: "service-offerings-search",
   CONFIGURATION_ITEMS_SEARCH: "configuration-items-search",
   USERS_SEARCH_BY_NAME: "users-search-by-name",
+  CASES_SEARCH_FOR_SELECT: "cases-search-for-select",
+  INCIDENTS_SEARCH_FOR_SELECT: "incidents-search-for-select",
   CATALOGS_SEARCH: "catalogs-search",
   CATALOG_ITEM_VARIABLES: "catalog-item-variables",
   REGISTRY_TOKENS_SEARCH: "registry-tokens-search",

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/usePostProblem.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/usePostProblem.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeCreateProblemPayload, BeProblemDetail } from "@api/backend/types";
+
+/**
+ * Create a problem via `POST /problems` (ServiceNow data source only). Unlike
+ * change requests/incidents, the response is the full problem-detail object
+ * directly (no wrapper envelope) — the same shape `GET /problems/{id}`
+ * returns. On success the problems list is invalidated so the new record
+ * appears.
+ */
+export function usePostProblem(): UseMutationResult<
+  BeProblemDetail,
+  Error,
+  BeCreateProblemPayload
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BeProblemDetail, Error, BeCreateProblemPayload>({
+    mutationFn: (payload): Promise<BeProblemDetail> =>
+      api.post<BeCreateProblemPayload, BeProblemDetail>("/problems", payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: [ApiQueryKeys.PROBLEMS] });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCasesForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCasesForSelect.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCaseSearchPayload,
+  BeCaseSearchResponse,
+  BeCaseSearchView,
+} from "@api/backend/types";
+
+/** A single page of matches is plenty for a type-ahead picker. */
+const CASE_SEARCH_LIMIT = 20;
+
+/**
+ * Type-ahead case search (`POST /cases/search`, `filters.searchQuery`) for
+ * the problem create form's "Origin case" picker. Matches the
+ * `(query, enabled) => {data, isFetching, isError}` shape `AsyncEntitySelect`
+ * expects — same template as `useSearchGroups`/`useSearchUsersByName`.
+ * Disabled until the caller has typed something.
+ */
+export function useSearchCasesForSelect(
+  query: string,
+  enabled: boolean,
+): UseQueryResult<BeCaseSearchView[], Error> {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<BeCaseSearchView[], Error>({
+    queryKey: [ApiQueryKeys.CASES_SEARCH_FOR_SELECT, q],
+    queryFn: async (): Promise<BeCaseSearchView[]> => {
+      const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+        "/cases/search",
+        { filters: { searchQuery: q }, pagination: { offset: 0, limit: CASE_SEARCH_LIMIT } },
+      );
+      return res.cases ?? [];
+    },
+    enabled: enabled && q.length > 0,
+    placeholderData: keepPreviousData,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeIncident,
+  BeIncidentSearchPayload,
+  BeIncidentSearchResponse,
+} from "@api/backend/types";
+
+/** A single page of matches is plenty for a type-ahead picker. */
+const INCIDENT_SEARCH_LIMIT = 20;
+
+/**
+ * Type-ahead incident search (`POST /incidents/search`, `filters.searchQuery`)
+ * for the problem create form's "Primary incident" picker. `useSearchIncidents`
+ * already wraps this endpoint but takes the full paginated-listing payload/
+ * result shape used by `IncidentsTab`; this wraps the same endpoint in the
+ * `(query, enabled) => {data, isFetching, isError}` shape `AsyncEntitySelect`
+ * expects instead — same template as `useSearchGroups`/`useSearchUsersByName`.
+ * Disabled until the caller has typed something. Filters out any result
+ * without an id (the `BeIncident.id` field is nullable) so every option
+ * `AsyncEntitySelect` renders is guaranteed to have one.
+ */
+export function useSearchIncidentsForSelect(
+  query: string,
+  enabled: boolean,
+): UseQueryResult<BeIncident[], Error> {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<BeIncident[], Error>({
+    queryKey: [ApiQueryKeys.INCIDENTS_SEARCH_FOR_SELECT, q],
+    queryFn: async (): Promise<BeIncident[]> => {
+      const res = await api.post<BeIncidentSearchPayload, BeIncidentSearchResponse>(
+        "/incidents/search",
+        { filters: { searchQuery: q }, pagination: { offset: 0, limit: INCIDENT_SEARCH_LIMIT } },
+      );
+      return (res.incidents ?? []).filter((i) => !!i.id);
+    },
+    enabled: enabled && q.length > 0,
+    placeholderData: keepPreviousData,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -17,6 +17,7 @@
 import {
   Box,
   Button,
+  Chip,
   LinearProgress,
   Skeleton,
   Table,
@@ -36,6 +37,8 @@ import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProblems } from "@features/csm-operations/api/useSearchProblems";
 import {
   DEFAULT_PROBLEM_FILTERS,
+  problemStateColor,
+  problemStateLabel,
   type ProblemFilters,
 } from "@features/csm-operations/utils/problems";
 import ProblemsFilterBar from "@features/csm-operations/components/ProblemsFilterBar";
@@ -46,9 +49,7 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
 /**
  * Problems listing for the Operations → Problem management tab. Searches
  * `POST /problems/search` with server-side pagination, free-text search, and
- * a state filter. Unlike change requests/incidents, the search view is
- * minimal (id/number/subject only — no `state`), so the table can't show a
- * State column even though the filter can still be applied server-side.
+ * a state filter.
  */
 export default function ProblemsTab(): JSX.Element {
   const navigate = useNavTransition();
@@ -123,6 +124,9 @@ export default function ProblemsTab(): JSX.Element {
               <TableRow sx={{ bgcolor: "action.hover" }}>
                 <TableCell>Number</TableCell>
                 <TableCell>Subject</TableCell>
+                <TableCell>State</TableCell>
+                <TableCell>Assignment group</TableCell>
+                <TableCell>Assigned to</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -131,11 +135,14 @@ export default function ProblemsTab(): JSX.Element {
                   <TableRow key={i}>
                     <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
                     <TableCell><Skeleton variant="rounded" width="90%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={90} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="70%" height={18} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width="70%" height={18} /></TableCell>
                   </TableRow>
                 ))
               ) : isError ? (
                 <TableRow>
-                  <TableCell colSpan={2} align="center">
+                  <TableCell colSpan={5} align="center">
                     <QueryErrorState
                       message={`Failed to load problems: ${error instanceof Error ? error.message : "unknown error"}`}
                       error={error}
@@ -144,7 +151,7 @@ export default function ProblemsTab(): JSX.Element {
                 </TableRow>
               ) : problems.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={2} align="center" sx={{ py: 4 }}>
+                  <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       No problems found.
                     </Typography>
@@ -174,6 +181,20 @@ export default function ProblemsTab(): JSX.Element {
                         {problem.subject || "—"}
                       </Typography>
                     </TableCell>
+                    <TableCell>
+                      {problem.state ? (
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          color={problemStateColor(problem.state)}
+                          label={problemStateLabel(problem.state)}
+                        />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell>{problem.assignmentGroup?.name || "—"}</TableCell>
+                    <TableCell>{problem.assignedTo?.name || "—"}</TableCell>
                   </TableRow>
                   );
                 })

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -16,6 +16,7 @@
 
 import {
   Box,
+  Button,
   LinearProgress,
   Skeleton,
   Table,
@@ -27,6 +28,7 @@ import {
   TableRow,
   Typography,
 } from "@wso2/oxygen-ui";
+import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
@@ -89,6 +91,18 @@ export default function ProblemsTab(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          startIcon={<Plus size={16} />}
+          onClick={() => navigate("/operations/problems/new")}
+        >
+          Create problem
+        </Button>
+      </Box>
+
       <ProblemsFilterBar
         filters={filters}
         onChange={handleFiltersChange}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.test.tsx
@@ -51,6 +51,24 @@ vi.mock("@api/backend/client", () => ({
     }
   },
 }));
+// The Origin case / Primary incident pickers are a generic AsyncEntitySelect
+// (a full type-ahead Autocomplete backed by a search hook) — out of scope to
+// drive through its real search/dropdown interaction here, so it's stubbed
+// as a plain labeled input that reports its id straight through onChange,
+// same as the plain TextFields it replaced from the page's point of view.
+vi.mock("@components/AsyncEntitySelect", () => ({
+  default: ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: string;
+    onChange: (next: string) => void;
+  }) => (
+    <input aria-label={label} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
 
 // Imported after the mocks above so the module picks them up.
 import CreateProblemPage from "@features/csm-operations/pages/CreateProblemPage";
@@ -81,13 +99,32 @@ describe("CreateProblemPage", () => {
     fireEvent.change(screen.getByLabelText(/subject/i), {
       target: { value: "  Recurring gateway 502s  " },
     });
-    fireEvent.change(screen.getByLabelText(/^category$/i), {
-      target: { value: "software" },
-    });
+    // Category is a dependent Select — open it and pick an option rather
+    // than firing a raw change event on a text input.
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /^category$/i }));
+    fireEvent.click(screen.getByRole("option", { name: "Software" }));
     fireEvent.click(screen.getByRole("button", { name: /create problem/i }));
     expect(postProblemMutateMock).toHaveBeenCalledWith(
       { subject: "Recurring gateway 502s", category: "software" },
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("narrows Subcategory to the selected Category and clears a stale selection", () => {
+    render(<CreateProblemPage />);
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /^category$/i }));
+    fireEvent.click(screen.getByRole("option", { name: "Hardware" }));
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /^subcategory$/i }));
+    fireEvent.click(screen.getByRole("option", { name: "Memory" }));
+    expect(screen.getByRole("combobox", { name: /^subcategory$/i })).toHaveTextContent("Memory");
+
+    // Switching Category to one whose option list doesn't include "Memory"
+    // must drop the now-invalid Subcategory selection.
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /^category$/i }));
+    fireEvent.click(screen.getByRole("option", { name: "Software" }));
+    expect(screen.getByRole("combobox", { name: /^subcategory$/i })).toHaveTextContent(
+      "-- Select --",
     );
   });
 
@@ -96,10 +133,10 @@ describe("CreateProblemPage", () => {
     fireEvent.change(screen.getByLabelText(/subject/i), {
       target: { value: "Recurring gateway 502s" },
     });
-    fireEvent.change(screen.getByLabelText(/origin case id/i), {
+    fireEvent.change(screen.getByLabelText(/origin case/i), {
       target: { value: "case-123" },
     });
-    fireEvent.change(screen.getByLabelText(/primary incident id/i), {
+    fireEvent.change(screen.getByLabelText(/primary incident/i), {
       target: { value: "inc-456" },
     });
     fireEvent.click(screen.getByRole("button", { name: /create problem/i }));

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.test.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const navigateMock = vi.fn();
+const postProblemMutateMock = vi.fn();
+const showErrorMock = vi.fn();
+const isPending = false;
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: showErrorMock }),
+}));
+vi.mock("@features/csm-operations/api/usePostProblem", () => ({
+  usePostProblem: () => ({
+    mutate: postProblemMutateMock,
+    get isPending() {
+      return isPending;
+    },
+  }),
+}));
+// CreateProblemPage imports BackendApiError from the real API client module,
+// which reads window.config at module load and throws outside a configured
+// runtime. Mock it with a real class (so `instanceof` still works) rather
+// than exercising the real config — mirrors the pattern in
+// useTimeSheets.test.ts.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Imported after the mocks above so the module picks them up.
+import CreateProblemPage from "@features/csm-operations/pages/CreateProblemPage";
+
+describe("CreateProblemPage", () => {
+  it("disables submit until Subject is filled in", () => {
+    render(<CreateProblemPage />);
+    expect(screen.getByRole("button", { name: /create problem/i })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Recurring gateway 502s" },
+    });
+    expect(screen.getByRole("button", { name: /create problem/i })).not.toBeDisabled();
+  });
+
+  it("shows a required error once Subject is touched and left blank", () => {
+    render(<CreateProblemPage />);
+    fireEvent.blur(screen.getByLabelText(/subject/i));
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  it("never renders a Priority field — priority is not settable on create", () => {
+    render(<CreateProblemPage />);
+    expect(screen.queryByLabelText(/priority/i)).not.toBeInTheDocument();
+  });
+
+  it("submits only the fields the user filled in, with subject trimmed", () => {
+    render(<CreateProblemPage />);
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "  Recurring gateway 502s  " },
+    });
+    fireEvent.change(screen.getByLabelText(/^category$/i), {
+      target: { value: "software" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create problem/i }));
+    expect(postProblemMutateMock).toHaveBeenCalledWith(
+      { subject: "Recurring gateway 502s", category: "software" },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("includes the optional linking IDs when provided", () => {
+    render(<CreateProblemPage />);
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Recurring gateway 502s" },
+    });
+    fireEvent.change(screen.getByLabelText(/origin case id/i), {
+      target: { value: "case-123" },
+    });
+    fireEvent.change(screen.getByLabelText(/primary incident id/i), {
+      target: { value: "inc-456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create problem/i }));
+    expect(postProblemMutateMock).toHaveBeenCalledWith(
+      {
+        subject: "Recurring gateway 502s",
+        originCaseId: "case-123",
+        primaryIncidentId: "inc-456",
+      },
+      expect.anything(),
+    );
+  });
+
+  it("navigates to the new problem's detail page on success", () => {
+    render(<CreateProblemPage />);
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Recurring gateway 502s" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create problem/i }));
+    const [, options] = postProblemMutateMock.mock.calls[0];
+    options.onSuccess({ id: "prb-1", number: "PRB0040200" });
+    expect(navigateMock).toHaveBeenCalledWith("/operations/problems/prb-1");
+  });
+
+  it("surfaces a mutation error via the shared error banner", () => {
+    render(<CreateProblemPage />);
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Recurring gateway 502s" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create problem/i }));
+    const [, options] = postProblemMutateMock.mock.calls[0];
+    options.onError(new Error("network down"));
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "Could not create the problem. Please try again.",
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.tsx
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Card, TextField, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import { useNavigate } from "react-router";
+import { BackendApiError } from "@api/backend/client";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { usePostProblem } from "@features/csm-operations/api/usePostProblem";
+import type { BeCreateProblemPayload } from "@api/backend/types";
+
+const OPERATIONS_PROBLEMS_PATH = "/operations?tab=problems";
+
+/**
+ * Create-problem form against `POST /problems` (ServiceNow data source only).
+ * `subject` is the only required field. There is no Priority field — priority
+ * is not settable on create (SN computes/defaults it server-side, confirmed
+ * by live testing) — and there's no metadata source yet for a Category /
+ * Subcategory picker, so both are plain text inputs, same as the "advanced
+ * linking" ID fields on `CreateIncidentPage`.
+ */
+export default function CreateProblemPage(): JSX.Element {
+  const navigate = useNavigate();
+  const { showError } = useErrorBanner();
+  const postProblem = usePostProblem();
+
+  const [subject, setSubject] = useState("");
+  const [category, setCategory] = useState("");
+  const [subcategory, setSubcategory] = useState("");
+  const [originCaseId, setOriginCaseId] = useState("");
+  const [primaryIncidentId, setPrimaryIncidentId] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  const isSubjectValid = subject.trim().length > 0;
+  const canSubmit = isSubjectValid && !postProblem.isPending;
+
+  const handleSubmit = (): void => {
+    if (!canSubmit) {
+      setTouched(true);
+      return;
+    }
+
+    const payload: BeCreateProblemPayload = { subject: subject.trim() };
+    if (category.trim()) payload.category = category.trim();
+    if (subcategory.trim()) payload.subcategory = subcategory.trim();
+    if (originCaseId.trim()) payload.originCaseId = originCaseId.trim();
+    if (primaryIncidentId.trim()) payload.primaryIncidentId = primaryIncidentId.trim();
+
+    postProblem.mutate(payload, {
+      onSuccess: (created) => navigate(`/operations/problems/${created.id}`),
+      onError: (err) => {
+        // The backend surfaces real validation messages on 4xx (e.g. an
+        // invalid UUID in one of the linking fields); show them.
+        const msg =
+          err instanceof BackendApiError && err.status < 500 && err.message
+            ? err.message
+            : "Could not create the problem. Please try again.";
+        showError(msg, err);
+      },
+    });
+  };
+
+  return (
+    <Box sx={{ width: "100%", px: 3, py: 3 }}>
+      <Button
+        variant="text"
+        startIcon={<ArrowLeft size={16} />}
+        onClick={() => navigate(OPERATIONS_PROBLEMS_PATH)}
+        sx={{ mb: 1 }}
+      >
+        Back to operations
+      </Button>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        New problem
+      </Typography>
+
+      <Card variant="outlined" sx={{ p: 3 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <Typography variant="subtitle2">Problem details</Typography>
+
+          <TextField
+            label="Subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            onBlur={() => setTouched(true)}
+            fullWidth
+            required
+            error={touched && !isSubjectValid}
+            helperText={touched && !isSubjectValid ? "Required" : undefined}
+            disabled={postProblem.isPending}
+            placeholder="Short summary of the problem"
+          />
+
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <TextField
+              label="Category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              disabled={postProblem.isPending}
+              sx={{ flex: "1 1 220px" }}
+            />
+            <TextField
+              label="Subcategory"
+              value={subcategory}
+              onChange={(e) => setSubcategory(e.target.value)}
+              disabled={postProblem.isPending}
+              sx={{ flex: "1 1 220px" }}
+            />
+          </Box>
+
+          <Typography variant="caption" color="text.secondary">
+            Advanced linking (portal UUIDs — no lookup available for these yet)
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <TextField
+              label="Origin case ID"
+              size="small"
+              value={originCaseId}
+              onChange={(e) => setOriginCaseId(e.target.value)}
+              disabled={postProblem.isPending}
+              sx={{ flex: "1 1 220px" }}
+            />
+            <TextField
+              label="Primary incident ID"
+              size="small"
+              value={primaryIncidentId}
+              onChange={(e) => setPrimaryIncidentId(e.target.value)}
+              disabled={postProblem.isPending}
+              sx={{ flex: "1 1 220px" }}
+            />
+          </Box>
+        </Box>
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, mt: 2.5 }}>
+          <Button variant="outlined" onClick={() => navigate(OPERATIONS_PROBLEMS_PATH)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            loading={postProblem.isPending}
+          >
+            Create problem
+          </Button>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateProblemPage.tsx
@@ -14,14 +14,84 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Card, TextField, Typography } from "@wso2/oxygen-ui";
+import {
+  Box,
+  Button,
+  Card,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import { useNavigate } from "react-router";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { usePostProblem } from "@features/csm-operations/api/usePostProblem";
-import type { BeCreateProblemPayload } from "@api/backend/types";
+import { useSearchCasesForSelect } from "@features/csm-operations/api/useSearchCasesForSelect";
+import { useSearchIncidentsForSelect } from "@features/csm-operations/api/useSearchIncidentsForSelect";
+import AsyncEntitySelect from "@components/AsyncEntitySelect";
+import type {
+  BeCaseSearchView,
+  BeCreateProblemPayload,
+  BeIncident,
+} from "@api/backend/types";
+
+const UNSET = "";
+const SELECT_PLACEHOLDER = "-- Select --";
+
+// Live SN choice-list values for problem.category / problem.subcategory
+// (confirmed via sys_choice against wso2sndev), hardcoded here since there is
+// no metadata endpoint for problem categories/subcategories the way there is
+// for cases. Subcategory is dependent on category — see
+// PROBLEM_SUBCATEGORY_OPTIONS_BY_CATEGORY below.
+const PROBLEM_CATEGORY_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "software", label: "Software" },
+  { value: "hardware", label: "Hardware" },
+  { value: "network", label: "Network" },
+  { value: "database", label: "Database" },
+];
+
+const PROBLEM_SUBCATEGORY_OPTIONS_BY_CATEGORY: Record<
+  string,
+  Array<{ value: string; label: string }>
+> = {
+  hardware: [
+    { value: "cpu", label: "CPU" },
+    { value: "monitor", label: "Monitor" },
+    { value: "disk", label: "Disk" },
+    { value: "mouse", label: "Mouse" },
+    { value: "keyboard", label: "Keyboard" },
+    { value: "memory", label: "Memory" },
+  ],
+  database: [
+    { value: "sql server", label: "MS SQL Server" },
+    { value: "db2", label: "DB2" },
+    { value: "oracle", label: "Oracle" },
+  ],
+  network: [
+    { value: "vpn", label: "VPN" },
+    { value: "dhcp", label: "DHCP" },
+    { value: "wireless", label: "Wireless" },
+    { value: "dns", label: "DNS" },
+    { value: "ip address", label: "IP Address" },
+  ],
+  software: [
+    { value: "email", label: "Email" },
+    { value: "os", label: "Operating System" },
+  ],
+};
+
+function caseSearchLabel(c: BeCaseSearchView): string {
+  return [c.number, c.subject].filter(Boolean).join(" — ") || c.id;
+}
+
+function incidentSearchLabel(i: BeIncident): string {
+  return [i.number, i.subject].filter(Boolean).join(" — ") || i.id || "";
+}
 
 const OPERATIONS_PROBLEMS_PATH = "/operations?tab=problems";
 
@@ -29,9 +99,7 @@ const OPERATIONS_PROBLEMS_PATH = "/operations?tab=problems";
  * Create-problem form against `POST /problems` (ServiceNow data source only).
  * `subject` is the only required field. There is no Priority field — priority
  * is not settable on create (SN computes/defaults it server-side, confirmed
- * by live testing) — and there's no metadata source yet for a Category /
- * Subcategory picker, so both are plain text inputs, same as the "advanced
- * linking" ID fields on `CreateIncidentPage`.
+ * by live testing).
  */
 export default function CreateProblemPage(): JSX.Element {
   const navigate = useNavigate();
@@ -39,11 +107,25 @@ export default function CreateProblemPage(): JSX.Element {
   const postProblem = usePostProblem();
 
   const [subject, setSubject] = useState("");
-  const [category, setCategory] = useState("");
-  const [subcategory, setSubcategory] = useState("");
+  const [category, setCategory] = useState<string>(UNSET);
+  const [subcategory, setSubcategory] = useState<string>(UNSET);
   const [originCaseId, setOriginCaseId] = useState("");
   const [primaryIncidentId, setPrimaryIncidentId] = useState("");
   const [touched, setTouched] = useState(false);
+
+  const subcategoryOptions = category
+    ? (PROBLEM_SUBCATEGORY_OPTIONS_BY_CATEGORY[category] ?? [])
+    : [];
+
+  const handleCategoryChange = (next: string): void => {
+    setCategory(next);
+    // Drop the subcategory if it no longer belongs to the newly selected
+    // category rather than leaving a stale, no-longer-valid pairing.
+    const stillValid = (PROBLEM_SUBCATEGORY_OPTIONS_BY_CATEGORY[next] ?? []).some(
+      (o) => o.value === subcategory,
+    );
+    if (!stillValid) setSubcategory(UNSET);
+  };
 
   const isSubjectValid = subject.trim().length > 0;
   const canSubmit = isSubjectValid && !postProblem.isPending;
@@ -55,10 +137,10 @@ export default function CreateProblemPage(): JSX.Element {
     }
 
     const payload: BeCreateProblemPayload = { subject: subject.trim() };
-    if (category.trim()) payload.category = category.trim();
-    if (subcategory.trim()) payload.subcategory = subcategory.trim();
-    if (originCaseId.trim()) payload.originCaseId = originCaseId.trim();
-    if (primaryIncidentId.trim()) payload.primaryIncidentId = primaryIncidentId.trim();
+    if (category) payload.category = category;
+    if (subcategory) payload.subcategory = subcategory;
+    if (originCaseId) payload.originCaseId = originCaseId;
+    if (primaryIncidentId) payload.primaryIncidentId = primaryIncidentId;
 
     postProblem.mutate(payload, {
       onSuccess: (created) => navigate(`/operations/problems/${created.id}`),
@@ -106,42 +188,96 @@ export default function CreateProblemPage(): JSX.Element {
           />
 
           <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-            <TextField
-              label="Category"
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
+            <FormControl
+              fullWidth
+              size="small"
               disabled={postProblem.isPending}
               sx={{ flex: "1 1 220px" }}
-            />
-            <TextField
-              label="Subcategory"
-              value={subcategory}
-              onChange={(e) => setSubcategory(e.target.value)}
-              disabled={postProblem.isPending}
+            >
+              <InputLabel id="problem-category-label" shrink>
+                Category
+              </InputLabel>
+              <Select
+                labelId="problem-category-label"
+                label="Category"
+                value={category}
+                displayEmpty
+                onChange={(e) => handleCategoryChange(String(e.target.value))}
+              >
+                <MenuItem value={UNSET}>
+                  <Typography component="span" color="text.secondary">
+                    {SELECT_PLACEHOLDER}
+                  </Typography>
+                </MenuItem>
+                {PROBLEM_CATEGORY_OPTIONS.map((o) => (
+                  <MenuItem key={o.value} value={o.value}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl
+              fullWidth
+              size="small"
+              disabled={postProblem.isPending || subcategoryOptions.length === 0}
               sx={{ flex: "1 1 220px" }}
-            />
+            >
+              <InputLabel id="problem-subcategory-label" shrink>
+                Subcategory
+              </InputLabel>
+              <Select
+                labelId="problem-subcategory-label"
+                label="Subcategory"
+                value={subcategory}
+                displayEmpty
+                onChange={(e) => setSubcategory(String(e.target.value))}
+              >
+                <MenuItem value={UNSET}>
+                  <Typography component="span" color="text.secondary">
+                    {SELECT_PLACEHOLDER}
+                  </Typography>
+                </MenuItem>
+                {subcategoryOptions.map((o) => (
+                  <MenuItem key={o.value} value={o.value}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Box>
 
           <Typography variant="caption" color="text.secondary">
-            Advanced linking (portal UUIDs — no lookup available for these yet)
+            Advanced linking
           </Typography>
           <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-            <TextField
-              label="Origin case ID"
-              size="small"
-              value={originCaseId}
-              onChange={(e) => setOriginCaseId(e.target.value)}
-              disabled={postProblem.isPending}
-              sx={{ flex: "1 1 220px" }}
-            />
-            <TextField
-              label="Primary incident ID"
-              size="small"
-              value={primaryIncidentId}
-              onChange={(e) => setPrimaryIncidentId(e.target.value)}
-              disabled={postProblem.isPending}
-              sx={{ flex: "1 1 220px" }}
-            />
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeCaseSearchView>
+                id="problem-origin-case"
+                label="Origin case"
+                placeholder="Search cases…"
+                value={originCaseId}
+                onChange={setOriginCaseId}
+                disabled={postProblem.isPending}
+                useSearch={useSearchCasesForSelect}
+                getId={(c) => c.id}
+                getLabel={caseSearchLabel}
+              />
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeIncident>
+                id="problem-primary-incident"
+                label="Primary incident"
+                placeholder="Search incidents…"
+                value={primaryIncidentId}
+                onChange={setPrimaryIncidentId}
+                disabled={postProblem.isPending}
+                useSearch={useSearchIncidentsForSelect}
+                // useSearchIncidentsForSelect only returns incidents that
+                // have an id (server-populated), so this is never null here.
+                getId={(i) => i.id!}
+                getLabel={incidentSearchLabel}
+              />
+            </Box>
           </Box>
         </Box>
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { BeChangeRequestDetail } from "@api/backend/types";
+
+const navigateMock = vi.fn();
+const useGetChangeRequestMock = vi.fn();
+const patchMutateMock = vi.fn();
+const showErrorMock = vi.fn();
+
+vi.mock("react-router", () => ({
+  useParams: () => ({ id: "chg-1" }),
+}));
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: showErrorMock }),
+}));
+vi.mock("@features/csm-operations/api/useGetChangeRequest", () => ({
+  useGetChangeRequest: () => useGetChangeRequestMock(),
+}));
+vi.mock("@features/csm-operations/api/usePatchChangeRequest", () => ({
+  usePatchChangeRequest: () => ({
+    mutate: patchMutateMock,
+    isPending: false,
+  }),
+}));
+vi.mock("@features/csm-operations/components/ChangeRequestApprovals", () => ({
+  default: () => null,
+}));
+
+// Imported after the mocks above so the module picks them up.
+import CsmChangeRequestDetailPage from "@features/csm-operations/pages/CsmChangeRequestDetailPage";
+
+const BASE_CR: BeChangeRequestDetail = {
+  id: "chg-1",
+  number: "CHG0009988",
+  subject: "Upgrade the gateway cluster",
+  state: "new",
+  type: "normal",
+};
+
+function mockQueryResult(
+  overrides: Partial<UseQueryResult<BeChangeRequestDetail | null, Error>>,
+): void {
+  useGetChangeRequestMock.mockReturnValue({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+describe("CsmChangeRequestDetailPage — Request approval (New -> Assess)", () => {
+  it("shows the Request approval button when the backend flags 'assess' as a legal next state", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    render(<CsmChangeRequestDetailPage />);
+    expect(
+      screen.getByRole("button", { name: /request approval/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the button when legalNextStates is empty (no transition available)", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: [] } });
+    render(<CsmChangeRequestDetailPage />);
+    expect(
+      screen.queryByRole("button", { name: /request approval/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the button when legalNextStates is absent — data-driven, no hardcoded state check", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: undefined } });
+    render(<CsmChangeRequestDetailPage />);
+    expect(
+      screen.queryByRole("button", { name: /request approval/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("PATCHes { requestApproval: true } for this CR when clicked", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "chg-1", patch: { requestApproval: true } },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it("surfaces a mutation error via the shared error banner", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    const [, options] = patchMutateMock.mock.calls[0];
+    const err = new Error("boom");
+    options.onError(err);
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "Could not request approval for this change request.",
+      err,
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -22,7 +22,7 @@ import {
   Skeleton,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft, Check, Pencil, X } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Check, Pencil, Send, X } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode, useState } from "react";
 import {  useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
@@ -174,6 +174,21 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   }
 
   const cr = data;
+  // Data-driven, like CaseActionBar's nextStates handling: only "assess" is
+  // ever modeled today (New -> Assess), but this checks membership rather
+  // than hardcoding `cr.state === "new"` so a backend-added transition needs
+  // no FE change to show up.
+  const canRequestApproval = !!cr.legalNextStates?.includes("assess");
+
+  const requestApproval = (): void => {
+    patchCr.mutate(
+      { id: cr.id, patch: { requestApproval: true } },
+      {
+        onError: (err) =>
+          showError("Could not request approval for this change request.", err),
+      },
+    );
+  };
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
@@ -197,12 +212,25 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               label={`${changeRequestImpactLabel(cr.impact)} impact`}
             />
           )}
+          {canRequestApproval && (
+            <Button
+              variant="contained"
+              color="primary"
+              size="small"
+              startIcon={<Send size={14} />}
+              onClick={requestApproval}
+              loading={patchCr.isPending}
+              sx={{ ml: "auto", flexShrink: 0 }}
+            >
+              Request approval
+            </Button>
+          )}
           <Button
             variant="outlined"
             size="small"
             startIcon={<Pencil size={14} />}
             onClick={() => setEditOpen(true)}
-            sx={{ ml: "auto", flexShrink: 0 }}
+            sx={{ ml: canRequestApproval ? 0 : "auto", flexShrink: 0 }}
           >
             Edit
           </Button>

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1789,6 +1789,7 @@ type PatchChangeRequestRequest struct {
 	TestPlan           *string              `json:"testPlan,omitempty"`
 	IsCustomerApproved *bool                `json:"isCustomerApproved,omitempty"`
 	IsCustomerReviewed *bool                `json:"isCustomerReviewed,omitempty"`
+	RequestApproval    *bool                `json:"requestApproval,omitempty"`
 }
 
 // PatchChangeRequestResponse is the response for PATCH /change-requests/{id}.
@@ -1956,6 +1957,7 @@ type ChangeRequest struct {
 	HasCustomerReviewed bool       `json:"hasCustomerReviewed"`
 	ApprovedBy          *EntityRef `json:"approvedBy"`
 	ApprovedOn          *string    `json:"approvedOn"`
+	LegalNextStates     []string   `json:"legalNextStates"`
 }
 
 // ChangeRequestApproverType is a string enum for the kind of approver assigned to an
@@ -2819,6 +2821,17 @@ type ProblemDetail struct {
 	ResolvedBy          *EntityRef      `json:"resolvedBy"`
 	OpenedOn            *string         `json:"openedOn"`
 	ClosedOn            *string         `json:"closedOn"`
+}
+
+// CreateProblemRequest is the request body for POST /problems. Subject is required;
+// Category, Subcategory, OriginCaseID, and PrimaryIncidentID are optional. OriginCaseID
+// and PrimaryIncidentID are UUIDs from the caller's perspective.
+type CreateProblemRequest struct {
+	Subject           string  `json:"subject"`
+	Category          *string `json:"category,omitempty"`
+	Subcategory       *string `json:"subcategory,omitempty"`
+	OriginCaseID      *string `json:"originCaseId,omitempty"`
+	PrimaryIncidentID *string `json:"primaryIncidentId,omitempty"`
 }
 
 // ConversationState represents the state of a conversation.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2790,9 +2790,12 @@ type SearchProblemsRequest struct {
 
 // SearchProblemView is the problem representation returned in search results.
 type SearchProblemView struct {
-	ID      *string `json:"id"`
-	Number  *string `json:"number"`
-	Subject *string `json:"subject"`
+	ID              *string    `json:"id"`
+	Number          *string    `json:"number"`
+	Subject         *string    `json:"subject"`
+	State           *string    `json:"state"`
+	AssignmentGroup *EntityRef `json:"assignmentGroup"`
+	AssignedTo      *EntityRef `json:"assignedTo"`
 }
 
 // SearchProblemsResponse is the paginated result of a problem search.

--- a/entity-service/internal/handler/problem_handler.go
+++ b/entity-service/internal/handler/problem_handler.go
@@ -61,3 +61,19 @@ func (h *ProblemHandler) GetProblem(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)
 }
+
+// CreateProblem handles POST /problems.
+func (h *ProblemHandler) CreateProblem(w http.ResponseWriter, r *http.Request) {
+	var req domain.CreateProblemRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.CreateProblem(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -339,6 +339,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	}
 
 	if problemHandler != nil {
+		mux.HandleFunc("POST /problems", problemHandler.CreateProblem)
 		mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 		mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
 	}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -376,7 +376,7 @@ type ProblemService interface {
 	// A NotFoundError is returned if the problem does not exist.
 	GetProblem(ctx context.Context, id string) (domain.ProblemDetail, error)
 
-	// CreateProblem creates a new problem. Subject and OriginCaseID are required.
+	// CreateProblem creates a new problem. Subject is required; OriginCaseID is optional.
 	// Supported by the ServiceNow data source only.
 	CreateProblem(ctx context.Context, req domain.CreateProblemRequest) (domain.ProblemDetail, error)
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -375,6 +375,10 @@ type ProblemService interface {
 	// GetProblem returns the full detail of a single problem by its UUID.
 	// A NotFoundError is returned if the problem does not exist.
 	GetProblem(ctx context.Context, id string) (domain.ProblemDetail, error)
+
+	// CreateProblem creates a new problem. Subject and OriginCaseID are required.
+	// Supported by the ServiceNow data source only.
+	CreateProblem(ctx context.Context, req domain.CreateProblemRequest) (domain.ProblemDetail, error)
 }
 
 // ConversationService defines the operations available on the conversations entity.

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -652,6 +652,20 @@ func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id stri
 		return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "at least one field must be provided"}
 	}
 
+	exclusiveApprovalFields := 0
+	if req.IsCustomerApproved != nil {
+		exclusiveApprovalFields++
+	}
+	if req.IsCustomerReviewed != nil {
+		exclusiveApprovalFields++
+	}
+	if req.RequestApproval != nil {
+		exclusiveApprovalFields++
+	}
+	if exclusiveApprovalFields > 1 {
+		return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "isCustomerApproved, isCustomerReviewed, and requestApproval are mutually exclusive"}
+	}
+
 	if req.Title != nil && *req.Title == "" {
 		return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "title cannot be empty"}
 	}

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -626,6 +626,7 @@ type snPatchChangeRequestPayload struct {
 	TestPlan           *string `json:"testPlan,omitempty"`
 	IsCustomerApproved *bool   `json:"isCustomerApproved,omitempty"`
 	IsCustomerReviewed *bool   `json:"isCustomerReviewed,omitempty"`
+	RequestApproval    *bool   `json:"requestApproval,omitempty"`
 }
 
 // snPatchChangeRequestResponse mirrors the Choreo PATCH /change-requests/{id} response.
@@ -647,7 +648,7 @@ func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id stri
 		req.Impact == nil && req.State == nil && req.Type == nil && req.Justification == nil &&
 		req.ImpactDescription == nil && req.ServiceOutage == nil && req.CommunicationPlan == nil &&
 		req.RollbackPlan == nil && req.TestPlan == nil && req.IsCustomerApproved == nil &&
-		req.IsCustomerReviewed == nil {
+		req.IsCustomerReviewed == nil && req.RequestApproval == nil {
 		return domain.PatchChangeRequestResponse{}, &apierror.ValidationError{Msg: "at least one field must be provided"}
 	}
 
@@ -709,6 +710,7 @@ func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id stri
 		TestPlan:           req.TestPlan,
 		IsCustomerApproved: req.IsCustomerApproved,
 		IsCustomerReviewed: req.IsCustomerReviewed,
+		RequestApproval:    req.RequestApproval,
 	}
 	if req.ProjectID != nil {
 		payload.ProjectID = strPtr(uuidToSysid(*req.ProjectID))
@@ -771,6 +773,7 @@ type snChangeRequestDetail struct {
 	HasCustomerReviewed bool           `json:"hasCustomerReviewed"`
 	ApprovedBy          *snCREntityRef `json:"approvedBy"`
 	ApprovedOn          *string        `json:"approvedOn"`
+	LegalNextStates     []string       `json:"legalNextStates"`
 }
 
 func (s *snChangeRequestService) GetChangeRequest(ctx context.Context, id string) (domain.ChangeRequest, error) {
@@ -912,6 +915,7 @@ func mapSNChangeRequestDetailToView(cr snChangeRequestDetail) domain.ChangeReque
 		HasCustomerApproved:     cr.HasCustomerApproved,
 		HasCustomerReviewed:     cr.HasCustomerReviewed,
 		ApprovedOn:              cr.ApprovedOn,
+		LegalNextStates:         cr.LegalNextStates,
 	}
 	if cr.ApprovedBy != nil {
 		result.ApprovedBy = &domain.EntityRef{ID: sysidToUUID(cr.ApprovedBy.ID), Name: cr.ApprovedBy.Name}

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -35,9 +35,12 @@ type snProblemsResponse struct {
 }
 
 type snProblem struct {
-	ID      *string `json:"id"`
-	Number  *string `json:"number"`
-	Subject *string `json:"subject"`
+	ID              *string           `json:"id"`
+	Number          *string           `json:"number"`
+	Subject         *string           `json:"subject"`
+	State           *string           `json:"state"`
+	AssignmentGroup *snProblemUserRef `json:"assignmentGroup"`
+	AssignedTo      *snProblemUserRef `json:"assignedTo"`
 }
 
 // snProblemSearchPayload is the Choreo POST /problems/search request body.
@@ -89,10 +92,17 @@ func (s *snProblemService) SearchProblems(ctx context.Context, req domain.Search
 		view := domain.SearchProblemView{
 			Subject: p.Subject,
 			Number:  p.Number,
+			State:   p.State,
 		}
 		if p.ID != nil && *p.ID != "" {
 			id := sysidToUUID(*p.ID)
 			view.ID = &id
+		}
+		if p.AssignmentGroup != nil {
+			view.AssignmentGroup = &domain.EntityRef{ID: sysidToUUID(p.AssignmentGroup.ID), Name: p.AssignmentGroup.Name}
+		}
+		if p.AssignedTo != nil {
+			view.AssignedTo = &domain.EntityRef{ID: sysidToUUID(p.AssignedTo.ID), Name: p.AssignedTo.Name}
 		}
 		views = append(views, view)
 	}

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -185,6 +187,10 @@ type snCreateProblemPayload struct {
 // CreateProblem implements ProblemService for the ServiceNow data source.
 func (s *snProblemService) CreateProblem(ctx context.Context, req domain.CreateProblemRequest) (domain.ProblemDetail, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
+
+	if strings.TrimSpace(req.Subject) == "" {
+		return domain.ProblemDetail{}, &apierror.ValidationError{Msg: "subject cannot be empty"}
+	}
 
 	uuidFields := map[string]string{}
 	if req.OriginCaseID != nil {

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -160,6 +160,63 @@ func (s *snProblemService) GetProblem(ctx context.Context, id string) (domain.Pr
 		return domain.ProblemDetail{}, fmt.Errorf("sn get problem: parse response: %w", err)
 	}
 
+	return mapSNProblemDetailToView(p), nil
+}
+
+// snCreateProblemPayload is the Choreo POST /problems request body.
+type snCreateProblemPayload struct {
+	Subject           string  `json:"subject"`
+	Category          *string `json:"category,omitempty"`
+	Subcategory       *string `json:"subcategory,omitempty"`
+	OriginCaseID      *string `json:"originCaseId,omitempty"`
+	PrimaryIncidentID *string `json:"primaryIncidentId,omitempty"`
+}
+
+// CreateProblem implements ProblemService for the ServiceNow data source.
+func (s *snProblemService) CreateProblem(ctx context.Context, req domain.CreateProblemRequest) (domain.ProblemDetail, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	uuidFields := map[string]string{}
+	if req.OriginCaseID != nil {
+		uuidFields["originCaseId"] = *req.OriginCaseID
+	}
+	if req.PrimaryIncidentID != nil {
+		uuidFields["primaryIncidentId"] = *req.PrimaryIncidentID
+	}
+	for field, val := range uuidFields {
+		if err := validateUUIDs(field, []string{val}); err != nil {
+			return domain.ProblemDetail{}, err
+		}
+	}
+
+	payload := snCreateProblemPayload{
+		Subject:     req.Subject,
+		Category:    req.Category,
+		Subcategory: req.Subcategory,
+	}
+	if req.OriginCaseID != nil {
+		payload.OriginCaseID = strPtr(uuidToSysid(*req.OriginCaseID))
+	}
+	if req.PrimaryIncidentID != nil {
+		payload.PrimaryIncidentID = strPtr(uuidToSysid(*req.PrimaryIncidentID))
+	}
+
+	raw, err := s.client.Post(ctx, "/problems", token, payload)
+	if err != nil {
+		return domain.ProblemDetail{}, err
+	}
+
+	var p snProblemDetailResponse
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return domain.ProblemDetail{}, fmt.Errorf("sn create problem: parse response: %w", err)
+	}
+
+	return mapSNProblemDetailToView(p), nil
+}
+
+// mapSNProblemDetailToView maps a Choreo problem detail payload to the domain view,
+// shared by GetProblem and CreateProblem.
+func mapSNProblemDetailToView(p snProblemDetailResponse) domain.ProblemDetail {
 	problemID := sysidToUUID(p.ID)
 	number := p.Number
 	subject := p.Subject
@@ -203,5 +260,5 @@ func (s *snProblemService) GetProblem(ctx context.Context, id string) (domain.Pr
 		view.ResolvedBy = &domain.EntityRef{ID: sysidToUUID(p.ResolvedBy.ID), Name: p.ResolvedBy.Name}
 	}
 
-	return view, nil
+	return view
 }

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -216,12 +216,19 @@ func (s *snProblemService) CreateProblem(ctx context.Context, req domain.CreateP
 		return domain.ProblemDetail{}, err
 	}
 
-	var p snProblemDetailResponse
-	if err := json.Unmarshal(raw, &p); err != nil {
+	var resp snCreateProblemResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
 		return domain.ProblemDetail{}, fmt.Errorf("sn create problem: parse response: %w", err)
 	}
 
-	return mapSNProblemDetailToView(p), nil
+	return mapSNProblemDetailToView(resp.Problem), nil
+}
+
+// snCreateProblemResponse mirrors the Choreo POST /problems response, which wraps
+// the created problem's detail payload in a message envelope.
+type snCreateProblemResponse struct {
+	Message string                  `json:"message"`
+	Problem snProblemDetailResponse `json:"problem"`
 }
 
 // mapSNProblemDetailToView maps a Choreo problem detail payload to the domain view,


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Change requests had no path for a regular user to move a request out of its initial state — only a raw, unchecked field-level patch existed, and the existing approve/reject actions only appear once a request already reaches a later stage. Separately, problem records could only be searched and viewed — there was no way to create one anywhere in the stack. This PR adds both capabilities, propagated through the entity service, the CSM portal backend, and the webapp.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Let a regular user move a change request out of its initial state via a single, backend-validated action, and let the UI discover when that action is legal from the change request's own detail response (no hardcoded state checks in the frontend).
- Add a create endpoint and a create form for problems, consistent with how change requests and incidents are already created.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**Change request approval action**
- Entity service: `PatchChangeRequestRequest` gains `RequestApproval *bool`; the change request detail type gains `LegalNextStates []string`. Both are pure passthrough — the data source performs all transition validation.
- Backend: this service is a byte-level passthrough proxy for change requests, so the new field and the new response field flow through automatically; the work here is documenting both in `openapi.yaml` and adding direct handler test coverage for the patch endpoint (which had none before).
- Webapp: a data-driven "Request approval" button on the change request detail page, shown only when `legalNextStates` includes `"assess"` — mirrors the existing `CaseActionBar` pattern of rendering off a backend-provided list rather than a hardcoded from-state check. Uses the existing patch mutation hook, which already invalidates the detail query on success, so the page updates without a manual reload. Errors surface through the existing error-banner pattern.

**Problem creation**
- Entity service: new `CreateProblem` method on the problem service, new request domain type, reusing the existing problem-detail type for the created-record response. Origin-case and primary-incident IDs are converted between the public UUID and the data source's native id the same way every other cross-link in this file is.
- Backend: new `POST /problems` handler mirroring the existing problem read handlers' auth pattern (401 with no authenticated user, no per-record access check since problems aren't project-scoped), a new entity-service client method, route registration, and `openapi.yaml` coverage including all four standard error responses.
- Webapp: a new create-problem page (subject required; category/subcategory/origin-case-id/primary-incident-id optional), a new API hook, a "New problem" entry point on the problems tab (which had none before), and route registration — all mirroring the existing change-request/incident create flows. No priority field: priority isn't settable on creation for this record type.

## User stories
> Summary of user stories addressed by this change

- As a CS engineer, I can move a change request out of its initial state without an unchecked, admin-only field edit.
- As a CS engineer, I can create a new problem record directly from the portal instead of only viewing existing ones.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added a "Request approval" action for change requests and a problem-creation flow, including entity-service, backend, and webapp support.

## Documentation
N/A — internal CS-engineer portal feature, no external product documentation is maintained for this workflow.

## Training
N/A — no training content is maintained for this internal portal.

## Certification
N/A — no certification exam covers this internal portal.

## Marketing
N/A — internal-only feature, not customer facing.

## Automation tests
 - Unit tests
   > Added/extended Go handler tests and mocks in the CSM portal backend for both the change request patch endpoint (previously untested directly) and the new problem-creation handler (success and unauthenticated cases). Added webapp component/hook tests for the new problem-creation page and the change request detail page's new action button.
 - Integration tests
   > None added at this layer; the underlying data-source behavior was already live-verified end to end (state transition + resulting downstream automation, and record creation with cross-links) before this PR.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — this is a Go/TypeScript codebase, not Java; `go vet` and `eslint` were run clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample projects reference this API.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Verified locally: `go build`/`go test`/`go vet` (entity service), `make build`/`make test`/`make vet` (CSM portal backend), `pnpm build`/`pnpm test`/`pnpm lint` (webapp).

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Followed this codebase's existing conventions throughout: the sibling boolean action-flag fields already on the change request patch type, the existing case-detail action-bar pattern for backend-driven legal-transition buttons, and the existing change-request/incident create-page structure for the new problem create page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ServiceNow “Create problem” support (POST /problems) with a new guided page at `/operations/problems/new`.
  * Expanded the problems list to show State, Assignment group, and Assigned to.
  * Added type-ahead selectors for Origin case and Primary incident during problem creation.
  * Added “Request approval” for eligible change requests based on modeled legal next states.
* **Bug Fixes**
  * Improved validation and error responses for problem creation and change-request approval flows, with updated tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->