### PR TITLE
[CSM Portal] surface case watchers, auto-closure hold, editable case fields, case linking, tags, and tasks

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1105,6 +1105,10 @@ type SearchCasesFilters struct {
 	// gap as CaseView.Tags — no Ballerina search-filter support exists yet, so this
 	// filter is accepted here but has no effect until Ballerina wires it through.
 	Tags []string `json:"tags"`
+	// ParentID filters to child cases of this case (the hierarchical major-case/
+	// child-case relationship set via the case PATCH parentId field). Ballerina
+	// support added on ballerina-case-field-additions.
+	ParentID *string `json:"parentId"`
 }
 
 // SearchCasesRequest is the input for a case search operation.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1039,6 +1039,29 @@ type CaseView struct {
 	ResolutionCode  *CaseResolutionCode `json:"resolutionCode"`
 	Cause           *CaseCause          `json:"cause"`
 	ResolutionNotes *string             `json:"resolutionNotes"`
+	// FixEta is the single customer-facing fix-commitment date/time
+	// (ServiceNow u_fix_eta_shared). Per project-owner decision, this is the only
+	// fix-ETA field exposed by this API; the three internal-only estimates
+	// (best/worst/most-likely case) are deliberately not surfaced anywhere.
+	FixEta *time.Time `json:"fixEta"`
+	// Tags are the free-text labels attached to the case via ServiceNow's generic
+	// platform label/label_entry mechanism (not a case-specific column).
+	//
+	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina adapter exists yet for SN's generic
+	// label/label_entry tables. Confirmed real tag values exist in production
+	// (e.g. "micro-gw", "ws-policy", "node") but nothing in the current Choreo
+	// GET /cases/{id} contract returns them. This field is always nil until a
+	// Ballerina endpoint surfaces the case's tags.
+	Tags []Tag `json:"tags"`
+}
+
+// Tag is a free-text label attached to a case via ServiceNow's generic
+// label/label_entry mechanism. Color is optional because not every label in SN
+// carries a display color.
+type Tag struct {
+	ID    string  `json:"id"`
+	Label string  `json:"label"`
+	Color *string `json:"color"`
 }
 
 // SearchCasesFilters holds all optional filter criteria for a case search.
@@ -1062,6 +1085,10 @@ type SearchCasesFilters struct {
 	WorkStates       []CaseWorkState  `json:"workStates"`
 	AssignedUserIDs  []string         `json:"assignedUserIds"`
 	ProductNames     []string         `json:"productNames"`
+	// Tags filters cases by attached free-text label. Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): same
+	// gap as CaseView.Tags — no Ballerina search-filter support exists yet, so this
+	// filter is accepted here but has no effect until Ballerina wires it through.
+	Tags []string `json:"tags"`
 }
 
 // SearchCasesRequest is the input for a case search operation.
