### PR TITLE
[CSM Portal] add fix-ETA estimates, searchable tags, and case-detail review follow-ups

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -116,6 +116,7 @@ func main() {
 	mux.HandleFunc("POST /cases/{id}/github-issues", caseHandler.CreateCaseGithubIssue)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
+	mux.HandleFunc("GET /tags/search", caseHandler.SearchTags)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)

--- a/apps/csm-portal/backend/internal/entity/entity.go
+++ b/apps/csm-portal/backend/internal/entity/entity.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 // CreateCase calls POST /cases on the entity service.
@@ -434,4 +435,21 @@ func (c *Client) AddCaseTag(ctx context.Context, caseID string, body []byte) ([]
 // Response is returned as raw JSON (typically empty for a 204 No Content).
 func (c *Client) RemoveCaseTag(ctx context.Context, caseID, tagID string) ([]byte, error) {
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/cases/%s/tags/%s", url.PathEscape(caseID), url.PathEscape(tagID)), nil)
+}
+
+// SearchTags calls GET /tags/search on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *Client) SearchTags(ctx context.Context, query string, limit int) ([]byte, error) {
+	params := url.Values{}
+	if query != "" {
+		params.Set("q", query)
+	}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/tags/search"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	return c.do(ctx, http.MethodGet, path, nil)
 }

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -638,7 +638,7 @@ func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
 	var limit int
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
 		parsed, err := strconv.Atoi(limitStr)
