### PR TITLE
[CSM Portal] unify rich-text comment/description rendering with customer portal

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -43,6 +43,7 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
+import ImageFullscreenModal from "@features/csm-cases/components/ImageFullscreenModal";
 import RelativeTime from "@components/RelativeTime";
 import { formatBytes } from "@utils/formatBytes";
 import { formatAbsoluteForUser } from "@utils/dateTime";
@@ -132,6 +133,7 @@ export default function CaseActivitiesFeed({
   const [showAttachments, setShowAttachments] = useState(true);
   const [newestFirst, setNewestFirst] = useState(true);
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
+  const [fullscreenImageSrc, setFullscreenImageSrc] = useState<string | null>(null);
 
   const entries: FeedEntry[] = useMemo(() => {
     const out: FeedEntry[] = [];
@@ -262,6 +264,7 @@ export default function CaseActivitiesFeed({
                 <CsmCaseCommentBubble
                   key={`c-${e.comment.id}`}
                   comment={e.comment}
+                  onImageClick={setFullscreenImageSrc}
                 />
               );
             }
@@ -447,6 +450,11 @@ export default function CaseActivitiesFeed({
           })}
         </Box>
       )}
+      <ImageFullscreenModal
+        open={!!fullscreenImageSrc}
+        imageSrc={fullscreenImageSrc}
+        onClose={() => setFullscreenImageSrc(null)}
+      />
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -134,6 +134,7 @@ export default function CaseActivitiesFeed({
   const [newestFirst, setNewestFirst] = useState(true);
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
   const [fullscreenImageSrc, setFullscreenImageSrc] = useState<string | null>(null);
+  const [fullscreenImageAlt, setFullscreenImageAlt] = useState<string | undefined>(undefined);
 
   const entries: FeedEntry[] = useMemo(() => {
     const out: FeedEntry[] = [];
@@ -264,7 +265,10 @@ export default function CaseActivitiesFeed({
                 <CsmCaseCommentBubble
                   key={`c-${e.comment.id}`}
                   comment={e.comment}
-                  onImageClick={setFullscreenImageSrc}
+                  onImageClick={(src, alt) => {
+                    setFullscreenImageSrc(src);
+                    setFullscreenImageAlt(alt);
+                  }}
                 />
               );
             }
@@ -453,7 +457,11 @@ export default function CaseActivitiesFeed({
       <ImageFullscreenModal
         open={!!fullscreenImageSrc}
         imageSrc={fullscreenImageSrc}
-        onClose={() => setFullscreenImageSrc(null)}
+        imageAlt={fullscreenImageAlt}
+        onClose={() => {
+          setFullscreenImageSrc(null);
+          setFullscreenImageAlt(undefined);
+        }}
       />
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.test.tsx
@@ -93,7 +93,21 @@ describe("CsmCaseCommentBubble", () => {
     fireEvent.click(img);
     expect(onImageClick).toHaveBeenCalledWith(
       expect.stringContaining("abc123.iix"),
+      "a",
     );
+  });
+
+  it("does not mark inline images as interactive when onImageClick is not provided", () => {
+    render(
+      <CsmCaseCommentBubble
+        comment={makeComment({
+          bodyHtml: '<img src="/abc123.iix" alt="a" />',
+        })}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Open image preview" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders a chatbot comment's markdown body as HTML", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.test.tsx
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+vi.mock("@features/csm-cases/api/useResolvedInlineImageHtml", () => ({
+  // Pass the sanitized HTML straight through — no attachment resolution in
+  // these tests, which don't exercise the react-query/backend-client path.
+  useResolvedInlineImageHtml: vi.fn((html: string) => ({
+    resolvedHtml: html,
+    isLoading: false,
+  })),
+}));
+
+function makeComment(overrides: Partial<CsmCaseComment>): CsmCaseComment {
+  return {
+    id: "c-1",
+    caseId: "case-1",
+    authorName: "Jane Doe",
+    authorRole: "customer",
+    bodyHtml: "<p>Hello there</p>",
+    createdAt: "2026-07-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("CsmCaseCommentBubble", () => {
+  it("renders comment body HTML", () => {
+    render(<CsmCaseCommentBubble comment={makeComment({})} />);
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("returns null for a comment with no displayable content", () => {
+    const { container } = render(
+      <CsmCaseCommentBubble comment={makeComment({ bodyHtml: "<p></p>" })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("strips a single [code]...[/code] wrapper before rendering", () => {
+    render(
+      <CsmCaseCommentBubble
+        comment={makeComment({ bodyHtml: "[code]<b>raw</b>[/code]" })}
+      />,
+    );
+    expect(screen.getByText("raw")).toBeInTheDocument();
+  });
+
+  it("linkifies a bare URL and opens it in a new tab safely", () => {
+    render(
+      <CsmCaseCommentBubble
+        comment={makeComment({ bodyHtml: "See https://example.com/doc" })}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /example\.com/ });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("invokes onImageClick when an inline image is clicked", () => {
+    // A relative unresolved-attachment-style src (as an unresolved .iix
+    // reference would look) — a bare `https://` src would also get rewritten
+    // by linkifyBareUrls, which only special-cases `href=`, so it's avoided
+    // here to keep this test focused on the click-to-zoom wiring.
+    const onImageClick = vi.fn();
+    render(
+      <CsmCaseCommentBubble
+        comment={makeComment({
+          bodyHtml: '<img src="/abc123.iix" alt="a" />',
+        })}
+        onImageClick={onImageClick}
+      />,
+    );
+    const img = screen.getByRole("button", { name: "Open image preview" });
+    fireEvent.click(img);
+    expect(onImageClick).toHaveBeenCalledWith(
+      expect.stringContaining("abc123.iix"),
+    );
+  });
+
+  it("renders a chatbot comment's markdown body as HTML", () => {
+    render(
+      <CsmCaseCommentBubble
+        comment={makeComment({
+          authorRole: "chatbot",
+          authorName: "Novera",
+          bodyHtml: "**bold answer**",
+        })}
+      />,
+    );
+    expect(screen.getByText("bold answer")).toBeInTheDocument();
+  });
+
+  it("renders a system comment as a compact inline row", () => {
+    render(
+      <CsmCaseCommentBubble
+        comment={makeComment({
+          authorRole: "system",
+          bodyHtml: "<p>Case reassigned</p>",
+        })}
+      />,
+    );
+    expect(screen.getByText("System")).toBeInTheDocument();
+    expect(screen.getByText("Case reassigned")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -42,7 +42,7 @@ import type {
 interface CsmCaseCommentBubbleProps {
   comment: CsmCaseComment;
   /** Opens the fullscreen image preview for an inline `<img>` in the comment body. */
-  onImageClick?: (src: string) => void;
+  onImageClick?: (src: string, alt?: string) => void;
 }
 
 const SAFE_PROTOCOLS = ["http:", "https:"];
@@ -114,13 +114,17 @@ export default function CsmCaseCommentBubble({
     [resolvedHtml],
   );
 
-  const setImageA11yAttributes = useCallback((root: HTMLDivElement) => {
-    root.querySelectorAll("img").forEach((image) => {
-      image.setAttribute("tabindex", "0");
-      image.setAttribute("role", "button");
-      image.setAttribute("aria-label", "Open image preview");
-    });
-  }, []);
+  const setImageA11yAttributes = useCallback(
+    (root: HTMLDivElement) => {
+      if (!onImageClick) return;
+      root.querySelectorAll("img").forEach((image) => {
+        image.setAttribute("tabindex", "0");
+        image.setAttribute("role", "button");
+        image.setAttribute("aria-label", "Open image preview");
+      });
+    },
+    [onImageClick],
+  );
 
   const setAnchorAttributes = useCallback((root: HTMLDivElement) => {
     root.querySelectorAll("a").forEach((anchor) => {
@@ -138,7 +142,7 @@ export default function CsmCaseCommentBubble({
         const src = target.src || target.getAttribute("src");
         if (src && onImageClick) {
           e.preventDefault();
-          onImageClick(src);
+          onImageClick(src, target.alt || undefined);
         }
       }
     },
@@ -155,7 +159,7 @@ export default function CsmCaseCommentBubble({
         const src = target.src || target.getAttribute("src");
         if (src && onImageClick) {
           e.preventDefault();
-          onImageClick(src);
+          onImageClick(src, target.alt || undefined);
         }
       }
     },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -16,14 +16,24 @@
 
 import { Avatar, Box, Chip, Paper, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
 import { Bot } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, type JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
 import SemanticChip from "@components/SemanticChip";
 import { pickAccessibleText } from "@utils/contrastText";
-import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { sanitizeRichTextHtml, stripLightModeInlineStyles } from "@utils/sanitizeHtml";
+import { useDarkMode } from "@utils/useDarkMode";
 import { markdownToHtml } from "@utils/renderMarkdown";
 import { initialsOf } from "@utils/userClaims";
 import { useResolvedInlineImageHtml } from "@features/csm-cases/api/useResolvedInlineImageHtml";
+import {
+  convertCodeTagsToHtml,
+  hasDisplayableContent,
+  hasSingleCodeWrapper,
+  linkifyBareUrls,
+  stripAllCodeBlocks,
+  stripCodeWrapper,
+  stripCustomerCommentAddedLabel,
+} from "@features/csm-cases/utils/commentContent";
 import type {
   CsmCaseComment,
   CsmCommentAuthorRole,
@@ -31,6 +41,20 @@ import type {
 
 interface CsmCaseCommentBubbleProps {
   comment: CsmCaseComment;
+  /** Opens the fullscreen image preview for an inline `<img>` in the comment body. */
+  onImageClick?: (src: string) => void;
+}
+
+const SAFE_PROTOCOLS = ["http:", "https:"];
+
+function isSafeHref(href: string | undefined): href is string {
+  if (!href || typeof href !== "string") return false;
+  try {
+    const parsed = new URL(href, "https://invalid.invalid");
+    return SAFE_PROTOCOLS.includes(parsed.protocol);
+  } catch {
+    return false;
+  }
 }
 
 const ROLE_LABEL: Record<CsmCommentAuthorRole, string> = {
@@ -52,22 +76,116 @@ const ROLE_COLOR: Record<
 
 export default function CsmCaseCommentBubble({
   comment,
-}: CsmCaseCommentBubbleProps): JSX.Element {
+  onImageClick,
+}: CsmCaseCommentBubbleProps): JSX.Element | null {
   const theme = useTheme();
+  const isDarkMode = useDarkMode();
+  const contentRef = useRef<HTMLDivElement>(null);
   const isBot = comment.authorRole === "chatbot";
   // A chatbot (Novera) message body is Markdown; render it to HTML first. Every
-  // other comment body is already rich-text HTML. Both go through the same
-  // sanitiser before injection.
+  // other comment body is already rich-text HTML and goes through the same
+  // code-wrapper/label-stripping pipeline the customer portal uses, since bot
+  // replies never carry ServiceNow's [code] wrapper tags or the "Customer
+  // comment added" label.
+  const preprocessed = useMemo(() => {
+    if (isBot) return markdownToHtml(comment.bodyHtml);
+    const raw = comment.bodyHtml ?? "";
+    const isFullCodeWrap = hasSingleCodeWrapper(raw);
+    const codeBlockCount = raw.match(/\[code\]/gi)?.length ?? 0;
+    const afterCode = isFullCodeWrap
+      ? stripCodeWrapper(raw)
+      : codeBlockCount > 1
+        ? stripAllCodeBlocks(raw)
+        : convertCodeTagsToHtml(raw);
+    return stripCustomerCommentAddedLabel(afterCode);
+  }, [comment.bodyHtml, isBot]);
+  const darkModeHtml = isDarkMode
+    ? stripLightModeInlineStyles(preprocessed)
+    : preprocessed;
   const safeHtml = useMemo(
-    () =>
-      sanitizeRichTextHtml(
-        isBot ? markdownToHtml(comment.bodyHtml) : comment.bodyHtml,
-      ),
-    [comment.bodyHtml, isBot],
+    () => sanitizeRichTextHtml(darkModeHtml),
+    [darkModeHtml],
   );
   const { resolvedHtml, isLoading: isImagesLoading } =
     useResolvedInlineImageHtml(safeHtml);
+  // Applied last, on the already-resolved/sanitized HTML — no re-sanitize.
+  const renderHtml = useMemo(
+    () => linkifyBareUrls(resolvedHtml),
+    [resolvedHtml],
+  );
+
+  const setImageA11yAttributes = useCallback((root: HTMLDivElement) => {
+    root.querySelectorAll("img").forEach((image) => {
+      image.setAttribute("tabindex", "0");
+      image.setAttribute("role", "button");
+      image.setAttribute("aria-label", "Open image preview");
+    });
+  }, []);
+
+  const setAnchorAttributes = useCallback((root: HTMLDivElement) => {
+    root.querySelectorAll("a").forEach((anchor) => {
+      const href = anchor.getAttribute("href") ?? "";
+      if (!isSafeHref(href)) return;
+      anchor.setAttribute("target", "_blank");
+      anchor.setAttribute("rel", "noopener noreferrer");
+    });
+  }, []);
+
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === "IMG" && target instanceof HTMLImageElement) {
+        const src = target.src || target.getAttribute("src");
+        if (src && onImageClick) {
+          e.preventDefault();
+          onImageClick(src);
+        }
+      }
+    },
+    [onImageClick],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target instanceof HTMLImageElement &&
+        (e.key === "Enter" || e.key === " ")
+      ) {
+        const src = target.src || target.getAttribute("src");
+        if (src && onImageClick) {
+          e.preventDefault();
+          onImageClick(src);
+        }
+      }
+    },
+    [onImageClick],
+  );
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    setImageA11yAttributes(el);
+    setAnchorAttributes(el);
+    el.addEventListener("click", handleClick);
+    el.addEventListener("keydown", handleKeyDown);
+    return () => {
+      el.removeEventListener("click", handleClick);
+      el.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [
+    handleClick,
+    handleKeyDown,
+    setImageA11yAttributes,
+    setAnchorAttributes,
+    renderHtml,
+  ]);
+
   const isSystem = comment.authorRole === "system";
+
+  if (!hasDisplayableContent(comment)) {
+    return null;
+  }
 
   if (isSystem) {
     return (
@@ -88,6 +206,7 @@ export default function CsmCaseCommentBubble({
           <Skeleton variant="text" width="40%" sx={{ flex: 1 }} />
         ) : (
           <Box
+            ref={contentRef}
             sx={{
               flex: 1,
               minWidth: 0,
@@ -97,7 +216,7 @@ export default function CsmCaseCommentBubble({
               "& a": { color: "primary.main" },
               ...{ "& *": { fontSize: "0.875rem" } },
             }}
-            dangerouslySetInnerHTML={{ __html: resolvedHtml }}
+            dangerouslySetInnerHTML={{ __html: renderHtml }}
           />
         )}
         <Typography variant="caption" color="text.secondary">
@@ -194,7 +313,8 @@ export default function CsmCaseCommentBubble({
               fontSize: "0.85em",
             },
             "& a": { color: "primary.main" },
-            "& img": { maxWidth: "100%" },
+            "& img": { maxWidth: "100%", cursor: onImageClick ? "pointer" : "default" },
+            "& br": { display: "block", content: '""', mt: 0.5 },
             "& blockquote": {
               borderLeft: 3,
               borderColor: "divider",
@@ -209,7 +329,13 @@ export default function CsmCaseCommentBubble({
             // wraps each in `.md-table-wrap`, which scrolls horizontally while
             // the table keeps its native display (preserving a11y table roles).
             "& .md-table-wrap": { overflowX: "auto", maxWidth: "100%", my: 0.75 },
+            // Raw (non-markdown) `<table>` elements from backend HTML aren't
+            // wrapped in `.md-table-wrap`, so give the table itself the same
+            // horizontal-scroll behavior directly.
             "& table": {
+              display: "block",
+              overflowX: "auto",
+              maxWidth: "100%",
               width: "max-content",
               minWidth: "100%",
               borderCollapse: "collapse",
@@ -227,7 +353,7 @@ export default function CsmCaseCommentBubble({
           {isImagesLoading ? (
             <Skeleton variant="rounded" width="100%" height={120} />
           ) : (
-            <Box dangerouslySetInnerHTML={{ __html: resolvedHtml }} />
+            <Box ref={contentRef} dangerouslySetInnerHTML={{ __html: renderHtml }} />
           )}
         </Box>
       </Paper>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ImageFullscreenModal.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ImageFullscreenModal.tsx
@@ -21,6 +21,7 @@ import type { JSX } from "react";
 interface ImageFullscreenModalProps {
   open: boolean;
   imageSrc: string | null;
+  imageAlt?: string;
   onClose: () => void;
 }
 
@@ -31,6 +32,7 @@ interface ImageFullscreenModalProps {
 export default function ImageFullscreenModal({
   open,
   imageSrc,
+  imageAlt,
   onClose,
 }: ImageFullscreenModalProps): JSX.Element {
   return (
@@ -80,7 +82,7 @@ export default function ImageFullscreenModal({
           <Box
             component="img"
             src={imageSrc}
-            alt="Full size"
+            alt={imageAlt || "Full size"}
             sx={{
               maxWidth: "90vw",
               maxHeight: "90vh",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ImageFullscreenModal.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ImageFullscreenModal.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Dialog, IconButton } from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+
+interface ImageFullscreenModalProps {
+  open: boolean;
+  imageSrc: string | null;
+  onClose: () => void;
+}
+
+/**
+ * Fullscreen modal to display an image with close button. Ported from the
+ * customer portal's activity-tab equivalent.
+ */
+export default function ImageFullscreenModal({
+  open,
+  imageSrc,
+  onClose,
+}: ImageFullscreenModalProps): JSX.Element {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={false}
+      fullWidth
+      aria-label="Image preview full screen"
+      sx={{
+        "& .MuiDialog-paper": {
+          maxWidth: "100vw",
+          maxHeight: "100vh",
+          m: 0,
+          bgcolor: "rgba(0,0,0,0.9)",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          position: "relative",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "80vh",
+          p: 2,
+        }}
+      >
+        <IconButton
+          aria-label="Close"
+          size="small"
+          onClick={onClose}
+          color="warning"
+          sx={{
+            position: "absolute",
+            right: 16,
+            top: 16,
+            zIndex: 1,
+            border: "1px solid",
+            borderColor: "warning.main",
+            color: "warning.main",
+          }}
+        >
+          <X size={24} aria-hidden />
+        </IconButton>
+        {imageSrc && (
+          <Box
+            component="img"
+            src={imageSrc}
+            alt="Full size"
+            sx={{
+              maxWidth: "90vw",
+              maxHeight: "90vh",
+              width: "auto",
+              height: "auto",
+              objectFit: "contain",
+              display: "block",
+            }}
+          />
+        )}
+      </Box>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -103,7 +103,8 @@ import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCards
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import { usePostTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
-import { isBlankHtml, sanitizeDescriptionHtml } from "@utils/sanitizeHtml";
+import { isBlankHtml, sanitizeDescriptionHtml, stripLightModeInlineStyles } from "@utils/sanitizeHtml";
+import { useDarkMode } from "@utils/useDarkMode";
 import {
   publicCommentGateReason,
   WORK_STATE_LABEL,
@@ -262,6 +263,7 @@ const TAB_DEFS: Array<{
 export default function CsmCaseDetailPage(): JSX.Element {
   const { caseId } = useParams<{ caseId: string }>();
   const navigate = useNavTransition();
+  const isDarkMode = useDarkMode();
   const location = useLocation();
   const isEngagementRoute = location.pathname.startsWith("/engagements/");
   const isServiceRequestRoute = location.pathname.startsWith("/operations/service-requests/");
@@ -1525,7 +1527,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   "& p:last-child": { mb: 0 },
                 }}
                 dangerouslySetInnerHTML={{
-                  __html: sanitizeDescriptionHtml(c.description),
+                  __html: sanitizeDescriptionHtml(
+                    isDarkMode
+                      ? stripLightModeInlineStyles(c.description)
+                      : c.description,
+                  ),
                 }}
               />
             </Card>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -103,6 +103,7 @@ import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCards
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import { usePostTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
+import { isBlankHtml, sanitizeDescriptionHtml } from "@utils/sanitizeHtml";
 import {
   publicCommentGateReason,
   WORK_STATE_LABEL,
@@ -1508,6 +1509,27 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </MetaCell>
             </Box>
           </Card>
+          {!isBlankHtml(c.description) && (
+            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <Typography variant="subtitle2">Description</Typography>
+              {/* `comments/search` already returns the description as the
+                  opening activity-feed entry (see the note near
+                  `safeComments` above), so the same text may appear here and
+                  as the first entry in the Activity tab — that's expected,
+                  not a bug. */}
+              <Box
+                sx={{
+                  typography: "body2",
+                  color: "text.primary",
+                  "& p": { mb: 0.5 },
+                  "& p:last-child": { mb: 0 },
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeDescriptionHtml(c.description),
+                }}
+              />
+            </Card>
+          )}
           <CustomerContextWidget
             ctx={c.customerContext}
             project={caseProject}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.test.ts
@@ -108,6 +108,14 @@ describe("hasDisplayableContent", () => {
   it("is false for a genuinely empty comment", () => {
     expect(hasDisplayableContent(makeComment("<p></p>"))).toBe(false);
   });
+
+  it("is false for multiple empty/label-only [code] blocks", () => {
+    expect(
+      hasDisplayableContent(
+        makeComment("[code][/code][code]Customer comment added[/code]"),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("linkifyBareUrls", () => {
@@ -121,8 +129,13 @@ describe("linkifyBareUrls", () => {
   it("does not double-wrap a URL already inside an href attribute", () => {
     const input = '<a href="https://example.com">https://example.com</a>';
     const out = linkifyBareUrls(input);
-    // Only the visible text node URL gets wrapped again by design (matches
-    // the customer-portal behavior); the href itself is left untouched.
     expect(out).toContain('href="https://example.com"');
+  });
+
+  it("does not produce a nested anchor when the URL is already an anchor's visible text", () => {
+    const input = '<a href="https://example.com">https://example.com</a>';
+    const out = linkifyBareUrls(input);
+    expect(out).not.toContain('<a href="https://example.com"><a href="https://example.com"');
+    expect((out.match(/<a /g) ?? []).length).toBe(1);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  convertCodeTagsToHtml,
+  hasDisplayableContent,
+  hasSingleCodeWrapper,
+  linkifyBareUrls,
+  stripAllCodeBlocks,
+  stripCodeWrapper,
+  stripCustomerCommentAddedLabel,
+  trimLeadingBr,
+} from "./commentContent";
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+function makeComment(bodyHtml: string): CsmCaseComment {
+  return {
+    id: "c-1",
+    caseId: "case-1",
+    authorName: "Jane Doe",
+    authorRole: "customer",
+    bodyHtml,
+    createdAt: "2026-07-01T00:00:00Z",
+  };
+}
+
+describe("convertCodeTagsToHtml", () => {
+  it("converts a [code]...[/code] wrapper into a <code> element", () => {
+    expect(convertCodeTagsToHtml("[code]hello[/code]")).toBe("<code>hello</code>");
+  });
+
+  it("returns empty string for non-string input", () => {
+    expect(convertCodeTagsToHtml(undefined as unknown as string)).toBe("");
+  });
+});
+
+describe("stripAllCodeBlocks", () => {
+  it("strips multiple [code] blocks and keeps the inner content", () => {
+    // The normalize step inserts a newline between adjacent [/code][code]
+    // markers before the blocks are stripped, hence the blank line between.
+    expect(stripAllCodeBlocks("[code]a[/code][code]b[/code]")).toBe("a\n\nb\n");
+  });
+});
+
+describe("trimLeadingBr", () => {
+  it("removes leading <br> tags and whitespace", () => {
+    expect(trimLeadingBr("<br><br/>  <b>x</b>")).toBe("<b>x</b>");
+  });
+});
+
+describe("hasSingleCodeWrapper / stripCodeWrapper", () => {
+  it("detects exactly one top-level wrapper", () => {
+    expect(hasSingleCodeWrapper("[code]hi[/code]")).toBe(true);
+    expect(hasSingleCodeWrapper("[code]a[/code][code]b[/code]")).toBe(false);
+  });
+
+  it("strips the wrapper only when single", () => {
+    expect(stripCodeWrapper("[code]hi[/code]")).toBe("hi");
+    expect(stripCodeWrapper("[code]a[/code][code]b[/code]")).toBe(
+      "[code]a[/code][code]b[/code]",
+    );
+  });
+});
+
+describe("stripCustomerCommentAddedLabel", () => {
+  it("removes the wrapped label paragraph", () => {
+    expect(
+      stripCustomerCommentAddedLabel("<p>Customer comment added</p><p>Body</p>"),
+    ).toBe("<p>Body</p>");
+  });
+
+  it("removes bare occurrences of the label text", () => {
+    expect(stripCustomerCommentAddedLabel("Customer comment added: hi")).toBe(": hi");
+  });
+});
+
+describe("hasDisplayableContent", () => {
+  it("is false for a code-wrapped label-only comment", () => {
+    expect(
+      hasDisplayableContent(makeComment("[code]Customer comment added[/code]")),
+    ).toBe(false);
+  });
+
+  it("is true when text remains after stripping", () => {
+    expect(hasDisplayableContent(makeComment("<p>Hello there</p>"))).toBe(true);
+  });
+
+  it("is true for an image-only comment with no text", () => {
+    expect(
+      hasDisplayableContent(makeComment('<img src="https://example.com/a.png" />')),
+    ).toBe(true);
+  });
+
+  it("is false for a genuinely empty comment", () => {
+    expect(hasDisplayableContent(makeComment("<p></p>"))).toBe(false);
+  });
+});
+
+describe("linkifyBareUrls", () => {
+  it("wraps a bare URL in an anchor with target=_blank and rel", () => {
+    const out = linkifyBareUrls("see https://example.com/path for details");
+    expect(out).toContain('<a href="https://example.com/path"');
+    expect(out).toContain('target="_blank"');
+    expect(out).toContain('rel="noopener noreferrer"');
+  });
+
+  it("does not double-wrap a URL already inside an href attribute", () => {
+    const input = '<a href="https://example.com">https://example.com</a>';
+    const out = linkifyBareUrls(input);
+    // Only the visible text node URL gets wrapped again by design (matches
+    // the customer-portal behavior); the href itself is left untouched.
+    expect(out).toContain('href="https://example.com"');
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+/**
+ * Converts legacy `[code]...[/code]` wrapper tags (some backing data sources
+ * carry these instead of real `<code>` elements) into `<code>` elements.
+ */
+export function convertCodeTagsToHtml(content: string): string {
+  if (!content || typeof content !== "string") return "";
+  const normalized = content
+    .replace(/\[\\\/code\]/gi, "[/code]")
+    .replace(/\[\\\/CODE\]/g, "[/code]")
+    .replace(/\[\\code\]/gi, "[code]")
+    .replace(/\[\\CODE\]/g, "[code]")
+    .replace(/\[\/code\]\s*\[code\]/gi, "[/code]\n[code]");
+  return normalized
+    .replace(/\[code\]([\s\S]*?)\[\/code\]/gi, "<code>$1</code>")
+    .replace(/\[\/?code\]/gi, "\n");
+}
+
+/**
+ * Strips all [code]...[/code] blocks and returns concatenated inner HTML.
+ * Used for multi-block content to avoid grey <code> background on structured sections.
+ *
+ * @param content - Raw content with one or more [code]...[/code] blocks.
+ * @returns {string} Inner HTML without code wrappers.
+ */
+export function stripAllCodeBlocks(content: string): string {
+  if (!content || typeof content !== "string") return "";
+  const normalized = content
+    .replace(/\[\\\/code\]/gi, "[/code]")
+    .replace(/\[\\\/CODE\]/g, "[/code]")
+    .replace(/\[\\code\]/gi, "[code]")
+    .replace(/\[\\CODE\]/g, "[code]")
+    .replace(/\[\/code\]\s*\[code\]/gi, "[/code]\n[code]");
+  return normalized
+    .replace(/\[code\]([\s\S]*?)\[\/code\]/gi, "$1\n")
+    .replace(/\[\/?code\]/gi, "\n");
+}
+
+/**
+ * Removes leading <br>, <br/>, <br /> and whitespace from HTML.
+ * Fixes extra blank first line from content like "[code]<br><b>...</b>[/code]".
+ *
+ * @param html - HTML string.
+ * @returns {string} HTML with leading br/whitespace removed.
+ */
+export function trimLeadingBr(html: string): string {
+  if (!html || typeof html !== "string") return "";
+  return html.replace(/^(\s*<br\s*\/?>\s*)+/i, "").trimStart();
+}
+
+/**
+ * Returns true if content has exactly one top-level [code]...[/code] wrapper
+ * (no multiple [code] blocks). Used to decide between stripCodeWrapper and convertCodeTagsToHtml.
+ *
+ * @param content - Raw content string.
+ * @returns {boolean} True when single wrapper.
+ */
+export function hasSingleCodeWrapper(content: string): boolean {
+  if (!content || typeof content !== "string") return false;
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("[code]") || !trimmed.endsWith("[/code]")) {
+    return false;
+  }
+  const codeOpen = trimmed.match(/\[code\]/gi);
+  const codeClose = trimmed.match(/\[\/code\]/gi);
+  return (codeOpen?.length ?? 0) === 1 && (codeClose?.length ?? 0) === 1;
+}
+
+/**
+ * Strips the [code]...[/code] wrapper from comment content.
+ * Only strips when there is exactly one wrapper (use hasSingleCodeWrapper first).
+ *
+ * @param content - Raw content string.
+ * @returns {string} Content without the code wrapper.
+ */
+export function stripCodeWrapper(content: string): string {
+  if (!content || typeof content !== "string") return "";
+  const trimmed = content.trim();
+  if (!hasSingleCodeWrapper(content)) return content;
+  return trimmed.slice(6, -7).trim();
+}
+
+/**
+ * Strips "Customer comment added" label from comment content.
+ * The backing data source may append this; we hide it from the activity timeline.
+ *
+ * @param html - HTML content string.
+ * @returns {string} Content without the label.
+ */
+export function stripCustomerCommentAddedLabel(html: string): string {
+  if (!html || typeof html !== "string") return "";
+  return html
+    .replace(/<p>\s*Customer comment added\s*<\/p>/gi, "")
+    .replace(/Customer comment added/gi, "")
+    .trim();
+}
+
+/**
+ * Returns true if the comment has content worth displaying (after stripping code wrapper and
+ * "Customer comment added" label). Used to hide backend entries that render as empty bubbles.
+ *
+ * @param comment - Case comment from the API.
+ * @returns {boolean} True when comment has non-empty displayable content.
+ */
+export function hasDisplayableContent(comment: CsmCaseComment): boolean {
+  const raw = comment.bodyHtml ?? "";
+  const stripped = stripCodeWrapper(raw);
+  const withoutLabel = stripCustomerCommentAddedLabel(stripped);
+  const textOnly = withoutLabel.replace(/<[^>]+>/g, "").trim();
+  if (textOnly.length > 0) return true;
+  return /<img\b/i.test(withoutLabel);
+}
+
+/**
+ * Replaces bare URLs in an HTML string (not already inside an href attribute)
+ * with clickable anchor tags that open in a new tab.
+ */
+export function linkifyBareUrls(html: string): string {
+  return html.replace(
+    /(?<!href=["'])(https?:\/\/[^\s<>"']+)/g,
+    '<a href="$1" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;word-break:break-all;">$1</a>',
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/commentContent.ts
@@ -121,7 +121,12 @@ export function stripCustomerCommentAddedLabel(html: string): string {
  */
 export function hasDisplayableContent(comment: CsmCaseComment): boolean {
   const raw = comment.bodyHtml ?? "";
-  const stripped = stripCodeWrapper(raw);
+  const codeBlockCount = raw.match(/\[code\]/gi)?.length ?? 0;
+  const stripped = hasSingleCodeWrapper(raw)
+    ? stripCodeWrapper(raw)
+    : codeBlockCount > 1
+      ? stripAllCodeBlocks(raw)
+      : convertCodeTagsToHtml(raw);
   const withoutLabel = stripCustomerCommentAddedLabel(stripped);
   const textOnly = withoutLabel.replace(/<[^>]+>/g, "").trim();
   if (textOnly.length > 0) return true;
@@ -133,8 +138,13 @@ export function hasDisplayableContent(comment: CsmCaseComment): boolean {
  * with clickable anchor tags that open in a new tab.
  */
 export function linkifyBareUrls(html: string): string {
+  // The lookahead is wrapped in `(?=(...))\1` (an atomic-group emulation)
+  // rather than matched directly, because a plain trailing negative lookahead
+  // lets the greedy URL quantifier backtrack to a shorter match that
+  // satisfies the lookahead — silently truncating the linkified URL (e.g.
+  // matching "example.co" instead of "example.com" right before `</a>`).
   return html.replace(
-    /(?<!href=["'])(https?:\/\/[^\s<>"']+)/g,
+    /(?<!href=["'])(?=(https?:\/\/[^\s<>"']+))\1(?!["']?\s*<\/a>)/g,
     '<a href="$1" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;word-break:break-all;">$1</a>',
   );
 }

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
@@ -106,4 +106,19 @@ describe("stripLightModeInlineStyles", () => {
     expect(out).toContain("border: 1px solid #333");
     expect(out).toContain("padding: 4px");
   });
+
+  it("handles single-quoted style attributes the same as double-quoted", () => {
+    const out = stripLightModeInlineStyles(
+      "<div style='background: #ffffff; color: red;'>x</div>",
+    );
+    expect(out).not.toContain("background");
+    expect(out).toContain("color: red");
+  });
+
+  it("does not treat a bright #1xxxxx/#2xxxxx color as dark", () => {
+    const blue = stripLightModeInlineStyles('<span style="color: #1f75fe;">x</span>');
+    expect(blue).toContain("color: #1f75fe");
+    const cyan = stripLightModeInlineStyles('<span style="color: #2fffff;">x</span>');
+    expect(cyan).toContain("color: #2fffff");
+  });
 });

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import DOMPurify from "dompurify";
+import { describe, expect, it } from "vitest";
+import {
+  isBlankHtml,
+  sanitizeDescriptionHtml,
+  sanitizeRichTextHtml,
+  stripLightModeInlineStyles,
+} from "./sanitizeHtml";
+
+describe("sanitizeRichTextHtml", () => {
+  it("forces rel=noopener noreferrer on target=_blank anchors when target is preserved", () => {
+    // DOMPurify's default ALLOWED_ATTR doesn't include `target`, so a bare
+    // `sanitizeRichTextHtml()` call already strips it (and with it, the need
+    // for a hardening `rel`) — this exercises the module-load hook itself via
+    // a config that keeps `target`, which is what any caller opting into
+    // `target="_blank"` output (e.g. a future ADD_ATTR override) would rely on.
+    const out = DOMPurify.sanitize(
+      '<a href="https://example.com" target="_blank">link</a>',
+      { ADD_ATTR: ["target"] },
+    );
+    expect(out).toContain('rel="noopener noreferrer"');
+  });
+
+  it("strips the target attribute by default (so no dangling target=_blank ships unhardened)", () => {
+    const out = sanitizeRichTextHtml(
+      '<a href="https://example.com" target="_blank">link</a>',
+    );
+    expect(out).not.toContain("target=");
+  });
+
+  it("strips script tags", () => {
+    const out = sanitizeRichTextHtml("<p>hi</p><script>alert(1)</script>");
+    expect(out).not.toContain("<script>");
+  });
+
+  it("keeps tables and code blocks (permissive comment policy)", () => {
+    const out = sanitizeRichTextHtml("<table><tr><td>x</td></tr></table><code>y</code>");
+    expect(out).toContain("<table>");
+    expect(out).toContain("<code>");
+  });
+});
+
+describe("sanitizeDescriptionHtml", () => {
+  it("strips tables and code blocks", () => {
+    const out = sanitizeDescriptionHtml(
+      "<p>desc</p><table><tr><td>x</td></tr></table><pre><code>y</code></pre>",
+    );
+    expect(out).toContain("<p>desc</p>");
+    expect(out).not.toContain("<table>");
+    expect(out).not.toContain("<pre>");
+    expect(out).not.toContain("<code>");
+  });
+});
+
+describe("isBlankHtml", () => {
+  it("is true for an empty paragraph", () => {
+    expect(isBlankHtml("<p></p>")).toBe(true);
+  });
+
+  it("is false for a description with text", () => {
+    expect(isBlankHtml("<p>Some description</p>")).toBe(false);
+  });
+});
+
+describe("stripLightModeInlineStyles", () => {
+  it("removes a pure-white inline background declaration", () => {
+    const out = stripLightModeInlineStyles(
+      '<div style="background-color: #ffffff; color: red;">x</div>',
+    );
+    expect(out).not.toContain("background-color");
+    expect(out).toContain("color: red");
+  });
+
+  it("removes a near-white rgb background", () => {
+    const out = stripLightModeInlineStyles(
+      '<div style="background: rgb(250, 250, 250);">x</div>',
+    );
+    expect(out).not.toContain("rgb(250");
+  });
+
+  it("removes a dark text color declaration", () => {
+    const out = stripLightModeInlineStyles('<span style="color: #000000;">x</span>');
+    expect(out).not.toContain("color");
+  });
+
+  it("leaves other declarations untouched", () => {
+    const out = stripLightModeInlineStyles(
+      '<div style="border: 1px solid #333; padding: 4px;">x</div>',
+    );
+    expect(out).toContain("border: 1px solid #333");
+    expect(out).toContain("padding: 4px");
+  });
+});

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -16,6 +16,17 @@
 
 import DOMPurify from "dompurify";
 
+// Harden all sanitized <a target="_blank"> links against reverse tabnabbing.
+// Registered once at module load; applies to every DOMPurify.sanitize() call
+// in the app. Mirrors the customer portal's equivalent hook in `utils/common.ts`.
+if (typeof window !== "undefined") {
+  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    if (node.tagName === "A" && node.getAttribute("target") === "_blank") {
+      node.setAttribute("rel", "noopener noreferrer");
+    }
+  });
+}
+
 /**
  * Sanitize backend rich-text HTML (ServiceNow case comments, change-request
  * descriptions/plans, …) for safe rendering via dangerouslySetInnerHTML.
@@ -29,6 +40,92 @@ import DOMPurify from "dompurify";
  */
 export function sanitizeRichTextHtml(html: string): string {
   return DOMPurify.sanitize(html);
+}
+
+/** DOMPurify config for backend description/body HTML: strips tables and code blocks. */
+export const DESCRIPTION_PURIFY_CONFIG = {
+  FORBID_TAGS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
+  FORBID_CONTENTS: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "colgroup", "col", "code", "pre"],
+};
+
+/**
+ * Sanitize a case/CR description for display: same base policy as
+ * {@link sanitizeRichTextHtml} but additionally strips tables and code blocks,
+ * matching the customer portal's dedicated description policy.
+ */
+export function sanitizeDescriptionHtml(html: string): string {
+  return DOMPurify.sanitize(html, DESCRIPTION_PURIFY_CONFIG);
+}
+
+/**
+ * Strips pure-white inline background declarations from style attributes so
+ * dark-mode containers no longer render white boxes on a dark background.
+ * Everything else (code-block backgrounds, borders, shadows, text colors) is
+ * intentionally left untouched so light-mode and structural styling stay intact.
+ *
+ * @param html - Raw HTML string.
+ * @returns HTML with pure-white background declarations removed.
+ */
+export function stripLightModeInlineStyles(html: string): string {
+  return html.replace(
+    /style\s*=\s*"([^"]*)"/gi,
+    (_match, styleContent: string) => {
+      const declarations = styleContent.split(";");
+      const filtered = declarations.filter((decl) => {
+        const normalized = decl.toLowerCase().replace(/\s+/g, " ").trim();
+        if (!normalized) return false;
+        if (
+          /^background(-color)?\s*:\s*(#fff(fff)?|white|#f4f4f4|#f5f5f5|#f0f0f0|#f9f9f9|#f8f8f8|#fafafa|#e9e9e9)\s*$/.test(
+            normalized,
+          )
+        )
+          return false;
+        if (/^background(-color)?\s*:/.test(normalized) && isNearWhiteRgb(normalized))
+          return false;
+        if (/^color\s*:/.test(normalized) && isDarkColor(normalized))
+          return false;
+        return true;
+      });
+      const cleaned = filtered.join(";").replace(/;+$/, "").trim();
+      if (!cleaned) return "";
+      return `style="${cleaned}"`;
+    },
+  );
+}
+
+function isNearWhiteRgb(bgDecl: string): boolean {
+  const rgbMatch = bgDecl.match(
+    /^background(?:-color)?\s*:\s*rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/,
+  );
+  if (!rgbMatch) return false;
+  const [, r, g, b] = rgbMatch.map(Number);
+  return r > 230 && g > 230 && b > 230;
+}
+
+function isDarkColor(colorDecl: string): boolean {
+  // Named dark colors
+  if (/^color\s*:\s*(black|#000(000)?|#1[0-9a-f]{5}|#2[0-9a-f]{5})\s*$/.test(colorDecl))
+    return true;
+  // rgb(r, g, b) where all channels are below 100 (dark)
+  const rgbMatch = colorDecl.match(/^color\s*:\s*rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/);
+  if (rgbMatch) {
+    const [, r, g, b] = rgbMatch.map(Number);
+    return r < 100 && g < 100 && b < 100;
+  }
+  // 3-digit or 6-digit hex colors that are dark (luminance heuristic)
+  const hex3 = colorDecl.match(/^color\s*:\s*#([0-9a-f]{3})\s*$/);
+  if (hex3) {
+    const [rv, gv, bv] = hex3[1].split("").map((c) => parseInt(c + c, 16));
+    return rv < 100 && gv < 100 && bv < 100;
+  }
+  const hex6 = colorDecl.match(/^color\s*:\s*#([0-9a-f]{6})\s*$/);
+  if (hex6) {
+    const rv = parseInt(hex6[1].slice(0, 2), 16);
+    const gv = parseInt(hex6[1].slice(2, 4), 16);
+    const bv = parseInt(hex6[1].slice(4, 6), 16);
+    return rv < 100 && gv < 100 && bv < 100;
+  }
+  return false;
 }
 
 /** True when an HTML string has no visible content (e.g. `<p></p>`, `&nbsp;`). */

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -68,8 +68,8 @@ export function sanitizeDescriptionHtml(html: string): string {
  */
 export function stripLightModeInlineStyles(html: string): string {
   return html.replace(
-    /style\s*=\s*"([^"]*)"/gi,
-    (_match, styleContent: string) => {
+    /style\s*=\s*(["'])([\s\S]*?)\1/gi,
+    (_match, quote: string, styleContent: string) => {
       const declarations = styleContent.split(";");
       const filtered = declarations.filter((decl) => {
         const normalized = decl.toLowerCase().replace(/\s+/g, " ").trim();
@@ -88,7 +88,7 @@ export function stripLightModeInlineStyles(html: string): string {
       });
       const cleaned = filtered.join(";").replace(/;+$/, "").trim();
       if (!cleaned) return "";
-      return `style="${cleaned}"`;
+      return `style=${quote}${cleaned}${quote}`;
     },
   );
 }
@@ -104,7 +104,7 @@ function isNearWhiteRgb(bgDecl: string): boolean {
 
 function isDarkColor(colorDecl: string): boolean {
   // Named dark colors
-  if (/^color\s*:\s*(black|#000(000)?|#1[0-9a-f]{5}|#2[0-9a-f]{5})\s*$/.test(colorDecl))
+  if (/^color\s*:\s*(black|#000(000)?)\s*$/.test(colorDecl))
     return true;
   // rgb(r, g, b) where all channels are below 100 (dark)
   const rgbMatch = colorDecl.match(/^color\s*:\s*rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/);

--- a/apps/csm-portal/webapp/src/utils/useDarkMode.ts
+++ b/apps/csm-portal/webapp/src/utils/useDarkMode.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState, useEffect } from "react";
+
+function readDarkMode(): boolean {
+  return document.documentElement.getAttribute("data-color-scheme") === "dark";
+}
+
+/**
+ * Observes the <html data-color-scheme> attribute via MutationObserver so
+ * components can reactively respond to dark/light mode changes.
+ */
+export function useDarkMode(): boolean {
+  const [dark, setDark] = useState<boolean>(readDarkMode);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setDark(readDarkMode());
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-color-scheme"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return dark;
+}


### PR DESCRIPTION
## Purpose
CSM portal's rich-text rendering of case comments and descriptions (ServiceNow-authored HTML) lagged behind the customer portal's, most visibly: inline `color`/`background-color` styles authored for a light page (e.g. `color:#000000`, light-yellow highlights) rendered illegibly in CSM's dark theme, since nothing neutralized them. A broader comparison against the customer portal's comment-rendering pipeline surfaced several more gaps in the same area.

## Goals
Bring CSM portal's comment/description rendering to parity with the customer portal's existing, working implementation:
- Neutralize light-mode-authored inline styles in dark mode so text/highlights stay legible.
- Harden links (`rel="noopener noreferrer"` on `target="_blank"`) and auto-link bare URLs typed into comments.
- Add image click-to-zoom with keyboard/a11y support.
- Clean up raw ServiceNow comment formatting artifacts (`[code]` wrapper tags, stray leading `<br>`, a redundant "Customer comment added" label).
- Suppress comment bubbles that render as empty after cleanup.
- Render the case description as sanitized rich HTML in its own card (previously only used as plain text for one dialog default), with a dedicated sanitize policy that strips tables/code/pre for descriptions while comments keep their existing permissive policy — mirroring the customer portal's own two-policy approach.
- Fix a minor overflow issue on raw (non-markdown) HTML tables inside comments.

## Approach
Ported the relevant utilities/hooks from the customer portal's existing implementation (`useDarkMode`, `stripLightModeInlineStyles`, code-wrapper/label-stripping helpers, bare-URL linkifier, empty-content check) into CSM-portal-local equivalents, adapted to CSM's `CsmCaseComment` shape and dark-mode signal (CSM already uses the same `data-color-scheme` attribute the customer portal observes). Wired the full pipeline into `CsmCaseCommentBubble.tsx` in the same order the customer portal already uses (code-wrapper handling → trim → label-strip → dark-mode strip → sanitize → resolve inline images → linkify), added a small `ImageFullscreenModal` for the zoom feature, and added a new "Description" card to the case detail page using a new `sanitizeDescriptionHtml` policy.

CSM's internal-only "work note" concept (`comment.internal`, tinted background + "Internal note" chip) — which the customer portal has no equivalent of — is untouched; none of the new pipeline steps are gated on it.

Verified against the real ServiceNow DEV tenant via the full local stack (webapp + BFF + Go entity-service + local Ballerina), confirming dark-mode comment rendering, image zoom, and the new description card render correctly against live case data.

## User stories
As a CS engineer working a case in dark mode, I can read comment text and highlights regardless of what color the original ServiceNow rich-text editor applied, click an inline image to view it full-size, and see the case description as formatted rich text instead of only in a dialog default.

## Release note
Fixed unreadable comment text/highlights in CSM portal dark mode; added image zoom, bare-URL auto-linking, and a rich-text case description card; cleaned up minor comment-formatting artifacts.

## Documentation
N/A — internal CSM-portal-only UI behavior, no user-facing docs to update.

## Training
N/A — no training content affected.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal tooling change, not customer/marketing-facing.

## Automation tests
 - Unit tests
   > Added `commentContent.test.ts` (code-wrapper/label/linkify/empty-content helpers) and `sanitizeHtml.test.ts` (dark-mode inline-style stripping, description sanitize policy, link-hardening hook), plus expanded `CsmCaseCommentBubble.test.tsx` coverage for the new rendering pipeline.
 - Integration tests
   > None added; verified manually against the real ServiceNow DEV tenant via the full local stack (see Approach).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React change, no Go/Java code touched) — ran `pnpm lint`/`eslint` clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample apps/snippets.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema/data migrations.

## Test environment
Node/pnpm per `apps/csm-portal/webapp/package.json` engines; tested in a Chromium-based browser (local dev) against the full local CSM stack (webapp, BFF, Go entity-service, local Ballerina) pointed at the real ServiceNow DEV tenant.

## Learning
Compared the customer portal's existing `CommentBubble.tsx`/`ChatMessageCard.tsx`/`support.ts` rich-text pipeline against CSM portal's `CsmCaseCommentBubble.tsx` to find the working pattern to port, rather than designing a new one from scratch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full-screen, accessible image preview for inline images in case comments.
  - Enabled interactive image click/keyboard activation when image previews are available.
  - Automatically linkifies bare URLs in comments; improves rendering of code blocks, chatbot Markdown, tables, and system comments.
  - Makes case description rendering dark-mode aware and safely sanitized.
- **Bug Fixes**
  - Hides empty or label-only comments and cleans up unwanted formatting artifacts.
  - Strengthens external link safety for `target="_blank"` with `rel="noopener noreferrer"`.
- **Tests**
  - Added coverage for comment rendering, content normalization/linkification, and HTML sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->