### PR TITLE
[CSM][Web] Build create-incident-from-case and link-to-incident actions

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -207,7 +207,10 @@ interface SecondaryItem {
  *   - Hold auto-closure              → ISSU-027 (PATCH /cases/{id} { autocloseHoldUntil }, see SetAutocloseHoldDialog.tsx)
  *   - Edit case details              → subject/description/deployment/deployed product (see EditCaseDetailsDialog.tsx)
  *   - Link to another case           → parent or related case (see LinkCaseDialog.tsx)
- *   - Create incident / link incident → ISSU-021
+ *   - Create incident from case      → ISSU-021 (POST /incidents { parentId }, see
+ *                                       CreateIncidentPage.tsx's read of the nav state)
+ *   - Link to incident               → ISSU-021 (PATCH /cases/{id} { parentId }, see
+ *                                       LinkIncidentDialog.tsx)
  *   - Raise Git issue                → ISSU-020
  *   - Create task                    → ISSU-025 (POST /cases/{caseId}/tasks, see CreateTaskDialog.tsx)
  *   - Set fix ETA                    → PATCH /cases/{id} { fixEta }, see SetFixEtaDialog.tsx
@@ -269,16 +272,6 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
     caseDetail.state,
   );
 
-  // Roadmap items with no backend flow yet: kept visible (so the menu still
-  // advertises what's coming) but disabled with a tooltip explaining why,
-  // rather than clickable and silently no-op'ing or toasting a mock message.
-  // "Hold auto-closure…" belongs here too — it isn't state-gated, it's simply
-  // not built yet, regardless of the case's current state.
-  const NOT_BUILT_YET = "Not available yet — this action is planned but not built.";
-
-  // Only "Create incident from case…" and "Link to incident…" remain
-  // disabled/not-built — every other item below (including "Create task…"
-  // and "Set fix ETA…") is wired up.
   items.push(
     {
       key: "raise_git_issue",
@@ -341,8 +334,21 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
       disabled: caseClosed,
       tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
     },
-    { key: "create_incident", label: "Create incident from case…", icon: <AlertTriangle size={16} />, disabled: true, tooltip: NOT_BUILT_YET },
-    { key: "link_incident", label: "Link to incident…", icon: <LinkIcon size={16} />, divider: true, disabled: true, tooltip: NOT_BUILT_YET },
+    {
+      key: "create_incident",
+      label: "Create incident from case…",
+      icon: <AlertTriangle size={16} />,
+      disabled: caseClosed,
+      tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
+    },
+    {
+      key: "link_incident",
+      label: "Link to incident…",
+      icon: <LinkIcon size={16} />,
+      divider: true,
+      disabled: caseClosed,
+      tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
+    },
     {
       key: "create_task",
       label: "Create task…",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkIncidentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkIncidentDialog.tsx
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import AsyncEntitySelect from "@components/AsyncEntitySelect";
+import { useSearchIncidentsForSelect } from "@features/csm-operations/api/useSearchIncidentsForSelect";
+import type { BeIncident } from "@api/backend/types";
+
+interface LinkIncidentDialogProps {
+  /** True while a PATCH is in flight; disables the actions. */
+  isLinking: boolean;
+  onClose: () => void;
+  /** Link the current case to `targetIncidentId` as its parent. */
+  onLink: (targetIncidentId: string) => void;
+}
+
+function incidentSearchLabel(i: BeIncident): string {
+  return [i.number, i.subject].filter(Boolean).join(" — ") || i.id || "";
+}
+
+/**
+ * Search-and-select an incident to link the current case to as its
+ * **parent** (`PATCH { parentId }`) — the same generic task-parent
+ * relationship {@link LinkCaseDialog} uses for case-to-case parent links.
+ * There is no incident equivalent of the looser `relatedCaseId` cross-link
+ * (that field is case-only), so this only offers the one link type. Reuses
+ * {@link AsyncEntitySelect}/`useSearchIncidentsForSelect`, the same
+ * type-ahead picker `CreateProblemPage`/`CreateIncidentPage` already use for
+ * their own incident reference fields, rather than a bespoke list like
+ * `LinkCaseDialog`. ServiceNow-source only; the caller surfaces a rejection
+ * on another source.
+ */
+export default function LinkIncidentDialog({
+  isLinking,
+  onClose,
+  onLink,
+}: LinkIncidentDialogProps): JSX.Element {
+  const [incidentId, setIncidentId] = useState("");
+
+  const handleLink = (): void => {
+    if (!incidentId) return;
+    onLink(incidentId);
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Link to incident</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1.5 }}>
+          Links this case to an incident as its parent — the hierarchical
+          relationship, e.g. a case reported against an incident that's
+          already being tracked.
+        </Typography>
+
+        <AsyncEntitySelect<BeIncident>
+          id="link-incident-picker"
+          label="Incident"
+          placeholder="Search incidents…"
+          value={incidentId}
+          onChange={setIncidentId}
+          disabled={isLinking}
+          useSearch={useSearchIncidentsForSelect}
+          getId={(i) => i.id!}
+          getLabel={incidentSearchLabel}
+        />
+
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1.5 }}>
+          Linking applies to ServiceNow-managed cases.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isLinking}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleLink}
+          disabled={!incidentId || isLinking}
+          loading={isLinking}
+        >
+          Link
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -126,6 +126,7 @@ import { formatAbsoluteForUser } from "@utils/dateTime";
 import {
   isBlankHtml,
   sanitizeDescriptionHtml,
+  stripHtmlTags,
   stripLightModeInlineStyles,
 } from "@utils/sanitizeHtml";
 import { useDarkMode } from "@utils/useDarkMode";
