### PR TITLE
[Entity-Service] map 422 responses from the integration client instead of falling through to 500

### DIFF
--- a/entity-service/internal/apierror/errors.go
+++ b/entity-service/internal/apierror/errors.go
@@ -85,6 +85,17 @@ type ConflictError struct {
 // Error implements the error interface.
 func (e *ConflictError) Error() string { return e.Msg }
 
+// UnprocessableEntityError signals that the request was well-formed but
+// semantically rejected by a downstream dependency (e.g. an invalid state
+// transition) and should be reported as HTTP 422. The Msg is safe to log and
+// return to the caller.
+type UnprocessableEntityError struct {
+	Msg string
+}
+
+// Error implements the error interface.
+func (e *UnprocessableEntityError) Error() string { return e.Msg }
+
 // WriteJSON writes an ErrorResponse JSON body with the given HTTP status code.
 func WriteJSON(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")

--- a/entity-service/internal/handler/decode.go
+++ b/entity-service/internal/handler/decode.go
@@ -95,6 +95,7 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 		ue  *apierror.UnauthorizedError
 		fe  *apierror.ForbiddenError
 		ce  *apierror.ConflictError
+		uee *apierror.UnprocessableEntityError
 	)
 	switch {
 	case errors.As(err, &ve):
@@ -121,6 +122,12 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 		// 409 – request conflicts with the current state of the resource; message is safe to return.
 		log.Printf("Conflict: %s %s: %s", r.Method, sanitizeLog(r.URL.Path), sanitizeLog(ce.Msg)) // #nosec G706 -- path and message sanitized
 		apierror.WriteJSON(w, http.StatusConflict, ce.Msg)
+
+	case errors.As(err, &uee):
+		// 422 – request was well-formed but semantically rejected by a downstream
+		// dependency (e.g. an invalid state transition); message is safe to return.
+		log.Printf("Unprocessable entity: %s %s: %s", r.Method, sanitizeLog(r.URL.Path), sanitizeLog(uee.Msg)) // #nosec G706 -- path and message sanitized
+		apierror.WriteJSON(w, http.StatusUnprocessableEntity, uee.Msg)
 
 	case errors.As(err, &sue):
 		// 503 – downstream dependency unavailable; log details, return generic message.

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -339,6 +339,8 @@ func (c *Client) do(req *http.Request, path string) (json.RawMessage, error) {
 		return nil, &apierror.NotFoundError{Msg: extractDownstreamMessage(raw, "resource not found in downstream service")}
 	case resp.StatusCode == http.StatusConflict:
 		return nil, &apierror.ConflictError{Msg: extractDownstreamMessage(raw, "request conflicts with current state of the resource")}
+	case resp.StatusCode == http.StatusUnprocessableEntity:
+		return nil, &apierror.UnprocessableEntityError{Msg: extractDownstreamMessage(raw, "downstream service rejected the request as semantically invalid")}
 	case resp.StatusCode == http.StatusServiceUnavailable:
 		return nil, &apierror.ServiceUnavailableError{Msg: "downstream service unavailable"}
 	default:

--- a/entity-service/internal/servicenow-integration-service/client_test.go
+++ b/entity-service/internal/servicenow-integration-service/client_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package integrationservice
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+)
+
+// newTestClient builds a Client pointed at srv with a pre-seeded bearer token
+// so tests exercise do()'s status-code switch without standing up a token
+// endpoint.
+func newTestClient(srv *httptest.Server) *Client {
+	c := New(srv.URL, ClientCredentialsConfig{})
+	c.cachedToken = "test-token"
+	c.tokenExpiry = time.Now().Add(time.Hour)
+	return c
+}
+
+func TestClient_Do_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		check      func(t *testing.T, err error)
+	}{
+		{
+			name:       "409 conflict maps to typed ConflictError with upstream message",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"Call is already closed."}`,
+			check: func(t *testing.T, err error) {
+				var ce *apierror.ConflictError
+				if !errors.As(err, &ce) {
+					t.Fatalf("expected *apierror.ConflictError, got %T: %v", err, err)
+				}
+				if ce.Msg != "Call is already closed." {
+					t.Errorf("Msg = %q, want upstream message preserved", ce.Msg)
+				}
+			},
+		},
+		{
+			name:       "422 unprocessable entity maps to typed UnprocessableEntityError with upstream message",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"message":"Call can only be rejected from Pending on WSO2 state."}`,
+			check: func(t *testing.T, err error) {
+				var uee *apierror.UnprocessableEntityError
+				if !errors.As(err, &uee) {
+					t.Fatalf("expected *apierror.UnprocessableEntityError, got %T: %v", err, err)
+				}
+				if uee.Msg != "Call can only be rejected from Pending on WSO2 state." {
+					t.Errorf("Msg = %q, want upstream message preserved", uee.Msg)
+				}
+			},
+		},
+		{
+			name:       "422 with non-JSON body falls back to default message",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       "not json",
+			check: func(t *testing.T, err error) {
+				var uee *apierror.UnprocessableEntityError
+				if !errors.As(err, &uee) {
+					t.Fatalf("expected *apierror.UnprocessableEntityError, got %T: %v", err, err)
+				}
+				if uee.Msg == "" {
+					t.Errorf("expected a non-empty fallback message")
+				}
+			},
+		},
+		{
+			name:       "500 falls through to the untyped default branch",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"message":"boom"}`,
+			check: func(t *testing.T, err error) {
+				var uee *apierror.UnprocessableEntityError
+				var ce *apierror.ConflictError
+				if errors.As(err, &uee) || errors.As(err, &ce) {
+					t.Fatalf("500 should not be mapped to a 4xx typed error, got %T: %v", err, err)
+				}
+				if err == nil {
+					t.Fatalf("expected an error for status 500")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			c := newTestClient(srv)
+
+			_, err := c.Get(context.Background(), "/some/path", "")
+			tt.check(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
The entity-service's ServiceNow integration client (`entity-service/internal/servicenow-integration-service/client.go`) has an HTTP status-code switch in its `do()` function with explicit cases for 400/401/403/404/409/503, but no case for 422 (Unprocessable Entity). A legitimate 422 from the downstream integration service (e.g. rejecting an invalid state transition, such as trying to reject a call from a state other than Pending) fell through to the generic `default` branch and produced an untyped error. The entity-service's own HTTP layer (`writeServiceError` in `internal/handler/decode.go`) could not recognize that untyped error via `errors.As`, so it collapsed to a generic HTTP 500 — even though the failure was a legitimate, well-formed 422 with a specific, actionable upstream message.

## Goals
- Preserve the real upstream 422 message and status code instead of masking it as a 500.
- Keep the fix scoped to entity-service only; no other component's code is touched.

## Approach
- Added `apierror.UnprocessableEntityError` (`internal/apierror/errors.go`), mirroring the existing `ConflictError` type.
- Added a case for `http.StatusUnprocessableEntity` in `client.go`'s `do()` switch, mirroring the existing 409 case: it reads the body and constructs the new typed error, preserving the upstream message via the existing `extractDownstreamMessage` helper.
- Added a matching case in `handler/decode.go`'s `writeServiceError` so the entity-service's own HTTP response actually surfaces the error as 422 (there was previously no path to 422 anywhere in this function; everything unhandled fell through to 500).
- Verified there is only one HTTP client wrapper of this shape in entity-service, so no other instance of the same gap exists in this service.
- Verified the downstream consumer (`apps/csm-portal/backend`'s `mapUpstreamError`) already has a correct `case http.StatusConflict, http.StatusUnprocessableEntity` ready to consume a properly-typed 422 — that file was not touched.

Note: full end-to-end resolution also needs a corresponding fix in the downstream Ballerina integration layer to actually emit a 422 instead of a 500 for this case; that is tracked separately.

## User stories
N/A — internal error-handling correctness fix, no user-facing story.

## Release note
Fix: a legitimate 422 (Unprocessable Entity) response from the ServiceNow integration service is now correctly surfaced to callers as HTTP 422 with the real upstream message, instead of being flattened into a generic HTTP 500.

## Documentation
N/A — internal error-mapping fix with no external API contract change (the entity-service already returns JSON error bodies; this only corrects the status code and typed error for one previously-unhandled case).

## Training
N/A — no training content affected.

## Certification
N/A — no certification content affected.

## Marketing
N/A — internal bug fix, not user-facing feature.

## Automation tests
 - Unit tests
   > Added `client_test.go` in `internal/servicenow-integration-service`, table-driven over `do()`'s status-code switch: asserts a 409 response still maps to `*apierror.ConflictError` with the upstream message preserved, a 422 response maps to the new `*apierror.UnprocessableEntityError` with the upstream message preserved, a 422 with a non-JSON body falls back to a non-empty default message, and a 500 is not misclassified as either 4xx type. Ran `go build ./...`, `go vet ./...`, and `go test ./...` in `entity-service` — all pass.
 - Integration tests
   > None added; this is a unit-level client/error-mapping fix.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for Go — ran `go vet ./...` instead, clean
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new samples.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data migration.

## Test environment
Go 1.23 (darwin/arm64), local `go build`/`go vet`/`go test` against `entity-service` module.

## Learning
Traced from a staging log investigation of a "Call Rejection" request that returned a generic 500 despite the downstream service correctly rejecting the request with a specific 422 message; root-caused to the missing 422 case in the integration client's status switch and the corresponding gap in the entity-service's own error-to-HTTP-status mapping.


---
**Update (2026-07-27):** the call-request rejection bug that originally motivated this fix is being resolved separately at the ServiceNow layer (switching that specific response from 422 to 409, which this client already handles). This PR is no longer blocking that fix — it remains a correct, general improvement so any future legitimate 422 from the backing data source doesn't get flattened into a generic 500.
