### PR TITLE
[Customer Portal][Webapp] Disable De-escalate button with permission tooltip, use green styling

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -232,7 +232,7 @@ export default function CaseDetailsActionRow({
               disabled={!canDeescalateCase}
               startIcon={<TriangleAlert size={ACTION_BUTTON_ICON_SIZE} />}
               onClick={() => setDeescalateModalOpen(true)}
-              sx={getActionButtonSx(theme, "info") as Record<string, unknown>}
+              sx={getActionButtonSx(theme, "success") as Record<string, unknown>}
             >
               De-escalate Case
             </Button>

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -224,7 +224,10 @@ export default function CaseDetailsActionRow({
         </Button>
       )}
       {showDeescalateButton && (
-        <Tooltip title={canDeescalateCase ? "" : DEESCALATE_PERMISSION_TOOLTIP}>
+        <Tooltip
+          title={canDeescalateCase ? "" : DEESCALATE_PERMISSION_TOOLTIP}
+          describeChild
+        >
           <Box component="span">
             <Button
               variant="outlined"

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -16,9 +16,11 @@
 
 import type { CaseDetailsActionRowProps } from "@features/support/types/supportComponents";
 import {
+  Box,
   Button,
   CircularProgress,
   Stack,
+  Tooltip,
   alpha,
   useTheme,
   type Theme,
@@ -49,6 +51,8 @@ import {
 import { TriangleAlert } from "@wso2/oxygen-ui-icons-react";
 
 const ACTION_BUTTON_ICON_SIZE = 12;
+const DEESCALATE_PERMISSION_TOOLTIP =
+  "Only customer admins, project leads, or the user who created an escalation on this case can de-escalate it.";
 
 function getActionButtonSx(
   theme: Theme,
@@ -131,7 +135,8 @@ export default function CaseDetailsActionRow({
     resolvedEscalationLevelId !== ESCALATION_MAX_LEVEL_ID &&
     !!escalationLevelInfo &&
     (!needsLead || isCurrentUserLead === true);
-  const showDeescalateButton = isEscalated === true && canDeescalate === true;
+  const showDeescalateButton = isEscalated === true;
+  const canDeescalateCase = canDeescalate === true;
 
   const availableActions = getAvailableCaseActions(statusLabel).filter(
     (label) => {
@@ -219,15 +224,20 @@ export default function CaseDetailsActionRow({
         </Button>
       )}
       {showDeescalateButton && (
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<TriangleAlert size={ACTION_BUTTON_ICON_SIZE} />}
-          onClick={() => setDeescalateModalOpen(true)}
-          sx={getActionButtonSx(theme, "info") as Record<string, unknown>}
-        >
-          De-escalate Case
-        </Button>
+        <Tooltip title={canDeescalateCase ? "" : DEESCALATE_PERMISSION_TOOLTIP}>
+          <Box component="span">
+            <Button
+              variant="outlined"
+              size="small"
+              disabled={!canDeescalateCase}
+              startIcon={<TriangleAlert size={ACTION_BUTTON_ICON_SIZE} />}
+              onClick={() => setDeescalateModalOpen(true)}
+              sx={getActionButtonSx(theme, "info") as Record<string, unknown>}
+            >
+              De-escalate Case
+            </Button>
+          </Box>
+        </Tooltip>
       )}
       <CaseStateConfirmDialog
         open={!!confirmAction}


### PR DESCRIPTION
## Summary
- Always render the De-escalate button when a case is escalated, instead of hiding it for users without permission — disable it and show a tooltip explaining who can de-escalate (customer admins, project leads, or the user who created an escalation on the case)
- Switch the button's color from info/blue to success/green so it reads as a positive action, distinct from the warning-colored Escalate button

## Test plan
- [ ] De-escalate button shown but disabled, with tooltip, for a user with no permission
- [ ] De-escalate button enabled and green for a customer admin, project lead, or the user who created an escalation on the case
- [ ] Clicking the disabled button does not open the modal
- [ ] `tsc --noEmit` and `eslint` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Updated the case de-escalation action to use success styling.
  - Disabled the de-escalation button when the required permission is unavailable.
  - Added a tooltip to explain why de-escalation cannot be used.
  - Refined the display logic to base the button state on escalation status and permission eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->