### PR TITLE
[Customer Portal] Display project dates as backend values without timezone conversion

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/utils/projectDetails.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/utils/projectDetails.ts
@@ -143,6 +143,14 @@ const MONTH_ABBREVIATIONS = [
   "Dec",
 ];
 
+const isLeapYear = (year: number): boolean =>
+  (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+
+const daysInMonth = (month: number, year: number): number => {
+  const days = [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return days[month - 1] ?? 0;
+};
+
 /**
  * Formats a date string into "MMM DD, YYYY" format using the date parts
  * as provided by the backend, without converting to any timezone.
@@ -155,12 +163,17 @@ export const formatProjectDate = (dateString: string): string => {
   if (!dateString) {
     return "";
   }
-  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})/.exec(dateString.trim());
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T ].*)?$/.exec(
+    dateString.trim(),
+  );
   if (match) {
     const [, yyyy, mm, dd] = match;
-    const monthName = MONTH_ABBREVIATIONS[Number(mm) - 1];
-    if (monthName) {
-      return `${monthName} ${Number(dd)}, ${yyyy}`;
+    const year = Number(yyyy);
+    const month = Number(mm);
+    const day = Number(dd);
+    const monthName = MONTH_ABBREVIATIONS[month - 1];
+    if (monthName && day >= 1 && day <= daysInMonth(month, year)) {
+      return `${monthName} ${day}, ${year}`;
     }
   }
   const formatted = formatBackendTimestampForDisplay(dateString, {

--- a/apps/customer-portal/webapp/src/features/project-details/utils/projectDetails.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/utils/projectDetails.ts
@@ -128,8 +128,24 @@ export const displayValue = (
   return typeof value === "string" ? value : fallback;
 };
 
+const MONTH_ABBREVIATIONS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
 /**
- * Formats a date string into "MMM DD, YYYY" format.
+ * Formats a date string into "MMM DD, YYYY" format using the date parts
+ * as provided by the backend, without converting to any timezone.
  * Example: "Jan 15, 2024"
  *
  * @param {string} dateString - The date string to format.
@@ -138,6 +154,14 @@ export const displayValue = (
 export const formatProjectDate = (dateString: string): string => {
   if (!dateString) {
     return "";
+  }
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})/.exec(dateString.trim());
+  if (match) {
+    const [, yyyy, mm, dd] = match;
+    const monthName = MONTH_ABBREVIATIONS[Number(mm) - 1];
+    if (monthName) {
+      return `${monthName} ${Number(dd)}, ${yyyy}`;
+    }
   }
   const formatted = formatBackendTimestampForDisplay(dateString, {
     month: "short",


### PR DESCRIPTION
## Summary
- Project detail dates (Created Date, Go Live Date, Subscription Period Start/End) were being parsed into a `Date` object and reformatted via `Intl.DateTimeFormat` with a resolved local/browser timezone, which could shift the displayed day depending on the viewer's timezone.
- `formatProjectDate` now parses the `YYYY-MM-DD` parts directly from the backend value and formats them as-is (e.g. `Jul 17, 2025`), with no timezone conversion involved.
- Falls back to the previous `Intl`-based formatting only for values that don't match the plain date prefix.

## Test plan
- [ ] Verify Project Information card (Created Date, Go Live Date, Support Tier, Onboarding Status) shows the same date regardless of system timezone
- [ ] Verify Subscription Period Start/End dates render correctly
- [ ] Confirm `formatProjectDateTime` (timestamps with time-of-day) is unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project dates now display using the backend-provided calendar date without unintended timezone shifts.
  * Added a fallback for dates that cannot be parsed in the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->