### PR TITLE
[CSM Portal Microapp] Add Security Center (Security reports + Vulnerabilities)

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -35,6 +35,7 @@ import EngagementsPage from "@pages/EngagementsPage";
 import CustomersPage from "@pages/CustomersPage";
 import AccountDetailPage from "@pages/AccountDetailPage";
 import ProjectDetailPage from "@pages/ProjectDetailPage";
+import VulnerabilityDetailPage from "@pages/VulnerabilityDetailPage";
 import SettingsPage from "@pages/SettingsPage";
 import ProfilePage from "@pages/ProfilePage";
 
@@ -74,6 +75,7 @@ export default function App() {
           <Route path="/more/announcements" element={<AnnouncementsPage />} />
           <Route path="/more/time-cards" element={<TimeCardsPage />} />
           <Route path="/more/security-center" element={<SecurityCenterPage />} />
+          <Route path="/more/security-center/vulnerabilities/:id" element={<VulnerabilityDetailPage />} />
           <Route path="/more/updates" element={<UpdatesPage />} />
           <Route path="/more/engagements" element={<EngagementsPage />} />
           <Route path="/more/customers" element={<CustomersPage />} />

--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -30,6 +30,7 @@ import MorePage from "@pages/MorePage";
 import AnnouncementsPage from "@pages/AnnouncementsPage";
 import TimeCardsPage from "@pages/TimeCardsPage";
 import SecurityCenterPage from "@pages/SecurityCenterPage";
+import NewSecurityReportPage from "@pages/NewSecurityReportPage";
 import UpdatesPage from "@pages/UpdatesPage";
 import EngagementsPage from "@pages/EngagementsPage";
 import CustomersPage from "@pages/CustomersPage";
@@ -75,6 +76,7 @@ export default function App() {
           <Route path="/more/announcements" element={<AnnouncementsPage />} />
           <Route path="/more/time-cards" element={<TimeCardsPage />} />
           <Route path="/more/security-center" element={<SecurityCenterPage />} />
+          <Route path="/more/security-center/reports/new" element={<NewSecurityReportPage />} />
           <Route path="/more/security-center/vulnerabilities/:id" element={<VulnerabilityDetailPage />} />
           <Route path="/more/updates" element={<UpdatesPage />} />
           <Route path="/more/engagements" element={<EngagementsPage />} />

--- a/apps/csm-portal/microapp/src/components/common/MetaRow.tsx
+++ b/apps/csm-portal/microapp/src/components/common/MetaRow.tsx
@@ -17,9 +17,9 @@
 import { Stack, Typography, type TypographyProps } from "@wso2/oxygen-ui";
 import type { ReactNode } from "react";
 
-/** One "label / value" row in an Account/Project overview card — the mobile
- * equivalent of the webapp's grid-cell MetaCell (a single narrow column reads
- * better as stacked rows than as a multi-column grid). */
+/** One "label / value" row in an overview/detail card (Accounts, Projects, Deployments,
+ * Vulnerabilities, ...) — the mobile equivalent of the webapp's grid-cell MetaCell (a single
+ * narrow column reads better as stacked rows than as a multi-column grid). */
 export function MetaRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={2}>

--- a/apps/csm-portal/microapp/src/components/customers/DeploymentDetailDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/customers/DeploymentDetailDialog.tsx
@@ -19,7 +19,7 @@ import { X } from "@wso2/oxygen-ui-icons-react";
 import type { Deployment } from "@src/types";
 import { formatDateOnly, formatEnumLabel } from "@utils/customers";
 import { DialogPaper } from "@components/common/DialogPaper";
-import { MetaRow, MetaValue } from "@components/customers/MetaRow";
+import { MetaRow, MetaValue } from "@components/common/MetaRow";
 import { DeployedProductsList } from "@components/customers/DeployedProductsList";
 
 interface DeploymentDetailDialogProps {

--- a/apps/csm-portal/microapp/src/components/security-center/SecurityReportFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/security-center/SecurityReportFiltersSheet.tsx
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Autocomplete,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { useQuery } from "@tanstack/react-query";
+import { projects } from "@src/services/projects";
+import { adminUsers } from "@src/services/adminUsers";
+import { products } from "@src/services/products";
+import type { Project } from "@src/types";
+import { ALL_WORK_STATES, FILTERABLE_STATES, STATE_LABELS, WORK_STATE_LABEL } from "@components/support/config";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import {
+  EMPTY_SECURITY_REPORT_FILTERS,
+  type SecurityReportAssignee,
+  type SecurityReportFilters,
+} from "@utils/securityReports";
+
+// The Acrylic theme renders popup papers translucent, so a dropdown that opens
+// over the dialog reads as see-through — force the opaque `background.default`.
+const OPAQUE_POPUP = { sx: { backgroundColor: "background.default", backgroundImage: "none" } };
+
+function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+// Async, type-to-search multi-select of projects (server-side `projectIds`).
+// Mirrors the equivalent field in EngagementFiltersSheet (debounced 300ms);
+// already-picked projects stay in the option list so their chips keep their labels.
+function ProjectMultiSelect({ value, onChange }: { value: Project[]; onChange: (projects: Project[]) => void }) {
+  const [input, setInput] = useState("");
+  const debounced = useDebouncedValue(input, 300);
+  const { data, isFetching } = useQuery(projects.search(debounced.trim()));
+
+  const options = useMemo(() => {
+    const results = data ?? [];
+    return [...value, ...results.filter((r) => !value.some((v) => v.id === r.id))];
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={options}
+      value={value}
+      loading={isFetching}
+      getOptionLabel={(o) => o.name}
+      isOptionEqualToValue={(a, b) => a.id === b.id}
+      onChange={(_, next) => onChange(next)}
+      onInputChange={(_, next) => setInput(next)}
+      slotProps={{ paper: OPAQUE_POPUP }}
+      renderInput={(params) => <TextField {...params} label="Project" size="small" />}
+    />
+  );
+}
+
+// Async, type-to-search multi-select of engineers (server-side `assignedUserIds`).
+// Reuses adminUsers.search's internal-roles scope, same as EngagementFiltersSheet's own
+// AssigneeMultiSelect. Requires at least one typed character.
+function AssigneeMultiSelect({
+  value,
+  onChange,
+}: {
+  value: SecurityReportAssignee[];
+  onChange: (assignees: SecurityReportAssignee[]) => void;
+}) {
+  const [input, setInput] = useState("");
+  const debounced = useDebouncedValue(input, 300);
+  const { data, isFetching } = useQuery(adminUsers.search(debounced.trim()));
+
+  const options = useMemo(() => {
+    const results = data?.users ?? [];
+    return [...value, ...results.filter((r) => !value.some((v) => v.id === r.id))];
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={options}
+      value={value}
+      loading={isFetching}
+      getOptionLabel={(o) => o.name}
+      isOptionEqualToValue={(a, b) => a.id === b.id}
+      onChange={(_, next) => onChange(next.map((o) => ({ id: o.id, name: o.name })))}
+      onInputChange={(_, next) => setInput(next)}
+      slotProps={{ paper: OPAQUE_POPUP }}
+      renderInput={(params) => <TextField {...params} label="Assignee" size="small" placeholder="Search engineers…" />}
+    />
+  );
+}
+
+// Products are a bounded catalogue, so the distinct family names are fetched
+// once (products.names()) and filtered locally as the user types.
+function ProductMultiSelect({ value, onChange }: { value: string[]; onChange: (names: string[]) => void }) {
+  const { data, isFetching } = useQuery(products.names());
+
+  const options = useMemo(() => {
+    const merged = new Set<string>(data ?? []);
+    value.forEach((v) => merged.add(v));
+    return [...merged].sort((a, b) => a.localeCompare(b));
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={options}
+      value={value}
+      loading={isFetching}
+      onChange={(_, next) => onChange(next)}
+      slotProps={{ paper: OPAQUE_POPUP }}
+      renderInput={(params) => <TextField {...params} label="Product" size="small" />}
+    />
+  );
+}
+
+interface SecurityReportFiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: SecurityReportFilters;
+  onApply: (filters: SecurityReportFilters) => void;
+}
+
+// Mobile bottom-sheet filters for the security reports list: State, Work state
+// (chip multi-selects) + Assignee, Project, Product (async multi-selects). Search
+// lives in the always-visible bar on the page, not here. Mirrors the webapp's
+// CasesFilterBar for a view locked to `caseTypes: ["security_report_analysis"]`
+// — severity and case type are left out entirely (severity's a "case"-only
+// concept, case type is fixed here), and there's no engagement-type group
+// (that's engagement-only).
+export function SecurityReportFiltersSheet({ open, onClose, filters, onApply }: SecurityReportFiltersSheetProps) {
+  const [draft, setDraft] = useState<SecurityReportFilters>(filters);
+
+  // Re-seed the draft from the last-applied filters each time the sheet opens, so reopening it
+  // doesn't show stale in-progress edits from a previous open that was dismissed without applying.
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open, not on every filters identity change
+  }, [open]);
+
+  const workInProgressSelected = draft.states.includes("work_in_progress");
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xs"
+      slotProps={{ paper: { sx: { backgroundImage: "none", backgroundColor: "background.default" } } }}
+    >
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={2.5}>
+          <Stack gap={1}>
+            <Typography variant="subtitle2">State</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {FILTERABLE_STATES.map((state) => {
+                const isSelected = draft.states.includes(state);
+                return (
+                  <Chip
+                    key={state}
+                    label={STATE_LABELS[state] ?? state}
+                    size="small"
+                    aria-pressed={isSelected}
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    onClick={() => {
+                      const states = toggle(draft.states, state);
+                      // Work sub-state only applies to work_in_progress cases, so drop any
+                      // selected work states when that state leaves the filter — keeps a
+                      // stale, inert work-state selection from lingering.
+                      setDraft({
+                        ...draft,
+                        states,
+                        workStates: states.includes("work_in_progress") ? draft.workStates : [],
+                      });
+                    }}
+                  />
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="subtitle2">Work state</Typography>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {ALL_WORK_STATES.map((workState) => {
+                const isSelected = draft.workStates.includes(workState);
+                const chip = (
+                  <Chip
+                    label={WORK_STATE_LABEL[workState]}
+                    size="small"
+                    aria-pressed={isSelected}
+                    variant={isSelected ? "filled" : "outlined"}
+                    color={isSelected ? "primary" : "default"}
+                    disabled={!workInProgressSelected}
+                    onClick={() => setDraft({ ...draft, workStates: toggle(draft.workStates, workState) })}
+                  />
+                );
+                // Disabled MUI chips don't fire pointer events, so the tooltip needs a
+                // span wrapper to still show on hover/focus.
+                return workInProgressSelected ? (
+                  <span key={workState}>{chip}</span>
+                ) : (
+                  <Tooltip key={workState} title={`Select "${STATE_LABELS.work_in_progress}" to filter by work state`}>
+                    <span>{chip}</span>
+                  </Tooltip>
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <AssigneeMultiSelect value={draft.assignees} onChange={(next) => setDraft({ ...draft, assignees: next })} />
+
+          <ProjectMultiSelect value={draft.projects} onChange={(next) => setDraft({ ...draft, projects: next })} />
+
+          <ProductMultiSelect
+            value={draft.productNames}
+            onChange={(next) => setDraft({ ...draft, productNames: next })}
+          />
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            // Keep the current search text; only the sheet's own filters reset.
+            const cleared = { ...EMPTY_SECURITY_REPORT_FILTERS, search: draft.search };
+            setDraft(cleared);
+            onApply(cleared);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/security-center/SecurityReportsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/security-center/SecurityReportsTab.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { useState } from "react";
-import { Badge, IconButton, Stack, Typography } from "@wso2/oxygen-ui";
-import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "react-router-dom";
+import { Badge, Fab, IconButton, Stack, Typography } from "@wso2/oxygen-ui";
+import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { securityReports } from "@src/services/securityReports";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
@@ -37,9 +38,10 @@ import { SecurityReportFiltersSheet } from "@components/security-center/Security
 // Security reports tab — a CsmIssuesView locked to
 // `caseTypes: ["security_report_analysis"]` with severity hidden. Search +
 // State + Work state + Assignee + Project + Product filters, infinite-scrolled
-// newest-updated first. Read-only for this pass — "New security report" is
-// deliberately deferred, same call Engagements/Operations already made.
+// newest-updated first, plus a Fab into NewSecurityReportPage — mirrors
+// SupportPage's own "New Case" Fab.
 export function SecurityReportsTab() {
+  const navigate = useNavigate();
   const [filters, setFilters] = useState<SecurityReportFilters>(EMPTY_SECURITY_REPORT_FILTERS);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
@@ -104,6 +106,18 @@ export function SecurityReportsTab() {
         filters={filters}
         onApply={setFilters}
       />
+
+      {/* Fixed bottom-right, offset above the fixed TabBar — same positioning as SupportPage's own
+          "Create case" Fab. */}
+      <Fab
+        aria-label="New security report"
+        size="medium"
+        color="primary"
+        onClick={() => navigate("/more/security-center/reports/new")}
+        sx={{ position: "fixed", right: 10, bottom: "calc(var(--tab-bar-height) + 60px)" }}
+      >
+        <Plus size={20} />
+      </Fab>
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/components/security-center/SecurityReportsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/security-center/SecurityReportsTab.tsx
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState } from "react";
+import { Badge, IconButton, Stack, Typography } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { securityReports } from "@src/services/securityReports";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { useInfiniteScrollSentinel } from "@utils/useInfiniteScrollSentinel";
+import {
+  countActiveSecurityReportFilters,
+  EMPTY_SECURITY_REPORT_FILTERS,
+  type SecurityReportFilters,
+} from "@utils/securityReports";
+import { SearchBar } from "@components/support/SearchBar";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
+import { SecurityReportFiltersSheet } from "@components/security-center/SecurityReportFiltersSheet";
+
+// Cross-customer security reports list (security reports are cases of type
+// "security_report_analysis"), mirroring the webapp's CsmSecurityCenterPage's
+// Security reports tab — a CsmIssuesView locked to
+// `caseTypes: ["security_report_analysis"]` with severity hidden. Search +
+// State + Work state + Assignee + Project + Product filters, infinite-scrolled
+// newest-updated first. Read-only for this pass — "New security report" is
+// deliberately deferred, same call Engagements/Operations already made.
+export function SecurityReportsTab() {
+  const [filters, setFilters] = useState<SecurityReportFilters>(EMPTY_SECURITY_REPORT_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
+  const activeFilterCount = countActiveSecurityReportFilters(filters);
+
+  // Search is debounced into the query so typing doesn't refetch every keystroke.
+  const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    securityReports.infinite({ ...filters, search: debouncedSearch }),
+  );
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? items.length;
+
+  const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
+
+  return (
+    <Stack gap={2}>
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar
+          value={filters.search}
+          onChange={(value) => setFilters((prev) => ({ ...prev, search: value }))}
+          placeholder="Search by number or subject…"
+        />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
+      {isLoading ? (
+        <ListSkeleton />
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No security reports found." />
+      ) : (
+        <Stack gap={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {items.length} of {total}
+          </Typography>
+
+          {items.map((item) => (
+            <CaseCard key={item.id} item={item} />
+          ))}
+
+          {/* IntersectionObserver can miss a zero-height target, so give the sentinel 1px to observe. */}
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <CaseCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={1}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+
+      <SecurityReportFiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        filters={filters}
+        onApply={setFilters}
+      />
+    </Stack>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <CaseCardSkeleton key={i} />
+      ))}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/security-center/VulnerabilitiesTab.tsx
+++ b/apps/csm-portal/microapp/src/components/security-center/VulnerabilitiesTab.tsx
@@ -83,7 +83,7 @@ function VulnerabilityCardSkeleton() {
 // Table/TablePagination (this app's list pages are all infinite-scrolled).
 export function VulnerabilitiesTab() {
   const [filters, setFilters] = useState<VulnerabilityFilters>(EMPTY_VULNERABILITY_FILTERS);
-  const debouncedSearch = useDebouncedValue(filters.search, 300);
+  const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
 
   const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
     vulnerabilities.infinite({ ...filters, search: debouncedSearch }),

--- a/apps/csm-portal/microapp/src/components/security-center/VulnerabilitiesTab.tsx
+++ b/apps/csm-portal/microapp/src/components/security-center/VulnerabilitiesTab.tsx
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState } from "react";
+import { Card, Chip, Stack, Typography } from "@wso2/oxygen-ui";
+import { Link } from "react-router-dom";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { EMPTY_VULNERABILITY_FILTERS, vulnerabilities, type VulnerabilityFilters } from "@src/services/vulnerabilities";
+import type { Vulnerability, VulnerabilityPriority } from "@src/types";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { useInfiniteScrollSentinel } from "@utils/useInfiniteScrollSentinel";
+import {
+  ALL_VULNERABILITY_PRIORITIES,
+  VULNERABILITY_PRIORITY_LABEL,
+  vulnerabilityPriorityColor,
+} from "@utils/vulnerabilities";
+import { SearchBar } from "@components/support/SearchBar";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+
+function VulnerabilityCard({ item }: { item: Vulnerability }) {
+  return (
+    <Card
+      component={Link}
+      to={`/more/security-center/vulnerabilities/${item.id}`}
+      variant="outlined"
+      sx={{ p: 2, textDecoration: "none", display: "block" }}
+    >
+      <Stack gap={1}>
+        <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
+          <Typography variant="body2" noWrap sx={{ minWidth: 0, fontFamily: "monospace" }}>
+            {item.cveId || item.vulnerabilityId || "—"}
+          </Typography>
+          {item.priority && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color={vulnerabilityPriorityColor(item.priority)}
+              label={item.priority}
+            />
+          )}
+        </Stack>
+        <Typography variant="body2" noWrap>
+          {item.componentName || "—"}
+          {item.componentVersion ? ` ${item.componentVersion}` : ""}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" noWrap>
+          {item.productName || "—"}
+          {item.productVersion ? ` ${item.productVersion}` : ""}
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+function VulnerabilityCardSkeleton() {
+  return (
+    <Card variant="outlined" sx={{ p: 2 }}>
+      <Stack gap={1}>
+        <Typography variant="body2" color="text.secondary">
+          &nbsp;
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}
+
+// Read-only product vulnerabilities list (search + single-select priority filter),
+// infinite-scrolled — mirrors the webapp's ProductVulnerabilitiesTab, minus its
+// Table/TablePagination (this app's list pages are all infinite-scrolled).
+export function VulnerabilitiesTab() {
+  const [filters, setFilters] = useState<VulnerabilityFilters>(EMPTY_VULNERABILITY_FILTERS);
+  const debouncedSearch = useDebouncedValue(filters.search, 300);
+
+  const { data, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    vulnerabilities.infinite({ ...filters, search: debouncedSearch }),
+  );
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? items.length;
+
+  const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
+
+  const togglePriority = (priority: VulnerabilityPriority) => {
+    setFilters((prev) => ({ ...prev, priority: prev.priority === priority ? null : priority }));
+  };
+
+  return (
+    <Stack gap={2}>
+      <SearchBar
+        value={filters.search}
+        onChange={(value) => setFilters((prev) => ({ ...prev, search: value }))}
+        placeholder="Search vulnerabilities…"
+      />
+
+      <Stack direction="row" gap={1} flexWrap="wrap">
+        {ALL_VULNERABILITY_PRIORITIES.map((priority) => {
+          const isSelected = filters.priority === priority;
+          return (
+            <Chip
+              key={priority}
+              label={VULNERABILITY_PRIORITY_LABEL[priority]}
+              size="small"
+              aria-pressed={isSelected}
+              variant={isSelected ? "filled" : "outlined"}
+              color={isSelected ? "primary" : "default"}
+              onClick={() => togglePriority(priority)}
+            />
+          );
+        })}
+      </Stack>
+
+      {isLoading ? (
+        <Stack gap={1.5}>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <VulnerabilityCardSkeleton key={i} />
+          ))}
+        </Stack>
+      ) : isError ? (
+        <ErrorState onRetry={() => void refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState message="No vulnerabilities found." />
+      ) : (
+        <Stack gap={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {items.length} of {total}
+          </Typography>
+
+          {items.map((item) => (
+            <VulnerabilityCard key={item.id} item={item} />
+          ))}
+
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {isFetchingNextPage && <VulnerabilityCardSkeleton />}
+          {!hasNextPage && (
+            <Typography variant="body2" color="text.secondary" textAlign="center" py={1}>
+              You're all caught up!
+            </Typography>
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/support/AttachmentsField.tsx
+++ b/apps/csm-portal/microapp/src/components/support/AttachmentsField.tsx
@@ -173,6 +173,9 @@ interface AttachmentsFieldProps {
   /** Per-file size cap. Defaults to the standalone-attachment ceiling; callers with a tighter
    * budget (e.g. inline attachments on a comment) pass MAX_INLINE_ATTACHMENT_SIZE_BYTES. */
   maxSizeBytes?: number;
+  /** Overrides the default "Attachments (optional)" label — e.g. NewSecurityReportPage passes
+   * "Attachments (required)" since the backend rejects a security report with none. */
+  label?: string;
 }
 
 // Mirrors the webapp's shared AttachmentsField
@@ -184,6 +187,7 @@ export function AttachmentsField({
   onChange,
   disabled,
   maxSizeBytes = MAX_ATTACHMENT_SIZE_BYTES,
+  label = "Attachments (optional)",
 }: AttachmentsFieldProps) {
   const { inputRef, error, handleFiles, openPicker } = useAttachmentPicker(onChange, maxSizeBytes);
 
@@ -193,7 +197,7 @@ export function AttachmentsField({
 
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <Typography variant="body2" fontWeight={500}>
-          Attachments (optional)
+          {label}
         </Typography>
         <Button
           size="small"

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -45,6 +45,8 @@ export const ACCOUNT_ENDPOINT = (id: string) => `/accounts/${id}`;
 export const PROJECTS_SEARCH_ENDPOINT = "/projects/search";
 export const PROJECT_ENDPOINT = (id: string) => `/projects/${id}`;
 export const PRODUCTS_SEARCH_ENDPOINT = "/products/search";
+export const PRODUCT_VULNERABILITIES_SEARCH_ENDPOINT = "/products/vulnerabilities/search";
+export const PRODUCT_VULNERABILITY_ENDPOINT = (id: string) => `/products/vulnerabilities/${id}`;
 export const DEPLOYMENTS_SEARCH_ENDPOINT = "/deployments/search";
 export const DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT = (deploymentId: string) =>
   `/deployments/${deploymentId}/products/search`;

--- a/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/AccountDetailPage.tsx
@@ -19,7 +19,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, Chip, Divider, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import { accounts } from "@src/services/accounts";
 import { formatDateOnly } from "@utils/customers";
-import { MetaRow, MetaValue } from "@components/customers/MetaRow";
+import { MetaRow, MetaValue } from "@components/common/MetaRow";
 import { ErrorState } from "@components/support/ErrorState";
 
 export default function AccountDetailPage() {

--- a/apps/csm-portal/microapp/src/pages/NewSecurityReportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewSecurityReportPage.tsx
@@ -30,7 +30,7 @@ import {
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
 import { deployments } from "@src/services/deployments";
-import type { Project } from "@src/types";
+import type { Project, SecurityReportCreatePayloadDto } from "@src/types";
 import { toRawBase64, type PendingAttachment } from "@utils/attachments";
 import { AttachmentsField } from "@components/support/AttachmentsField";
 import { ProjectSelect } from "@components/support/ProjectSelect";
@@ -76,18 +76,29 @@ export default function NewSecurityReportPage() {
 
   const createSecurityReport = useMutation({ mutationFn: cases.create });
 
-  // Raw-base64 (data URI stripped) sizes are what actually goes over the wire for this endpoint —
-  // budget against those, not the data-URI-prefixed lengths PendingAttachment.file holds.
-  const attachmentBytes = useMemo(
-    () => attachments.reduce((sum, a) => sum + toRawBase64(a.file).length, 0),
-    [attachments],
+  // The exact object handleSubmit sends — reused for the size check below so the two can never
+  // drift apart.
+  const buildPayload = (): SecurityReportCreatePayloadDto => ({
+    type: "security_report_analysis",
+    projectId: project?.id ?? "",
+    deploymentId,
+    deployedProductId,
+    subject: subject.trim(),
+    description,
+    attachments: attachments.map((a) => ({ name: a.name, file: toRawBase64(a.file) })),
+  });
+
+  // Measures the real wire size of the actual payload (JSON structure, field names, IDs, filenames,
+  // and all) rather than approximating from subject/description bytes plus a flat overhead buffer —
+  // that approximation undercounts the per-attachment JSON overhead (braces, commas, quoted
+  // filenames), which could let a submission with several small attachments slip past the check
+  // and still 413 against the backend's real cap.
+  const payloadBytes = useMemo(
+    () => new TextEncoder().encode(JSON.stringify(buildPayload())).length,
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- buildPayload is a plain closure over these same primitives, not memoized itself
+    [project, deploymentId, deployedProductId, subject, description, attachments],
   );
-  const nonAttachmentBytes = useMemo(
-    () => new TextEncoder().encode(subject + description).length,
-    [subject, description],
-  );
-  const attachmentsBudget = Math.max(0, MAX_BODY_BYTES - nonAttachmentBytes - 4 * 1024);
-  const overLimit = attachmentBytes > attachmentsBudget;
+  const overLimit = payloadBytes > MAX_BODY_BYTES;
 
   // Auto-generate "{Deployment} - {Product} - {date}" once both names are loaded, matching the
   // webapp. Event-driven (fired from the product-change handler) rather than a setState effect, so
@@ -134,15 +145,7 @@ export default function NewSecurityReportPage() {
     setIsSubmitting(true);
 
     try {
-      const created = await createSecurityReport.mutateAsync({
-        type: "security_report_analysis",
-        projectId: project.id,
-        deploymentId,
-        deployedProductId,
-        subject: subject.trim(),
-        description,
-        attachments: attachments.map((a) => ({ name: a.name, file: toRawBase64(a.file) })),
-      });
+      const created = await createSecurityReport.mutateAsync(buildPayload());
 
       navigate(`/cases/${created.id}`);
     } catch {

--- a/apps/csm-portal/microapp/src/pages/NewSecurityReportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewSecurityReportPage.tsx
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Button,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { cases } from "@src/services/cases";
+import { deployments } from "@src/services/deployments";
+import type { Project } from "@src/types";
+import { toRawBase64, type PendingAttachment } from "@utils/attachments";
+import { AttachmentsField } from "@components/support/AttachmentsField";
+import { ProjectSelect } from "@components/support/ProjectSelect";
+
+const SUBJECT_MAX_LENGTH = 200;
+
+// POST /cases caps the whole body at 10 MiB (backend's maxCaseBodyBytes) — unlike NewCasePage's
+// attachments (uploaded separately, one request per file after the case exists), a security
+// report's attachments are embedded directly in this same create request alongside subject and
+// description, so the combined size has to stay under the same cap the backend enforces.
+const MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+/** Today as YYYY-MM-DD, for the auto-generated report subject. */
+function todayStamp(): string {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+// Ports apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx.
+// Deviations from the webapp, called out where they matter: description is a plain multiline field
+// rather than the rich-text editor (same call NewCasePage already made), and there's no
+// cloud-support-project special case for the deployment picker — the webapp's own reference page
+// doesn't have one either, unlike NewCasePage's "case" flow.
+export default function NewSecurityReportPage() {
+  const navigate = useNavigate();
+
+  const [project, setProject] = useState<Project | null>(null);
+  const [deploymentId, setDeploymentId] = useState("");
+  const [deployedProductId, setDeployedProductId] = useState("");
+  const [subject, setSubject] = useState("");
+  // Once the user edits the subject we stop auto-regenerating it, so a later product reselect
+  // doesn't clobber their text.
+  const [subjectEdited, setSubjectEdited] = useState(false);
+  const [description, setDescription] = useState("");
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const deploymentsQuery = useQuery(deployments.byProject(project?.id ?? ""));
+  const productsQuery = useQuery(deployments.productsByDeployment(deploymentId));
+
+  const createSecurityReport = useMutation({ mutationFn: cases.create });
+
+  // Raw-base64 (data URI stripped) sizes are what actually goes over the wire for this endpoint —
+  // budget against those, not the data-URI-prefixed lengths PendingAttachment.file holds.
+  const attachmentBytes = useMemo(
+    () => attachments.reduce((sum, a) => sum + toRawBase64(a.file).length, 0),
+    [attachments],
+  );
+  const nonAttachmentBytes = useMemo(
+    () => new TextEncoder().encode(subject + description).length,
+    [subject, description],
+  );
+  const attachmentsBudget = Math.max(0, MAX_BODY_BYTES - nonAttachmentBytes - 4 * 1024);
+  const overLimit = attachmentBytes > attachmentsBudget;
+
+  // Auto-generate "{Deployment} - {Product} - {date}" once both names are loaded, matching the
+  // webapp. Event-driven (fired from the product-change handler) rather than a setState effect, so
+  // it stays editable and doesn't fight the subjectEdited guard.
+  const regenerateSubject = (depId: string, prodId: string): void => {
+    if (subjectEdited) return;
+    const depName = deploymentsQuery.data?.find((d) => d.id === depId)?.name;
+    const prodLabel = productsQuery.data?.find((p) => p.id === prodId)?.label;
+    if (depName && prodLabel) {
+      setSubject(`${depName} - ${prodLabel} - ${todayStamp()}`.slice(0, SUBJECT_MAX_LENGTH));
+    }
+  };
+
+  const handleProjectChange = (next: Project | null) => {
+    setProject(next);
+    setDeploymentId("");
+    setDeployedProductId("");
+  };
+
+  const handleDeploymentChange = (next: string) => {
+    setDeploymentId(next);
+    setDeployedProductId("");
+  };
+
+  const handleProductChange = (next: string) => {
+    setDeployedProductId(next);
+    regenerateSubject(deploymentId, next);
+  };
+
+  const canSubmit =
+    !!project &&
+    !!deploymentId &&
+    !!deployedProductId &&
+    subject.trim().length > 0 &&
+    description.trim().length > 0 &&
+    attachments.length > 0 &&
+    !overLimit &&
+    !createSecurityReport.isPending &&
+    !isSubmitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !project) return;
+    setSubmitError(null);
+    setIsSubmitting(true);
+
+    try {
+      const created = await createSecurityReport.mutateAsync({
+        type: "security_report_analysis",
+        projectId: project.id,
+        deploymentId,
+        deployedProductId,
+        subject: subject.trim(),
+        description,
+        attachments: attachments.map((a) => ({ name: a.name, file: toRawBase64(a.file) })),
+      });
+
+      navigate(`/cases/${created.id}`);
+    } catch {
+      setSubmitError("Could not create the security report. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="h6">New Security Report</Typography>
+
+      <Stack gap={2}>
+        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createSecurityReport.isPending} />
+
+        <FormControl size="small" fullWidth disabled={!project || createSecurityReport.isPending}>
+          <InputLabel id="new-sr-deployment-label">Deployment</InputLabel>
+          <Select
+            labelId="new-sr-deployment-label"
+            label="Deployment"
+            value={deploymentId}
+            onChange={(event) => handleDeploymentChange(event.target.value)}
+          >
+            {(deploymentsQuery.data ?? []).map((d) => (
+              <MenuItem key={d.id} value={d.id}>
+                {d.name}
+              </MenuItem>
+            ))}
+          </Select>
+          {!project && <FormHelperText>Select a project first</FormHelperText>}
+        </FormControl>
+
+        <FormControl size="small" fullWidth disabled={!deploymentId || createSecurityReport.isPending}>
+          <InputLabel id="new-sr-product-label">Deployed Product</InputLabel>
+          <Select
+            labelId="new-sr-product-label"
+            label="Deployed Product"
+            value={deployedProductId}
+            onChange={(event) => handleProductChange(event.target.value)}
+          >
+            {(productsQuery.data ?? []).map((p) => (
+              <MenuItem key={p.id} value={p.id}>
+                {p.label}
+              </MenuItem>
+            ))}
+          </Select>
+          {!deploymentId && <FormHelperText>Select a deployment first</FormHelperText>}
+        </FormControl>
+
+        <TextField
+          label="Subject"
+          value={subject}
+          onChange={(event) => {
+            setSubjectEdited(true);
+            setSubject(event.target.value.slice(0, SUBJECT_MAX_LENGTH));
+          }}
+          size="small"
+          fullWidth
+          disabled={createSecurityReport.isPending}
+          helperText={
+            subject.length >= 160
+              ? `${subject.length}/${SUBJECT_MAX_LENGTH}`
+              : "Auto-generated from deployment and product; edit if needed."
+          }
+        />
+
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          size="small"
+          fullWidth
+          multiline
+          minRows={5}
+          disabled={createSecurityReport.isPending}
+        />
+
+        <AttachmentsField
+          attachments={attachments}
+          onChange={setAttachments}
+          disabled={createSecurityReport.isPending}
+          label="Attachments (required)"
+        />
+        {overLimit && (
+          <Typography variant="body2" color="error.main">
+            Attachments are too large for a single security report. Remove one or reduce their size.
+          </Typography>
+        )}
+
+        {submitError && (
+          <Typography variant="body2" color="error.main">
+            {submitError}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={1} justifyContent="flex-end">
+          <Button onClick={() => navigate(-1)} disabled={createSecurityReport.isPending}>
+            Cancel
+          </Button>
+          <Button variant="contained" disabled={!canSubmit} onClick={() => void handleSubmit()}>
+            {isSubmitting ? "Creating…" : "Create Security Report"}
+          </Button>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/ProjectDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/ProjectDetailPage.tsx
@@ -20,7 +20,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, Chip, Divider, Skeleton, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import { projects } from "@src/services/projects";
 import { formatDateOnly, formatEnumLabel } from "@utils/customers";
-import { MetaRow, MetaValue } from "@components/customers/MetaRow";
+import { MetaRow, MetaValue } from "@components/common/MetaRow";
 import { ProjectIssuesTab } from "@components/customers/ProjectIssuesTab";
 import { DeploymentsTab } from "@components/customers/DeploymentsTab";
 import { ErrorState } from "@components/support/ErrorState";

--- a/apps/csm-portal/microapp/src/pages/SecurityCenterPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SecurityCenterPage.tsx
@@ -28,8 +28,9 @@ const TABS: { id: SecurityCenterTabId; label: string }[] = [
 
 // Mirrors the webapp's CsmSecurityCenterPage: Security reports (cases of type
 // "security_report_analysis") | Vulnerabilities (a separate, non-case-backed
-// entity). Read-only for this pass — "New security report" is deliberately
-// deferred, same call Engagements/Operations already made.
+// entity). "New security report" lives behind SecurityReportsTab's own Fab
+// (see NewSecurityReportPage.tsx) — Vulnerabilities stays read-only, there's no
+// create flow for that entity in either app.
 export default function SecurityCenterPage() {
   const [activeTab, setActiveTab] = useState<SecurityCenterTabId>("security_reports");
 

--- a/apps/csm-portal/microapp/src/pages/SecurityCenterPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SecurityCenterPage.tsx
@@ -14,9 +14,35 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { ComingSoonPage } from "@components/common/ComingSoonPage";
+import { useState } from "react";
+import { Stack, Tab, Tabs } from "@wso2/oxygen-ui";
+import { SecurityReportsTab } from "@components/security-center/SecurityReportsTab";
+import { VulnerabilitiesTab } from "@components/security-center/VulnerabilitiesTab";
 
-// The webapp also marks Security Center as wip:true (apps/csm-portal/webapp/src/config/csmNavItems.ts).
+type SecurityCenterTabId = "security_reports" | "vulnerabilities";
+
+const TABS: { id: SecurityCenterTabId; label: string }[] = [
+  { id: "security_reports", label: "Security reports" },
+  { id: "vulnerabilities", label: "Vulnerabilities" },
+];
+
+// Mirrors the webapp's CsmSecurityCenterPage: Security reports (cases of type
+// "security_report_analysis") | Vulnerabilities (a separate, non-case-backed
+// entity). Read-only for this pass — "New security report" is deliberately
+// deferred, same call Engagements/Operations already made.
 export default function SecurityCenterPage() {
-  return <ComingSoonPage title="Security Center" description="Security report analysis is still under construction." />;
+  const [activeTab, setActiveTab] = useState<SecurityCenterTabId>("security_reports");
+
+  return (
+    <Stack gap={2}>
+      <Tabs variant="scrollable" value={activeTab} onChange={(_, value: SecurityCenterTabId) => setActiveTab(value)}>
+        {TABS.map((tab) => (
+          <Tab key={tab.id} label={tab.label} value={tab.id} disableRipple />
+        ))}
+      </Tabs>
+
+      {activeTab === "security_reports" && <SecurityReportsTab />}
+      {activeTab === "vulnerabilities" && <VulnerabilitiesTab />}
+    </Stack>
+  );
 }

--- a/apps/csm-portal/microapp/src/pages/VulnerabilityDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/VulnerabilityDetailPage.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Chip, Divider, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { vulnerabilities } from "@src/services/vulnerabilities";
+import { vulnerabilityPriorityColor } from "@utils/vulnerabilities";
+import { MetaRow, MetaValue } from "@components/common/MetaRow";
+import { ErrorState } from "@components/support/ErrorState";
+
+function TextSection({ title, text }: { title: string; text: string | null }) {
+  if (!text || text.trim().length === 0) return null;
+  return (
+    <Stack gap={0.5}>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+        {text}
+      </Typography>
+    </Stack>
+  );
+}
+
+export default function VulnerabilityDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data, isLoading, isError, refetch } = useQuery(vulnerabilities.get(id ?? ""));
+
+  if (isLoading) {
+    return (
+      <Stack gap={2}>
+        <Skeleton variant="rounded" height={28} width="60%" />
+        <Skeleton variant="rounded" height={260} />
+      </Stack>
+    );
+  }
+
+  if (isError || !data) {
+    return <ErrorState onRetry={() => void refetch()} />;
+  }
+
+  const v = data;
+  const heading = v.cveId || v.vulnerabilityId || "Vulnerability";
+  const hasLongFormContent = !!(v.useCase?.trim() || v.justification?.trim() || v.resolution?.trim());
+
+  return (
+    <Stack gap={2}>
+      <Stack gap={0.5}>
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+          <Typography variant="h6" sx={{ fontFamily: "monospace" }}>
+            {heading}
+          </Typography>
+          {v.priority && <Chip size="small" color={vulnerabilityPriorityColor(v.priority)} label={v.priority} />}
+        </Stack>
+        {v.cveId && v.vulnerabilityId && v.cveId !== v.vulnerabilityId && (
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: "monospace" }}>
+            {v.vulnerabilityId}
+          </Typography>
+        )}
+      </Stack>
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Stack gap={1.5}>
+          <MetaRow label="Component">
+            <MetaValue>{v.componentName ?? "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Component version">
+            <MetaValue>{v.componentVersion ?? "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Component type">
+            <MetaValue>{v.componentType ?? "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Product">
+            <MetaValue>{v.productName ?? "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Product version">
+            <MetaValue>{v.productVersion ?? "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Type">
+            <MetaValue>{v.type ?? "—"}</MetaValue>
+          </MetaRow>
+          <Divider />
+          <MetaRow label="Update level">
+            <MetaValue>{v.updateLevel ?? "—"}</MetaValue>
+          </MetaRow>
+        </Stack>
+      </Card>
+
+      {hasLongFormContent && (
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Stack gap={2}>
+            <TextSection title="Use case" text={v.useCase} />
+            <TextSection title="Justification" text={v.justification} />
+            <TextSection title="Resolution" text={v.resolution} />
+          </Stack>
+        </Card>
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -27,6 +27,7 @@ import type {
   CaseCommentCreateResponseDto,
   CaseCommentSearchResponseDto,
   CaseCreatePayloadDto,
+  CaseCreateResponseDto,
   CasePatchPayloadDto,
   CaseSearchFiltersDto,
   CaseSearchPayloadDto,
@@ -202,8 +203,8 @@ const getCaseComments = async (id: string): Promise<Comment[]> => {
 };
 
 const createCase = async (payload: CaseCreatePayloadDto | SecurityReportCreatePayloadDto): Promise<CreatedCaseDto> => {
-  const { data } = await apiClient.post<CreatedCaseDto>(CASES_ENDPOINT, payload);
-  return data;
+  const { data } = await apiClient.post<CaseCreateResponseDto>(CASES_ENDPOINT, payload);
+  return data.case;
 };
 
 const patchCase = async (id: string, payload: CasePatchPayloadDto): Promise<UpdateCaseResponseDto> => {

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -34,6 +34,7 @@ import type {
   CaseType,
   CaseViewDto,
   CreatedCaseDto,
+  SecurityReportCreatePayloadDto,
   UpdateCaseResponseDto,
 } from "@src/types";
 import { toCaseDetail, toCaseSummary, toComment, type CaseDetail, type CaseSummary, type Comment } from "@src/types";
@@ -200,7 +201,7 @@ const getCaseComments = async (id: string): Promise<Comment[]> => {
   return data.comments.map(toComment);
 };
 
-const createCase = async (payload: CaseCreatePayloadDto): Promise<CreatedCaseDto> => {
+const createCase = async (payload: CaseCreatePayloadDto | SecurityReportCreatePayloadDto): Promise<CreatedCaseDto> => {
   const { data } = await apiClient.post<CreatedCaseDto>(CASES_ENDPOINT, payload);
   return data;
 };

--- a/apps/csm-portal/microapp/src/services/securityReports.ts
+++ b/apps/csm-portal/microapp/src/services/securityReports.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Security reports are cases of `type: "security_report_analysis"`, so this is
+// a single `POST /cases/search` scoped to that type — read-only (create isn't
+// in scope for this pass, mirrors the webapp's CsmSecurityCenterPage's Security
+// reports tab, which only lists/filters; "New security report" is deliberately
+// deferred, same call Engagements/Operations already made). Paged via infinite
+// scroll, newest-updated first, mirroring services/engagements.ts.
+
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { CASES_SEARCH_ENDPOINT } from "@config/endpoints";
+import type { CaseSearchPayloadDto, CaseSearchResponseDto } from "@src/types";
+import { toCaseSummary, type CaseSummary } from "@src/types";
+import type { SecurityReportFilters } from "@utils/securityReports";
+import apiClient from "./apiClient";
+
+export interface SecurityReportSearchResult {
+  items: CaseSummary[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+const SECURITY_REPORTS_PAGE_LIMIT = 20;
+
+// Empty filter arrays are omitted so the search defaults to every state across
+// all projects. `searchQuery` matches subject/number.
+async function searchSecurityReports(
+  filters: SecurityReportFilters,
+  offset: number,
+): Promise<SecurityReportSearchResult> {
+  const q = filters.search.trim();
+  const payload: CaseSearchPayloadDto = {
+    pagination: { offset, limit: SECURITY_REPORTS_PAGE_LIMIT },
+    sortBy: { field: "updatedOn", order: "desc" },
+    filters: {
+      types: ["security_report_analysis"],
+      ...(q ? { searchQuery: q } : {}),
+      ...(filters.states.length ? { states: filters.states } : {}),
+      ...(filters.workStates.length ? { workStates: filters.workStates } : {}),
+      ...(filters.projects.length ? { projectIds: filters.projects.map((p) => p.id) } : {}),
+      ...(filters.assignees.length ? { assignedUserIds: filters.assignees.map((a) => a.id) } : {}),
+      ...(filters.productNames.length ? { productNames: filters.productNames } : {}),
+    },
+  };
+  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const items = data.cases.map(toCaseSummary);
+  return {
+    items,
+    total: data.total,
+    offset: data.offset,
+    limit: data.limit,
+    // Some data sources omit hasMore from the search envelope (see cases.ts's
+    // getAllCases and adminUsers.ts's searchUsers, which hit the same quirk);
+    // derive it from offset/total when that happens instead of treating a
+    // missing/false field as "no more pages" after the first page. Also require
+    // a non-empty page — even when the backend *does* send an explicit
+    // hasMore: true — since an empty page with a stale/inconsistent total
+    // should never report hasMore, or the infinite query would keep
+    // requesting further pages forever.
+    hasMore: items.length > 0 && (data.hasMore ?? data.offset + items.length < data.total),
+  };
+}
+
+export const securityReports = {
+  infinite: (filters: SecurityReportFilters) =>
+    infiniteQueryOptions({
+      queryKey: ["security-reports", filters],
+      queryFn: ({ pageParam }) => searchSecurityReports(filters, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (last) => (last.hasMore ? last.offset + last.limit : undefined),
+    }),
+};

--- a/apps/csm-portal/microapp/src/services/vulnerabilities.ts
+++ b/apps/csm-portal/microapp/src/services/vulnerabilities.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { PRODUCT_VULNERABILITIES_SEARCH_ENDPOINT, PRODUCT_VULNERABILITY_ENDPOINT } from "@config/endpoints";
+import type { VulnerabilityDto, VulnerabilityPriority, VulnerabilitySearchResponseDto } from "@src/types";
+import { toVulnerability, type Vulnerability } from "@src/types";
+import apiClient from "./apiClient";
+
+export interface VulnerabilityFilters {
+  search: string;
+  priority: VulnerabilityPriority | null;
+}
+
+export const EMPTY_VULNERABILITY_FILTERS: VulnerabilityFilters = { search: "", priority: null };
+
+export interface VulnerabilitySearchResult {
+  items: Vulnerability[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+// openapi.yaml declares this endpoint's pagination.limit maximum as 100, but every other search
+// endpoint on this backend that claims the same (comments, products, deployments) actually
+// rejects it with a 400 — see services/cases.ts's COMMENTS_PAGE_LIMIT and
+// services/deployments.ts's SEARCH_PAGE_LIMIT for the confirmed cases. Match that real, working
+// value defensively here too rather than waiting to hit the same 400 live.
+const VULNERABILITIES_PAGE_LIMIT = 50;
+
+async function searchVulnerabilities(
+  filters: VulnerabilityFilters,
+  offset: number,
+): Promise<VulnerabilitySearchResult> {
+  const q = filters.search.trim();
+  const { data } = await apiClient.post<VulnerabilitySearchResponseDto>(PRODUCT_VULNERABILITIES_SEARCH_ENDPOINT, {
+    pagination: { offset, limit: VULNERABILITIES_PAGE_LIMIT },
+    filters: {
+      ...(q ? { searchQuery: q } : {}),
+      ...(filters.priority ? { priority: filters.priority } : {}),
+    },
+  });
+  const items = data.productVulnerabilities.map(toVulnerability);
+  return {
+    items,
+    total: data.total,
+    offset: data.offset,
+    limit: data.limit,
+    // The search response carries no hasMore field at all (unlike every other search endpoint in
+    // this app), so this is always derived, with the same empty-page guard used elsewhere against
+    // looping forever on a stale/inconsistent total.
+    hasMore: items.length > 0 && data.offset + items.length < data.total,
+  };
+}
+
+const getVulnerability = async (id: string): Promise<Vulnerability> => {
+  const { data } = await apiClient.get<VulnerabilityDto>(PRODUCT_VULNERABILITY_ENDPOINT(id));
+  return toVulnerability(data);
+};
+
+export const vulnerabilities = {
+  infinite: (filters: VulnerabilityFilters) =>
+    infiniteQueryOptions({
+      queryKey: ["vulnerabilities", "infinite", filters],
+      queryFn: ({ pageParam }) => searchVulnerabilities(filters, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (last) => (last.hasMore ? last.offset + last.limit : undefined),
+    }),
+
+  get: (id: string) =>
+    queryOptions({
+      queryKey: ["vulnerability", id],
+      queryFn: () => getVulnerability(id),
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -318,3 +318,13 @@ export interface SecurityReportCreatePayloadDto {
 export interface CreatedCaseDto {
   id: string;
 }
+
+// POST /cases wraps the created case in a { message, case } envelope rather than returning it
+// flat — confirmed against the webapp's usePostCsmCase.ts (BeCaseCreateResponse/BeCreatedCase),
+// which unwraps res.case for exactly this reason. openapi.yaml's postCases 201 response
+// ($ref: Case) doesn't reflect the envelope; trust the webapp's actual working code over the spec
+// here, same doc-vs-reality gap seen elsewhere in this backend family.
+export interface CaseCreateResponseDto {
+  message?: string;
+  case: CreatedCaseDto;
+}

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -288,8 +288,8 @@ export type CaseCause =
   | "INFRASTRUCTURE_SAAS_SIDE_OTHER"
   | "UNKNOWN";
 
-// Mirrors the webapp's BeCaseCreatePayload (the "case" type variant only — service_request and
-// security_report_analysis creation aren't in the microapp's scope, see NewCasePage.tsx).
+// Mirrors the webapp's BeCaseCreatePayload (the "case" type variant only — service_request
+// creation isn't in the microapp's scope, see NewCasePage.tsx).
 export interface CaseCreatePayloadDto {
   type: "case";
   projectId: string;
@@ -299,6 +299,20 @@ export interface CaseCreatePayloadDto {
   description: string;
   severity: CaseSeverity;
   issueType: CaseIssueType;
+}
+
+// The "security_report_analysis" type variant — see NewSecurityReportPage.tsx. Unlike the "case"
+// type, attachments are embedded directly in the create payload (raw base64, no `data:` prefix)
+// rather than uploaded separately via POST /attachments after the case exists; the backend
+// requires at least one entry.
+export interface SecurityReportCreatePayloadDto {
+  type: "security_report_analysis";
+  projectId: string;
+  deploymentId: string;
+  deployedProductId: string;
+  subject: string;
+  description: string;
+  attachments: { name: string; file: string }[];
 }
 
 export interface CreatedCaseDto {

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -40,3 +40,5 @@ export * from "./changeRequest.dto";
 export * from "./changeRequest.model";
 export * from "./updates.dto";
 export * from "./updates.model";
+export * from "./vulnerability.dto";
+export * from "./vulnerability.model";

--- a/apps/csm-portal/microapp/src/types/vulnerability.dto.ts
+++ b/apps/csm-portal/microapp/src/types/vulnerability.dto.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export type VulnerabilityPriority = "info" | "low" | "medium" | "high" | "critical" | "unknown";
+
+// Same shape for both a search-result row and GET /products/vulnerabilities/{id} — like Account,
+// unlike Project/Deployment, there's no separate enriched detail shape.
+export interface VulnerabilityDto {
+  id: string;
+  cveId?: string;
+  vulnerabilityId?: string;
+  /** Priority label from the upstream (e.g. "High", "Critical") — not the lowercase
+   * VulnerabilityPriority enum. */
+  priority?: string;
+  productName?: string | null;
+  productVersion?: string | null;
+  componentName?: string;
+  version?: string;
+  type?: string;
+  componentType?: string | null;
+  updateLevel?: string | null;
+  useCase?: string | null;
+  justification?: string | null;
+  resolution?: string | null;
+}
+
+export interface VulnerabilitySearchFiltersDto {
+  searchQuery?: string;
+  priority?: VulnerabilityPriority;
+  productName?: string;
+  productVersion?: string;
+}
+
+export interface VulnerabilitySearchPayloadDto {
+  filters?: VulnerabilitySearchFiltersDto;
+  pagination?: { offset?: number; limit?: number };
+}
+
+// The backend's SearchProductVulnerabilitiesResponse carries no `hasMore` field at all — derive
+// it from offset/total instead.
+export interface VulnerabilitySearchResponseDto {
+  productVulnerabilities: VulnerabilityDto[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/csm-portal/microapp/src/types/vulnerability.model.ts
+++ b/apps/csm-portal/microapp/src/types/vulnerability.model.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { VulnerabilityDto } from "./vulnerability.dto";
+
+export interface Vulnerability {
+  id: string;
+  cveId: string | null;
+  vulnerabilityId: string | null;
+  /** Priority label from the upstream (e.g. "High"), not the lowercase enum — see
+   * utils/vulnerabilities.ts's vulnerabilityPriorityColor for the display-color mapping. */
+  priority: string | null;
+  productName: string | null;
+  productVersion: string | null;
+  componentName: string | null;
+  componentVersion: string | null;
+  type: string | null;
+  componentType: string | null;
+  updateLevel: string | null;
+  useCase: string | null;
+  justification: string | null;
+  resolution: string | null;
+}
+
+export function toVulnerability(dto: VulnerabilityDto): Vulnerability {
+  return {
+    id: dto.id,
+    cveId: dto.cveId ?? null,
+    vulnerabilityId: dto.vulnerabilityId ?? null,
+    priority: dto.priority ?? null,
+    productName: dto.productName ?? null,
+    productVersion: dto.productVersion ?? null,
+    componentName: dto.componentName ?? null,
+    componentVersion: dto.version ?? null,
+    type: dto.type ?? null,
+    componentType: dto.componentType ?? null,
+    updateLevel: dto.updateLevel ?? null,
+    useCase: dto.useCase ?? null,
+    justification: dto.justification ?? null,
+    resolution: dto.resolution ?? null,
+  };
+}

--- a/apps/csm-portal/microapp/src/utils/attachments.ts
+++ b/apps/csm-portal/microapp/src/utils/attachments.ts
@@ -60,3 +60,11 @@ export async function toPendingAttachment(file: File): Promise<PendingAttachment
     file: dataUrl,
   };
 }
+
+/** Strips the "data:<mime>;base64," prefix from a PendingAttachment's data URI, producing the raw
+ * base64 payload the case-create endpoint's embedded `attachments` field wants (security reports
+ * only — every other attachment path uses POST /attachments, which wants the full data URI). */
+export function toRawBase64(dataUrl: string): string {
+  const comma = dataUrl.indexOf(",");
+  return comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+}

--- a/apps/csm-portal/microapp/src/utils/securityReports.ts
+++ b/apps/csm-portal/microapp/src/utils/securityReports.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CaseState, CaseWorkState, Project } from "@src/types";
+
+/** Lightweight assignee ref for the filter chip — mirrors how `projects` stores a
+ * display-ready `Project[]` rather than bare ids (see utils/engagements.ts's own copy). */
+export interface SecurityReportAssignee {
+  id: string;
+  name: string;
+}
+
+// UI-facing security report filters. `search` matches subject/number (server-side
+// `searchQuery`); `states` → server-side `states`; `workStates` → server-side
+// `workStates` (only meaningful while `states` includes "work_in_progress");
+// `projects` → server-side `projectIds`; `assignees` → server-side
+// `assignedUserIds`; `productNames` → server-side `productNames`. All empty by
+// default, so the list shows every state across all projects. (No severity —
+// security reports carry none, same as the webapp's CsmIssuesView locks it out
+// for any non-"case" type. No engagement type either — that's engagement-only.)
+export interface SecurityReportFilters {
+  search: string;
+  states: CaseState[];
+  workStates: NonNullable<CaseWorkState>[];
+  projects: Project[];
+  assignees: SecurityReportAssignee[];
+  productNames: string[];
+}
+
+export const EMPTY_SECURITY_REPORT_FILTERS: SecurityReportFilters = {
+  search: "",
+  states: [],
+  workStates: [],
+  projects: [],
+  assignees: [],
+  productNames: [],
+};
+
+/** Active filter groups — drives the "Filters (n)" badge. Search is excluded (it
+ * has its own always-visible box). */
+export function countActiveSecurityReportFilters(filters: SecurityReportFilters): number {
+  let count = 0;
+  if (filters.states.length > 0) count += 1;
+  if (filters.workStates.length > 0) count += 1;
+  if (filters.projects.length > 0) count += 1;
+  if (filters.assignees.length > 0) count += 1;
+  if (filters.productNames.length > 0) count += 1;
+  return count;
+}

--- a/apps/csm-portal/microapp/src/utils/vulnerabilities.ts
+++ b/apps/csm-portal/microapp/src/utils/vulnerabilities.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ChipProps } from "@wso2/oxygen-ui";
+import type { VulnerabilityPriority } from "@src/types";
+
+/** All vulnerability priorities in display order (highest to lowest) — mirrors the
+ * webapp's VULNERABILITY_PRIORITIES (csm-security-center/utils/vulnerabilities.ts). */
+export const ALL_VULNERABILITY_PRIORITIES: VulnerabilityPriority[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+  "unknown",
+];
+
+export const VULNERABILITY_PRIORITY_LABEL: Record<VulnerabilityPriority, string> = {
+  critical: "Critical",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+  info: "Info",
+  unknown: "Unknown",
+};
+
+const PRIORITY_COLOR: Record<string, NonNullable<ChipProps["color"]>> = {
+  critical: "error",
+  high: "error",
+  medium: "warning",
+  low: "info",
+  info: "default",
+  unknown: "default",
+};
+
+/** Chip colour for a priority value. Accepts both the enum values ("high") and the label
+ * strings the search/detail endpoints actually return ("High") by normalizing to lowercase —
+ * mirrors the webapp's vulnerabilityPriorityColor. */
+export function vulnerabilityPriorityColor(priority?: string | null): NonNullable<ChipProps["color"]> {
+  if (!priority) return "default";
+  return PRIORITY_COLOR[priority.toLowerCase()] ?? "default";
+}


### PR DESCRIPTION
## Purpose
Ports the webapp's Security Center (`CsmSecurityCenterPage`) to the microapp: cross-customer security reports, product vulnerabilities, and creating a new security report — none of which existed in the microapp yet.

## Goals
- Security reports tab: cases of type `security_report_analysis`, search + State/Work state/Assignee/Project/Product filters, infinite-scrolled
- Vulnerabilities tab: a separate, non-case-backed entity with its own detail page
- New Security Report: Project → Deployment → Deployed Product cascade, auto-generated subject, required attachments, matching the webapp's `CreateSecurityReportPage`

## Approach
- `pages/SecurityCenterPage.tsx` — 2-tab shell, mirrors the webapp's tab split
- `components/security-center/{SecurityReportsTab,VulnerabilitiesTab,SecurityReportFiltersSheet}.tsx`, `pages/VulnerabilityDetailPage.tsx`, `services/{securityReports,vulnerabilities}.ts`, `types/vulnerability.{dto,model}.ts`
- `pages/NewSecurityReportPage.tsx` — reuses the same Project/Deployment/Product cascade pattern as `NewCasePage.tsx`, but attachments are embedded raw-base64 directly in the create payload (backend requires ≥1 for this case type) rather than uploaded separately afterward, and there's an aggregate 10 MiB body-size budget check matching the backend's actual cap
- Fixed a real bug surfaced while testing this: `POST /cases` wraps its response in a `{ message, case }` envelope (confirmed against the webapp's `usePostCsmCase.ts`) — the microapp's `cases.create` was reading `.id` off the wrapper instead of `.case.id`, so **every** case-create redirect (New Case and New Security Report both) landed on `/cases/undefined`. Fixed once at the `services/cases.ts` level.
- Read-only for reports/vulnerabilities beyond creation — no report editing, matching the webapp's own scope

## User stories
As a CSM engineer, I can browse security reports and product vulnerabilities, and file a new security report, from the microapp.

## Release note
Added the Security Center feature (security reports, vulnerabilities, new-report creation) to the CSM Portal microapp.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- No test runner wired up yet for the microapp (matches the rest of this app's PRs)
- `npm run lint` and `npm run build` passing locally
- Manually verified in a local dev server: report/vulnerability lists load and filter, vulnerability detail navigates correctly, and the create-report flow (including the `/cases/undefined` redirect bug) was caught and fixed via live testing

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `npm run lint`, `npm run build` all passing locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Security Center with tabs for security reports and product vulnerabilities, including search, filters, and infinite scrolling.
  * Added security report creation page (project/deployment selection, description, attachments) with payload-size enforcement.
  * Added vulnerability list and vulnerability detail pages with priority and metadata.
* **Bug Fixes**
  * Updated mobile metadata rows to use the shared presentation component across account, project, and deployment views for consistent display.
* **Documentation**
  * Improved in-app component documentation for the shared metadata row component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->