### PR TITLE
feat(customer-portal): close a chat from the support dashboard

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/close-chat/CloseChatConfirmDialog.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/close-chat/CloseChatConfirmDialog.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+
+export interface CloseChatConfirmDialogProps {
+  /** Whether the dialog is visible. */
+  open: boolean;
+  /** Whether the close request is in flight (disables the actions). */
+  isClosing: boolean;
+  /** Called when the user dismisses the dialog. */
+  onCancel: () => void;
+  /** Called when the user confirms closing the chat. */
+  onConfirm: () => void;
+}
+
+/**
+ * Confirmation dialog shown before a Novera chat is closed. Shared by the
+ * conversations list and the support dashboard so the copy and behavior stay
+ * in one place.
+ *
+ * @param {CloseChatConfirmDialogProps} props - Open state and handlers.
+ * @returns {JSX.Element} The confirmation dialog.
+ */
+export default function CloseChatConfirmDialog({
+  open,
+  isClosing,
+  onCancel,
+  onConfirm,
+}: CloseChatConfirmDialogProps): JSX.Element {
+  return (
+    <Dialog
+      open={open}
+      onClose={isClosing ? undefined : onCancel}
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle>Close this chat?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This chat will be closed and can no longer be resumed. Any case
+          created from it is not affected.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} disabled={isClosing}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={onConfirm}
+          disabled={isClosing}
+        >
+          {isClosing ? "Closing…" : "Close chat"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/close-chat/__tests__/CloseChatConfirmDialog.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/close-chat/__tests__/CloseChatConfirmDialog.test.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
+import { describe, expect, it, vi } from "vitest";
+import CloseChatConfirmDialog from "../CloseChatConfirmDialog";
+
+describe("CloseChatConfirmDialog", () => {
+  it("fires onConfirm and onCancel from the dialog actions", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <CloseChatConfirmDialog
+          open
+          isClosing={false}
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText("Close this chat?")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /close chat/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the actions while a close is in flight", () => {
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <CloseChatConfirmDialog
+          open
+          isClosing
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </ThemeProvider>,
+    );
+    expect(screen.getByRole("button", { name: /closing/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryCard.tsx
@@ -25,7 +25,7 @@ import {
   Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Bot, ExternalLink, Play, User } from "@wso2/oxygen-ui-icons-react";
+import { Bot, ExternalLink, Play, User, X } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import { ChatAction } from "@features/support/constants/supportConstants";
 import {
@@ -34,10 +34,12 @@ import {
   getConversationStatusColor,
   formatDateTime,
 } from "@features/support/utils/support";
+import { isConversationResumable } from "@features/support/utils/conversationsList";
 
 export interface ChatHistoryCardProps {
   item: ChatHistoryItem;
   onItemAction?: (chatId: string, action: ChatAction) => void;
+  onCloseChat?: (chatId: string) => void;
 }
 
 /**
@@ -49,6 +51,7 @@ export interface ChatHistoryCardProps {
 export default function ChatHistoryCard({
   item,
   onItemAction,
+  onCloseChat,
 }: ChatHistoryCardProps): JSX.Element {
   const action = getChatStatusAction(item.status);
   const statusColorPath = getConversationStatusColor(item.status);
@@ -180,32 +183,61 @@ export default function ChatHistoryCard({
             {item.status}
           </Typography>
         </Box>
-        <Button
-          component="span"
-          size="small"
-          variant="text"
-          color={getChatActionColor(action)}
-          disableRipple
-          onClick={(e) => {
-            e.stopPropagation();
-            onItemAction?.(item.chatId, action);
-          }}
-          startIcon={
-            action === ChatAction.VIEW ? (
-              <ExternalLink size={12} />
-            ) : (
-              <Play size={12} />
-            )
-          }
-          sx={{
-            textTransform: "none",
-            fontWeight: 500,
-            minWidth: 0,
-            p: 0,
-          }}
+        <Stack
+          direction="row"
+          spacing={1.5}
+          alignItems="center"
+          sx={{ flexShrink: 0 }}
         >
-          {action === ChatAction.VIEW ? "View" : "Resume"}
-        </Button>
+          {onCloseChat && isConversationResumable(item.status) && (
+            <Button
+              component="span"
+              size="small"
+              variant="text"
+              color="error"
+              disableRipple
+              onClick={(e) => {
+                e.stopPropagation();
+                onCloseChat(item.chatId);
+              }}
+              startIcon={<X size={12} />}
+              sx={{
+                textTransform: "none",
+                fontWeight: 500,
+                minWidth: 0,
+                p: 0,
+              }}
+            >
+              Close
+            </Button>
+          )}
+          <Button
+            component="span"
+            size="small"
+            variant="text"
+            color={getChatActionColor(action)}
+            disableRipple
+            onClick={(e) => {
+              e.stopPropagation();
+              onItemAction?.(item.chatId, action);
+            }}
+            startIcon={
+              action === ChatAction.VIEW ? (
+                <ExternalLink size={12} />
+              ) : (
+                <Play size={12} />
+              )
+            }
+            sx={{
+              textTransform: "none",
+              fontWeight: 500,
+              minWidth: 0,
+              p: 0,
+            }}
+          >
+            {action === ChatAction.VIEW ? "View" : "Resume"}
+          </Button>
+        </Stack>
       </CardActions>
     </Form.CardButton>
   );

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryList.tsx
@@ -36,6 +36,7 @@ export default function ChatHistoryList({
   isLoading,
   isError,
   onItemAction,
+  onCloseChat,
 }: ChatHistoryListProps): JSX.Element {
   const listShellSx = {
     display: "flex",
@@ -90,6 +91,7 @@ export default function ChatHistoryList({
           key={item.chatId}
           item={item}
           onItemAction={onItemAction}
+          onCloseChat={onCloseChat}
         />
       ))}
     </Box>

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/__tests__/ChatHistoryCard.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/__tests__/ChatHistoryCard.test.tsx
@@ -46,4 +46,58 @@ describe("ChatHistoryCard", () => {
     fireEvent.click(actionButton as Element);
     expect(onItemAction).toHaveBeenCalled();
   });
+
+  it("shows Close for a resumable chat and calls onCloseChat without opening the chat", () => {
+    const onItemAction = vi.fn();
+    const onCloseChat = vi.fn();
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <ChatHistoryCard
+          item={
+            {
+              chatId: "chat-1",
+              title: "Chat title",
+              status: "Active",
+              startedTime: "2026-01-01T00:00:00Z",
+              messages: 3,
+              kbArticles: 1,
+            } as never
+          }
+          onItemAction={onItemAction}
+          onCloseChat={onCloseChat}
+        />
+      </ThemeProvider>,
+    );
+    const closeButton = screen
+      .getAllByRole("button", { name: /close/i })
+      .find((element) => element.tagName.toLowerCase() === "span");
+    expect(closeButton).toBeDefined();
+    fireEvent.click(closeButton as Element);
+    expect(onCloseChat).toHaveBeenCalledWith("chat-1");
+    expect(onItemAction).not.toHaveBeenCalled();
+  });
+
+  it("does not show Close for a terminal chat", () => {
+    const onCloseChat = vi.fn();
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <ChatHistoryCard
+          item={
+            {
+              chatId: "chat-2",
+              title: "Chat title",
+              status: "Close",
+              startedTime: "2026-01-01T00:00:00Z",
+              messages: 2,
+              kbArticles: 0,
+            } as never
+          }
+          onCloseChat={onCloseChat}
+        />
+      </ThemeProvider>,
+    );
+    expect(
+      screen.queryByRole("button", { name: /^close$/i }),
+    ).toBeNull();
+  });
 });

--- a/apps/customer-portal/webapp/src/features/support/hooks/useCloseConversationFlow.ts
+++ b/apps/customer-portal/webapp/src/features/support/hooks/useCloseConversationFlow.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState } from "react";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useUpdateConversationState } from "@features/support/api/useUpdateConversationState";
+
+export interface CloseConversationFlow {
+  /** Whether the confirmation dialog should be shown. */
+  isConfirmOpen: boolean;
+  /** Whether the close request is in flight. */
+  isClosing: boolean;
+  /** Open the confirmation dialog for the given conversation. */
+  requestClose: (conversationId: string) => void;
+  /** Confirm and send the close request for the pending conversation. */
+  confirmClose: () => void;
+  /** Dismiss the confirmation dialog without closing. */
+  cancelClose: () => void;
+}
+
+/**
+ * Owns the "close a chat" interaction — confirmation-dialog state plus the
+ * PATCH mutation — so the conversations list and the support dashboard share a
+ * single implementation instead of duplicating the dialog and mutation.
+ *
+ * @param {string} projectId - Project ID for cache invalidation.
+ * @returns {CloseConversationFlow} Dialog state and handlers.
+ */
+export function useCloseConversationFlow(
+  projectId: string,
+): CloseConversationFlow {
+  const { showError } = useErrorBanner();
+  const closeConversation = useUpdateConversationState(projectId, "closed");
+  const [chatIdToClose, setChatIdToClose] = useState<string | null>(null);
+
+  const requestClose = (conversationId: string): void => {
+    if (conversationId) {
+      setChatIdToClose(conversationId);
+    }
+  };
+
+  const cancelClose = (): void => setChatIdToClose(null);
+
+  const confirmClose = (): void => {
+    if (!chatIdToClose) return;
+    closeConversation.mutate(chatIdToClose, {
+      onSuccess: () => setChatIdToClose(null),
+      onError: (error: Error) => {
+        setChatIdToClose(null);
+        showError(
+          error.message || "Failed to close the chat. Please try again.",
+        );
+      },
+    });
+  };
+
+  return {
+    isConfirmOpen: chatIdToClose !== null,
+    isClosing: closeConversation.isPending,
+    requestClose,
+    confirmClose,
+    cancelClose,
+  };
+}

--- a/apps/customer-portal/webapp/src/features/support/pages/AllConversationsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllConversationsPage.tsx
@@ -29,20 +29,14 @@ import {
 } from "react";
 import { useSessionState } from "@hooks/useSessionState";
 import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
   Divider,
   Stack,
 } from "@wso2/oxygen-ui";
 import { useLoader } from "@context/linear-loader/LoaderContext";
-import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import useGetProjectFilters from "@api/useGetProjectFilters";
 import { useSearchConversations } from "@features/support/api/useSearchConversations";
-import { useUpdateConversationState } from "@features/support/api/useUpdateConversationState";
+import { useCloseConversationFlow } from "@features/support/hooks/useCloseConversationFlow";
+import CloseChatConfirmDialog from "@features/support/components/close-chat/CloseChatConfirmDialog";
 import type {
   AllConversationsFilterValues,
   Conversation,
@@ -191,24 +185,7 @@ export default function AllConversationsPage(): JSX.Element {
   const conversations = data?.conversations ?? [];
   const totalRecords = data?.totalRecords ?? 0;
 
-  const { showError } = useErrorBanner();
-  const closeConversation = useUpdateConversationState(projectId || "", "closed");
-  const [chatToClose, setChatToClose] = useState<Conversation | null>(null);
-
-  const handleCloseConversation = (conv: Conversation) => {
-    setChatToClose(conv);
-  };
-
-  const handleConfirmClose = () => {
-    if (!chatToClose) return;
-    closeConversation.mutate(chatToClose.id, {
-      onSuccess: () => setChatToClose(null),
-      onError: (error: Error) => {
-        setChatToClose(null);
-        showError(error.message || "Failed to close the chat. Please try again.");
-      },
-    });
-  };
+  const closeFlow = useCloseConversationFlow(projectId || "");
 
   const handleConversationClick = (conv: Conversation) => {
     if (!projectId) return;
@@ -348,7 +325,7 @@ export default function AllConversationsPage(): JSX.Element {
         isError={isConversationsError}
         hasListRefinement={listHasRefinement}
         onConversationClick={handleConversationClick}
-        onCloseConversation={handleCloseConversation}
+        onCloseConversation={(conv) => closeFlow.requestClose(conv.id)}
       />
 
       <ListPagination
@@ -359,38 +336,12 @@ export default function AllConversationsPage(): JSX.Element {
         onRowsPerPageChange={handleRowsPerPageChange}
       />
 
-      <Dialog
-        open={chatToClose !== null}
-        onClose={
-          closeConversation.isPending ? undefined : () => setChatToClose(null)
-        }
-        maxWidth="xs"
-        fullWidth
-      >
-        <DialogTitle>Close this chat?</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            This chat will be closed and can no longer be resumed. Any case
-            created from it is not affected.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => setChatToClose(null)}
-            disabled={closeConversation.isPending}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={handleConfirmClose}
-            disabled={closeConversation.isPending}
-          >
-            {closeConversation.isPending ? "Closing…" : "Close chat"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <CloseChatConfirmDialog
+        open={closeFlow.isConfirmOpen}
+        isClosing={closeFlow.isClosing}
+        onCancel={closeFlow.cancelClose}
+        onConfirm={closeFlow.confirmClose}
+      />
     </Stack>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
@@ -25,6 +25,8 @@ import SupportOverviewCard from "@features/support/components/support-overview-c
 import { SupportOverviewIconVariant } from "@features/support/types/supportOverview";
 import OutstandingCasesList from "@features/support/components/support-overview-cards/OutstandingCasesList";
 import ChatHistoryList from "@features/support/components/support-overview-cards/ChatHistoryList";
+import CloseChatConfirmDialog from "@features/support/components/close-chat/CloseChatConfirmDialog";
+import { useCloseConversationFlow } from "@features/support/hooks/useCloseConversationFlow";
 import { useGetProjectSupportStats } from "@features/support/api/useGetProjectSupportStats";
 import useGetProjectDetails from "@api/useGetProjectDetails";
 import useGetProjectFeatures from "@api/useGetProjectFeatures";
@@ -52,6 +54,7 @@ export default function SupportPage(): JSX.Element {
   const logger = useLogger();
   const navigate = useModifierAwareNavigate();
   const { projectId } = useParams<{ projectId: string }>();
+  const closeFlow = useCloseConversationFlow(projectId || "");
   const supportPath = `/projects/${projectId}/support`;
 
   const { data: project } = useGetProjectDetails(projectId || "");
@@ -289,10 +292,18 @@ export default function SupportPage(): JSX.Element {
                     }
                   : undefined
               }
+              onCloseChat={projectId ? closeFlow.requestClose : undefined}
             />
           </SupportOverviewCard>
         </Grid>
       </Grid>
+
+      <CloseChatConfirmDialog
+        open={closeFlow.isConfirmOpen}
+        isClosing={closeFlow.isClosing}
+        onCancel={closeFlow.cancelClose}
+        onConfirm={closeFlow.confirmClose}
+      />
     </Stack>
   );
 }

--- a/apps/customer-portal/webapp/src/features/support/pages/__tests__/SupportPage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/__tests__/SupportPage.test.tsx
@@ -71,6 +71,16 @@ vi.mock("@features/support/api/useSearchConversations", () => ({
   useSearchConversations: () => mockUseSearchConversations(),
 }));
 
+vi.mock("@features/support/hooks/useCloseConversationFlow", () => ({
+  useCloseConversationFlow: () => ({
+    isConfirmOpen: false,
+    isClosing: false,
+    requestClose: vi.fn(),
+    confirmClose: vi.fn(),
+    cancelClose: vi.fn(),
+  }),
+}));
+
 vi.mock("@utils/permission", () => ({
   getProjectPermissions: () => ({ includeS0InSupportMetrics: true }),
 }));

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -481,6 +481,7 @@ export type ChatHistoryListProps = {
   isLoading?: boolean;
   isError?: boolean;
   onItemAction?: (chatId: string, action: ChatAction) => void;
+  onCloseChat?: (chatId: string) => void;
 };
 
 export type ChatInputProps = {


### PR DESCRIPTION
Follow-up enhancement to the Novera chat-close feature (#1162). Lets users **close a resumable chat directly from the support dashboard** ("Recent Novera conversations" cards), instead of only from the full All Conversations list.

## What
- **Close** action on dashboard chat cards, shown **only for resumable chats** (Active/Open) — same gate as the full list — styled as a secondary text action next to Resume, with the existing confirmation dialog as the safety net.

## How (no duplication)
The close dialog + mutation previously lived inline in `AllConversationsPage`. Rather than copy that onto the dashboard path, this extracts a shared flow:
- **`useCloseConversationFlow(projectId)`** — owns confirm-dialog state + the `PATCH /conversations/{id}` mutation and error handling.
- **`CloseChatConfirmDialog`** — the shared confirmation dialog.

`AllConversationsPage` is refactored onto the shared flow (net **−85 lines** of inline dialog/handler code there), and `ChatHistoryCard` → `ChatHistoryList` → `SupportPage` wire the new Close action to the same flow.

## Tests
- `ChatHistoryCard`: Close shown for resumable / hidden for terminal; clicking Close calls `onCloseChat` and does **not** trigger row navigation (stopPropagation).
- `CloseChatConfirmDialog`: confirm/cancel fire; actions disabled while closing.
- `SupportPage` test updated to mock the new hook.

## Validation
- `tsc --noEmit`: 0 errors
- `eslint`: clean on changed files (the 1 pre-existing `preserve-manual-memoization` error on `AllConversationsPage`'s search-`useMemo` is on `main`, untouched here)
- Affected tests: 26 passing (close-chat, support-overview-cards, SupportPage, conversationsList)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to close resumable chats directly from chat history.
  * Added a confirmation dialog before closing a chat.
  * Displays a “Closing…” state while the request is processing.
  * Shows an error notification if closing a chat fails.

* **Tests**
  * Added coverage for close actions, confirmation behavior, disabled states, and terminal chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->