### PR TITLE
[Customer Portal][Backend]Support de-escalation on the case escalation API

### DIFF
--- a/apps/customer-portal/backend/constants.bal
+++ b/apps/customer-portal/backend/constants.bal
@@ -33,6 +33,14 @@ const CONVERSATION_STATUS_CLOSED = "closed";
 const CONVERSATION_STATUS_ABANDONED = "abandoned";
 const CONVERSATION_STATUS_CONVERTED = "converted";
 
+// Escalation actions (POST /cases/{caseId}/escalations).
+const ESCALATION_ACTION_ESCALATE = "ESCALATE";
+const ESCALATION_ACTION_DEESCALATE = "DEESCALATE";
+const ERR_MSG_ESCALATION_REASON_REQUIRED = "Reason is required when escalating a case.";
+const ERR_MSG_ESCALATION_INVALID_ACTION = "Invalid action. Allowed values are ESCALATE or DEESCALATE.";
+const ERR_MSG_CASE_NOT_FOUND_FOR_ESCALATION = "The case for which you're trying to create an escalation does not exist.";
+const ERR_MSG_CASE_CLOSED_FOR_ESCALATION = "Cannot create an escalation for a closed case.";
+
 // Default Pagination Values
 public const int DEFAULT_OFFSET = 0;
 public const int DEFAULT_LIMIT = 10;

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2538,7 +2538,7 @@ public type CreatedEscalation record {|
     # Created date and time
     string createdOn;
     # Reason for the escalation
-    string reason;
+    string? reason;
     # Users notified about the escalation
     record {|
         # System ID of the user
@@ -2579,7 +2579,7 @@ public type Escalation record {|
     # Updated date and time
     string updatedOn;
     # Reason for the escalation
-    string reason;
+    string? reason;
     # Users notified about the escalation
     record {|
         # System ID of the user

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2518,7 +2518,9 @@ public type EscalationCreatePayload record {|
     # Case ID
     IdString caseId;
     # Reason for the escalation
-    string reason;
+    string reason?;
+    # Action to perform. One of "ESCALATE" or "DEESCALATE"
+    string action?;
 |};
 
 # Created escalation details.

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1301,7 +1301,7 @@ public type CreatedEscalation record {|
     # Created date and time
     string createdOn;
     # Reason for the escalation
-    string reason;
+    string? reason;
     # Users notified about the escalation
     record {|
         # ID of the user
@@ -1353,7 +1353,7 @@ public type Escalation record {|
     # Updated date and time
     string updatedOn;
     # Reason for the escalation
-    string reason;
+    string? reason;
     # Users notified about the escalation
     record {|
         # ID of the user

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1280,8 +1280,10 @@ public type CallRequestCreatePayload record {|
 
 # Request payload for creating an escalation.
 public type EscalationCreatePayload record {|
-    # Reason for the escalation
-    string reason;
+    # Reason for the escalation. Mandatory when action is ESCALATE
+    string reason?;
+    # Action to perform. One of "ESCALATE" (default) or "DEESCALATE", case-insensitive
+    string action?;
 |};
 
 # Created escalation details.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -7240,13 +7240,17 @@ components:
       additionalProperties: false
       description: Watch list information.
     EscalationCreatePayload:
-      required:
-      - reason
       type: object
       properties:
         reason:
           type: string
-          description: Reason for the escalation
+          description: Reason for the escalation. Mandatory when action is ESCALATE
+        action:
+          type: string
+          enum:
+          - ESCALATE
+          - DEESCALATE
+          description: Action to perform. Defaults to ESCALATE, case-insensitive
       additionalProperties: false
       description: Request payload for creating an escalation.
     EscalationSortField:

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2173,6 +2173,18 @@ paths:
           description: Unauthorized
         "403":
           description: Forbidden
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
   /cases/{caseId}/escalations/search:
@@ -7240,19 +7252,36 @@ components:
       additionalProperties: false
       description: Watch list information.
     EscalationCreatePayload:
-      type: object
-      properties:
-        reason:
-          type: string
-          description: Reason for the escalation. Mandatory when action is ESCALATE
-        action:
-          type: string
-          enum:
-          - ESCALATE
-          - DEESCALATE
-          description: Action to perform. Defaults to ESCALATE, case-insensitive
-      additionalProperties: false
       description: Request payload for creating an escalation.
+      oneOf:
+      - type: object
+        title: Escalate
+        required:
+        - reason
+        properties:
+          reason:
+            type: string
+            minLength: 1
+            description: Reason for the escalation. Mandatory when action is ESCALATE
+          action:
+            type: string
+            pattern: (?i)^ESCALATE$
+            default: ESCALATE
+            description: Action to perform. Defaults to ESCALATE, case-insensitive
+        additionalProperties: false
+      - type: object
+        title: Deescalate
+        required:
+        - action
+        properties:
+          reason:
+            type: string
+            description: Reason for the escalation. Mandatory when action is ESCALATE
+          action:
+            type: string
+            pattern: (?i)^DEESCALATE$
+            description: Action to perform. Defaults to ESCALATE, case-insensitive
+        additionalProperties: false
     EscalationSortField:
       type: string
       description: Valid escalation sort field values.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -7339,6 +7339,7 @@ components:
           description: Created date and time
         reason:
           type: string
+          nullable: true
           description: Reason for the escalation
         notificationSentTo:
           type: array
@@ -7410,6 +7411,7 @@ components:
           description: Updated date and time
         reason:
           type: string
+          nullable: true
           description: Reason for the escalation
         notificationSentTo:
           type: array

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -6652,7 +6652,8 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
     # + return - Created escalation details or error response
     resource function post cases/[entity:IdString caseId]/escalations(
             http:RequestContext ctx, types:EscalationCreatePayload payload)
-        returns http:Created|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError {
+        returns http:Created|http:BadRequest|http:Unauthorized|http:Forbidden|http:NotFound|http:Conflict|
+            http:InternalServerError {
 
         authorization:UserInfoPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -6663,10 +6664,27 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             };
         }
 
+        string action = (payload.action ?: ESCALATION_ACTION_ESCALATE).toUpperAscii();
+        if action != ESCALATION_ACTION_ESCALATE && action != ESCALATION_ACTION_DEESCALATE {
+            return <http:BadRequest>{
+                body: {
+                    message: ERR_MSG_ESCALATION_INVALID_ACTION
+                }
+            };
+        }
+        if action == ESCALATION_ACTION_ESCALATE && (payload.reason ?: "").trim().length() == 0 {
+            return <http:BadRequest>{
+                body: {
+                    message: ERR_MSG_ESCALATION_REASON_REQUIRED
+                }
+            };
+        }
+
         entity:EscalationCreateResponse|error response = entity:createEscalation(userInfo.idToken,
                 {
                     caseId: caseId,
-                    reason: payload.reason
+                    reason: payload.reason,
+                    action: action
                 });
         if response is error {
             if getStatusCode(response) == http:STATUS_UNAUTHORIZED {
@@ -6682,6 +6700,20 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
                 return <http:Forbidden>{
                     body: {
                         message: ERR_MSG_CASE_ACCESS_FORBIDDEN
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_NOT_FOUND {
+                return <http:NotFound>{
+                    body: {
+                        message: ERR_MSG_CASE_NOT_FOUND_FOR_ESCALATION
+                    }
+                };
+            }
+            if getStatusCode(response) == http:STATUS_CONFLICT {
+                return <http:Conflict>{
+                    body: {
+                        message: ERR_MSG_CASE_CLOSED_FOR_ESCALATION
                     }
                 };
             }


### PR DESCRIPTION
## Summary
- Add an optional `action` field to `POST /cases/{caseId}/escalations`, accepting `ESCALATE` (default) or `DEESCALATE`, case-insensitive
- Make `reason` conditionally required: mandatory for `ESCALATE`, optional for `DEESCALATE`
- Surface upstream 404 (case not found) and 409 (case closed) responses instead of collapsing them into a generic 500
- Update the OpenAPI spec to match the new request contract

## Test plan
- [ ] `bal build` passes
- [ ] Escalate with reason omitted → 400
- [ ] Escalate with reason present → 201
- [ ] De-escalate with reason omitted → 201
- [ ] De-escalate with non-string reason → 400
- [ ] Invalid `action` value → 400
- [ ] Escalation on a closed/non-existent case → 409 / 404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for escalating or de-escalating cases through the case escalation endpoint.
  * Escalation actions are case-insensitive and default to escalation.
  * Escalation reasons are required when escalating a case.

* **Bug Fixes**
  * Added clear validation errors for invalid actions and missing reasons.
  * Improved handling for nonexistent and closed cases with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->