### PR TITLE
feat(support): thumbs up/down feedback on Novera answers

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -19,13 +19,15 @@ import {
   Avatar,
   Box,
   Button,
+  IconButton,
   Paper,
   Stack,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
 } from "@wso2/oxygen-ui";
-import { Bot, User } from "@wso2/oxygen-ui-icons-react";
+import { Bot, ThumbsDown, ThumbsUp, User } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, useEffect, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -139,6 +141,8 @@ function MarkdownContent({ text }: { text: string }) {
  */
 export default function ChatMessageBubble({
   message,
+  onThumbsUp,
+  onThumbsDown,
   onRequestTokenIncrease,
 }: ChatMessageBubbleProps): JSX.Element {
   const isUser = message.sender === ChatSender.USER;
@@ -183,6 +187,18 @@ export default function ChatMessageBubble({
 
   /** Faded frame wraps analyzing, live thinking steps, and streamed tokens. */
   const showThinkingStreamFrame = hideFeedbackRow;
+
+  /**
+   * Show 👍/👎 on a completed assistant answer that carries a stable
+   * feedbackMessageId (from the WS `final` event). Never on user, error,
+   * streaming, or history messages that lack an id.
+   */
+  const showFeedbackRow =
+    message.sender === ChatSender.BOT &&
+    !message.isError &&
+    !hideFeedbackRow &&
+    !!message.feedbackMessageId &&
+    (!!onThumbsUp || !!onThumbsDown);
 
   const streamBodyText = collapseStreamLineBreaks(displayText);
   const analyzingLeadText = "Novera is analyzing your request...";
@@ -425,6 +441,52 @@ export default function ChatMessageBubble({
               </Box>
             )}
           </Box>
+
+          {showFeedbackRow && (
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={0.5}
+              sx={{ mt: 0.25, ml: -0.75 }}
+            >
+              <Tooltip title="Good response">
+                <IconButton
+                  size="small"
+                  aria-label="Good response"
+                  aria-pressed={message.feedbackRating === 1}
+                  onClick={() =>
+                    onThumbsUp?.(message.feedbackMessageId as string)
+                  }
+                  sx={{
+                    color:
+                      message.feedbackRating === 1
+                        ? "primary.main"
+                        : "text.secondary",
+                  }}
+                >
+                  <ThumbsUp size={16} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Bad response">
+                <IconButton
+                  size="small"
+                  aria-label="Bad response"
+                  aria-pressed={message.feedbackRating === -1}
+                  onClick={() =>
+                    onThumbsDown?.(message.feedbackMessageId as string)
+                  }
+                  sx={{
+                    color:
+                      message.feedbackRating === -1
+                        ? "error.main"
+                        : "text.secondary",
+                  }}
+                >
+                  <ThumbsDown size={16} />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+          )}
 
           {showTokenRequestCta && (
             <Box sx={{ mt: 1 }}>

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
@@ -14,10 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
 import ChatMessageBubble from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble";
+import type { ChatMessageBubbleProps } from "@features/support/types/supportComponents";
 import {
   ChatSender,
   type Message,
@@ -29,13 +30,25 @@ vi.mock("react-markdown", () => ({
   ),
 }));
 
-function renderBubble(message: Message) {
+function renderBubble(
+  message: Message,
+  props: Partial<ChatMessageBubbleProps> = {},
+) {
   return render(
     <ThemeProvider theme={createTheme()}>
-      <ChatMessageBubble message={message} />
+      <ChatMessageBubble message={message} {...props} />
     </ThemeProvider>,
   );
 }
+
+const botAnswer = (over: Partial<Message> = {}): Message => ({
+  id: "bot-1",
+  text: "Here is your answer",
+  sender: ChatSender.BOT,
+  timestamp: new Date(),
+  feedbackMessageId: "msg-123",
+  ...over,
+});
 
 describe("ChatMessageBubble", () => {
   it("should render user message correctly", () => {
@@ -101,5 +114,63 @@ describe("ChatMessageBubble", () => {
     expect(
       screen.queryByText("NullPointerException at line 42"),
     ).not.toBeInTheDocument();
+  });
+
+  describe("answer feedback (👍/👎)", () => {
+    it("renders thumbs on a completed answer with a feedbackMessageId", () => {
+      renderBubble(botAnswer(), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.getByLabelText("Good response")).toBeInTheDocument();
+      expect(screen.getByLabelText("Bad response")).toBeInTheDocument();
+    });
+
+    it("calls onThumbsUp / onThumbsDown with the feedbackMessageId", () => {
+      const onThumbsUp = vi.fn();
+      const onThumbsDown = vi.fn();
+      renderBubble(botAnswer(), { onThumbsUp, onThumbsDown });
+
+      fireEvent.click(screen.getByLabelText("Good response"));
+      expect(onThumbsUp).toHaveBeenCalledWith("msg-123");
+
+      fireEvent.click(screen.getByLabelText("Bad response"));
+      expect(onThumbsDown).toHaveBeenCalledWith("msg-123");
+    });
+
+    it("reflects the chosen rating via aria-pressed", () => {
+      renderBubble(botAnswer({ feedbackRating: 1 }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.getByLabelText("Good response")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByLabelText("Bad response")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("hides thumbs when there is no feedbackMessageId", () => {
+      renderBubble(botAnswer({ feedbackMessageId: undefined }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+    });
+
+    it("hides thumbs while the answer is still streaming", () => {
+      renderBubble(botAnswer({ isStreaming: true }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -381,7 +381,9 @@ export default function ConversationDetailsPage(): JSX.Element {
         const idx = prev.findIndex((m) => m.id === activeId);
         if (idx === -1) return prev;
         pendingFinalRef.current = null;
-        const { finalMessage } = pending;
+        const { finalMessage, payload } = pending;
+        const answerId =
+          typeof payload.messageId === "string" ? payload.messageId : undefined;
         const msg = prev[idx];
         const next = [...prev];
         next[idx] = {
@@ -389,6 +391,8 @@ export default function ConversationDetailsPage(): JSX.Element {
           isLoading: false,
           isError: false,
           text: finalMessage || msg.text,
+          showFeedbackActions: !!answerId,
+          feedbackMessageId: answerId,
           isStreaming: false,
           thinkingSteps: [],
           thinkingLabel: null,
@@ -486,6 +490,21 @@ export default function ConversationDetailsPage(): JSX.Element {
           const finalMessage = getFinalMessageFromPayload(payload);
           pendingFinalRef.current = { payload, finalMessage };
           flushPendingFinalIfReady();
+          break;
+        }
+        case "feedback_ack": {
+          const ackId = String(event.messageId ?? "");
+          const ackRating =
+            event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          if (ackId) {
+            setNewMessages((prev) =>
+              prev.map((m) =>
+                m.feedbackMessageId === ackId
+                  ? { ...m, feedbackRating: ackRating }
+                  : m,
+              ),
+            );
+          }
           break;
         }
         case "error":
@@ -592,6 +611,48 @@ export default function ConversationDetailsPage(): JSX.Element {
     await sendViaWebSocket(text);
     return true;
   }, [accountId, isSending, projectId, sendViaWebSocket, setInputValueAndRef]);
+
+  // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic
+  // with revert-on-failure; feedback_ack confirms the persisted value.
+  const submitFeedback = useCallback(
+    (messageId: string, rating: 1 | -1) => {
+      if (!projectId) return;
+      setNewMessages((prev) =>
+        prev.map((m) =>
+          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
+        ),
+      );
+      void connect(projectId)
+        .then(() =>
+          sendUserMessage({
+            type: "feedback",
+            messageId,
+            rating,
+            conversationId: conversationId ?? undefined,
+            accountId: accountId || undefined,
+          }),
+        )
+        .catch(() => {
+          setNewMessages((prev) =>
+            prev.map((m) =>
+              m.feedbackMessageId === messageId
+                ? { ...m, feedbackRating: null }
+                : m,
+            ),
+          );
+        });
+    },
+    [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  const handleThumbsUp = useCallback(
+    (messageId: string) => submitFeedback(messageId, 1),
+    [submitFeedback],
+  );
+  const handleThumbsDown = useCallback(
+    (messageId: string) => submitFeedback(messageId, -1),
+    [submitFeedback],
+  );
 
   const conversationStatus = summary?.status;
   const conversationStatusLabel = conversationStatus ?? "--";
@@ -814,7 +875,12 @@ export default function ConversationDetailsPage(): JSX.Element {
                     m.isLoading ? (
                       <LoadingDotsBubble key={m.id} />
                     ) : (
-                      <ChatMessageBubble key={m.id} message={m} />
+                      <ChatMessageBubble
+                        key={m.id}
+                        message={m}
+                        onThumbsUp={handleThumbsUp}
+                        onThumbsDown={handleThumbsDown}
+                      />
                     ),
                   )}
                 </>

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -408,12 +408,16 @@ export default function NoveraChatPage(): JSX.Element {
           ? (payload.actions as NoveraAction[])
           : undefined;
         const next = [...prev];
+        const answerId =
+          typeof payload.messageId === "string" ? payload.messageId : undefined;
         next[idx] = {
           ...msg,
           isLoading: false,
           isError: false,
           text: finalMessage || msg.text,
           showCreateCaseAction: payload.actions != null,
+          showFeedbackActions: !!answerId,
+          feedbackMessageId: answerId,
           slotState: payload.slotState as SlotState | undefined,
           thinkingSteps: [],
           thinkingLabel: null,
@@ -559,6 +563,21 @@ export default function NoveraChatPage(): JSX.Element {
           }
           break;
         }
+        case "feedback_ack": {
+          const ackId = String(event.messageId ?? "");
+          const ackRating =
+            event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          if (ackId) {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.feedbackMessageId === ackId
+                  ? { ...m, feedbackRating: ackRating }
+                  : m,
+              ),
+            );
+          }
+          break;
+        }
         case "error":
           pendingFinalRef.current = null;
           tokenQueueRef.current = [];
@@ -671,6 +690,49 @@ export default function NoveraChatPage(): JSX.Element {
     void sendViaWebSocket("This Resolved My Issue");
   }, [isSending, sendViaWebSocket]);
 
+  // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic:
+  // reflect the vote immediately, revert if the send fails. feedback_ack later
+  // confirms the persisted value.
+  const submitFeedback = useCallback(
+    (messageId: string, rating: 1 | -1) => {
+      if (!projectId) return;
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
+        ),
+      );
+      void connect(projectId)
+        .then(() =>
+          sendUserMessage({
+            type: "feedback",
+            messageId,
+            rating,
+            conversationId: conversationId ?? undefined,
+            accountId: accountId || undefined,
+          }),
+        )
+        .catch(() => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.feedbackMessageId === messageId
+                ? { ...m, feedbackRating: null }
+                : m,
+            ),
+          );
+        });
+    },
+    [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  const handleThumbsUp = useCallback(
+    (messageId: string) => submitFeedback(messageId, 1),
+    [submitFeedback],
+  );
+  const handleThumbsDown = useCallback(
+    (messageId: string) => submitFeedback(messageId, -1),
+    [submitFeedback],
+  );
+
   // Feature-flagged (config.js): request a token limit increase over the chat
   // WebSocket. Kept off until the backend handler is ready.
   const tokenRequestEnabled =
@@ -756,6 +818,8 @@ export default function NoveraChatPage(): JSX.Element {
               messages={messages}
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
+              onThumbsUp={handleThumbsUp}
+              onThumbsDown={handleThumbsDown}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={
                 tokenRequestEnabled

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -210,6 +210,10 @@ export type Message = {
   createdOnRaw?: string;
   showFeedbackActions?: boolean;
   showCreateCaseAction?: boolean;
+  /** Stable id of this assistant answer (from the WS `final` event), used to rate it. */
+  feedbackMessageId?: string;
+  /** The rating the user has given this answer, if any (+1 up / -1 down). */
+  feedbackRating?: 1 | -1 | null;
   isLoading?: boolean;
   isError?: boolean;
   slotState?: SlotState;
@@ -250,6 +254,14 @@ export type ChatWebSocketPayload =
       accountId: string;
       reason: string;
       limitType: "session" | "monthly";
+    }
+  | {
+      type: "feedback";
+      messageId: string;
+      rating: 1 | -1;
+      conversationId?: string;
+      accountId?: string;
+      comment?: string;
     };
 
 // Model type for chat WebSocket hook options.


### PR DESCRIPTION
## Purpose

Adds a 👍/👎 answer-feedback control to the Novera AI assistant chat so customers can rate answers. Part of the answer-feedback epic (backend in `wso2-enterprise/digiops-cs`).

Implements wso2-enterprise/digiops-cs#2534 · epic wso2-enterprise/digiops-cs#2529.

## Approach

Feedback rides the **existing chat WebSocket** — no new REST endpoint, base URL, CORS, or second auth path from the portal:

- The novera backend stamps a stable `messageId` on each `final` answer. The UI stores it as `feedbackMessageId`.
- Clicking 👍/👎 sends `{ type: "feedback", messageId, rating, conversationId?, accountId? }` over the socket; the backend persists it and replies `feedback_ack`.
- Optimistic: the vote highlights immediately and reverts if the send fails; `feedback_ack` confirms the persisted value. Attribution (account/conversation) is resolved server-side from the authenticated session.

## Changes

- `types/conversations.ts` — `Message.feedbackMessageId` / `feedbackRating`; `feedback` variant on `ChatWebSocketPayload`.
- `ChatMessageBubble.tsx` — thumbs row, gated to completed non-error answers that carry an id; active rating shown via `aria-pressed` + colour.
- `NoveraChatPage.tsx` & `ConversationDetailsPage.tsx` — stamp the id on `final`, handle `feedback_ack`, optimistic submit handlers wired to the bubble.

## Testing

- `tsc -b` clean; `eslint` clean on changed files.
- `ChatMessageBubble.test.tsx` — 10 passing (5 new: renders thumbs, click callbacks carry the id, `aria-pressed` reflects the rating, hidden without an id, hidden while streaming).

## Dependencies

Requires the backend WS handler (`wso2-enterprise/digiops-cs` #2542: stamps `messageId`, handles the `feedback` event → `feedback_ack`) and the feedback table (#2537). Until deployed, the buttons render but persistence is a no-op.

## Notes

The thumbs reuse the pre-existing `onThumbsUp`/`onThumbsDown` contract already present on `ChatMessageListProps` / `ChatMessageBubbleProps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbs-up and thumbs-down controls to completed AI chat responses.
  * Selected feedback is visibly indicated for each response.
  * Feedback is saved automatically and reflected in the conversation.

* **Bug Fixes**
  * Feedback controls are hidden for streaming, incomplete, error, or unidentified responses.
  * Failed feedback submissions no longer leave an incorrect rating displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->