### PR TITLE
[CSM Portal Microapp] Add create service request flow to the microapp

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -25,6 +25,7 @@ import SupportPage from "@pages/SupportPage";
 import CaseDetailPage from "@pages/CaseDetailPage";
 import NewCasePage from "@pages/NewCasePage";
 import OperationsPage from "@pages/OperationsPage";
+import NewServiceRequestPage from "@pages/NewServiceRequestPage";
 import ChangeRequestDetailPage from "@pages/ChangeRequestDetailPage";
 import MorePage from "@pages/MorePage";
 import AnnouncementsPage from "@pages/AnnouncementsPage";
@@ -71,6 +72,7 @@ export default function App() {
           <Route path="/cases/new" element={<NewCasePage />} />
           <Route path="/cases/:id" element={<CaseDetailPage />} />
           <Route path="/operations" element={<OperationsPage />} />
+          <Route path="/operations/service-requests/new" element={<NewServiceRequestPage />} />
           <Route path="/operations/change-requests/:id" element={<ChangeRequestDetailPage />} />
           <Route path="/more" element={<MorePage />} />
           <Route path="/more/announcements" element={<AnnouncementsPage />} />

--- a/apps/csm-portal/microapp/src/components/operations/CatalogVariableFields.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/CatalogVariableFields.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  AdapterDateFns,
+  DatePickers,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from "@wso2/oxygen-ui";
+import type { CatalogItemVariableDto } from "@src/types";
+import {
+  formatDateTimeLocal,
+  isChoiceField,
+  isDateTimeField,
+  isDescriptionField,
+  isFileCopyPathField,
+  isMultiLineField,
+  parseDateTimeLocal,
+  variableLabel,
+} from "@utils/catalogVariables";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
+
+interface CatalogVariableFieldsProps {
+  /** Already filtered to user-editable variables (no context/hidden fields). */
+  variables: CatalogItemVariableDto[];
+  values: Record<string, string>;
+  onChange: (id: string, value: string) => void;
+  disabled?: boolean;
+}
+
+// Mobile counterpart of the webapp's CatalogVariableFields.tsx: single-column Stack rather than a
+// responsive Grid, and the Description field is a plain multiline TextField rather than a
+// rich-text editor (see utils/catalogVariables.ts's file comment for why). Otherwise renders the
+// same control per variable type/label: Yes/No select, multi-line text, datetime picker, or
+// single-line text.
+export function CatalogVariableFields({ variables, values, onChange, disabled }: CatalogVariableFieldsProps) {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Stack gap={2}>
+        {variables.map((v) => {
+          const value = values[v.id] ?? "";
+          const label = variableLabel(v);
+
+          if (isChoiceField(v)) {
+            const labelId = `sr-var-${v.id}-label`;
+            return (
+              <FormControl key={v.id} size="small" fullWidth required disabled={disabled}>
+                <InputLabel id={labelId}>{label}</InputLabel>
+                <Select
+                  labelId={labelId}
+                  label={label}
+                  value={value}
+                  onChange={(e) => onChange(v.id, String(e.target.value))}
+                >
+                  <MenuItem value="Yes">Yes</MenuItem>
+                  <MenuItem value="No">No</MenuItem>
+                </Select>
+              </FormControl>
+            );
+          }
+
+          if (isDescriptionField(v.questionText ?? "")) {
+            return (
+              <TextField
+                key={v.id}
+                label={label}
+                size="small"
+                fullWidth
+                required
+                multiline
+                minRows={5}
+                disabled={disabled}
+                value={value}
+                onChange={(e) => onChange(v.id, e.target.value)}
+              />
+            );
+          }
+
+          if (isMultiLineField(v)) {
+            return (
+              <TextField
+                key={v.id}
+                label={label}
+                size="small"
+                fullWidth
+                required
+                multiline
+                minRows={4}
+                disabled={disabled}
+                value={value}
+                onChange={(e) => onChange(v.id, e.target.value)}
+              />
+            );
+          }
+
+          if (isDateTimeField(v)) {
+            return (
+              <DateTimePicker
+                key={v.id}
+                label={label}
+                value={parseDateTimeLocal(value)}
+                disabled={disabled}
+                onChange={(next) =>
+                  onChange(v.id, next instanceof Date && !Number.isNaN(next.getTime()) ? formatDateTimeLocal(next) : "")
+                }
+                slotProps={{
+                  textField: { size: "small", fullWidth: true, required: true },
+                  field: { clearable: true },
+                }}
+              />
+            );
+          }
+
+          // File Copy Path is an optional plain text input.
+          const optional = isFileCopyPathField(v);
+          return (
+            <TextField
+              key={v.id}
+              label={label}
+              size="small"
+              fullWidth
+              required={!optional}
+              disabled={disabled}
+              value={value}
+              onChange={(e) => onChange(v.id, e.target.value)}
+            />
+          );
+        })}
+      </Stack>
+    </LocalizationProvider>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
-import { Badge, Chip, IconButton, Stack, Tab, Tabs } from "@wso2/oxygen-ui";
-import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "react-router-dom";
+import { Badge, Chip, Fab, IconButton, Stack, Tab, Tabs } from "@wso2/oxygen-ui";
+import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useQuery, useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
 import { currentUser } from "@src/services/currentUser";
@@ -39,6 +40,7 @@ type StateTabValue = CaseState | typeof ALL_STATES_TAB;
 // hides its severity filter the same way when locked to a non-"case" type); work state stays,
 // same as the webapp.
 export function ServiceRequestsTab() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 300);
   const [filters, setFilters] = useState<CaseFilters>(EMPTY_FILTERS);
@@ -85,6 +87,19 @@ export function ServiceRequestsTab() {
         filters={filters}
         onApply={setFilters}
       />
+
+      {/* Mirrors the webapp's "Create service request" button (OperationsPage.tsx's `actions`
+          prop on CsmIssuesView), rendered as this app's own floating create affordance — same
+          Fab convention as SupportPage.tsx's "Create case" button. */}
+      <Fab
+        aria-label="Create service request"
+        size="medium"
+        color="primary"
+        onClick={() => navigate("/operations/service-requests/new")}
+        sx={{ position: "fixed", right: 10, bottom: "calc(var(--tab-bar-height) + 60px)" }}
+      >
+        <Plus size={20} />
+      </Fab>
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -51,6 +51,10 @@ export const DEPLOYMENTS_SEARCH_ENDPOINT = "/deployments/search";
 export const DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT = (deploymentId: string) =>
   `/deployments/${deploymentId}/products/search`;
 
+export const CATALOGS_SEARCH_ENDPOINT = "/catalogs/search";
+export const CATALOG_ITEM_VARIABLES_ENDPOINT = (catalogId: string, catalogItemId: string) =>
+  `/catalogs/${catalogId}/items/${catalogItemId}/variables`;
+
 export const ATTACHMENTS_ENDPOINT = "/attachments";
 export const ATTACHMENTS_SEARCH_ENDPOINT = "/attachments/search";
 

--- a/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
@@ -172,7 +172,8 @@ export default function NewServiceRequestPage() {
       }
 
       navigate(`/cases/${created.id}`);
-    } catch {
+    } catch (error) {
+      Logger.warn("Could not create the service request", error);
       setSubmitError("Could not create the service request. Please try again.");
     } finally {
       setIsSubmitting(false);
@@ -184,9 +185,13 @@ export default function NewServiceRequestPage() {
       <Typography variant="h6">New Service Request</Typography>
 
       <Stack gap={2}>
-        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createCase.isPending} />
+        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createCase.isPending || isSubmitting} />
 
-        <FormControl size="small" fullWidth disabled={!project || deploymentsQuery.isLoading || createCase.isPending}>
+        <FormControl
+          size="small"
+          fullWidth
+          disabled={!project || deploymentsQuery.isLoading || createCase.isPending || isSubmitting}
+        >
           <InputLabel id="sr-deployment-label">Deployment</InputLabel>
           <Select
             labelId="sr-deployment-label"
@@ -209,7 +214,11 @@ export default function NewServiceRequestPage() {
           ) : null}
         </FormControl>
 
