### PR TITLE
[CSM Portal] FE bug fixes: require close notes, surface real change-request error messages

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.test.tsx
@@ -27,7 +27,7 @@ function chooseOption(labelId: string, optionText: RegExp): void {
 }
 
 describe("ResolutionDialog", () => {
-  it("disables submit until both resolution code and cause are chosen", () => {
+  it("disables submit until resolution code, cause, and close notes are all provided", () => {
     render(
       <ResolutionDialog
         kind="close"
@@ -42,7 +42,30 @@ describe("ResolutionDialog", () => {
     expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
 
     chooseOption("case-cause-label", /product\/bug/i);
+    expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/close notes/i), {
+      target: { value: "Fixed by rolling back the config change." },
+    });
     expect(screen.getByRole("button", { name: /close case/i })).not.toBeDisabled();
+  });
+
+  it("shows a validation message when close notes is left blank", () => {
+    render(
+      <ResolutionDialog
+        kind="close"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    chooseOption("resolution-code-label", /solved.*fixed by support\/guidance provided/i);
+    chooseOption("case-cause-label", /product\/bug/i);
+
+    // Submit stays disabled while blank, but leaving the field surfaces why.
+    fireEvent.blur(screen.getByLabelText(/close notes/i));
+    expect(screen.getByRole("button", { name: /close case/i })).toBeDisabled();
+    expect(screen.getByText(/close notes are required/i)).toBeInTheDocument();
   });
 
   it("submits the chosen resolution code, cause, and close notes", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
@@ -95,8 +95,11 @@ export default function ResolutionDialog({
   );
   const [cause, setCause] = useState<BeCaseCause | "">(initial?.cause ?? "");
   const [closeNotes, setCloseNotes] = useState(initial?.closeNotes ?? "");
+  const [closeNotesTouched, setCloseNotesTouched] = useState(false);
   const copy = COPY[kind];
-  const canSubmit = !!resolutionCode && !!cause && !isSubmitting;
+  const hasCloseNotes = closeNotes.trim().length > 0;
+  const closeNotesInvalid = closeNotesTouched && !hasCloseNotes;
+  const canSubmit = !!resolutionCode && !!cause && hasCloseNotes && !isSubmitting;
 
   return (
     <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
@@ -145,13 +148,21 @@ export default function ResolutionDialog({
 
         <TextField
           label="Close notes"
+          required
           size="small"
           fullWidth
           multiline
           minRows={3}
           value={closeNotes}
           onChange={(e) => setCloseNotes(e.target.value)}
-          placeholder="Optional free-text notes about the resolution…"
+          onBlur={() => setCloseNotesTouched(true)}
+          error={closeNotesInvalid}
+          helperText={
+            closeNotesInvalid
+              ? "Close notes are required."
+              : "Free-text notes about the resolution, shared with the customer."
+          }
+          placeholder="Describe the resolution…"
         />
       </DialogContent>
       <DialogActions>
@@ -163,7 +174,10 @@ export default function ResolutionDialog({
           color={kind === "close" ? "warning" : "primary"}
           disabled={!canSubmit}
           onClick={() => {
-            if (!resolutionCode || !cause) return;
+            if (!resolutionCode || !cause || !hasCloseNotes) {
+              setCloseNotesTouched(true);
+              return;
+            }
             onSubmit({ resolutionCode, cause, closeNotes });
           }}
         >

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -19,11 +19,26 @@ import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeChangeRequestDetail } from "@api/backend/types";
+import { BackendApiError } from "@api/backend/client";
 
 const navigateMock = vi.fn();
 const useGetChangeRequestMock = vi.fn();
 const patchMutateMock = vi.fn();
 const showErrorMock = vi.fn();
+
+// The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
+// module load, which isn't present under vitest. The page imports
+// `BackendApiError` from it directly, so stub the module with a real class
+// (so `instanceof` still works) — same approach as CsmIncidentDetailPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
 
 vi.mock("react-router", () => ({
   useParams: () => ({ id: "chg-1" }),
@@ -149,6 +164,32 @@ describe("CsmChangeRequestDetailPage — Request approval (New -> Assess)", () =
     fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
     const [, options] = patchMutateMock.mock.calls[0];
     const err = new Error("boom");
+    options.onError(err);
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "Could not request approval for this change request.",
+      err,
+    );
+  });
+
+  it("surfaces the backend's real rejection reason for a 4xx state-transition error", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    const [, options] = patchMutateMock.mock.calls[0];
+    const err = new BackendApiError(409, "State transition rejected: approver required");
+    options.onError(err);
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "State transition rejected: approver required",
+      err,
+    );
+  });
+
+  it("falls back to the generic message for a 5xx error even with a body message", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    const [, options] = patchMutateMock.mock.calls[0];
+    const err = new BackendApiError(500, "internal error detail");
     options.onError(err);
     expect(showErrorMock).toHaveBeenCalledWith(
       "Could not request approval for this change request.",

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -27,6 +27,7 @@ import { type JSX, type ReactNode, useCallback, useMemo, useState } from "react"
 import {  useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
 import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
@@ -57,6 +58,17 @@ import type { BeEntityRef } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 
 const OPERATIONS_CR_PATH = "/operations?tab=change_requests";
+
+/**
+ * The backend surfaces real rejection reasons on 4xx (e.g. a state
+ * transition rejected by the backing data source); prefer that message over
+ * a generic fallback whenever one is available.
+ */
+function backendErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof BackendApiError && err.status < 500 && err.message
+    ? err.message
+    : fallback;
+}
 
 function formatDateTime(value?: string | null): string {
   return (
@@ -232,7 +244,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
       { id: cr.id, patch: { requestApproval: true } },
       {
         onError: (err) =>
-          showError("Could not request approval for this change request.", err),
+          showError(
+            backendErrorMessage(
+              err,
+              "Could not request approval for this change request.",
+            ),
+            err,
+          ),
       },
     );
   };
@@ -466,7 +484,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               {
                 onSuccess: () => setEditOpen(false),
                 onError: (err) =>
-                  showError("Could not update the change request.", err),
+                  showError(
+                    backendErrorMessage(
+                      err,
+                      "Could not update the change request.",
+                    ),
+                    err,
+                  ),
               },
             )
           }


### PR DESCRIPTION
## Purpose
Consolidates two independent, unrelated-but-small FE bug fixes into one PR (each was originally opened separately as #1242/#1251; those are closed in favor of this one) to reduce review overhead. Each commit is self-contained and independently revertable.

## Goals
- Fix Close case / Propose solution, which failed with a 400 whenever close notes was left blank (the backing data source requires it; the dialog presented it as optional).
- Fix the change-request detail page's error banner, which always showed a generic message instead of the real 4xx detail from the backend.

## Approach
Two independent commits, each addressing one bug in its own files with its own tests — see individual commit messages for detail. No shared code between them; a review can evaluate each commit in isolation.

## Release note
Fixes two staging bugs: Close case / Propose solution validation, and change-request error messaging.

## Documentation
N/A — internal bug fixes, no contract/shape changes.

## Security checks
- Secure coding standards followed: yes
- FindSecurityBugs / static analysis: N/A for TS/React — `eslint`/`tsc` clean
- No secrets committed: yes

## Related PRs
Supersedes #1242, #1251 (closed in favor of this consolidated PR).