### PR TITLE
fix(customer-portal): don't block case creation on attachment uploads

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/api/usePostAttachments.ts
+++ b/apps/customer-portal/webapp/src/features/support/api/usePostAttachments.ts
@@ -45,6 +45,7 @@ export function usePostAttachments(): UseMutationResult<
   const authFetch = useAuthApiClient();
 
   return useMutation<void, Error, PostAttachmentsVariables>({
+    mutationKey: ["postCaseAttachment"],
     mutationFn: async ({
       caseId,
       body,

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/CaseDetailsAttachmentsPanel.tsx
@@ -19,12 +19,14 @@ import { Box, Button, Stack, Typography } from "@wso2/oxygen-ui";
 import ListPagination from "@components/list-view/ListPagination";
 import { Paperclip } from "@wso2/oxygen-ui-icons-react";
 import { useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { useMutationState } from "@tanstack/react-query";
 import { setPendingCaseDetailsTab } from "@features/settings/utils/settingsStorage";
 import {
   useGetCaseAttachments,
   flattenCaseAttachments,
 } from "@features/support/api/useGetCaseAttachments";
 import type { CaseAttachment } from "@features/support/types/cases";
+import type { PostAttachmentsVariables } from "@features/support/types/supportApi";
 import { useDeleteAttachment } from "@features/support/api/useDeleteAttachment";
 import { useGetAttachmentContent } from "@api/useGetAttachmentContent";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
@@ -33,6 +35,7 @@ import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import UploadAttachmentModal from "@case-details-attachments/UploadAttachmentModal";
 import AttachmentListItem from "@case-details-attachments/AttachmentListItem";
 import AttachmentsListSkeleton from "@case-details-attachments/AttachmentsListSkeleton";
+import UploadingAttachmentPlaceholder from "@case-details-attachments/UploadingAttachmentPlaceholder";
 import DeleteAttachmentModal from "@case-details-attachments/DeleteAttachmentModal";
 import EditCaseAttachmentModal from "@case-details-attachments/EditCaseAttachmentModal";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
@@ -91,6 +94,14 @@ export default function CaseDetailsAttachmentsPanel({
   } = useGetCaseAttachments(caseId);
 
   const deleteAttachment = useDeleteAttachment();
+
+  const pendingUploads = useMutationState({
+    filters: { mutationKey: ["postCaseAttachment"], status: "pending" },
+    select: (mutation) =>
+      mutation.state.variables as PostAttachmentsVariables | undefined,
+  }).filter(
+    (vars): vars is PostAttachmentsVariables => vars?.caseId === caseId,
+  );
 
   const allAttachments = useMemo(() => flattenCaseAttachments(data), [data]);
 
@@ -205,9 +216,13 @@ export default function CaseDetailsAttachmentsPanel({
   return (
     <>
       <Stack spacing={3}>
-        {!(allAttachments.length === 0 && !isLoading && minTimeElapsed && !isError) && (
-          <Box sx={{ alignSelf: "flex-start" }}>{uploadButton}</Box>
-        )}
+        {!(
+          allAttachments.length === 0 &&
+          pendingUploads.length === 0 &&
+          !isLoading &&
+          minTimeElapsed &&
+          !isError
+        ) && <Box sx={{ alignSelf: "flex-start" }}>{uploadButton}</Box>}
 
         {isLoading || !minTimeElapsed ? (
           <AttachmentsListSkeleton />
@@ -216,7 +231,7 @@ export default function CaseDetailsAttachmentsPanel({
             error={error}
             fallbackMessage="Failed to load attachments."
           />
-        ) : allAttachments.length === 0 ? (
+        ) : allAttachments.length === 0 && pendingUploads.length === 0 ? (
           <Stack
             spacing={2}
             alignItems="center"
@@ -242,6 +257,12 @@ export default function CaseDetailsAttachmentsPanel({
           </Stack>
         ) : (
           <Stack spacing={2}>
+            {pendingUploads.map((vars, index) => (
+              <UploadingAttachmentPlaceholder
+                key={`pending-upload-${index}`}
+                name={vars.body.name}
+              />
+            ))}
             {isFetchingNextPage && paginatedAttachments.length === 0 ? (
               <AttachmentsListSkeleton />
             ) : (

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/UploadingAttachmentPlaceholder.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/attachments-tab/UploadingAttachmentPlaceholder.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, CircularProgress, Paper, Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+
+interface UploadingAttachmentPlaceholderProps {
+  name: string;
+}
+
+/**
+ * Placeholder row for an attachment that is still uploading in the background
+ * (e.g. one created on the create-case page whose upload outlasted the wait window).
+ *
+ * @param {UploadingAttachmentPlaceholderProps} props - name of the attachment being uploaded.
+ * @returns {JSX.Element} The placeholder row.
+ */
+export default function UploadingAttachmentPlaceholder({
+  name,
+}: UploadingAttachmentPlaceholderProps): JSX.Element {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        minWidth: 0,
+      }}
+    >
+      <Box
+        sx={{
+          width: 40,
+          height: 40,
+          bgcolor: "action.hover",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "text.secondary",
+          flexShrink: 0,
+        }}
+        aria-hidden
+      >
+        <CircularProgress color="inherit" size={20} />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          variant="body2"
+          color="text.primary"
+          sx={{
+            fontWeight: 500,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {name}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          Uploading…
+        </Typography>
+      </Box>
+    </Paper>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -974,6 +974,7 @@ export default function CreateCasePage(): JSX.Element {
       onSuccess: async (data) => {
         setIsNavigatingAfterCreate(true);
         const caseId = data.id;
+        showSuccess("Case created successfully");
         const createdCase = data as {
           isSecurityReport?: boolean;
           reportType?: string;
@@ -1026,11 +1027,10 @@ export default function CreateCasePage(): JSX.Element {
             void uploadPromise.then((failed) => {
               if (failed.length > 0) {
                 showError(
-                  `Case created, but failed to upload: ${failed.join(", ")}. You can retry from the Attachments tab.`,
+                  `Failed to upload: ${failed.join(", ")}. You can retry from the Attachments tab.`,
                 );
-              } else {
-                showSuccess("Attachments uploaded successfully.");
               }
+              // no-op on success: the case-created confirmation was already shown above
             });
           } else {
             setIsPreparingAttachments(false);
@@ -1079,14 +1079,10 @@ export default function CreateCasePage(): JSX.Element {
           navigate(`/projects/${projectId}/support/cases/${caseId}`);
         }
 
-        if (!attachmentsStillUploading) {
-          if (failedAttachmentNames.length > 0) {
-            showError(
-              `Case created, but failed to upload: ${failedAttachmentNames.join(", ")}. You can retry from the Attachments tab.`,
-            );
-          } else {
-            showSuccess("Case created successfully");
-          }
+        if (!attachmentsStillUploading && failedAttachmentNames.length > 0) {
+          showError(
+            `Failed to upload: ${failedAttachmentNames.join(", ")}. You can retry from the Attachments tab.`,
+          );
         }
       },
       onError: (error) => {

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -38,6 +38,7 @@ import {
   usePostDeploymentProductsSearchInfinite,
 } from "@features/project-details/api/usePostDeploymentProductsSearch";
 import { usePostCase } from "@features/operations/api/usePostCase";
+import { usePostAttachments } from "@features/support/api/usePostAttachments";
 import { useLoader } from "@context/linear-loader/LoaderContext";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
@@ -95,6 +96,7 @@ import type { RelatedCaseState } from "@features/support/types/createCasePage";
 
 const DEFAULT_CASE_TITLE = "Support case";
 const DEFAULT_CASE_DESCRIPTION = "Please describe your issue here.";
+const ATTACHMENT_UPLOAD_WAIT_MS = 5_000;
 
 const RELATED_DESCRIPTION_PREFIX_HTML =
   "<p>-- This is the previous description (Edit or Delete if you want to alter) --</p>";
@@ -240,9 +242,10 @@ export default function CreateCasePage(): JSX.Element {
   }, [baseProductOptions]);
 
   const { showError } = useErrorBanner();
-  const piiGuard = usePiiGuard();
   const { showSuccess } = useSuccessBanner();
+  const piiGuard = usePiiGuard();
   const { mutate: postCase, isPending: isCreatePending } = usePostCase();
+  const postAttachments = usePostAttachments();
   const [isNavigatingAfterCreate, setIsNavigatingAfterCreate] = useState(false);
   const authFetch = useAuthApiClient();
   const logger = useLogger();
@@ -947,33 +950,7 @@ export default function CreateCasePage(): JSX.Element {
       severityKey = parsedSeverity;
     }
 
-    const encodedAttachments: Array<{ file: string; name: string }> = [];
-    if (attachments.length > 0) {
-      setIsPreparingAttachments(true);
-      try {
-        for (const item of attachments) {
-          const encodedAttachment = await fileToBase64Content(item.file);
-          const attachmentName =
-            attachmentNamesRef.current.get(item.id) || item.file.name;
-          encodedAttachments.push({
-            file: encodedAttachment,
-            name: attachmentName,
-          });
-        }
-      } catch (error) {
-        const message =
-          error instanceof Error && error.message
-            ? error.message
-            : "Failed to process attachments. Please try again.";
-        showError(message);
-        return;
-      } finally {
-        setIsPreparingAttachments(false);
-      }
-    }
-
     const payload: CreateCaseRequest = {
-      ...(encodedAttachments.length > 0 && { attachments: encodedAttachments }),
       type: isSecurityReport
         ? CaseType.SECURITY_REPORT_ANALYSIS
         : CaseType.DEFAULT_CASE,
@@ -1007,17 +984,79 @@ export default function CreateCasePage(): JSX.Element {
           isSecurityReport,
         );
 
+        const uploadAttachments = async (): Promise<string[]> => {
+          const failed: string[] = [];
+          for (const item of attachments) {
+            const attachmentName =
+              attachmentNamesRef.current.get(item.id) || item.file.name;
+            try {
+              const content = await fileToBase64Content(item.file);
+              await postAttachments.mutateAsync({
+                caseId,
+                body: {
+                  name: attachmentName,
+                  type: item.file.type || "application/octet-stream",
+                  content,
+                },
+              });
+            } catch (error) {
+              logger.error(
+                `Failed to upload attachment ${attachmentName}`,
+                error,
+              );
+              failed.push(attachmentName);
+            }
+          }
+          return failed;
+        };
+
+        let failedAttachmentNames: string[] = [];
+        let attachmentsStillUploading = false;
+        if (attachments.length > 0) {
+          setIsPreparingAttachments(true);
+          const uploadPromise = uploadAttachments();
+          const timedOut = await Promise.race([
+            uploadPromise.then(() => false),
+            new Promise<boolean>((resolve) =>
+              setTimeout(() => resolve(true), ATTACHMENT_UPLOAD_WAIT_MS),
+            ),
+          ]);
+          if (timedOut) {
+            attachmentsStillUploading = true;
+            void uploadPromise.then((failed) => {
+              if (failed.length > 0) {
+                showError(
+                  `Case created, but failed to upload: ${failed.join(", ")}. You can retry from the Attachments tab.`,
+                );
+              } else {
+                showSuccess("Attachments uploaded successfully.");
+              }
+            });
+          } else {
+            setIsPreparingAttachments(false);
+            failedAttachmentNames = await uploadPromise;
+          }
+        }
+
+        // Fire-and-forget: these hit the same backend origin as the (possibly
+        // still in-flight) attachment upload, so awaiting them here could queue
+        // behind it under the browser's per-origin connection limit and delay
+        // navigation well past the attachment wait window above.
         if (projectId) {
-          await triggerPostCreationApiCalls(
+          triggerPostCreationApiCalls(
             authFetch,
             projectId,
             CaseType.DEFAULT_CASE,
-          );
-          await refreshCaseQueriesAfterCreation(
+          ).catch((error) => {
+            logger.error("Failed to trigger post-creation API calls", error);
+          });
+          refreshCaseQueriesAfterCreation(
             queryClient,
             projectId,
             CaseType.DEFAULT_CASE,
-          );
+          ).catch((error) => {
+            logger.error("Failed to refresh case queries after creation", error);
+          });
         }
 
         // Clean up sessionStorage safely
@@ -1033,15 +1072,22 @@ export default function CreateCasePage(): JSX.Element {
 
         // Refetch security vulnerabilities if this was a security report
         if (isCreatedSecurityReport) {
-          window.location.assign(
+          navigate(
             `/projects/${projectId}/security-center/security-report-analysis/${caseId}?tab=${SecurityTabId.VULNERABILITIES}`,
           );
         } else {
-          window.location.assign(
-            `/projects/${projectId}/support/cases/${caseId}`,
-          );
+          navigate(`/projects/${projectId}/support/cases/${caseId}`);
         }
-        showSuccess("Case created successfully");
+
+        if (!attachmentsStillUploading) {
+          if (failedAttachmentNames.length > 0) {
+            showError(
+              `Case created, but failed to upload: ${failedAttachmentNames.join(", ")}. You can retry from the Attachments tab.`,
+            );
+          } else {
+            showSuccess("Case created successfully");
+          }
+        }
       },
       onError: (error) => {
         setIsNavigatingAfterCreate(false);
@@ -1228,7 +1274,7 @@ export default function CreateCasePage(): JSX.Element {
               }
             >
               {isPreparingAttachments
-                ? "Preparing Attachments..."
+                ? "Uploading attachments..."
                 : isCreatePending
                   ? isSecurityReport
                     ? "Submitting..."


### PR DESCRIPTION
## Summary
- Case creation now uploads attachments via `POST /cases/:id/attachments` after the case exists (instead of bundling them into the create-case payload), so a failed attachment no longer blocks the case from being created.
- Case creation waits up to 5s for attachments to finish before navigating to the case; past that, it navigates immediately and the upload continues in the background, with an "Uploading..." placeholder shown in the case's Attachments tab until it completes.
- Stopped awaiting the post-creation stats/query-refresh calls before navigating — they hit the same backend origin as a still in-flight attachment upload and were queuing behind it under the browser's per-origin connection limit, adding delay past the intended wait window.

## Test plan
- [ ] `tsc -b --noEmit` and `eslint` pass on the changed files (verified locally)
- [ ] Create a case with a normal attachment — case is created, attachment appears in the Attachments tab, success banner shows
- [ ] Create a case with a deliberately slow/failing attachment upload (>5s) — case still creates, app navigates to the case page after 5s, Attachments tab shows an "Uploading..." placeholder, and the success/failure banner fires once the background upload actually finishes
- [ ] Create a case with zero attachments — unaffected, navigates immediately
- [ ] Upload directly via the case-details Attachments tab — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Attachments are now uploaded after a case is created, allowing the case creation process to complete more smoothly.
  - Upload progress is displayed directly in the attachments panel with placeholders, progress indicators, filenames, and “Uploading…” status.
  - Attachment lists update automatically after successful uploads.

- **Bug Fixes**
  - The attachments panel no longer incorrectly shows an empty state while uploads are still in progress.
  - Submission messaging now accurately reflects the “Uploading attachments...” step and reports upload results when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->