-        <FormControl size="small" fullWidth disabled={!deploymentId || productsQuery.isLoading || createCase.isPending}>
+        <FormControl
+          size="small"
+          fullWidth
+          disabled={!deploymentId || productsQuery.isLoading || createCase.isPending || isSubmitting}
+        >
           <InputLabel id="sr-product-label">Deployed Product</InputLabel>
           <Select
             labelId="sr-product-label"
@@ -235,7 +244,7 @@ export default function NewServiceRequestPage() {
         <FormControl
           size="small"
           fullWidth
-          disabled={!deployedProductId || catalogsQuery.isLoading || noCatalogs || createCase.isPending}
+          disabled={!deployedProductId || catalogsQuery.isLoading || noCatalogs || createCase.isPending || isSubmitting}
         >
           <InputLabel id="sr-catalog-label">Catalog</InputLabel>
           <Select
@@ -261,7 +270,7 @@ export default function NewServiceRequestPage() {
           ) : null}
         </FormControl>
 
-        <FormControl size="small" fullWidth disabled={!catalogId || createCase.isPending}>
+        <FormControl size="small" fullWidth disabled={!catalogId || createCase.isPending || isSubmitting}>
           <InputLabel id="sr-catalog-item-label">Catalog Item</InputLabel>
           <Select
             labelId="sr-catalog-item-label"
@@ -301,7 +310,7 @@ export default function NewServiceRequestPage() {
               <CatalogVariableFields
                 variables={renderableVars}
                 values={answers}
-                disabled={createCase.isPending}
+                disabled={createCase.isPending || isSubmitting}
                 onChange={(id, value) => setAnswers((prev) => ({ ...prev, [id]: value }))}
               />
             )}
