### PR TITLE
[Entity-Service] send the auto-closure hold as a date, not a datetime

### DIFF
--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -370,6 +370,20 @@ func formatSNDate(t *time.Time) string {
 	return t.UTC().Format(snCreatedOnLayout)
 }
 
+// snDateOnlyLayout is the date-only wire format the integration service expects for
+// fields whose contract carries a date with no time component.
+const snDateOnlyLayout = "2006-01-02"
+
+// formatSNDateOnly renders a date-only value. The auto-closure hold is a date, not a
+// datetime: the integration service constrains it to YYYY-MM-DD, and sending a
+// datetime fails payload binding before the request ever reaches the data source.
+func formatSNDateOnly(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format(snDateOnlyLayout)
+}
+
 type snCaseService struct {
 	client     *integrationservice.Client
 	pgFallback CaseService
@@ -1253,7 +1267,7 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		payload.RelatedCaseID = &sysid
 	}
 	if req.AutocloseHoldUntil != nil {
-		holdUntil := req.AutocloseHoldUntil.Format(snCreatedOnLayout)
+		holdUntil := formatSNDateOnly(req.AutocloseHoldUntil)
 		payload.AutocloseHoldUntil = &holdUntil
 	}
 	if req.Subject != nil {

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -309,9 +309,11 @@ func TestSNCaseService_UpdateCase_NewSingleFieldVariants(t *testing.T) {
 		wantPayload map[string]any
 	}{
 		{
-			name:        "autocloseHoldUntil",
-			req:         domain.UpdateCaseRequest{ID: testDeploymentUUID, AutocloseHoldUntil: timePtr(testAutocloseHoldUntil)},
-			wantPayload: map[string]any{"autocloseHoldUntil": testAutocloseHoldUntil.Format(snCreatedOnLayout)},
+			name: "autocloseHoldUntil",
+			req:  domain.UpdateCaseRequest{ID: testDeploymentUUID, AutocloseHoldUntil: timePtr(testAutocloseHoldUntil)},
+			// Date only: the integration service constrains autocloseHoldUntil to
+			// YYYY-MM-DD, so a datetime fails payload binding upstream.
+			wantPayload: map[string]any{"autocloseHoldUntil": testAutocloseHoldUntil.UTC().Format(snDateOnlyLayout)},
 		},
 		{
 			name:        "subject",


### PR DESCRIPTION
## Purpose
The case auto-closure hold (`autocloseHoldUntil`) carries a date with no time component, but the case-update path formatted it with the shared datetime layout. The integration service rejected the payload before it reached the backing data source, so the field could never be set (staging report: `Hold auto closure` returns 400).

## Goals
- Let `autocloseHoldUntil` writes succeed against the backing data source.

## Approach
Adds `snDateOnlyLayout`/`formatSNDateOnly` and uses it for `autocloseHoldUntil` only; every other date field on this path stays on the existing datetime layout. Updates the one test that asserted the old datetime layout for this field.

## Release note
Fixes case auto-closure hold, which previously failed with a 400 on every attempt.

## Documentation
N/A — internal date-formatting fix, no contract/shape change.

## Security checks
- Secure coding standards followed: yes
- FindSecurityBugs / static analysis: N/A for Go — `go vet ./...` clean
- No secrets committed: yes

## Related PRs
N/A