### PR TITLE
[CSM Portal] require close notes when closing a case or proposing a solution

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.test.tsx
@@ -27,7 +27,7 @@ function chooseOption(labelId: string, optionText: RegExp): void {
 }
 
 describe("ResolutionDialog", () => {
-  it("disables submit until both resolution code and cause are chosen", () => {
+  it("disables submit until resolution code, cause, and close notes are all provided", () => {
     render(
       <ResolutionDialog
         kind="close"
@@ -42,7 +42,30 @@ describe("ResolutionDialog", () => {
     expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
 
     chooseOption("case-cause-label", /product\/bug/i);
+    expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/close notes/i), {
+      target: { value: "Fixed by rolling back the config change." },
+    });
     expect(screen.getByRole("button", { name: /close case/i })).not.toBeDisabled();
+  });
+
+  it("shows a validation message when close notes is left blank", () => {
+    render(
+      <ResolutionDialog
+        kind="close"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    chooseOption("resolution-code-label", /solved.*fixed by support\/guidance provided/i);
+    chooseOption("case-cause-label", /product\/bug/i);
+
+    // Submit stays disabled while blank, but leaving the field surfaces why.
+    fireEvent.blur(screen.getByLabelText(/close notes/i));
+    expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
+    expect(screen.getByText(/close notes are required/i)).toBeInTheDocument();
   });
 
   it("submits the chosen resolution code, cause, and close notes", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
@@ -95,8 +95,11 @@ export default function ResolutionDialog({
   );
   const [cause, setCause] = useState<BeCaseCause | "">(initial?.cause ?? "");
   const [closeNotes, setCloseNotes] = useState(initial?.closeNotes ?? "");
+  const [closeNotesTouched, setCloseNotesTouched] = useState(false);
   const copy = COPY[kind];
-  const canSubmit = !!resolutionCode && !!cause && !isSubmitting;
+  const hasCloseNotes = closeNotes.trim().length > 0;
+  const closeNotesInvalid = closeNotesTouched && !hasCloseNotes;
+  const canSubmit = !!resolutionCode && !!cause && hasCloseNotes && !isSubmitting;
 
   return (
     <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
@@ -145,13 +148,21 @@ export default function ResolutionDialog({
 
         <TextField
           label="Close notes"
+          required
           size="small"
           fullWidth
           multiline
           minRows={3}
           value={closeNotes}
           onChange={(e) => setCloseNotes(e.target.value)}
-          placeholder="Optional free-text notes about the resolution…"
+          onBlur={() => setCloseNotesTouched(true)}
+          error={closeNotesInvalid}
+          helperText={
+            closeNotesInvalid
+              ? "Close notes are required."
+              : "Free-text notes about the resolution, shared with the customer."
+          }
+          placeholder="Describe the resolution…"
         />
       </DialogContent>
       <DialogActions>
@@ -163,7 +174,10 @@ export default function ResolutionDialog({
           color={kind === "close" ? "warning" : "primary"}
           disabled={!canSubmit}
           onClick={() => {
-            if (!resolutionCode || !cause) return;
+            if (!resolutionCode || !cause || !hasCloseNotes) {
+              setCloseNotesTouched(true);
+              return;
+            }
             onSubmit({ resolutionCode, cause, closeNotes });
           }}
         >


### PR DESCRIPTION
## Purpose
On staging, closing a case or proposing a solution from the CSM portal fails with an error from the backing data source when the close notes field is left blank, because that transition requires non-empty close notes alongside the resolution code and cause. The CSM portal's resolution dialog didn't reflect this: `canSubmit` only checked resolution code and cause, and the close notes field's placeholder said "Optional free-text notes...", so a user could submit blank close notes and get a rejected request with no clear explanation.

## Goals
Make the CSM portal's resolution dialog require close notes for both the close and propose-solution transitions, matching what the backend requires, and give the user visible feedback instead of a silent submit failure.

## Approach
In `ResolutionDialog.tsx`:
- `canSubmit` now also requires `closeNotes.trim()` to be non-empty.
- The close notes field is marked `required`, the "Optional" wording is removed from the placeholder, and a helper/error text is shown (consistent with the existing MUI TextField helper-text pattern) when the field has been touched and left blank.
- Updated the component's existing test file to cover the new required-field behavior.

No backend, entity-service, or customer-portal changes are involved; this is a CSM-portal-only frontend fix.

## User stories
N/A

## Release note
Fixed: closing a case or proposing a solution in the CSM portal now requires close notes, preventing a rejected request when the field is left blank.

## Documentation
N/A — internal validation fix with no user-facing documentation impact.

## Training
N/A

## Certification
N/A — no certification exam impact.

## Marketing
N/A

## Automation tests
 - Unit tests
   Updated `ResolutionDialog.test.tsx` to assert the submit button stays disabled until close notes are filled in (in addition to resolution code and cause), and that a validation message appears when the field is left blank. All 5 tests pass (`npx vitest run src/features/csm-cases/components/ResolutionDialog.test.tsx`).
 - Integration tests
   N/A — no integration test harness for this component; covered by the unit test above per project convention.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React project; ran `npx eslint` clean instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Verified locally with `npx tsc -b`, `npx eslint`, `npx vitest run`, and `pnpm build` — all pass.

## Learning
N/A
