### PR TITLE
fix(customer-portal): await chat convert before navigating to case flow

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -302,6 +302,19 @@ export default function NoveraChatPage(): JSX.Element {
       return;
     }
 
+    // A case is being created from this chat, so mark the conversation
+    // Converted before we navigate into the case flow. This is awaited on
+    // purpose: firing it without awaiting lets the imminent navigation cancel
+    // the in-flight request, so the state change is lost. A conversion failure
+    // must not block case creation, so the error is swallowed.
+    if (conversationId) {
+      try {
+        await convertConversation.mutateAsync(conversationId);
+      } catch {
+        // Non-blocking: proceed with case creation even if the update fails.
+      }
+    }
+
     try {
       const chatHistory = formatChatHistoryForClassification(messages);
       if (chatHistory) {
@@ -338,18 +351,16 @@ export default function NoveraChatPage(): JSX.Element {
     classifyCase,
     conversationId,
     projectTypeId,
+    convertConversation,
   ]);
 
   const handleCreateCase = useCallback(() => {
     setIsCreateCaseLoading(true);
 
-    // A case is being created from this chat, so mark the conversation
-    // Converted so it is no longer counted as an open chat.
-    if (conversationId) {
-      convertConversation.mutate(conversationId);
-    } else {
-      // Conversation id not received yet (very fast bail). Defer the update
-      // until the conversation_created event arrives.
+    if (!conversationId) {
+      // Conversation id not received yet (very fast bail). Defer the convert
+      // until the conversation_created event arrives. When the id is present,
+      // performClassification converts (awaited) before navigating away.
       pendingConvertRef.current = true;
     }
 
@@ -358,12 +369,7 @@ export default function NoveraChatPage(): JSX.Element {
     } else {
       performClassification();
     }
-  }, [
-    isAllProductsLoading,
-    performClassification,
-    conversationId,
-    convertConversation,
-  ]);
+  }, [isAllProductsLoading, performClassification, conversationId]);
 
   useEffect(() => {
     if (isWaitingForClassification && !isAllProductsLoading) {

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -81,6 +81,11 @@ import {
   dateFromApiCreatedOn,
 } from "@features/support/utils/support";
 
+// Max time (ms) to wait for the conversation "Converted" update before
+// proceeding with case creation. Bounds the await so a slow or hung request
+// can never block the case-creation flow.
+const CONVERT_STATE_TIMEOUT_MS = 5000;
+
 /**
  * NoveraChatPage component to provide AI-powered support assistance.
  *
@@ -309,8 +314,16 @@ export default function NoveraChatPage(): JSX.Element {
     // the in-flight request, so the state change is lost. A conversion failure
     // must not block case creation, so the error is swallowed.
     if (activeConversationId) {
+      // Bound the wait: a conversion failure (caught below) or a hung request
+      // (the timeout) must never block case creation. The convert still runs;
+      // we simply stop waiting on it once the timeout elapses.
       try {
-        await convertConversation.mutateAsync(activeConversationId);
+        await Promise.race([
+          convertConversation.mutateAsync(activeConversationId),
+          new Promise<void>((resolve) =>
+            setTimeout(resolve, CONVERT_STATE_TIMEOUT_MS),
+          ),
+        ]);
       } catch {
         // Non-blocking: proceed with case creation even if the update fails.
       }

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -294,7 +294,8 @@ export default function NoveraChatPage(): JSX.Element {
     }
   }, [urlConversationId, conversationResponse, projectId, navigate]);
 
-  const performClassification = useCallback(async () => {
+  const performClassification = useCallback(async (overrideConversationId?: string) => {
+    const activeConversationId = overrideConversationId ?? conversationId;
     if (!projectId) {
       navigate("/");
       setIsCreateCaseLoading(false);
@@ -307,9 +308,9 @@ export default function NoveraChatPage(): JSX.Element {
     // purpose: firing it without awaiting lets the imminent navigation cancel
     // the in-flight request, so the state change is lost. A conversion failure
     // must not block case creation, so the error is swallowed.
-    if (conversationId) {
+    if (activeConversationId) {
       try {
-        await convertConversation.mutateAsync(conversationId);
+        await convertConversation.mutateAsync(activeConversationId);
       } catch {
         // Non-blocking: proceed with case creation even if the update fails.
       }
@@ -327,16 +328,20 @@ export default function NoveraChatPage(): JSX.Element {
             projectTypeId,
           });
           navigate(`/projects/${projectId}/support/chat/create-case`, {
-            state: { messages, classificationResponse, conversationId },
+            state: {
+              messages,
+              classificationResponse,
+              conversationId: activeConversationId,
+            },
           });
         } catch {
           navigate(`/projects/${projectId}/support/chat/create-case`, {
-            state: { messages, conversationId },
+            state: { messages, conversationId: activeConversationId },
           });
         }
       } else {
         navigate(`/projects/${projectId}/support/chat/create-case`, {
-          state: { messages, conversationId },
+          state: { messages, conversationId: activeConversationId },
         });
       }
     } finally {
@@ -358,10 +363,11 @@ export default function NoveraChatPage(): JSX.Element {
     setIsCreateCaseLoading(true);
 
     if (!conversationId) {
-      // Conversation id not received yet (very fast bail). Defer the convert
-      // until the conversation_created event arrives. When the id is present,
-      // performClassification converts (awaited) before navigating away.
+      // Conversation id not received yet. Defer the whole create-case flow
+      // (convert + classify + navigate) until conversation_created arrives, so
+      // the conversion runs with a real id and is awaited before navigation.
       pendingConvertRef.current = true;
+      return;
     }
 
     if (isAllProductsLoading) {
@@ -500,12 +506,17 @@ export default function NoveraChatPage(): JSX.Element {
           const nextConversationId = String(event.conversationId ?? "");
           if (nextConversationId) {
             setConversationId(nextConversationId);
-            // The user created a case before the id was available — convert now.
             if (pendingConvertRef.current) {
+              // A case was requested before the id arrived — resume the
+              // create-case flow now with the fresh id, so the conversion is
+              // awaited before navigation instead of being fired-and-cancelled.
               pendingConvertRef.current = false;
-              convertConversation.mutate(nextConversationId);
-            }
-            if (!urlConversationId && projectId) {
+              if (isAllProductsLoading) {
+                setIsWaitingForClassification(true);
+              } else {
+                performClassification(nextConversationId);
+              }
+            } else if (!urlConversationId && projectId) {
               navigate(
                 `/projects/${projectId}/support/chat/${nextConversationId}`,
                 {


### PR DESCRIPTION
## Bug
Creating a case from a Novera chat left the conversation **Active** instead of **Converted**, even with everything deployed. Network showed the `PATCH /conversations/{id}` `{status:"converted"}` firing — but with **no response**: the request was **cancelled by the navigation** into the Create-Case page before it completed. `authFetch` adds no abort of its own; the in-flight request simply died when `performClassification` navigated away right after `mutate()`.

(The manual **Close** from the conversations list was unaffected — it fires from a page that doesn't navigate.)

## Fix
Move the convert into `performClassification` and **`await` it before navigating**:
- `await convertConversation.mutateAsync(conversationId)` before the classify + `navigate(...)`.
- Wrapped in try/catch — a conversion failure must never block case creation.
- `handleCreateCase` now only sets the deferred flag when the id isn't ready yet; the deferred path still fires on `conversation_created`.

## Validation
- `tsc --noEmit` ✓ · eslint clean on the changed file.
- Manual: the `PATCH …{status:"converted"}` now completes (200) before navigating, and the chat shows **Converted**.
- `NoveraChatPage.test` can't mount on `main` (pre-existing `LoggerProvider`/`ErrorBannerProvider` harness gap), so no unit test added here.

## Depends on
entity-service #2549 (accept stateKey 4) deployed — otherwise the now-completing PATCH returns 500 instead of converting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the transition from chat conversations to support cases.
  * Ensured conversations are converted at the appropriate stage, even when an ID is not immediately available.
  * Prevented conversion errors from blocking navigation into the case flow.