-		if err != nil || parsed < 0 {
+		if err != nil || parsed < 0 || parsed > 100 {
 			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 			return
 		}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
@@ -86,6 +87,7 @@ type entityCaseClient interface {
 	CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	AddCaseTag(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	RemoveCaseTag(ctx context.Context, caseID, tagID string) ([]byte, error)
+	SearchTags(ctx context.Context, query string, limit int) ([]byte, error)
 }
 
 // CaseHandler handles HTTP requests for case operations, delegating to the
@@ -619,6 +621,38 @@ func (h *CaseHandler) RemoveCaseTag(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// SearchTags handles GET /tags/search.
+// Forwards the q and limit query parameters to the entity service and returns
+// the raw response verbatim.
+func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	q := r.URL.Query().Get("q")
+
+	var limit int
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		parsed, err := strconv.Atoi(limitStr)
+		if err != nil || parsed < 0 {
+			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+			return
+		}
+		limit = parsed
+	}
+
+	result, err := h.entity.SearchTags(r.Context(), q, limit)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchTags failed", "userID", user.UserID, "err", err)
+		mapUpstreamError(w, err, "Failed to search tags.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // PatchCase handles PATCH /cases/{id}.

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -2320,6 +2320,34 @@ func TestSearchTags(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	t.Run("rejects a limit above the documented maximum", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=101", nil))
+		w := httptest.NewRecorder()
+		h.SearchTags(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("accepts a limit of exactly 100", func(t *testing.T) {
+		var capturedLimit int
+		client := &mockEntityCaseClient{
+			searchTagsFn: func(_ context.Context, _ string, limit int) ([]byte, error) {
+				capturedLimit = limit
+				return []byte(`{"tags":[]}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=100", nil))
+		w := httptest.NewRecorder()
+		h.SearchTags(w, r)
+		assertStatus(t, w, http.StatusOK)
+		if capturedLimit != 100 {
+			t.Errorf("upstream received limit %d, want 100", capturedLimit)
+		}
+	})
+
 	t.Run("forwards q and limit verbatim, returns 200 with matching tags", func(t *testing.T) {
 		var capturedQuery string
 		var capturedLimit int
@@ -2327,7 +2355,7 @@ func TestSearchTags(t *testing.T) {
 			searchTagsFn: func(_ context.Context, query string, limit int) ([]byte, error) {
 				capturedQuery = query
 				capturedLimit = limit
-				return []byte(`[{"id":"22222222-2222-2222-2222-222222222222","label":"micro-gw","color":null}]`), nil
+				return []byte(`{"tags":[{"id":"22222222-2222-2222-2222-222222222222","label":"micro-gw","color":null}]}`), nil
 			},
 		}
 		h := NewCaseHandler(client)
@@ -2344,16 +2372,18 @@ func TestSearchTags(t *testing.T) {
 			t.Errorf("upstream received limit %d, want %d", capturedLimit, 10)
 		}
 
-		var tags []struct {
-			ID    string  `json:"id"`
-			Label string  `json:"label"`
-			Color *string `json:"color"`
+		var body struct {
+			Tags []struct {
+				ID    string  `json:"id"`
+				Label string  `json:"label"`
+				Color *string `json:"color"`
+			} `json:"tags"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &tags); err != nil {
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 			t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
 		}
-		if len(tags) != 1 || tags[0].Label != "micro-gw" {
-			t.Errorf("tags = %+v, want a single micro-gw entry", tags)
+		if len(body.Tags) != 1 || body.Tags[0].Label != "micro-gw" {
+			t.Errorf("tags = %+v, want a single micro-gw entry", body.Tags)
 		}
 	})
 
@@ -2366,7 +2396,7 @@ func TestSearchTags(t *testing.T) {
 				called = true
 				capturedQuery = query
 				capturedLimit = limit
-				return []byte(`[]`), nil
+				return []byte(`{"tags":[]}`), nil
 			},
 		}
 		h := NewCaseHandler(client)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -2095,3 +2095,314 @@ func TestSearchCasesForwardsTagsFilter(t *testing.T) {
 		t.Errorf("upstream received body %s, want %s (must forward verbatim)", capturedBody, reqBody)
 	}
 }
+
+func TestPatchCaseBestCaseFixEta(t *testing.T) {
+	// bestCaseFixEta is a pure pass-through single-field PATCH variant, same shape as
+	// the existing fixEta test. It does not trip the state/workState peek, so
+	// patchCaseFn is invoked directly with the raw body and the upstream response
+	// passes through unchanged.
+	const testCaseID = "11111111-1111-1111-1111-111111111111"
+	const reqBody = `{"bestCaseFixEta":"2026-08-01T00:00:00Z"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","bestCaseFixEta":"2026-08-01T00:00:00Z"}}`
+
+	var capturedBody []byte
+	client := &mockEntityCaseClient{
+		patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+			capturedBody = body
+			return []byte(upstream), nil
+		},
+	}
+	h := NewCaseHandler(client)
+	r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(reqBody)))
+	r.SetPathValue("id", testCaseID)
+	w := httptest.NewRecorder()
+	h.PatchCase(w, r)
+
+	assertStatus(t, w, http.StatusOK)
+	assertContentType(t, w, "application/json")
+
+	if string(capturedBody) != reqBody {
+		t.Errorf("upstream received body %s, want %s (must forward verbatim)", capturedBody, reqBody)
+	}
+
+	var wrapper struct {
+		Case struct {
+			BestCaseFixEta string `json:"bestCaseFixEta"`
+		} `json:"case"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
+		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
+	}
+	if wrapper.Case.BestCaseFixEta != "2026-08-01T00:00:00Z" {
+		t.Errorf("case.bestCaseFixEta = %q, want %q", wrapper.Case.BestCaseFixEta, "2026-08-01T00:00:00Z")
+	}
+}
+
+func TestPatchCaseMostLikelyFixEta(t *testing.T) {
+	// mostLikelyFixEta is a pure pass-through single-field PATCH variant, same
+	// shape as the existing fixEta test.
+	const testCaseID = "11111111-1111-1111-1111-111111111111"
+	const reqBody = `{"mostLikelyFixEta":"2026-08-01T00:00:00Z"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","mostLikelyFixEta":"2026-08-01T00:00:00Z"}}`
+
+	var capturedBody []byte
+	client := &mockEntityCaseClient{
+		patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+			capturedBody = body
+			return []byte(upstream), nil
+		},
+	}
+	h := NewCaseHandler(client)
+	r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(reqBody)))
+	r.SetPathValue("id", testCaseID)
+	w := httptest.NewRecorder()
+	h.PatchCase(w, r)
+
+	assertStatus(t, w, http.StatusOK)
+	assertContentType(t, w, "application/json")
+
+	if string(capturedBody) != reqBody {
+		t.Errorf("upstream received body %s, want %s (must forward verbatim)", capturedBody, reqBody)
+	}
+
+	var wrapper struct {
+		Case struct {
+			MostLikelyFixEta string `json:"mostLikelyFixEta"`
+		} `json:"case"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
+		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
+	}
+	if wrapper.Case.MostLikelyFixEta != "2026-08-01T00:00:00Z" {
+		t.Errorf("case.mostLikelyFixEta = %q, want %q", wrapper.Case.MostLikelyFixEta, "2026-08-01T00:00:00Z")
+	}
+}
+
+func TestPatchCaseWorstCaseFixEta(t *testing.T) {
+	// worstCaseFixEta is a pure pass-through single-field PATCH variant, same
+	// shape as the existing fixEta test.
+	const testCaseID = "11111111-1111-1111-1111-111111111111"
+	const reqBody = `{"worstCaseFixEta":"2026-08-01T00:00:00Z"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","worstCaseFixEta":"2026-08-01T00:00:00Z"}}`
+
+	var capturedBody []byte
+	client := &mockEntityCaseClient{
+		patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+			capturedBody = body
+			return []byte(upstream), nil
+		},
+	}
+	h := NewCaseHandler(client)
+	r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(reqBody)))
+	r.SetPathValue("id", testCaseID)
+	w := httptest.NewRecorder()
+	h.PatchCase(w, r)
+
+	assertStatus(t, w, http.StatusOK)
+	assertContentType(t, w, "application/json")
+
+	if string(capturedBody) != reqBody {
+		t.Errorf("upstream received body %s, want %s (must forward verbatim)", capturedBody, reqBody)
+	}
+
+	var wrapper struct {
+		Case struct {
+			WorstCaseFixEta string `json:"worstCaseFixEta"`
+		} `json:"case"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
+		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
+	}
+	if wrapper.Case.WorstCaseFixEta != "2026-08-01T00:00:00Z" {
+		t.Errorf("case.worstCaseFixEta = %q, want %q", wrapper.Case.WorstCaseFixEta, "2026-08-01T00:00:00Z")
+	}
+}
+
+func TestGetCasePassesThroughNewFixEtaFields(t *testing.T) {
+	// bestCaseFixEta, mostLikelyFixEta, and worstCaseFixEta are additive
+	// entity-response fields with zero BFF handling — GetCase's injectNextStates
+	// merge must not drop or alter them, matching the existing fixEta coverage.
+	const testCaseID = "11111111-1111-1111-1111-111111111111"
+	const upstreamBody = `{
+		"id":"` + testCaseID + `",
+		"state":"open",
+		"bestCaseFixEta":"2026-07-28T00:00:00Z",
+		"mostLikelyFixEta":"2026-08-01T00:00:00Z",
+		"worstCaseFixEta":"2026-08-15T00:00:00Z"
+	}`
+	client := &mockEntityCaseClient{
+		getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte(upstreamBody), nil
+		},
+	}
+	h := NewCaseHandler(client)
+	r := withUser(httptest.NewRequest(http.MethodGet, "/cases/"+testCaseID, nil))
+	r.SetPathValue("id", testCaseID)
+	w := httptest.NewRecorder()
+	h.GetCase(w, r)
+
+	assertStatus(t, w, http.StatusOK)
+
+	type resp struct {
+		BestCaseFixEta   string `json:"bestCaseFixEta"`
+		MostLikelyFixEta string `json:"mostLikelyFixEta"`
+		WorstCaseFixEta  string `json:"worstCaseFixEta"`
+	}
+	got := decodeJSON[resp](t, w)
+
+	if got.BestCaseFixEta != "2026-07-28T00:00:00Z" {
+		t.Errorf("bestCaseFixEta = %q, want 2026-07-28T00:00:00Z", got.BestCaseFixEta)
+	}
+	if got.MostLikelyFixEta != "2026-08-01T00:00:00Z" {
+		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01T00:00:00Z", got.MostLikelyFixEta)
+	}
+	if got.WorstCaseFixEta != "2026-08-15T00:00:00Z" {
+		t.Errorf("worstCaseFixEta = %q, want 2026-08-15T00:00:00Z", got.WorstCaseFixEta)
+	}
+}
+
+func TestSearchCasesPassesThroughNewFixEtaFields(t *testing.T) {
+	// Item: the 3 new fix-ETA fields flow through SearchCases's response verbatim,
+	// same zero-BFF-handling pattern as fixEta/tags on GetCase.
+	const upstream = `{"cases":[{"id":"11111111-1111-1111-1111-111111111111","bestCaseFixEta":"2026-07-28T00:00:00Z","mostLikelyFixEta":"2026-08-01T00:00:00Z","worstCaseFixEta":"2026-08-15T00:00:00Z"}],"total":1}`
+	client := &mockEntityCaseClient{
+		searchCasesFn: func(_ context.Context, _ []byte) ([]byte, error) {
+			return []byte(upstream), nil
+		},
+	}
+	h := NewCaseHandler(client)
+	r := withUser(httptest.NewRequest(http.MethodPost, "/cases/search", strings.NewReader(`{}`)))
+	w := httptest.NewRecorder()
+	h.SearchCases(w, r)
+
+	assertStatus(t, w, http.StatusOK)
+
+	type resp struct {
+		Cases []struct {
+			BestCaseFixEta   string `json:"bestCaseFixEta"`
+			MostLikelyFixEta string `json:"mostLikelyFixEta"`
+			WorstCaseFixEta  string `json:"worstCaseFixEta"`
+		} `json:"cases"`
+	}
+	got := decodeJSON[resp](t, w)
+	if len(got.Cases) != 1 {
+		t.Fatalf("cases = %+v, want 1 entry", got.Cases)
+	}
+	if got.Cases[0].BestCaseFixEta != "2026-07-28T00:00:00Z" {
+		t.Errorf("bestCaseFixEta = %q, want 2026-07-28T00:00:00Z", got.Cases[0].BestCaseFixEta)
+	}
+	if got.Cases[0].MostLikelyFixEta != "2026-08-01T00:00:00Z" {
+		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01T00:00:00Z", got.Cases[0].MostLikelyFixEta)
+	}
+	if got.Cases[0].WorstCaseFixEta != "2026-08-15T00:00:00Z" {
+		t.Errorf("worstCaseFixEta = %q, want 2026-08-15T00:00:00Z", got.Cases[0].WorstCaseFixEta)
+	}
+}
+
+func TestSearchTags(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=10", nil)
+		w := httptest.NewRecorder()
+		h.SearchTags(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects a non-numeric limit", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=abc", nil))
+		w := httptest.NewRecorder()
+		h.SearchTags(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards q and limit verbatim, returns 200 with matching tags", func(t *testing.T) {
+		var capturedQuery string
+		var capturedLimit int
+		client := &mockEntityCaseClient{
+			searchTagsFn: func(_ context.Context, query string, limit int) ([]byte, error) {
+				capturedQuery = query
+				capturedLimit = limit
+				return []byte(`[{"id":"22222222-2222-2222-2222-222222222222","label":"micro-gw","color":null}]`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=10", nil))
+		w := httptest.NewRecorder()
+		h.SearchTags(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedQuery != "micro" {
+			t.Errorf("upstream received q %q, want %q", capturedQuery, "micro")
+		}
+		if capturedLimit != 10 {
+			t.Errorf("upstream received limit %d, want %d", capturedLimit, 10)
+		}
+
+		var tags []struct {
+			ID    string  `json:"id"`
+			Label string  `json:"label"`
+			Color *string `json:"color"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &tags); err != nil {
+			t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
+		}
+		if len(tags) != 1 || tags[0].Label != "micro-gw" {
+			t.Errorf("tags = %+v, want a single micro-gw entry", tags)
+		}
+	})
+
+	t.Run("works with no query parameters", func(t *testing.T) {
+		var capturedQuery string
+		var capturedLimit int
+		var called bool
+		client := &mockEntityCaseClient{
+			searchTagsFn: func(_ context.Context, query string, limit int) ([]byte, error) {
+				called = true
+				capturedQuery = query
+				capturedLimit = limit
+				return []byte(`[]`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search", nil))
+		w := httptest.NewRecorder()
+		h.SearchTags(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		if !called {
+			t.Fatal("expected entity SearchTags to be called")
+		}
+		if capturedQuery != "" {
+			t.Errorf("upstream received q %q, want empty", capturedQuery)
+		}
+		if capturedLimit != 0 {
+			t.Errorf("upstream received limit %d, want 0", capturedLimit)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to search tags.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					searchTagsFn: func(_ context.Context, _ string, _ int) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro", nil))
+				w := httptest.NewRecorder()
+				h.SearchTags(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -228,7 +228,7 @@ func (m *mockEntityCaseClient) SearchTags(ctx context.Context, query string, lim
 	if m.searchTagsFn != nil {
 		return m.searchTagsFn(ctx, query, limit)
 	}
-	return []byte(`[]`), nil
+	return []byte(`{"tags":[]}`), nil
 }
 
 // ----- mock updates client -----

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -102,6 +102,7 @@ type mockEntityCaseClient struct {
 	createCaseGithubIssueFn    func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	addCaseTagFn               func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	removeCaseTagFn            func(ctx context.Context, caseID, tagID string) ([]byte, error)
+	searchTagsFn               func(ctx context.Context, query string, limit int) ([]byte, error)
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {
@@ -221,6 +222,13 @@ func (m *mockEntityCaseClient) RemoveCaseTag(ctx context.Context, caseID, tagID 
 		return m.removeCaseTagFn(ctx, caseID, tagID)
 	}
 	return nil, nil
+}
+
+func (m *mockEntityCaseClient) SearchTags(ctx context.Context, query string, limit int) ([]byte, error) {
+	if m.searchTagsFn != nil {
+		return m.searchTagsFn(ctx, query, limit)
+	}
+	return []byte(`[]`), nil
 }
 
 // ----- mock updates client -----

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -130,7 +130,8 @@ paths:
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
         `workState`, `watchList`, `assigneeEmail`, `parentId`, `subject`, `description`,
-        `deploymentId`, `deployedProductId`, `relatedCaseId`, `autocloseHoldUntil`, or `fixEta`.
+        `deploymentId`, `deployedProductId`, `relatedCaseId`, `autocloseHoldUntil`, `fixEta`,
+        `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`.
         `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are supported only when
         the ServiceNow data source is active.
       operationId: patchCasesId
@@ -2244,6 +2245,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /tags/search:
+    get:
+      summary: Search existing free-text tags by label (ServiceNow data source only).
+      description: >
+        Forwards the q and limit query parameters to the integration service as-is and
+        returns the matching tags.
+      operationId: searchTags
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Free-text search query matched against tag labels.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of tags to return.
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Matching tags.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Tag'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /change-requests/{id}:
     patch:
       summary: Update a change request (ServiceNow data source only).
@@ -4303,8 +4360,9 @@ components:
       description: |
         Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`, `parentId`,
         `subject`, `description`, `deploymentId`, `deployedProductId`, `relatedCaseId`,
-        `autocloseHoldUntil`, or `fixEta` must be provided. `watchList`, `assigneeEmail`,
-        `parentId`, and `autocloseHoldUntil` are supported only for the ServiceNow data source.
+        `autocloseHoldUntil`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`
+        must be provided. `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are
+        supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional resolution fields that may only be
         provided alongside `state: closed` or `state: solution_proposed`.
       oneOf:
@@ -4321,6 +4379,9 @@ components:
         - required: [relatedCaseId]
         - required: [autocloseHoldUntil]
         - required: [fixEta]
+        - required: [bestCaseFixEta]
+        - required: [mostLikelyFixEta]
+        - required: [worstCaseFixEta]
       properties:
         state:
           type: string
@@ -4401,6 +4462,21 @@ components:
           description: >
             Sets the customer-facing fix-commitment date/time for the case. This is the only
             fix-ETA field exposed by this API; internal-only estimates are not surfaced.
+        bestCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: Sets the best-case fix-commitment date/time estimate for the case.
+        mostLikelyFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: Sets the most-likely fix-commitment date/time estimate for the case.
+        worstCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: Sets the worst-case fix-commitment date/time estimate for the case.
 
     UpdateCaseResponse:
       type: object
@@ -5120,6 +5196,21 @@ components:
           description: >-
             The single customer-facing fix-commitment date/time for the case. This is the
             only fix-ETA field exposed by this API; internal-only estimates are not surfaced.
+        bestCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: Best-case fix-commitment date/time estimate for the case.
+        mostLikelyFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: Most-likely fix-commitment date/time estimate for the case.
+        worstCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: Worst-case fix-commitment date/time estimate for the case.
         tags:
           type: array
           nullable: true

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2273,9 +2273,13 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Tag'
+                type: object
+                required: [tags]
+                properties:
+                  tags:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Tag'
         "400":
           description: Bad request.
           content:

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -326,11 +326,27 @@ export interface BeCaseView {
    */
   autoclosureStateTime?: string | null;
   /**
-   * The single customer-facing fix-commitment date/time for the case. This is
-   * the only fix-ETA field exposed by this API; internal-only estimates are
-   * not surfaced. Settable via `PATCH /cases/{id}` (`fixEta`).
+   * The customer-facing fix-commitment date/time for the case — the shared
+   * commitment shown to the customer. Settable via `PATCH /cases/{id}`
+   * (`fixEta`). Distinct from the three internal-only estimates below, which
+   * are never shared with the customer.
    */
   fixEta?: string | null;
+  /**
+   * Internal-only best-case fix estimate. Settable via `PATCH /cases/{id}`
+   * (`bestCaseFixEta`). Never surfaced to the customer.
+   */
+  bestCaseFixEta?: string | null;
+  /**
+   * Internal-only most-likely fix estimate. Settable via `PATCH /cases/{id}`
+   * (`mostLikelyFixEta`). Never surfaced to the customer.
+   */
+  mostLikelyFixEta?: string | null;
+  /**
+   * Internal-only worst-case fix estimate. Settable via `PATCH /cases/{id}`
+   * (`worstCaseFixEta`). Never surfaced to the customer.
+   */
+  worstCaseFixEta?: string | null;
   /** Free-text labels attached to the case. Null/absent when none are set. */
   tags?: BeTag[] | null;
 }
@@ -346,6 +362,12 @@ export interface BeTag {
 /** `POST /cases/{id}/tags` request body. */
 export interface BeAddCaseTagPayload {
   label: string;
+}
+
+/** `GET /tags/search?q=&limit=` response: existing free-text tag labels matching the query. */
+export interface BeSearchTagsResponse {
+  tags?: BeTag[];
+  total?: number;
 }
 
 export interface BeCaseCreatePayload {
@@ -512,20 +534,25 @@ interface BeCaseUpdateNever {
   relatedCaseId?: never;
   autocloseHoldUntil?: never;
   fixEta?: never;
+  bestCaseFixEta?: never;
+  mostLikelyFixEta?: never;
+  worstCaseFixEta?: never;
 }
 
 /**
  * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
  * **Exactly one** of `state` / `severity` / `workState` / `assigneeEmail` /
  * `watchList` / `parentId` / `subject` / `description` / `deploymentId` /
- * `deployedProductId` / `relatedCaseId` / `autocloseHoldUntil` / `fixEta` is
- * sent per call — the backend rejects zero or more than one. Encoded as a
- * discriminated union (each variant carries every other field as `never`,
- * via {@link BeCaseUpdateNever}) so the exactly-one-field contract is
- * enforced at compile time, not just in docs. `assigneeEmail`, `watchList`,
- * `parentId`, and `autocloseHoldUntil` are supported **only** for the
- * ServiceNow data source. `workState` is only accepted while the case is
- * `work_in_progress`.
+ * `deployedProductId` / `relatedCaseId` / `autocloseHoldUntil` / `fixEta` /
+ * `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` is sent per call —
+ * the backend rejects zero or more than one. Encoded as a discriminated union
+ * (each variant carries every other field as `never`, via
+ * {@link BeCaseUpdateNever}) so the exactly-one-field contract is enforced at
+ * compile time, not just in docs. `assigneeEmail`, `watchList`, `parentId`,
+ * and `autocloseHoldUntil` are supported **only** for the ServiceNow data
+ * source. `workState` is only accepted while the case is `work_in_progress`.
+ * `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` are internal-only
+ * estimates, independent of the customer-facing `fixEta`.
  */
 export type BeCaseUpdatePayload =
   | (Omit<BeCaseUpdateNever, "state"> & {
@@ -566,9 +593,15 @@ export type BeCaseUpdatePayload =
   | (Omit<BeCaseUpdateNever, "autocloseHoldUntil"> & { autocloseHoldUntil: string })
   /**
    * Sets the customer-facing fix-commitment date/time for the case (ISO
-   * date-time). The only fix-ETA field this API exposes.
+   * date-time).
    */
-  | (Omit<BeCaseUpdateNever, "fixEta"> & { fixEta: string });
+  | (Omit<BeCaseUpdateNever, "fixEta"> & { fixEta: string })
+  /** Sets the internal-only best-case fix estimate (ISO date-time). */
+  | (Omit<BeCaseUpdateNever, "bestCaseFixEta"> & { bestCaseFixEta: string })
+  /** Sets the internal-only most-likely fix estimate (ISO date-time). */
+  | (Omit<BeCaseUpdateNever, "mostLikelyFixEta"> & { mostLikelyFixEta: string })
+  /** Sets the internal-only worst-case fix estimate (ISO date-time). */
+  | (Omit<BeCaseUpdateNever, "worstCaseFixEta"> & { worstCaseFixEta: string });
 
 /** A user in the case watch list, as echoed by `PATCH /cases/{id}`. */
 export interface BeWatchListUser {
@@ -592,6 +625,12 @@ export interface BeUpdatedCase {
   parentCase?: BeCaseNumberRef | null;
   /** Echoes the updated customer-facing fix-commitment date/time. Present when the update set `fixEta`. */
   fixEta?: string | null;
+  /** Echoes the updated internal-only best-case fix estimate. Present when the update set `bestCaseFixEta`. */
+  bestCaseFixEta?: string | null;
+  /** Echoes the updated internal-only most-likely fix estimate. Present when the update set `mostLikelyFixEta`. */
+  mostLikelyFixEta?: string | null;
+  /** Echoes the updated internal-only worst-case fix estimate. Present when the update set `worstCaseFixEta`. */
+  worstCaseFixEta?: string | null;
 }
 
 /** `PATCH /cases/{id}` response: a message plus the mutated case fields. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -135,6 +135,9 @@ function detailFromBeCase(
     attachments: [],
     isWatching: watchers.some((w) => w.isMe),
     fixEta: c.fixEta ?? null,
+    bestCaseFixEta: c.bestCaseFixEta ?? null,
+    mostLikelyFixEta: c.mostLikelyFixEta ?? null,
+    worstCaseFixEta: c.worstCaseFixEta ?? null,
     resolution:
       c.resolutionCode || c.cause || c.resolutionNotes
         ? {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchTags.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchTags.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  keepPreviousData,
+  useQuery,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useBackendApi } from "@api/backend/client";
+import type { BeSearchTagsResponse, BeTag } from "@api/backend/types";
+
+/** Cap on how many matching tags a search returns — this is a type-ahead list, not a paged browse. */
+const TAG_SEARCH_LIMIT = 20;
+
+/**
+ * Searches existing free-text tag labels via `GET /tags/search?q=&limit=`, for
+ * the {@link AddTagDialog} type-ahead. Tags are genuinely free-text on the
+ * backing data source (SN's generic label mechanism) — this only offers
+ * already-used labels as suggestions; the dialog still allows creating a
+ * label with no match. Runs even for an empty query (lists recently/commonly
+ * used tags) while `enabled` — callers gate that on the dialog being open.
+ */
+export function useSearchTags(
+  query: string,
+  enabled: boolean,
+): UseQueryResult<BeTag[], Error> {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<BeTag[], Error>({
+    queryKey: ["csm-tags-search", q],
+    queryFn: async (): Promise<BeTag[]> => {
+      const params = new URLSearchParams();
+      if (q) params.set("q", q);
+      params.set("limit", String(TAG_SEARCH_LIMIT));
+      const res = await api.get<BeSearchTagsResponse>(
+        `/tags/search?${params.toString()}`,
+      );
+      return res?.tags ?? [];
+    },
+    enabled,
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.test.tsx
@@ -15,11 +15,34 @@
 // under the License.
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import AddTagDialog from "@features/csm-cases/components/AddTagDialog";
+import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
 
-describe("AddTagDialog — free-text tag creation", () => {
+vi.mock("@features/csm-cases/api/useSearchTags", () => ({
+  useSearchTags: vi.fn(),
+}));
+
+const mockedUseSearchTags = vi.mocked(useSearchTags);
+
+function mockSearchResult(
+  overrides: Partial<ReturnType<typeof useSearchTags>>,
+): void {
+  mockedUseSearchTags.mockReturnValue({
+    data: [],
+    isFetching: false,
+    isError: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSearchTags>);
+}
+
+describe("AddTagDialog — search-and-select-or-create tag entry", () => {
+  beforeEach(() => {
+    mockedUseSearchTags.mockReset();
+    mockSearchResult({});
+  });
+
   it("disables Add tag until a label is typed", () => {
     render(
       <AddTagDialog
@@ -32,7 +55,7 @@ describe("AddTagDialog — free-text tag creation", () => {
     expect(screen.getByRole("button", { name: /add tag/i })).toBeDisabled();
   });
 
-  it("submits the trimmed label typed into the free-text field", () => {
+  it("submits the trimmed label typed into the field", () => {
     const onSave = vi.fn();
     render(
       <AddTagDialog
@@ -81,6 +104,30 @@ describe("AddTagDialog — free-text tag creation", () => {
     expect(screen.getByRole("button", { name: /add tag/i })).toBeDisabled();
     expect(screen.getByText(/already has that tag/i)).toBeInTheDocument();
     expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("offers matching existing tags as suggestions, excluding ones already on the case", () => {
+    mockSearchResult({
+      data: [
+        { id: "t1", label: "micro-gw" },
+        { id: "t2", label: "micro-gw-2" },
+        { id: "t3", label: "ws-policy" },
+      ],
+    });
+    render(
+      <AddTagDialog
+        existingLabels={["ws-policy"]}
+        isSaving={false}
+        onClose={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/^tag$/i), {
+      target: { value: "micro" },
+    });
+    expect(screen.getByText("micro-gw")).toBeInTheDocument();
+    expect(screen.getByText("micro-gw-2")).toBeInTheDocument();
+    expect(screen.queryByText("ws-policy")).not.toBeInTheDocument();
   });
 
   it("calls onClose on Cancel without calling onSave", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.tsx
@@ -25,7 +25,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useMemo, useState, type JSX } from "react";
+import { useMemo, useState, type JSX, type KeyboardEvent } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
 
@@ -124,7 +124,7 @@ export default function AddTagDialog({
                   // they fire for the same DOM keydown here — cast rather
                   // than drop the call, so listbox keyboard nav still works.
                   params.inputProps.onKeyDown?.(
-                    e as unknown as React.KeyboardEvent<HTMLInputElement>,
+                    e as unknown as KeyboardEvent<HTMLInputElement>,
                   );
                   if (e.key === "Enter" && !e.defaultPrevented) {
                     e.preventDefault();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.tsx
@@ -15,6 +15,7 @@
 // under the License.
 
 import {
+  Autocomplete,
   Box,
   Button,
   Dialog,
@@ -24,9 +25,12 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useState, type JSX } from "react";
+import { useMemo, useState, type JSX } from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
 
 const MAX_TAG_LABEL_LEN = 100;
+const TAG_SEARCH_DEBOUNCE_MS = 300;
 
 interface AddTagDialogProps {
   /** Tags already on the case, so a duplicate label can't be submitted twice. */
@@ -37,11 +41,13 @@ interface AddTagDialogProps {
 }
 
 /**
- * Add a free-text tag to a case (`POST /cases/{id}/tags`). Tags are genuinely
- * free-text on the backing data source (SN's generic label mechanism, e.g.
- * `micro-gw`, `ws-policy`) — a plain text field, not a picker constrained to a
- * closed enum. ServiceNow-source only; the caller surfaces a rejection on
- * another source.
+ * Add a tag to a case (`POST /cases/{id}/tags`). Tags are genuinely free-text
+ * on the backing data source (SN's generic label mechanism, e.g. `micro-gw`,
+ * `ws-policy`) — this is a search-and-select-or-create combobox, not a picker
+ * constrained to a closed enum: it searches existing labels via
+ * `GET /tags/search` as the user types (debounced), and still lets them type a
+ * label with no match to create a genuinely new tag. ServiceNow-source only;
+ * the caller surfaces a rejection on another source.
  */
 export default function AddTagDialog({
   existingLabels,
@@ -50,11 +56,24 @@ export default function AddTagDialog({
   onSave,
 }: AddTagDialogProps): JSX.Element {
   const [label, setLabel] = useState("");
+  const debouncedLabel = useDebouncedValue(label, TAG_SEARCH_DEBOUNCE_MS);
+  const query = debouncedLabel.trim();
+  const { data: matches, isFetching, isError } = useSearchTags(query, true);
+
   const trimmed = label.trim();
   const isDuplicate = existingLabels.some(
     (l) => l.toLowerCase() === trimmed.toLowerCase(),
   );
   const canSubmit = trimmed.length > 0 && !isDuplicate;
+
+  // Suggestions from the search, minus labels already on this case (those
+  // would just be rejected as a duplicate anyway).
+  const options = useMemo(() => {
+    const existing = new Set(existingLabels.map((l) => l.toLowerCase()));
+    return (matches ?? [])
+      .map((t) => t.label)
+      .filter((l) => !existing.has(l.toLowerCase()));
+  }, [matches, existingLabels]);
 
   const handleSubmit = (): void => {
     if (!canSubmit) return;
@@ -66,28 +85,58 @@ export default function AddTagDialog({
       <DialogTitle>Add tag</DialogTitle>
       <DialogContent dividers>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-          <TextField
-            label="Tag"
-            placeholder="e.g. micro-gw, ws-policy"
+          <Autocomplete<string, false, false, true>
+            freeSolo
             size="small"
             fullWidth
-            autoFocus
-            value={label}
-            onChange={(e) => setLabel(e.target.value.slice(0, MAX_TAG_LABEL_LEN))}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleSubmit();
+            options={options}
+            inputValue={label}
+            loading={isFetching}
+            disabled={isSaving}
+            onInputChange={(_event, value, reason) => {
+              if (reason === "input" || reason === "reset" || reason === "clear") {
+                setLabel(value.slice(0, MAX_TAG_LABEL_LEN));
               }
             }}
-            disabled={isSaving}
-            error={isDuplicate}
-            helperText={
-              isDuplicate ? "This case already has that tag." : undefined
+            noOptionsText={
+              isError
+                ? "Couldn't search existing tags — you can still type a new one."
+                : query
+                  ? "No matching tags — press Enter to create it."
+                  : "Type to search existing tags…"
             }
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Tag"
+                placeholder="e.g. micro-gw, ws-policy"
+                autoFocus
+                error={isDuplicate}
+                helperText={
+                  isDuplicate ? "This case already has that tag." : undefined
+                }
+                onKeyDown={(e) => {
+                  // `params.inputProps.onKeyDown` is the built-in listbox
+                  // navigation handler (arrow keys / Enter-to-select) that
+                  // Autocomplete wires onto the underlying <input>. MUI types
+                  // this TextField's `onKeyDown` against the root div and
+                  // `inputProps.onKeyDown` against the input element, but
+                  // they fire for the same DOM keydown here — cast rather
+                  // than drop the call, so listbox keyboard nav still works.
+                  params.inputProps.onKeyDown?.(
+                    e as unknown as React.KeyboardEvent<HTMLInputElement>,
+                  );
+                  if (e.key === "Enter" && !e.defaultPrevented) {
+                    e.preventDefault();
+                    handleSubmit();
+                  }
+                }}
+              />
+            )}
           />
           <Typography variant="caption" color="text.secondary">
-            Tags are free-text — type any label, there's no fixed list.
+            Search existing tags or type a new label — tags are free-text,
+            there's no fixed list.
           </Typography>
         </Box>
       </DialogContent>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -17,12 +17,20 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { TagsWidget } from "@features/csm-cases/components/CaseDetailWidgets";
-import type { CaseTag } from "@features/csm-cases/types/csmCases";
+import {
+  TagsWidget,
+  WatchersWidget,
+} from "@features/csm-cases/components/CaseDetailWidgets";
+import type { CaseTag, CaseWatcher } from "@features/csm-cases/types/csmCases";
 
 const TAGS: CaseTag[] = [
   { id: "tag-1", label: "micro-gw" },
   { id: "tag-2", label: "ws-policy" },
+];
+
+const WATCHERS: CaseWatcher[] = [
+  { id: "w-1", name: "Jane Doe" },
+  { id: "w-2", name: "John Smith", isMe: true },
 ];
 
 describe("TagsWidget", () => {
@@ -58,5 +66,29 @@ describe("TagsWidget", () => {
     render(<TagsWidget tags={TAGS} />);
     const chip = screen.getByText("micro-gw").closest(".MuiChip-root");
     expect(chip?.querySelector(".MuiChip-deleteIcon")).toBeFalsy();
+  });
+});
+
+describe("WatchersWidget", () => {
+  it("renders an empty state when there are no watchers", () => {
+    render(<WatchersWidget watchers={[]} />);
+    expect(
+      screen.getByText("No one is watching this case."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders every watcher as a chip, marking the current user", () => {
+    render(<WatchersWidget watchers={WATCHERS} />);
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("John Smith (you)")).toBeInTheDocument();
+  });
+
+  it("calls onManage when the Manage watchers button is clicked", () => {
+    const onManage = vi.fn();
+    render(<WatchersWidget watchers={WATCHERS} onManage={onManage} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /manage watchers/i }),
+    );
+    expect(onManage).toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -91,4 +91,11 @@ describe("WatchersWidget", () => {
     );
     expect(onManage).toHaveBeenCalled();
   });
+
+  it("hides the Manage watchers action when onManage is omitted", () => {
+    render(<WatchersWidget watchers={WATCHERS} />);
+    expect(
+      screen.queryByRole("button", { name: /manage watchers/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -364,9 +364,11 @@ export function WatchersWidget({
       title="Watchers"
       icon={<Users size={16} />}
       action={
-        <Button size="small" variant="text" onClick={onManage}>
-          Manage watchers
-        </Button>
+        onManage ? (
+          <Button size="small" variant="text" onClick={onManage}>
+            Manage watchers
+          </Button>
+        ) : undefined
       }
     >
       {watchers.length === 0 ? (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -54,6 +54,7 @@ import type {
   CaseProductContext,
   CaseTag,
   CaseTimeLogEntry,
+  CaseWatcher,
 } from "@features/csm-cases/types/csmCases";
 import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import {
@@ -338,6 +339,49 @@ export function TagsWidget({
               variant="outlined"
               onDelete={onRemove ? () => onRemove(t) : undefined}
               disabled={removingId === t.id}
+            />
+          ))}
+        </Box>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3b. Watchers
+// ---------------------------------------------------------------------------
+
+export function WatchersWidget({
+  watchers,
+  onManage,
+}: {
+  watchers: CaseWatcher[];
+  /** Opens the "Manage watchers" dialog (`WatchersDialog`). Omit to hide the action. */
+  onManage?: () => void;
+}): JSX.Element {
+  return (
+    <WidgetCard
+      title="Watchers"
+      icon={<Users size={16} />}
+      action={
+        <Button size="small" variant="text" onClick={onManage}>
+          Manage watchers
+        </Button>
+      }
+    >
+      {watchers.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No one is watching this case.
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+          {watchers.map((w) => (
+            <Chip
+              key={w.id}
+              size="small"
+              variant="outlined"
+              icon={<User size={14} />}
+              label={w.isMe ? `${w.name} (you)` : w.name}
             />
           ))}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -291,15 +291,6 @@ export default function CaseMetaBand({
               </Typography>
             </Cell>
           )}
-          {!isAnnouncement && (
-            <Cell label="Watchers">
-              <Typography variant="body2" noWrap>
-                {c.watchers.length > 0
-                  ? c.watchers.map((w) => w.name).join(", ")
-                  : "None"}
-              </Typography>
-            </Cell>
-          )}
           <Cell label="Project" maxWidth={isAnnouncement ? 240 : undefined}>
             {c.projectId ? (
               <LinkText to={`/customers/projects/${c.projectId}`}>
@@ -359,12 +350,32 @@ export default function CaseMetaBand({
                   )}
                 </Typography>
               </Cell>
-              {c.fixEta && (
-                <Cell label="Fix ETA">
-                  <Typography variant="body2" noWrap>
-                    {formatAbsoluteForUser(c.fixEta) ?? "—"}
-                  </Typography>
-                </Cell>
+              {(c.fixEta ||
+                c.bestCaseFixEta ||
+                c.mostLikelyFixEta ||
+                c.worstCaseFixEta) && (
+                <>
+                  <Cell label="Fix ETA">
+                    <Typography variant="body2" noWrap>
+                      {formatAbsoluteForUser(c.fixEta) ?? "—"}
+                    </Typography>
+                  </Cell>
+                  <Cell label="Best case fix ETA">
+                    <Typography variant="body2" noWrap>
+                      {formatAbsoluteForUser(c.bestCaseFixEta) ?? "—"}
+                    </Typography>
+                  </Cell>
+                  <Cell label="Most likely fix ETA">
+                    <Typography variant="body2" noWrap>
+                      {formatAbsoluteForUser(c.mostLikelyFixEta) ?? "—"}
+                    </Typography>
+                  </Cell>
+                  <Cell label="Worst case fix ETA">
+                    <Typography variant="body2" noWrap>
+                      {formatAbsoluteForUser(c.worstCaseFixEta) ?? "—"}
+                    </Typography>
+                  </Cell>
+                </>
               )}
             </>
           )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.test.tsx
@@ -19,27 +19,34 @@ import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import SetFixEtaDialog from "@features/csm-cases/components/SetFixEtaDialog";
 
-describe("SetFixEtaDialog — submission gating", () => {
-  it("disables Save until a date/time is picked", () => {
+describe("SetFixEtaDialog — four independent fields", () => {
+  it("renders one Save button per field, each disabled until a date/time is picked", () => {
     render(
       <SetFixEtaDialog isSaving={false} onClose={() => {}} onSave={() => {}} />,
     );
-    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+    const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
+    expect(saveButtons).toHaveLength(4);
+    saveButtons.forEach((btn) => expect(btn).toBeDisabled());
   });
 
-  it("seeds the picker from currentFixEta and enables Save immediately", () => {
+  it("seeds each field from its current value and enables that field's Save immediately", () => {
     render(
       <SetFixEtaDialog
         currentFixEta="2099-06-15T10:30:00.000Z"
+        currentBestCaseFixEta="2099-06-16T10:30:00.000Z"
+        currentMostLikelyFixEta="2099-06-17T10:30:00.000Z"
+        currentWorstCaseFixEta="2099-06-18T10:30:00.000Z"
         isSaving={false}
         onClose={() => {}}
         onSave={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: /^save$/i })).toBeEnabled();
+    const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
+    expect(saveButtons).toHaveLength(4);
+    saveButtons.forEach((btn) => expect(btn).toBeEnabled());
   });
 
-  it("calls onSave with a UTC ISO string once a pre-seeded value is submitted", () => {
+  it("saves only the fixEta field with a UTC ISO string, independent of the other three", () => {
     const onSave = vi.fn();
     render(
       <SetFixEtaDialog
@@ -49,20 +56,25 @@ describe("SetFixEtaDialog — submission gating", () => {
         onSave={onSave}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
+    // The fixEta row is the only one seeded, so it's the only enabled Save.
+    const enabled = saveButtons.filter((btn) => !btn.hasAttribute("disabled"));
+    expect(enabled).toHaveLength(1);
+    fireEvent.click(enabled[0]);
     expect(onSave).toHaveBeenCalledTimes(1);
-    const arg = onSave.mock.calls[0][0] as string;
+    const [field, arg] = onSave.mock.calls[0] as [string, string];
+    expect(field).toBe("fixEta");
     expect(() => new Date(arg).toISOString()).not.toThrow();
     expect(new Date(arg).getUTCFullYear()).toBe(2099);
   });
 
-  it("calls onClose on Cancel without calling onSave", () => {
+  it("calls onClose on Close without calling onSave", () => {
     const onSave = vi.fn();
     const onClose = vi.fn();
     render(
       <SetFixEtaDialog isSaving={false} onClose={onClose} onSave={onSave} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
     expect(onClose).toHaveBeenCalled();
     expect(onSave).not.toHaveBeenCalled();
   });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.tsx
@@ -23,6 +23,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   Typography,
 } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
@@ -35,91 +36,181 @@ import {
 
 const { DateTimePicker, LocalizationProvider } = DatePickers;
 
+/** One of the four independent fix-ETA fields this dialog can set. */
+export type FixEtaField =
+  | "fixEta"
+  | "bestCaseFixEta"
+  | "mostLikelyFixEta"
+  | "worstCaseFixEta";
+
 interface SetFixEtaDialogProps {
-  /** Current fix-ETA, if any (ISO), shown as the picker's initial value. */
+  /** Current customer-facing fix-commitment date/time, if any (ISO). */
   currentFixEta?: string | null;
-  /** True while a PATCH is in flight; disables the actions. */
+  /** Current internal-only best-case estimate, if any (ISO). */
+  currentBestCaseFixEta?: string | null;
+  /** Current internal-only most-likely estimate, if any (ISO). */
+  currentMostLikelyFixEta?: string | null;
+  /** Current internal-only worst-case estimate, if any (ISO). */
+  currentWorstCaseFixEta?: string | null;
+  /** True while any of the four PATCHes is in flight; disables every field's Save. */
   isSaving: boolean;
   onClose: () => void;
-  /** Apply the new fix-ETA (`PATCH { fixEta }`), as a UTC ISO string. */
-  onSave: (fixEtaIso: string) => void;
+  /** Apply one field's new value (`PATCH { [field]: valueIso }`), as a UTC ISO string. */
+  onSave: (field: FixEtaField, valueIso: string) => void;
+}
+
+const FIELD_LABEL: Record<FixEtaField, string> = {
+  fixEta: "Fix ETA",
+  bestCaseFixEta: "Best case",
+  mostLikelyFixEta: "Most likely",
+  worstCaseFixEta: "Worst case",
+};
+
+interface FixEtaFieldRowProps {
+  field: FixEtaField;
+  currentValue?: string | null;
+  timeZone: string;
+  isSaving: boolean;
+  onSave: (field: FixEtaField, valueIso: string) => void;
 }
 
 /**
- * Set the case's single customer-facing fix-commitment date/time
- * (`fixEta` on `PATCH /cases/{id}`). Single-value date/time shape, modeled on
- * {@link SetAutocloseHoldDialog} but with a date **and** time component (like
- * {@link ScheduleCallDialog}'s custom-time picker) since a fix commitment is
- * a specific moment, not an end-of-day date. ServiceNow-source only; the
- * caller surfaces a rejection on another source.
+ * One independently-saved date/time field. Each row owns its own draft value
+ * and Save action — the four fields are unrelated PATCH variants (see
+ * `BeCaseUpdatePayload`), so saving one never requires the others to be filled.
+ */
+function FixEtaFieldRow({
+  field,
+  currentValue,
+  timeZone,
+  isSaving,
+  onSave,
+}: FixEtaFieldRowProps): JSX.Element {
+  const [value, setValue] = useState<string>(
+    currentValue ? formatDateTimeLocal(new Date(currentValue)) : "",
+  );
+  const parsed = parseDateTimeLocal(value);
+  const canSubmit = !!parsed;
+
+  const handleSave = (): void => {
+    if (!canSubmit) return;
+    const iso = zonedInputToUtcIso(value, timeZone);
+    if (!iso) return;
+    onSave(field, iso);
+  };
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DateTimePicker
+          label={`${FIELD_LABEL[field]} (${timeZone})`}
+          value={parsed}
+          onChange={(next) =>
+            setValue(
+              next instanceof Date && !Number.isNaN(next.getTime())
+                ? formatDateTimeLocal(next)
+                : "",
+            )
+          }
+          disabled={isSaving}
+          slotProps={{
+            textField: { fullWidth: true, size: "small" },
+            field: { clearable: true },
+          }}
+        />
+      </LocalizationProvider>
+      <Button
+        variant="outlined"
+        size="small"
+        disabled={!canSubmit || isSaving}
+        loading={isSaving}
+        onClick={handleSave}
+        sx={{ flexShrink: 0, mt: 0.25 }}
+      >
+        Save
+      </Button>
+    </Box>
+  );
+}
+
+/**
+ * Set the case's four independent fix-ETA fields: the single customer-facing
+ * commitment (`fixEta` on `PATCH /cases/{id}`) plus three internal-only
+ * estimates (`bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta`) never
+ * shared with the customer. Each field is its own single-field PATCH variant
+ * (see `BeCaseUpdatePayload`), so every row saves independently — filling in
+ * one estimate never requires the others. ServiceNow-source only for
+ * `fixEta`; the caller surfaces a rejection on another source.
  */
 export default function SetFixEtaDialog({
   currentFixEta,
+  currentBestCaseFixEta,
+  currentMostLikelyFixEta,
+  currentWorstCaseFixEta,
   isSaving,
   onClose,
   onSave,
 }: SetFixEtaDialogProps): JSX.Element {
   const timeZone = resolveDisplayTimeZone();
-  const [value, setValue] = useState<string>(
-    currentFixEta ? formatDateTimeLocal(new Date(currentFixEta)) : "",
-  );
-
-  const parsed = parseDateTimeLocal(value);
-  const canSubmit = !!parsed;
-
-  const handleSubmit = (): void => {
-    if (!canSubmit) return;
-    const iso = zonedInputToUtcIso(value, timeZone);
-    if (!iso) return;
-    onSave(iso);
-  };
 
   return (
-    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Set fix ETA</DialogTitle>
       <DialogContent>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, pt: 0.5 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
           <Typography variant="body2" color="text.secondary">
-            Sets the customer-facing fix-commitment date/time for this case.
-            This is the only fix-ETA field the platform exposes — it is
-            distinct from the backend-computed SLA clocks shown on the SLAs
-            tab.
+            Each field below is saved independently — you don't need to fill
+            in every estimate to save one.
           </Typography>
-          <LocalizationProvider dateAdapter={AdapterDateFns}>
-            <DateTimePicker
-              label={`Fix ETA (${timeZone})`}
-              value={parsed}
-              onChange={(next) =>
-                setValue(
-                  next instanceof Date && !Number.isNaN(next.getTime())
-                    ? formatDateTimeLocal(next)
-                    : "",
-                )
-              }
-              disabled={isSaving}
-              slotProps={{
-                textField: {
-                  fullWidth: true,
-                  required: true,
-                  size: "small",
-                },
-                field: { clearable: true },
-              }}
+
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+            <Typography variant="caption" color="text.secondary">
+              Customer-facing fix-commitment date/time. Shared with the
+              customer — distinct from the backend-computed SLA clocks shown
+              on the SLAs tab.
+            </Typography>
+            <FixEtaFieldRow
+              field="fixEta"
+              currentValue={currentFixEta}
+              timeZone={timeZone}
+              isSaving={isSaving}
+              onSave={onSave}
             />
-          </LocalizationProvider>
+          </Box>
+
+          <Divider />
+
+          <Typography variant="subtitle2">Internal-only estimates</Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ mt: -1.5 }}>
+            Never shared with the customer.
+          </Typography>
+
+          <FixEtaFieldRow
+            field="bestCaseFixEta"
+            currentValue={currentBestCaseFixEta}
+            timeZone={timeZone}
+            isSaving={isSaving}
+            onSave={onSave}
+          />
+          <FixEtaFieldRow
+            field="mostLikelyFixEta"
+            currentValue={currentMostLikelyFixEta}
+            timeZone={timeZone}
+            isSaving={isSaving}
+            onSave={onSave}
+          />
+          <FixEtaFieldRow
+            field="worstCaseFixEta"
+            currentValue={currentWorstCaseFixEta}
+            timeZone={timeZone}
+            isSaving={isSaving}
+            onSave={onSave}
+          />
         </Box>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={isSaving}>
-          Cancel
-        </Button>
-        <Button
-          variant="contained"
-          disabled={!canSubmit || isSaving}
-          loading={isSaving}
-          onClick={handleSubmit}
-        >
-          Save
+          Close
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -124,6 +124,12 @@ import { usePostTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import {
+  isBlankHtml,
+  sanitizeDescriptionHtml,
+  stripLightModeInlineStyles,
+} from "@utils/sanitizeHtml";
+import { useDarkMode } from "@utils/useDarkMode";
+import {
   publicCommentGateReason,
   WORK_STATE_LABEL,
 } from "@features/csm-cases/utils/caseWorkState";
@@ -394,6 +400,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     claims?.email?.split("@")[0] ||
     "Unknown engineer";
   const { showError } = useErrorBanner();
+  const isDarkMode = useDarkMode();
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [activeTab, setActiveTab] = useState<CaseTabId>("activities");
   const [metaCollapsed, setMetaCollapsed] = useState(false);
@@ -1808,7 +1815,32 @@ export default function CsmCaseDetailPage(): JSX.Element {
               feed (see the note near `safeComments` above). Editing it is
               still available via the action bar's "Edit case details…" item
               (EditCaseDetailsDialog), which is the only place the description
-              is shown for editing. */}
+              is shown for editing.
+
+              Exception: if comments/search failed, safeComments is empty and
+              the description never renders anywhere — fall back to a
+              read-only card here so the description isn't invisible whenever
+              the activity feed is unavailable. */}
+          {isCommentsError && !isBlankHtml(c.description) && (
+            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <Typography variant="subtitle2">Description</Typography>
+              <Box
+                sx={{
+                  typography: "body2",
+                  color: "text.primary",
+                  "& p": { mb: 0.5 },
+                  "& p:last-child": { mb: 0 },
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeDescriptionHtml(
+                    isDarkMode
+                      ? stripLightModeInlineStyles(c.description)
+                      : c.description,
+                  ),
+                }}
+              />
+            </Card>
+          )}
           <CustomerContextWidget
             ctx={c.customerContext}
             project={caseProject}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -42,6 +42,7 @@ import {
   Paperclip,
   PauseCircle,
   Phone,
+  Users,
   X,
 } from "@wso2/oxygen-ui-icons-react";
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
@@ -107,6 +108,7 @@ import {
   CustomerContextWidget,
   ProductContextWidget,
   TagsWidget,
+  WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
 import { CallRequestsWidget } from "@features/csm-cases/components/CallRequestsWidget";
 import { useGetCsmCaseCallRequests } from "@features/csm-cases/api/useCsmCaseCallRequests";
@@ -120,9 +122,7 @@ import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCards
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import { usePostTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
-import { isBlankHtml, sanitizeDescriptionHtml, stripLightModeInlineStyles } from "@utils/sanitizeHtml";
 import { formatAbsoluteForUser } from "@utils/dateTime";
-import { useDarkMode } from "@utils/useDarkMode";
 import {
   publicCommentGateReason,
   WORK_STATE_LABEL,
@@ -237,6 +237,7 @@ const SECONDARY_TOAST: Record<string, string> = {
 type CaseTabId =
   | "activities"
   | "details"
+  | "related"
   | "sla"
   | "attachments"
   | "time"
@@ -271,6 +272,7 @@ const TAB_DEFS: Array<{
 }> = [
   { id: "activities", label: "Activities", icon: <Activity size={16} /> },
   { id: "details", label: "Details", icon: <ListChecks size={16} /> },
+  { id: "related", label: "Related", icon: <Users size={16} /> },
   { id: "sla", label: "SLAs", icon: <Clock size={16} /> },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
   { id: "time", label: "Time tracking", icon: <Layers size={16} /> },
@@ -281,7 +283,6 @@ const TAB_DEFS: Array<{
 export default function CsmCaseDetailPage(): JSX.Element {
   const { caseId } = useParams<{ caseId: string }>();
   const navigate = useNavTransition();
-  const isDarkMode = useDarkMode();
   const location = useLocation();
   const isEngagementRoute = location.pathname.startsWith("/engagements/");
   const isServiceRequestRoute = location.pathname.startsWith("/operations/service-requests/");
@@ -477,7 +478,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // above rather than an effect, to avoid an extra render pass.
   if (
     isAnnouncement &&
-    (activeTab === "sla" ||
+    (activeTab === "related" ||
+      activeTab === "sla" ||
       activeTab === "time" ||
       activeTab === "call-requests" ||
       activeTab === "tasks")
@@ -1565,12 +1567,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
           {TAB_DEFS.filter(
             (t) =>
               !isAnnouncement ||
-              (t.id !== "sla" &&
+              (t.id !== "related" &&
+                t.id !== "sla" &&
                 t.id !== "time" &&
                 t.id !== "call-requests" &&
                 t.id !== "tasks"),
           ).map((t) => {
-            // Counts shown only where the tab IS the list (unambiguous).
+            // Counts shown only where the tab IS the list (unambiguous). Not
+            // shown for "related" — it combines two lists (watchers + child
+            // cases), so a single count would be misleading.
             const count =
               t.id === "sla"
                 ? slaList?.count
@@ -1798,31 +1803,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </MetaCell>
             </Box>
           </Card>
-          {!isBlankHtml(c.description) && (
-            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-              <Typography variant="subtitle2">Description</Typography>
-              {/* `comments/search` already returns the description as the
-                  opening activity-feed entry (see the note near
-                  `safeComments` above), so the same text may appear here and
-                  as the first entry in the Activity tab — that's expected,
-                  not a bug. */}
-              <Box
-                sx={{
-                  typography: "body2",
-                  color: "text.primary",
-                  "& p": { mb: 0.5 },
-                  "& p:last-child": { mb: 0 },
-                }}
-                dangerouslySetInnerHTML={{
-                  __html: sanitizeDescriptionHtml(
-                    isDarkMode
-                      ? stripLightModeInlineStyles(c.description)
-                      : c.description,
-                  ),
-                }}
-              />
-            </Card>
-          )}
+          {/* The case description is not passively re-displayed here — it
+              already renders as the opening entry in the Activities tab's
+              feed (see the note near `safeComments` above). Editing it is
+              still available via the action bar's "Edit case details…" item
+              (EditCaseDetailsDialog), which is the only place the description
+              is shown for editing. */}
           <CustomerContextWidget
             ctx={c.customerContext}
             project={caseProject}
@@ -1873,6 +1859,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </Typography>
             )}
           </Card>
+        </Box>
+      )}
+
+      {activeTab === "related" && (
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              md: "repeat(2, minmax(0, 1fr))",
+            },
+            alignItems: "start",
+          }}
+        >
+          {/* Watchers list — moved off the (single-line) overview Cell so a
+              long watch list has room to wrap as chips. "Manage watchers…" in
+              the action bar opens the same WatchersDialog regardless of which
+              tab is active; this button is a convenience shortcut to it. */}
+          <WatchersWidget
+            watchers={c.watchers}
+            onManage={() => setWatchersOpen(true)}
+          />
           <ChildCasesWidget caseId={c.id} />
         </Box>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -422,11 +422,19 @@ export interface CsmCaseDetail extends CsmCaseRow {
   /** When the auto-closure sequence next advances (ServiceNow only). Read-only. */
   autoclosureStateTime?: string;
   /**
-   * The single customer-facing fix-commitment date/time for the case; `null`/
-   * absent when not set. Distinct from the backend-computed SLA clocks shown
-   * in {@link CaseSla} — this is a settable commitment, not a derived clock.
+   * The customer-facing fix-commitment date/time for the case; `null`/absent
+   * when not set. Distinct from the backend-computed SLA clocks shown in
+   * {@link CaseSla} — this is a settable commitment, not a derived clock. Also
+   * distinct from the three internal-only estimates below, which are never
+   * shared with the customer.
    */
   fixEta?: string | null;
+  /** Internal-only best-case fix estimate; `null`/absent when not set. */
+  bestCaseFixEta?: string | null;
+  /** Internal-only most-likely fix estimate; `null`/absent when not set. */
+  mostLikelyFixEta?: string | null;
+  /** Internal-only worst-case fix estimate; `null`/absent when not set. */
+  worstCaseFixEta?: string | null;
   /** Display name of the person who opened the case. */
   createdBy?: string;
   /** Email of the creator — used to tell a WSO2 engineer from a customer. */

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1056,10 +1056,17 @@ type CaseView struct {
 	// "eligible again after" date for a held case). Read-only (ServiceNow data source only).
 	AutoclosureStateTime *time.Time `json:"autoclosureStateTime,omitempty"`
 	// FixEta is the single customer-facing fix-commitment date/time
-	// (ServiceNow u_fix_eta_shared). Per project-owner decision, this is the only
-	// fix-ETA field exposed by this API; the three internal-only estimates
-	// (best/worst/most-likely case) are deliberately not surfaced anywhere.
+	// (ServiceNow u_fix_eta_shared).
 	FixEta *time.Time `json:"fixEta"`
+	// BestCaseFixEta is the internal-only best-case fix-commitment date
+	// (ServiceNow u_best_case_fix_eta). CSM-engineer-facing only.
+	BestCaseFixEta *time.Time `json:"bestCaseFixEta"`
+	// MostLikelyFixEta is the internal-only most-likely fix-commitment date
+	// (ServiceNow u_most_likely_fix_eta). CSM-engineer-facing only.
+	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta is the internal-only worst-case fix-commitment date
+	// (ServiceNow u_worst_case_fix_eta). CSM-engineer-facing only.
+	WorstCaseFixEta *time.Time `json:"worstCaseFixEta"`
 	// Tags are the free-text labels attached to the case via ServiceNow's generic
 	// platform label/label_entry mechanism (not a case-specific column).
 	//
@@ -1158,10 +1165,11 @@ type SearchCasesResponse struct {
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
 // Exactly one of State, Severity, WorkState, WatchList, AssigneeEmail, ParentID, RelatedCaseID,
-// AutocloseHoldUntil, Subject, Description, DeploymentID, DeployedProductID, or FixEta must be
-// provided.
+// AutocloseHoldUntil, Subject, Description, DeploymentID, DeployedProductID, FixEta,
+// BestCaseFixEta, MostLikelyFixEta, or WorstCaseFixEta must be provided.
 // WatchList, AssigneeEmail, ParentID, RelatedCaseID, AutocloseHoldUntil, Subject, Description,
-// DeploymentID, DeployedProductID, and FixEta are only supported for the ServiceNow data source.
+// DeploymentID, DeployedProductID, FixEta, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta
+// are only supported for the ServiceNow data source.
 // ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
 // State is closed or solution_proposed.
 type UpdateCaseRequest struct {
@@ -1205,6 +1213,18 @@ type UpdateCaseRequest struct {
 	// u_fix_eta_shared). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists yet
 	// for this field — see snUpdateCasePayload.FixEta in sn_case_service.go.
 	FixEta *time.Time `json:"fixEta"`
+	// BestCaseFixEta sets the internal-only best-case fix-commitment date (ServiceNow
+	// u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists
+	// yet for this field — see snUpdateCasePayload.BestCaseFixEta in sn_case_service.go.
+	BestCaseFixEta *time.Time `json:"bestCaseFixEta"`
+	// MostLikelyFixEta sets the internal-only most-likely fix-commitment date (ServiceNow
+	// u_most_likely_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support
+	// exists yet for this field — see snUpdateCasePayload.MostLikelyFixEta in sn_case_service.go.
+	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta sets the internal-only worst-case fix-commitment date (ServiceNow
+	// u_worst_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists
+	// yet for this field — see snUpdateCasePayload.WorstCaseFixEta in sn_case_service.go.
+	WorstCaseFixEta *time.Time `json:"worstCaseFixEta"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -1238,6 +1258,21 @@ type UpdatedCase struct {
 	// (u_fix_eta_shared) back on a successful PATCH. Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
 	// UpdateCaseRequest.FixEta doc comment; always nil until Ballerina supports the write.
 	FixEta *time.Time `json:"fixEta,omitempty"`
+	// BestCaseFixEta echoes the updated internal-only best-case fix-commitment date
+	// (u_best_case_fix_eta) back on a successful PATCH. Ballerina support added on
+	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
+	// UpdateCaseRequest.BestCaseFixEta doc comment; always nil until Ballerina supports the write.
+	BestCaseFixEta *time.Time `json:"bestCaseFixEta,omitempty"`
+	// MostLikelyFixEta echoes the updated internal-only most-likely fix-commitment date
+	// (u_most_likely_fix_eta) back on a successful PATCH. Ballerina support added on
+	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
+	// UpdateCaseRequest.MostLikelyFixEta doc comment; always nil until Ballerina supports the write.
+	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta,omitempty"`
+	// WorstCaseFixEta echoes the updated internal-only worst-case fix-commitment date
+	// (u_worst_case_fix_eta) back on a successful PATCH. Ballerina support added on
+	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
+	// UpdateCaseRequest.WorstCaseFixEta doc comment; always nil until Ballerina supports the write.
+	WorstCaseFixEta *time.Time `json:"worstCaseFixEta,omitempty"`
 }
 
 // WatchListUser is a compact user reference within the watch list.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -259,3 +259,18 @@ func (h *CaseHandler) RemoveCaseTag(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// SearchTags handles GET /tags/search?q={query}. Not scoped to a single case; used for FE
+// autocomplete when attaching a tag. The optional "limit" query parameter is currently accepted
+// but not forwarded (the downstream tag search is not limit-aware yet).
+func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query().Get("q")
+
+	tags, err := h.svc.SearchTags(r.Context(), query)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string][]domain.Tag{"tags": tags})
+}

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -20,8 +20,10 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
 )
@@ -260,13 +262,22 @@ func (h *CaseHandler) RemoveCaseTag(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// SearchTags handles GET /tags/search?q={query}. Not scoped to a single case; used for FE
-// autocomplete when attaching a tag. The optional "limit" query parameter is currently accepted
-// but not forwarded (the downstream tag search is not limit-aware yet).
+// SearchTags handles GET /tags/search?q={query}&limit={limit}. Not scoped to a single case; used
+// for FE autocomplete when attaching a tag.
 func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")
 
-	tags, err := h.svc.SearchTags(r.Context(), query)
+	limit := 0
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			writeServiceError(w, r, &apierror.ValidationError{Msg: "limit must be a non-negative integer"})
+			return
+		}
+		limit = parsed
+	}
+
+	tags, err := h.svc.SearchTags(r.Context(), query, limit)
 	if err != nil {
 		writeServiceError(w, r, err)
 		return

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -268,6 +268,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
+	mux.HandleFunc("GET /tags/search", caseHandler.SearchTags)
 
 	if callRequestHandler != nil {
 		mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -466,3 +466,7 @@ func (s *caseService) AddCaseTag(_ context.Context, _, _ string) (domain.Tag, er
 func (s *caseService) RemoveCaseTag(_ context.Context, _, _ string) error {
 	return &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }
+
+func (s *caseService) SearchTags(_ context.Context, _ string) ([]domain.Tag, error) {
+	return nil, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
+}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -467,6 +467,6 @@ func (s *caseService) RemoveCaseTag(_ context.Context, _, _ string) error {
 	return &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }
 
-func (s *caseService) SearchTags(_ context.Context, _ string) ([]domain.Tag, error) {
+func (s *caseService) SearchTags(_ context.Context, _ string, _ int) ([]domain.Tag, error) {
 	return nil, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -182,9 +182,11 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
-	// UpdateCase updates the state, severity, watch list, assignee, or fix ETA of a case.
+	// UpdateCase updates the state, severity, watch list, assignee, or fix ETA (customer-facing
+	// or internal best-case/most-likely/worst-case) of a case.
 	// A ValidationError is returned for invalid values or malformed UUID; a NotFoundError if no case matches.
-	// WatchList, AssigneeEmail, and FixEta are only supported for the ServiceNow data source.
+	// WatchList, AssigneeEmail, FixEta, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta are
+	// only supported for the ServiceNow data source.
 	// Transitioning State to closed is rejected with a ValidationError if the case has any
 	// open task that is visible to the customer (the authoritative case-close gate).
 	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error)
@@ -215,6 +217,11 @@ type CaseService interface {
 	// A NotFoundError is returned if the tag does not exist on the case.
 	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): same gap as AddCaseTag above.
 	RemoveCaseTag(ctx context.Context, caseID, tagID string) error
+	// SearchTags returns the tags (not scoped to any single case) whose label matches query,
+	// for FE autocomplete when attaching a tag to a case. An empty query returns all known tags.
+	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina/Choreo endpoint exists yet for a
+	// case-agnostic tag search; see SearchTags in sn_case_service.go for the requested contract.
+	SearchTags(ctx context.Context, query string) ([]domain.Tag, error)
 }
 
 // CaseGithubIssueService defines the operation for filing a GitHub issue from a case.

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -219,9 +219,10 @@ type CaseService interface {
 	RemoveCaseTag(ctx context.Context, caseID, tagID string) error
 	// SearchTags returns the tags (not scoped to any single case) whose label matches query,
 	// for FE autocomplete when attaching a tag to a case. An empty query returns all known tags.
+	// limit caps the number of results (<=0 means use the downstream default).
 	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina/Choreo endpoint exists yet for a
 	// case-agnostic tag search; see SearchTags in sn_case_service.go for the requested contract.
-	SearchTags(ctx context.Context, query string) ([]domain.Tag, error)
+	SearchTags(ctx context.Context, query string, limit int) ([]domain.Tag, error)
 }
 
 // CaseGithubIssueService defines the operation for filing a GitHub issue from a case.

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -98,6 +99,24 @@ type snCase struct {
 	// "fixEta" key today, so this always unmarshals to nil. Ask: add a
 	// "fixEta" (glide_date_time) field to servicenow:CaseResponse.
 	FixEta *string `json:"fixEta"`
+	// BestCaseFixEta is the internal-only best-case fix-commitment date
+	// (u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
+	// surfaces this — the Choreo GET /cases/{id} response does not include a
+	// "bestCaseFixEta" key today, so this always unmarshals to nil. Ask: add a
+	// "bestCaseFixEta" (glide_date) field to servicenow:CaseResponse.
+	BestCaseFixEta *string `json:"bestCaseFixEta"`
+	// MostLikelyFixEta is the internal-only most-likely fix-commitment date
+	// (u_most_likely_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
+	// surfaces this — the Choreo GET /cases/{id} response does not include a
+	// "mostLikelyFixEta" key today, so this always unmarshals to nil. Ask: add a
+	// "mostLikelyFixEta" (glide_date) field to servicenow:CaseResponse.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta is the internal-only worst-case fix-commitment date
+	// (u_worst_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
+	// surfaces this — the Choreo GET /cases/{id} response does not include a
+	// "worstCaseFixEta" key today, so this always unmarshals to nil. Ask: add a
+	// "worstCaseFixEta" (glide_date) field to servicenow:CaseResponse.
+	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 }
 
 // snWatchListUser mirrors the watch-list user shape ServiceNow/Ballerina returns on both
@@ -693,6 +712,33 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.FixEta = &fixEta
 	}
+	// BestCaseFixEta passes through once Ballerina's matching field (see
+	// snCase.BestCaseFixEta doc comment) lands; until then this is always nil.
+	if c.BestCaseFixEta != nil && *c.BestCaseFixEta != "" {
+		bestCaseFixEta, err := time.Parse(snCreatedOnLayout, *c.BestCaseFixEta)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse bestCaseFixEta %q: %w", *c.BestCaseFixEta, err)
+		}
+		cv.BestCaseFixEta = &bestCaseFixEta
+	}
+	// MostLikelyFixEta passes through once Ballerina's matching field (see
+	// snCase.MostLikelyFixEta doc comment) lands; until then this is always nil.
+	if c.MostLikelyFixEta != nil && *c.MostLikelyFixEta != "" {
+		mostLikelyFixEta, err := time.Parse(snCreatedOnLayout, *c.MostLikelyFixEta)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse mostLikelyFixEta %q: %w", *c.MostLikelyFixEta, err)
+		}
+		cv.MostLikelyFixEta = &mostLikelyFixEta
+	}
+	// WorstCaseFixEta passes through once Ballerina's matching field (see
+	// snCase.WorstCaseFixEta doc comment) lands; until then this is always nil.
+	if c.WorstCaseFixEta != nil && *c.WorstCaseFixEta != "" {
+		worstCaseFixEta, err := time.Parse(snCreatedOnLayout, *c.WorstCaseFixEta)
+		if err != nil {
+			return domain.CaseView{}, fmt.Errorf("sn get case: parse worstCaseFixEta %q: %w", *c.WorstCaseFixEta, err)
+		}
+		cv.WorstCaseFixEta = &worstCaseFixEta
+	}
 	// Tags are not populated: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see CaseView.Tags doc comment.
 	// cv.Tags is left nil.
 
@@ -913,6 +959,21 @@ type snUpdateCasePayload struct {
 	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field exists yet for this — ask:
 	// add a "fixEta" field to servicenow:CaseUpdatePayload backed by u_fix_eta_shared.
 	FixEta *string `json:"fixEta,omitempty"`
+	// BestCaseFixEta writes the internal-only best-case fix-commitment date
+	// (u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field exists
+	// yet for this — ask: add a "bestCaseFixEta" field to servicenow:CaseUpdatePayload
+	// backed by u_best_case_fix_eta.
+	BestCaseFixEta *string `json:"bestCaseFixEta,omitempty"`
+	// MostLikelyFixEta writes the internal-only most-likely fix-commitment date
+	// (u_most_likely_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field
+	// exists yet for this — ask: add a "mostLikelyFixEta" field to
+	// servicenow:CaseUpdatePayload backed by u_most_likely_fix_eta.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta,omitempty"`
+	// WorstCaseFixEta writes the internal-only worst-case fix-commitment date
+	// (u_worst_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field
+	// exists yet for this — ask: add a "worstCaseFixEta" field to
+	// servicenow:CaseUpdatePayload backed by u_worst_case_fix_eta.
+	WorstCaseFixEta *string `json:"worstCaseFixEta,omitempty"`
 }
 
 // snResolutionStates are the state keys that allow resolution fields.
@@ -1038,6 +1099,15 @@ type snUpdateCaseResponse struct {
 		ParentCase *snCaseRef `json:"parentCase"`
 		// FixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see snUpdateCasePayload.FixEta doc comment.
 		FixEta *string `json:"fixEta"`
+		// BestCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
+		// snUpdateCasePayload.BestCaseFixEta doc comment.
+		BestCaseFixEta *string `json:"bestCaseFixEta"`
+		// MostLikelyFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
+		// snUpdateCasePayload.MostLikelyFixEta doc comment.
+		MostLikelyFixEta *string `json:"mostLikelyFixEta"`
+		// WorstCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
+		// snUpdateCasePayload.WorstCaseFixEta doc comment.
+		WorstCaseFixEta *string `json:"worstCaseFixEta"`
 	} `json:"case"`
 }
 
@@ -1088,8 +1158,18 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.FixEta != nil {
 		fieldCount++
 	}
+	if req.BestCaseFixEta != nil {
+		fieldCount++
+	}
+	if req.MostLikelyFixEta != nil {
+		fieldCount++
+	}
+	if req.WorstCaseFixEta != nil {
+		fieldCount++
+	}
 	const fieldList = "state, severity, workState, watchList, assigneeEmail, parentId, relatedCaseId, " +
-		"autocloseHoldUntil, subject, description, deploymentId, deployedProductId, or fixEta"
+		"autocloseHoldUntil, subject, description, deploymentId, deployedProductId, fixEta, " +
+		"bestCaseFixEta, mostLikelyFixEta, or worstCaseFixEta"
 	if fieldCount == 0 {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of " + fieldList + " must be provided"}
 	}
@@ -1206,6 +1286,18 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		fixEta := formatSNDate(req.FixEta)
 		payload.FixEta = &fixEta
 	}
+	if req.BestCaseFixEta != nil {
+		bestCaseFixEta := formatSNDate(req.BestCaseFixEta)
+		payload.BestCaseFixEta = &bestCaseFixEta
+	}
+	if req.MostLikelyFixEta != nil {
+		mostLikelyFixEta := formatSNDate(req.MostLikelyFixEta)
+		payload.MostLikelyFixEta = &mostLikelyFixEta
+	}
+	if req.WorstCaseFixEta != nil {
+		worstCaseFixEta := formatSNDate(req.WorstCaseFixEta)
+		payload.WorstCaseFixEta = &worstCaseFixEta
+	}
 
 	// Close-gate: reject closing a case that still has an open, customer-visible task.
 	// This is the authoritative server-side check (item 1's close-gating requirement) --
@@ -1302,6 +1394,36 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse fixEta %q: %w", *snResp.Case.FixEta, err)
 		}
 		resp.Case.FixEta = &fixEta
+	}
+	// BestCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
+	// snUpdateCasePayload.BestCaseFixEta doc comment; snResp.Case.BestCaseFixEta is always
+	// nil until Ballerina echoes it back.
+	if snResp.Case.BestCaseFixEta != nil && *snResp.Case.BestCaseFixEta != "" {
+		bestCaseFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.BestCaseFixEta)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse bestCaseFixEta %q: %w", *snResp.Case.BestCaseFixEta, err)
+		}
+		resp.Case.BestCaseFixEta = &bestCaseFixEta
+	}
+	// MostLikelyFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
+	// snUpdateCasePayload.MostLikelyFixEta doc comment; snResp.Case.MostLikelyFixEta is
+	// always nil until Ballerina echoes it back.
+	if snResp.Case.MostLikelyFixEta != nil && *snResp.Case.MostLikelyFixEta != "" {
+		mostLikelyFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.MostLikelyFixEta)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse mostLikelyFixEta %q: %w", *snResp.Case.MostLikelyFixEta, err)
+		}
+		resp.Case.MostLikelyFixEta = &mostLikelyFixEta
+	}
+	// WorstCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
+	// snUpdateCasePayload.WorstCaseFixEta doc comment; snResp.Case.WorstCaseFixEta is always
+	// nil until Ballerina echoes it back.
+	if snResp.Case.WorstCaseFixEta != nil && *snResp.Case.WorstCaseFixEta != "" {
+		worstCaseFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.WorstCaseFixEta)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse worstCaseFixEta %q: %w", *snResp.Case.WorstCaseFixEta, err)
+		}
+		resp.Case.WorstCaseFixEta = &worstCaseFixEta
 	}
 
 	return resp, nil
@@ -2068,4 +2190,49 @@ func (s *snCaseService) RemoveCaseTag(ctx context.Context, caseID, tagID string)
 
 	_, err := s.client.Delete(ctx, "/cases/"+uuidToSysid(caseID)+"/tags/"+uuidToSysid(tagID), token)
 	return err
+}
+
+// snSearchTagsResponse mirrors the Choreo GET /tags/search response (once it exists).
+type snSearchTagsResponse struct {
+	Tags []snTag `json:"tags"`
+}
+
+// SearchTags returns the tags (not scoped to any single case) whose label matches query, for
+// FE autocomplete when attaching a tag to a case.
+//
+// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina/Choreo endpoint exists yet for this.
+// SN's tagging is the generic platform label mechanism (table-agnostic, not a case column), so
+// listing/searching existing labels needs a new adapter -- ask: add
+// GET /tags/search?q={query} (response: {"tags": [{"id", "label", "color"}]}) to servicenow.bal,
+// backed by the sys_label table (optionally scoped to labels used against
+// reference_table="sn_customerservice_case" label_entry rows). This is implemented so the
+// entity-service side is ready the moment Ballerina adds the endpoint; until then, calling it
+// returns a downstream error (no such Choreo route today).
+func (s *snCaseService) SearchTags(ctx context.Context, query string) ([]domain.Tag, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	path := "/tags/search"
+	if query != "" {
+		path += "?q=" + url.QueryEscape(query)
+	}
+
+	raw, err := s.client.Get(ctx, path, token)
+	if err != nil {
+		return nil, err
+	}
+
+	var snResp snSearchTagsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return nil, fmt.Errorf("sn search tags: parse response: %w", err)
+	}
+
+	tags := make([]domain.Tag, 0, len(snResp.Tags))
+	for _, t := range snResp.Tags {
+		tags = append(tags, domain.Tag{
+			ID:    sysidToUUID(t.ID),
+			Label: t.Label,
+			Color: t.Color,
+		})
+	}
+	return tags, nil
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2203,17 +2203,24 @@ type snSearchTagsResponse struct {
 // Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina/Choreo endpoint exists yet for this.
 // SN's tagging is the generic platform label mechanism (table-agnostic, not a case column), so
 // listing/searching existing labels needs a new adapter -- ask: add
-// GET /tags/search?q={query} (response: {"tags": [{"id", "label", "color"}]}) to servicenow.bal,
-// backed by the sys_label table (optionally scoped to labels used against
+// GET /tags/search?q={query}&limit={limit} (response: {"tags": [{"id", "label", "color"}]}) to
+// servicenow.bal, backed by the sys_label table (optionally scoped to labels used against
 // reference_table="sn_customerservice_case" label_entry rows). This is implemented so the
 // entity-service side is ready the moment Ballerina adds the endpoint; until then, calling it
 // returns a downstream error (no such Choreo route today).
-func (s *snCaseService) SearchTags(ctx context.Context, query string) ([]domain.Tag, error) {
+func (s *snCaseService) SearchTags(ctx context.Context, query string, limit int) ([]domain.Tag, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
 
-	path := "/tags/search"
+	q := url.Values{}
 	if query != "" {
-		path += "?q=" + url.QueryEscape(query)
+		q.Set("q", query)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/tags/search"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
 	}
 
 	raw, err := s.client.Get(ctx, path, token)

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -850,7 +850,7 @@ func TestSNCaseService_SearchTags_Success(t *testing.T) {
 	client := newTestSNClient(t, mux)
 	svc := NewServiceNowCaseService(client, nil)
 
-	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "micro")
+	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "micro", 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -871,6 +871,25 @@ func TestSNCaseService_SearchTags_Success(t *testing.T) {
 	}
 }
 
+func TestSNCaseService_SearchTags_ForwardsLimit(t *testing.T) {
+	var gotLimit string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("limit")
+		_ = json.NewEncoder(w).Encode(map[string]any{"tags": []map[string]any{}})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	if _, err := svc.SearchTags(contextWithUserIDToken("token"), "micro", 5); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotLimit != "5" {
+		t.Fatalf("limit sent = %q, want 5", gotLimit)
+	}
+}
+
 func TestSNCaseService_SearchTags_EmptyQuery(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
@@ -883,7 +902,7 @@ func TestSNCaseService_SearchTags_EmptyQuery(t *testing.T) {
 	client := newTestSNClient(t, mux)
 	svc := NewServiceNowCaseService(client, nil)
 
-	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "")
+	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "", 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -895,7 +914,7 @@ func TestSNCaseService_SearchTags_EmptyQuery(t *testing.T) {
 func TestCaseService_SearchTags_ServiceUnavailable(t *testing.T) {
 	svc := &caseService{}
 
-	if _, err := svc.SearchTags(contextWithUserIDToken("token"), "micro"); err == nil {
+	if _, err := svc.SearchTags(contextWithUserIDToken("token"), "micro", 0); err == nil {
 		t.Fatalf("expected error")
 	} else if _, ok := err.(*apierror.ServiceUnavailableError); !ok {
 		t.Fatalf("expected *apierror.ServiceUnavailableError, got %T: %v", err, err)

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -62,7 +62,7 @@ func sysid32(r byte) string {
 }
 
 var (
-	testWLCaseSysid    = sysid32('a')
+	testWLCaseSysid  = sysid32('a')
 	testProjectSysid = sysid32('b')
 	testWatcherSysid = sysid32('c')
 	testAccountSysid = sysid32('d')
@@ -413,9 +413,9 @@ func jsonEqual(got, want any) bool {
 const (
 	testCaseUUID  = "11111111-1111-1111-1111-111111111111"
 	testCaseSysid = "11111111111111111111111111111111"
-	testTagUUID         = "22222222-2222-2222-2222-222222222222"
-	testTagSysid        = "22222222222222222222222222222222"
-	testTaskSysid       = "33333333333333333333333333333333"
+	testTagUUID   = "22222222-2222-2222-2222-222222222222"
+	testTagSysid  = "22222222222222222222222222222222"
+	testTaskSysid = "33333333333333333333333333333333"
 )
 
 // --- UpdateCase: field-count union (including the new fixEta variant) ---
@@ -662,5 +662,242 @@ func TestSNCaseService_RemoveCaseTag_Success(t *testing.T) {
 	}
 	if !deleteCalled {
 		t.Fatalf("expected DELETE /cases/{id}/tags/{tagId} to be called")
+	}
+}
+
+// --- Internal-only fix-ETA estimates: best/most-likely/worst case ---
+
+func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t *testing.T) {
+	svc := NewServiceNowCaseService(nil, nil)
+	closed := domain.CaseStateClosed
+	fixEta := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	bestCase := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	mostLikely := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	worstCase := time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		req  domain.UpdateCaseRequest
+	}{
+		{
+			name: "state and bestCaseFixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, BestCaseFixEta: &bestCase},
+		},
+		{
+			name: "fixEta and mostLikelyFixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, FixEta: &fixEta, MostLikelyFixEta: &mostLikely},
+		},
+		{
+			name: "bestCaseFixEta and worstCaseFixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &bestCase, WorstCaseFixEta: &worstCase},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestSNCaseService_UpdateCase_InternalFixEtaVariants_EachIndependentlySettable(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     func(t time.Time) domain.UpdateCaseRequest
+		bodyKey string
+	}{
+		{
+			name: "bestCaseFixEta",
+			req: func(t time.Time) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &t}
+			},
+			bodyKey: "bestCaseFixEta",
+		},
+		{
+			name: "mostLikelyFixEta",
+			req: func(t time.Time) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: &t}
+			},
+			bodyKey: "mostLikelyFixEta",
+		},
+		{
+			name: "worstCaseFixEta",
+			req: func(t time.Time) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, WorstCaseFixEta: &t}
+			},
+			bodyKey: "worstCaseFixEta",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			mux := http.NewServeMux()
+			mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
+			})
+
+			client := newTestSNClient(t, mux)
+			svc := NewServiceNowCaseService(client, nil)
+
+			value := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req(value))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got, _ := gotBody[tt.bodyKey].(string)
+			want := "2026-03-01 12:00:00"
+			if got != want {
+				t.Fatalf("%s sent = %q, want %q", tt.bodyKey, got, want)
+			}
+		})
+	}
+}
+
+func TestSNCaseService_GetCaseByID_MapsInternalFixEtaFields(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": testCaseSysid, "internalId": "INT-1", "number": "CS0001",
+			"title": "t", "description": "d",
+			"createdOn": "2026-01-01 00:00:00", "createdBy": "a@example.com",
+			"project":          map[string]any{"id": "", "name": ""},
+			"deployment":       map[string]any{"id": "", "name": ""},
+			"deployedProduct":  map[string]any{"id": "", "name": "", "version": ""},
+			"bestCaseFixEta":   "2026-02-10 00:00:00",
+			"mostLikelyFixEta": "2026-02-15 00:00:00",
+			"worstCaseFixEta":  "2026-02-20 00:00:00",
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantBestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	if cv.BestCaseFixEta == nil || !cv.BestCaseFixEta.Equal(wantBestCase) {
+		t.Fatalf("BestCaseFixEta = %v, want %v", cv.BestCaseFixEta, wantBestCase)
+	}
+	wantMostLikely := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	if cv.MostLikelyFixEta == nil || !cv.MostLikelyFixEta.Equal(wantMostLikely) {
+		t.Fatalf("MostLikelyFixEta = %v, want %v", cv.MostLikelyFixEta, wantMostLikely)
+	}
+	wantWorstCase := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
+	if cv.WorstCaseFixEta == nil || !cv.WorstCaseFixEta.Equal(wantWorstCase) {
+		t.Fatalf("WorstCaseFixEta = %v, want %v", cv.WorstCaseFixEta, wantWorstCase)
+	}
+}
+
+func TestSNCaseService_UpdateCase_EchoesInternalFixEtaFieldsBack(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "ok",
+			"case": map[string]any{
+				"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00",
+				"bestCaseFixEta":   "2026-02-10 00:00:00",
+				"mostLikelyFixEta": "2026-02-15 00:00:00",
+				"worstCaseFixEta":  "2026-02-20 00:00:00",
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	bestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &bestCase})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantBestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	if resp.Case.BestCaseFixEta == nil || !resp.Case.BestCaseFixEta.Equal(wantBestCase) {
+		t.Fatalf("BestCaseFixEta = %v, want %v", resp.Case.BestCaseFixEta, wantBestCase)
+	}
+	wantMostLikely := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	if resp.Case.MostLikelyFixEta == nil || !resp.Case.MostLikelyFixEta.Equal(wantMostLikely) {
+		t.Fatalf("MostLikelyFixEta = %v, want %v", resp.Case.MostLikelyFixEta, wantMostLikely)
+	}
+	wantWorstCase := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
+	if resp.Case.WorstCaseFixEta == nil || !resp.Case.WorstCaseFixEta.Equal(wantWorstCase) {
+		t.Fatalf("WorstCaseFixEta = %v, want %v", resp.Case.WorstCaseFixEta, wantWorstCase)
+	}
+}
+
+// --- SearchTags ---
+
+func TestSNCaseService_SearchTags_Success(t *testing.T) {
+	var gotQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("q")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tags": []map[string]any{
+				{"id": testTagSysid, "label": "micro-gw", "color": "#f97316"},
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "micro")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotQuery != "micro" {
+		t.Fatalf("q sent = %q, want micro", gotQuery)
+	}
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+	if tags[0].ID != testTagUUID {
+		t.Fatalf("tag.ID = %q, want %q", tags[0].ID, testTagUUID)
+	}
+	if tags[0].Label != "micro-gw" {
+		t.Fatalf("tag.Label = %q, want micro-gw", tags[0].Label)
+	}
+	if tags[0].Color == nil || *tags[0].Color != "#f97316" {
+		t.Fatalf("tag.Color = %v, want #f97316", tags[0].Color)
+	}
+}
+
+func TestSNCaseService_SearchTags_EmptyQuery(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
+		if q := r.URL.Query().Get("q"); q != "" {
+			t.Fatalf("expected no q param, got %q", q)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"tags": []map[string]any{}})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("expected 0 tags, got %d", len(tags))
+	}
+}
+
+func TestCaseService_SearchTags_ServiceUnavailable(t *testing.T) {
+	svc := &caseService{}
+
+	if _, err := svc.SearchTags(contextWithUserIDToken("token"), "micro"); err == nil {
+		t.Fatalf("expected error")
+	} else if _, ok := err.(*apierror.ServiceUnavailableError); !ok {
+		t.Fatalf("expected *apierror.ServiceUnavailableError, got %T: %v", err, err)
 	}
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -575,8 +575,10 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
-        `workState`, `watchList`, or `assigneeEmail`. `watchList` and `assigneeEmail` are supported
-        only when the ServiceNow data source is active.
+        `workState`, `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`,
+        or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`,
+        `mostLikelyFixEta`, and `worstCaseFixEta` are supported only when the ServiceNow data
+        source is active.
       operationId: patchCase
       parameters:
         - name: id
@@ -746,6 +748,55 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /tags/search:
+    get:
+      summary: Search existing case tags, not scoped to any single case.
+      description: |
+        Returns tags whose label matches the free-text query, for use in FE autocomplete when
+        attaching a tag to a case. An empty/omitted `q` returns all known tags.
+        Only supported for the ServiceNow data source.
+      operationId: searchTags
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Free-text label query. Omit or leave empty to return all known tags.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+          description: Maximum number of tags to return.
+      responses:
+        "200":
+          description: Tags matching the query.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchTagsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Case tags are only supported for the ServiceNow data source.
           content:
             application/json:
               schema:
@@ -3522,8 +3573,10 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `state`, `severity`, `workState`, `watchList`, or `assigneeEmail` must be provided.
-        `watchList` and `assigneeEmail` are supported only for the ServiceNow data source.
+        Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`, `fixEta`,
+        `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta` must be provided.
+        `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`, and
+        `worstCaseFixEta` are supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
         `state` when the state is `closed` or `solution_proposed`.
       oneOf:
@@ -3532,6 +3585,10 @@ components:
         - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
+        - required: [fixEta]
+        - required: [bestCaseFixEta]
+        - required: [mostLikelyFixEta]
+        - required: [worstCaseFixEta]
       properties:
         state:
           type: string
@@ -3609,6 +3666,28 @@ components:
         closeNotes:
           type: string
           description: Close notes. Only allowed when state is closed or solution_proposed.
+        fixEta:
+          type: string
+          format: date-time
+          description: The single customer-facing fix-commitment date/time (ServiceNow only).
+        bestCaseFixEta:
+          type: string
+          format: date-time
+          description: >-
+            Internal-only best-case fix-commitment date, visible to CSM engineers only
+            (ServiceNow only).
+        mostLikelyFixEta:
+          type: string
+          format: date-time
+          description: >-
+            Internal-only most-likely fix-commitment date, visible to CSM engineers only
+            (ServiceNow only).
+        worstCaseFixEta:
+          type: string
+          format: date-time
+          description: >-
+            Internal-only worst-case fix-commitment date, visible to CSM engineers only
+            (ServiceNow only).
 
     UpdateCaseResponse:
       type: object
@@ -3712,6 +3791,34 @@ components:
           format: date-time
           nullable: true
           description: Timestamp when the case was resolved, present when state is closed or solution_proposed.
+        fixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Echoes the updated customer-facing fix-commitment date/time back, present when
+            fixEta was the field updated.
+        bestCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Echoes the updated internal-only best-case fix-commitment date back, present when
+            bestCaseFixEta was the field updated.
+        mostLikelyFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Echoes the updated internal-only most-likely fix-commitment date back, present when
+            mostLikelyFixEta was the field updated.
+        worstCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Echoes the updated internal-only worst-case fix-commitment date back, present when
+            worstCaseFixEta was the field updated.
 
     CaseLabelRef:
       type: object
@@ -3723,6 +3830,30 @@ components:
         label:
           type: string
           description: Human-readable label for the choice-list value.
+
+    Tag:
+      type: object
+      required: [id, label]
+      properties:
+        id:
+          type: string
+          format: uuid
+        label:
+          type: string
+          description: Free-text label attached to a case.
+        color:
+          type: string
+          nullable: true
+          description: Optional display color for the label; null if the label carries none.
+
+    SearchTagsResponse:
+      type: object
+      required: [tags]
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tag'
 
     WatchListUser:
       type: object
@@ -4177,6 +4308,34 @@ components:
           type: string
           nullable: true
           description: Free-text resolution/close notes. Populated for resolved/closed ServiceNow cases; null otherwise.
+        fixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            The single customer-facing fix-commitment date/time. Populated for ServiceNow
+            cases; null otherwise.
+        bestCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Internal-only best-case fix-commitment date, visible to CSM engineers only.
+            Populated for ServiceNow cases; null otherwise.
+        mostLikelyFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Internal-only most-likely fix-commitment date, visible to CSM engineers only.
+            Populated for ServiceNow cases; null otherwise.
+        worstCaseFixEta:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Internal-only worst-case fix-commitment date, visible to CSM engineers only.
+            Populated for ServiceNow cases; null otherwise.
 
     CaseSearchView:
       type: object


### PR DESCRIPTION
## Purpose
Follow-up to the recently-merged CSM portal case-feature work (#1216, #1217, #1218): closes review feedback from the project owner and adds two capabilities that need all three layers together (entity-service, backend, webapp) — engineer-only fix-ETA estimates and a searchable tag list — plus several webapp UX fixes from reviewing the shipped feature.

## Goals
- Expose 3 additional engineer-only fix-ETA estimate fields (best case / most likely / worst case) alongside the existing customer-facing fix ETA.
- Add a searchable tag list so attaching a tag is select-from-existing-or-create, not free-text-only.
- Stop duplicating the case description (it already renders as the first activity-feed entry).
- Move watchers and child/related case links off the main case-detail view into a dedicated tab, since either list can grow long.
- Move the tag chip row to sit alongside the existing severity/state chips.

## Approach
The two backend-dependent items follow this codebase's established patterns exactly: the 3 new fix-ETA fields are additive fields + independent single-field PATCH variants (mirroring the existing `fixEta`), and tag search is a new `GET /tags/search` route following the same client/handler/route shape as the existing tag add/remove endpoints. The webapp changes are UI-only reorganization plus wiring the two new backend capabilities — a new "Related" tab hosts watchers and child-case links, the description display was removed (editing stays available via the existing edit-details dialog), and the tag chip row moved next to severity/state.

## User stories
As a CS engineer, I want to record fix-ETA estimates for internal planning (not just the customer-facing commitment), search existing tags instead of guessing at spelling, and find watchers/linked cases in a dedicated place instead of a cluttered overview.

## Release note
Adds engineer-only fix-ETA estimates, a searchable tag list, and a "Related" tab for watchers and child/related cases; removes a duplicate case-description display.

## Documentation
N/A — internal tool, no external product docs affected.

## Automation tests
- Unit tests: added for every new field mapping, PATCH variant, and the new tag-search route/hook, across all three layers, following each package's existing test conventions.
- Integration tests: N/A beyond the unit level, consistent with this codebase's existing coverage.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (Go/TypeScript codebase — `go vet` and `pnpm lint` both run clean)
- Confirmed no keys/passwords/tokens/usernames/secrets committed: yes

## Samples
N/A

## Related PRs
Companion PR in a separate, sibling entity-service repository adds the matching downstream fields/endpoint; tracked separately.

## Migrations (if applicable)
N/A

## Test environment
Go 1.x / Node+pnpm (as pinned by this repo), macOS, verified via `go build/vet/test`, `make build`, `npx tsc -b`, `pnpm build`, `npx vitest run`, `pnpm lint`.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag search and autocomplete for case tag entry, with type-ahead suggestions excluding tags already on the case.
  * Added a new “Related” tab showing watchers, with an optional Manage watchers action.
  * Introduced best-case, most-likely, and worst-case fix ETA fields alongside the customer-facing ETA, each editable independently.
* **Improvements**
  * Case description card behavior changed to appear in the Activities feed instead of Details.
  * Added stronger request validation and error handling for tag search and fix ETA updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->