@@ -1129,6 +1156,10 @@ type UpdateCaseRequest struct {
 	// record (case, incident, change request, or problem) as its parent. Platform UUID,
 	// converted to the backing data source's internal id before dispatch.
 	ParentID *string `json:"parentId"`
+	// FixEta sets the customer-facing fix-commitment date/time (ServiceNow
+	// u_fix_eta_shared). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists yet
+	// for this field — see snUpdateCasePayload.FixEta in sn_case_service.go.
+	FixEta *time.Time `json:"fixEta"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -1158,6 +1189,10 @@ type UpdatedCase struct {
 	CloseNotes     *string              `json:"closeNotes,omitempty"`
 	ResolvedOn     *time.Time           `json:"resolvedOn,omitempty"`
 	ParentCase     *CaseNumberRef       `json:"parentCase,omitempty"`
+	// FixEta echoes the updated customer-facing fix-commitment date/time
+	// (u_fix_eta_shared) back on a successful PATCH. Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
+	// UpdateCaseRequest.FixEta doc comment; always nil until Ballerina supports the write.
+	FixEta *time.Time `json:"fixEta,omitempty"`
 }
 
 // WatchListUser is a compact user reference within the watch list.
@@ -1258,6 +1293,18 @@ type CreateCaseCommentRequest struct {
 	CreatedBy string      `json:"-"`
 	Type      CommentType `json:"type"`
 	Content   string      `json:"content"`
+}
+
+// AddCaseTagRequest is the request body for POST /cases/{id}/tags.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): SN's tagging is the generic platform label/label_entry
+// mechanism (table-agnostic, not a case column), so it needs an entirely new
+// Ballerina/Choreo adapter — nothing in the current contract creates a label on a
+// case. This request/the AddCaseTag service method are implemented so the
+// entity-service side is ready once Ballerina adds the endpoint.
+type AddCaseTagRequest struct {
+	CaseID string `json:"-"`
+	Label  string `json:"label"`
 }
 
 // CreateCaseCommentResponse is the response for creating a new case comment.
@@ -2534,6 +2581,34 @@ type TaskDetail struct {
 	ParentCase        *CaseNumberRef `json:"parentCase"`
 	CreatedOn         string         `json:"createdOn"`
 	UpdatedOn         string         `json:"updatedOn"`
+}
+
+// CreateCaseTaskRequest is the request body for POST /cases/{id}/tasks.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): ServiceNow/Ballerina task support is read-only today
+// (SearchCaseTasks/GetTask only). No Choreo endpoint exists yet to create a
+// sn_customerservice_task record. This request/the CreateCaseTask service method
+// are implemented so the entity-service side is ready the moment Ballerina adds
+// the corresponding endpoint; until then, calling it returns a downstream error.
+type CreateCaseTaskRequest struct {
+	CaseID            string     `json:"-"`
+	Subject           string     `json:"subject"`
+	DueDate           *time.Time `json:"dueDate"`
+	AssignedToEmail   *string    `json:"assignedToEmail"`
+	VisibleToCustomer *bool      `json:"visibleToCustomer"`
+}
+
+// UpdateTaskRequest is the request body for PATCH /tasks/{id}. Exactly one of
+// State, AssignedToEmail, or DueDate must be provided per request, following the
+// same convention as UpdateCaseRequest.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): same gap as CreateCaseTaskRequest above — no Choreo
+// write endpoint exists yet for sn_customerservice_task.
+type UpdateTaskRequest struct {
+	ID              string     `json:"-"`
+	State           *string    `json:"state"`
+	AssignedToEmail *string    `json:"assignedToEmail"`
+	DueDate         *time.Time `json:"dueDate"`
 }
 
 // IncidentPriority represents the priority level of an incident.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -981,6 +981,12 @@ type AccountRef struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	Type string `json:"type"`
+	// CreTeam is the account's CRE (customer relationship engineering) team, resolved to a
+	// named group reference (ServiceNow data source only).
+	CreTeam *EntityRef `json:"creTeam,omitempty"`
+	// SreTeam is the account's SRE team, resolved to a named group reference (ServiceNow
+	// data source only).
+	SreTeam *EntityRef `json:"sreTeam,omitempty"`
 }
 
 // UserIDEmailRef is a compact user reference carrying only id and email.
@@ -1039,6 +1045,16 @@ type CaseView struct {
 	ResolutionCode  *CaseResolutionCode `json:"resolutionCode"`
 	Cause           *CaseCause          `json:"cause"`
 	ResolutionNotes *string             `json:"resolutionNotes"`
+	// WatchList is the set of users watching the case (ServiceNow data source only).
+	WatchList []WatchListUser `json:"watchList,omitempty"`
+	// AutoclosureStep indicates where the case sits in ServiceNow's staged auto-closure
+	// sequence: DEFAULT -> FIRST_COMMENT -> ON_HOLD -> SECOND_COMMENT. Read-only —
+	// informational only; the sequence itself is fully owned by ServiceNow's own flows
+	// (ServiceNow data source only).
+	AutoclosureStep *string `json:"autoclosureStep,omitempty"`
+	// AutoclosureStateTime is when the auto-closure sequence next advances (e.g. the
+	// "eligible again after" date for a held case). Read-only (ServiceNow data source only).
+	AutoclosureStateTime *time.Time `json:"autoclosureStateTime,omitempty"`
 }
 
 // SearchCasesFilters holds all optional filter criteria for a case search.
@@ -1110,9 +1126,10 @@ type SearchCasesResponse struct {
 }
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
-// Exactly one of State, Severity, WorkState, WatchList, AssigneeEmail, or ParentID must be
-// provided. WatchList, AssigneeEmail, and ParentID are only supported for the ServiceNow
-// data source.
+// Exactly one of State, Severity, WorkState, WatchList, AssigneeEmail, ParentID, RelatedCaseID,
+// AutocloseHoldUntil, Subject, Description, DeploymentID, or DeployedProductID must be provided.
+// WatchList, AssigneeEmail, ParentID, RelatedCaseID, AutocloseHoldUntil, Subject, Description,
+// DeploymentID, and DeployedProductID are only supported for the ServiceNow data source.
 // ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
 // State is closed or solution_proposed.
 type UpdateCaseRequest struct {
@@ -1127,8 +1144,31 @@ type UpdateCaseRequest struct {
 	CloseNotes     *string             `json:"closeNotes"`
 	// ParentID links this case (typically a service request) to another task-derived
 	// record (case, incident, change request, or problem) as its parent. Platform UUID,
-	// converted to the backing data source's internal id before dispatch.
+	// converted to the backing data source's internal id before dispatch. This is the
+	// native hierarchical "major case / child case" relationship — subject to the
+	// close-gating rule that rejects closing a case with open children.
 	ParentID *string `json:"parentId"`
+	// RelatedCaseID links this case to another case via a looser, non-hierarchical
+	// cross-link, not subject to any close-gating rule. Platform UUID, converted to the
+	// backing data source's internal id before dispatch (ServiceNow data source only).
+	RelatedCaseID *string `json:"relatedCaseId"`
+	// AutocloseHoldUntil places the case on hold in ServiceNow's staged auto-closure
+	// sequence: internally sets u_autoclosure_step = ON_HOLD and u_autoclosure_state_time
+	// to this date together, mirroring the real UX (an engineer picks a hold-until date).
+	// This is the only supported write against the auto-closure sequence — the raw step
+	// enum is not freely settable (ServiceNow data source only).
+	AutocloseHoldUntil *time.Time `json:"autocloseHoldUntil"`
+	// Subject updates the case's short description/title (ServiceNow data source only).
+	Subject *string `json:"subject"`
+	// Description updates the case's full description (ServiceNow data source only).
+	Description *string `json:"description"`
+	// DeploymentID moves the case to a different deployment. Platform UUID, converted to
+	// the backing data source's internal id before dispatch (ServiceNow data source only).
+	DeploymentID *string `json:"deploymentId"`
+	// DeployedProductID moves the case to a different deployed product. Platform UUID,
+	// converted to the backing data source's internal id before dispatch (ServiceNow data
+	// source only).
+	DeployedProductID *string `json:"deployedProductId"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -227,3 +227,35 @@ func (h *CaseHandler) DeleteCaseAttachment(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// AddCaseTag handles POST /cases/{id}/tags.
+func (h *CaseHandler) AddCaseTag(w http.ResponseWriter, r *http.Request) {
+	caseID := r.PathValue("id")
+
+	var req domain.AddCaseTagRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.CaseID = caseID
+
+	tag, err := h.svc.AddCaseTag(r.Context(), caseID, req.Label)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(tag)
+}
+
+// RemoveCaseTag handles DELETE /cases/{id}/tags/{tagId}.
+func (h *CaseHandler) RemoveCaseTag(w http.ResponseWriter, r *http.Request) {
+	caseID := r.PathValue("id")
+	tagID := r.PathValue("tagId")
+
+	if err := h.svc.RemoveCaseTag(r.Context(), caseID, tagID); err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/entity-service/internal/handler/task_handler.go
+++ b/entity-service/internal/handler/task_handler.go
@@ -63,3 +63,42 @@ func (h *TaskHandler) GetTask(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)
 }
+
+// CreateCaseTask handles POST /cases/{id}/tasks.
+func (h *TaskHandler) CreateCaseTask(w http.ResponseWriter, r *http.Request) {
+	caseID := r.PathValue("id")
+
+	var req domain.CreateCaseTaskRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.CaseID = caseID
+
+	result, err := h.svc.CreateCaseTask(r.Context(), caseID, req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// UpdateTask handles PATCH /tasks/{id}.
+func (h *TaskHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req domain.UpdateTaskRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.ID = id
+
+	result, err := h.svc.UpdateTask(r.Context(), id, req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -266,6 +266,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
+	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
+	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
 
 	if callRequestHandler != nil {
 		mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)
@@ -331,6 +333,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	if taskHandler != nil {
 		mux.HandleFunc("POST /cases/{id}/tasks/search", taskHandler.SearchCaseTasks)
 		mux.HandleFunc("GET /tasks/{id}", taskHandler.GetTask)
+		mux.HandleFunc("POST /cases/{id}/tasks", taskHandler.CreateCaseTask)
+		mux.HandleFunc("PATCH /tasks/{id}", taskHandler.UpdateTask)
 	}
 
 	if incidentHandler != nil {

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -292,8 +292,10 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}
-	if len(req.WatchList) > 0 || req.AssigneeEmail != nil || req.FixEta != nil {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, and fixEta are only supported for the ServiceNow data source"}
+	if len(req.WatchList) > 0 || req.AssigneeEmail != nil || req.FixEta != nil ||
+		req.RelatedCaseID != nil || req.ParentID != nil || req.AutocloseHoldUntil != nil ||
+		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, fixEta, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, and deployedProductId are only supported for the ServiceNow data source"}
 	}
 	fieldCount := 0
 	if req.State != nil {

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -292,8 +292,8 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}
-	if len(req.WatchList) > 0 || req.AssigneeEmail != nil {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList and assigneeEmail are only supported for the ServiceNow data source"}
+	if len(req.WatchList) > 0 || req.AssigneeEmail != nil || req.FixEta != nil {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, and fixEta are only supported for the ServiceNow data source"}
 	}
 	fieldCount := 0
 	if req.State != nil {
@@ -455,4 +455,12 @@ func (s *caseService) GetCaseAttachmentContent(_ context.Context, _ string) ([]b
 
 func (s *caseService) DeleteCaseAttachment(_ context.Context, _ domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error) {
 	return domain.DeleteAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) AddCaseTag(_ context.Context, _, _ string) (domain.Tag, error) {
+	return domain.Tag{}, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) RemoveCaseTag(_ context.Context, _, _ string) error {
+	return &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -182,9 +182,11 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
-	// UpdateCase updates the state, severity, watch list, or assignee of a case.
+	// UpdateCase updates the state, severity, watch list, assignee, or fix ETA of a case.
 	// A ValidationError is returned for invalid values or malformed UUID; a NotFoundError if no case matches.
-	// WatchList and AssigneeEmail are only supported for the ServiceNow data source.
+	// WatchList, AssigneeEmail, and FixEta are only supported for the ServiceNow data source.
+	// Transitioning State to closed is rejected with a ValidationError if the case has any
+	// open task that is visible to the customer (the authoritative case-close gate).
 	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error)
 	// CreateCaseAttachment uploads a new attachment for the case identified by req.CaseID.
 	// A ValidationError is returned for invalid input.
@@ -204,6 +206,15 @@ type CaseService interface {
 	// DeleteCaseAttachment removes the attachment identified by req.AttachmentID from the case.
 	// A NotFoundError is returned if the attachment does not exist.
 	DeleteCaseAttachment(ctx context.Context, req domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error)
+	// AddCaseTag attaches a free-text label to the case identified by caseID.
+	// A ValidationError is returned for invalid input (e.g. malformed UUID, empty label).
+	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina adapter exists yet for ServiceNow's generic
+	// label/label_entry mechanism; see AddCaseTagRequest doc comment.
+	AddCaseTag(ctx context.Context, caseID, label string) (domain.Tag, error)
+	// RemoveCaseTag removes the tag identified by tagID from the case identified by caseID.
+	// A NotFoundError is returned if the tag does not exist on the case.
+	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): same gap as AddCaseTag above.
+	RemoveCaseTag(ctx context.Context, caseID, tagID string) error
 }
 
 // CaseGithubIssueService defines the operation for filing a GitHub issue from a case.
@@ -339,6 +350,16 @@ type TaskService interface {
 	// GetTask returns the full detail of a single task by its UUID.
 	// A NotFoundError is returned if the task does not exist.
 	GetTask(ctx context.Context, id string) (domain.TaskDetail, error)
+	// CreateCaseTask creates a new task on the case identified by caseID.
+	// A ValidationError is returned for invalid input (e.g. malformed UUID, empty subject).
+	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina/Choreo endpoint exists yet to create a
+	// sn_customerservice_task record; see CreateCaseTaskRequest doc comment.
+	CreateCaseTask(ctx context.Context, caseID string, req domain.CreateCaseTaskRequest) (domain.TaskDetail, error)
+	// UpdateTask updates exactly one of state, assignedToEmail, or dueDate on the task
+	// identified by taskID. A ValidationError is returned for invalid values, a malformed
+	// UUID, or if zero or more than one field is provided.
+	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): same gap as CreateCaseTask above.
+	UpdateTask(ctx context.Context, taskID string, req domain.UpdateTaskRequest) (domain.TaskDetail, error)
 }
 
 // ProductVulnerabilityService defines the operations available on product vulnerabilities.

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -352,13 +352,13 @@ type TaskService interface {
 	GetTask(ctx context.Context, id string) (domain.TaskDetail, error)
 	// CreateCaseTask creates a new task on the case identified by caseID.
 	// A ValidationError is returned for invalid input (e.g. malformed UUID, empty subject).
-	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina/Choreo endpoint exists yet to create a
-	// sn_customerservice_task record; see CreateCaseTaskRequest doc comment.
+	// Returns a ServiceUnavailableError until the downstream ballerina-tasks-fixeta-tags
+	// endpoint (not yet merged to digiops-cs main) ships; see CreateCaseTaskRequest doc comment.
 	CreateCaseTask(ctx context.Context, caseID string, req domain.CreateCaseTaskRequest) (domain.TaskDetail, error)
 	// UpdateTask updates exactly one of state, assignedToEmail, or dueDate on the task
 	// identified by taskID. A ValidationError is returned for invalid values, a malformed
 	// UUID, or if zero or more than one field is provided.
-	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): same gap as CreateCaseTask above.
+	// Returns a ServiceUnavailableError until the downstream endpoint ships, same as CreateCaseTask above.
 	UpdateTask(ctx context.Context, taskID string, req domain.UpdateTaskRequest) (domain.TaskDetail, error)
 }
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -251,6 +251,8 @@ type snCaseFilters struct {
 	// Forwarded to Choreo so filtering starts working the moment Ballerina adds
 	// support, but the current POST /cases/search contract ignores this field.
 	Tags []string `json:"tags,omitempty"`
+	// ParentID: see domain.SearchCasesFilters.ParentID doc comment.
+	ParentID string `json:"parentId,omitempty"`
 }
 
 // snStateIDMap maps domain CaseState enums to SN numeric state IDs.
@@ -1688,6 +1690,11 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	if err := validateUUIDs("assignedUserIds", req.Filters.AssignedUserIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
+	if req.Filters.ParentID != nil {
+		if err := validateUUIDs("parentId", []string{*req.Filters.ParentID}); err != nil {
+			return domain.SearchCasesResponse{}, err
+		}
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -1736,6 +1743,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			AssignedUserIDs:    uuidsToSysids(req.Filters.AssignedUserIDs),
 			ProductNames:       req.Filters.ProductNames,
 			Tags:               req.Filters.Tags,
+			ParentID:           snParentIDFilter(req.Filters.ParentID),
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -77,6 +77,31 @@ type snCase struct {
 	} `json:"cause"`
 	ResolutionNotes *string `json:"resolutionNotes"`
 	ResolvedOn      *string `json:"resolvedOn"`
+	// WatchList carries the watchers on the case (four SN glide_lists collapsed into one
+	// list by Ballerina). Confirmed present on the Choreo GET /cases/{id} response
+	// (CaseResponse.watchList in digiops-cs modules/servicenow/types.bal).
+	WatchList []snWatchListUser `json:"watchList"`
+	// AutoclosureStep/AutoclosureStateTime surface ServiceNow's real staged auto-closure
+	// sequence (u_autoclosure_step / u_autoclosure_state_time), confirmed live against a
+	// held case on wso2sndev (see EntityLayerSpec-2026-07-23.md item 6). Ballerina's
+	// Case/CaseResponse carry matching autoclosureStep/autoclosureStateTime fields (added
+	// on the ballerina-case-field-additions branch, not yet merged to digiops-cs main --
+	// the closest field on main today, hasAutoClosed, means something different: case has
+	// already been auto-closed, not "where the case sits in the auto-closure sequence").
+	AutoclosureStep *string `json:"autoclosureStep"`
+	// AutoclosureStateTime is when the auto-closure sequence next advances (e.g. the
+	// "eligible again after" date for a held case).
+	AutoclosureStateTime *string `json:"autoclosureStateTime"`
+}
+
+// snWatchListUser mirrors the watch-list user shape ServiceNow/Ballerina returns on both
+// the case detail read (CaseResponse.watchList) and the update-case response
+// (snUpdateCaseResponse.Case.WatchList below).
+type snWatchListUser struct {
+	ID       string  `json:"id"`
+	UserName string  `json:"userName"`
+	Name     *string `json:"name"`
+	Email    *string `json:"email"`
 }
 
 type snCaseEntityRef struct {
@@ -111,6 +136,13 @@ type snCaseAccount struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	Type string `json:"type"`
+	// CreTeam and SreTeam resolve the account's CRE/SRE group refs. Per the project
+	// owner's resolution, SN's u_integration_cs_team maps to CreTeam and u_sre_team maps
+	// to SreTeam -- both refs to sys_user_group. Ballerina's Case/CaseResponse.account
+	// gained matching fields on ballerina-case-field-additions, not yet merged to
+	// digiops-cs main.
+	CreTeam *snCaseEntityRef `json:"creTeam"`
+	SreTeam *snCaseEntityRef `json:"sreTeam"`
 }
 
 type snCaseState struct {
@@ -578,6 +610,18 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	}
 	if c.Account != nil {
 		cv.AccountDetails = &domain.AccountRef{ID: sysidToUUID(c.Account.ID), Name: c.Account.Name, Type: c.Account.Type}
+		// CRE/SRE team (see snCaseAccount.CreTeam/SreTeam doc comment) pass through once
+		// Ballerina's matching fields land on digiops-cs main; until then these are nil.
+		if c.Account.CreTeam != nil {
+			if id := sysidToUUID(c.Account.CreTeam.ID); id != "" {
+				cv.AccountDetails.CreTeam = &domain.EntityRef{ID: id, Name: c.Account.CreTeam.Name}
+			}
+		}
+		if c.Account.SreTeam != nil {
+			if id := sysidToUUID(c.Account.SreTeam.ID); id != "" {
+				cv.AccountDetails.SreTeam = &domain.EntityRef{ID: id, Name: c.Account.SreTeam.Name}
+			}
+		}
 	}
 	if len(c.LinkedServiceRequests) > 0 {
 		lsr := make([]domain.LinkedServiceRequestRef, 0, len(c.LinkedServiceRequests))
@@ -603,6 +647,30 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 			return domain.CaseView{}, fmt.Errorf("sn get case: parse resolvedOn %q: %w", *c.ResolvedOn, err)
 		}
 		cv.ResolvedOn = &resolvedOn
+	}
+	if len(c.WatchList) > 0 {
+		wl := make([]domain.WatchListUser, 0, len(c.WatchList))
+		for _, u := range c.WatchList {
+			wlu := domain.WatchListUser{ID: sysidToUUID(u.ID), UserName: u.UserName}
+			if u.Name != nil {
+				wlu.Name = *u.Name
+			}
+			if u.Email != nil {
+				wlu.Email = *u.Email
+			}
+			wl = append(wl, wlu)
+		}
+		cv.WatchList = wl
+	}
+	// AutoclosureStep/AutoclosureStateTime pass through once Ballerina's matching fields
+	// (see snCase field doc comments) land on digiops-cs main; until then these are nil.
+	cv.AutoclosureStep = c.AutoclosureStep
+	if c.AutoclosureStateTime != nil && *c.AutoclosureStateTime != "" {
+		autoclosureStateTime, err := time.Parse(snCreatedOnLayout, *c.AutoclosureStateTime)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse autoclosureStateTime %q: %w", *c.AutoclosureStateTime, err)
+		}
+		cv.AutoclosureStateTime = &autoclosureStateTime
 	}
 
 	return cv, nil
@@ -796,7 +864,28 @@ type snUpdateCasePayload struct {
 	ResolutionCode *int     `json:"resolutionCode,omitempty"`
 	Cause          *string  `json:"cause,omitempty"`
 	CloseNotes     *string  `json:"closeNotes,omitempty"`
-	ParentID       *string  `json:"parentId,omitempty"`
+	// ParentID writes the native task.parent field. Confirmed already supported by
+	// digiops-cs (servicenow:CaseUpdatePayload.parentId + validateCaseUpdatePayload in
+	// utils.bal already validate it as an exactly-one-field option) -- fully wired.
+	ParentID *string `json:"parentId,omitempty"`
+	// RelatedCaseID writes the looser, non-hierarchical u_related_case cross-link.
+	// servicenow:CaseUpdatePayload's relatedCaseId field + validateCaseUpdatePayload
+	// support (ballerina-case-field-additions branch, not yet merged to digiops-cs main).
+	RelatedCaseID *string `json:"relatedCaseId,omitempty"`
+	// AutocloseHoldUntil places the case on hold in ServiceNow's staged auto-closure
+	// sequence, internally setting u_autoclosure_step = ON_HOLD and
+	// u_autoclosure_state_time = this date together. Matching field on
+	// servicenow:CaseUpdatePayload added on ballerina-case-field-additions, not yet
+	// merged to digiops-cs main.
+	AutocloseHoldUntil *string `json:"autocloseHoldUntil,omitempty"`
+	// Title/Description/DeploymentID/DeployedProductID as PATCH-time fields (previously
+	// servicenow:CaseUpdatePayload only supported these at create time, via
+	// CaseCreatePayload) -- added on ballerina-case-field-additions, not yet merged to
+	// digiops-cs main.
+	Title             *string `json:"title,omitempty"`
+	Description       *string `json:"description,omitempty"`
+	DeploymentID      *string `json:"deploymentId,omitempty"`
+	DeployedProductID *string `json:"deployedProductId,omitempty"`
 }
 
 // snResolutionStates are the state keys that allow resolution fields.
@@ -949,11 +1038,31 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.ParentID != nil {
 		fieldCount++
 	}
+	if req.RelatedCaseID != nil {
+		fieldCount++
+	}
+	if req.AutocloseHoldUntil != nil {
+		fieldCount++
+	}
+	if req.Subject != nil {
+		fieldCount++
+	}
+	if req.Description != nil {
+		fieldCount++
+	}
+	if req.DeploymentID != nil {
+		fieldCount++
+	}
+	if req.DeployedProductID != nil {
+		fieldCount++
+	}
+	const fieldList = "state, severity, workState, watchList, assigneeEmail, parentId, relatedCaseId, " +
+		"autocloseHoldUntil, subject, description, deploymentId, or deployedProductId"
 	if fieldCount == 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state, severity, workState, watchList, assigneeEmail, or parentId must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of " + fieldList + " must be provided"}
 	}
 	if fieldCount > 1 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, severity, workState, watchList, assigneeEmail, or parentId may be provided per request"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of " + fieldList + " may be provided per request"}
 	}
 	if hasResolutionFields && req.State == nil {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode, cause, and closeNotes are only allowed when state is also provided"}
@@ -1023,6 +1132,43 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		}
 		sysid := uuidToSysid(*req.ParentID)
 		payload.ParentID = &sysid
+	}
+	if req.RelatedCaseID != nil {
+		if err := validateUUIDs("relatedCaseId", []string{*req.RelatedCaseID}); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		sysid := uuidToSysid(*req.RelatedCaseID)
+		payload.RelatedCaseID = &sysid
+	}
+	if req.AutocloseHoldUntil != nil {
+		holdUntil := req.AutocloseHoldUntil.Format(snCreatedOnLayout)
+		payload.AutocloseHoldUntil = &holdUntil
+	}
+	if req.Subject != nil {
+		if *req.Subject == "" {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "subject cannot be empty"}
+		}
+		payload.Title = req.Subject
+	}
+	if req.Description != nil {
+		if *req.Description == "" {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "description cannot be empty"}
+		}
+		payload.Description = req.Description
+	}
+	if req.DeploymentID != nil {
+		if err := validateUUIDs("deploymentId", []string{*req.DeploymentID}); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		sysid := uuidToSysid(*req.DeploymentID)
+		payload.DeploymentID = &sysid
+	}
+	if req.DeployedProductID != nil {
+		if err := validateUUIDs("deployedProductId", []string{*req.DeployedProductID}); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		sysid := uuidToSysid(*req.DeployedProductID)
+		payload.DeployedProductID = &sysid
 	}
 
 	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -77,6 +77,12 @@ type snCase struct {
 	} `json:"cause"`
 	ResolutionNotes *string `json:"resolutionNotes"`
 	ResolvedOn      *string `json:"resolvedOn"`
