### PR TITLE
[CSM Portal] fix: enforce reject comment, gate time-card review by assigned approver

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2157,6 +2157,15 @@ export interface BeTimeCardView {
   rejectionReason?: string | null;
   project?: BeTimeCardRef;
   case?: BeTimeCardCaseRef;
+  /**
+   * The engineers eligible to decide this card (SN `approver_list`). Not in
+   * the BFF's `openapi.yaml` (stale doc — `time-cards` responses are a raw
+   * passthrough of the entity-service's `TimeCardView`, which does return
+   * this), but confirmed present on the wire. Used to gate the "Review"
+   * action in the UI: the backend 403s a decision from anyone not in this
+   * list, regardless of team-lead status.
+   */
+  approvers?: BeTimeCardRef[];
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -118,6 +118,7 @@ export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
     approvedById: v.approvedBy?.id,
     approvedByName: v.approvedBy?.name,
     rejectionReason: v.rejectionReason ?? undefined,
+    approvers: v.approvers,
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -167,11 +167,16 @@ export default function CaseTimeCardsPanel({
                   <TimeCardStatusChip state={c.state} />
                   {/* Never shown on your own card: the backend 403s a
                    self-decide regardless of approver status, so a card you
-                   submitted yourself can never actually be reviewed by you. */}
+                   submitted yourself can never actually be reviewed by you.
+                   Also gated on being in the card's own approver list — this
+                   panel shows every submitted card on the case, not just
+                   ones assigned to the signed-in lead, and the backend 403s
+                   a decision from anyone not in that list (confirmed live). */}
                   {isTeamLead &&
                     c.state === "submitted" &&
                     !!me.id &&
-                    c.userId !== me.id && (
+                    c.userId !== me.id &&
+                    !!c.approvers?.some((a) => a.id === me.id) && (
                       <Button
                         size="small"
                         variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
@@ -78,12 +78,25 @@ export default function TimeCardReviewDialog({
   onDecide,
 }: TimeCardReviewDialogProps): JSX.Element {
   const [leadComment, setLeadComment] = useState("");
+  const [rejectBlocked, setRejectBlocked] = useState(false);
+  const trimmedComment = leadComment.trim();
 
-  const decide = (state: "approved" | "rejected"): void =>
+  const decide = (state: "approved" | "rejected"): void => {
+    // The backend requires a non-empty leadComment when rejecting (there's no
+    // other trace a rejection leaves — see CsmTimeCard.rejectionReason), but
+    // doesn't say so anywhere in its error response, so this is enforced here
+    // rather than surfacing a generic "Invalid request payload." after the fact.
+    if (state === "rejected" && trimmedComment === "") {
+      setRejectBlocked(true);
+      return;
+    }
     onDecide({ cardId: card.id, state, leadComment });
+  };
 
   const titlePrefix =
     action === "approve" ? "Accept" : action === "reject" ? "Reject" : "Review";
+  const rejectAllowed = action !== "approve";
+  const commentMissingForReject = rejectBlocked && trimmedComment === "";
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
@@ -113,14 +126,24 @@ export default function TimeCardReviewDialog({
           </Box>
 
           <TextField
-            label="Lead's comment (optional)"
+            label={
+              rejectAllowed
+                ? "Lead's comment (required to reject)"
+                : "Lead's comment (optional)"
+            }
             multiline
             minRows={2}
             value={leadComment}
-            onChange={(e) =>
-              setLeadComment(e.target.value.slice(0, LEAD_COMMENT_MAX))
+            onChange={(e) => {
+              setLeadComment(e.target.value.slice(0, LEAD_COMMENT_MAX));
+              setRejectBlocked(false);
+            }}
+            error={commentMissingForReject}
+            helperText={
+              commentMissingForReject
+                ? "A comment is required to reject a time card."
+                : `${LEAD_COMMENT_MAX - leadComment.length} characters left`
             }
-            helperText={`${LEAD_COMMENT_MAX - leadComment.length} characters left`}
           />
         </Box>
       </DialogContent>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
@@ -106,6 +106,15 @@ export interface CsmTimeCard {
    * timestamp exists upstream).
    */
   rejectionReason?: string;
+  /**
+   * The engineers eligible to decide this card (SN `approver_list`). Used to
+   * gate the "Review" action: the backend 403s a decision from anyone not
+   * in this list, regardless of team-lead status — the approval queue tab
+   * already scopes server-side (`approverId` filter), but a case's own
+   * "Time tracking" panel shows every submitted card on the case, so it
+   * needs this to know which ones the signed-in lead can actually decide.
+   */
+  approvers?: TimeCardApprover[];
 }
 
 /**


### PR DESCRIPTION
## Purpose
Two time-card decision flows were failing with unhelpful errors:

1. Rejecting a card without a lead comment 400s — the backend requires
   `leadComment` when `state: "rejected"`, but the FE labelled the field
   "optional" for both actions and never enforced it, so the failure surfaced
   as a generic "Invalid request payload." with no indication of the real cause.
2. The case's "Time tracking" panel offered a "Review" (approve/reject) action
   on *any* other engineer's submitted card, not just ones the signed-in lead
   is actually the assigned approver for. The backend 403s ("Access to the
   requested resource is forbidden!") for anyone not in that card's approver
   list — confirmed live, and already documented as a known gap in
   `tests/e2e/README.md` for this same panel.

## Goals
- Block the Reject action client-side until a comment is entered, with an
  inline error explaining why, instead of a round-trip to a generic 400.
- Only show the "Review" action on a card when the signed-in user is actually
  in that card's assigned-approver list, mirroring how the Approvals queue tab
  is already scoped server-side (`approverId` filter).

## Approach
- `TimeCardReviewDialog`: track whether a Reject attempt was blocked by an
  empty comment; show an inline error/helper text and relabel the field
  "required to reject" instead of "optional" when reject is a possible action.
- The entity-service's `TimeCardView` already returns each card's
  `approvers` (`approver_list`) on search results; the portal backend passes
  search responses through as-is, so this was already on the wire but unused.
  Added `approvers` to the backend response type, the portal's `CsmTimeCard`
  domain type, and the `mapTimeCard` mapper, then gated
  `CaseTimeCardsPanel`'s "Review" button on `approvers.some(a => a.id === me.id)`
  in addition to the existing team-lead / not-your-own-card checks.

## User stories
As a team lead, I can reject a time card and get told immediately if I forgot
a comment, instead of a confusing generic error. I only see a "Review" action
on cards I'm actually able to decide, so I don't hit a 403 by clicking it.

## Release note
Fixed: rejecting a time card without a comment now shows a clear inline
error instead of a generic failure. Fixed: the case Time-tracking panel no
longer offers Approve/Reject on time cards you aren't the assigned approver
for.

## Documentation
N/A — internal CSM portal UI behavior, no external-facing docs.

## Automation tests
- Unit tests: none added; this is UI-state gating covered by existing manual
  verification (`pnpm build` + `pnpm lint` clean, no regressions in the
  existing time-card test suite).
- Integration tests: N/A — no integration test harness covers this flow.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change; `pnpm lint` (ESLint) ran clean instead.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Verified with `pnpm build` and `pnpm lint` in `apps/csm-portal/webapp` (Node/pnpm on macOS).

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review actions are now shown only to authorized approvers.
  - Rejecting a time card now requires a lead comment.

- **Bug Fixes**
  - Prevented unauthorized users from attempting to review submitted time cards.
  - Added clear validation feedback when a rejection comment is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->