### PR TITLE
[CSM Portal] surface the real change-request state-transition error instead of a generic message

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -19,11 +19,26 @@ import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeChangeRequestDetail } from "@api/backend/types";
+import { BackendApiError } from "@api/backend/client";
 
 const navigateMock = vi.fn();
 const useGetChangeRequestMock = vi.fn();
 const patchMutateMock = vi.fn();
 const showErrorMock = vi.fn();
+
+// The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
+// module load, which isn't present under vitest. The page imports
+// `BackendApiError` from it directly, so stub the module with a real class
+// (so `instanceof` still works) — same approach as CsmIncidentDetailPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
 
 vi.mock("react-router", () => ({
   useParams: () => ({ id: "chg-1" }),
@@ -149,6 +164,32 @@ describe("CsmChangeRequestDetailPage — Request approval (New -> Assess)", () =
     fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
     const [, options] = patchMutateMock.mock.calls[0];
     const err = new Error("boom");
+    options.onError(err);
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "Could not request approval for this change request.",
+      err,
+    );
+  });
+
+  it("surfaces the backend's real rejection reason for a 4xx state-transition error", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    const [, options] = patchMutateMock.mock.calls[0];
+    const err = new BackendApiError(409, "State transition rejected: approver required");
+    options.onError(err);
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "State transition rejected: approver required",
+      err,
+    );
+  });
+
+  it("falls back to the generic message for a 5xx error even with a body message", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    const [, options] = patchMutateMock.mock.calls[0];
+    const err = new BackendApiError(500, "internal error detail");
     options.onError(err);
     expect(showErrorMock).toHaveBeenCalledWith(
       "Could not request approval for this change request.",

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -27,6 +27,7 @@ import { type JSX, type ReactNode, useCallback, useMemo, useState } from "react"
 import {  useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
 import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
@@ -57,6 +58,17 @@ import type { BeEntityRef } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 
 const OPERATIONS_CR_PATH = "/operations?tab=change_requests";
+
+/**
+ * The backend surfaces real rejection reasons on 4xx (e.g. a state
+ * transition rejected by the backing data source); prefer that message over
+ * a generic fallback whenever one is available.
+ */
+function backendErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof BackendApiError && err.status < 500 && err.message
+    ? err.message
+    : fallback;
+}
 
 function formatDateTime(value?: string | null): string {
   return (
@@ -232,7 +244,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
       { id: cr.id, patch: { requestApproval: true } },
       {
         onError: (err) =>
-          showError("Could not request approval for this change request.", err),
+          showError(
+            backendErrorMessage(
+              err,
+              "Could not request approval for this change request.",
+            ),
+            err,
+          ),
       },
     );
   };
@@ -466,7 +484,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               {
                 onSuccess: () => setEditOpen(false),
                 onError: (err) =>
-                  showError("Could not update the change request.", err),
+                  showError(
+                    backendErrorMessage(
+                      err,
+                      "Could not update the change request.",
+                    ),
+                    err,
+                  ),
               },
             )
           }


### PR DESCRIPTION
## Purpose
Clicking "Request approval" (and saving edits) on the CSM portal's Change Request detail page always showed a fixed, generic error banner string on failure, even when the backing data source rejected the request with a specific, useful reason (e.g. a state-transition rejection). A companion fix further down the stack is making that rejection surface as a real HTTP 4xx with a specific message; this PR makes the frontend actually show it.

## Goals
- When a change-request PATCH (request approval or the edit dialog's save) fails with a 4xx that carries a message, show that real message instead of the generic fallback string.
- Keep the generic fallback for 5xx errors or when no message body is present, so users aren't shown a raw/unhelpful internal error string.

## Approach
Added a small `backendErrorMessage(err, fallback)` helper in `CsmChangeRequestDetailPage.tsx` that prefers `err.message` when `err` is a `BackendApiError` with `status < 500`, falling back to the existing generic string otherwise. This mirrors the same pattern already used in `CreateChangeRequestPage.tsx` for surfacing real validation messages. Applied it to both `onError` handlers on the page (request approval, and the edit-change-request save).

No backend, entity-service, or customer-portal changes in this PR — frontend only.

## User stories
As a CS engineer, when a change-request action is rejected for a specific reason, I want to see that reason so I know what to fix or who to follow up with, instead of a generic "could not update" message.

## Release note
The change request detail page now shows the backend's actual rejection reason (when available) for a failed "Request approval" or edit action, instead of always showing a generic error message.

## Documentation
N/A — internal error-message behavior change, no user-facing docs to update.

## Automation tests
- Unit tests: extended `CsmChangeRequestDetailPage.test.tsx` with two new cases: (1) a 4xx `BackendApiError` with a message is passed through to the error banner verbatim, (2) a 5xx error still falls back to the generic message even when it carries a body. All 9 tests in the file pass.
- Integration tests: N/A, no integration test harness covers this page.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React, not Java) — ran `eslint` and `tsc -b` clean instead
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Stacked alongside a companion fix (backend + backing data source) that makes the rejected state-transition surface as a real HTTP 4xx with a specific message; without that companion change this PR has no visible effect since the generic fallback still applies to 5xx/no-message errors.

## Migrations (if applicable)
N/A

## Test environment
Verified with `npx tsc -b`, `npx eslint` on the changed files, `npx vitest run` on the changed test file (9/9 passing) and the full suite (pre-existing unrelated failures in `CaseActionBar.test.tsx`, `CaseActivitiesFeed.test.tsx`, `CsmAnnouncementsPage.test.tsx` confirmed present before this change too), and `pnpm build`.

## Learning
N/A