+	// FixEta is the single customer-facing fix-commitment date/time
+	// (u_fix_eta_shared). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
+	// surfaces this — the Choreo GET /cases/{id} response does not include a
+	// "fixEta" key today, so this always unmarshals to nil. Ask: add a
+	// "fixEta" (glide_date_time) field to servicenow:CaseResponse.
+	FixEta *string `json:"fixEta"`
 }
 
 type snCaseEntityRef struct {
@@ -209,6 +215,10 @@ type snCaseFilters struct {
 	WorkStateKeys      []int    `json:"workStateKeys,omitempty"`
 	AssignedUserIDs    []string `json:"assignedUserIds,omitempty"`
 	ProductNames       []string `json:"productNames,omitempty"`
+	// Tags: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see domain.SearchCasesFilters.Tags doc comment.
+	// Forwarded to Choreo so filtering starts working the moment Ballerina adds
+	// support, but the current POST /cases/search contract ignores this field.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // snStateIDMap maps domain CaseState enums to SN numeric state IDs.
@@ -604,6 +614,17 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.ResolvedOn = &resolvedOn
 	}
+	// FixEta passes through once Ballerina's matching field (see snCase.FixEta doc
+	// comment) lands; until then this is always nil.
+	if c.FixEta != nil && *c.FixEta != "" {
+		fixEta, err := time.Parse(snCreatedOnLayout, *c.FixEta)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse fixEta %q: %w", *c.FixEta, err)
+		}
+		cv.FixEta = &fixEta
+	}
+	// Tags are not populated: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see CaseView.Tags doc comment.
+	// cv.Tags is left nil.
 
 	return cv, nil
 }
