### PR TITLE
docs(customer-portal): add PATCH /conversations/{id} to openapi spec

### DIFF
--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1072,6 +1072,38 @@ paths:
           description: InternalServerError
         "403":
           description: Forbidden
+    patch:
+      summary: Update a conversation's status (close or abandon).
+      operationId: patchConversationsId
+      parameters:
+      - name: id
+        in: path
+        description: ID of the conversation to update
+        required: true
+        schema:
+          $ref: '#/components/schemas/IdString'
+      requestBody:
+        description: Target status for the conversation
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConversationStatusUpdate'
+        required: true
+      responses:
+        "200":
+          description: Ok
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+        "403":
+          description: Forbidden
   /cases/{id}/comments:
     get:
       summary: Get comments for a specific case.
@@ -4809,6 +4841,18 @@ components:
           format: int64
       additionalProperties: false
       description: Conversation statistics by state for a project.
+    ConversationStatusUpdate:
+      required:
+      - status
+      type: object
+      properties:
+        status:
+          type: string
+          description: |-
+            Target status: "closed" (user-initiated) or "abandoned" (set
+            automatically when a case is created before the assistant responds).
+      additionalProperties: false
+      description: Payload to update a conversation's status via PATCH /conversations/{id}.
     ConversationSummaryResponse:
       required:
       - accountId


### PR DESCRIPTION
Follow-up to #1162 (merged). The consolidated conversation status endpoint — `PATCH /conversations/{id}` with `{ "status": "closed" | "abandoned" }` — was serving but its `openapi.yaml` still listed only `GET` on that path.

## Change
- Adds the `patch` operation (`operationId: patchConversationsId`) under `/conversations/{id}`, with `ConversationStatusUpdate` as the request body and the standard 200/400/401/403/500 responses.
- Adds the `ConversationStatusUpdate` schema (`{ status: string }`, `additionalProperties: false`).

No code change — spec-only, matching the generated-spec conventions (`bal openapi`) and the existing `PATCH /cases/{id}` operation style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating a conversation’s status.
  * Conversations can now be marked as **closed** or **abandoned**.
  * Added validation and standard error handling for status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->