### PR TITLE
[CSM Portal] Document PATCH /projects/{id} in entity-service OpenAPI spec

### DIFF
--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -266,6 +266,59 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+    patch:
+      summary: Update a project's closure-state fields or hasAgent/hasKbReferences toggles.
+      description: >
+        ServiceNow data source only; there is no Postgres equivalent. At least one
+        field must be provided. closureState itself is not settable — it is derived
+        automatically from the three closure sub-state fields by an SN business
+        rule, so setting one of those and re-fetching the project is how a caller
+        observes the resulting overall status.
+      operationId: updateProject
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectUpdateRequest'
+      responses:
+        "200":
+          description: The project was updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectUpdateResponse'
+        "400":
+          description: Bad request — no field provided, or an invalid value.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Missing or invalid x-user-id-token header (ServiceNow data source only).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /projects/search:
     post:
       summary: Search projects by name, key, or subscription type.
@@ -3060,6 +3113,72 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    ProjectUpdateRequest:
+      type: object
+      minProperties: 1
+      description: >
+        At least one field must be provided. hasAgent and hasKbReferences are
+        simple toggles; the closure-state fields track sub-states of an
+        Account Closure Process and are only applicable to projects sourced
+        from ServiceNow.
+      properties:
+        hasAgent:
+          type: boolean
+        hasKbReferences:
+          type: boolean
+        endDateClosureState:
+          type: string
+        invoiceDueDateClosureState:
+          type: string
+        complianceViolationClosureState:
+          type: string
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: >
+            Free-form, per-dimension Account Closure Process (ACP) suspension-process
+            state (event type + action results) written by an existing ServiceNow
+            suspension flow. This is opaque JSON passed through as-is — its shape is
+            not defined or validated by this layer.
+
+    ProjectUpdateResponse:
+      type: object
+      required: [message, project]
+      properties:
+        message:
+          type: string
+        project:
+          $ref: '#/components/schemas/ProjectUpdateResult'
+
+    ProjectUpdateResult:
+      type: object
+      required: [id, updatedBy, updatedOn]
+      properties:
+        id:
+          type: string
+        updatedBy:
+          type: string
+        updatedOn:
+          type: string
+          format: date-time
+        closureState:
+          type: string
+          nullable: true
+        endDateClosureState:
+          type: string
+          nullable: true
+        invoiceDueDateClosureState:
+          type: string
+          nullable: true
+        complianceViolationClosureState:
+          type: string
+          nullable: true
+        suspensionProcessState:
+          type: object
+          additionalProperties: true
+          nullable: true
 
     SearchProjectContactsRequest:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -281,6 +281,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         required: true
         content:
@@ -3117,6 +3118,7 @@ components:
     ProjectUpdateRequest:
       type: object
       minProperties: 1
+      additionalProperties: false
       description: >
         At least one field must be provided. hasAgent and hasKbReferences are
         simple toggles; the closure-state fields track sub-states of an


### PR DESCRIPTION
## Purpose
`PATCH /projects/{id}` has been implemented and live on `main` since an earlier merged PR (`internal/server/routes.go` wires it to `ProjectUpdateService.UpdateProject`), but `entity-service/openapi.yaml` never documented it — only `GET /projects/{id}` was present. This left the spec out of sync with a working, in-use endpoint.

## Goals
Bring `entity-service/openapi.yaml` in sync with the actual implementation so the PATCH operation is discoverable in the spec.

## Approach
Added a `patch:` operation under the existing `/projects/{id}:` path, plus three new schema components (`ProjectUpdateRequest`, `ProjectUpdateResponse`, `ProjectUpdateResult`) mirroring the real Go domain types in `internal/domain/entity.go` field-for-field. Followed this file's existing conventions for sibling PATCH endpoints (e.g. `PATCH /deployments/{id}`) for response codes (200/400/401/404/500) and structure. Docs-only change — no code touched.

## User stories
N/A — documentation-only change, no behavior change.

## Release note
N/A — internal API documentation fix, not a user-facing change.

## Documentation
N/A — this PR *is* the documentation fix (OpenAPI spec).

## Automation tests
 - Unit tests: N/A, no code changed.
 - Integration tests: N/A, no code changed. Validated the YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — docs-only change, no code touched.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A — docs-only change.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced project updates to support changing agent and knowledge-base settings, closure statuses, and suspension process state.
  * Added validation requiring at least one project field when submitting an update.
  * Project update responses now include a confirmation message and updated project details, including audit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->