### PR TITLE
chore(customer-portal): clarify close-chat confirmation copy

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/close-chat/CloseChatConfirmDialog.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/close-chat/CloseChatConfirmDialog.tsx
@@ -59,8 +59,8 @@ export default function CloseChatConfirmDialog({
       <DialogTitle>Close this chat?</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          This chat will be closed and can no longer be resumed. Any case
-          created from it is not affected.
+          This chat is about to be permanently closed. Once closed, it cannot be
+          resumed.
         </DialogContentText>
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
Rewords the close-chat confirmation dialog to make the permanence explicit.

**Before:** "This chat will be closed and can no longer be resumed. Any case created from it is not affected."
**After:** "This chat is about to be permanently closed. Once closed, it cannot be resumed."

Copy-only change to `CloseChatConfirmDialog`. tsc ✓ · eslint ✓ · close-chat tests 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the chat closure confirmation message to clearly state that closed chats cannot be resumed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->