### PR TITLE
feat(customer-portal): mark chat Converted when a case is created from it

### DIFF
--- a/apps/customer-portal/backend/constants.bal
+++ b/apps/customer-portal/backend/constants.bal
@@ -31,6 +31,7 @@ const ERR_MSG_CONVERSATION_STATISTICS = "Failed to retrieve project conversation
 // Conversation status update actions (PATCH /conversations/{id}).
 const CONVERSATION_STATUS_CLOSED = "closed";
 const CONVERSATION_STATUS_ABANDONED = "abandoned";
+const CONVERSATION_STATUS_CONVERTED = "converted";
 
 // Default Pagination Values
 public const int DEFAULT_OFFSET = 0;

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2092,11 +2092,13 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             stateKey = entity:conversationStateIds.close;
         } else if payload.status == CONVERSATION_STATUS_ABANDONED {
             stateKey = entity:conversationStateIds.abandonded;
+        } else if payload.status == CONVERSATION_STATUS_CONVERTED {
+            stateKey = entity:conversationStateIds.converted;
         } else {
             return <http:BadRequest>{
                 body: {
                     message: string `Invalid conversation status: '${payload.status}'. ` +
-                        string `Allowed values: ${CONVERSATION_STATUS_CLOSED}, ${CONVERSATION_STATUS_ABANDONED}.`
+                        string `Allowed values: ${CONVERSATION_STATUS_CLOSED}, ${CONVERSATION_STATUS_ABANDONED}, ${CONVERSATION_STATUS_CONVERTED}.`
                 }
             };
         }

--- a/apps/customer-portal/webapp/src/features/support/api/useUpdateConversationState.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/useUpdateConversationState.ts
@@ -25,7 +25,7 @@ import { ApiQueryKeys } from "@constants/apiConstants";
 import { parseApiResponseMessage } from "@utils/ApiError";
 
 /** Terminal status a conversation can be moved to via PATCH /conversations/:id. */
-export type ConversationStatusAction = "closed" | "abandoned";
+export type ConversationStatusAction = "closed" | "abandoned" | "converted";
 
 /**
  * Moves a Novera conversation to a terminal state via

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -146,13 +146,13 @@ export default function NoveraChatPage(): JSX.Element {
   const [conversationId, setConversationId] = useState<string | null>(
     () => urlConversationId ?? conversationResponse?.conversationId ?? null,
   );
-  const abandonConversation = useUpdateConversationState(
+  const convertConversation = useUpdateConversationState(
     projectId || "",
-    "abandoned",
+    "converted",
   );
   // Set when the user creates a case before the conversation id has been
-  // received; the conversation is then abandoned once conversation_created fires.
-  const pendingAbandonRef = useRef(false);
+  // received; the conversation is then converted once conversation_created fires.
+  const pendingConvertRef = useRef(false);
 
   const {
     data: conversationHistory,
@@ -343,24 +343,14 @@ export default function NoveraChatPage(): JSX.Element {
   const handleCreateCase = useCallback(() => {
     setIsCreateCaseLoading(true);
 
-    // If the user creates a case before Novera has produced any response, mark
-    // the conversation Abandoned so it isn't left counted as an open chat.
-    // (The welcome message is static; real bot replies have non-empty text.)
-    const userAsked = messages.some((m) => m.sender === ChatSender.USER);
-    const aiResponded = messages.some(
-      (m) =>
-        m.sender === ChatSender.BOT &&
-        m.id !== NOVERA_WELCOME_MESSAGE_ID &&
-        m.text.trim() !== "",
-    );
-    if (userAsked && !aiResponded) {
-      if (conversationId) {
-        abandonConversation.mutate(conversationId);
-      } else {
-        // Conversation id not received yet (very fast bail). Defer the abandon
-        // until the conversation_created event arrives.
-        pendingAbandonRef.current = true;
-      }
+    // A case is being created from this chat, so mark the conversation
+    // Converted so it is no longer counted as an open chat.
+    if (conversationId) {
+      convertConversation.mutate(conversationId);
+    } else {
+      // Conversation id not received yet (very fast bail). Defer the update
+      // until the conversation_created event arrives.
+      pendingConvertRef.current = true;
     }
 
     if (isAllProductsLoading) {
@@ -371,9 +361,8 @@ export default function NoveraChatPage(): JSX.Element {
   }, [
     isAllProductsLoading,
     performClassification,
-    messages,
     conversationId,
-    abandonConversation,
+    convertConversation,
   ]);
 
   useEffect(() => {
@@ -505,10 +494,10 @@ export default function NoveraChatPage(): JSX.Element {
           const nextConversationId = String(event.conversationId ?? "");
           if (nextConversationId) {
             setConversationId(nextConversationId);
-            // The user created a case before the id was available — abandon now.
-            if (pendingAbandonRef.current) {
-              pendingAbandonRef.current = false;
-              abandonConversation.mutate(nextConversationId);
+            // The user created a case before the id was available — convert now.
+            if (pendingConvertRef.current) {
+              pendingConvertRef.current = false;
+              convertConversation.mutate(nextConversationId);
             }
             if (!urlConversationId && projectId) {
               navigate(


### PR DESCRIPTION
## What
When a user creates a case from a Novera chat, the conversation now moves to **Converted (4)** — so it stops being counted as an open/active chat.

## Why (the bug this fixes)
Previously the chat was only **auto-abandoned** when a case was created *before* the assistant responded. But that gate treated the **"Novera is analyzing…" placeholder** (a bot message with non-empty text, added on `thinking_start`) as a real response — so `aiResponded` became true during "thinking", the abandon was skipped, and the chat **stayed Active** even after a case was created.

Per product decision, this is replaced with: **any case created from a chat → Converted**, fired optimistically on **Create Case** click (mirroring the old mechanism). The faulty `aiResponded` gate is removed entirely.

## Changes
- **Frontend** (`NoveraChatPage`): converts the conversation — immediately if the id is known, otherwise once `conversation_created` arrives — instead of abandoning. `useUpdateConversationState` now accepts `"converted"`.
- **Backend**: `PATCH /conversations/{id}` maps status `"converted"` → `conversationStateIds.converted` (4).

## Dependencies
- **entity-service** must permit state key `4` — wso2-enterprise/digiops-cs#2549. **Merge/deploy that first**, or the PATCH 400s (surfaced as 500) exactly like the earlier Close rollout.
- ServiceNow `Converted = 4` choice on `u_chat_conversation.u_state` — already present.

## Notes
- Behavior is optimistic (fires on Create Case click), so a chat converts even if the user then cancels case creation — chosen deliberately to match the existing mechanism.
- `Abandoned (5)` is no longer set by this flow (the PATCH path still supports it).

## Validation
- `bal build` (backend) ✓ · `tsc --noEmit` ✓ · eslint clean on changed files
- `NoveraChatPage.test` failure is pre-existing on `main` (`useLogger`/`LoggerProvider` harness gap), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)