### PR TITLE
[Entity-Service][BE} Replace acpLastNoticeWindow with suspensionProcessState

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5400,6 +5400,15 @@ components:
         updatedOn:
           type: string
           format: date-time
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: >
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
 
     ProjectUpdatePayload:
       type: object
@@ -5423,6 +5432,7 @@ components:
         suspensionProcessState:
           type: object
           additionalProperties: true
+          nullable: true
           description: >
             Free-form, per-dimension Account Closure Process (ACP) suspension-process
             state (event type + action results) written by an existing ServiceNow

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5420,11 +5420,14 @@ components:
           type: string
         complianceViolationClosureState:
           type: string
-        acpLastNoticeWindow:
-          type: string
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
           description: >
-            Last ACP (Account Closure Process) notice window the automation sent an
-            email for. Must be one of "90", "60", "30", "15", "7", "0".
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
 
     ProjectUpdateResponse:
       type: object
@@ -5456,8 +5459,9 @@ components:
             complianceViolationClosureState:
               type: string
               nullable: true
-            acpLastNoticeWindow:
-              type: string
+            suspensionProcessState:
+              type: object
+              additionalProperties: true
               nullable: true
 
     DeploymentCreatePayload:

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -353,13 +353,13 @@ type ProjectClosureFields struct {
 	// ComplianceViolationDate is the date a compliance violation was recorded, if any
 	// (ServiceNow data source only).
 	ComplianceViolationDate *string `json:"complianceViolationDate"`
-	// AcpLastNoticeWindow is the last Account Closure Process (ACP) notice window
-	// the automation sent an email for (e.g. "90", "60", "30", "15", "7", "0" days),
-	// used by that job to avoid re-sending the same notice on its next daily run.
-	// Unlike the other fields in this struct, it is not derived by any SN business
-	// rule — the ACP job writes it directly to record its own progress (ServiceNow
-	// data source only).
-	AcpLastNoticeWindow *string `json:"acpLastNoticeWindow"`
+	// SuspensionProcessState is a free-form JSON object tracking per-dimension
+	// Account Closure Process (ACP) suspension-process state (event type + action
+	// results, e.g. per the "based_on_subscription_end_date"/"based_on_due_invoices"/
+	// "based_on_compliance" keys an existing SN suspension flow writes). This layer
+	// does not interpret, validate, or impose any schema on its contents — it is
+	// passed through opaquely as written by that SN flow (ServiceNow data source only).
+	SuspensionProcessState json.RawMessage `json:"suspensionProcessState"`
 }
 
 // ProjectDetailsView is the enriched response shape for GET /projects/{id}.