@@ -491,6 +492,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     setPendingDelete(null);
     setPauseConflict(null);
     setLinkCaseOpen(false);
+    setLinkIncidentOpen(false);
     setAutocloseHoldOpen(false);
     setEditDetailsOpen(false);
     setCreateTaskOpen(false);
@@ -835,6 +837,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
           caseId: data.id,
           caseNumber: data.caseNumber,
           subject: data.subject,
+          // The case description is rich-text HTML; the incident form's
+          // Description field is plain text (sent as additionalComments), so
+          // strip tags rather than carrying markup through as visible text.
+          description: isBlankHtml(data.description)
+            ? undefined
+            : stripHtmlTags(data.description),
         };
         navigate("/operations/incidents/new", { state: navState });
         return;

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -88,6 +88,7 @@ import SetAutocloseHoldDialog from "@features/csm-cases/components/SetAutocloseH
 import EditCaseDetailsDialog, {
   type FieldSaveResult,
 } from "@features/csm-cases/components/EditCaseDetailsDialog";
+import LinkIncidentDialog from "@features/csm-cases/components/LinkIncidentDialog";
 import LinkCaseDialog, {
   type CaseLinkType,
 } from "@features/csm-cases/components/LinkCaseDialog";
@@ -144,6 +145,7 @@ import type {
   CaseAttachment,
   CaseLifecycleAction,
   CaseWatcher,
+  CreateIncidentFromCaseNavState,
   CreateRelatedCaseNavState,
 } from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
@@ -426,6 +428,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
   const [linkCaseOpen, setLinkCaseOpen] = useState(false);
+  const [linkIncidentOpen, setLinkIncidentOpen] = useState(false);
   const [autocloseHoldOpen, setAutocloseHoldOpen] = useState(false);
   const [editDetailsOpen, setEditDetailsOpen] = useState(false);
   const [createTaskOpen, setCreateTaskOpen] = useState(false);
@@ -823,6 +826,27 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Create incident from case navigates to the create-incident form,
+      // pre-filled with this case as the new incident's parent (ServiceNow's
+      // generic task-parent reference — see CreateIncidentPage.tsx's read of
+      // the nav state).
+      if (action.secondary === "create_incident" && data) {
+        const navState: CreateIncidentFromCaseNavState = {
+          caseId: data.id,
+          caseNumber: data.caseNumber,
+          subject: data.subject,
+        };
+        navigate("/operations/incidents/new", { state: navState });
+        return;
+      }
+
+      // Link to incident opens the search-and-pick dialog; the PATCH happens
+      // in onLinkIncident once a target incident is chosen.
+      if (action.secondary === "link_incident") {
+        setLinkIncidentOpen(true);
+        return;
+      }
+
       // Create task opens the task-create form; the POST happens in
       // onCreateTask once it's submitted.
       if (action.secondary === "create_task") {
@@ -1211,6 +1235,26 @@ export default function CsmCaseDetailPage(): JSX.Element {
             });
           },
           onError: (err) => showError("Could not link this case.", err),
