### PR TITLE
[CSM][Web] Fix phantom bullet left behind when indenting a list item

### DIFF
--- a/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -290,6 +290,15 @@ const DEFAULT_EDITOR_CONFIG = {
     list: {
       ul: "editor-list-ul",
       ol: "editor-list-ol",
+      // Indenting a list item wraps it in a new, textless parent <li> that exists only
+      // to hold the nested <ul>/<ol> ($handleIndent in @lexical/list). Lexical tags that
+      // wrapper with this class (see $setListItemThemeClassNames) whenever a list item's
+      // children include a nested list, so its own bullet/number can be hidden below —
+      // otherwise it renders an empty marker next to nothing, above the actually-indented
+      // item's marker.
+      nested: {
+        listitem: "editor-list-item-nested",
+      },
     },
     link: "editor-link",
     code: "editor-code",
@@ -463,6 +472,7 @@ const Editor = ({
             },
             "& .editor-list-ul": { ml: 3, listStyleType: "disc" },
             "& .editor-list-ol": { ml: 3, listStyleType: "decimal" },
+            "& .editor-list-item-nested": { listStyleType: "none" },
             "& .editor-link": {
               color: "primary.main",
               textDecoration: "underline",


### PR DESCRIPTION
## Purpose
Indenting a bulleted/numbered list item in the rich text editor (used for case comments/work notes, descriptions, etc.) left behind a stray empty bullet at the original indent level, on top of the correctly nested item below it.

## Goals
- Indenting a list item should not leave a visible orphaned marker behind.

## Approach
- Root cause: Lexical's list indent logic (`$handleIndent` in `@lexical/list`) wraps the indented item in a new, text-less parent `<li>` whose only purpose is to hold the nested `<ul>`/`<ol>` — that's normal, valid nested-list HTML. Lexical hides that wrapper's own marker automatically, but only if the editor's theme registers a `theme.list.nested.listitem` class for it (`$setListItemThemeClassNames` in `@lexical/list`). This editor's theme never set that key, so the wrapper rendered a default browser bullet next to nothing.
- Added the `nested.listitem` theme class Lexical already looks for, plus one CSS rule (`list-style-type: none`) to hide it, in `Editor.tsx`. No behavioral/logic changes elsewhere.

## User stories
As a CSM Portal user writing a comment or work note, indenting a list item nests it cleanly without leaving a stray empty bullet behind.

## Release note
Fix a stray empty bullet left behind when indenting a list item in the rich text editor.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- No existing automated coverage for this component's rendering behavior (no test infra for `Editor.tsx` yet).
- Verified against the reported repro live: created a bulleted list, added a second item, indented it — confirmed the phantom bullet no longer appears.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint`, `pnpm run build` (via local binaries, pnpm CLI broken in this environment) passing locally, plus live manual verification of the repro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested list formatting in the rich text editor.
  * Nested list items now display without unwanted list markers, resulting in cleaner list structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->