### PR TITLE
[Webapp] Add de-escalate action to case escalation UI

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/api/usePostCaseEscalation.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/usePostCaseEscalation.ts
@@ -17,29 +17,32 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthApiClient } from "@/hooks/useAuthApiClient";
 import { ApiQueryKeys } from "@constants/apiConstants";
-import type { CreateEscalationResponse } from "@features/support/types/cases";
+import type {
+  CreateEscalationRequest,
+  CreateEscalationResponse,
+} from "@features/support/types/cases";
 
 export type EscalationApiError = Error & { status: number };
 
 /**
- * Creates a new escalation for a case.
+ * Creates a new escalation, or de-escalates an existing one, for a case.
  *
- * @param {string} caseId - The case ID to escalate.
+ * @param {string} caseId - The case ID to escalate/de-escalate.
  * @returns Mutation result for POST /cases/{caseId}/escalations.
  */
 export function usePostCaseEscalation(caseId: string) {
   const authFetch = useAuthApiClient();
   const queryClient = useQueryClient();
 
-  return useMutation<CreateEscalationResponse, EscalationApiError, { reason: string }>({
-    mutationFn: async ({ reason }) => {
+  return useMutation<CreateEscalationResponse, EscalationApiError, CreateEscalationRequest>({
+    mutationFn: async (payload) => {
       const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL ?? "";
       const response = await authFetch(
         `${baseUrl}/cases/${caseId}/escalations`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ reason }),
+          body: JSON.stringify(payload),
         },
       );
       if (!response.ok) {

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -31,6 +31,7 @@ import { buildRecommendationRequestFromCase } from "@features/support/utils/reco
 import { usePostCaseEscalationsSearch } from "@features/support/api/usePostCaseEscalationsSearch";
 import useGetProjectContacts from "@features/settings/api/useGetProjectContacts";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
+import { SETTINGS_CUSTOMER_ADMIN_ROLE } from "@features/settings/constants/settingsConstants";
 import {
   getStatusColor,
   resolveColorFromTheme,
@@ -211,6 +212,22 @@ export default function CaseDetailsContent({
         )?.isLead
       : undefined;
 
+  // De-escalation is allowed for customer admins, leads, and users who created
+  // at least one escalation on this case (matched by email against the
+  // escalation history's createdBy).
+  const isCurrentUserCsAdmin: boolean | undefined = isUserDetailsLoading
+    ? undefined
+    : (userDetails?.roles ?? []).includes(SETTINGS_CUSTOMER_ADMIN_ROLE);
+  const hasCreatedEscalation =
+    !!userDetails?.email &&
+    !!escalationData?.escalations?.some(
+      (e) => e.createdBy.toLowerCase() === userDetails.email!.toLowerCase(),
+    );
+  const canDeescalate =
+    isCurrentUserCsAdmin === true ||
+    isCurrentUserLead === true ||
+    hasCreatedEscalation;
+
   const visibleTabs = useMemo(
     () => [
       0,
@@ -380,6 +397,9 @@ export default function CaseDetailsContent({
                     escalationLevelId={hideEscalationTab ? null : escalationLevelId}
                     onEscalateSuccess={() => void refetchEscalations()}
                     isCurrentUserLead={isCurrentUserLead}
+                    isEscalated={!hideEscalationTab && isEscalated}
+                    canDeescalate={!hideEscalationTab && canDeescalate}
+                    onDeescalateSuccess={() => void refetchEscalations()}
                   />
                 )}
               </Box>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/DeescalateCaseModal.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/DeescalateCaseModal.tsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { DeescalateCaseModalProps } from "@features/support/types/supportComponents";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+  useTheme,
+} from "@wso2/oxygen-ui";
+import { TriangleAlert, X } from "@wso2/oxygen-ui-icons-react";
+import { useCallback, useState, type ChangeEvent, type JSX } from "react";
+import { usePostCaseEscalation } from "@features/support/api/usePostCaseEscalation";
+
+const INLINE_ERROR_STATUSES = new Set([400, 403, 404, 409]);
+
+/**
+ * Modal for de-escalating a case that is currently escalated.
+ * Reason is optional. HTTP 4xx errors are shown inline; 500+ errors are forwarded via onError.
+ *
+ * @param {DeescalateCaseModalProps} props - Modal control props.
+ * @returns {JSX.Element} The de-escalate case modal.
+ */
+export default function DeescalateCaseModal({
+  open,
+  caseId,
+  onClose,
+  onSuccess,
+  onError,
+}: DeescalateCaseModalProps): JSX.Element {
+  const theme = useTheme();
+  const [reason, setReason] = useState("");
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  const { mutate, isPending } = usePostCaseEscalation(caseId);
+
+  const resetAndClose = useCallback(() => {
+    setReason("");
+    setInlineError(null);
+    onClose();
+  }, [onClose]);
+
+  const handleClose = useCallback(() => {
+    if (isPending) return;
+    resetAndClose();
+  }, [isPending, resetAndClose]);
+
+  const handleReasonChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setReason(e.target.value);
+      if (inlineError) setInlineError(null);
+    },
+    [inlineError],
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (isPending) return;
+    setInlineError(null);
+    const trimmedReason = reason.trim();
+    mutate(
+      {
+        action: "DEESCALATE",
+        ...(trimmedReason ? { reason: trimmedReason } : {}),
+      },
+      {
+        onSuccess: () => {
+          resetAndClose();
+          onSuccess?.();
+        },
+        onError: (err) => {
+          if (INLINE_ERROR_STATUSES.has(err.status)) {
+            setInlineError(err.message);
+          } else {
+            const msg = err.message ?? "Failed to de-escalate case. Please try again.";
+            onError?.(msg);
+            resetAndClose();
+          }
+        },
+      },
+    );
+  }, [reason, isPending, mutate, resetAndClose, onSuccess, onError]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="deescalate-case-modal-title"
+    >
+      <IconButton
+        aria-label="Close"
+        size="small"
+        onClick={handleClose}
+        disabled={isPending}
+        sx={{ position: "absolute", right: 12, top: 12, zIndex: 1 }}
+      >
+        <X size={18} />
+      </IconButton>
+
+      <DialogTitle
+        id="deescalate-case-modal-title"
+        sx={{ pr: 6, pb: 0.5 }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <TriangleAlert size={22} color={theme.palette.warning.main} />
+          <Typography variant="h6" component="span" fontWeight={700}>
+            De-escalate Case
+          </Typography>
+        </Box>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mt: 0.5, fontWeight: "normal" }}
+        >
+          This will remove the escalation from this case.
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1.5 }}>
+        {inlineError && (
+          <Alert severity="error" onClose={() => setInlineError(null)} sx={{ mb: 2 }}>
+            {inlineError}
+          </Alert>
+        )}
+
+        <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+          Reason (optional)
+        </Typography>
+        <TextField
+          id="deescalation-reason"
+          placeholder="Optionally describe why this case no longer needs to be escalated..."
+          value={reason}
+          onChange={handleReasonChange}
+          fullWidth
+          multiline
+          rows={4}
+          disabled={isPending}
+          inputProps={{ "aria-label": "Reason for de-escalation" }}
+        />
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2.5, gap: 1 }}>
+        <Button variant="outlined" onClick={handleClose} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleConfirm}
+          disabled={isPending}
+          startIcon={
+            isPending ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <TriangleAlert size={16} />
+            )
+          }
+        >
+          {isPending ? "De-escalating..." : "Confirm De-escalation"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/EscalateCaseModal.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/escalation/EscalateCaseModal.tsx
@@ -86,7 +86,7 @@ export default function EscalateCaseModal({
     if (!reason.trim() || isPending || !nextLevel) return;
     setInlineError(null);
     mutate(
-      { reason: reason.trim() },
+      { reason: reason.trim(), action: "ESCALATE" },
       {
         onSuccess: () => {
           resetAndClose();

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -25,6 +25,7 @@ import {
 } from "@wso2/oxygen-ui";
 import CaseStateConfirmDialog from "@features/support/components/case-details/dialogs/CaseStateConfirmDialog";
 import EscalateCaseModal from "../escalation/EscalateCaseModal";
+import DeescalateCaseModal from "../escalation/DeescalateCaseModal";
 import CaseFeedbackModal from "../feedback/CaseFeedbackModal";
 import { type JSX, useState } from "react";
 import {
@@ -97,6 +98,9 @@ export default function CaseDetailsActionRow({
   escalationLevelId,
   onEscalateSuccess,
   isCurrentUserLead,
+  isEscalated,
+  canDeescalate,
+  onDeescalateSuccess,
 }: CaseDetailsActionRowProps): JSX.Element {
   void assignedEngineer;
   void engineerInitials;
@@ -115,6 +119,7 @@ export default function CaseDetailsActionRow({
     stateKey: number;
   } | null>(null);
   const [escalateModalOpen, setEscalateModalOpen] = useState(false);
+  const [deescalateModalOpen, setDeescalateModalOpen] = useState(false);
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
 
   const resolvedEscalationLevelId = escalationLevelId != null ? String(escalationLevelId) : null;
@@ -126,6 +131,7 @@ export default function CaseDetailsActionRow({
     resolvedEscalationLevelId !== ESCALATION_MAX_LEVEL_ID &&
     !!escalationLevelInfo &&
     (!needsLead || isCurrentUserLead === true);
+  const showDeescalateButton = isEscalated === true && canDeescalate === true;
 
   const availableActions = getAvailableCaseActions(statusLabel).filter(
     (label) => {
@@ -212,6 +218,17 @@ export default function CaseDetailsActionRow({
           Escalate Case
         </Button>
       )}
+      {showDeescalateButton && (
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<TriangleAlert size={ACTION_BUTTON_ICON_SIZE} />}
+          onClick={() => setDeescalateModalOpen(true)}
+          sx={getActionButtonSx(theme, "info") as Record<string, unknown>}
+        >
+          De-escalate Case
+        </Button>
+      )}
       <CaseStateConfirmDialog
         open={!!confirmAction}
         actionLabel={confirmAction ? toPresentTenseActionLabel(confirmAction.label) : ""}
@@ -254,6 +271,18 @@ export default function CaseDetailsActionRow({
           onSuccess={() => {
             showSuccess("Case escalated successfully.");
             onEscalateSuccess?.();
+          }}
+          onError={(msg) => showError(msg)}
+        />
+      )}
+      {showDeescalateButton && (
+        <DeescalateCaseModal
+          open={deescalateModalOpen}
+          caseId={caseId}
+          onClose={() => setDeescalateModalOpen(false)}
+          onSuccess={() => {
+            showSuccess("Case de-escalated successfully.");
+            onDeescalateSuccess?.();
           }}
           onError={(msg) => showError(msg)}
         />

--- a/apps/customer-portal/webapp/src/features/support/types/cases.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/cases.ts
@@ -225,13 +225,14 @@ export type EscalationRecord = {
   createdBy: string;
   createdOn: string;
   updatedOn?: string;
-  reason: string;
+  reason: string | null;
   notificationSentTo?: EscalationNotifiedUser[] | null;
 };
 
 // Request type for creating an escalation.
 export type CreateEscalationRequest = {
-  reason: string;
+  reason?: string;
+  action?: "ESCALATE" | "DEESCALATE";
 };
 
 // Response type for creating an escalation.

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -449,6 +449,9 @@ export type CaseDetailsActionRowProps = {
   escalationLevelId?: string | null;
   onEscalateSuccess?: () => void;
   isCurrentUserLead?: boolean | undefined;
+  isEscalated?: boolean;
+  canDeescalate?: boolean;
+  onDeescalateSuccess?: () => void;
 };
 
 export type EscalateCaseModalProps = {
@@ -456,6 +459,14 @@ export type EscalateCaseModalProps = {
   caseId: string;
   escalationLevelId: string;
   escalationLevelLabel: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+  onError?: (message: string) => void;
+};
+
+export type DeescalateCaseModalProps = {
+  open: boolean;
+  caseId: string;
   onClose: () => void;
   onSuccess?: () => void;
   onError?: (message: string) => void;


### PR DESCRIPTION
## Summary
- Add a "De-escalate Case" button/modal, shown next to Escalate when a case is currently escalated
- Restrict de-escalation to: customer admins (sn_customerservice.customer_admin role), project leads, and users who created at least one escalation on the case
- Update escalation request/response types: `reason` optional on requests (required only for ESCALATE), nullable on responses (ServiceNow returns `null` for reason-less de-escalations)
- `POST /cases/{caseId}/escalations` now always sends an explicit `action` (`ESCALATE` or `DEESCALATE`)

## Test plan
- [ ] Escalate button unaffected on a non-escalated case
- [ ] De-escalate button hidden for a non-admin/non-lead user with no
      escalations on the case
- [ ] De-escalate button shown for a customer admin (sn_customerservice.customer_admin)
- [ ] De-escalate button shown for a project lead
- [ ] De-escalate button shown for the user who created an escalation on the case
- [ ] Submit de-escalation with and without a reason — both succeed
- [ ] 4xx errors surface inline in the modal; 500+ forwarded to error banner
- [ ] `tsc --noEmit` and `eslint` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to de-escalate eligible cases from the case details view.
  * Added a confirmation dialog with optional reasons and clear error messaging.
  * Case details now refresh automatically after successful de-escalation.
  * Escalation actions now explicitly distinguish between escalating and de-escalating a case.

* **Bug Fixes**
  * Improved support for escalations without a reason and records with unavailable reasons.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->