### PR TITLE
fix(customer-portal): gate dashboard Close on explicit isResumable flag

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryCard.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/ChatHistoryCard.tsx
@@ -34,7 +34,6 @@ import {
   getConversationStatusColor,
   formatDateTime,
 } from "@features/support/utils/support";
-import { isConversationResumable } from "@features/support/utils/conversationsList";
 
 export interface ChatHistoryCardProps {
   item: ChatHistoryItem;
@@ -189,7 +188,7 @@ export default function ChatHistoryCard({
           alignItems="center"
           sx={{ flexShrink: 0 }}
         >
-          {onCloseChat && isConversationResumable(item.status) && (
+          {onCloseChat && item.isResumable && (
             <Button
               component="span"
               size="small"

--- a/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/__tests__/ChatHistoryCard.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/support-overview-cards/__tests__/ChatHistoryCard.test.tsx
@@ -61,6 +61,7 @@ describe("ChatHistoryCard", () => {
               startedTime: "2026-01-01T00:00:00Z",
               messages: 3,
               kbArticles: 1,
+              isResumable: true,
             } as never
           }
           onItemAction={onItemAction}
@@ -90,6 +91,7 @@ describe("ChatHistoryCard", () => {
               startedTime: "2026-01-01T00:00:00Z",
               messages: 2,
               kbArticles: 0,
+              isResumable: false,
             } as never
           }
           onCloseChat={onCloseChat}

--- a/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/SupportPage.tsx
@@ -27,6 +27,7 @@ import OutstandingCasesList from "@features/support/components/support-overview-
 import ChatHistoryList from "@features/support/components/support-overview-cards/ChatHistoryList";
 import CloseChatConfirmDialog from "@features/support/components/close-chat/CloseChatConfirmDialog";
 import { useCloseConversationFlow } from "@features/support/hooks/useCloseConversationFlow";
+import { isConversationResumable } from "@features/support/utils/conversationsList";
 import { useGetProjectSupportStats } from "@features/support/api/useGetProjectSupportStats";
 import useGetProjectDetails from "@api/useGetProjectDetails";
 import useGetProjectFeatures from "@api/useGetProjectFeatures";
@@ -136,6 +137,7 @@ export default function SupportPage(): JSX.Element {
     kbArticles: 0,
     status: c.state?.label ?? "Open",
     createdBy: c.createdBy ?? undefined,
+    isResumable: isConversationResumable(c.state?.label),
   }));
 
   const isActuallyLoading = isAuthLoading || isLoading || (!stats && !isError);

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -33,6 +33,9 @@ export type ChatHistoryItem = {
   kbArticles: number;
   status: string;
   createdBy?: string | null;
+  // Whether the chat can be resumed (and therefore closed). Derived from the
+  // conversation state upstream; missing/unknown state is treated as false.
+  isResumable?: boolean;
 };
 
 // Response type for project chat history list.


### PR DESCRIPTION
Follow-up to #1229 (merged) — this fix was pushed to #1229's branch just after it merged, so it missed the merge.

## Problem
`ChatHistoryCard` decided whether to show **Close** from `item.status`, a display label that `SupportPage` defaults to `"Open"` when the conversation state is missing (`c.state?.label ?? "Open"`). So a stateless chat resolves to "Open" → resumable → **Close shown incorrectly**. The card also re-parsed a display string to decide behavior.

## Fix
- Add an explicit `ChatHistoryItem.isResumable` flag, derived **once** in `SupportPage` from the real conversation state via `isConversationResumable(c.state?.label)`.
- `ChatHistoryCard` gates Close on `item.isResumable` instead of `isConversationResumable(item.status)`.
- Missing/unknown state → `isResumable` falsy → **not closable** (correct default); explicitly resumable chats keep Close.

## Validation
- `tsc --noEmit` ✓ · `ChatHistoryCard` tests 3/3 (Close shown for resumable / hidden for terminal / doesn't trigger row nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)