@@ -386,12 +386,12 @@ type ProjectDetailsView struct {
 // SN business rule, so setting one of those and re-fetching the project is
 // how a caller observes the resulting overall status.
 type ProjectUpdateRequest struct {
-	HasAgent                        *bool   `json:"hasAgent,omitempty"`
-	HasKbReferences                 *bool   `json:"hasKbReferences,omitempty"`
-	EndDateClosureState             *string `json:"endDateClosureState,omitempty"`
-	InvoiceDueDateClosureState      *string `json:"invoiceDueDateClosureState,omitempty"`
-	ComplianceViolationClosureState *string `json:"complianceViolationClosureState,omitempty"`
-	AcpLastNoticeWindow             *string `json:"acpLastNoticeWindow,omitempty"`
+	HasAgent                        *bool           `json:"hasAgent,omitempty"`
+	HasKbReferences                 *bool           `json:"hasKbReferences,omitempty"`
+	EndDateClosureState             *string         `json:"endDateClosureState,omitempty"`
+	InvoiceDueDateClosureState      *string         `json:"invoiceDueDateClosureState,omitempty"`
+	ComplianceViolationClosureState *string         `json:"complianceViolationClosureState,omitempty"`
+	SuspensionProcessState          json.RawMessage `json:"suspensionProcessState,omitempty"`
 }
 
 // ProjectUpdateResponse is the result of a project update operation
@@ -404,14 +404,14 @@ type ProjectUpdateResponse struct {
 // ProjectUpdateResult is the updated project's metadata, including the
 // closure state as recomputed by ServiceNow after the update.
 type ProjectUpdateResult struct {
-	ID                              string    `json:"id"`
-	UpdatedBy                       string    `json:"updatedBy"`
-	UpdatedOn                       time.Time `json:"updatedOn"`
-	ClosureState                    *string   `json:"closureState"`
-	EndDateClosureState             *string   `json:"endDateClosureState"`
-	InvoiceDueDateClosureState      *string   `json:"invoiceDueDateClosureState"`
-	ComplianceViolationClosureState *string   `json:"complianceViolationClosureState"`
-	AcpLastNoticeWindow             *string   `json:"acpLastNoticeWindow"`
+	ID                              string          `json:"id"`
+	UpdatedBy                       string          `json:"updatedBy"`
+	UpdatedOn                       time.Time       `json:"updatedOn"`
+	ClosureState                    *string         `json:"closureState"`
+	EndDateClosureState             *string         `json:"endDateClosureState"`
+	InvoiceDueDateClosureState      *string         `json:"invoiceDueDateClosureState"`
+	ComplianceViolationClosureState *string         `json:"complianceViolationClosureState"`
+	SuspensionProcessState          json.RawMessage `json:"suspensionProcessState"`
 }
 
 // SearchProjectsRequest is the input for a project search operation.

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -42,12 +42,12 @@ type snProjectsResponse struct {
 // snProject and snProjectDetailsResponse; ServiceNow specific, no Postgres
 // equivalent. Embedded anonymously; JSON field names are unaffected.
 type snProjectClosureFields struct {
-	ClosureState                    *string `json:"closureState"`
-	EndDateClosureState             *string `json:"endDateClosureState"`
-	InvoiceDueDateClosureState      *string `json:"invoiceDueDateClosureState"`
-	ComplianceViolationClosureState *string `json:"complianceViolationClosureState"`
-	ComplianceViolationDate         *string `json:"complianceViolationDate"`
-	AcpLastNoticeWindow             *string `json:"acpLastNoticeWindow"`
+	ClosureState                    *string         `json:"closureState"`
+	EndDateClosureState             *string         `json:"endDateClosureState"`
+	InvoiceDueDateClosureState      *string         `json:"invoiceDueDateClosureState"`
+	ComplianceViolationClosureState *string         `json:"complianceViolationClosureState"`
+	ComplianceViolationDate         *string         `json:"complianceViolationDate"`
+	SuspensionProcessState          json.RawMessage `json:"suspensionProcessState"`
 }
 
 type snProject struct {
@@ -169,7 +169,7 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 				InvoiceDueDateClosureState:      p.InvoiceDueDateClosureState,
 				ComplianceViolationClosureState: p.ComplianceViolationClosureState,
 				ComplianceViolationDate:         p.ComplianceViolationDate,
-				AcpLastNoticeWindow:             p.AcpLastNoticeWindow,
+				SuspensionProcessState:          p.SuspensionProcessState,
 			},
 		})
 	}
@@ -267,7 +267,7 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 			InvoiceDueDateClosureState:      sn.InvoiceDueDateClosureState,
 			ComplianceViolationClosureState: sn.ComplianceViolationClosureState,
 			ComplianceViolationDate:         sn.ComplianceViolationDate,
