### PR TITLE
[CSM Portal Microapp] Add create change request flow to the microapp

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -25,6 +25,7 @@ import SupportPage from "@pages/SupportPage";
 import CaseDetailPage from "@pages/CaseDetailPage";
 import NewCasePage from "@pages/NewCasePage";
 import OperationsPage from "@pages/OperationsPage";
+import NewChangeRequestPage from "@pages/NewChangeRequestPage";
 import ChangeRequestDetailPage from "@pages/ChangeRequestDetailPage";
 import MorePage from "@pages/MorePage";
 import AnnouncementsPage from "@pages/AnnouncementsPage";
@@ -71,6 +72,7 @@ export default function App() {
           <Route path="/cases/new" element={<NewCasePage />} />
           <Route path="/cases/:id" element={<CaseDetailPage />} />
           <Route path="/operations" element={<OperationsPage />} />
+          <Route path="/operations/change-requests/new" element={<NewChangeRequestPage />} />
           <Route path="/operations/change-requests/:id" element={<ChangeRequestDetailPage />} />
           <Route path="/more" element={<MorePage />} />
           <Route path="/more/announcements" element={<AnnouncementsPage />} />

--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -25,6 +25,7 @@ import SupportPage from "@pages/SupportPage";
 import CaseDetailPage from "@pages/CaseDetailPage";
 import NewCasePage from "@pages/NewCasePage";
 import OperationsPage from "@pages/OperationsPage";
+import NewServiceRequestPage from "@pages/NewServiceRequestPage";
 import ChangeRequestDetailPage from "@pages/ChangeRequestDetailPage";
 import MorePage from "@pages/MorePage";
 import AnnouncementsPage from "@pages/AnnouncementsPage";
@@ -71,6 +72,7 @@ export default function App() {
           <Route path="/cases/new" element={<NewCasePage />} />
           <Route path="/cases/:id" element={<CaseDetailPage />} />
           <Route path="/operations" element={<OperationsPage />} />
+          <Route path="/operations/service-requests/new" element={<NewServiceRequestPage />} />
           <Route path="/operations/change-requests/:id" element={<ChangeRequestDetailPage />} />
           <Route path="/more" element={<MorePage />} />
           <Route path="/more/announcements" element={<AnnouncementsPage />} />

--- a/apps/csm-portal/microapp/src/components/operations/AsyncEntitySelect.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/AsyncEntitySelect.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState } from "react";
+import { Autocomplete, TextField } from "@wso2/oxygen-ui";
+import { useQuery } from "@tanstack/react-query";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import type { EntityOption } from "@src/services/changeRequestLookups";
+
+interface AsyncEntitySelectProps {
+  label: string;
+  placeholder?: string;
+  value: EntityOption | null;
+  onChange: (next: EntityOption | null) => void;
+  disabled?: boolean;
+  helperText?: string;
+  /** Type-ahead search function, called with the debounced query text (and, for the Service
+   * offering field, the currently-picked Service id to narrow by — see `searchExtra`). Must be a
+   * stable reference (e.g. `search={changeRequestLookups.groups}`), not an inline arrow function,
+   * so the query key below stays stable across renders. */
+  search: (query: string, extra?: string) => Promise<EntityOption[]>;
+  /** Forwarded as `search`'s second argument. */
+  searchExtra?: string;
+}
+
+// Mobile counterpart of the webapp's generic AsyncEntitySelect.tsx: same one-component-for-five-
+// fields idea (Service / Service offering / Configuration item / Assignment group / Assigned to /
+// Requested by all reuse this with their own search function), but follows this app's own simpler
+// debounced-search pattern (see ProjectSelect.tsx, LogTimeCardDialog's approver picker) instead of
+// the webapp's open-state-gated infinite pagination — a single page of matches is enough for a
+// mobile type-ahead field. Owns its own useQuery (keyed by label + query + extra) rather than
+// taking a queryOptions factory from the caller, so it doesn't have to fight TanStack's queryKey
+// generics across five differently-shaped lookups.
+export function AsyncEntitySelect({
+  label,
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  helperText,
+  search,
+  searchExtra,
+}: AsyncEntitySelectProps) {
+  const [inputValue, setInputValue] = useState("");
+  const debouncedQuery = useDebouncedValue(inputValue, 300);
+  const query = debouncedQuery.trim();
+  const { data, isFetching, isError } = useQuery({
+    queryKey: ["async-entity-select", label, query, searchExtra ?? ""],
+    queryFn: () => search(query, searchExtra),
+    enabled: query.length > 0,
+    staleTime: 60_000,
+  });
+
+  const options = useMemo(() => {
+    const results = data ?? [];
+    if (value && !results.some((o) => o.id === value.id)) return [value, ...results];
+    return results;
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      options={options}
+      value={value}
+      loading={isFetching}
+      disabled={disabled}
+      fullWidth
+      size="small"
+      getOptionLabel={(option) => option.label}
+      isOptionEqualToValue={(option, val) => option.id === val.id}
+      onChange={(_, next) => onChange(next)}
+      onInputChange={(_, next) => setInputValue(next)}
+      noOptionsText={
+        query.length === 0 ? "Type to search…" : isError ? "Search failed. Try again." : "No matches found"
+      }
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={value ? undefined : placeholder}
+          error={isError}
+          helperText={isError ? "Search failed." : helperText}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/CatalogVariableFields.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/CatalogVariableFields.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  AdapterDateFns,
+  DatePickers,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from "@wso2/oxygen-ui";
+import type { CatalogItemVariableDto } from "@src/types";
+import {
+  formatDateTimeLocal,
+  isChoiceField,
+  isDateTimeField,
+  isDescriptionField,
+  isFileCopyPathField,
+  isMultiLineField,
+  parseDateTimeLocal,
+  variableLabel,
+} from "@utils/catalogVariables";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
+
+interface CatalogVariableFieldsProps {
+  /** Already filtered to user-editable variables (no context/hidden fields). */
+  variables: CatalogItemVariableDto[];
+  values: Record<string, string>;
+  onChange: (id: string, value: string) => void;
+  disabled?: boolean;
+}
+
+// Mobile counterpart of the webapp's CatalogVariableFields.tsx: single-column Stack rather than a
+// responsive Grid, and the Description field is a plain multiline TextField rather than a
+// rich-text editor (see utils/catalogVariables.ts's file comment for why). Otherwise renders the
+// same control per variable type/label: Yes/No select, multi-line text, datetime picker, or
+// single-line text.
+export function CatalogVariableFields({ variables, values, onChange, disabled }: CatalogVariableFieldsProps) {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Stack gap={2}>
+        {variables.map((v) => {
+          const value = values[v.id] ?? "";
+          const label = variableLabel(v);
+
+          if (isChoiceField(v)) {
+            const labelId = `sr-var-${v.id}-label`;
+            return (
+              <FormControl key={v.id} size="small" fullWidth required disabled={disabled}>
+                <InputLabel id={labelId}>{label}</InputLabel>
+                <Select
+                  labelId={labelId}
+                  label={label}
+                  value={value}
+                  onChange={(e) => onChange(v.id, String(e.target.value))}
+                >
+                  <MenuItem value="Yes">Yes</MenuItem>
+                  <MenuItem value="No">No</MenuItem>
+                </Select>
+              </FormControl>
+            );
+          }
+
+          if (isDescriptionField(v.questionText ?? "")) {
+            return (
+              <TextField
+                key={v.id}
+                label={label}
+                size="small"
+                fullWidth
+                required
+                multiline
+                minRows={5}
+                disabled={disabled}
+                value={value}
+                onChange={(e) => onChange(v.id, e.target.value)}
+              />
+            );
+          }
+
+          if (isMultiLineField(v)) {
+            return (
+              <TextField
+                key={v.id}
+                label={label}
+                size="small"
+                fullWidth
+                required
+                multiline
+                minRows={4}
+                disabled={disabled}
+                value={value}
+                onChange={(e) => onChange(v.id, e.target.value)}
+              />
+            );
+          }
+
+          if (isDateTimeField(v)) {
+            return (
+              <DateTimePicker
+                key={v.id}
+                label={label}
+                value={parseDateTimeLocal(value)}
+                disabled={disabled}
+                onChange={(next) =>
+                  onChange(v.id, next instanceof Date && !Number.isNaN(next.getTime()) ? formatDateTimeLocal(next) : "")
+                }
+                slotProps={{
+                  textField: { size: "small", fullWidth: true, required: true },
+                  field: { clearable: true },
+                }}
+              />
+            );
+          }
+
+          // File Copy Path is an optional plain text input.
+          const optional = isFileCopyPathField(v);
+          return (
+            <TextField
+              key={v.id}
+              label={label}
+              size="small"
+              fullWidth
+              required={!optional}
+              disabled={disabled}
+              value={value}
+              onChange={(e) => onChange(v.id, e.target.value)}
+            />
+          );
+        })}
+      </Stack>
+    </LocalizationProvider>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ChangeRequestsTab.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
-import { Badge, Chip, IconButton, Stack } from "@wso2/oxygen-ui";
-import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "react-router-dom";
+import { Badge, Chip, Fab, IconButton, Stack } from "@wso2/oxygen-ui";
+import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { changeRequests } from "@src/services/changeRequests";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
@@ -38,6 +39,7 @@ import {
 // Mirrors the shape of SupportPage's own list content (search + filter sheet + infinite scroll),
 // scoped to change requests instead of cases.
 export function ChangeRequestsTab() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 300);
   const [filters, setFilters] = useState<ChangeRequestFilters>(EMPTY_CR_FILTERS);
@@ -69,6 +71,18 @@ export function ChangeRequestsTab() {
         filters={filters}
         onApply={setFilters}
       />
+
+      {/* Same floating create affordance as ServiceRequestsTab.tsx's own Fab — mirrors the
+          webapp's "Create change request" button (OperationsPage.tsx's `actions` prop). */}
+      <Fab
+        aria-label="Create change request"
+        size="medium"
+        color="primary"
+        onClick={() => navigate("/operations/change-requests/new")}
+        sx={{ position: "fixed", right: 10, bottom: "calc(var(--tab-bar-height) + 60px)" }}
+      >
+        <Plus size={20} />
+      </Fab>
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
-import { Badge, Chip, IconButton, Stack, Tab, Tabs } from "@wso2/oxygen-ui";
-import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "react-router-dom";
+import { Badge, Chip, Fab, IconButton, Stack, Tab, Tabs } from "@wso2/oxygen-ui";
+import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useQuery, useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
 import { currentUser } from "@src/services/currentUser";
@@ -39,6 +40,7 @@ type StateTabValue = CaseState | typeof ALL_STATES_TAB;
 // hides its severity filter the same way when locked to a non-"case" type); work state stays,
 // same as the webapp.
 export function ServiceRequestsTab() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 300);
   const [filters, setFilters] = useState<CaseFilters>(EMPTY_FILTERS);
@@ -85,6 +87,19 @@ export function ServiceRequestsTab() {
         filters={filters}
         onApply={setFilters}
       />
+
+      {/* Mirrors the webapp's "Create service request" button (OperationsPage.tsx's `actions`
+          prop on CsmIssuesView), rendered as this app's own floating create affordance — same
+          Fab convention as SupportPage.tsx's "Create case" button. */}
+      <Fab
+        aria-label="Create service request"
+        size="medium"
+        color="primary"
+        onClick={() => navigate("/operations/service-requests/new")}
+        sx={{ position: "fixed", right: 10, bottom: "calc(var(--tab-bar-height) + 60px)" }}
+      >
+        <Plus size={20} />
+      </Fab>
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -51,6 +51,10 @@ export const DEPLOYMENTS_SEARCH_ENDPOINT = "/deployments/search";
 export const DEPLOYMENT_PRODUCTS_SEARCH_ENDPOINT = (deploymentId: string) =>
   `/deployments/${deploymentId}/products/search`;
 
+export const CATALOGS_SEARCH_ENDPOINT = "/catalogs/search";
+export const CATALOG_ITEM_VARIABLES_ENDPOINT = (catalogId: string, catalogItemId: string) =>
+  `/catalogs/${catalogId}/items/${catalogItemId}/variables`;
+
 export const ATTACHMENTS_ENDPOINT = "/attachments";
 export const ATTACHMENTS_SEARCH_ENDPOINT = "/attachments/search";
 

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -36,8 +36,14 @@ export const CASE_ACTIVITIES_SEARCH_ENDPOINT = (id: string) => `/cases/${id}/act
 
 export const SLAS_SEARCH_ENDPOINT = "/slas/search";
 
+export const CHANGE_REQUESTS_ENDPOINT = "/change-requests";
 export const CHANGE_REQUESTS_SEARCH_ENDPOINT = "/change-requests/search";
 export const CHANGE_REQUEST_ENDPOINT = (id: string) => `/change-requests/${id}`;
+
+export const GROUPS_SEARCH_ENDPOINT = "/groups/search";
+export const IT_SERVICES_SEARCH_ENDPOINT = "/services/search";
+export const SERVICE_OFFERINGS_SEARCH_ENDPOINT = "/service-offerings/search";
+export const CONFIGURATION_ITEMS_SEARCH_ENDPOINT = "/configuration-items/search";
 
 export const ACCOUNTS_SEARCH_ENDPOINT = "/accounts/search";
 export const ACCOUNT_ENDPOINT = (id: string) => `/accounts/${id}`;

--- a/apps/csm-portal/microapp/src/pages/NewChangeRequestPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewChangeRequestPage.tsx
@@ -1,0 +1,478 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  AdapterDateFns,
+  Button,
+  DatePickers,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { changeRequests } from "@src/services/changeRequests";
+import { changeRequestLookups, type EntityOption } from "@src/services/changeRequestLookups";
+import { users } from "@src/services/users";
+import type {
+  ChangeRequestCategory,
+  ChangeRequestCreatePayloadDto,
+  ChangeRequestPriority,
+  ChangeRequestRisk,
+  ChangeRequestState,
+  ChangeRequestType,
+} from "@src/types";
+import { Logger } from "@utils/logger";
+import { changeRequestStateLabel } from "@components/operations/config";
+import { AsyncEntitySelect } from "@components/operations/AsyncEntitySelect";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
+
+const UNSET = "";
+const SELECT_PLACEHOLDER = "-- Select --";
+const SUBJECT_MAX = 500;
+
+const TYPE_OPTIONS: Array<{ value: ChangeRequestType; label: string }> = [
+  { value: "standard", label: "Standard" },
+  { value: "normal", label: "Normal" },
+  { value: "emergency", label: "Emergency" },
+  { value: "model", label: "Model" },
+  { value: "site_reliability_ops", label: "Site reliability ops" },
+  { value: "azure", label: "Azure" },
+];
+
+const CATEGORY_OPTIONS: Array<{ value: ChangeRequestCategory; label: string }> = [
+  { value: "hardware", label: "Hardware" },
+  { value: "software", label: "Software" },
+  { value: "service", label: "Service" },
+  { value: "system_software", label: "System software" },
+  { value: "applications_software", label: "Applications software" },
+  { value: "network", label: "Network" },
+  { value: "telecom", label: "Telecom" },
+  { value: "documentation", label: "Documentation" },
+  { value: "regular_release_cloud", label: "Regular release (cloud)" },
+  { value: "hotfix_release_cloud", label: "Hotfix release (cloud)" },
+  { value: "devops", label: "DevOps" },
+  { value: "cloud_computing", label: "Cloud computing" },
+  { value: "other", label: "Other" },
+];
+
+const IMPACT_OPTIONS: Array<{ value: "high" | "medium" | "low"; label: string }> = [
+  { value: "high", label: "High" },
+  { value: "medium", label: "Medium" },
+  { value: "low", label: "Low" },
+];
+
+const PRIORITY_OPTIONS: Array<{ value: ChangeRequestPriority; label: string }> = [
+  { value: "critical", label: "Critical" },
+  { value: "high", label: "High" },
+  { value: "moderate", label: "Moderate" },
+  { value: "low", label: "Low" },
+];
+
+const RISK_OPTIONS: Array<{ value: ChangeRequestRisk; label: string }> = [
+  { value: "high", label: "High" },
+  { value: "moderate", label: "Moderate" },
+  { value: "low", label: "Low" },
+];
+
+// Only the pre-workflow states are selectable at creation — a new change request must enter its
+// lifecycle at the start (new/assess/authorize) and move forward from there, same restriction the
+// webapp's create form applies.
+const CREATE_STATE_VALUES: ChangeRequestState[] = ["new", "assess", "authorize"];
+const STATE_OPTIONS: Array<{ value: ChangeRequestState; label: string }> = CREATE_STATE_VALUES.map((s) => ({
+  value: s,
+  label: changeRequestStateLabel(s),
+}));
+
+/** "Characters left: N" once a field is more than half full, matching the webapp's live counter. */
+function charsLeftHelper(value: string, max: number): string | undefined {
+  return value.length >= max / 2 ? `Characters left: ${max - value.length}` : undefined;
+}
+
+/** Local Date to the backend's expected "YYYY-MM-DD HH:MM:SS" string. */
+function toBackendDateTime(date: Date): string {
+  const y = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  const mi = String(date.getMinutes()).padStart(2, "0");
+  const s = String(date.getSeconds()).padStart(2, "0");
+  return `${y}-${mo}-${d} ${h}:${mi}:${s}`;
+}
+
+// Ports the webapp's CreateChangeRequestPage.tsx. Two sections, same as the webapp: the core
+// fields (subject, type/category/priority/impact/risk/state, six Planning fields, planned
+// start/end) always visible, and a collapsed "More options" section for the six ServiceNow
+// reference lookups (Service/Service offering/Configuration item/Assignment group/Assigned
+// to/Requested by) plus the two journal fields — collapsed by default since they're used less
+// often at creation time, same as the webapp's own Accordion. Layout follows this app's own
+// NewCasePage.tsx/NewServiceRequestPage.tsx (single-column Stack) rather than the webapp's
+// Grid/Card, and the six Planning fields are plain multiline TextFields rather than the webapp's
+// rich-text editor (this app has no rich-text component) — same deviation those two pages made.
+export default function NewChangeRequestPage() {
+  const navigate = useNavigate();
+
+  const [subject, setSubject] = useState("");
+  // Pre-selected to match the webapp's own defaults (itself matching the legacy ServiceNow form):
+  // most change requests are Normal type, Other category, Low impact, Moderate risk. Priority has
+  // no default there either, so it stays unset here too.
+  const [type, setType] = useState<ChangeRequestType | typeof UNSET>("normal");
+  const [category, setCategory] = useState<ChangeRequestCategory | typeof UNSET>("other");
+  const [impact, setImpact] = useState<"high" | "medium" | "low" | typeof UNSET>("low");
+  const [priority, setPriority] = useState<ChangeRequestPriority | typeof UNSET>(UNSET);
+  const [risk, setRisk] = useState<ChangeRequestRisk | typeof UNSET>("moderate");
+  const [state, setState] = useState<ChangeRequestState | typeof UNSET>("new");
+  const [plannedStartDate, setPlannedStartDate] = useState<Date | null>(null);
+  const [plannedEndDate, setPlannedEndDate] = useState<Date | null>(null);
+  const [description, setDescription] = useState("");
+  const [justification, setJustification] = useState("");
+  const [implementationPlan, setImplementationPlan] = useState("");
+  const [riskImpactAnalysis, setRiskImpactAnalysis] = useState("");
+  const [backoutPlan, setBackoutPlan] = useState("");
+  const [testPlan, setTestPlan] = useState("");
+  const [service, setService] = useState<EntityOption | null>(null);
+  const [serviceOffering, setServiceOffering] = useState<EntityOption | null>(null);
+  const [configurationItem, setConfigurationItem] = useState<EntityOption | null>(null);
+  const [group, setGroup] = useState<EntityOption | null>(null);
+  const [assignedEngineer, setAssignedEngineer] = useState<EntityOption | null>(null);
+  const [requestedBy, setRequestedBy] = useState<EntityOption | null>(null);
+  const [comment, setComment] = useState("");
+  const [workNote, setWorkNote] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Defaults "Requested by" to the signed-in user, matching the webapp's own create form (the
+  // backend doesn't do this itself). Fires once, when the current user first loads; a ref (not
+  // the field's own emptiness) gates it so manually clearing the field afterward sticks. Adjusted
+  // during render (React's recommended pattern for this) rather than in an effect, which would
+  // call setState synchronously post-commit — same approach the webapp's own page takes.
+  const { data: me } = useQuery(users.me());
+  const autoFilledRequester = useRef(false);
+  if (me?.id && !autoFilledRequester.current) {
+    autoFilledRequester.current = true;
+    setRequestedBy({ id: me.id, label: me.fullName });
+  }
+
+  const createChangeRequest = useMutation({ mutationFn: changeRequests.create });
+
+  const canSubmit = subject.trim().length > 0 && !createChangeRequest.isPending;
+
+  const handleSubmit = (): void => {
+    if (!canSubmit) return;
+    setSubmitError(null);
+
+    const payload: ChangeRequestCreatePayloadDto = { subject: subject.trim() };
+    if (type) payload.type = type;
+    if (category) payload.category = category;
+    if (impact) payload.impact = impact;
+    if (priority) payload.priority = priority;
+    if (risk) payload.risk = risk;
+    if (state) payload.state = state;
+    if (plannedStartDate) payload.plannedStartDate = toBackendDateTime(plannedStartDate);
+    if (plannedEndDate) payload.plannedEndDate = toBackendDateTime(plannedEndDate);
+    if (description.trim()) payload.description = description.trim();
+    if (justification.trim()) payload.justification = justification.trim();
+    if (implementationPlan.trim()) payload.implementationPlan = implementationPlan.trim();
+    if (riskImpactAnalysis.trim()) payload.riskImpactAnalysis = riskImpactAnalysis.trim();
+    if (backoutPlan.trim()) payload.backoutPlan = backoutPlan.trim();
+    if (testPlan.trim()) payload.testPlan = testPlan.trim();
+    if (service) payload.serviceId = service.id;
+    if (serviceOffering) payload.serviceOfferingId = serviceOffering.id;
+    if (configurationItem) payload.configurationItemId = configurationItem.id;
+    if (group) payload.groupId = group.id;
+    if (assignedEngineer) payload.assignedEngineerId = assignedEngineer.id;
+    if (requestedBy) payload.requestedById = requestedBy.id;
+    if (comment.trim()) payload.comment = comment.trim();
+    if (workNote.trim()) payload.workNote = workNote.trim();
+
+    createChangeRequest.mutate(payload, {
+      onSuccess: (created) => navigate(`/operations/change-requests/${created.changeRequest.id}`),
+      onError: (err) => {
+        Logger.warn("Could not create the change request", err);
+        setSubmitError("Could not create the change request. Please try again.");
+      },
+    });
+  };
+
+  // Shared renderer for a "-- Select --" dropdown — every field here is optional, so clearing back
+  // to the placeholder is valid and just omits the field from the payload.
+  const renderSelect = <T extends string>(
+    id: string,
+    label: string,
+    value: T | typeof UNSET,
+    onChange: (v: T | typeof UNSET) => void,
+    options: Array<{ value: T; label: string }>,
+  ) => (
+    <FormControl fullWidth size="small" disabled={createChangeRequest.isPending}>
+      <InputLabel id={`${id}-label`} shrink>
+        {label}
+      </InputLabel>
+      <Select
+        labelId={`${id}-label`}
+        label={label}
+        value={value}
+        displayEmpty
+        onChange={(e) => onChange(e.target.value as T | typeof UNSET)}
+      >
+        <MenuItem value={UNSET}>
+          <Typography component="span" color="text.secondary">
+            {SELECT_PLACEHOLDER}
+          </Typography>
+        </MenuItem>
+        {options.map((o) => (
+          <MenuItem key={o.value} value={o.value}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="h6">New Change Request</Typography>
+
+      <Stack gap={2}>
+        <TextField
+          label="Subject"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value.slice(0, SUBJECT_MAX))}
+          size="small"
+          fullWidth
+          required
+          disabled={createChangeRequest.isPending}
+          placeholder="Short summary of the change"
+          helperText={charsLeftHelper(subject, SUBJECT_MAX)}
+        />
+
+        {renderSelect("cr-type", "Type", type, setType, TYPE_OPTIONS)}
+        {renderSelect("cr-category", "Category", category, setCategory, CATEGORY_OPTIONS)}
+        {renderSelect("cr-priority", "Priority", priority, setPriority, PRIORITY_OPTIONS)}
+        {renderSelect("cr-impact", "Impact", impact, setImpact, IMPACT_OPTIONS)}
+        {renderSelect("cr-risk", "Risk", risk, setRisk, RISK_OPTIONS)}
+        {renderSelect("cr-state", "State", state, setState, STATE_OPTIONS)}
+
+        <Typography variant="subtitle2">Planning</Typography>
+
+        <TextField
+          label="Description"
+          placeholder="What is changing?"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          disabled={createChangeRequest.isPending}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <TextField
+          label="Justification"
+          placeholder="Why is this change needed?"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          disabled={createChangeRequest.isPending}
+          value={justification}
+          onChange={(e) => setJustification(e.target.value)}
+        />
+        <TextField
+          label="Implementation plan"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          disabled={createChangeRequest.isPending}
+          value={implementationPlan}
+          onChange={(e) => setImplementationPlan(e.target.value)}
+        />
+        <TextField
+          label="Risk and impact analysis"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          disabled={createChangeRequest.isPending}
+          value={riskImpactAnalysis}
+          onChange={(e) => setRiskImpactAnalysis(e.target.value)}
+        />
+        <TextField
+          label="Backout plan"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          disabled={createChangeRequest.isPending}
+          value={backoutPlan}
+          onChange={(e) => setBackoutPlan(e.target.value)}
+        />
+        <TextField
+          label="Test plan"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          disabled={createChangeRequest.isPending}
+          value={testPlan}
+          onChange={(e) => setTestPlan(e.target.value)}
+        />
+
+        <Typography variant="subtitle2">Schedule</Typography>
+
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DateTimePicker
+            label="Planned start"
+            value={plannedStartDate}
+            maxDateTime={plannedEndDate ?? undefined}
+            onChange={(date) =>
+              setPlannedStartDate(date instanceof Date && !Number.isNaN(date.getTime()) ? date : null)
+            }
+            disabled={createChangeRequest.isPending}
+            slotProps={{ textField: { size: "small", fullWidth: true }, field: { clearable: true } }}
+          />
+          <DateTimePicker
+            label="Planned end"
+            value={plannedEndDate}
+            minDateTime={plannedStartDate ?? undefined}
+            onChange={(date) => setPlannedEndDate(date instanceof Date && !Number.isNaN(date.getTime()) ? date : null)}
+            disabled={createChangeRequest.isPending}
+            slotProps={{ textField: { size: "small", fullWidth: true }, field: { clearable: true } }}
+          />
+        </LocalizationProvider>
+
+        {/* Everything below is optional and used less often at creation time — collapsed by
+            default so the form isn't dominated by fields most requests won't need up front. */}
+        <Accordion disableGutters sx={{ "&:before": { display: "none" } }}>
+          <AccordionSummary expandIcon={<ChevronDown size={16} />}>
+            <Typography variant="body2" color="text.secondary">
+              More options (optional)
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {/* These map to two different ServiceNow journal fields — mixing them up would either
+                leak an internal note to the customer or bury something they were meant to see. */}
+            <TextField
+              label="Additional comments (customer-visible)"
+              multiline
+              minRows={2}
+              size="small"
+              fullWidth
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              disabled={createChangeRequest.isPending}
+              helperText="Visible to the customer — do not include internal-only details."
+            />
+            <TextField
+              label="Internal work note"
+              multiline
+              minRows={2}
+              size="small"
+              fullWidth
+              value={workNote}
+              onChange={(e) => setWorkNote(e.target.value)}
+              disabled={createChangeRequest.isPending}
+              helperText="Internal only — never shown to the customer."
+            />
+
+            <AsyncEntitySelect
+              label="Service"
+              placeholder="Search services…"
+              value={service}
+              onChange={(next) => {
+                setService(next);
+                // A service offering only makes sense under its own service — drop it rather than
+                // leave a stale pairing.
+                setServiceOffering(null);
+              }}
+              disabled={createChangeRequest.isPending}
+              search={changeRequestLookups.itServices}
+            />
+            <AsyncEntitySelect
+              label="Service offering"
+              placeholder="Search service offerings…"
+              value={serviceOffering}
+              onChange={setServiceOffering}
+              disabled={createChangeRequest.isPending}
+              search={changeRequestLookups.serviceOfferings}
+              searchExtra={service?.id}
+              helperText={service ? undefined : "Narrows to a Service once one is picked."}
+            />
+            <AsyncEntitySelect
+              label="Configuration item"
+              placeholder="Search configuration items…"
+              value={configurationItem}
+              onChange={setConfigurationItem}
+              disabled={createChangeRequest.isPending}
+              search={changeRequestLookups.configurationItems}
+            />
+            <AsyncEntitySelect
+              label="Assignment group"
+              placeholder="Search groups…"
+              value={group}
+              onChange={setGroup}
+              disabled={createChangeRequest.isPending}
+              search={changeRequestLookups.groups}
+            />
+            <AsyncEntitySelect
+              label="Assigned to"
+              placeholder="Search people…"
+              value={assignedEngineer}
+              onChange={setAssignedEngineer}
+              disabled={createChangeRequest.isPending}
+              search={changeRequestLookups.users}
+            />
+            <AsyncEntitySelect
+              label="Requested by"
+              placeholder="Search people…"
+              value={requestedBy}
+              onChange={setRequestedBy}
+              disabled={createChangeRequest.isPending}
+              search={changeRequestLookups.users}
+              helperText="Defaults to you — clear it if this wasn't your request."
+            />
+          </AccordionDetails>
+        </Accordion>
+
+        {submitError && (
+          <Typography variant="body2" color="error.main">
+            {submitError}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={1} justifyContent="flex-end">
+          {/* navigate(-1) rather than a hardcoded /operations path — this app's Operations tab
+              state isn't URL-driven, so going back preserves whichever tab (Change Requests) the
+              Fab was pressed from, same as NewServiceRequestPage.tsx's own Cancel button. */}
+          <Button onClick={() => navigate(-1)} disabled={createChangeRequest.isPending}>
+            Cancel
+          </Button>
+          <Button variant="contained" disabled={!canSubmit} onClick={handleSubmit}>
+            {createChangeRequest.isPending ? "Creating…" : "Create Change Request"}
+          </Button>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
@@ -172,7 +172,8 @@ export default function NewServiceRequestPage() {
       }
 
       navigate(`/cases/${created.id}`);
-    } catch {
+    } catch (error) {
+      Logger.warn("Could not create the service request", error);
       setSubmitError("Could not create the service request. Please try again.");
     } finally {
       setIsSubmitting(false);
@@ -184,9 +185,13 @@ export default function NewServiceRequestPage() {
       <Typography variant="h6">New Service Request</Typography>
 
       <Stack gap={2}>
-        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createCase.isPending} />
+        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createCase.isPending || isSubmitting} />
 
-        <FormControl size="small" fullWidth disabled={!project || deploymentsQuery.isLoading || createCase.isPending}>
+        <FormControl
+          size="small"
+          fullWidth
+          disabled={!project || deploymentsQuery.isLoading || createCase.isPending || isSubmitting}
+        >
           <InputLabel id="sr-deployment-label">Deployment</InputLabel>
           <Select
             labelId="sr-deployment-label"
@@ -209,7 +214,11 @@ export default function NewServiceRequestPage() {
           ) : null}
         </FormControl>
 
-        <FormControl size="small" fullWidth disabled={!deploymentId || productsQuery.isLoading || createCase.isPending}>
+        <FormControl
+          size="small"
+          fullWidth
+          disabled={!deploymentId || productsQuery.isLoading || createCase.isPending || isSubmitting}
+        >
           <InputLabel id="sr-product-label">Deployed Product</InputLabel>
           <Select
             labelId="sr-product-label"
@@ -235,7 +244,7 @@ export default function NewServiceRequestPage() {
         <FormControl
           size="small"
           fullWidth
-          disabled={!deployedProductId || catalogsQuery.isLoading || noCatalogs || createCase.isPending}
+          disabled={!deployedProductId || catalogsQuery.isLoading || noCatalogs || createCase.isPending || isSubmitting}
         >
           <InputLabel id="sr-catalog-label">Catalog</InputLabel>
           <Select
@@ -261,7 +270,7 @@ export default function NewServiceRequestPage() {
           ) : null}
         </FormControl>
 
-        <FormControl size="small" fullWidth disabled={!catalogId || createCase.isPending}>
+        <FormControl size="small" fullWidth disabled={!catalogId || createCase.isPending || isSubmitting}>
           <InputLabel id="sr-catalog-item-label">Catalog Item</InputLabel>
           <Select
             labelId="sr-catalog-item-label"
@@ -301,7 +310,7 @@ export default function NewServiceRequestPage() {
               <CatalogVariableFields
                 variables={renderableVars}
                 values={answers}
-                disabled={createCase.isPending}
+                disabled={createCase.isPending || isSubmitting}
                 onChange={(id, value) => setAnswers((prev) => ({ ...prev, [id]: value }))}
               />
             )}
@@ -309,7 +318,11 @@ export default function NewServiceRequestPage() {
         )}
 
         {catalogItemId && !variablesQuery.isLoading && !variablesQuery.isError && (
-          <AttachmentsField attachments={attachments} onChange={setAttachments} disabled={createCase.isPending} />
+          <AttachmentsField
+            attachments={attachments}
+            onChange={setAttachments}
+            disabled={createCase.isPending || isSubmitting}
+          />
         )}
 
         {firstEmptyRequired && !variablesQuery.isLoading && catalogItemId && (
@@ -325,7 +338,7 @@ export default function NewServiceRequestPage() {
         )}
 
         <Stack direction="row" gap={1} justifyContent="flex-end">
-          <Button onClick={() => navigate(-1)} disabled={createCase.isPending}>
+          <Button onClick={() => navigate(-1)} disabled={createCase.isPending || isSubmitting}>
             Cancel
           </Button>
           <Button variant="contained" disabled={!canSubmit} onClick={() => void handleSubmit()}>

--- a/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack, Typography } from "@wso2/oxygen-ui";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { cases } from "@src/services/cases";
+import { deployments } from "@src/services/deployments";
+import { catalogs } from "@src/services/catalogs";
+import { attachments as attachmentsService } from "@src/services/attachments";
+import type { Project } from "@src/types";
+import { Logger } from "@utils/logger";
+import { AttachmentsField } from "@components/support/AttachmentsField";
+import { ProjectSelect } from "@components/support/ProjectSelect";
+import { CatalogVariableFields } from "@components/operations/CatalogVariableFields";
+import {
+  encodeVariableValue,
+  getFirstEmptyRequiredField,
+  getUserEditableVariables,
+  isAttachmentField,
+} from "@utils/catalogVariables";
+import type { PendingAttachment } from "@utils/attachments";
+
+// Ports the webapp's CreateServiceRequestPage.tsx (features/csm-operations/pages/): the same
+// cascading Project → Deployment → Deployed product → Catalog → Catalog item picker, driving a
+// dynamic form built from the chosen catalog item's ServiceNow variables. Layout follows this
+// app's own NewCasePage.tsx (single-column Stack, no locked-project entry point) rather than the
+// webapp's Grid/Card, and — like NewCasePage — the Description variable renders as a plain
+// multiline field rather than the rich-text editor (this app has no rich-text component).
+export default function NewServiceRequestPage() {
+  const navigate = useNavigate();
+
+  const [project, setProject] = useState<Project | null>(null);
+  const [deploymentId, setDeploymentId] = useState("");
+  const [deployedProductId, setDeployedProductId] = useState("");
+  const [catalogId, setCatalogId] = useState("");
+  const [catalogItemId, setCatalogItemId] = useState("");
+  // Variable answers, keyed by variable id.
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  // createCase.isPending alone only covers the case-creation call — it flips back to false while
+  // the attachment uploads below are still in flight, which would let the button re-enable and
+  // fire a duplicate submission. Tracks the whole handleSubmit lifecycle instead, same as
+  // NewCasePage.tsx.
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const deploymentsQuery = useQuery(deployments.byProject(project?.id ?? ""));
+  const productsQuery = useQuery(deployments.productsByDeployment(deploymentId));
+  const catalogsQuery = useQuery(catalogs.search(deployedProductId));
+  const variablesQuery = useQuery(catalogs.itemVariables(catalogId, catalogItemId));
+
+  const createCase = useMutation({ mutationFn: cases.create });
+  const uploadAttachment = useMutation({ mutationFn: attachmentsService.create });
+
+  const catalogItems = useMemo(
+    () => catalogsQuery.data?.find((c) => c.id === catalogId)?.catalogItems ?? [],
+    [catalogsQuery.data, catalogId],
+  );
+
+  // ServiceNow returns context/hidden fields mixed in; only user-editable (non-attachment)
+  // variables get a rendered input. Attachments go through the shared AttachmentsField below.
+  const allVariables = useMemo(() => variablesQuery.data ?? [], [variablesQuery.data]);
+  const renderableVars = useMemo(
+    () => getUserEditableVariables(allVariables).filter((v) => !isAttachmentField(v)),
+    [allVariables],
+  );
+  const firstEmptyRequired = useMemo(() => getFirstEmptyRequiredField(allVariables, answers), [allVariables, answers]);
+
+  // A deployed product with no catalogs is the common non-ServiceNow case; tell the engineer
+  // rather than leaving an empty dropdown.
+  const noCatalogs = !!deployedProductId && catalogsQuery.isSuccess && (catalogsQuery.data?.length ?? 0) === 0;
+
+  // Cascade resets: a parent change invalidates every dependent field below it.
+  const handleProjectChange = (next: Project | null) => {
+    setProject(next);
+    setDeploymentId("");
+    setDeployedProductId("");
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleDeploymentChange = (next: string) => {
+    setDeploymentId(next);
+    setDeployedProductId("");
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleDeployedProductChange = (next: string) => {
+    setDeployedProductId(next);
+    setCatalogId("");
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleCatalogChange = (next: string) => {
+    setCatalogId(next);
+    setCatalogItemId("");
+    setAnswers({});
+  };
+  const handleCatalogItemChange = (next: string) => {
+    setCatalogItemId(next);
+    setAnswers({});
+  };
+
+  const canSubmit =
+    !!project &&
+    !!deploymentId &&
+    !!deployedProductId &&
+    !!catalogId &&
+    !!catalogItemId &&
+    !variablesQuery.isLoading &&
+    !variablesQuery.isError &&
+    // Hot fix (mirrors the webapp and, upstream, the customer portal): all typable variables required.
+    firstEmptyRequired === null &&
+    !createCase.isPending &&
+    !isSubmitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !project) return;
+    setSubmitError(null);
+    setIsSubmitting(true);
+
+    // Send user-editable, non-attachment variables, encoded by type, omitting empties.
+    // Context/hidden fields are excluded by getUserEditableVariables.
+    const variablePayload = getUserEditableVariables(allVariables)
+      .filter((v) => !isAttachmentField(v))
+      .map((v) => ({ id: v.id, value: encodeVariableValue(v, answers[v.id] ?? "") }))
+      .filter((v) => v.value !== "");
+
+    try {
+      const created = await createCase.mutateAsync({
+        type: "service_request",
+        projectId: project.id,
+        deploymentId,
+        deployedProductId,
+        catalogId,
+        catalogItemId,
+        variables: variablePayload,
+      });
+
+      // The create endpoint doesn't attach files for service requests, so upload them to the new
+      // case afterwards, same as NewCasePage.tsx — a partial failure still lands the case.
+      const results = await Promise.allSettled(
+        attachments.map((attachment) =>
+          uploadAttachment.mutateAsync({
+            referenceId: created.id,
+            referenceType: "case",
+            name: attachment.name,
+            type: attachment.type,
+            file: attachment.file,
+          }),
+        ),
+      );
+      const failedCount = results.filter((r) => r.status === "rejected").length;
+      if (failedCount > 0) {
+        Logger.warn(`${failedCount} attachment(s) failed to upload to service request ${created.id}`);
+      }
+
+      navigate(`/cases/${created.id}`);
+    } catch {
+      setSubmitError("Could not create the service request. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="h6">New Service Request</Typography>
+
+      <Stack gap={2}>
+        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createCase.isPending} />
+
+        <FormControl size="small" fullWidth disabled={!project || deploymentsQuery.isLoading || createCase.isPending}>
+          <InputLabel id="sr-deployment-label">Deployment</InputLabel>
+          <Select
+            labelId="sr-deployment-label"
+            label="Deployment"
+            value={deploymentId}
+            onChange={(event) => handleDeploymentChange(event.target.value)}
+          >
+            {(deploymentsQuery.data ?? []).map((d) => (
+              <MenuItem key={d.id} value={d.id}>
+                {d.name}
+              </MenuItem>
+            ))}
+          </Select>
+          {!project ? (
+            <FormHelperText>Select a project first</FormHelperText>
+          ) : deploymentsQuery.isLoading ? (
+            <FormHelperText>Loading deployments…</FormHelperText>
+          ) : (deploymentsQuery.data ?? []).length === 0 ? (
+            <FormHelperText>No deployments found for this project.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        <FormControl size="small" fullWidth disabled={!deploymentId || productsQuery.isLoading || createCase.isPending}>
+          <InputLabel id="sr-product-label">Deployed Product</InputLabel>
+          <Select
+            labelId="sr-product-label"
+            label="Deployed Product"
+            value={deployedProductId}
+            onChange={(event) => handleDeployedProductChange(event.target.value)}
+          >
+            {(productsQuery.data ?? []).map((p) => (
+              <MenuItem key={p.id} value={p.id}>
+                {p.label}
+              </MenuItem>
+            ))}
+          </Select>
+          {!deploymentId ? (
+            <FormHelperText>Select a deployment first</FormHelperText>
+          ) : productsQuery.isLoading ? (
+            <FormHelperText>Loading products…</FormHelperText>
+          ) : (productsQuery.data ?? []).length === 0 ? (
+            <FormHelperText>No deployed products found for this deployment.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        <FormControl
+          size="small"
+          fullWidth
+          disabled={!deployedProductId || catalogsQuery.isLoading || noCatalogs || createCase.isPending}
+        >
+          <InputLabel id="sr-catalog-label">Catalog</InputLabel>
+          <Select
+            labelId="sr-catalog-label"
+            label="Catalog"
+            value={catalogId}
+            onChange={(event) => handleCatalogChange(event.target.value)}
+          >
+            {(catalogsQuery.data ?? []).map((c) => (
+              <MenuItem key={c.id} value={c.id}>
+                {c.name ?? c.id}
+              </MenuItem>
+            ))}
+          </Select>
+          {!deployedProductId ? (
+            <FormHelperText>Select a deployed product first</FormHelperText>
+          ) : catalogsQuery.isLoading ? (
+            <FormHelperText>Loading catalogs…</FormHelperText>
+          ) : catalogsQuery.isError ? (
+            <FormHelperText error>Couldn't load catalogs. Try again.</FormHelperText>
+          ) : noCatalogs ? (
+            <FormHelperText>No service catalogs are available for this product.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        <FormControl size="small" fullWidth disabled={!catalogId || createCase.isPending}>
+          <InputLabel id="sr-catalog-item-label">Catalog Item</InputLabel>
+          <Select
+            labelId="sr-catalog-item-label"
+            label="Catalog Item"
+            value={catalogItemId}
+            onChange={(event) => handleCatalogItemChange(event.target.value)}
+          >
+            {catalogItems.map((ci) => (
+              <MenuItem key={ci.id} value={ci.id}>
+                {ci.name ?? ci.id}
+              </MenuItem>
+            ))}
+          </Select>
+          {!catalogId ? (
+            <FormHelperText>Select a catalog first</FormHelperText>
+          ) : catalogItems.length === 0 ? (
+            <FormHelperText>No items found in this catalog.</FormHelperText>
+          ) : null}
+        </FormControl>
+
+        {/* Dynamic variable form for the chosen catalog item. */}
+        {catalogItemId && (
+          <>
+            {variablesQuery.isLoading ? (
+              <Typography variant="body2" color="text.secondary">
+                Loading request form…
+              </Typography>
+            ) : variablesQuery.isError ? (
+              <Typography variant="body2" color="error.main">
+                Could not load the request form for this catalog item. Try again.
+              </Typography>
+            ) : renderableVars.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                This catalog item has no additional fields.
+              </Typography>
+            ) : (
+              <CatalogVariableFields
+                variables={renderableVars}
+                values={answers}
+                disabled={createCase.isPending}
+                onChange={(id, value) => setAnswers((prev) => ({ ...prev, [id]: value }))}
+              />
+            )}
+          </>
+        )}
+
+        {catalogItemId && !variablesQuery.isLoading && !variablesQuery.isError && (
+          <AttachmentsField attachments={attachments} onChange={setAttachments} disabled={createCase.isPending} />
+        )}
+
+        {firstEmptyRequired && !variablesQuery.isLoading && catalogItemId && (
+          <Typography variant="caption" color="text.secondary">
+            Required field: {firstEmptyRequired}
+          </Typography>
+        )}
+
+        {submitError && (
+          <Typography variant="body2" color="error.main">
+            {submitError}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={1} justifyContent="flex-end">
+          <Button onClick={() => navigate(-1)} disabled={createCase.isPending}>
+            Cancel
+          </Button>
+          <Button variant="contained" disabled={!canSubmit} onClick={() => void handleSubmit()}>
+            {isSubmitting ? "Creating…" : "Create Service Request"}
+          </Button>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
@@ -30,11 +30,11 @@ const TABS: { id: OperationsTabId; label: string }[] = [
 
 // Mirrors the webapp's OperationsPage (apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx):
 // three tabs — Service requests (cases with type=service_request, reusing the Support page's own
-// list/pagination/filter infra), Change requests (its own list/detail/edit), and Incidents (no
-// backend endpoint exists yet, in this repo or the webapp's — kept as a placeholder like the
-// webapp's own IssuesListUnavailable). "Create service request"/"Create change request" are
-// deliberately out of scope for this pass — each is its own large form (cascading
-// project/deployment/catalog selects with dynamic variables, or a 15+ field change-request form).
+// list/pagination/filter infra), Change requests (its own list/detail/edit, with its own "Create
+// change request" Fab — see ChangeRequestsTab.tsx), and Incidents (no backend endpoint exists yet,
+// in this repo or the webapp's — kept as a placeholder like the webapp's own
+// IssuesListUnavailable). "Create service request" is deliberately out of scope for this pass —
+// it's its own large form (cascading project/deployment/catalog selects with dynamic variables).
 export default function OperationsPage() {
   const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
 

--- a/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
@@ -30,11 +30,11 @@ const TABS: { id: OperationsTabId; label: string }[] = [
 
 // Mirrors the webapp's OperationsPage (apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx):
 // three tabs — Service requests (cases with type=service_request, reusing the Support page's own
-// list/pagination/filter infra), Change requests (its own list/detail/edit), and Incidents (no
-// backend endpoint exists yet, in this repo or the webapp's — kept as a placeholder like the
-// webapp's own IssuesListUnavailable). "Create service request"/"Create change request" are
-// deliberately out of scope for this pass — each is its own large form (cascading
-// project/deployment/catalog selects with dynamic variables, or a 15+ field change-request form).
+// list/pagination/filter infra, with its own "Create service request" Fab — see
+// ServiceRequestsTab.tsx), Change requests (its own list/detail/edit), and Incidents (no backend
+// endpoint exists yet, in this repo or the webapp's — kept as a placeholder like the webapp's own
+// IssuesListUnavailable). "Create change request" is deliberately out of scope for this pass —
+// it's its own 15+ field form.
 export default function OperationsPage() {
   const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
 

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -36,6 +36,7 @@ import type {
   CaseViewDto,
   CreatedCaseDto,
   SecurityReportCreatePayloadDto,
+  ServiceRequestCreatePayloadDto,
   UpdateCaseResponseDto,
 } from "@src/types";
 import { toCaseDetail, toCaseSummary, toComment, type CaseDetail, type CaseSummary, type Comment } from "@src/types";
@@ -202,7 +203,9 @@ const getCaseComments = async (id: string): Promise<Comment[]> => {
   return data.comments.map(toComment);
 };
 
-const createCase = async (payload: CaseCreatePayloadDto | SecurityReportCreatePayloadDto): Promise<CreatedCaseDto> => {
+const createCase = async (
+  payload: CaseCreatePayloadDto | SecurityReportCreatePayloadDto | ServiceRequestCreatePayloadDto,
+): Promise<CreatedCaseDto> => {
   const { data } = await apiClient.post<CaseCreateResponseDto>(CASES_ENDPOINT, payload);
   return data.case;
 };

--- a/apps/csm-portal/microapp/src/services/catalogs.ts
+++ b/apps/csm-portal/microapp/src/services/catalogs.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { queryOptions } from "@tanstack/react-query";
+import { CATALOGS_SEARCH_ENDPOINT, CATALOG_ITEM_VARIABLES_ENDPOINT } from "@config/endpoints";
+import type {
+  CatalogItemVariableDto,
+  CatalogItemVariablesResponseDto,
+  CatalogRefDto,
+  CatalogSearchResponseDto,
+} from "@src/types";
+import apiClient from "./apiClient";
+
+// Matches deployments.ts's SEARCH_PAGE_LIMIT — the live entity service rejects the openapi-declared
+// 100 max with a 400.
+const SEARCH_PAGE_LIMIT = 50;
+
+// Service catalogs (and the catalog items they embed) only exist for ServiceNow-sourced deployed
+// products; managed-cloud products resolve to an empty list. The catalog select has no
+// infinite-scroll UI of its own, so fetch every page rather than just the first — same technique
+// as deployments.ts's listDeployments. Advances the offset by the actual page size (the backend
+// may clamp `limit` below SEARCH_PAGE_LIMIT) and stops on an empty page or once the reported total
+// is reached.
+const searchCatalogs = async (deployedProductId: string): Promise<CatalogRefDto[]> => {
+  const all: CatalogRefDto[] = [];
+  let offset = 0;
+  for (;;) {
+    const { data } = await apiClient.post<CatalogSearchResponseDto>(CATALOGS_SEARCH_ENDPOINT, {
+      deployedProductId,
+      pagination: { offset, limit: SEARCH_PAGE_LIMIT },
+    });
+    const page = data?.catalogs ?? [];
+    all.push(...page);
+    offset += page.length;
+    const total = data?.total;
+    if (page.length === 0) break;
+    if (total != null && all.length >= total) break;
+  }
+  return all;
+};
+
+// Sorted by the backend's display order so the form renders fields in the catalog's intended
+// sequence, mirroring the webapp's useCatalogItemVariables.ts.
+const getCatalogItemVariables = async (catalogId: string, catalogItemId: string): Promise<CatalogItemVariableDto[]> => {
+  const { data } = await apiClient.get<CatalogItemVariablesResponseDto>(
+    CATALOG_ITEM_VARIABLES_ENDPOINT(catalogId, catalogItemId),
+  );
+  const variables = data?.variables ?? [];
+  return [...variables].sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+};
+
+export const catalogs = {
+  search: (deployedProductId: string) =>
+    queryOptions({
+      queryKey: ["catalogs", deployedProductId],
+      queryFn: () => searchCatalogs(deployedProductId),
+      enabled: !!deployedProductId,
+      staleTime: 60_000,
+    }),
+
+  itemVariables: (catalogId: string, catalogItemId: string) =>
+    queryOptions({
+      queryKey: ["catalog-item-variables", catalogId, catalogItemId],
+      queryFn: () => getCatalogItemVariables(catalogId, catalogItemId),
+      enabled: !!catalogId && !!catalogItemId,
+      staleTime: 60_000,
+    }),
+};

--- a/apps/csm-portal/microapp/src/services/changeRequestLookups.ts
+++ b/apps/csm-portal/microapp/src/services/changeRequestLookups.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  CONFIGURATION_ITEMS_SEARCH_ENDPOINT,
+  GROUPS_SEARCH_ENDPOINT,
+  IT_SERVICES_SEARCH_ENDPOINT,
+  SERVICE_OFFERINGS_SEARCH_ENDPOINT,
+  USERS_SEARCH_ENDPOINT,
+} from "@config/endpoints";
+import type {
+  ConfigurationItemSearchResponseDto,
+  GroupSearchResponseDto,
+  ItServiceSearchResponseDto,
+  ServiceOfferingSearchResponseDto,
+  UserSearchResponseDto,
+} from "@src/types";
+import { toAdminUser } from "@src/types";
+import apiClient from "./apiClient";
+
+// Type-ahead pickers for the change-request create form's "More options" section (Service,
+// Service offering, Configuration item, Assignment group, Assigned to, Requested by). Mirrors the
+// webapp's useSearchGroups/useSearchItServices/useSearchServiceOfferings/
+// useSearchConfigurationItems/useSearchUsersByName — a single page of matches is plenty for a
+// type-ahead field, so unlike deployments.ts/catalogs.ts these don't page through the full result
+// set.
+const LOOKUP_SEARCH_LIMIT = 20;
+
+export interface EntityOption {
+  id: string;
+  label: string;
+}
+
+const searchGroups = async (query: string): Promise<EntityOption[]> => {
+  const { data } = await apiClient.post<GroupSearchResponseDto>(GROUPS_SEARCH_ENDPOINT, {
+    filters: { searchQuery: query },
+    pagination: { offset: 0, limit: LOOKUP_SEARCH_LIMIT },
+  });
+  return (data.groups ?? []).map((g) => ({ id: g.id, label: g.name }));
+};
+
+const searchItServices = async (query: string): Promise<EntityOption[]> => {
+  const { data } = await apiClient.post<ItServiceSearchResponseDto>(IT_SERVICES_SEARCH_ENDPOINT, {
+    filters: { searchQuery: query },
+    pagination: { offset: 0, limit: LOOKUP_SEARCH_LIMIT },
+  });
+  return (data.services ?? []).map((s) => ({ id: s.id, label: s.name || s.id }));
+};
+
+// Narrows to offerings under `serviceId` when one is given, matching how the ServiceNow form
+// itself scopes this field once a Service is picked.
+const searchServiceOfferings = async (query: string, serviceId?: string): Promise<EntityOption[]> => {
+  const { data } = await apiClient.post<ServiceOfferingSearchResponseDto>(SERVICE_OFFERINGS_SEARCH_ENDPOINT, {
+    filters: { searchQuery: query, ...(serviceId && { serviceIds: [serviceId] }) },
+    pagination: { offset: 0, limit: LOOKUP_SEARCH_LIMIT },
+  });
+  return (data.serviceOfferings ?? []).map((o) => ({ id: o.id, label: o.name }));
+};
+
+const searchConfigurationItems = async (query: string): Promise<EntityOption[]> => {
+  const { data } = await apiClient.post<ConfigurationItemSearchResponseDto>(CONFIGURATION_ITEMS_SEARCH_ENDPOINT, {
+    filters: { searchQuery: query },
+    pagination: { offset: 0, limit: LOOKUP_SEARCH_LIMIT },
+  });
+  return (data.configurationItems ?? []).map((ci) => ({ id: ci.id, label: ci.name || ci.id }));
+};
+
+// Unlike adminUsers.ts's `search` (scoped to active internal approver roles, for the time-card
+// approver picker), "Requested by"/"Assigned to" on a change request can be anyone — no
+// role/active filter, same as the webapp's useSearchUsersByName.
+const searchUsersByName = async (query: string): Promise<EntityOption[]> => {
+  const { data } = await apiClient.post<UserSearchResponseDto>(USERS_SEARCH_ENDPOINT, {
+    filters: { searchQuery: query },
+    pagination: { offset: 0, limit: LOOKUP_SEARCH_LIMIT },
+  });
+  return data.users.map((u) => {
+    const user = toAdminUser(u);
+    return { id: user.id, label: user.name || user.email };
+  });
+};
+
+// Plain async functions rather than queryOptions() factories — AsyncEntitySelect builds its own
+// useQuery around whichever of these it's given (see that component for why), so these just need
+// to satisfy its `search: (query, extra?) => Promise<EntityOption[]>` contract.
+export const changeRequestLookups = {
+  groups: searchGroups,
+  itServices: searchItServices,
+  serviceOfferings: searchServiceOfferings,
+  configurationItems: searchConfigurationItems,
+  users: searchUsersByName,
+};

--- a/apps/csm-portal/microapp/src/services/changeRequests.ts
+++ b/apps/csm-portal/microapp/src/services/changeRequests.ts
@@ -15,8 +15,10 @@
 // under the License.
 
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
-import { CHANGE_REQUESTS_SEARCH_ENDPOINT, CHANGE_REQUEST_ENDPOINT } from "@config/endpoints";
+import { CHANGE_REQUESTS_ENDPOINT, CHANGE_REQUESTS_SEARCH_ENDPOINT, CHANGE_REQUEST_ENDPOINT } from "@config/endpoints";
 import type {
+  ChangeRequestCreatePayloadDto,
+  ChangeRequestCreateResponseDto,
   ChangeRequestDetailDto,
   ChangeRequestSearchPayloadDto,
   ChangeRequestSearchResponseDto,
@@ -62,6 +64,11 @@ const patchChangeRequest = async (id: string, payload: PatchChangeRequestPayload
   return data;
 };
 
+const createChangeRequest = async (payload: ChangeRequestCreatePayloadDto): Promise<ChangeRequestCreateResponseDto> => {
+  const { data } = await apiClient.post<ChangeRequestCreateResponseDto>(CHANGE_REQUESTS_ENDPOINT, payload);
+  return data;
+};
+
 const CHANGE_REQUEST_PAGE_LIMIT = 20;
 
 export const changeRequests = {
@@ -81,4 +88,5 @@ export const changeRequests = {
     }),
 
   patch: patchChangeRequest,
+  create: createChangeRequest,
 };

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -288,8 +288,7 @@ export type CaseCause =
   | "INFRASTRUCTURE_SAAS_SIDE_OTHER"
   | "UNKNOWN";
 
-// Mirrors the webapp's BeCaseCreatePayload (the "case" type variant only — service_request
-// creation isn't in the microapp's scope, see NewCasePage.tsx).
+// Mirrors the webapp's BeCaseCreatePayload (the "case" type variant).
 export interface CaseCreatePayloadDto {
   type: "case";
   projectId: string;
@@ -313,6 +312,29 @@ export interface SecurityReportCreatePayloadDto {
   subject: string;
   description: string;
   attachments: { name: string; file: string }[];
+}
+
+/** A single answered catalog-item variable in a service-request create. */
+export interface CaseVariableDto {
+  /** Variable (question) id, as returned by the catalog-item variables endpoint. */
+  id: string;
+  /** The engineer's answer for this variable. */
+  value: string;
+}
+
+// The "service_request" type variant — see NewServiceRequestPage.tsx. Mirrors the webapp's
+// BeServiceRequestCreatePayload: catalog/catalogItem come from the deployed-product-scoped
+// catalog cascade, variables from that catalog item's form. Like the "case" type, attachments
+// upload separately via POST /attachments after the case exists (the create endpoint only
+// embeds attachments for "security_report_analysis").
+export interface ServiceRequestCreatePayloadDto {
+  type: "service_request";
+  projectId: string;
+  deploymentId: string;
+  deployedProductId: string;
+  catalogId: string;
+  catalogItemId: string;
+  variables: CaseVariableDto[];
 }
 
 export interface CreatedCaseDto {

--- a/apps/csm-portal/microapp/src/types/catalog.dto.ts
+++ b/apps/csm-portal/microapp/src/types/catalog.dto.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Service catalogs (ServiceNow only) — drive service-request creation. Mirrors the webapp's
+// BeCatalogRef/BeCatalogItemRef/BeCatalogItemVariable (api/backend/types.ts).
+
+export interface CatalogItemRefDto {
+  id: string;
+  name?: string;
+}
+
+/** A service catalog and the catalog items it offers. */
+export interface CatalogRefDto {
+  id: string;
+  name?: string;
+  catalogItems?: CatalogItemRefDto[];
+}
+
+export interface CatalogSearchPayloadDto {
+  deployedProductId: string;
+  pagination?: { offset?: number; limit?: number };
+}
+
+export interface CatalogSearchResponseDto {
+  catalogs?: CatalogRefDto[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * A catalog-item variable (form field). The contract carries the question text, display order,
+ * and a free-form `type` hint, but no choice/option list or mandatory flag — every variable
+ * renders as a text field unless its type/questionText matches one of the classifiers in
+ * utils/catalogVariables.ts.
+ */
+export interface CatalogItemVariableDto {
+  id: string;
+  questionText?: string;
+  order?: number;
+  type?: string;
+}
+
+export interface CatalogItemVariablesResponseDto {
+  variables?: CatalogItemVariableDto[];
+}

--- a/apps/csm-portal/microapp/src/types/changeRequest.dto.ts
+++ b/apps/csm-portal/microapp/src/types/changeRequest.dto.ts
@@ -109,3 +109,70 @@ export interface PatchChangeRequestResponseDto {
   updatedOn?: string;
   updatedBy?: string;
 }
+
+// Create-only enums (not part of the search/detail response's looser `type`/`state` strings) —
+// mirrors the webapp's BeChangeRequestType/Priority/Risk/Category.
+export type ChangeRequestType = "standard" | "normal" | "emergency" | "model" | "site_reliability_ops" | "azure";
+
+export type ChangeRequestPriority = "critical" | "high" | "moderate" | "low";
+
+export type ChangeRequestRisk = "high" | "moderate" | "low";
+
+export type ChangeRequestCategory =
+  | "hardware"
+  | "software"
+  | "service"
+  | "system_software"
+  | "applications_software"
+  | "network"
+  | "telecom"
+  | "documentation"
+  | "other"
+  | "regular_release_cloud"
+  | "hotfix_release_cloud"
+  | "devops"
+  | "cloud_computing";
+
+/**
+ * `POST /change-requests` body (ServiceNow data source only). Mirrors the webapp's
+ * BeCreateChangeRequestPayload: `subject` is the only required field; every ID field
+ * (serviceId/serviceOfferingId/configurationItemId/groupId/assignedEngineerId/requestedById) is a
+ * portal UUID resolved server-side, via the matching search endpoint (see
+ * services/changeRequestLookups.ts). `plannedStartDate`/`plannedEndDate` are
+ * "YYYY-MM-DD HH:MM:SS" strings.
+ */
+export interface ChangeRequestCreatePayloadDto {
+  subject: string;
+  category?: ChangeRequestCategory;
+  serviceId?: string;
+  serviceOfferingId?: string;
+  configurationItemId?: string;
+  priority?: ChangeRequestPriority;
+  impact?: ChangeRequestImpact;
+  type?: ChangeRequestType;
+  state?: ChangeRequestState;
+  groupId?: string;
+  assignedEngineerId?: string;
+  risk?: ChangeRequestRisk;
+  requestedById?: string;
+  description?: string;
+  justification?: string;
+  implementationPlan?: string;
+  riskImpactAnalysis?: string;
+  backoutPlan?: string;
+  testPlan?: string;
+  plannedStartDate?: string;
+  plannedEndDate?: string;
+  comment?: string;
+  workNote?: string;
+}
+
+export interface ChangeRequestCreateResponseDto {
+  message: string;
+  changeRequest: {
+    id: string;
+    number: string;
+    createdOn: string;
+    createdBy: string;
+  };
+}

--- a/apps/csm-portal/microapp/src/types/changeRequestLookup.dto.ts
+++ b/apps/csm-portal/microapp/src/types/changeRequestLookup.dto.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Change-request reference lookups (ServiceNow CMDB — groups, IT services, service offerings,
+// configuration items). Drive the "More options" pickers on the change-request create form.
+// Mirrors the webapp's BeGroup/BeItService/BeServiceOffering/BeConfigurationItem, trimmed to the
+// fields the picker actually renders (id + a display name).
+
+export interface GroupDto {
+  id: string;
+  name: string;
+}
+
+export interface GroupSearchResponseDto {
+  groups: GroupDto[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ItServiceDto {
+  id: string;
+  name?: string | null;
+}
+
+export interface ItServiceSearchResponseDto {
+  services: ItServiceDto[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ServiceOfferingDto {
+  id: string;
+  name: string;
+}
+
+export interface ServiceOfferingSearchResponseDto {
+  serviceOfferings: ServiceOfferingDto[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ConfigurationItemDto {
+  id: string;
+  name?: string | null;
+}
+
+export interface ConfigurationItemSearchResponseDto {
+  configurationItems: ConfigurationItemDto[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -16,6 +16,7 @@
 
 export * from "./case.dto";
 export * from "./case.model";
+export * from "./catalog.dto";
 export * from "./account.dto";
 export * from "./account.model";
 export * from "./activity.dto";

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -38,6 +38,7 @@ export * from "./timecard.dto";
 export * from "./timecard.model";
 export * from "./changeRequest.dto";
 export * from "./changeRequest.model";
+export * from "./changeRequestLookup.dto";
 export * from "./updates.dto";
 export * from "./updates.model";
 export * from "./vulnerability.dto";

--- a/apps/csm-portal/microapp/src/utils/catalogVariables.ts
+++ b/apps/csm-portal/microapp/src/utils/catalogVariables.ts
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Service-catalog variable classification + value encoding for the service request form. Ports
+// the webapp's features/csm-operations/utils/catalogVariables.ts. ServiceNow returns the full raw
+// variable set for a catalog item — including auto-populated "context" fields
+// (project/deployment/product) and hidden system fields (case type, priority, ...) — so these
+// must be classified client-side, exactly as the webapp (and, upstream of it, the customer portal)
+// does. One deviation from the webapp: the Description field is a plain multiline TextField here
+// rather than a rich-text editor (mirrors NewCasePage.tsx's own case-description field, and this
+// app has no rich-text editor component), so its value is plain text, not HTML.
+
+import type { CatalogItemVariableDto } from "@src/types";
+
+// Variable `type` strings ServiceNow emits (matched case-insensitively).
+export const VARIABLE_TYPE_SINGLE_LINE = "Single Line Text";
+export const VARIABLE_TYPE_MULTI_LINE = "Multi Line Text";
+export const VARIABLE_TYPE_SELECT = "Select Box";
+export const VARIABLE_TYPE_CHECKBOX = "Checkbox";
+export const VARIABLE_TYPE_RADIO = "Radio Buttons";
+
+/** Boolean-ish field that renders a Yes/No dropdown (no choice list in the API). */
+export function isChoiceField(variable: CatalogItemVariableDto): boolean {
+  const t = (variable.type ?? "").trim().toLowerCase();
+  return (
+    t === VARIABLE_TYPE_SELECT.toLowerCase() ||
+    t === VARIABLE_TYPE_RADIO.toLowerCase() ||
+    t === VARIABLE_TYPE_CHECKBOX.toLowerCase()
+  );
+}
+
+/** Multi-line free text (but not the Description field, which gets its own larger text area). */
+export function isMultiLineField(variable: CatalogItemVariableDto): boolean {
+  const t = (variable.type ?? "").trim().toLowerCase();
+  return (
+    (t === VARIABLE_TYPE_MULTI_LINE.toLowerCase() || t.includes("multi")) &&
+    !isDescriptionField(variable.questionText ?? "")
+  );
+}
+
+/** The Description field — rendered with a larger multiline text area. */
+export function isDescriptionField(questionText: string): boolean {
+  const normalized = (questionText ?? "")
+    .replace(/^\s*\*?\s*/, "")
+    .trim()
+    .toLowerCase();
+  return normalized === "description";
+}
+
+/** File Copy Path field — a plain (optional) text input, not an upload. */
+export function isFileCopyPathField(variable: CatalogItemVariableDto): boolean {
+  const q = (variable.questionText ?? "").trim();
+  const t = (variable.type ?? "").trim();
+  return /file\s*copy\s*path/i.test(q) || /file\s*copy\s*path/i.test(t);
+}
+
+function isAttachmentType(type: string): boolean {
+  const t = (type ?? "").trim().toLowerCase();
+  return (
+    t === "attachment" ||
+    t === "file" ||
+    t === "file upload" ||
+    t.includes("attachment") ||
+    t.includes("file upload") ||
+    (t.includes("file") && !t.includes("configuration")) ||
+    t.includes("attach") ||
+    t.includes("document") ||
+    t.includes("upload")
+  );
+}
+
+function isAttachmentFieldByQuestionText(questionText: string): boolean {
+  const q = (questionText ?? "").trim().toLowerCase();
+  if (!q) return false;
+  const patterns = [
+    /attachment/i,
+    /attach\s/i,
+    /attach$/i,
+    /file\s*upload/i,
+    /upload\s*file/i,
+    /vulnerability\s*scan\s*report/i,
+    /scan\s*report/i,
+    /upload\s*document/i,
+    /document\s*upload/i,
+    /attach\s*report/i,
+    /attach\s*document/i,
+  ];
+  return patterns.some((p) => p.test(q));
+}
+
+/** Attachment/file-upload field (by type or questionText). Optional + collected in the shared
+ *  attachments section, so these are not rendered as text inputs. */
+export function isAttachmentField(variable: CatalogItemVariableDto): boolean {
+  // A File Copy Path field is a plain (optional) text input, not an upload — exclude it explicitly
+  // since its type/label can contain "file" and would otherwise be swallowed by isAttachmentType.
+  if (isFileCopyPathField(variable)) return false;
+  return isAttachmentType(variable.type ?? "") || isAttachmentFieldByQuestionText(variable.questionText ?? "");
+}
+
+const CONTEXT_FIELD_PATTERNS = [/^project$/i, /^deployments?$/i, /^product$/i, /^wso2\s*product$/i, /^environment$/i];
+
+const HIDDEN_FIELD_PATTERNS = [
+  /^case\s*type$/i,
+  /^service\s*request\s*category$/i,
+  /^classification$/i,
+  /^class\s*fication$/i,
+  /^srns$/i,
+  /^state$/i,
+  /^assignment\s*group$/i,
+  /^assigned\s*to$/i,
+  /^priority$/i,
+  /^impact$/i,
+];
+
+/** Auto-populated from the project/deployment/product cascade — not shown. */
+export function isContextField(questionText: string): boolean {
+  const normalized = questionText?.trim().toLowerCase() ?? "";
+  return CONTEXT_FIELD_PATTERNS.some((p) => p.test(normalized));
+}
+
+/** System field ServiceNow defaults — sent by the backend, not shown. */
+export function isHiddenField(questionText: string): boolean {
+  const normalized = questionText?.trim().toLowerCase() ?? "";
+  return HIDDEN_FIELD_PATTERNS.some((p) => p.test(normalized));
+}
+
+const DATE_TIME_FIELD_PATTERNS: RegExp[] = [
+  /start\s*(date|time)/i,
+  /end\s*(date|time)/i,
+  /scheduled\s*(date|time|start|end)/i,
+  /implementation\s*(date|time|start|end)/i,
+  /planned\s*(start|end|date|time)/i,
+  /actual\s*(start|end|date|time)/i,
+  /date\s*(and\s*)?\/?\s*time/i,
+  /time\s*(and\s*)?\/?\s*date/i,
+];
+
+/** Renders a datetime picker (by type or questionText). */
+export function isDateTimeField(variable: CatalogItemVariableDto): boolean {
+  const t = (variable.type ?? "").trim();
+  if (/date.*time|datetime/i.test(t) || /^date$/i.test(t)) return true;
+  const q = (variable.questionText ?? "").trim();
+  return DATE_TIME_FIELD_PATTERNS.some((p) => p.test(q));
+}
+
+/** Strip the leading `*`/whitespace ServiceNow prefixes onto required labels. */
+export function variableLabel(variable: CatalogItemVariableDto): string {
+  return (variable.questionText ?? "").replace(/^\s*\*?\s*/, "").trim() || variable.id;
+}
+
+/** User-editable variables — excludes context and hidden fields, sorted by the backend's display
+ *  order. This is the set the form renders and validates. */
+export function getUserEditableVariables(variables: CatalogItemVariableDto[]): CatalogItemVariableDto[] {
+  return variables
+    .filter((v) => !isContextField(v.questionText ?? "") && !isHiddenField(v.questionText ?? ""))
+    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+}
+
+/** First empty required field label, or null if all are filled. Hot fix (mirrors the webapp and,
+ *  upstream, the customer portal): every typable field is mandatory; attachment and File Copy Path
+ *  fields are optional and skipped. */
+export function getFirstEmptyRequiredField(
+  variables: CatalogItemVariableDto[],
+  values: Record<string, string>,
+): string | null {
+  for (const v of getUserEditableVariables(variables)) {
+    if (isAttachmentField(v) || isFileCopyPathField(v)) continue;
+    if (!(values[v.id] ?? "").trim()) return variableLabel(v);
+  }
+  return null;
+}
+
+/** Encode a variable's raw input into the value the payload carries: datetime becomes an
+ *  ISO-UTC string, everything else is sent as trimmed text. */
+export function encodeVariableValue(variable: CatalogItemVariableDto, raw: string): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return "";
+  if (isDateTimeField(variable)) {
+    const ms = Date.parse(trimmed);
+    return Number.isNaN(ms) ? trimmed : new Date(ms).toISOString();
+  }
+  return trimmed;
+}
+
+/** "YYYY-MM-DDTHH:MM" (the local-datetime wire format these fields store their state as) to a
+ *  local Date, for handing the value to the DateTimePicker. Same browser-local semantics a native
+ *  `datetime-local` input has. */
+export function parseDateTimeLocal(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]), Number(match[4]), Number(match[5]));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Local Date back to "YYYY-MM-DDTHH:MM", the inverse of {@link parseDateTimeLocal}. */
+export function formatDateTimeLocal(date: Date): string {
+  const y = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  const mi = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${mo}-${d}T${h}:${mi}`;
+}


### PR DESCRIPTION
## Summary

Adds the "Create change request" flow to the CSM Portal microapp, matching how it already works in the webapp (`CreateChangeRequestPage.tsx`). Sibling to #1232 (create service request) — built the same way, but as its own independent PR/branch off `dev-app-csm-portal` so it can be reviewed and merged separately.

- New Fab ("Create change request") on the Change Requests tab of the Operations page, same floating-icon pattern as the Support page's "Create case" and the Service Requests tab's own Fab.
- New `NewChangeRequestPage` at `/operations/change-requests/new`:
  - Core fields always visible: Subject, Type/Category/Priority/Impact/Risk/State (pre-filled with the webapp's own defaults — Normal/Other/Low/Moderate/New, Priority left unset), six Planning fields, Planned start/end.
  - A collapsed "More options" section (optional, used less often at creation time — same as the webapp's own Accordion) with the two journal fields (customer-visible comment / internal work note) and all six ServiceNow entity lookups: Service, Service offering (narrows to the picked Service), Configuration item, Assignment group, Assigned to, Requested by (auto-filled to the signed-in user, matching the webapp).
- New supporting infra, none of which existed in the microapp before:
  - 4 new search endpoints wired up: `/groups/search`, `/services/search`, `/service-offerings/search`, `/configuration-items/search`, plus `POST /change-requests` for the create call itself
  - `services/changeRequestLookups.ts` — plain async search functions for the 6 lookup fields
  - `components/operations/AsyncEntitySelect.tsx` — a generic single-entity type-ahead picker, reused across all 6 lookup fields (mirrors the webapp's own generic `AsyncEntitySelect.tsx`, but follows this app's simpler debounced-search convention — see `ProjectSelect.tsx` — instead of the webapp's open-gated infinite pagination)
  - `ChangeRequestCreatePayloadDto` and the create-only enums (`ChangeRequestType`/`Priority`/`Risk`/`Category`) added to `types/changeRequest.dto.ts`
  - `changeRequests.create` added to `services/changeRequests.ts`

Two deliberate mobile deviations from the webapp, consistent with this app's existing `NewCasePage.tsx`/`NewServiceRequestPage.tsx`:
- Single-column `Stack` layout instead of the webapp's responsive `Grid`/`Card`.
- The six Planning fields render as plain multiline `TextField`s instead of a rich-text editor (the microapp has no rich-text component).

## Test plan

- [x] `tsc -b` passes with no errors
- [x] `eslint`/`prettier` pass on all new/changed files
- [x] Verified in a headless browser: the Fab renders correctly on the Change Requests tab, the create page renders the full form with correct defaults, the "More options" accordion expands to show all 6 lookup fields, and typing into a debounced lookup field doesn't error
- [ ] Manual end-to-end verification inside the native app shell (submit a real change request) — not possible from this environment, since the app requires the WSO2 native device-auth bridge to obtain a token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated form for creating change requests.
  - Added a “Create change request” action to the Change Requests tab.
  - Added searchable selectors for groups, services, offerings, configuration items, and users.
  - Change requests can now be submitted with planning details, descriptions, and optional reference information.
  - Successful submissions open the newly created change request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->