### PR TITLE
[Customer Portal][Backend] Add project chat/case counts to global search and cap projects pagination limit

### DIFF
--- a/apps/customer-portal/backend/constants.bal
+++ b/apps/customer-portal/backend/constants.bal
@@ -45,6 +45,9 @@ const ERR_MSG_CASE_CLOSED_FOR_ESCALATION = "Cannot create an escalation for a cl
 public const int DEFAULT_OFFSET = 0;
 public const int DEFAULT_LIMIT = 10;
 
+// Maximum allowed limit for projects pagination in global search
+public const int GLOBAL_SEARCH_PROJECTS_MAX_LIMIT = 50;
+
 public const ERR_STATUS_CODE = "statusCode";
 public const ERR_BODY = "body";
 public const ERR_MESSAGE = "message";

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2670,6 +2670,12 @@ public type GlobalSearchProject record {|
     string? closureState;
     # Associated account
     ReferenceTableItem account;
+    # Number of active chats in the project
+    int activeChatsCount;
+    # Number of cases requiring action in the project
+    int actionRequiredCount;
+    # Number of outstanding cases in the project
+    int outstandingCount;
     json...;
 |};
 

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -2080,6 +2080,12 @@ public type GlobalSearchProject record {|
     string? closureState;
     # Associated account
     ReferenceItem account;
+    # Number of active chats in the project
+    int activeChatsCount;
+    # Number of cases requiring action in the project
+    int actionRequiredCount;
+    # Number of outstanding cases in the project
+    int outstandingCount;
 |};
 
 # Case item in a global search response.

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -7512,6 +7512,9 @@ components:
         - createdOn
         - hasPdpSubscription
         - account
+        - activeChatsCount
+        - actionRequiredCount
+        - outstandingCount
       properties:
         id:
           $ref: '#/components/schemas/IdString'
@@ -7547,6 +7550,18 @@ components:
           nullable: true
         account:
           $ref: '#/components/schemas/ReferenceItem'
+        activeChatsCount:
+          type: integer
+          description: Number of active chats in the project
+          format: int64
+        actionRequiredCount:
+          type: integer
+          description: Number of cases requiring action in the project
+          format: int64
+        outstandingCount:
+          type: integer
+          description: Number of outstanding cases in the project
+          format: int64
       additionalProperties: false
       description: Project item in a global search response.
     GlobalSearchCase:

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1307,13 +1307,18 @@ public isolated function mapEscalationsResponse(entity:EscalationsResponse respo
 public isolated function globalSearch(string idToken, types:GlobalSearchPayload payload)
     returns types:GlobalSearchResponse|error {
 
+    entity:Pagination? projectsPagination = payload.projectsPagination;
+    if projectsPagination is entity:Pagination && projectsPagination.'limit > GLOBAL_SEARCH_PROJECTS_MAX_LIMIT {
+        projectsPagination.'limit = GLOBAL_SEARCH_PROJECTS_MAX_LIMIT;
+    }
+
     entity:GlobalSearchPayload searchPayload = {
         filters: {
             searchQuery: payload.filters?.searchQuery,
             tables: payload.filters?.types
         },
         sortBy: payload.sortBy,
-        projectsPagination: payload.projectsPagination,
+        projectsPagination,
         casesPagination: payload.casesPagination
     };
 
@@ -1333,7 +1338,10 @@ public isolated function globalSearch(string idToken, types:GlobalSearchPayload 
             endDate: project.endDate,
             hasPdpSubscription: project.hasPdpSubscription,
             closureState: project.closureState,
-            account: {id: account.id, label: account.name}
+            account: {id: account.id, label: account.name},
+            activeChatsCount: project.activeChatsCount,
+            actionRequiredCount: project.actionRequiredCount,
+            outstandingCount: project.outstandingCount
         };
 
     types:GlobalSearchCase[] cases = from entity:GlobalSearchCase entityCase in response.cases


### PR DESCRIPTION
## Summary
- Surface `activeChatsCount`, `actionRequiredCount`, and `outstandingCount` on project results in the global search response
- Clamp `projectsPagination.limit` to a max of 50 in global search, matching the limit used by other paginated endpoints
- Updated `openapi.yaml` to reflect the new `GlobalSearchProject` fields

## Test plan
- [ ] `bal build` passes
- [ ] `POST /search` response includes the three new count fields for each project result
- [ ] Requesting `projectsPagination.limit` > 50 is clamped to 50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global search project results now include active chats, action-required items, and outstanding items counts.
  * Added support for project pagination with a maximum limit of 50 results.

* **Bug Fixes**
  * Project pagination requests are now capped to prevent limits exceeding the supported maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->