@@ -309,7 +318,11 @@ export default function NewServiceRequestPage() {
         )}
 
         {catalogItemId && !variablesQuery.isLoading && !variablesQuery.isError && (
-          <AttachmentsField attachments={attachments} onChange={setAttachments} disabled={createCase.isPending} />
+          <AttachmentsField
+            attachments={attachments}
+            onChange={setAttachments}
+            disabled={createCase.isPending || isSubmitting}
+          />
         )}
 
         {firstEmptyRequired && !variablesQuery.isLoading && catalogItemId && (
@@ -325,7 +338,7 @@ export default function NewServiceRequestPage() {
         )}
 
         <Stack direction="row" gap={1} justifyContent="flex-end">
-          <Button onClick={() => navigate(-1)} disabled={createCase.isPending}>
+          <Button onClick={() => navigate(-1)} disabled={createCase.isPending || isSubmitting}>
             Cancel
           </Button>
           <Button variant="contained" disabled={!canSubmit} onClick={() => void handleSubmit()}>

--- a/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack, Typography } from "@wso2/oxygen-ui";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { cases } from "@src/services/cases";
+import { deployments } from "@src/services/deployments";
+import { catalogs } from "@src/services/catalogs";
+import { attachments as attachmentsService } from "@src/services/attachments";
+import type { Project } from "@src/types";
+import { Logger } from "@utils/logger";
+import { AttachmentsField } from "@components/support/AttachmentsField";
+import { ProjectSelect } from "@components/support/ProjectSelect";
+import { CatalogVariableFields } from "@components/operations/CatalogVariableFields";
+import {
+  encodeVariableValue,
+  getFirstEmptyRequiredField,
+  getUserEditableVariables,
+  isAttachmentField,
+} from "@utils/catalogVariables";
+import type { PendingAttachment } from "@utils/attachments";
+
+// Ports the webapp's CreateServiceRequestPage.tsx (features/csm-operations/pages/): the same
+// cascading Project → Deployment → Deployed product → Catalog → Catalog item picker, driving a
+// dynamic form built from the chosen catalog item's ServiceNow variables. Layout follows this
+// app's own NewCasePage.tsx (single-column Stack, no locked-project entry point) rather than the
+// webapp's Grid/Card, and — like NewCasePage — the Description variable renders as a plain
+// multiline field rather than the rich-text editor (this app has no rich-text component).
+export default function NewServiceRequestPage() {
+  const navigate = useNavigate();
+
+  const [project, setProject] = useState<Project | null>(null);
+  const [deploymentId, setDeploymentId] = useState("");
+  const [deployedProductId, setDeployedProductId] = useState("");
+  const [catalogId, setCatalogId] = useState("");
+  const [catalogItemId, setCatalogItemId] = useState("");
+  // Variable answers, keyed by variable id.
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  // createCase.isPending alone only covers the case-creation call — it flips back to false while
+  // the attachment uploads below are still in flight, which would let the button re-enable and
+  // fire a duplicate submission. Tracks the whole handleSubmit lifecycle instead, same as
+  // NewCasePage.tsx.
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const deploymentsQuery = useQuery(deployments.byProject(project?.id ?? ""));
+  const productsQuery = useQuery(deployments.productsByDeployment(deploymentId));
+  const catalogsQuery = useQuery(catalogs.search(deployedProductId));
+  const variablesQuery = useQuery(catalogs.itemVariables(catalogId, catalogItemId));
+
+  const createCase = useMutation({ mutationFn: cases.create });
+  const uploadAttachment = useMutation({ mutationFn: attachmentsService.create });
+
+  const catalogItems = useMemo(
+    () => catalogsQuery.data?.find((c) => c.id === catalogId)?.catalogItems ?? [],
+    [catalogsQuery.data, catalogId],
+  );
+
+  // ServiceNow returns context/hidden fields mixed in; only user-editable (non-attachment)
+  // variables get a rendered input. Attachments go through the shared AttachmentsField below.
+  const allVariables = useMemo(() => variablesQuery.data ?? [], [variablesQuery.data]);
+  const renderableVars = useMemo(
+    () => getUserEditableVariables(allVariables).filter((v) => !isAttachmentField(v)),
+    [allVariables],
+  );
+  const firstEmptyRequired = useMemo(() => getFirstEmptyRequiredField(allVariables, answers), [allVariables, answers]);
+
+  // A deployed product with no catalogs is the common non-ServiceNow case; tell the engineer
+  // rather than leaving an empty dropdown.
+  const noCatalogs = !!deployedProductId && catalogsQuery.isSuccess && (catalogsQuery.data?.length ?? 0) === 0;
+
+  // Cascade resets: a parent change invalidates every dependent field below it.
+  const handleProjectChange = (next: Project | null) => {
+    setProject(next);
+    setDeploymentId("");
+    setDeployedProductId("");
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleDeploymentChange = (next: string) => {
+    setDeploymentId(next);
+    setDeployedProductId("");
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleDeployedProductChange = (next: string) => {
+    setDeployedProductId(next);
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleCatalogChange = (next: string) => {
+    setCatalogId(next);
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleCatalogItemChange = (next: string) => {
+    setCatalogItemId(next);
+    setAnswers({});
+  };
+
+  const canSubmit =
+    !!project &&
+    !!deploymentId &&
+    !!deployedProductId &&
+    !!catalogId &&
+    !!catalogItemId &&
+    !variablesQuery.isLoading &&
+    !variablesQuery.isError &&
+    // Hot fix (mirrors the webapp and, upstream, the customer portal): all typable variables required.
+    firstEmptyRequired === null &&
+    !createCase.isPending &&
+    !isSubmitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !project) return;
+    setSubmitError(null);
+    setIsSubmitting(true);
+
+    // Send user-editable, non-attachment variables, encoded by type, omitting empties.
+    // Context/hidden fields are excluded by getUserEditableVariables.
+    const variablePayload = getUserEditableVariables(allVariables)
+      .filter((v) => !isAttachmentField(v))
+      .map((v) => ({ id: v.id, value: encodeVariableValue(v, answers[v.id] ?? "") }))
+      .filter((v) => v.value !== "");
+
+    try {
+      const created = await createCase.mutateAsync({
+        type: "service_request",
+        projectId: project.id,
+        deploymentId,
+        deployedProductId,
+        catalogId,
+        catalogItemId,
+        variables: variablePayload,
+      });
+
+      // The create endpoint doesn't attach files for service requests, so upload them to the new
+      // case afterwards, same as NewCasePage.tsx — a partial failure still lands the case.
+      const results = await Promise.allSettled(
+        attachments.map((attachment) =>
+          uploadAttachment.mutateAsync({
+            referenceId: created.id,
+            referenceType: "case",
+            name: attachment.name,
+            type: attachment.type,
+            file: attachment.file,
+          }),
+        ),
+      );
+      const failedCount = results.filter((r) => r.status === "rejected").length;
+      if (failedCount > 0) {
+        Logger.warn(`${failedCount} attachment(s) failed to upload to service request ${created.id}`);
+      }
+
+      navigate(`/cases/${created.id}`);
+    } catch {
+      setSubmitError("Could not create the service request. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="h6">New Service Request</Typography>
+
+      <Stack gap={2}>
+        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createCase.isPending} />
+
+        <FormControl size="small" fullWidth disabled={!project || deploymentsQuery.isLoading || createCase.isPending}>
+          <InputLabel id="sr-deployment-label">Deployment</InputLabel>
+          <Select
+            labelId="sr-deployment-label"
+            label="Deployment"
+            value={deploymentId}
+            onChange={(event) => handleDeploymentChange(event.target.value)}
+          >
+            {(deploymentsQuery.data ?? []).map((d) => (
+              <MenuItem key={d.id} value={d.id}>
+                {d.name}
+              </MenuItem>
+            ))}
+          </Select>
+          {!project ? (
+            <FormHelperText>Select a project first</FormHelperText>
+          ) : deploymentsQuery.isLoading ? (
+            <FormHelperText>Loading deployments…</FormHelperText>
+          ) : (deploymentsQuery.data ?? []).length === 0 ? (
+            <FormHelperText>No deployments found for this project.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        <FormControl size="small" fullWidth disabled={!deploymentId || productsQuery.isLoading || createCase.isPending}>
+          <InputLabel id="sr-product-label">Deployed Product</InputLabel>
+          <Select
+            labelId="sr-product-label"
+            label="Deployed Product"
+            value={deployedProductId}
+            onChange={(event) => handleDeployedProductChange(event.target.value)}
+          >
+            {(productsQuery.data ?? []).map((p) => (
+              <MenuItem key={p.id} value={p.id}>
+                {p.label}
+              </MenuItem>
+            ))}
+          </Select>
+          {!deploymentId ? (
+            <FormHelperText>Select a deployment first</FormHelperText>
+          ) : productsQuery.isLoading ? (
+            <FormHelperText>Loading products…</FormHelperText>
+          ) : (productsQuery.data ?? []).length === 0 ? (
+            <FormHelperText>No deployed products found for this deployment.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        <FormControl
+          size="small"
+          fullWidth
+          disabled={!deployedProductId || catalogsQuery.isLoading || noCatalogs || createCase.isPending}
+        >
+          <InputLabel id="sr-catalog-label">Catalog</InputLabel>
+          <Select
+            labelId="sr-catalog-label"
+            label="Catalog"
+            value={catalogId}
+            onChange={(event) => handleCatalogChange(event.target.value)}
+          >
+            {(catalogsQuery.data ?? []).map((c) => (
+              <MenuItem key={c.id} value={c.id}>
+                {c.name ?? c.id}
+              </MenuItem>
+            ))}
+          </Select>
+          {!deployedProductId ? (
+            <FormHelperText>Select a deployed product first</FormHelperText>
+          ) : catalogsQuery.isLoading ? (
+            <FormHelperText>Loading catalogs…</FormHelperText>
+          ) : catalogsQuery.isError ? (
+            <FormHelperText error>Couldn't load catalogs. Try again.</FormHelperText>
+          ) : noCatalogs ? (
+            <FormHelperText>No service catalogs are available for this product.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        <FormControl size="small" fullWidth disabled={!catalogId || createCase.isPending}>
+          <InputLabel id="sr-catalog-item-label">Catalog Item</InputLabel>
+          <Select
+            labelId="sr-catalog-item-label"
+            label="Catalog Item"
+            value={catalogItemId}
+            onChange={(event) => handleCatalogItemChange(event.target.value)}
+          >
+            {catalogItems.map((ci) => (
+              <MenuItem key={ci.id} value={ci.id}>
+                {ci.name ?? ci.id}
+              </MenuItem>
+            ))}
+          </Select>
+          {!catalogId ? (
+            <FormHelperText>Select a catalog first</FormHelperText>
+          ) : catalogItems.length === 0 ? (
+            <FormHelperText>No items found in this catalog.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        {/* Dynamic variable form for the chosen catalog item. */}
+        {catalogItemId && (
+          <>
+            {variablesQuery.isLoading ? (
+              <Typography variant="body2" color="text.secondary">
+                Loading request form…
+              </Typography>
+            ) : variablesQuery.isError ? (
+              <Typography variant="body2" color="error.main">
+                Could not load the request form for this catalog item. Try again.
+              </Typography>
+            ) : renderableVars.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                This catalog item has no additional fields.
+              </Typography>
+            ) : (
+              <CatalogVariableFields
+                variables={renderableVars}
+                values={answers}
+                disabled={createCase.isPending}
+                onChange={(id, value) => setAnswers((prev) => ({ ...prev, [id]: value }))}
+              />
+            )}
+          </>
+        )}
+
+        {catalogItemId && !variablesQuery.isLoading && !variablesQuery.isError && (
+          <AttachmentsField attachments={attachments} onChange={setAttachments} disabled={createCase.isPending} />
+        )}
+
+        {firstEmptyRequired && !variablesQuery.isLoading && catalogItemId && (
+          <Typography variant="caption" color="text.secondary">
+            Required field: {firstEmptyRequired}
+          </Typography>
+        )}
+
+        {submitError && (
+          <Typography variant="body2" color="error.main">
+            {submitError}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={1} justifyContent="flex-end">
+          <Button onClick={() => navigate(-1)} disabled={createCase.isPending}>
+            Cancel
+          </Button>
+          <Button variant="contained" disabled={!canSubmit} onClick={() => void handleSubmit()}>
+            {isSubmitting ? "Creating…" : "Create Service Request"}
+          </Button>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
@@ -30,11 +30,11 @@ const TABS: { id: OperationsTabId; label: string }[] = [
 
 // Mirrors the webapp's OperationsPage (apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx):
 // three tabs — Service requests (cases with type=service_request, reusing the Support page's own
-// list/pagination/filter infra), Change requests (its own list/detail/edit), and Incidents (no
-// backend endpoint exists yet, in this repo or the webapp's — kept as a placeholder like the
-// webapp's own IssuesListUnavailable). "Create service request"/"Create change request" are
-// deliberately out of scope for this pass — each is its own large form (cascading
-// project/deployment/catalog selects with dynamic variables, or a 15+ field change-request form).
+// list/pagination/filter infra, with its own "Create service request" Fab — see
+// ServiceRequestsTab.tsx), Change requests (its own list/detail/edit), and Incidents (no backend
+// endpoint exists yet, in this repo or the webapp's — kept as a placeholder like the webapp's own
+// IssuesListUnavailable). "Create change request" is deliberately out of scope for this pass —
+// it's its own 15+ field form.
 export default function OperationsPage() {
   const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
 

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -36,6 +36,7 @@ import type {
   CaseViewDto,
   CreatedCaseDto,
   SecurityReportCreatePayloadDto,
+  ServiceRequestCreatePayloadDto,
   UpdateCaseResponseDto,
 } from "@src/types";
 import { toCaseDetail, toCaseSummary, toComment, type CaseDetail, type CaseSummary, type Comment } from "@src/types";
@@ -202,7 +203,9 @@ const getCaseComments = async (id: string): Promise<Comment[]> => {
   return data.comments.map(toComment);
 };
 
-const createCase = async (payload: CaseCreatePayloadDto | SecurityReportCreatePayloadDto): Promise<CreatedCaseDto> => {
+const createCase = async (
+  payload: CaseCreatePayloadDto | SecurityReportCreatePayloadDto | ServiceRequestCreatePayloadDto,
+): Promise<CreatedCaseDto> => {
   const { data } = await apiClient.post<CaseCreateResponseDto>(CASES_ENDPOINT, payload);
   return data.case;
 };

--- a/apps/csm-portal/microapp/src/services/catalogs.ts
+++ b/apps/csm-portal/microapp/src/services/catalogs.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { queryOptions } from "@tanstack/react-query";
+import { CATALOGS_SEARCH_ENDPOINT, CATALOG_ITEM_VARIABLES_ENDPOINT } from "@config/endpoints";
+import type {
+  CatalogItemVariableDto,
+  CatalogItemVariablesResponseDto,
+  CatalogRefDto,
+  CatalogSearchResponseDto,
+} from "@src/types";
+import apiClient from "./apiClient";
+
+// Matches deployments.ts's SEARCH_PAGE_LIMIT — the live entity service rejects the openapi-declared
+// 100 max with a 400.
+const SEARCH_PAGE_LIMIT = 50;
+
+// Service catalogs (and the catalog items they embed) only exist for ServiceNow-sourced deployed
+// products; managed-cloud products resolve to an empty list. The catalog select has no
+// infinite-scroll UI of its own, so fetch every page rather than just the first — same technique
+// as deployments.ts's listDeployments. Advances the offset by the actual page size (the backend
+// may clamp `limit` below SEARCH_PAGE_LIMIT) and stops on an empty page or once the reported total
+// is reached.
+const searchCatalogs = async (deployedProductId: string): Promise<CatalogRefDto[]> => {
+  const all: CatalogRefDto[] = [];
+  let offset = 0;
+  for (;;) {
+    const { data } = await apiClient.post<CatalogSearchResponseDto>(CATALOGS_SEARCH_ENDPOINT, {
+      deployedProductId,
+      pagination: { offset, limit: SEARCH_PAGE_LIMIT },
+    });
+    const page = data?.catalogs ?? [];
+    all.push(...page);
+    offset += page.length;
+    const total = data?.total;
+    if (page.length === 0) break;
+    if (total != null && all.length >= total) break;
+  }
+  return all;
+};
+
+// Sorted by the backend's display order so the form renders fields in the catalog's intended
+// sequence, mirroring the webapp's useCatalogItemVariables.ts.
+const getCatalogItemVariables = async (catalogId: string, catalogItemId: string): Promise<CatalogItemVariableDto[]> => {
+  const { data } = await apiClient.get<CatalogItemVariablesResponseDto>(
+    CATALOG_ITEM_VARIABLES_ENDPOINT(catalogId, catalogItemId),
+  );
+  const variables = data?.variables ?? [];
+  return [...variables].sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+};
+
+export const catalogs = {
+  search: (deployedProductId: string) =>
+    queryOptions({
+      queryKey: ["catalogs", deployedProductId],
+      queryFn: () => searchCatalogs(deployedProductId),
+      enabled: !!deployedProductId,
+      staleTime: 60_000,
+    }),
+
+  itemVariables: (catalogId: string, catalogItemId: string) =>
+    queryOptions({
+      queryKey: ["catalog-item-variables", catalogId, catalogItemId],
+      queryFn: () => getCatalogItemVariables(catalogId, catalogItemId),
+      enabled: !!catalogId && !!catalogItemId,
+      staleTime: 60_000,
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -288,8 +288,7 @@ export type CaseCause =
   | "INFRASTRUCTURE_SAAS_SIDE_OTHER"
   | "UNKNOWN";
 
-// Mirrors the webapp's BeCaseCreatePayload (the "case" type variant only — service_request
-// creation isn't in the microapp's scope, see NewCasePage.tsx).
+// Mirrors the webapp's BeCaseCreatePayload (the "case" type variant).
 export interface CaseCreatePayloadDto {
   type: "case";
   projectId: string;
@@ -313,6 +312,29 @@ export interface SecurityReportCreatePayloadDto {
   subject: string;
   description: string;
   attachments: { name: string; file: string }[];
+}
+
+/** A single answered catalog-item variable in a service-request create. */
+export interface CaseVariableDto {
+  /** Variable (question) id, as returned by the catalog-item variables endpoint. */
+  id: string;
+  /** The engineer's answer for this variable. */
+  value: string;
+}
+
+// The "service_request" type variant — see NewServiceRequestPage.tsx. Mirrors the webapp's
+// BeServiceRequestCreatePayload: catalog/catalogItem come from the deployed-product-scoped
+// catalog cascade, variables from that catalog item's form. Like the "case" type, attachments
+// upload separately via POST /attachments after the case exists (the create endpoint only
+// embeds attachments for "security_report_analysis").
+export interface ServiceRequestCreatePayloadDto {
+  type: "service_request";
+  projectId: string;
+  deploymentId: string;
+  deployedProductId: string;
+  catalogId: string;
+  catalogItemId: string;
+  variables: CaseVariableDto[];
 }
 
 export interface CreatedCaseDto {

--- a/apps/csm-portal/microapp/src/types/catalog.dto.ts
+++ b/apps/csm-portal/microapp/src/types/catalog.dto.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Service catalogs (ServiceNow only) — drive service-request creation. Mirrors the webapp's
+// BeCatalogRef/BeCatalogItemRef/BeCatalogItemVariable (api/backend/types.ts).
+
+export interface CatalogItemRefDto {
+  id: string;
+  name?: string;
+}
+
+/** A service catalog and the catalog items it offers. */
+export interface CatalogRefDto {
+  id: string;
+  name?: string;
+  catalogItems?: CatalogItemRefDto[];
+}
+
+export interface CatalogSearchPayloadDto {
+  deployedProductId: string;
+  pagination?: { offset?: number; limit?: number };
+}
+
+export interface CatalogSearchResponseDto {
+  catalogs?: CatalogRefDto[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * A catalog-item variable (form field). The contract carries the question text, display order,
+ * and a free-form `type` hint, but no choice/option list or mandatory flag — every variable
+ * renders as a text field unless its type/questionText matches one of the classifiers in
+ * utils/catalogVariables.ts.
+ */
+export interface CatalogItemVariableDto {
+  id: string;
+  questionText?: string;
+  order?: number;
+  type?: string;
+}
+
+export interface CatalogItemVariablesResponseDto {
+  variables?: CatalogItemVariableDto[];
+}

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -16,6 +16,7 @@
 
 export * from "./case.dto";
 export * from "./case.model";
+export * from "./catalog.dto";
 export * from "./account.dto";
 export * from "./account.model";
 export * from "./activity.dto";

--- a/apps/csm-portal/microapp/src/utils/catalogVariables.ts
+++ b/apps/csm-portal/microapp/src/utils/catalogVariables.ts
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Service-catalog variable classification + value encoding for the service request form. Ports
+// the webapp's features/csm-operations/utils/catalogVariables.ts. ServiceNow returns the full raw
+// variable set for a catalog item — including auto-populated "context" fields
+// (project/deployment/product) and hidden system fields (case type, priority, ...) — so these
+// must be classified client-side, exactly as the webapp (and, upstream of it, the customer portal)
+// does. One deviation from the webapp: the Description field is a plain multiline TextField here
+// rather than a rich-text editor (mirrors NewCasePage.tsx's own case-description field, and this
+// app has no rich-text editor component), so its value is plain text, not HTML.
+
+import type { CatalogItemVariableDto } from "@src/types";
+
+// Variable `type` strings ServiceNow emits (matched case-insensitively).
+export const VARIABLE_TYPE_SINGLE_LINE = "Single Line Text";
+export const VARIABLE_TYPE_MULTI_LINE = "Multi Line Text";
+export const VARIABLE_TYPE_SELECT = "Select Box";
+export const VARIABLE_TYPE_CHECKBOX = "Checkbox";
+export const VARIABLE_TYPE_RADIO = "Radio Buttons";
+
+/** Boolean-ish field that renders a Yes/No dropdown (no choice list in the API). */
+export function isChoiceField(variable: CatalogItemVariableDto): boolean {
+  const t = (variable.type ?? "").trim().toLowerCase();
+  return (
+    t === VARIABLE_TYPE_SELECT.toLowerCase() ||
+    t === VARIABLE_TYPE_RADIO.toLowerCase() ||
+    t === VARIABLE_TYPE_CHECKBOX.toLowerCase()
+  );
+}
+
+/** Multi-line free text (but not the Description field, which gets its own larger text area). */
+export function isMultiLineField(variable: CatalogItemVariableDto): boolean {
+  const t = (variable.type ?? "").trim().toLowerCase();
+  return (
+    (t === VARIABLE_TYPE_MULTI_LINE.toLowerCase() || t.includes("multi")) &&
+    !isDescriptionField(variable.questionText ?? "")
+  );
+}
+
+/** The Description field — rendered with a larger multiline text area. */
+export function isDescriptionField(questionText: string): boolean {
+  const normalized = (questionText ?? "")
+    .replace(/^\s*\*?\s*/, "")
+    .trim()
+    .toLowerCase();
+  return normalized === "description";
+}
+
+/** File Copy Path field — a plain (optional) text input, not an upload. */
+export function isFileCopyPathField(variable: CatalogItemVariableDto): boolean {
+  const q = (variable.questionText ?? "").trim();
+  const t = (variable.type ?? "").trim();
+  return /file\s*copy\s*path/i.test(q) || /file\s*copy\s*path/i.test(t);
+}
+
+function isAttachmentType(type: string): boolean {
+  const t = (type ?? "").trim().toLowerCase();
+  return (
+    t === "attachment" ||
+    t === "file" ||
+    t === "file upload" ||
+    t.includes("attachment") ||
+    t.includes("file upload") ||
+    (t.includes("file") && !t.includes("configuration")) ||
+    t.includes("attach") ||
+    t.includes("document") ||
+    t.includes("upload")
+  );
+}
+
+function isAttachmentFieldByQuestionText(questionText: string): boolean {
+  const q = (questionText ?? "").trim().toLowerCase();
+  if (!q) return false;
+  const patterns = [
+    /attachment/i,
+    /attach\s/i,
+    /attach$/i,
+    /file\s*upload/i,
+    /upload\s*file/i,
+    /vulnerability\s*scan\s*report/i,
+    /scan\s*report/i,
+    /upload\s*document/i,
+    /document\s*upload/i,
+    /attach\s*report/i,
+    /attach\s*document/i,
+  ];
+  return patterns.some((p) => p.test(q));
+}
+
+/** Attachment/file-upload field (by type or questionText). Optional + collected in the shared
+ *  attachments section, so these are not rendered as text inputs. */
+export function isAttachmentField(variable: CatalogItemVariableDto): boolean {
+  // A File Copy Path field is a plain (optional) text input, not an upload — exclude it explicitly
+  // since its type/label can contain "file" and would otherwise be swallowed by isAttachmentType.
+  if (isFileCopyPathField(variable)) return false;
+  return isAttachmentType(variable.type ?? "") || isAttachmentFieldByQuestionText(variable.questionText ?? "");
+}
+
+const CONTEXT_FIELD_PATTERNS = [/^project$/i, /^deployments?$/i, /^product$/i, /^wso2\s*product$/i, /^environment$/i];
+
+const HIDDEN_FIELD_PATTERNS = [
+  /^case\s*type$/i,
+  /^service\s*request\s*category$/i,
+  /^classification$/i,
+  /^class\s*fication$/i,
+  /^srns$/i,
+  /^state$/i,
+  /^assignment\s*group$/i,
+  /^assigned\s*to$/i,
+  /^priority$/i,
+  /^impact$/i,
+];
+
+/** Auto-populated from the project/deployment/product cascade — not shown. */
+export function isContextField(questionText: string): boolean {
+  const normalized = questionText?.trim().toLowerCase() ?? "";
+  return CONTEXT_FIELD_PATTERNS.some((p) => p.test(normalized));
+}
+
+/** System field ServiceNow defaults — sent by the backend, not shown. */
+export function isHiddenField(questionText: string): boolean {
+  const normalized = questionText?.trim().toLowerCase() ?? "";
+  return HIDDEN_FIELD_PATTERNS.some((p) => p.test(normalized));
+}
+
+const DATE_TIME_FIELD_PATTERNS: RegExp[] = [
+  /start\s*(date|time)/i,
+  /end\s*(date|time)/i,
+  /scheduled\s*(date|time|start|end)/i,
+  /implementation\s*(date|time|start|end)/i,
+  /planned\s*(start|end|date|time)/i,
+  /actual\s*(start|end|date|time)/i,
+  /date\s*(and\s*)?\/?\s*time/i,
+  /time\s*(and\s*)?\/?\s*date/i,
+];
+
+/** Renders a datetime picker (by type or questionText). */
+export function isDateTimeField(variable: CatalogItemVariableDto): boolean {
+  const t = (variable.type ?? "").trim();
+  if (/date.*time|datetime/i.test(t) || /^date$/i.test(t)) return true;
+  const q = (variable.questionText ?? "").trim();
+  return DATE_TIME_FIELD_PATTERNS.some((p) => p.test(q));
+}
+
+/** Strip the leading `*`/whitespace ServiceNow prefixes onto required labels. */
+export function variableLabel(variable: CatalogItemVariableDto): string {
+  return (variable.questionText ?? "").replace(/^\s*\*?\s*/, "").trim() || variable.id;
+}
+
+/** User-editable variables — excludes context and hidden fields, sorted by the backend's display
+ *  order. This is the set the form renders and validates. */
+export function getUserEditableVariables(variables: CatalogItemVariableDto[]): CatalogItemVariableDto[] {
+  return variables
+    .filter((v) => !isContextField(v.questionText ?? "") && !isHiddenField(v.questionText ?? ""))
+    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+}
+
+/** First empty required field label, or null if all are filled. Hot fix (mirrors the webapp and,
+ *  upstream, the customer portal): every typable field is mandatory; attachment and File Copy Path
+ *  fields are optional and skipped. */
+export function getFirstEmptyRequiredField(
+  variables: CatalogItemVariableDto[],
+  values: Record<string, string>,
+): string | null {
+  for (const v of getUserEditableVariables(variables)) {
+    if (isAttachmentField(v) || isFileCopyPathField(v)) continue;
+    if (!(values[v.id] ?? "").trim()) return variableLabel(v);
+  }
+  return null;
+}
+
+/** Encode a variable's raw input into the value the payload carries: datetime becomes an
+ *  ISO-UTC string, everything else is sent as trimmed text. */
+export function encodeVariableValue(variable: CatalogItemVariableDto, raw: string): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return "";
+  if (isDateTimeField(variable)) {
+    const ms = Date.parse(trimmed);
+    return Number.isNaN(ms) ? trimmed : new Date(ms).toISOString();
+  }
+  return trimmed;
+}
+
+/** "YYYY-MM-DDTHH:MM" (the local-datetime wire format these fields store their state as) to a
+ *  local Date, for handing the value to the DateTimePicker. Same browser-local semantics a native
+ *  `datetime-local` input has. */
+export function parseDateTimeLocal(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]), Number(match[4]), Number(match[5]));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Local Date back to "YYYY-MM-DDTHH:MM", the inverse of {@link parseDateTimeLocal}. */
+export function formatDateTimeLocal(date: Date): string {
+  const y = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  const mi = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${mo}-${d}T${h}:${mi}`;
+}


### PR DESCRIPTION
## Summary

Adds the "Create service request" flow to the CSM Portal microapp, matching how it already works in the webapp (`CreateServiceRequestPage.tsx`).

- New Fab ("Create service request") on the Service Requests tab of the Operations page, using the same floating-icon pattern the Support page already uses for "Create case".
- New `NewServiceRequestPage` at `/operations/service-requests/new`: cascading Project → Deployment → Deployed Product → Catalog → Catalog Item picker, followed by a dynamically generated form built from that catalog item's ServiceNow variables, plus attachments.
- New supporting infra ported from the webapp, none of which previously existed in the microapp:
  - `types/catalog.dto.ts` — catalog / catalog-item / catalog-item-variable DTOs
  - `services/catalogs.ts` — `POST /catalogs/search` and the catalog-item-variables endpoint
  - `utils/catalogVariables.ts` — ServiceNow variable classification (context/hidden/attachment/date-time/description fields) and value encoding, mirroring the webapp's `features/csm-operations/utils/catalogVariables.ts`
  - `components/operations/CatalogVariableFields.tsx` — renders the dynamic per-variable inputs
  - `ServiceRequestCreatePayloadDto` / `CaseVariableDto` added to `types/case.dto.ts`, and `services/cases.ts`'s create call extended to accept the new payload type

Two deliberate mobile deviations from the webapp, consistent with this app's existing `NewCasePage.tsx`:
- Single-column `Stack` layout instead of the webapp's responsive `Grid`/`Card`.
- The catalog item's "Description" variable renders as a plain multiline `TextField` instead of a rich-text editor (the microapp has no rich-text component).

## Review fixes

Addressed CodeRabbit findings on `NewServiceRequestPage.tsx`:
- The submit `catch` block now captures and logs the underlying error via `Logger.warn` before showing the existing generic user-facing message.
- Every field's `disabled` state (project/deployment/product/catalog/catalog item selects, the dynamic variable fields, attachments, and Cancel) now also checks `isSubmitting`, not just `createCase.isPending` — the case-create mutation resolves before attachment uploads finish, so `createCase.isPending` alone was letting the form re-enable mid-submission.

## Test plan

- [x] `tsc -b` passes with no errors
- [x] `eslint` passes on all new/changed files
- [x] Verified in a headless browser: the Fab renders correctly on the Service Requests tab, and `/operations/service-requests/new` renders the full cascading form with correct disabled/helper-text states at each step
- [ ] Manual end-to-end verification inside the native app shell (submit a real service request) — not possible from this environment, since the app requires the WSO2 native device-auth bridge to obtain a token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create service requests from the Operations area.
  * Added guided selection of projects, deployments, products, catalogs, and catalog items.
  * Added dynamic request forms with required fields, date/time inputs, and file attachments.
  * Added validation, loading states, error messages, and automatic navigation to the created case.
  * Added a floating “Create service request” action to the service requests view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