+        },
+      );
+    },
+    [patchCase, showError],
+  );
+
+  const onLinkIncident = useCallback(
+    (targetIncidentId: string) => {
+      patchCase.mutate(
+        { parentId: targetIncidentId },
+        {
+          onSuccess: () => {
+            setLinkIncidentOpen(false);
+            setFeedback({
+              message: "Incident linked as parent.",
+              severity: "success",
+              sticky: false,
+            });
+          },
+          onError: (err) => showError("Could not link this incident.", err),
         },
       );
     },
@@ -2108,6 +2152,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
           isLinking={patchCase.isPending}
           onClose={() => setLinkCaseOpen(false)}
           onLink={onLinkCase}
+        />
+      )}
+
+      {linkIncidentOpen && (
+        <LinkIncidentDialog
+          isLinking={patchCase.isPending}
+          onClose={() => setLinkIncidentOpen(false)}
+          onLink={onLinkIncident}
         />
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -393,6 +393,8 @@ export interface CreateIncidentFromCaseNavState {
   caseId: string;
   caseNumber?: string;
   subject?: string;
+  /** Plain text — the case's rich-text description with tags stripped. */
+  description?: string;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -378,6 +378,24 @@ export interface CreateRelatedCaseNavState {
 }
 
 /**
+ * Router (`navigate(..., { state })`) payload carried from a case's "Create
+ * incident from case…" action to `/operations/incidents/new`, so the
+ * create-incident form can prefill from the originating case without a
+ * query-string round trip or a full page load. `caseId` seeds the incident's
+ * `parentId` (ServiceNow's generic task-parent reference — the same field
+ * used for the case-to-case/case-to-incident hierarchical link, not the
+ * incident-specific `parentIncidentId`); every field is just a starting
+ * value the form leaves editable. See CsmCaseDetailPage.tsx's
+ * `create_incident` handler and CreateIncidentPage.tsx's read of
+ * `useLocation().state`.
+ */
+export interface CreateIncidentFromCaseNavState {
+  caseId: string;
+  caseNumber?: string;
+  subject?: string;
+}
+
+/**
  * Full case detail used by the case detail page. Extends the lightweight
  * row type used in lists with all the side-widget data plus a curated set
  * of state-driven primary actions.

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateIncidentPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateIncidentPage.tsx
@@ -107,7 +107,7 @@ export default function CreateIncidentPage(): JSX.Element {
       ? `Incident from case ${originCaseState.caseNumber ?? originCaseState.caseId}: ${originCaseState.subject}`
       : "",
   );
-  const [description, setDescription] = useState("");
+  const [description, setDescription] = useState(originCaseState?.description ?? "");
   const [category, setCategory] = useState<BeIncidentCategory | "">(UNSET);
   const [subcategory, setSubcategory] = useState<BeIncidentSubcategory | "">(UNSET);
   const [contactType, setContactType] = useState<BeIncidentContactType | "">(UNSET);

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateIncidentPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateIncidentPage.tsx
@@ -33,9 +33,10 @@ import {
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, ChevronDown } from "@wso2/oxygen-ui-icons-react";
 import { useRef, useState, type JSX } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import type { CreateIncidentFromCaseNavState } from "@features/csm-cases/types/csmCases";
 import { usePostIncident } from "@features/csm-operations/api/usePostIncident";
 import { useGetUsersMe } from "@features/settings/api/useGetUsersMe";
 import { useSearchGroups } from "@api/useSearchGroups";
@@ -92,7 +93,20 @@ export default function CreateIncidentPage(): JSX.Element {
   const { showError } = useErrorBanner();
   const postIncident = usePostIncident();
 
-  const [shortDescription, setShortDescription] = useState("");
+  // Set when opened from a case's "Create incident from case…" action, which
+  // navigates here with router state (not query params) so the case's id
+  // carries over as the new incident's parent without a query-string round
+  // trip or a full page load. See CsmCaseDetailPage.tsx's `create_incident`
+  // handler.
+  const originCaseState = useLocation().state as
+    | CreateIncidentFromCaseNavState
+    | undefined;
+
+  const [shortDescription, setShortDescription] = useState(
+    originCaseState?.subject
+      ? `Incident from case ${originCaseState.caseNumber ?? originCaseState.caseId}: ${originCaseState.subject}`
+      : "",
+  );
   const [description, setDescription] = useState("");
   const [category, setCategory] = useState<BeIncidentCategory | "">(UNSET);
   const [subcategory, setSubcategory] = useState<BeIncidentSubcategory | "">(UNSET);
@@ -107,7 +121,7 @@ export default function CreateIncidentPage(): JSX.Element {
   const [assignedEngineerId, setAssignedEngineerId] = useState("");
   const [watchList, setWatchList] = useState<string[]>([]);
   const [workNotes, setWorkNotes] = useState("");
-  const [parentId, setParentId] = useState("");
+  const [parentId, setParentId] = useState(originCaseState?.caseId ?? "");
   const [changeRequestId, setChangeRequestId] = useState("");
   const [problemId, setProblemId] = useState("");
   const [causedById, setCausedById] = useState("");
@@ -280,9 +294,15 @@ export default function CreateIncidentPage(): JSX.Element {
       >
         Back to operations
       </Button>
-      <Typography variant="h5" sx={{ mb: 2 }}>
+      <Typography variant="h5" sx={{ mb: originCaseState ? 0.5 : 2 }}>
         New incident
       </Typography>
+      {originCaseState && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Linked to case {originCaseState.caseNumber ?? originCaseState.caseId} — its id is
+          carried through automatically as this incident's parent.
+        </Typography>
+      )}
 
       <Card variant="outlined" sx={{ p: 3 }}>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -547,11 +567,16 @@ export default function CreateIncidentPage(): JSX.Element {
               </Typography>
               <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
                 <TextField
-                  label="Parent incident ID"
+                  label="Parent ID (case / incident / CR / problem)"
                   size="small"
                   value={parentId}
                   onChange={(e) => setParentId(e.target.value)}
                   disabled={postIncident.isPending}
+                  helperText={
+                    originCaseState
+                      ? `Carried through from case ${originCaseState.caseNumber ?? originCaseState.caseId}.`
+                      : undefined
+                  }
                   sx={{ flex: "1 1 220px" }}
                 />
                 <TextField


### PR DESCRIPTION
## Purpose
ISSU-021: "Create incident from case…" and "Link to incident…" were present in the case action bar's overflow menu but hard-disabled with a "not built" tooltip. The backend already supports both through the existing generic parent-link mechanism, so this only needed frontend wiring.

## Goals
- Let an engineer create a new incident directly from a case, pre-linked as its parent.
- Let an engineer link a case to an existing incident.

## Approach
- **Create incident from case**: `CaseActionBar`'s `create_incident` action now navigates to `/operations/incidents/new` with router state (case id/number/subject), mirroring the existing `create_related_case` → `/cases/new` pattern. `CreateIncidentPage` reads that state to prefill the short description and the `parentId` field.
- **Link to incident**: added `LinkIncidentDialog.tsx`, a search-and-pick dialog reusing `AsyncEntitySelect` + the existing `useSearchIncidentsForSelect` hook (already built for the problem-create form). Confirming a pick calls the same `PATCH /cases/{id} { parentId }` the existing `LinkCaseDialog` already uses for case-to-case parent links — incidents don't have an equivalent of the looser `relatedCaseId` cross-link, so there's no second link-type option here.
- Fixed a pre-existing mislabeled field on the create-incident form: the "Parent incident ID" text field is actually a generic parent reference (accepts a case, incident, change request, or problem id — confirmed against the entity-service's `parentId`/`parentIncident` schema split), not incident-specific. Relabeled to make that clear, since this PR prefills it from a case.

## User stories
As a CSM engineer working a case, I can create a new incident from it (linked back to the case as its parent) or link the case to an incident that's already being tracked, without leaving the case detail page.

## Release note
Enable "Create incident from case…" and "Link to incident…" case actions.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- No existing automated coverage for `CaseActionBar`/`CsmCaseDetailPage`/`CreateIncidentPage` interactions.
- Verified live against staging end-to-end: created a real incident from an open case — its "Linked records" correctly shows the originating case as parent — and separately linked a different case to an existing incident via the new dialog, confirmed by the "Incident linked as parent." success toast.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `tsc -b`, `eslint`, `vite build` all passing locally, plus the live staging verification described above (originally verified against dev-app-csm-portal before it was merged into main — same code, cherry-picked cleanly with zero conflicts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to create an incident directly from a case, prefilled with case details and linked automatically.
  * Added support for linking an existing incident to a case via a searchable selection dialog.
  * Improved case “More” menu incident actions to reflect the case’s current status (editable for open cases, read-only for closed cases).
  * Added contextual indicators on the incident creation screen showing when it was created from a linked case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->