@@ -797,6 +818,10 @@ type snUpdateCasePayload struct {
 	Cause          *string  `json:"cause,omitempty"`
 	CloseNotes     *string  `json:"closeNotes,omitempty"`
 	ParentID       *string  `json:"parentId,omitempty"`
+	// FixEta writes the customer-facing fix-commitment date/time (u_fix_eta_shared).
+	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field exists yet for this — ask:
+	// add a "fixEta" field to servicenow:CaseUpdatePayload backed by u_fix_eta_shared.
+	FixEta *string `json:"fixEta,omitempty"`
 }
 
 // snResolutionStates are the state keys that allow resolution fields.
@@ -920,6 +945,8 @@ type snUpdateCaseResponse struct {
 		CloseNotes *string    `json:"closeNotes"`
 		ResolvedOn *string    `json:"resolvedOn"`
 		ParentCase *snCaseRef `json:"parentCase"`
+		// FixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see snUpdateCasePayload.FixEta doc comment.
+		FixEta *string `json:"fixEta"`
 	} `json:"case"`
 }
 
@@ -949,11 +976,15 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.ParentID != nil {
 		fieldCount++
 	}
+	if req.FixEta != nil {
+		fieldCount++
+	}
+	const updateCaseFieldList = "state, severity, workState, watchList, assigneeEmail, parentId, or fixEta"
 	if fieldCount == 0 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of state, severity, workState, watchList, assigneeEmail, or parentId must be provided"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of " + updateCaseFieldList + " must be provided"}
 	}
 	if fieldCount > 1 {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of state, severity, workState, watchList, assigneeEmail, or parentId may be provided per request"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "only one of " + updateCaseFieldList + " may be provided per request"}
 	}
 	if hasResolutionFields && req.State == nil {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode, cause, and closeNotes are only allowed when state is also provided"}
@@ -1023,6 +1054,24 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		}
 		sysid := uuidToSysid(*req.ParentID)
 		payload.ParentID = &sysid
+	}
+	if req.FixEta != nil {
+		fixEta := formatSNDate(req.FixEta)
+		payload.FixEta = &fixEta
+	}
+
+	// Close-gate: reject closing a case that still has an open, customer-visible task.
+	// This is the authoritative server-side check (item 1's close-gating requirement) --
+	// it only needs the existing read path (task search + task detail), so it is fully
+	// wired even though task writes themselves are still Ballerina-blocked.
+	if payload.StateKey != nil && *payload.StateKey == snStateIDMap[domain.CaseStateClosed] {
+		blocked, err := s.hasOpenVisibleTasks(ctx, uuidToSysid(req.ID), token)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		if blocked {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "case cannot be closed while it has an open task visible to the customer"}
+		}
 	}
 
 	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)
@@ -1097,6 +1146,15 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse resolvedAt %q: %w", *snResp.Case.ResolvedOn, err)
 		}
 		resp.Case.ResolvedOn = &resolvedOn
+	}
+	// FixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see snUpdateCasePayload.FixEta doc comment;
+	// snResp.Case.FixEta is always nil until Ballerina echoes it back.
+	if snResp.Case.FixEta != nil && *snResp.Case.FixEta != "" {
+		fixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.FixEta)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse fixEta %q: %w", *snResp.Case.FixEta, err)
+		}
+		resp.Case.FixEta = &fixEta
 	}
 
 	return resp, nil
@@ -1532,6 +1590,7 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			WorkStateKeys:      domainWorkStatesToSNIDs(req.Filters.WorkStates),
 			AssignedUserIDs:    uuidsToSysids(req.Filters.AssignedUserIDs),
 			ProductNames:       req.Filters.ProductNames,
+			Tags:               req.Filters.Tags,
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
@@ -1737,4 +1796,123 @@ func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
 	default:
 		return nil
 	}
