### PR TITLE
[Entity-Service] convert incident watchlist UUIDs to ServiceNow sysids

### DIFF
--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -527,6 +527,9 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 			}
 		}
 	}
+	if err := validateUUIDs("watchList", req.WatchList); err != nil {
+		return domain.CreateIncidentResponse{}, err
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -537,7 +540,7 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 		ImpactKey:          snIncidentImpactKeyMap[req.Impact],
 		UrgencyKey:         snIncidentUrgencyKeyMap[req.Urgency],
 		Subject:            req.Subject,
-		WatchList:          req.WatchList,
+		WatchList:          uuidsToSysids(req.WatchList),
 		AdditionalComments: req.AdditionalComments,
 		WorkNotes:          req.WorkNotes,
 	}
@@ -949,6 +952,11 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 			}
 		}
 	}
+	if req.WatchList != nil {
+		if err := validateUUIDs("watchList", *req.WatchList); err != nil {
+			return domain.UpdateIncidentResponse{}, err
+		}
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -958,7 +966,10 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 		IncidentReport:     req.IncidentReport,
 		AdditionalComments: req.AdditionalComments,
 		WorkNotes:          req.WorkNotes,
-		WatchList:          req.WatchList,
+	}
+	if req.WatchList != nil {
+		v := uuidsToSysids(*req.WatchList)
+		payload.WatchList = &v
 	}
 	if req.Priority != nil {
 		v := snIncidentPriorityKeyMap[*req.Priority]

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+const (
+	testIncidentWatcherUUID1  = "44444444-4444-4444-4444-444444444444"
+	testIncidentWatcherUUID2  = "55555555-5555-5555-5555-555555555555"
+	testIncidentWatcherSysid1 = "44444444444444444444444444444444"
+	testIncidentWatcherSysid2 = "55555555555555555555555555555555"
+	testIncidentUUID          = "66666666-6666-6666-6666-666666666666"
+	testIncidentSysid         = "66666666666666666666666666666666"
+)
+
+// validCreateIncidentRequest returns a minimally valid CreateIncidentRequest so
+// that only the field under test needs to be overridden per case.
+func validCreateIncidentRequest() domain.CreateIncidentRequest {
+	return domain.CreateIncidentRequest{
+		CallerID:  testCaseUUID,
+		Category:  domain.IncidentCategoryInquiry,
+		ServiceID: testCaseUUID,
+		Impact:    domain.IncidentImpactLow,
+		Urgency:   domain.IncidentUrgencyLow,
+		Subject:   "subject",
+	}
+}
+
+// TestSNIncidentService_CreateIncident_WatchListConvertedToSysids verifies that
+// every watchList UUID is converted to a ServiceNow sysid before it reaches the
+// outgoing payload, so SN resolves sys_user records instead of 404ing on a raw
+// platform UUID.
+func TestSNIncidentService_CreateIncident_WatchListConvertedToSysids(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Incident created successfully.",
+			"incident": {"id": "` + testIncidentSysid + `", "number": "INC0001", "createdOn": "2026-01-01 00:00:00", "createdBy": "engineer@example.com"}
+		}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowIncidentService(client)
+
+	req := validCreateIncidentRequest()
+	req.WatchList = []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2}
+
+	if _, err := svc.CreateIncident(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotWatchList, ok := gotBody["watchList"].([]any)
+	if !ok {
+		t.Fatalf("expected watchList array in payload, got %+v", gotBody["watchList"])
+	}
+	want := []string{testIncidentWatcherSysid1, testIncidentWatcherSysid2}
+	if len(gotWatchList) != len(want) {
+		t.Fatalf("watchList length: got %d, want %d", len(gotWatchList), len(want))
+	}
+	for i, w := range want {
+		if gotWatchList[i] != w {
+			t.Fatalf("watchList[%d]: got %v, want %q (raw UUID must not be sent to SN)", i, gotWatchList[i], w)
+		}
+	}
+}
+
+// TestSNIncidentService_CreateIncident_WatchList_InvalidUUID verifies a malformed
+// watchList entry is rejected with a clean validation error before any SN call.
+func TestSNIncidentService_CreateIncident_WatchList_InvalidUUID(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowIncidentService(nil)
+
+	req := validCreateIncidentRequest()
+	req.WatchList = []string{"not-a-uuid"}
+
+	_, err := svc.CreateIncident(contextWithUserIDToken("token"), req)
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestSNIncidentService_UpdateIncident_WatchListConvertedToSysids mirrors the
+// create-path coverage above for the PATCH /incidents/{id} path.
+func TestSNIncidentService_UpdateIncident_WatchListConvertedToSysids(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/incidents/"+testIncidentSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Incident updated successfully.",
+			"incident": {"id": "` + testIncidentSysid + `", "number": "INC0001", "createdOn": "2026-01-01 00:00:00", "createdBy": "engineer@example.com"}
+		}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowIncidentService(client)
+
+	watchList := []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2}
+	_, err := svc.UpdateIncident(contextWithUserIDToken("token"), domain.UpdateIncidentRequest{
+		ID:        testIncidentUUID,
+		WatchList: &watchList,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotWatchList, ok := gotBody["watchList"].([]any)
+	if !ok {
+		t.Fatalf("expected watchList array in payload, got %+v", gotBody["watchList"])
+	}
+	want := []string{testIncidentWatcherSysid1, testIncidentWatcherSysid2}
+	if len(gotWatchList) != len(want) {
+		t.Fatalf("watchList length: got %d, want %d", len(gotWatchList), len(want))
+	}
+	for i, w := range want {
+		if gotWatchList[i] != w {
+			t.Fatalf("watchList[%d]: got %v, want %q (raw UUID must not be sent to SN)", i, gotWatchList[i], w)
+		}
+	}
+}
+
+// TestSNIncidentService_UpdateIncident_WatchList_InvalidUUID verifies a malformed
+// watchList entry is rejected with a clean validation error before any SN call.
+func TestSNIncidentService_UpdateIncident_WatchList_InvalidUUID(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowIncidentService(nil)
+
+	watchList := []string{"not-a-uuid"}
+	_, err := svc.UpdateIncident(contextWithUserIDToken("token"), domain.UpdateIncidentRequest{
+		ID:        testIncidentUUID,
+		WatchList: &watchList,
+	})
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Incident watchlist PATCH/POST requests fail on staging with a 404 ("User not found"). `CreateIncident` and `UpdateIncident` in `entity-service/internal/service/sn_incident_service.go` convert every other reference-ID field (`parentId`, `assignmentGroupId`, `assignedEngineerId`, `serviceId`, etc.) from the platform's UUID to the backing data source's identifier format before building the outgoing payload, but `watchList` was passed through unconverted. The backing data source expects each watchlist entry to resolve to a user record identifier, so a raw platform UUID fails to resolve and the write is rejected.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Incident create/update requests with a `watchList` succeed against the backing data source instead of 404ing.
- A malformed UUID in `watchList` is rejected with a clean 400 validation error before any outbound call, matching the behavior of every other UUID field on this resource.

## Approach
> Describe how you are implementing the solutions.

- In `CreateIncident`, run `req.WatchList` through the existing `uuidsToSysids()` helper (already used for other multi-value UUID fields such as filter ID lists) before assigning it to the outgoing payload, and validate each entry with the existing `validateUUIDs()` helper alongside the other required/optional UUID checks.
- In `UpdateIncident`, do the same for the optional `*[]string` `WatchList` field: validate with `validateUUIDs()` when non-nil, and convert with `uuidsToSysids()` before assigning to the payload.
- No API contract change: the field shape and JSON key are unchanged, only the outgoing value is now correctly translated.

## User stories
N/A — internal bug fix, no new user-facing behavior beyond the fix.

## Release note
Fixed a bug where adding or updating watchers on an incident could fail because watcher identifiers were not translated to the format the backing data source expects.

## Documentation
N/A — internal service-layer bug fix, no user-facing or API contract change to document.

## Training
N/A — no training content impact.

## Certification
N/A — no certification content impact.

## Marketing
N/A — internal bug fix, no marketing impact.

## Automation tests
- Unit tests
  Added `entity-service/internal/service/sn_incident_service_test.go` covering: (1) `CreateIncident` and `UpdateIncident` convert every `watchList` UUID to the backing identifier format in the outgoing payload, and (2) an invalid UUID in `watchList` is rejected by validation before any outbound call, for both create and update.
- Integration tests
  N/A — covered by the above unit tests against a mocked backing-service client; no separate integration suite for this service.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go codebase; ran `go vet ./...`, clean)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample content impacted.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Go 1.x (per `entity-service/go.mod`), macOS, local `go build`/`go vet`/`go test` runs.

## Learning
Root cause was confirmed via staging logs prior to this change: other reference-ID fields on this resource already went through a UUID-to-backing-identifier conversion helper, but `watchList` was missed when it was added, so it was passed through raw.