-			AcpLastNoticeWindow:             sn.AcpLastNoticeWindow,
+			SuspensionProcessState:          sn.SuspensionProcessState,
 		},
 		Account: domain.ProjectAccountRef{
 			ID:                  sysidToUUID(sn.Account.ID),
@@ -283,12 +283,12 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 
 // snProjectUpdatePayload is the Choreo PATCH /projects/{id} request body.
 type snProjectUpdatePayload struct {
-	HasAgent                        *bool   `json:"hasAgent,omitempty"`
-	HasKbReferences                 *bool   `json:"hasKbReferences,omitempty"`
-	EndDateClosureState             *string `json:"endDateClosureState,omitempty"`
-	InvoiceDueDateClosureState      *string `json:"invoiceDueDateClosureState,omitempty"`
-	ComplianceViolationClosureState *string `json:"complianceViolationClosureState,omitempty"`
-	AcpLastNoticeWindow             *string `json:"acpLastNoticeWindow,omitempty"`
+	HasAgent                        *bool           `json:"hasAgent,omitempty"`
+	HasKbReferences                 *bool           `json:"hasKbReferences,omitempty"`
+	EndDateClosureState             *string         `json:"endDateClosureState,omitempty"`
+	InvoiceDueDateClosureState      *string         `json:"invoiceDueDateClosureState,omitempty"`
+	ComplianceViolationClosureState *string         `json:"complianceViolationClosureState,omitempty"`
+	SuspensionProcessState          json.RawMessage `json:"suspensionProcessState,omitempty"`
 }
 
 // snProjectUpdateResponse mirrors the Choreo PATCH /projects/{id} response.
@@ -298,14 +298,14 @@ type snProjectUpdateResponse struct {
 }
 
 type snProjectUpdateResult struct {
-	ID                              string  `json:"id"`
-	UpdatedBy                       string  `json:"updatedBy"`
-	UpdatedOn                       string  `json:"updatedOn"`
-	ClosureState                    *string `json:"closureState"`
-	EndDateClosureState             *string `json:"endDateClosureState"`
-	InvoiceDueDateClosureState      *string `json:"invoiceDueDateClosureState"`
-	ComplianceViolationClosureState *string `json:"complianceViolationClosureState"`
-	AcpLastNoticeWindow             *string `json:"acpLastNoticeWindow"`
+	ID                              string          `json:"id"`
+	UpdatedBy                       string          `json:"updatedBy"`
+	UpdatedOn                       string          `json:"updatedOn"`
+	ClosureState                    *string         `json:"closureState"`
+	EndDateClosureState             *string         `json:"endDateClosureState"`
+	InvoiceDueDateClosureState      *string         `json:"invoiceDueDateClosureState"`
+	ComplianceViolationClosureState *string         `json:"complianceViolationClosureState"`
+	SuspensionProcessState          json.RawMessage `json:"suspensionProcessState"`
 }
 
 type snProjectUpdateService struct {
@@ -331,20 +331,15 @@ func NewServiceNowProjectUpdateService(client *integrationservice.Client) Projec
 // during development. A validXxx map here would risk rejecting legitimate
 // values the ACP automation needs to write.
 //
-// AcpLastNoticeWindow, in contrast, IS validated against a fixed set
-// (validAcpNoticeWindows): it has no SN business rule or Flow Designer process
-// behind it at all — the ACP automation is the sole writer, so we fully own
-// its value domain from day one, unlike the sub-states above.
+// SuspensionProcessState is likewise not validated here: it is a free-form JSON
+// object written by an existing, actively-used SN suspension flow, and this
+// service passes it through opaquely without imposing any schema on its
+// contents.
 func (s *snProjectUpdateService) UpdateProject(ctx context.Context, id string, req domain.ProjectUpdateRequest) (domain.ProjectUpdateResponse, error) {
 	if req.HasAgent == nil && req.HasKbReferences == nil && req.EndDateClosureState == nil &&
 		req.InvoiceDueDateClosureState == nil && req.ComplianceViolationClosureState == nil &&
-		req.AcpLastNoticeWindow == nil {
+		req.SuspensionProcessState == nil {
 		return domain.ProjectUpdateResponse{}, &apierror.ValidationError{Msg: "at least one field must be provided"}
-	}
-	if req.AcpLastNoticeWindow != nil {
-		if _, ok := validAcpNoticeWindows[*req.AcpLastNoticeWindow]; !ok {
-			return domain.ProjectUpdateResponse{}, &apierror.ValidationError{Msg: "acpLastNoticeWindow must be one of: 90, 60, 30, 15, 7, 0"}
-		}
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
@@ -355,7 +350,7 @@ func (s *snProjectUpdateService) UpdateProject(ctx context.Context, id string, r
 		EndDateClosureState:             req.EndDateClosureState,
 		InvoiceDueDateClosureState:      req.InvoiceDueDateClosureState,
 		ComplianceViolationClosureState: req.ComplianceViolationClosureState,
-		AcpLastNoticeWindow:             req.AcpLastNoticeWindow,
+		SuspensionProcessState:          req.SuspensionProcessState,
 	}
 	raw, err := s.client.Patch(ctx, "/projects/"+uuidToSysid(id), token, payload)
 	if err != nil {
@@ -382,7 +377,7 @@ func (s *snProjectUpdateService) UpdateProject(ctx context.Context, id string, r
 			EndDateClosureState:             sn.Project.EndDateClosureState,
 			InvoiceDueDateClosureState:      sn.Project.InvoiceDueDateClosureState,
 			ComplianceViolationClosureState: sn.Project.ComplianceViolationClosureState,
-			AcpLastNoticeWindow:             sn.Project.AcpLastNoticeWindow,
+			SuspensionProcessState:          sn.Project.SuspensionProcessState,
 		},
 	}, nil
 }
@@ -397,19 +392,6 @@ var validClosureStatuses = map[string]struct{}{
 	"Open":       {},
 	"Suspended":  {},
 	"Restricted": {},
-}
-
-// validAcpNoticeWindows is the fixed set of notice-window buckets the ACP
-// automation may record — see the AcpLastNoticeWindow doc comment on
-// UpdateProject for why this field, unlike the other closure sub-states, is
-// safe to validate strictly.
-var validAcpNoticeWindows = map[string]struct{}{
-	"90": {},
-	"60": {},
-	"30": {},
-	"15": {},
-	"7":  {},
-	"0":  {},
 }
 
 // validSortOrders is the set of accepted SortOrder values.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2821,14 +2821,15 @@ components:
         complianceViolationDate:
           type: string
           nullable: true
-        acpLastNoticeWindow:
-          type: string
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
           nullable: true
           description: >
-            Last ACP (Account Closure Process) notice window the automation sent an
-            email for (e.g. "90", "60", "30", "15", "7", "0" days), used by that job
-            to avoid re-sending the same notice on subsequent runs. Not derived by
-            any SN business rule — written directly by the ACP automation.
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
 
     ProjectView:
       type: object
@@ -2873,14 +2874,15 @@ components:
         complianceViolationDate:
           type: string
           nullable: true
-        acpLastNoticeWindow:
-          type: string
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
           nullable: true
           description: >
-            Last ACP (Account Closure Process) notice window the automation sent an
-            email for (e.g. "90", "60", "30", "15", "7", "0" days), used by that job
-            to avoid re-sending the same notice on subsequent runs. Not derived by
-            any SN business rule — written directly by the ACP automation.
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
 
     SearchProjectsResponse:
       type: object

--- a/integrations/csm-integration-service/openapi.yaml
+++ b/integrations/csm-integration-service/openapi.yaml
@@ -598,11 +598,14 @@ components:
           type: string
         complianceViolationClosureState:
           type: string
-        acpLastNoticeWindow:
-          type: string
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
           description: >
-            Last ACP (Account Closure Process) notice window the automation sent an
-            email for. Must be one of "90", "60", "30", "15", "7", "0".
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
 
     ProjectUpdateResult:
       type: object
@@ -626,8 +629,9 @@ components:
         complianceViolationClosureState:
           type: string
           nullable: true
-        acpLastNoticeWindow:
-          type: string
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
           nullable: true
 
     ProjectUpdateResponse:

--- a/integrations/csm-integration-service/openapi.yaml
+++ b/integrations/csm-integration-service/openapi.yaml
@@ -517,6 +517,15 @@ components:
         updatedOn:
           type: string
           format: date-time
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: >
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
 
     ProjectSearchPayload:
       type: object
@@ -601,6 +610,7 @@ components:
         suspensionProcessState:
           type: object
           additionalProperties: true
+          nullable: true
           description: >
             Free-form, per-dimension Account Closure Process (ACP) suspension-process
             state (event type + action results) written by an existing ServiceNow


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

A prior change added `acpLastNoticeWindow` to the entity-service's Project types to let the Account Closure Process (ACP) automation record which notice window it last emailed a customer about, backed by a simple string column on the backing data source. That column has since been dropped in favor of an existing, actively-used column on the same record that already tracks richer, per-dimension ACP suspension-process state (event type + action results per dimension, e.g. subscription end date / due invoices / compliance). This PR makes the entity-service expose that existing field instead of the narrow one it replaces, tracked separately via a corresponding ServiceNow and Ballerina entity-service change.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Replace the `acpLastNoticeWindow` field (nullable string, enum-validated) with `suspensionProcessState`: a free-form JSON value with no shape or enum validation imposed by this layer, since its contents are owned and evolved entirely by the upstream suspension flow.
- Keep the field readable (project detail/search views) and writable (project update) exactly like its predecessor, just with a different name, type, and no validation.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `internal/domain/entity.go`: renamed `AcpLastNoticeWindow` to `SuspensionProcessState` in `ProjectClosureFields`, `ProjectUpdateRequest`, and `ProjectUpdateResult`, changing the Go type from `*string` to `json.RawMessage` (an existing opaque-pass-through pattern already used elsewhere in this codebase for fields whose shape the entity-service doesn't need to interpret, e.g. `UpdateDeployedProductRequest.Description`). Updated the field's doc comment to describe it as a free-form JSON object this layer does not validate.
- `internal/service/sn_project_service.go`: mirrored the same rename/type change across `snProjectClosureFields`, the two view-mapping call sites, `snProjectUpdatePayload`, and `snProjectUpdateResult`. Removed the `validAcpNoticeWindows` enum-check map and its associated validation block from `UpdateProject` (no enum applies to a free-form JSON field), and updated the "at least one field provided" check and doc comment accordingly.
- `openapi.yaml`: renamed the `acpLastNoticeWindow` (nullable string) property to `suspensionProcessState` in the `ProjectDetailsView` and `ProjectView` schemas, changed its schema to a generic free-form object (`type: object`, `additionalProperties: true`, `nullable: true`), and updated the description.
- No behavior/validation is added or removed elsewhere; this is a scoped rename + type/validation relaxation of one field.

## User stories
> Summary of user stories addressed by this change

N/A — internal data-model correction, no user-facing story.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

The entity-service now exposes the project's ACP suspension-process state (`suspensionProcessState`, opaque JSON) in place of the narrower `acpLastNoticeWindow` string field it replaces.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — internal API field rename documented in-line via updated `openapi.yaml` schema descriptions; no external product documentation references this field.

## Training
N/A — no training content references this field.

## Certification
N/A — no certification content references this field.

## Marketing
N/A — internal API change, no customer-facing feature to promote.

## Automation tests
 - Unit tests
   > No existing unit tests referenced the old field/type, so none required updating. Verified via `go build ./...`, `go vet ./...`, and `go test ./...` in `entity-service/`, all passing.
 - Integration tests
   > N/A — no integration test suite covers this endpoint in this repo.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go codebase; ran `go vet ./...` instead, clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples reference this field.

## Related PRs
None open at this time; a corresponding ServiceNow and Ballerina entity-service change is tracked separately.

## Migrations (if applicable)
N/A — no database migration; the backing data source's schema change happened upstream of this entity-service.

## Test environment
Verified with `go build ./...`, `go vet ./...`, and `go test ./...` on the entity-service module (Go toolchain per `go.mod`), macOS.

## Learning
N/A — straightforward rename/type-relaxation following an existing opaque-JSON-pass-through pattern already established in this codebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing and returning per-dimension suspension-process state as opaque JSON.
  * Project update requests and responses now accept and return this nullable, pass-through state.
  * Updated public API schemas to expose `suspensionProcessState` instead of the prior fixed-form field.
* **Changes**
  * Replaced the previous ACP notice-window value with `suspensionProcessState` across project view, details, and update APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->