+}
+
+// hasOpenVisibleTasks reports whether the case identified by caseSysid has any
+// open task that is visible to the customer. Used by the close-gate in
+// UpdateCase (item 1's authoritative "can this case close?" check).
+//
+// SN's case-scoped task listing (snTask/snCaseTasksResponse, see
+// sn_task_service.go) does not carry visibleToCustomer -- only the single-task
+// detail response (snTaskDetail) does. So this walks the non-closed tasks
+// returned by the search and fetches each one's detail to check visibility.
+// Case task counts are small in practice, so a single page (limit 100) is
+// fetched rather than paginating fully; if that assumption stops holding, this
+// should switch to paging until exhausted.
+func (s *snCaseService) hasOpenVisibleTasks(ctx context.Context, caseSysid, token string) (bool, error) {
+	payload := snCaseTasksSearchPayload{Pagination: snProjectPagination{Limit: 100, Offset: 0}}
+
+	raw, err := s.client.Post(ctx, "/cases/"+caseSysid+"/tasks/search", token, payload)
+	if err != nil {
+		return false, err
+	}
+
+	var tasksResp snCaseTasksResponse
+	if err := json.Unmarshal(raw, &tasksResp); err != nil {
+		return false, fmt.Errorf("sn update case: parse case tasks response: %w", err)
+	}
+
+	for _, t := range tasksResp.Tasks {
+		if t.State != nil && *t.State == "CLOSED" {
+			continue
+		}
+
+		detailRaw, err := s.client.Get(ctx, "/tasks/"+t.ID, token)
+		if err != nil {
+			return false, err
+		}
+		var detail snTaskDetail
+		if err := json.Unmarshal(detailRaw, &detail); err != nil {
+			return false, fmt.Errorf("sn update case: parse task detail response: %w", err)
+		}
+		if detail.VisibleToCustomer {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// snAddTagPayload is the Choreo POST /cases/{id}/tags request body.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina/Choreo endpoint exists yet for this. SN's
+// tagging is the generic platform label/label_entry mechanism (table-agnostic,
+// not a case column), so a new adapter is needed -- ask: add
+// POST /cases/{id}/tags (body: {"label": string}) and
+// DELETE /cases/{id}/tags/{tagId} to servicenow.bal, backed by the sys_label /
+// label_entry tables scoped to reference_table="sn_customerservice_case".
+type snAddTagPayload struct {
+	Label string `json:"label"`
+}
+
+// snTag mirrors the Choreo tag shape (once it exists).
+type snTag struct {
+	ID    string  `json:"id"`
+	Label string  `json:"label"`
+	Color *string `json:"color"`
+}
+
+type snAddTagResponse struct {
+	Message string `json:"message"`
+	Tag     snTag  `json:"tag"`
+}
+
+// AddCaseTag attaches a free-text label to the case identified by caseID.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): see snAddTagPayload doc comment. This is implemented so
+// the entity-service side is ready the moment Ballerina adds the endpoint;
+// until then, calling it returns a downstream error (no such Choreo route today).
+func (s *snCaseService) AddCaseTag(ctx context.Context, caseID, label string) (domain.Tag, error) {
+	if err := validateUUIDs("id", []string{caseID}); err != nil {
+		return domain.Tag{}, err
+	}
+	if strings.TrimSpace(label) == "" {
+		return domain.Tag{}, &apierror.ValidationError{Msg: "label is required"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snAddTagPayload{Label: label}
+	raw, err := s.client.Post(ctx, "/cases/"+uuidToSysid(caseID)+"/tags", token, payload)
+	if err != nil {
+		return domain.Tag{}, err
+	}
+
+	var snResp snAddTagResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.Tag{}, fmt.Errorf("sn add case tag: parse response: %w", err)
+	}
+
+	return domain.Tag{
+		ID:    sysidToUUID(snResp.Tag.ID),
+		Label: snResp.Tag.Label,
+		Color: snResp.Tag.Color,
+	}, nil
+}
+
+// RemoveCaseTag removes the tag identified by tagID from the case identified by caseID.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): see snAddTagPayload doc comment (no such Choreo route today).
+func (s *snCaseService) RemoveCaseTag(ctx context.Context, caseID, tagID string) error {
+	if err := validateUUIDs("id", []string{caseID}); err != nil {
+		return err
+	}
+	if err := validateUUIDs("tagId", []string{tagID}); err != nil {
+		return err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	_, err := s.client.Delete(ctx, "/cases/"+uuidToSysid(caseID)+"/tags/"+uuidToSysid(tagID), token)
+	return err
 }

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1,0 +1,409 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// newTestCaseClient spins up an httptest server that answers both the OAuth2
+// token endpoint and the Choreo API path with apiHandler, and returns a
+// Client wired to it. The server is closed automatically via t.Cleanup.
+func newTestCaseClient(t *testing.T, apiHandler http.HandlerFunc) *integrationservice.Client {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 3600})
+	})
+	mux.HandleFunc("/", apiHandler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return integrationservice.New(srv.URL, integrationservice.ClientCredentialsConfig{
+		TokenURL:     srv.URL + "/oauth2/token",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+}
+
+// sysid32 pads/truncates a repeated hex rune to exactly 32 characters, the
+// length ServiceNow sysids always have.
+func sysid32(r byte) string {
+	b := make([]byte, 32)
+	for i := range b {
+		b[i] = r
+	}
+	return string(b)
+}
+
+var (
+	testCaseSysid    = sysid32('a')
+	testProjectSysid = sysid32('b')
+	testWatcherSysid = sysid32('c')
+	testAccountSysid = sysid32('d')
+	testCreTeamSysid = sysid32('e')
+	testSreTeamSysid = sysid32('f')
+)
+
+const (
+	testDeploymentUUID  = "22222222-2222-2222-2222-222222222222"
+	testDeployedProdID  = "33333333-3333-3333-3333-333333333333"
+	testRelatedCaseUUID = "44444444-4444-4444-4444-444444444444"
+	testParentCaseUUID  = "55555555-5555-5555-5555-555555555555"
+)
+
+// testAutocloseHoldUntil is the hold-until date used by AutocloseHoldUntil test cases.
+var testAutocloseHoldUntil = time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+
+// timePtr returns a pointer to the given time.Time.
+func timePtr(t time.Time) *time.Time { return &t }
+
+// TestSNCaseService_GetCaseByID_MapsWatchListAutoclosureAndTeams verifies the
+// additive read-side wire-up for items 2 (watchers), 6 (autoclosureStep/autoclosureStateTime),
+// and 10 (CRE/SRE team on account). AutoclosureStep/AutoclosureStateTime/CreTeam/SreTeam are
+// Ballerina-blocked today (digiops-cs does not send them), but this test simulates a future
+// response carrying them to prove the entity-service mapping code is ready once Ballerina adds
+// the fields.
+func TestSNCaseService_GetCaseByID_MapsWatchListAutoclosureAndTeams(t *testing.T) {
+	body := `{
+		"id": "` + testCaseSysid + `",
+		"internalId": "WSO2-001",
+		"number": "CS0001001",
+		"title": "Case subject",
+		"description": "Case description",
+		"createdOn": "2026-01-01 10:00:00",
+		"updatedOn": "2026-01-02 10:00:00",
+		"createdBy": "reporter@example.com",
+		"project": {"id": "` + testProjectSysid + `", "name": "Project A"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"},
+		"watchList": [
+			{"id": "` + testWatcherSysid + `", "userName": "jdoe", "name": "Jane Doe", "email": "jane.doe@example.com"}
+		],
+		"account": {
+			"id": "` + testAccountSysid + `",
+			"name": "Account A",
+			"type": "enterprise",
+			"creTeam": {"id": "` + testCreTeamSysid + `", "name": "CRE Team A"},
+			"sreTeam": {"id": "` + testSreTeamSysid + `", "name": "SRE Team A"}
+		},
+		"autoclosureStep": "ON_HOLD",
+		"autoclosureStateTime": "2026-08-06 00:00:00"
+	}`
+
+	client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+
+	svc := NewServiceNowCaseService(client, nil)
+
+	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testCaseSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Item 2: watchers.
+	if len(cv.WatchList) != 1 {
+		t.Fatalf("expected 1 watcher, got %d", len(cv.WatchList))
+	}
+	gotWatcher := cv.WatchList[0]
+	if gotWatcher.ID != sysidToUUID(testWatcherSysid) || gotWatcher.UserName != "jdoe" ||
+		gotWatcher.Name != "Jane Doe" || gotWatcher.Email != "jane.doe@example.com" {
+		t.Fatalf("unexpected watcher mapping: %+v", gotWatcher)
+	}
+
+	// Item 6: autoclosureStep/autoclosureStateTime (both read-only; the only write is the
+	// derived autocloseHoldUntil variant).
+	if cv.AutoclosureStep == nil || *cv.AutoclosureStep != "ON_HOLD" {
+		t.Fatalf("expected autoclosureStep=ON_HOLD, got %+v", cv.AutoclosureStep)
+	}
+	wantStateTime, err := time.Parse(snCreatedOnLayout, "2026-08-06 00:00:00")
+	if err != nil {
+		t.Fatalf("parse want autoclosureStateTime: %v", err)
+	}
+	if cv.AutoclosureStateTime == nil || !cv.AutoclosureStateTime.Equal(wantStateTime) {
+		t.Fatalf("expected autoclosureStateTime=%v, got %+v", wantStateTime, cv.AutoclosureStateTime)
+	}
+
+	// Item 10: CRE/SRE team on account.
+	if cv.AccountDetails == nil {
+		t.Fatalf("expected account details to be populated")
+	}
+	if cv.AccountDetails.CreTeam == nil || cv.AccountDetails.CreTeam.ID != sysidToUUID(testCreTeamSysid) ||
+		cv.AccountDetails.CreTeam.Name != "CRE Team A" {
+		t.Fatalf("unexpected creTeam mapping: %+v", cv.AccountDetails.CreTeam)
+	}
+	if cv.AccountDetails.SreTeam == nil || cv.AccountDetails.SreTeam.ID != sysidToUUID(testSreTeamSysid) ||
+		cv.AccountDetails.SreTeam.Name != "SRE Team A" {
+		t.Fatalf("unexpected sreTeam mapping: %+v", cv.AccountDetails.SreTeam)
+	}
+}
+
+// TestSNCaseService_GetCaseByID_BallerinaBlockedFieldsAbsent documents current reality:
+// against a real (unmodified) digiops-cs response with none of the blocked fields present,
+// AutoclosureStep/AutoclosureStateTime/CreTeam/SreTeam all stay nil rather than zero-valuing.
+func TestSNCaseService_GetCaseByID_BallerinaBlockedFieldsAbsent(t *testing.T) {
+	body := `{
+		"id": "` + testCaseSysid + `",
+		"internalId": "WSO2-001",
+		"number": "CS0001001",
+		"title": "Case subject",
+		"description": "Case description",
+		"createdOn": "2026-01-01 10:00:00",
+		"updatedOn": null,
+		"createdBy": "reporter@example.com",
+		"project": {"id": "` + testProjectSysid + `", "name": "Project A"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"},
+		"account": {"id": "` + testAccountSysid + `", "name": "Account A", "type": "enterprise"}
+	}`
+
+	client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+
+	svc := NewServiceNowCaseService(client, nil)
+
+	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testCaseSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cv.AutoclosureStep != nil {
+		t.Fatalf("expected autoclosureStep nil (Ballerina-blocked), got %+v", cv.AutoclosureStep)
+	}
+	if cv.AutoclosureStateTime != nil {
+		t.Fatalf("expected autoclosureStateTime nil (Ballerina-blocked), got %+v", cv.AutoclosureStateTime)
+	}
+	if cv.AccountDetails == nil {
+		t.Fatalf("expected account details to be populated")
+	}
+	if cv.AccountDetails.CreTeam != nil || cv.AccountDetails.SreTeam != nil {
+		t.Fatalf("expected creTeam/sreTeam nil (Ballerina-blocked), got %+v / %+v",
+			cv.AccountDetails.CreTeam, cv.AccountDetails.SreTeam)
+	}
+	if len(cv.WatchList) != 0 {
+		t.Fatalf("expected no watchers, got %+v", cv.WatchList)
+	}
+}
+
+// TestSNCaseService_UpdateCase_ExactlyOneFieldValidation exercises the exactly-one-field
+// union for every new PATCH variant (items 6, 7, 9) alongside the pre-existing ones, using
+// a nil client so every case must fail validation before any network call is attempted.
+func TestSNCaseService_UpdateCase_ExactlyOneFieldValidation(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	emptyStr := ""
+
+	tests := []struct {
+		name string
+		req  domain.UpdateCaseRequest
+	}{
+		{
+			name: "no fields provided",
+			req:  domain.UpdateCaseRequest{ID: testDeploymentUUID},
+		},
+		{
+			name: "two new fields provided at once",
+			req: domain.UpdateCaseRequest{
+				ID:                 testDeploymentUUID,
+				Subject:            strPtr("New subject"),
+				AutocloseHoldUntil: timePtr(testAutocloseHoldUntil),
+			},
+		},
+		{
+			name: "new field mixed with a pre-existing field",
+			req: domain.UpdateCaseRequest{
+				ID:            testDeploymentUUID,
+				DeploymentID:  strPtr(testDeploymentUUID),
+				AssigneeEmail: strPtr("engineer@example.com"),
+			},
+		},
+		{
+			name: "relatedCaseId invalid uuid",
+			req: domain.UpdateCaseRequest{
+				ID:            testDeploymentUUID,
+				RelatedCaseID: strPtr("not-a-uuid"),
+			},
+		},
+		{
+			name: "deploymentId invalid uuid",
+			req: domain.UpdateCaseRequest{
+				ID:           testDeploymentUUID,
+				DeploymentID: strPtr("not-a-uuid"),
+			},
+		},
+		{
+			name: "deployedProductId invalid uuid",
+			req: domain.UpdateCaseRequest{
+				ID:                testDeploymentUUID,
+				DeployedProductID: strPtr("not-a-uuid"),
+			},
+		},
+		{
+			name: "subject empty string rejected",
+			req: domain.UpdateCaseRequest{
+				ID:      testDeploymentUUID,
+				Subject: &emptyStr,
+			},
+		},
+		{
+			name: "description empty string rejected",
+			req: domain.UpdateCaseRequest{
+				ID:          testDeploymentUUID,
+				Description: &emptyStr,
+			},
+		},
+	}
+
+	// client is intentionally nil: every case must fail validation before touching it.
+	svc := NewServiceNowCaseService(nil, nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// TestSNCaseService_UpdateCase_NewSingleFieldVariants verifies each new single-field PATCH
+// variant (items 6, 7, 9) builds the expected snUpdateCasePayload and round-trips a
+// successful response.
+func TestSNCaseService_UpdateCase_NewSingleFieldVariants(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name        string
+		req         domain.UpdateCaseRequest
+		wantPayload map[string]any
+	}{
+		{
+			name:        "autocloseHoldUntil",
+			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, AutocloseHoldUntil: timePtr(testAutocloseHoldUntil)},
+			wantPayload: map[string]any{"autocloseHoldUntil": testAutocloseHoldUntil.Format(snCreatedOnLayout)},
+		},
+		{
+			name:        "subject",
+			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, Subject: strPtr("Updated subject")},
+			wantPayload: map[string]any{"title": "Updated subject"},
+		},
+		{
+			name:        "description",
+			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, Description: strPtr("Updated description")},
+			wantPayload: map[string]any{"description": "Updated description"},
+		},
+		{
+			name:        "deploymentId",
+			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, DeploymentID: strPtr(testDeploymentUUID)},
+			wantPayload: map[string]any{"deploymentId": uuidToSysid(testDeploymentUUID)},
+		},
+		{
+			name:        "deployedProductId",
+			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, DeployedProductID: strPtr(testDeployedProdID)},
+			wantPayload: map[string]any{"deployedProductId": uuidToSysid(testDeployedProdID)},
+		},
+		{
+			name:        "relatedCaseId",
+			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, RelatedCaseID: strPtr(testRelatedCaseUUID)},
+			wantPayload: map[string]any{"relatedCaseId": uuidToSysid(testRelatedCaseUUID)},
+		},
+		{
+			name:        "parentCaseId (already-wired native parent field)",
+			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, ParentID: strPtr(testParentCaseUUID)},
+			wantPayload: map[string]any{"parentId": uuidToSysid(testParentCaseUUID)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Fatalf("expected PATCH, got %s", r.Method)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"message": "Case updated successfully.",
+					"case": {"id": "` + testCaseSysid + `", "updatedOn": "2026-01-02 10:00:00", "updatedBy": "engineer@example.com"}
+				}`))
+			})
+
+			svc := NewServiceNowCaseService(client, nil)
+			resp, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.Case.ID != sysidToUUID(testCaseSysid) {
+				t.Fatalf("unexpected response case id: %s", resp.Case.ID)
+			}
+
+			for field, want := range tt.wantPayload {
+				got, ok := gotBody[field]
+				if !ok {
+					t.Fatalf("expected payload field %q to be present in %+v", field, gotBody)
+				}
+				if fmt := jsonEqual(got, want); !fmt {
+					t.Fatalf("payload field %q: got %v, want %v", field, got, want)
+				}
+			}
+			// Every payload in this table must be a true single-field PATCH: no other
+			// recognised update field should be set alongside it.
+			for _, field := range []string{
+				"stateKey", "severityKey", "workStateKey", "watchList", "assigneeEmail",
+				"resolutionCode", "cause", "closeNotes",
+			} {
+				if _, ok := gotBody[field]; ok {
+					t.Fatalf("unexpected extra field %q present in single-field payload: %+v", field, gotBody)
+				}
+			}
+		})
+	}
+}
+
+// jsonEqual compares two decoded-JSON values (bool/string/number) for equality.
+func jsonEqual(got, want any) bool {
+	switch w := want.(type) {
+	case bool:
+		g, ok := got.(bool)
+		return ok && g == w
+	case string:
+		g, ok := got.(string)
+		return ok && g == w
+	default:
+		return got == want
+	}
+}

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+const (
+	testCaseUUID  = "11111111-1111-1111-1111-111111111111"
+	testCaseSysid = "11111111111111111111111111111111"
+	testTagUUID   = "22222222-2222-2222-2222-222222222222"
+	testTagSysid  = "22222222222222222222222222222222"
+	testTaskSysid = "33333333333333333333333333333333"
+)
+
+// --- UpdateCase: field-count union (including the new fixEta variant) ---
+
+func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
+	svc := NewServiceNowCaseService(nil, nil)
+	closed := domain.CaseStateClosed
+	fixEta := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		req  domain.UpdateCaseRequest
+	}{
+		{
+			name: "no fields provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID},
+		},
+		{
+			name: "state and fixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, FixEta: &fixEta},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// --- UpdateCase: close-gate ---
+
+func TestSNCaseService_UpdateCase_CloseGate_BlocksOnOpenVisibleTask(t *testing.T) {
+	patchCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tasks": []map[string]any{
+				{"id": testTaskSysid, "subject": "follow up", "state": "OPEN"},
+			},
+			"total": 1, "offset": 0, "limit": 100,
+		})
+	})
+	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": testTaskSysid, "subject": "follow up", "visibleToCustomer": true,
+		})
+	})
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		patchCalled = true
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	closed := domain.CaseStateClosed
+	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed})
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+	if patchCalled {
+		t.Fatalf("expected PATCH /cases/{id} not to be called when an open visible task blocks the close")
+	}
+}
+
+func TestSNCaseService_UpdateCase_CloseGate_AllowsWhenNoVisibleOpenTask(t *testing.T) {
+	patchCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tasks": []map[string]any{
+				{"id": testTaskSysid, "subject": "internal note", "state": "OPEN"},
+			},
+			"total": 1, "offset": 0, "limit": 100,
+		})
+	})
+	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": testTaskSysid, "subject": "internal note", "visibleToCustomer": false,
+		})
+	})
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		patchCalled = true
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	closed := domain.CaseStateClosed
+	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !patchCalled {
+		t.Fatalf("expected PATCH /cases/{id} to be called when no visible open task blocks the close")
+	}
+}
+
+// --- FixEta read/write mapping ---
+
+func TestSNCaseService_GetCaseByID_MapsFixEta(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": testCaseSysid, "internalId": "INT-1", "number": "CS0001",
+			"title": "t", "description": "d",
+			"createdOn": "2026-01-01 00:00:00", "createdBy": "a@example.com",
+			"project":         map[string]any{"id": "", "name": ""},
+			"deployment":      map[string]any{"id": "", "name": ""},
+			"deployedProduct": map[string]any{"id": "", "name": "", "version": ""},
+			"fixEta":          "2026-02-15 10:30:00",
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cv.FixEta == nil {
+		t.Fatalf("expected FixEta to be populated, got nil")
+	}
+	want := time.Date(2026, 2, 15, 10, 30, 0, 0, time.UTC)
+	if !cv.FixEta.Equal(want) {
+		t.Fatalf("FixEta = %v, want %v", cv.FixEta, want)
+	}
+}
+
+func TestSNCaseService_UpdateCase_FixEta_SendsFormattedDate(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	fixEta := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, FixEta: &fixEta})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := gotBody["fixEta"].(string)
+	want := "2026-03-01 12:00:00"
+	if got != want {
+		t.Fatalf("fixEta sent = %q, want %q", got, want)
+	}
+}
+
+// --- Case tags ---
+
+func TestSNCaseService_AddCaseTag_Validation(t *testing.T) {
+	svc := NewServiceNowCaseService(nil, nil)
+
+	if _, err := svc.AddCaseTag(contextWithUserIDToken("token"), "not-a-uuid", "micro-gw"); err == nil {
+		t.Fatalf("expected error for invalid case id")
+	} else if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+
+	if _, err := svc.AddCaseTag(contextWithUserIDToken("token"), testCaseUUID, "   "); err == nil {
+		t.Fatalf("expected error for empty label")
+	} else if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSNCaseService_AddCaseTag_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid+"/tags", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["label"] != "micro-gw" {
+			t.Fatalf("label sent = %v, want micro-gw", body["label"])
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "ok",
+			"tag":     map[string]any{"id": testTagSysid, "label": "micro-gw", "color": "#f97316"},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	tag, err := svc.AddCaseTag(contextWithUserIDToken("token"), testCaseUUID, "micro-gw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag.ID != testTagUUID {
+		t.Fatalf("tag.ID = %q, want %q", tag.ID, testTagUUID)
+	}
+	if tag.Label != "micro-gw" {
+		t.Fatalf("tag.Label = %q, want micro-gw", tag.Label)
+	}
+	if tag.Color == nil || *tag.Color != "#f97316" {
+		t.Fatalf("tag.Color = %v, want #f97316", tag.Color)
+	}
+}
+
+func TestSNCaseService_RemoveCaseTag_Validation(t *testing.T) {
+	svc := NewServiceNowCaseService(nil, nil)
+
+	if err := svc.RemoveCaseTag(contextWithUserIDToken("token"), "not-a-uuid", testTagUUID); err == nil {
+		t.Fatalf("expected error for invalid case id")
+	} else if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+
+	if err := svc.RemoveCaseTag(contextWithUserIDToken("token"), testCaseUUID, "not-a-uuid"); err == nil {
+		t.Fatalf("expected error for invalid tag id")
+	} else if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSNCaseService_RemoveCaseTag_Success(t *testing.T) {
+	deleteCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid+"/tags/"+testTagSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		deleteCalled = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok"})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	if err := svc.RemoveCaseTag(contextWithUserIDToken("token"), testCaseUUID, testTagUUID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deleteCalled {
+		t.Fatalf("expected DELETE /cases/{id}/tags/{tagId} to be called")
+	}
+}

--- a/entity-service/internal/service/sn_client_test_helper_test.go
+++ b/entity-service/internal/service/sn_client_test_helper_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// newTestSNClient builds an *integrationservice.Client backed by an httptest
+// server: apiHandler serves every path other than the token endpoint, which is
+// stubbed to always issue a fake bearer token. The server is closed
+// automatically via t.Cleanup.
+func newTestSNClient(t *testing.T, apiHandler http.Handler) *integrationservice.Client {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"expires_in":   3600,
+		})
+	})
+	mux.Handle("/", apiHandler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return integrationservice.New(srv.URL, integrationservice.ClientCredentialsConfig{
+		TokenURL:     srv.URL + "/oauth2/token",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+}

--- a/entity-service/internal/service/sn_id.go
+++ b/entity-service/internal/service/sn_id.go
@@ -36,6 +36,15 @@ func uuidToSysid(uuid string) string {
 	return uuid[0:8] + uuid[9:13] + uuid[14:18] + uuid[19:23] + uuid[24:36]
 }
 
+// snParentIDFilter converts an optional parentId filter UUID to a sysid,
+// returning "" (omitted via omitempty) when nil.
+func snParentIDFilter(uuid *string) string {
+	if uuid == nil {
+		return ""
+	}
+	return uuidToSysid(*uuid)
+}
+
 // uuidsToSysids converts a slice of UUID strings to sysids.
 // Returns the original slice unchanged if it is empty.
 func uuidsToSysids(uuids []string) []string {

--- a/entity-service/internal/service/sn_task_service.go
+++ b/entity-service/internal/service/sn_task_service.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -176,6 +177,14 @@ func (s *snTaskService) GetTask(ctx context.Context, id string) (domain.TaskDeta
 		return domain.TaskDetail{}, fmt.Errorf("sn get task: parse response: %w", err)
 	}
 
+	return snTaskDetailToDomain(t), nil
+}
+
+// snTaskDetailToDomain converts an snTaskDetail (the Choreo GET /tasks/{id}
+// response shape, reused here for the create/update responses) to the domain
+// TaskDetail view. Shared by GetTask, CreateCaseTask, and UpdateTask so all
+// three map the wire shape identically.
+func snTaskDetailToDomain(t snTaskDetail) domain.TaskDetail {
 	detail := domain.TaskDetail{
 		ID:                sysidToUUID(t.ID),
 		State:             t.State,
@@ -213,5 +222,137 @@ func (s *snTaskService) GetTask(ctx context.Context, id string) (domain.TaskDeta
 		detail.ParentCase = ref
 	}
 
-	return detail, nil
+	return detail
+}
+
+// snCreateTaskPayload is the request body for the (not yet existing) Choreo
+// POST /cases/{id}/tasks endpoint.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): ServiceNow/Ballerina task support is read-only today
+// (TaskSearchPayload/TaskResponse only -- see modules/servicenow/types.bal).
+// No Choreo endpoint exists yet to create a sn_customerservice_task record.
+// Ask: add POST /cases/{id}/tasks (this payload shape) to servicenow.bal,
+// returning a TaskResponse-shaped detail.
+type snCreateTaskPayload struct {
+	Subject           string  `json:"subject"`
+	DueDate           *string `json:"dueDate,omitempty"`
+	AssignedToEmail   *string `json:"assignedToEmail,omitempty"`
+	VisibleToCustomer *bool   `json:"visibleToCustomer,omitempty"`
+}
+
+type snCreateTaskResponse struct {
+	Message string       `json:"message"`
+	Task    snTaskDetail `json:"task"`
+}
+
+// CreateCaseTask creates a new task on the case identified by caseID.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): see snCreateTaskPayload doc comment. Implemented so the
+// entity-service side is ready the moment Ballerina adds the endpoint; until
+// then, calling it returns a downstream error (no such Choreo route today).
+func (s *snTaskService) CreateCaseTask(ctx context.Context, caseID string, req domain.CreateCaseTaskRequest) (domain.TaskDetail, error) {
+	if err := validateUUIDs("id", []string{caseID}); err != nil {
+		return domain.TaskDetail{}, err
+	}
+	if req.Subject == "" {
+		return domain.TaskDetail{}, &apierror.ValidationError{Msg: "subject is required"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snCreateTaskPayload{
+		Subject:           req.Subject,
+		AssignedToEmail:   req.AssignedToEmail,
+		VisibleToCustomer: req.VisibleToCustomer,
+	}
+	if req.DueDate != nil {
+		dueDate := formatSNDate(req.DueDate)
+		payload.DueDate = &dueDate
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/"+uuidToSysid(caseID)+"/tasks", token, payload)
+	if err != nil {
+		return domain.TaskDetail{}, err
+	}
+
+	var snResp snCreateTaskResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.TaskDetail{}, fmt.Errorf("sn create case task: parse response: %w", err)
+	}
+
+	return snTaskDetailToDomain(snResp.Task), nil
+}
+
+// snUpdateTaskPayload is the request body for the (not yet existing) Choreo
+// PATCH /tasks/{id} endpoint. Exactly one of State, AssignedToEmail, or DueDate
+// must be provided per request, following the same convention as
+// snUpdateCasePayload.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): same gap as snCreateTaskPayload above. Ask: add
+// PATCH /tasks/{id} (this payload shape) to servicenow.bal, returning a
+// TaskResponse-shaped detail.
+type snUpdateTaskPayload struct {
+	State           *string `json:"state,omitempty"`
+	AssignedToEmail *string `json:"assignedToEmail,omitempty"`
+	DueDate         *string `json:"dueDate,omitempty"`
+}
+
+type snUpdateTaskResponse struct {
+	Message string       `json:"message"`
+	Task    snTaskDetail `json:"task"`
+}
+
+// UpdateTask updates exactly one of state, assignedToEmail, or dueDate on the
+// task identified by taskID.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): see snUpdateTaskPayload doc comment. Implemented so the
+// entity-service side is ready the moment Ballerina adds the endpoint; until
+// then, calling it returns a downstream error (no such Choreo route today).
+func (s *snTaskService) UpdateTask(ctx context.Context, taskID string, req domain.UpdateTaskRequest) (domain.TaskDetail, error) {
+	if err := validateUUIDs("id", []string{taskID}); err != nil {
+		return domain.TaskDetail{}, err
+	}
+
+	fieldCount := 0
+	if req.State != nil {
+		fieldCount++
+	}
+	if req.AssignedToEmail != nil {
+		fieldCount++
+	}
+	if req.DueDate != nil {
+		fieldCount++
+	}
+	if fieldCount == 0 {
+		return domain.TaskDetail{}, &apierror.ValidationError{Msg: "exactly one of state, assignedToEmail, or dueDate must be provided"}
+	}
+	if fieldCount > 1 {
+		return domain.TaskDetail{}, &apierror.ValidationError{Msg: "only one of state, assignedToEmail, or dueDate may be provided per request"}
+	}
+	if req.State != nil && *req.State == "" {
+		return domain.TaskDetail{}, &apierror.ValidationError{Msg: "state cannot be empty"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snUpdateTaskPayload{
+		State:           req.State,
+		AssignedToEmail: req.AssignedToEmail,
+	}
+	if req.DueDate != nil {
+		dueDate := formatSNDate(req.DueDate)
+		payload.DueDate = &dueDate
+	}
+
+	raw, err := s.client.Patch(ctx, "/tasks/"+uuidToSysid(taskID), token, payload)
+	if err != nil {
+		return domain.TaskDetail{}, err
+	}
+
+	var snResp snUpdateTaskResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.TaskDetail{}, fmt.Errorf("sn update task: parse response: %w", err)
+	}
+
+	return snTaskDetailToDomain(snResp.Task), nil
 }

--- a/entity-service/internal/service/sn_task_service.go
+++ b/entity-service/internal/service/sn_task_service.go
@@ -225,6 +225,18 @@ func snTaskDetailToDomain(t snTaskDetail) domain.TaskDetail {
 	return detail
 }
 
+// taskWritesUnavailable gates CreateCaseTask/UpdateTask while the downstream
+// Choreo task-write endpoints don't exist yet (tracked on the
+// ballerina-tasks-fixeta-tags branch, not yet merged to digiops-cs main). A
+// deliberate ServiceUnavailableError here -- rather than letting the request
+// reach the downstream client and come back as a generic 404 -- avoids
+// conflating "this operation isn't deployed yet" with "task not found".
+// Flip this to false once the downstream endpoints ship; the send logic below
+// is already wired and ready. A var (not const) so tests can flip it locally
+// to exercise that send logic ahead of the downstream endpoints existing.
+var taskWritesUnavailable = true
+const taskWritesUnavailableMsg = "task creation/update is not yet available: the downstream ServiceNow integration for this operation has not been deployed"
+
 // snCreateTaskPayload is the request body for the (not yet existing) Choreo
 // POST /cases/{id}/tasks endpoint.
 //
@@ -248,8 +260,9 @@ type snCreateTaskResponse struct {
 // CreateCaseTask creates a new task on the case identified by caseID.
 //
 // Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): see snCreateTaskPayload doc comment. Implemented so the
-// entity-service side is ready the moment Ballerina adds the endpoint; until
-// then, calling it returns a downstream error (no such Choreo route today).
+// entity-service side is ready the moment Ballerina adds the endpoint; gated
+// with a deliberate ServiceUnavailableError (see taskWritesUnavailableMsg)
+// until then.
 func (s *snTaskService) CreateCaseTask(ctx context.Context, caseID string, req domain.CreateCaseTaskRequest) (domain.TaskDetail, error) {
 	if err := validateUUIDs("id", []string{caseID}); err != nil {
 		return domain.TaskDetail{}, err
@@ -268,6 +281,10 @@ func (s *snTaskService) CreateCaseTask(ctx context.Context, caseID string, req d
 	if req.DueDate != nil {
 		dueDate := formatSNDate(req.DueDate)
 		payload.DueDate = &dueDate
+	}
+
+	if taskWritesUnavailable {
+		return domain.TaskDetail{}, &apierror.ServiceUnavailableError{Msg: taskWritesUnavailableMsg}
 	}
 
 	raw, err := s.client.Post(ctx, "/cases/"+uuidToSysid(caseID)+"/tasks", token, payload)
@@ -306,8 +323,9 @@ type snUpdateTaskResponse struct {
 // task identified by taskID.
 //
 // Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): see snUpdateTaskPayload doc comment. Implemented so the
-// entity-service side is ready the moment Ballerina adds the endpoint; until
-// then, calling it returns a downstream error (no such Choreo route today).
+// entity-service side is ready the moment Ballerina adds the endpoint; gated
+// with a deliberate ServiceUnavailableError (see taskWritesUnavailableMsg)
+// until then.
 func (s *snTaskService) UpdateTask(ctx context.Context, taskID string, req domain.UpdateTaskRequest) (domain.TaskDetail, error) {
 	if err := validateUUIDs("id", []string{taskID}); err != nil {
 		return domain.TaskDetail{}, err
@@ -342,6 +360,10 @@ func (s *snTaskService) UpdateTask(ctx context.Context, taskID string, req domai
 	if req.DueDate != nil {
 		dueDate := formatSNDate(req.DueDate)
 		payload.DueDate = &dueDate
+	}
+
+	if taskWritesUnavailable {
+		return domain.TaskDetail{}, &apierror.ServiceUnavailableError{Msg: taskWritesUnavailableMsg}
 	}
 
 	raw, err := s.client.Patch(ctx, "/tasks/"+uuidToSysid(taskID), token, payload)

--- a/entity-service/internal/service/sn_task_service_test.go
+++ b/entity-service/internal/service/sn_task_service_test.go
@@ -58,7 +58,21 @@ func TestSNTaskService_CreateCaseTask_Validation(t *testing.T) {
 	}
 }
 
+func TestSNTaskService_CreateCaseTask_GatedUnavailable(t *testing.T) {
+	svc := NewServiceNowTaskService(nil)
+	_, err := svc.CreateCaseTask(contextWithUserIDToken("token"), testCaseUUID, domain.CreateCaseTaskRequest{Subject: "follow up"})
+	if _, ok := err.(*apierror.ServiceUnavailableError); !ok {
+		t.Fatalf("expected *apierror.ServiceUnavailableError while taskWritesUnavailable is true, got %T: %v", err, err)
+	}
+}
+
+// TestSNTaskService_CreateCaseTask_Success exercises the send logic that's
+// ready to go the moment the downstream endpoint ships -- it temporarily
+// disables the taskWritesUnavailable gate to prove that logic still works.
 func TestSNTaskService_CreateCaseTask_Success(t *testing.T) {
+	taskWritesUnavailable = false
+	defer func() { taskWritesUnavailable = true }()
+
 	var gotBody map[string]any
 	mux := http.NewServeMux()
 	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks", func(w http.ResponseWriter, r *http.Request) {
@@ -128,7 +142,22 @@ func TestSNTaskService_UpdateTask_FieldCountValidation(t *testing.T) {
 	}
 }
 
+func TestSNTaskService_UpdateTask_GatedUnavailable(t *testing.T) {
+	svc := NewServiceNowTaskService(nil)
+	state := "CLOSED"
+	_, err := svc.UpdateTask(contextWithUserIDToken("token"), "33333333-3333-3333-3333-333333333333", domain.UpdateTaskRequest{State: &state})
+	if _, ok := err.(*apierror.ServiceUnavailableError); !ok {
+		t.Fatalf("expected *apierror.ServiceUnavailableError while taskWritesUnavailable is true, got %T: %v", err, err)
+	}
+}
+
+// TestSNTaskService_UpdateTask_Success exercises the send logic that's ready
+// to go the moment the downstream endpoint ships -- it temporarily disables
+// the taskWritesUnavailable gate to prove that logic still works.
 func TestSNTaskService_UpdateTask_Success(t *testing.T) {
+	taskWritesUnavailable = false
+	defer func() { taskWritesUnavailable = true }()
+
 	var gotBody map[string]any
 	mux := http.NewServeMux()
 	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {

--- a/entity-service/internal/service/sn_task_service_test.go
+++ b/entity-service/internal/service/sn_task_service_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// --- CreateCaseTask ---
+
+func TestSNTaskService_CreateCaseTask_Validation(t *testing.T) {
+	svc := NewServiceNowTaskService(nil)
+
+	tests := []struct {
+		name   string
+		caseID string
+		req    domain.CreateCaseTaskRequest
+	}{
+		{
+			name:   "invalid case id",
+			caseID: "not-a-uuid",
+			req:    domain.CreateCaseTaskRequest{Subject: "follow up"},
+		},
+		{
+			name:   "empty subject",
+			caseID: testCaseUUID,
+			req:    domain.CreateCaseTaskRequest{Subject: ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.CreateCaseTask(contextWithUserIDToken("token"), tt.caseID, tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestSNTaskService_CreateCaseTask_Success(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "ok",
+			"task": map[string]any{
+				"id": testTaskSysid, "subject": "follow up", "state": "OPEN",
+				"visibleToCustomer": true,
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowTaskService(client)
+
+	due := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	email := "eng@example.com"
+	visible := true
+	detail, err := svc.CreateCaseTask(contextWithUserIDToken("token"), testCaseUUID, domain.CreateCaseTaskRequest{
+		Subject: "follow up", DueDate: &due, AssignedToEmail: &email, VisibleToCustomer: &visible,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail.Subject != "follow up" {
+		t.Fatalf("Subject = %q, want %q", detail.Subject, "follow up")
+	}
+	if !detail.VisibleToCustomer {
+		t.Fatalf("VisibleToCustomer = false, want true")
+	}
+	if gotBody["dueDate"] != "2026-08-01 00:00:00" {
+		t.Fatalf("dueDate sent = %v, want 2026-08-01 00:00:00", gotBody["dueDate"])
+	}
+	if gotBody["assignedToEmail"] != email {
+		t.Fatalf("assignedToEmail sent = %v, want %v", gotBody["assignedToEmail"], email)
+	}
+}
+
+// --- UpdateTask ---
+
+func TestSNTaskService_UpdateTask_FieldCountValidation(t *testing.T) {
+	svc := NewServiceNowTaskService(nil)
+	email := "eng@example.com"
+	state := "CLOSED"
+
+	tests := []struct {
+		name string
+		req  domain.UpdateTaskRequest
+	}{
+		{name: "no fields", req: domain.UpdateTaskRequest{ID: testCaseUUID}},
+		{name: "two fields", req: domain.UpdateTaskRequest{ID: testCaseUUID, State: &state, AssignedToEmail: &email}},
+		{name: "empty state", req: domain.UpdateTaskRequest{ID: testCaseUUID, State: strPtr("")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.UpdateTask(contextWithUserIDToken("token"), tt.req.ID, tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestSNTaskService_UpdateTask_Success(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "ok",
+			"task": map[string]any{
+				"id": testTaskSysid, "subject": "follow up", "state": "CLOSED",
+				"visibleToCustomer": true,
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowTaskService(client)
+
+	taskUUID := "33333333-3333-3333-3333-333333333333"
+	state := "CLOSED"
+	detail, err := svc.UpdateTask(contextWithUserIDToken("token"), taskUUID, domain.UpdateTaskRequest{State: &state})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail.State == nil || *detail.State != "CLOSED" {
+		t.Fatalf("State = %v, want CLOSED", detail.State)
+	}
+	if gotBody["state"] != "CLOSED" {
+		t.Fatalf("state sent = %v, want CLOSED", gotBody["state"])
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1974,6 +1974,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/{id}/tasks:
+    post:
+      summary: Create a task on a case (ServiceNow data source only).
+      operationId: createCaseTask
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCaseTaskRequest'
+      responses:
+        "201":
+          description: Task created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /tasks/{id}:
     get:
       summary: Get a task by ID (ServiceNow data source only).
@@ -1988,6 +2037,55 @@ paths:
       responses:
         "200":
           description: The task record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Task not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      summary: Update a task (ServiceNow data source only).
+      description: >
+        Updates exactly one of state, assignedToEmail, or dueDate.
+      operationId: updateTask
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTaskRequest'
+      responses:
+        "200":
+          description: Task updated.
           content:
             application/json:
               schema:
@@ -6174,6 +6272,42 @@ components:
           type: integer
         limit:
           type: integer
+
+    CreateCaseTaskRequest:
+      type: object
+      required: [subject]
+      properties:
+        subject:
+          type: string
+        dueDate:
+          type: string
+          format: date-time
+        assignedToEmail:
+          type: string
+          format: email
+        visibleToCustomer:
+          type: boolean
+
+    UpdateTaskRequest:
+      type: object
+      description: >
+        Exactly one of state, assignedToEmail, or dueDate must be provided.
+      oneOf:
+        - required: [state]
+        - required: [assignedToEmail]
+        - required: [dueDate]
+      properties:
+        state:
+          type: string
+          description: >
+            Plain string, not a closed enum — ServiceNow may surface undocumented
+            raw values; do not assume a closed set.
+        assignedToEmail:
+          type: string
+          format: email
+        dueDate:
+          type: string
+          format: date-time
 
     TaskDetail:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2022,6 +2022,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Task writes are not yet available (downstream integration not deployed).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /tasks/{id}:
     get:
@@ -2110,6 +2116,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Task writes are not yet available (downstream integration not deployed).
           content:
             application/json:
               schema:
@@ -6276,6 +6288,7 @@ components:
     CreateCaseTaskRequest:
       type: object
       required: [subject]
+      additionalProperties: false
       properties:
         subject:
           type: string
@@ -6290,6 +6303,7 @@ components:
 
     UpdateTaskRequest:
       type: object
+      additionalProperties: false
       description: >
         Exactly one of state, assignedToEmail, or dueDate must be provided.
       oneOf:


### PR DESCRIPTION
## Purpose
Closes several CSM-portal feature gaps that depend on data ServiceNow already has but the entity-service didn't yet expose: case watchers, an auto-closure hold indicator, editable case subject/description/deployment/deployed-product, child-case linking, case tags, case task create/update with a close-gate, a customer-facing fix ETA, and the account's CRE/SRE team.

## Goals
- Surface case watchers on read (write already existed).
- Surface ServiceNow's real staged auto-closure sequence and let an engineer place a case on hold.
- Allow editing a case's subject, description, deployment, and deployed product post-creation.
- Support linking a case to a parent (existing) and a related case (new), plus listing a case's children.
- Add case tag read/write and a tags search filter.
- Add case task create/update, plus a server-side close-gate rejecting closure while an open task exists.
- Surface a single customer-facing fix ETA field.
- Surface the account's CRE and SRE team on the case's embedded account object.

## Approach
Each item follows this service's existing case-read/update conventions: additive struct fields on `CaseView`/`snCase`, new single-field variants on the existing exactly-one-field case-update contract, and (for tasks and tags) new service methods/handlers/routes following the same auth/validation/error-mapping pattern already used elsewhere in this codebase. Some pieces are ready end-to-end today; others are wired on this side and will start returning real data once a matching change lands in the downstream integration service the entity-service calls — those spots carry an explicit comment naming exactly what's still needed downstream.

## User stories
As a CS engineer, I want to see and manage a case's watchers, hold a case out of auto-closure, edit case details after creation, link related/child cases, tag cases, and manage case tasks, so the CSM portal covers the workflows I currently need ServiceNow's own UI for.

## Release note
Extends the case data model with watchers, auto-closure status/hold, editable subject/description/deployment/deployed-product, related-case linking, tags, task CRUD with a close-gate, fix ETA, and account CRE/SRE team.

## Documentation
N/A — internal API surface, no external product docs affected.

## Automation tests
- Unit tests: added/extended for every new field mapping, PATCH variant, and service method, using this package's existing mocked-HTTP-response test pattern.
- Integration tests: N/A, none exist in this package beyond the unit level.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (Go codebase — `go vet` run clean as part of the build)
- Confirmed no keys/passwords/tokens/usernames/secrets committed: yes

## Samples
N/A

## Related PRs
Stacked alongside companion PRs for the CSM portal backend and webapp in this repo, and a corresponding downstream integration-service change tracked separately.

## Migrations (if applicable)
N/A — no schema/DB migration in this service.

## Test environment
Go 1.x (as pinned by this repo's go.mod), macOS, run via `go build`/`go vet`/`go test`.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case details now surface watch lists, auto-closure progress, fix ETAs, free-text tags, and CRE/SRE team references.
  * Added endpoints to add/remove case tags and to create/update case tasks.
  * Expanded ServiceNow-backed case updates to support related cases, deployment metadata, auto-close holds, descriptions, and fix ETAs.
* **Bug Fixes**
  * Prevents closing cases when customer-visible open tasks exist.
  * Enforces “exactly one field” updates for case and task mutations.
* **Tests**
  * Added integration coverage for metadata mapping, validations, tagging, and task operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->