### PR TITLE
[CSM Portal] entity-service: publish the create-problem operation in the API definition

### DIFF
--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2437,6 +2437,48 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /problems:
+    post:
+      summary: Create a new problem (available on data sources that support problem management).
+      operationId: createProblem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateProblemRequest'
+      responses:
+        "201":
+          description: Problem created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: A referenced record was not found (origin case or primary incident).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /problems/search:
     post:
       summary: Search problems (ServiceNow data source only).
@@ -7072,6 +7114,27 @@ components:
           type: string
         incident:
           $ref: '#/components/schemas/IncidentView'
+
+    CreateProblemRequest:
+      type: object
+      required: [subject]
+      properties:
+        subject:
+          type: string
+        category:
+          type: string
+          nullable: true
+        subcategory:
+          type: string
+          nullable: true
+        originCaseId:
+          type: string
+          format: uuid
+          nullable: true
+        primaryIncidentId:
+          type: string
+          format: uuid
+          nullable: true
 
     SearchProblemsRequest:
       type: object


### PR DESCRIPTION
## Purpose
The entity service already implements problem creation, but the operation is not reachable through the platform gateway, so callers get `404 {"message":"The requested resource was not found!"}` on every create attempt.

`entity-service/.choreo/component.yaml` publishes `openapi.yaml` as the endpoint's `schemaFilePath`, which makes that spec the component's routable API surface. The spec declares `/problems/search` and `/problems/{id}` but not `/problems`, so the gateway rejects the create call before it reaches the service. The request never appears in the service's application log, and the 404 comes back in ~5 ms versus ~400 ms for a call that actually traverses to the backing data source.

This is an addition, not a regression: the create operation was implemented and the corresponding declaration was simply never added alongside it. It works in a local stack because there is no gateway in front of the process there, which is why the gap went unnoticed.

Resolves: tracked on the delivery planning board.

## Goals
Make the already-implemented create-problem operation reachable in deployed environments, so the portal's "create problem" flow works end to end instead of failing at the gateway.

## Approach
Declare the operation in `entity-service/openapi.yaml`, mirroring the sibling `/incidents` create block so the two read identically:

- **New `/problems` path with a `post` operation** (`operationId: createProblem`): `201` returning `ProblemDetail` — the same schema the existing detail `GET` already returns — plus the `400`/`401`/`404`/`500` error responses the handler can produce. The `404` covers a referenced record (origin case or primary incident) not being found. The response set matches the existing `GET /problems/{id}` block.
- **New `CreateProblemRequest` schema**, placed next to `SearchProblemsRequest`, matching exactly what the handler decodes: `subject` required, with optional `category`, `subcategory`, `originCaseId` and `primaryIncidentId` (the two ids as `format: uuid`).

No Go code changes. The handler, service, and route already exist and are deployed; this only declares them. `category`/`subcategory` are left as plain strings rather than enums, matching the request struct the handler decodes, so no valid value can be rejected at the boundary.

## User stories
As a support engineer, I can create a problem record from the portal so recurring incidents can be tracked against a single root cause.

## Release note
Fixed the create-problem operation not being reachable in deployed environments because it was missing from the entity service's published API definition.

## Documentation
N/A — internal service-to-service API definition with no user-facing product documentation. The spec itself is the contract and is updated here.

## Training
N/A — no user-facing behaviour change; the operation was already the intended design.

## Certification
N/A — internal API definition, no impact on certification exams.

## Marketing
N/A — internal API definition.

## Automation tests
- Unit tests
  > No new unit tests. The change is a declarative API specification with no executable branch; the handler and service it describes are already covered by the existing problem handler and service tests. Validated the spec programmatically instead: it parses as YAML, every `$ref` in the file resolves to a declared schema, no `operationId` is duplicated across the 59 paths, and the declared request/response shapes match the structs the handler decodes and encodes.
- Integration tests
  > Verified against the deployed environment by probing the layers directly: the operation currently returns 404 in ~5 ms with no entry in the service's application log (gateway rejection), while sibling declared operations on the same path prefix return 200. Post-deploy verification is to re-issue the same create call and confirm a 201.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs targets Java; this PR changes only a YAML API definition and adds no code. `go vet ./...` and `go build ./...` remain clean for the component.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A — no samples relate to this internal API definition.

## Related PRs
None. This is a standalone declaration fix; the implementation it exposes is already merged.

## Migrations (if applicable)
N/A — no schema or data migration. Note the component must be rebuilt and redeployed for the updated endpoint definition to take effect, since the spec is read from the repository at build time. If the component uses per-operation security, the new operation also needs its resource scope configured.

## Test environment
Go toolchain as pinned by the component; spec validated with Python 3.13 YAML parsing. Behaviour confirmed against the deployed staging environment via direct API calls.

## Learning
The failure mode is worth noting for future endpoint work: a route registered in the service but absent from the published `openapi.yaml` is unreachable once deployed, yet works in a local stack that has no gateway in front of it. Latency is the quickest signal — a 404 returned in single-digit milliseconds is a gateway rejection, whereas a rejection from the backing data source takes hundreds of milliseconds. Confirming which layer logged the request pins the boundary exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “create problem” API endpoint (POST /problems).
  * Requests require a subject and can optionally include category, subcategory, and links to related cases or incidents.
  * Added documented responses for successful creation (201) and common error scenarios (validation, unauthorized, not found, and server errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->