### PR TITLE
[Customer Portal][Webapp] Show partner-style projects/cases overview for multi-project users

### DIFF
--- a/apps/customer-portal/webapp/src/App.tsx
+++ b/apps/customer-portal/webapp/src/App.tsx
@@ -52,6 +52,7 @@ import PartnerCasesPage from "@features/project-hub/pages/PartnerCasesPage";
 import UserProjectsPage from "@features/project-hub/pages/UserProjectsPage";
 import UserCasesPage from "@features/project-hub/pages/UserCasesPage";
 import PartnerGuard from "@layouts/PartnerGuard";
+import NonPartnerGuard from "@layouts/NonPartnerGuard";
 import Error401Page from "@components/error/Error401Page";
 import Error403Page from "@components/error/Error403Page";
 import Error404Page from "@components/error/Error404Page";
@@ -111,8 +112,10 @@ export default function App(): JSX.Element {
                 </Route>
 
                 {/* Home overview drill-down pages for non-partner users with multiple projects */}
-                <Route path="projects" element={<UserProjectsPage />} />
-                <Route path="cases" element={<UserCasesPage />} />
+                <Route element={<NonPartnerGuard />}>
+                  <Route path="projects" element={<UserProjectsPage />} />
+                  <Route path="cases" element={<UserCasesPage />} />
+                </Route>
 
                 {/* Project Specific Routes */}
                 <Route path="projects/:projectId" element={<ProjectGuard />}>

--- a/apps/customer-portal/webapp/src/App.tsx
+++ b/apps/customer-portal/webapp/src/App.tsx
@@ -49,6 +49,8 @@ import SettingsPage from "@features/settings/pages/SettingsPage";
 import ServiceNowCaseRedirectPage from "@features/project-hub/pages/ServiceNowCaseRedirectPage";
 import PartnerProjectsPage from "@features/project-hub/pages/PartnerProjectsPage";
 import PartnerCasesPage from "@features/project-hub/pages/PartnerCasesPage";
+import UserProjectsPage from "@features/project-hub/pages/UserProjectsPage";
+import UserCasesPage from "@features/project-hub/pages/UserCasesPage";
 import PartnerGuard from "@layouts/PartnerGuard";
 import Error401Page from "@components/error/Error401Page";
 import Error403Page from "@components/error/Error403Page";
@@ -107,6 +109,10 @@ export default function App(): JSX.Element {
                   <Route path="partner/projects" element={<PartnerProjectsPage />} />
                   <Route path="partner/cases" element={<PartnerCasesPage />} />
                 </Route>
+
+                {/* Home overview drill-down pages for non-partner users with multiple projects */}
+                <Route path="projects" element={<UserProjectsPage />} />
+                <Route path="cases" element={<UserCasesPage />} />
 
                 {/* Project Specific Routes */}
                 <Route path="projects/:projectId" element={<ProjectGuard />}>

--- a/apps/customer-portal/webapp/src/api/useGetProjects.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjects.ts
@@ -16,9 +16,7 @@
 
 import {
   useInfiniteQuery,
-  useQuery,
   type UseInfiniteQueryResult,
-  type UseQueryResult,
   type InfiniteData,
 } from "@tanstack/react-query";
 import { useAsgardeo } from "@asgardeo/react";
@@ -140,78 +138,6 @@ export default function useInfiniteProjects({
       return totalFetched;
     },
     initialPageParam: 0,
-    staleTime: 5 * 60 * 1000,
-  });
-}
-
-interface UseGetProjectsPageParams {
-  offset: number;
-  limit: number;
-  searchQuery?: string;
-}
-
-/**
- * Custom hook to fetch a single offset/limit page of projects.
- * Use this over useInfiniteProjects when the caller drives pagination itself
- * (e.g. a TablePagination component) rather than infinite scroll.
- *
- * @param {UseGetProjectsPageParams} params - Offset, limit, and search query.
- * @returns {UseQueryResult} The query result object with the project page.
- */
-export function useGetProjectsPage({
-  offset,
-  limit,
-  searchQuery,
-}: UseGetProjectsPageParams): UseQueryResult<SearchProjectsResponse, Error> {
-  const logger = useLogger();
-  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
-  const authFetch = useAuthApiClient();
-
-  const normalizedSearchQuery = searchQuery?.trim() || undefined;
-
-  return useQuery<SearchProjectsResponse, Error>({
-    queryKey: [ApiQueryKeys.PROJECTS, "page", offset, limit, normalizedSearchQuery],
-    enabled: isSignedIn && !isAuthLoading,
-    queryFn: async (): Promise<SearchProjectsResponse> => {
-      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
-      if (!baseUrl) {
-        throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
-      }
-
-      const body: SearchProjectsRequest = {
-        pagination: { offset, limit },
-        ...(normalizedSearchQuery
-          ? { filters: { searchQuery: normalizedSearchQuery } }
-          : {}),
-      };
-
-      const response = await authFetch(`${baseUrl}/projects/search`, {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        let apiMessage: string | undefined;
-        try {
-          const errBody = await response.json();
-          if (typeof errBody?.message === "string") {
-            apiMessage = errBody.message;
-          }
-        } catch {
-          // ignore – body may not be JSON
-        }
-        throw new ApiError(
-          response.status,
-          response.statusText,
-          apiMessage ?? `Error fetching projects: ${response.statusText}`,
-        );
-      }
-
-      logger.debug(
-        `[useGetProjectsPage] Fetched projects, offset: ${offset}, limit: ${limit}`,
-      );
-      return response.json();
-    },
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/apps/customer-portal/webapp/src/api/useGetProjects.ts
+++ b/apps/customer-portal/webapp/src/api/useGetProjects.ts
@@ -16,7 +16,9 @@
 
 import {
   useInfiniteQuery,
+  useQuery,
   type UseInfiniteQueryResult,
+  type UseQueryResult,
   type InfiniteData,
 } from "@tanstack/react-query";
 import { useAsgardeo } from "@asgardeo/react";
@@ -138,6 +140,78 @@ export default function useInfiniteProjects({
       return totalFetched;
     },
     initialPageParam: 0,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+interface UseGetProjectsPageParams {
+  offset: number;
+  limit: number;
+  searchQuery?: string;
+}
+
+/**
+ * Custom hook to fetch a single offset/limit page of projects.
+ * Use this over useInfiniteProjects when the caller drives pagination itself
+ * (e.g. a TablePagination component) rather than infinite scroll.
+ *
+ * @param {UseGetProjectsPageParams} params - Offset, limit, and search query.
+ * @returns {UseQueryResult} The query result object with the project page.
+ */
+export function useGetProjectsPage({
+  offset,
+  limit,
+  searchQuery,
+}: UseGetProjectsPageParams): UseQueryResult<SearchProjectsResponse, Error> {
+  const logger = useLogger();
+  const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
+  const authFetch = useAuthApiClient();
+
+  const normalizedSearchQuery = searchQuery?.trim() || undefined;
+
+  return useQuery<SearchProjectsResponse, Error>({
+    queryKey: [ApiQueryKeys.PROJECTS, "page", offset, limit, normalizedSearchQuery],
+    enabled: isSignedIn && !isAuthLoading,
+    queryFn: async (): Promise<SearchProjectsResponse> => {
+      const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
+      if (!baseUrl) {
+        throw new Error("CUSTOMER_PORTAL_BACKEND_BASE_URL is not configured");
+      }
+
+      const body: SearchProjectsRequest = {
+        pagination: { offset, limit },
+        ...(normalizedSearchQuery
+          ? { filters: { searchQuery: normalizedSearchQuery } }
+          : {}),
+      };
+
+      const response = await authFetch(`${baseUrl}/projects/search`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        let apiMessage: string | undefined;
+        try {
+          const errBody = await response.json();
+          if (typeof errBody?.message === "string") {
+            apiMessage = errBody.message;
+          }
+        } catch {
+          // ignore – body may not be JSON
+        }
+        throw new ApiError(
+          response.status,
+          response.statusText,
+          apiMessage ?? `Error fetching projects: ${response.statusText}`,
+        );
+      }
+
+      logger.debug(
+        `[useGetProjectsPage] Fetched projects, offset: ${offset}, limit: ${limit}`,
+      );
+      return response.json();
+    },
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
@@ -38,7 +38,6 @@ import {
 import { ChevronDown, Download, FileText, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type MouseEvent, useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router";
-import useInfiniteProjects, { flattenProjectPages, getTotalRecords } from "@api/useGetProjects";
 import { useGetGlobalSearch } from "@api/useGetGlobalSearch";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useAuthApiClient } from "@/hooks/useAuthApiClient";
@@ -57,7 +56,7 @@ import {
 import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
 import { formatCasesTableCaseIdentifier, getStatusColor } from "@features/dashboard/utils/casesTable";
 import { mapSeverityToDisplay } from "@features/support/utils/support";
-import type { GlobalSearchCase } from "@features/project-hub/types/globalSearch";
+import type { GlobalSearchCase, GlobalSearchProject } from "@features/project-hub/types/globalSearch";
 import { getCaseNavigationPath, getCaseTypeChipProps } from "@features/project-hub/utils/globalSearchNavigation";
 
 type ExportFormat = "csv" | "pdf";
@@ -170,33 +169,28 @@ export default function UserGlobalSearch(): JSX.Element {
 
   const isExportingCases = exportingCasesFormat !== null;
 
-  // Projects come from /projects/search so counts (action required, outstanding,
-  // active chats) are available — the generic /search endpoint doesn't return them.
+  // Both projects and cases come from the unified /search endpoint, same as
+  // the partner view — GlobalSearchProject includes the action required/
+  // outstanding/active chats counts this table needs.
   const {
-    data: projectsData,
-    isLoading: isLoadingProjects,
-    isError: isErrorProjects,
-  } = useInfiniteProjects({
-    searchQuery: debouncedSearchQuery || undefined,
-    pageSize: SUMMARY_PAGE_SIZE,
-  });
-  const projects = flattenProjectPages(projectsData);
-  const projectsTotal = getTotalRecords(projectsData);
-
-  // Cases come from the unified /search endpoint, same as the partner view.
-  const {
-    data: casesData,
-    isLoading: isLoadingCases,
-    isError: isErrorCases,
+    data: searchData,
+    isLoading: isLoadingSearch,
+    isError: isErrorSearch,
   } = useGetGlobalSearch({
-    filters: {
-      types: ["cases"],
-      ...(debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : {}),
-    },
+    ...(debouncedSearchQuery ? { filters: { searchQuery: debouncedSearchQuery } } : {}),
+    projectsPagination: { offset: 0, limit: SUMMARY_PAGE_SIZE },
     casesPagination: { offset: 0, limit: SUMMARY_PAGE_SIZE },
   });
-  const cases: GlobalSearchCase[] = casesData?.cases ?? [];
-  const casesTotal = casesData?.casesTotal ?? 0;
+
+  const isLoadingProjects = isLoadingSearch;
+  const isErrorProjects = isErrorSearch;
+  const projects: GlobalSearchProject[] = searchData?.projects ?? [];
+  const projectsTotal = searchData?.projectsTotal ?? 0;
+
+  const isLoadingCases = isLoadingSearch;
+  const isErrorCases = isErrorSearch;
+  const cases: GlobalSearchCase[] = searchData?.cases ?? [];
+  const casesTotal = searchData?.casesTotal ?? 0;
 
   const projectsMoreCount = Math.max(0, projectsTotal - projects.length);
   const casesMoreCount = Math.max(0, casesTotal - cases.length);

--- a/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
@@ -1,0 +1,672 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  alpha,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  Menu,
+  MenuItem,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ChevronDown, Download, FileText, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type MouseEvent, useCallback, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import useInfiniteProjects, { flattenProjectPages, getTotalRecords } from "@api/useGetProjects";
+import { useGetGlobalSearch } from "@api/useGetGlobalSearch";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { PROJECT_HUB_SEARCH_DEBOUNCE_MS } from "@features/project-hub/constants/projectHubConstants";
+import {
+  downloadProjectListCsv,
+  downloadProjectListPdf,
+  fetchAllProjectsForExport,
+} from "@features/project-hub/utils/projectsExport";
+import {
+  downloadCaseListCsv,
+  downloadCaseListPdf,
+  fetchAllCasesForExport,
+} from "@features/project-hub/utils/casesExport";
+import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
+import { formatCasesTableCaseIdentifier, getStatusColor } from "@features/dashboard/utils/casesTable";
+import { mapSeverityToDisplay } from "@features/support/utils/support";
+import type { GlobalSearchCase } from "@features/project-hub/types/globalSearch";
+import { getCaseNavigationPath, getCaseTypeChipProps } from "@features/project-hub/utils/globalSearchNavigation";
+
+type ExportFormat = "csv" | "pdf";
+
+const SUMMARY_PAGE_SIZE = 5;
+const SKELETON_ROW_COUNT = 5;
+
+function SkeletonRows({ cols }: { cols: number }): JSX.Element {
+  return (
+    <>
+      {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+        <TableRow key={`sk-${i}`}>
+          {Array.from({ length: cols }).map((_, j) => (
+            <TableCell key={j}>
+              <Skeleton variant="text" width="80%" />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Home overview for users with more than one project.
+ * Same layout as the partner global search page — Projects and Cases table
+ * sections with export — but the Projects table shows Action Required,
+ * Outstanding and Active Chats counts instead of Start/End Date.
+ */
+export default function UserGlobalSearch(): JSX.Element {
+  const navigate = useNavigate();
+  const authFetch = useAuthApiClient();
+  const { showError } = useErrorBanner();
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
+
+  const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
+  const isExportingRef = useRef(false);
+  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingRef.current) setExportAnchorEl(e.currentTarget);
+  };
+  const handleExportClose = () => setExportAnchorEl(null);
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingRef.current) return;
+      handleExportClose();
+      isExportingRef.current = true;
+      setExportingFormat(format);
+      try {
+        const allProjects = await fetchAllProjectsForExport(authFetch, debouncedSearchQuery);
+        if (allProjects.length === 0) {
+          showError("No projects to export.");
+          return;
+        }
+        if (format === "csv") {
+          downloadProjectListCsv(allProjects);
+        } else {
+          downloadProjectListPdf(allProjects);
+        }
+      } catch {
+        showError("Failed to export projects.");
+      } finally {
+        isExportingRef.current = false;
+        setExportingFormat(null);
+      }
+    },
+    [authFetch, debouncedSearchQuery, showError],
+  );
+
+  const isExporting = exportingFormat !== null;
+
+  const [exportingCasesFormat, setExportingCasesFormat] = useState<ExportFormat | null>(null);
+  const isExportingCasesRef = useRef(false);
+  const [exportCasesAnchorEl, setExportCasesAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleCasesExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingCasesRef.current) setExportCasesAnchorEl(e.currentTarget);
+  };
+  const handleCasesExportClose = () => setExportCasesAnchorEl(null);
+
+  const handleCasesExport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingCasesRef.current) return;
+      handleCasesExportClose();
+      isExportingCasesRef.current = true;
+      setExportingCasesFormat(format);
+      try {
+        const allCases = await fetchAllCasesForExport(authFetch, debouncedSearchQuery);
+        if (allCases.length === 0) {
+          showError("No cases to export.");
+          return;
+        }
+        if (format === "csv") {
+          downloadCaseListCsv(allCases);
+        } else {
+          downloadCaseListPdf(allCases);
+        }
+      } catch {
+        showError("Failed to export cases.");
+      } finally {
+        isExportingCasesRef.current = false;
+        setExportingCasesFormat(null);
+      }
+    },
+    [authFetch, debouncedSearchQuery, showError],
+  );
+
+  const isExportingCases = exportingCasesFormat !== null;
+
+  // Projects come from /projects/search so counts (action required, outstanding,
+  // active chats) are available — the generic /search endpoint doesn't return them.
+  const {
+    data: projectsData,
+    isLoading: isLoadingProjects,
+    isError: isErrorProjects,
+  } = useInfiniteProjects({
+    searchQuery: debouncedSearchQuery || undefined,
+    pageSize: SUMMARY_PAGE_SIZE,
+  });
+  const projects = flattenProjectPages(projectsData);
+  const projectsTotal = getTotalRecords(projectsData);
+
+  // Cases come from the unified /search endpoint, same as the partner view.
+  const {
+    data: casesData,
+    isLoading: isLoadingCases,
+    isError: isErrorCases,
+  } = useGetGlobalSearch({
+    filters: {
+      types: ["cases"],
+      ...(debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : {}),
+    },
+    casesPagination: { offset: 0, limit: SUMMARY_PAGE_SIZE },
+  });
+  const cases: GlobalSearchCase[] = casesData?.cases ?? [];
+  const casesTotal = casesData?.casesTotal ?? 0;
+
+  const projectsMoreCount = Math.max(0, projectsTotal - projects.length);
+  const casesMoreCount = Math.max(0, casesTotal - cases.length);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flex: 1,
+        flexDirection: "column",
+        minHeight: 0,
+        overflow: "hidden",
+        width: "100%",
+      }}
+    >
+      {/* Page header + search bar */}
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexDirection: "column",
+          flexShrink: 0,
+          pb: 2,
+          pt: 2.5,
+          px: 2,
+          textAlign: "center",
+        }}
+      >
+        <Box sx={{ maxWidth: 560, width: "100%" }}>
+          <TextField
+            fullWidth
+            inputProps={{ autoComplete: "off" }}
+            InputProps={{
+              endAdornment: searchQuery ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="Clear search"
+                    edge="end"
+                    onClick={() => setSearchQuery("")}
+                    size="small"
+                  >
+                    <X size={16} />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
+              startAdornment: <Search size={20} style={{ marginRight: 8 }} />,
+            }}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search projects and cases..."
+            size="small"
+            sx={{
+              "& input:-webkit-autofill, & input:-webkit-autofill:focus, & input:-webkit-autofill:hover":
+                {
+                  WebkitBoxShadow: "0 0 0 100px transparent inset",
+                  WebkitTextFillColor: "inherit",
+                  transition: "background-color 5000s ease-in-out 0s",
+                },
+            }}
+            value={searchQuery}
+          />
+          {debouncedSearchQuery.trim() && !isLoadingProjects && !isLoadingCases && (
+            <Typography
+              color="text.secondary"
+              sx={{ display: "block", mt: 1, textAlign: "left" }}
+              variant="caption"
+            >
+              Showing results for &ldquo;{debouncedSearchQuery.trim()}&rdquo;
+            </Typography>
+          )}
+        </Box>
+      </Box>
+
+      {/* Scrollable content: projects + cases sections */}
+      <Box
+        sx={{
+          display: "flex",
+          flex: "1 1 auto",
+          flexDirection: "column",
+          gap: 3,
+          overflowX: "hidden",
+          overflowY: "auto",
+          pb: 4,
+          px: 2,
+        }}
+      >
+        {/* Projects section */}
+        <Box>
+          <Box sx={{ alignItems: "center", display: "flex", mb: 1.5 }}>
+            <Box sx={{ alignItems: "center", display: "flex", flex: 1, gap: 1 }}>
+              <FolderOpen size={20} />
+              <Typography variant="h6">
+                Projects
+                {!isLoadingProjects && (
+                  <Typography
+                    color="text.secondary"
+                    component="span"
+                    variant="h6"
+                  >
+                    {" "}
+                    ({projectsTotal})
+                  </Typography>
+                )}
+              </Typography>
+            </Box>
+            <Button
+              aria-controls="user-projects-export-menu"
+              aria-expanded={Boolean(exportAnchorEl)}
+              aria-haspopup="menu"
+              disabled={isExporting || (!isLoadingProjects && projectsTotal === 0)}
+              endIcon={<ChevronDown size={16} />}
+              onClick={handleExportOpen}
+              size="small"
+              startIcon={
+                isExporting ? (
+                  <CircularProgress color="inherit" size={16} />
+                ) : (
+                  <Download size={16} />
+                )
+              }
+              type="button"
+              variant="outlined"
+            >
+              {isExporting ? "Exporting..." : "Export"}
+            </Button>
+            <Menu
+              anchorEl={exportAnchorEl}
+              id="user-projects-export-menu"
+              onClose={handleExportClose}
+              open={Boolean(exportAnchorEl)}
+            >
+              <MenuItem onClick={() => void handleExport("csv")}>Export to CSV</MenuItem>
+              <MenuItem onClick={() => void handleExport("pdf")}>Export to PDF</MenuItem>
+            </Menu>
+          </Box>
+
+          <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+            <Table sx={{ minWidth: 720 }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Project Key</TableCell>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell align="right">Action Required</TableCell>
+                  <TableCell align="right">Outstanding</TableCell>
+                  <TableCell align="right">Active Chats</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {isLoadingProjects ? (
+                  <SkeletonRows cols={6} />
+                ) : isErrorProjects ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={6}>
+                      <Typography color="text.secondary" variant="body2">
+                        Failed to load projects.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : projects.length === 0 ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={6}>
+                      <Typography color="text.secondary" variant="body2">
+                        No projects found.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  projects.map((project) => {
+                    const isSuspended =
+                      project.closureState?.toLowerCase() === "suspended";
+                    return (
+                      <TableRow
+                        hover
+                        key={project.id}
+                        onClick={() => navigate(`/projects/${project.id}/dashboard`)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            navigate(`/projects/${project.id}/dashboard`);
+                          }
+                        }}
+                        sx={{ cursor: "pointer" }}
+                        tabIndex={0}
+                      >
+                        <TableCell>
+                          <Typography fontWeight="medium" variant="body2">
+                            {project.key}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2">{project.name}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            color={isSuspended ? "warning" : "success"}
+                            label={project.closureState ?? "Active"}
+                            size="small"
+                            sx={{ fontWeight: 500 }}
+                            variant="outlined"
+                          />
+                        </TableCell>
+                        <TableCell align="right">
+                          <Typography variant="body2">
+                            {project.actionRequiredCount ?? 0}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="right">
+                          <Typography variant="body2">
+                            {project.outstandingCount ?? 0}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="right">
+                          <Typography variant="body2">
+                            {project.activeChatsCount ?? 0}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          {projectsMoreCount > 0 && (
+            <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+              <Button
+                onClick={() => {
+                  const params = debouncedSearchQuery
+                    ? `?q=${encodeURIComponent(debouncedSearchQuery)}`
+                    : "";
+                  navigate(`/projects${params}`);
+                }}
+                size="small"
+                variant="text"
+              >
+                {`View More (${projectsMoreCount} more)`}
+              </Button>
+            </Box>
+          )}
+        </Box>
+
+        {/* Cases section */}
+        <Box>
+          <Box sx={{ alignItems: "center", display: "flex", mb: 1.5 }}>
+            <Box sx={{ alignItems: "center", display: "flex", flex: 1, gap: 1 }}>
+              <FileText size={20} />
+              <Typography variant="h6">
+                Cases
+                {!isLoadingCases && (
+                  <Typography
+                    color="text.secondary"
+                    component="span"
+                    variant="h6"
+                  >
+                    {" "}
+                    ({casesTotal})
+                  </Typography>
+                )}
+              </Typography>
+            </Box>
+            <Button
+              aria-controls="user-cases-export-menu"
+              aria-expanded={Boolean(exportCasesAnchorEl)}
+              aria-haspopup="menu"
+              disabled={isExportingCases || (!isLoadingCases && casesTotal === 0)}
+              endIcon={<ChevronDown size={16} />}
+              onClick={handleCasesExportOpen}
+              size="small"
+              startIcon={
+                isExportingCases ? (
+                  <CircularProgress color="inherit" size={16} />
+                ) : (
+                  <Download size={16} />
+                )
+              }
+              type="button"
+              variant="outlined"
+            >
+              {isExportingCases ? "Exporting..." : "Export"}
+            </Button>
+            <Menu
+              anchorEl={exportCasesAnchorEl}
+              id="user-cases-export-menu"
+              onClose={handleCasesExportClose}
+              open={Boolean(exportCasesAnchorEl)}
+            >
+              <MenuItem onClick={() => void handleCasesExport("csv")}>Export to CSV</MenuItem>
+              <MenuItem onClick={() => void handleCasesExport("pdf")}>Export to PDF</MenuItem>
+            </Menu>
+          </Box>
+
+          <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+            <Table sx={{ minWidth: 720 }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Details</TableCell>
+                  <TableCell>Case Type</TableCell>
+                  <TableCell>Severity</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Created by</TableCell>
+                  <TableCell>Created on</TableCell>
+                  <TableCell>Project</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {isLoadingCases ? (
+                  <SkeletonRows cols={7} />
+                ) : isErrorCases ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={7}>
+                      <Typography color="text.secondary" variant="body2">
+                        Failed to load cases.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : cases.length === 0 ? (
+                  <TableRow>
+                    <TableCell align="center" colSpan={7}>
+                      <Typography color="text.secondary" variant="body2">
+                        No cases found.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  cases.map((c) => {
+                    const severityLabel = c.severity?.label;
+                    const severityDisplay = mapSeverityToDisplay(severityLabel);
+                    const severityColor = getSeverityLegendColor(severityLabel);
+                    const { color: caseTypeColor, displayLabel: caseTypeLabel } = getCaseTypeChipProps(c.caseType?.label);
+                    const casePath = getCaseNavigationPath(c);
+                    const handleNavigate = casePath ? () => navigate(casePath, { state: { returnTo: "/" } }) : undefined;
+                    return (
+                      <TableRow
+                        hover={Boolean(casePath)}
+                        key={c.id}
+                        onClick={handleNavigate}
+                        onKeyDown={(e) => {
+                          if (handleNavigate && (e.key === "Enter" || e.key === " ")) {
+                            e.preventDefault();
+                            handleNavigate();
+                          }
+                        }}
+                        sx={{ cursor: casePath ? "pointer" : "default" }}
+                        tabIndex={casePath ? 0 : undefined}
+                      >
+                        <TableCell sx={{ maxWidth: 320 }}>
+                          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+                            <Typography
+                              noWrap
+                              variant="body2"
+                              sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                            >
+                              {c.title ?? "--"}
+                            </Typography>
+                            <Typography color="text.secondary" variant="caption">
+                              {formatCasesTableCaseIdentifier(c.number, c.internalId)}
+                            </Typography>
+                          </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={caseTypeLabel}
+                            size="small"
+                            variant="outlined"
+                            sx={(theme) => ({
+                              bgcolor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.05 : 0.1),
+                              borderColor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.18 : 0.3),
+                              color: caseTypeColor,
+                              fontSize: "0.75rem",
+                              fontWeight: 500,
+                              height: 20,
+                              px: 0,
+                              "& .MuiChip-label": { pl: "6px", pr: "6px" },
+                            })}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          {severityLabel ? (
+                            <Chip
+                              label={severityDisplay}
+                              size="small"
+                              variant="outlined"
+                              sx={{
+                                bgcolor: alpha(severityColor, 0.1),
+                                borderColor: alpha(severityColor, 0.3),
+                                color: severityColor,
+                                fontSize: "0.75rem",
+                                fontWeight: 500,
+                                height: 20,
+                                px: 0,
+                                "& .MuiChip-label": { pl: "6px", pr: "6px" },
+                              }}
+                            />
+                          ) : (
+                            <Typography color="text.secondary" variant="body2">
+                              --
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Box sx={{ alignItems: "center", display: "flex", gap: 1 }}>
+                            <Box
+                              sx={{
+                                backgroundColor: getStatusColor(c.state?.label),
+                                borderRadius: "50%",
+                                flexShrink: 0,
+                                height: 8,
+                                width: 8,
+                              }}
+                            />
+                            <Typography variant="body2">
+                              {c.state?.label ?? "--"}
+                            </Typography>
+                          </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Typography color="text.secondary" variant="body2">
+                            {c.createdBy ?? "--"}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography color="text.secondary" variant="body2">
+                            {formatDateShort(c.createdOn)}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography color="text.secondary" variant="body2">
+                            {c.project?.label ?? "--"}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          {casesMoreCount > 0 && (
+            <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+              <Button
+                onClick={() => {
+                  const params = debouncedSearchQuery
+                    ? `?q=${encodeURIComponent(debouncedSearchQuery)}`
+                    : "";
+                  navigate(`/cases${params}`);
+                }}
+                size="small"
+                variant="text"
+              >
+                {`View More (${casesMoreCount} more)`}
+              </Button>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+const DATE_LOCALE = "en-US";
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+};
+
+function formatDateShort(value: string | null | undefined): string {
+  if (!value) return "--";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? "--" : d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT_OPTIONS);
+}

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -39,6 +39,7 @@ import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import ProjectCard from "@features/project-hub/components/ProjectCard";
 import ProjectCardSkeleton from "@features/project-hub/components/project-card/ProjectCardSkeleton";
 import PartnerGlobalSearch from "@features/project-hub/components/PartnerGlobalSearch";
+import UserGlobalSearch from "@features/project-hub/components/UserGlobalSearch";
 import useGetUserDetails from "@features/settings/api/useGetUserDetails";
 import { hasPartnerAccess } from "@features/settings/constants/settingsConstants";
 import { clearLastSelectedProject } from "@features/settings/utils/settingsStorage";
@@ -263,6 +264,22 @@ export default function ProjectHub(): JSX.Element {
   // Partner users always see the global search page (projects + cases).
   if (isPartner && !isAuthLoading && !isLoadingUserDetails) {
     return <PartnerGlobalSearch />;
+  }
+
+  // Non-partner users with more than one project see the same table-based
+  // overview as partners, with per-project stat counts instead of dates.
+  const showUserGlobalSearch =
+    !isPartner &&
+    !isLoading &&
+    !isAuthLoading &&
+    !isLoadingUserDetails &&
+    !isError &&
+    !allProjectsSuspended &&
+    !isCheckingAllSuspended &&
+    projects.length > 1;
+
+  if (showUserGlobalSearch) {
+    return <UserGlobalSearch />;
   }
 
   const showSearchBar = shouldShowProjectHubSearchBar(

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserCasesPage.tsx
@@ -85,26 +85,29 @@ export default function UserCasesPage(): JSX.Element {
   const authFetch = useAuthApiClient();
   const { showError } = useErrorBanner();
   const [searchParams, setSearchParams] = useSearchParams();
-  const urlQuery = searchParams.get("q") ?? "";
-
-  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const [searchQuery, setSearchQuery] = useState(() => searchParams.get("q") ?? "");
   const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
 
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
 
   useEffect(() => {
-    setSearchQuery(urlQuery);
-  }, [urlQuery]);
-
-  useEffect(() => {
     setPage(0);
   }, [debouncedSearchQuery]);
 
   useEffect(() => {
-    const params: Record<string, string> = {};
-    if (debouncedSearchQuery.trim()) params.q = debouncedSearchQuery.trim();
-    setSearchParams(params, { replace: true });
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (debouncedSearchQuery.trim()) {
+          next.set("q", debouncedSearchQuery.trim());
+        } else {
+          next.delete("q");
+        }
+        return next;
+      },
+      { replace: true },
+    );
   }, [debouncedSearchQuery, setSearchParams]);
 
   const { data, isLoading, isError } = useGetGlobalSearch({

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserCasesPage.tsx
@@ -1,0 +1,472 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  alpha,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  LinearProgress,
+  Menu,
+  MenuItem,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, ChevronDown, Download, FileText, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { type ChangeEvent, type JSX, type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { useGetGlobalSearch } from "@api/useGetGlobalSearch";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { PROJECT_HUB_SEARCH_DEBOUNCE_MS } from "@features/project-hub/constants/projectHubConstants";
+import { getSeverityLegendColor } from "@features/dashboard/utils/dashboard";
+import { formatCasesTableCaseIdentifier, getStatusColor } from "@features/dashboard/utils/casesTable";
+import { mapSeverityToDisplay } from "@features/support/utils/support";
+import { getCaseNavigationPath, getCaseTypeChipProps } from "@features/project-hub/utils/globalSearchNavigation";
+import {
+  downloadCaseListCsv,
+  downloadCaseListPdf,
+  fetchAllCasesForExport,
+} from "@features/project-hub/utils/casesExport";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+
+const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+const DEFAULT_ROWS_PER_PAGE = 10;
+const SKELETON_ROW_COUNT = 5;
+const COL_SPAN = 7;
+
+const DATE_LOCALE = "en-US";
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "--";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? "--" : d.toLocaleDateString(DATE_LOCALE, DATE_FORMAT_OPTIONS);
+}
+
+type ExportFormat = "csv" | "pdf";
+
+/**
+ * Full-page cases search for users with more than one project.
+ * Navigated to via "View More" on the home overview page.
+ * Pre-fills the search bar from the `?q=` URL parameter.
+ */
+export default function UserCasesPage(): JSX.Element {
+  const navigate = useNavigate();
+  const authFetch = useAuthApiClient();
+  const { showError } = useErrorBanner();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlQuery = searchParams.get("q") ?? "";
+
+  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
+
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  useEffect(() => {
+    setSearchQuery(urlQuery);
+  }, [urlQuery]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearchQuery]);
+
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (debouncedSearchQuery.trim()) params.q = debouncedSearchQuery.trim();
+    setSearchParams(params, { replace: true });
+  }, [debouncedSearchQuery, setSearchParams]);
+
+  const { data, isLoading, isError } = useGetGlobalSearch({
+    filters: {
+      types: ["cases"],
+      ...(debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : {}),
+    },
+    casesPagination: { offset: page * rowsPerPage, limit: rowsPerPage },
+  });
+
+  const cases = data?.cases ?? [];
+  const totalRecords = data?.casesTotal ?? 0;
+
+  const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
+  const isExportingRef = useRef(false);
+  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingRef.current) setExportAnchorEl(e.currentTarget);
+  };
+  const handleExportClose = () => setExportAnchorEl(null);
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingRef.current) return;
+      handleExportClose();
+      isExportingRef.current = true;
+      setExportingFormat(format);
+      try {
+        const allCases = await fetchAllCasesForExport(authFetch, debouncedSearchQuery);
+        if (allCases.length === 0) {
+          showError("No cases to export.");
+          return;
+        }
+        if (format === "csv") {
+          downloadCaseListCsv(allCases);
+        } else {
+          downloadCaseListPdf(allCases);
+        }
+      } catch {
+        showError("Failed to export cases.");
+      } finally {
+        isExportingRef.current = false;
+        setExportingFormat(null);
+      }
+    },
+    [authFetch, debouncedSearchQuery, showError],
+  );
+
+  const isExporting = exportingFormat !== null;
+
+  const handleChangePage = (_: unknown, newPage: number) => setPage(newPage);
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flex: 1,
+        flexDirection: "column",
+        minHeight: 0,
+        overflow: "hidden",
+        width: "100%",
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexShrink: 0,
+          gap: 1.5,
+          pb: 1.5,
+          pt: 2,
+          px: 2,
+        }}
+      >
+        <IconButton
+          aria-label="Back to overview"
+          onClick={() => navigate("/")}
+          size="small"
+        >
+          <ArrowLeft size={20} />
+        </IconButton>
+        <FileText size={22} />
+        <Typography sx={{ flex: 1 }} variant="h5">
+          Cases
+          {!isLoading && (
+            <Typography color="text.secondary" component="span" variant="h5">
+              {" "}({totalRecords})
+            </Typography>
+          )}
+          {isLoading && (
+            <Skeleton
+              sx={{ display: "inline-block", ml: 0.5 }}
+              variant="text"
+              width={36}
+            />
+          )}
+        </Typography>
+        <Button
+          aria-controls="user-cases-page-export-menu"
+          aria-expanded={Boolean(exportAnchorEl)}
+          aria-haspopup="menu"
+          disabled={isExporting || (!isLoading && totalRecords === 0)}
+          endIcon={<ChevronDown size={16} />}
+          onClick={handleExportOpen}
+          size="small"
+          startIcon={
+            isExporting ? (
+              <CircularProgress color="inherit" size={16} />
+            ) : (
+              <Download size={16} />
+            )
+          }
+          type="button"
+          variant="outlined"
+        >
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+        <Menu
+          anchorEl={exportAnchorEl}
+          id="user-cases-page-export-menu"
+          onClose={handleExportClose}
+          open={Boolean(exportAnchorEl)}
+        >
+          <MenuItem onClick={() => void handleExport("csv")}>Export to CSV</MenuItem>
+          <MenuItem onClick={() => void handleExport("pdf")}>Export to PDF</MenuItem>
+        </Menu>
+      </Box>
+
+      {/* Filtered-results hint */}
+      {debouncedSearchQuery.trim() && !isLoading && (
+        <Box sx={{ flexShrink: 0, pb: 0.5, px: 2 }}>
+          <Typography color="text.secondary" variant="caption">
+            Showing results for &ldquo;{debouncedSearchQuery.trim()}&rdquo;
+          </Typography>
+        </Box>
+      )}
+
+      {/* Search bar */}
+      <Box sx={{ flexShrink: 0, pb: 1.5, px: 2 }}>
+        <TextField
+          fullWidth
+          inputProps={{ autoComplete: "off" }}
+          InputProps={{
+            endAdornment: searchQuery ? (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="Clear search"
+                  edge="end"
+                  onClick={() => setSearchQuery("")}
+                  size="small"
+                >
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
+            startAdornment: <Search size={20} style={{ marginRight: 8 }} />,
+          }}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search cases..."
+          size="small"
+          sx={{
+            maxWidth: 560,
+            "& input:-webkit-autofill, & input:-webkit-autofill:focus, & input:-webkit-autofill:hover":
+              {
+                WebkitBoxShadow: "0 0 0 100px transparent inset",
+                WebkitTextFillColor: "inherit",
+                transition: "background-color 5000s ease-in-out 0s",
+              },
+          }}
+          value={searchQuery}
+        />
+      </Box>
+
+      {/* Loading indicator */}
+      {isLoading && (
+        <LinearProgress
+          color="inherit"
+          sx={{ flexShrink: 0, height: 2, mx: 2 }}
+        />
+      )}
+
+      {/* Scrollable table */}
+      <Box
+        sx={{
+          flex: "1 1 auto",
+          overflowX: "hidden",
+          overflowY: "auto",
+          pb: 3,
+          px: 2,
+        }}
+      >
+        <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+          <Table sx={{ minWidth: 720 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Details</TableCell>
+                <TableCell>Case Type</TableCell>
+                <TableCell>Severity</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Created by</TableCell>
+                <TableCell>Created on</TableCell>
+                <TableCell>Project</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+                  <TableRow key={`sk-${i}`}>
+                    {Array.from({ length: COL_SPAN }).map((_, j) => (
+                      <TableCell key={j}>
+                        <Skeleton variant="text" width="80%" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell align="center" colSpan={COL_SPAN}>
+                    <Typography color="text.secondary" variant="body2">
+                      Failed to load cases. Please try again.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : cases.length === 0 ? (
+                <TableRow>
+                  <TableCell align="center" colSpan={COL_SPAN}>
+                    <Typography color="text.secondary" variant="body2">
+                      No cases found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                cases.map((c) => {
+                  const severityLabel = c.severity?.label;
+                  const severityDisplay = mapSeverityToDisplay(severityLabel);
+                  const severityColor = getSeverityLegendColor(severityLabel);
+                  const { color: caseTypeColor, displayLabel: caseTypeLabel } = getCaseTypeChipProps(c.caseType?.label);
+                  const casePath = getCaseNavigationPath(c);
+                  const returnTo = `/cases${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
+                  const handleNavigate = casePath ? () => navigate(casePath, { state: { returnTo } }) : undefined;
+                  return (
+                    <TableRow
+                      hover={Boolean(casePath)}
+                      key={c.id}
+                      onClick={handleNavigate}
+                      onKeyDown={(e) => {
+                        if (handleNavigate && (e.key === "Enter" || e.key === " ")) {
+                          e.preventDefault();
+                          handleNavigate();
+                        }
+                      }}
+                      sx={{ cursor: casePath ? "pointer" : "default" }}
+                      tabIndex={casePath ? 0 : undefined}
+                    >
+                      <TableCell sx={{ maxWidth: 320 }}>
+                        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+                          <Typography
+                            noWrap
+                            variant="body2"
+                            sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                          >
+                            {c.title ?? "--"}
+                          </Typography>
+                          <Typography color="text.secondary" variant="caption">
+                            {formatCasesTableCaseIdentifier(c.number, c.internalId)}
+                          </Typography>
+                        </Box>
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={caseTypeLabel}
+                          size="small"
+                          variant="outlined"
+                          sx={(theme) => ({
+                            bgcolor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.05 : 0.1),
+                            borderColor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.18 : 0.3),
+                            color: caseTypeColor,
+                            fontSize: "0.75rem",
+                            fontWeight: 500,
+                            height: 20,
+                            px: 0,
+                            "& .MuiChip-label": { pl: "6px", pr: "6px" },
+                          })}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        {severityLabel ? (
+                          <Chip
+                            label={severityDisplay}
+                            size="small"
+                            variant="outlined"
+                            sx={{
+                              bgcolor: alpha(severityColor, 0.1),
+                              borderColor: alpha(severityColor, 0.3),
+                              color: severityColor,
+                              fontSize: "0.75rem",
+                              fontWeight: 500,
+                              height: 20,
+                              px: 0,
+                              "& .MuiChip-label": { pl: "6px", pr: "6px" },
+                            }}
+                          />
+                        ) : (
+                          <Typography color="text.secondary" variant="body2">
+                            --
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Box sx={{ alignItems: "center", display: "flex", gap: 1 }}>
+                          <Box
+                            sx={{
+                              backgroundColor: getStatusColor(c.state?.label),
+                              borderRadius: "50%",
+                              flexShrink: 0,
+                              height: 8,
+                              width: 8,
+                            }}
+                          />
+                          <Typography variant="body2">
+                            {c.state?.label ?? "--"}
+                          </Typography>
+                        </Box>
+                      </TableCell>
+                      <TableCell>
+                        <Typography color="text.secondary" variant="body2">
+                          {c.createdBy ?? "--"}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography color="text.secondary" variant="body2">
+                          {formatDate(c.createdOn)}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography color="text.secondary" variant="body2">
+                          {c.project?.label ?? "--"}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={totalRecords}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          page={page}
+          rowsPerPage={rowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
@@ -73,16 +73,18 @@ export default function UserProjectsPage(): JSX.Element {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
 
+  const normalizedQuery = debouncedSearchQuery.trim();
+
   useEffect(() => {
     setPage(0);
-  }, [debouncedSearchQuery]);
+  }, [normalizedQuery]);
 
   useEffect(() => {
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
-        if (debouncedSearchQuery.trim()) {
-          next.set("q", debouncedSearchQuery.trim());
+        if (normalizedQuery) {
+          next.set("q", normalizedQuery);
         } else {
           next.delete("q");
         }
@@ -90,12 +92,12 @@ export default function UserProjectsPage(): JSX.Element {
       },
       { replace: true },
     );
-  }, [debouncedSearchQuery, setSearchParams]);
+  }, [normalizedQuery, setSearchParams]);
 
   const { data, isLoading, isError } = useGetGlobalSearch({
     filters: {
       types: ["projects"],
-      ...(debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : {}),
+      ...(normalizedQuery ? { searchQuery: normalizedQuery } : {}),
     },
     projectsPagination: { offset: page * rowsPerPage, limit: rowsPerPage },
   });
@@ -119,7 +121,7 @@ export default function UserProjectsPage(): JSX.Element {
       isExportingRef.current = true;
       setExportingFormat(format);
       try {
-        const allProjects = await fetchAllProjectsForExport(authFetch, debouncedSearchQuery);
+        const allProjects = await fetchAllProjectsForExport(authFetch, normalizedQuery);
         if (allProjects.length === 0) {
           showError("No projects to export.");
           return;
@@ -136,7 +138,7 @@ export default function UserProjectsPage(): JSX.Element {
         setExportingFormat(null);
       }
     },
-    [authFetch, debouncedSearchQuery, showError],
+    [authFetch, normalizedQuery, showError],
   );
 
   const isExporting = exportingFormat !== null;
@@ -225,10 +227,10 @@ export default function UserProjectsPage(): JSX.Element {
       </Box>
 
       {/* Filtered-results hint */}
-      {debouncedSearchQuery.trim() && !isLoading && (
+      {normalizedQuery && !isLoading && (
         <Box sx={{ flexShrink: 0, pb: 0.5, px: 2 }}>
           <Typography color="text.secondary" variant="caption">
-            Showing results for &ldquo;{debouncedSearchQuery.trim()}&rdquo;
+            Showing results for &ldquo;{normalizedQuery}&rdquo;
           </Typography>
         </Box>
       )}

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
@@ -1,0 +1,395 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  LinearProgress,
+  Menu,
+  MenuItem,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, ChevronDown, Download, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
+import { type ChangeEvent, type JSX, type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { useGetProjectsPage } from "@api/useGetProjects";
+import { useAuthApiClient } from "@/hooks/useAuthApiClient";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { PROJECT_HUB_SEARCH_DEBOUNCE_MS } from "@features/project-hub/constants/projectHubConstants";
+import {
+  downloadProjectListCsv,
+  downloadProjectListPdf,
+  fetchAllProjectsForExport,
+} from "@features/project-hub/utils/projectsExport";
+
+const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+const DEFAULT_ROWS_PER_PAGE = 10;
+const SKELETON_ROW_COUNT = 5;
+const COL_SPAN = 6;
+
+type ExportFormat = "csv" | "pdf";
+
+/**
+ * Full-page projects search for users with more than one project.
+ * Navigated to via "View More" on the home overview page.
+ * Pre-fills the search bar from the `?q=` URL parameter.
+ */
+export default function UserProjectsPage(): JSX.Element {
+  const navigate = useNavigate();
+  const authFetch = useAuthApiClient();
+  const { showError } = useErrorBanner();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlQuery = searchParams.get("q") ?? "";
+
+  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
+
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  useEffect(() => {
+    setSearchQuery(urlQuery);
+  }, [urlQuery]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearchQuery]);
+
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (debouncedSearchQuery.trim()) params.q = debouncedSearchQuery.trim();
+    setSearchParams(params, { replace: true });
+  }, [debouncedSearchQuery, setSearchParams]);
+
+  const { data, isLoading, isError } = useGetProjectsPage({
+    offset: page * rowsPerPage,
+    limit: rowsPerPage,
+    searchQuery: debouncedSearchQuery,
+  });
+
+  const projects = data?.projects ?? [];
+  const totalRecords = data?.totalRecords ?? 0;
+
+  const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
+  const isExportingRef = useRef(false);
+  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleExportOpen = (e: MouseEvent<HTMLElement>) => {
+    if (!isExportingRef.current) setExportAnchorEl(e.currentTarget);
+  };
+  const handleExportClose = () => setExportAnchorEl(null);
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingRef.current) return;
+      handleExportClose();
+      isExportingRef.current = true;
+      setExportingFormat(format);
+      try {
+        const allProjects = await fetchAllProjectsForExport(authFetch, debouncedSearchQuery);
+        if (allProjects.length === 0) {
+          showError("No projects to export.");
+          return;
+        }
+        if (format === "csv") {
+          downloadProjectListCsv(allProjects);
+        } else {
+          downloadProjectListPdf(allProjects);
+        }
+      } catch {
+        showError("Failed to export projects.");
+      } finally {
+        isExportingRef.current = false;
+        setExportingFormat(null);
+      }
+    },
+    [authFetch, debouncedSearchQuery, showError],
+  );
+
+  const isExporting = exportingFormat !== null;
+
+  const handleChangePage = (_: unknown, newPage: number) => setPage(newPage);
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flex: 1,
+        flexDirection: "column",
+        minHeight: 0,
+        overflow: "hidden",
+        width: "100%",
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexShrink: 0,
+          gap: 1.5,
+          pb: 1.5,
+          pt: 2,
+          px: 2,
+        }}
+      >
+        <IconButton
+          aria-label="Back to overview"
+          onClick={() => navigate("/")}
+          size="small"
+        >
+          <ArrowLeft size={20} />
+        </IconButton>
+        <FolderOpen size={22} />
+        <Typography sx={{ flex: 1 }} variant="h5">
+          Projects
+          {!isLoading && (
+            <Typography color="text.secondary" component="span" variant="h5">
+              {" "}({totalRecords})
+            </Typography>
+          )}
+          {isLoading && (
+            <Skeleton
+              sx={{ display: "inline-block", ml: 0.5 }}
+              variant="text"
+              width={36}
+            />
+          )}
+        </Typography>
+        <Button
+          aria-controls="user-projects-page-export-menu"
+          aria-expanded={Boolean(exportAnchorEl)}
+          aria-haspopup="menu"
+          disabled={isExporting || (!isLoading && totalRecords === 0)}
+          endIcon={<ChevronDown size={16} />}
+          onClick={handleExportOpen}
+          size="small"
+          startIcon={
+            isExporting ? (
+              <CircularProgress color="inherit" size={16} />
+            ) : (
+              <Download size={16} />
+            )
+          }
+          type="button"
+          variant="outlined"
+        >
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+        <Menu
+          anchorEl={exportAnchorEl}
+          id="user-projects-page-export-menu"
+          onClose={handleExportClose}
+          open={Boolean(exportAnchorEl)}
+        >
+          <MenuItem onClick={() => void handleExport("csv")}>Export to CSV</MenuItem>
+          <MenuItem onClick={() => void handleExport("pdf")}>Export to PDF</MenuItem>
+        </Menu>
+      </Box>
+
+      {/* Filtered-results hint */}
+      {debouncedSearchQuery.trim() && !isLoading && (
+        <Box sx={{ flexShrink: 0, pb: 0.5, px: 2 }}>
+          <Typography color="text.secondary" variant="caption">
+            Showing results for &ldquo;{debouncedSearchQuery.trim()}&rdquo;
+          </Typography>
+        </Box>
+      )}
+
+      {/* Search bar */}
+      <Box sx={{ flexShrink: 0, pb: 1.5, px: 2 }}>
+        <TextField
+          fullWidth
+          inputProps={{ autoComplete: "off" }}
+          InputProps={{
+            endAdornment: searchQuery ? (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="Clear search"
+                  edge="end"
+                  onClick={() => setSearchQuery("")}
+                  size="small"
+                >
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
+            startAdornment: <Search size={20} style={{ marginRight: 8 }} />,
+          }}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search projects..."
+          size="small"
+          sx={{
+            maxWidth: 560,
+            "& input:-webkit-autofill, & input:-webkit-autofill:focus, & input:-webkit-autofill:hover":
+              {
+                WebkitBoxShadow: "0 0 0 100px transparent inset",
+                WebkitTextFillColor: "inherit",
+                transition: "background-color 5000s ease-in-out 0s",
+              },
+          }}
+          value={searchQuery}
+        />
+      </Box>
+
+      {/* Loading indicator */}
+      {isLoading && (
+        <LinearProgress
+          color="inherit"
+          sx={{ flexShrink: 0, height: 2, mx: 2 }}
+        />
+      )}
+
+      {/* Scrollable table */}
+      <Box
+        sx={{
+          flex: "1 1 auto",
+          overflowX: "hidden",
+          overflowY: "auto",
+          pb: 3,
+          px: 2,
+        }}
+      >
+        <TableContainer component={Paper} sx={{ overflowX: "auto" }}>
+          <Table sx={{ minWidth: 720 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Project Key</TableCell>
+                <TableCell>Name</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell align="right">Action Required</TableCell>
+                <TableCell align="right">Outstanding</TableCell>
+                <TableCell align="right">Active Chats</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+                  <TableRow key={`sk-${i}`}>
+                    {Array.from({ length: COL_SPAN }).map((_, j) => (
+                      <TableCell key={j}>
+                        <Skeleton variant="text" width="80%" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell align="center" colSpan={COL_SPAN}>
+                    <Typography color="text.secondary" variant="body2">
+                      Failed to load projects. Please try again.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : projects.length === 0 ? (
+                <TableRow>
+                  <TableCell align="center" colSpan={COL_SPAN}>
+                    <Typography color="text.secondary" variant="body2">
+                      No projects found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                projects.map((project) => {
+                  const isSuspended =
+                    project.closureState?.toLowerCase() === "suspended";
+                  return (
+                    <TableRow
+                      hover
+                      key={project.id}
+                      onClick={() =>
+                        navigate(`/projects/${project.id}/dashboard`)
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          navigate(`/projects/${project.id}/dashboard`);
+                        }
+                      }}
+                      sx={{ cursor: "pointer" }}
+                      tabIndex={0}
+                    >
+                      <TableCell>
+                        <Typography fontWeight="medium" variant="body2">
+                          {project.key}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2">{project.name}</Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          color={isSuspended ? "warning" : "success"}
+                          label={project.closureState ?? "Active"}
+                          size="small"
+                          sx={{ fontWeight: 500 }}
+                          variant="outlined"
+                        />
+                      </TableCell>
+                      <TableCell align="right">
+                        <Typography variant="body2">
+                          {project.actionRequiredCount ?? 0}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Typography variant="body2">
+                          {project.outstandingCount ?? 0}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Typography variant="body2">
+                          {project.activeChatsCount ?? 0}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={totalRecords}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          page={page}
+          rowsPerPage={rowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
@@ -39,7 +39,7 @@ import {
 import { ArrowLeft, ChevronDown, Download, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { type ChangeEvent, type JSX, type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-import { useGetProjectsPage } from "@api/useGetProjects";
+import { useGetGlobalSearch } from "@api/useGetGlobalSearch";
 import { useAuthApiClient } from "@/hooks/useAuthApiClient";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
@@ -67,36 +67,41 @@ export default function UserProjectsPage(): JSX.Element {
   const authFetch = useAuthApiClient();
   const { showError } = useErrorBanner();
   const [searchParams, setSearchParams] = useSearchParams();
-  const urlQuery = searchParams.get("q") ?? "";
-
-  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const [searchQuery, setSearchQuery] = useState(() => searchParams.get("q") ?? "");
   const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
 
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
 
   useEffect(() => {
-    setSearchQuery(urlQuery);
-  }, [urlQuery]);
-
-  useEffect(() => {
     setPage(0);
   }, [debouncedSearchQuery]);
 
   useEffect(() => {
-    const params: Record<string, string> = {};
-    if (debouncedSearchQuery.trim()) params.q = debouncedSearchQuery.trim();
-    setSearchParams(params, { replace: true });
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (debouncedSearchQuery.trim()) {
+          next.set("q", debouncedSearchQuery.trim());
+        } else {
+          next.delete("q");
+        }
+        return next;
+      },
+      { replace: true },
+    );
   }, [debouncedSearchQuery, setSearchParams]);
 
-  const { data, isLoading, isError } = useGetProjectsPage({
-    offset: page * rowsPerPage,
-    limit: rowsPerPage,
-    searchQuery: debouncedSearchQuery,
+  const { data, isLoading, isError } = useGetGlobalSearch({
+    filters: {
+      types: ["projects"],
+      ...(debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : {}),
+    },
+    projectsPagination: { offset: page * rowsPerPage, limit: rowsPerPage },
   });
 
   const projects = data?.projects ?? [];
-  const totalRecords = data?.totalRecords ?? 0;
+  const totalRecords = data?.projectsTotal ?? 0;
 
   const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
   const isExportingRef = useRef(false);

--- a/apps/customer-portal/webapp/src/features/project-hub/types/globalSearch.ts
+++ b/apps/customer-portal/webapp/src/features/project-hub/types/globalSearch.ts
@@ -49,6 +49,9 @@ export interface GlobalSearchProject {
   hasPdpSubscription: boolean;
   closureState?: string | null;
   account: ReferenceItem;
+  activeChatsCount: number;
+  actionRequiredCount: number;
+  outstandingCount: number;
 }
 
 export interface GlobalSearchCase {

--- a/apps/customer-portal/webapp/src/layouts/NonPartnerGuard.tsx
+++ b/apps/customer-portal/webapp/src/layouts/NonPartnerGuard.tsx
@@ -37,7 +37,7 @@ export default function NonPartnerGuard(): JSX.Element {
     );
   }
 
-  if (isError) {
+  if (isError || !userDetails) {
     return (
       <Box sx={{ alignItems: "center", display: "flex", flex: 1, justifyContent: "center" }}>
         <Typography color="text.secondary" variant="body2">
@@ -47,7 +47,7 @@ export default function NonPartnerGuard(): JSX.Element {
     );
   }
 
-  const isPartner = hasPartnerAccess(userDetails?.roles ?? []);
+  const isPartner = hasPartnerAccess(userDetails.roles ?? []);
 
   if (isPartner) {
     return <Navigate replace to="/" />;

--- a/apps/customer-portal/webapp/src/layouts/NonPartnerGuard.tsx
+++ b/apps/customer-portal/webapp/src/layouts/NonPartnerGuard.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type JSX } from "react";
+import { Navigate, Outlet } from "react-router";
+import { Box, LinearProgress, Typography } from "@wso2/oxygen-ui";
+import useGetUserDetails from "@features/settings/api/useGetUserDetails";
+import { hasPartnerAccess } from "@features/settings/constants/settingsConstants";
+
+/**
+ * Guards routes meant only for non-partner users (e.g. the user overview
+ * drill-down pages). Partner users are redirected to the home page, which
+ * renders their own global search overview.
+ * On fetch error the guard shows an error message rather than falsely redirecting.
+ */
+export default function NonPartnerGuard(): JSX.Element {
+  const { data: userDetails, isLoading, isError } = useGetUserDetails();
+
+  if (isLoading) {
+    return (
+      <Box sx={{ alignItems: "center", display: "flex", flex: 1, justifyContent: "center" }}>
+        <LinearProgress sx={{ maxWidth: 400, width: "60%" }} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ alignItems: "center", display: "flex", flex: 1, justifyContent: "center" }}>
+        <Typography color="text.secondary" variant="body2">
+          Unable to verify access. Please refresh and try again.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const isPartner = hasPartnerAccess(userDetails?.roles ?? []);
+
+  if (isPartner) {
+    return <Navigate replace to="/" />;
+  }
+
+  return <Outlet />;
+}


### PR DESCRIPTION
## Summary
- Non-partner users with more than one project now see the same table-based overview as partners (Projects + Cases tables, search, export) instead of a project-card grid.
- The Projects table shows Action Required, Outstanding, and Active Chats counts instead of Start/End Date. Both Projects and Cases are sourced from the unified `/search` endpoint (same as the partner view), now that `GlobalSearchProject` includes these per-project stat counts.
- Added `/projects` and `/cases` full-list pages as "View More" destinations, mirroring the existing partner drill-down pages. These routes are gated by a new `NonPartnerGuard`, so partner users navigating there directly are redirected home instead of reaching pages meant for regular multi-project users.
- Partner view (`PartnerGlobalSearch`, `PartnerProjectsPage`, `PartnerCasesPage`) is unchanged.
- Removed the now-unused `useGetProjectsPage` hook after switching `UserProjectsPage` to `/search`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on all changed/new files
- [x] Existing project-hub/api test suite passes (same pre-existing, unrelated test failures reproduce identically on `main` — not introduced by this change)
- [ ] Manually verify in browser:
  - Non-partner account with >1 project shows the new table overview (Action Required/Outstanding/Active Chats columns, no Start/End Date)
  - Non-partner account with exactly 1 project still redirects straight to that project's dashboard
  - Partner account view is unchanged
  - "View More" navigates to `/projects` and `/cases`, paginates correctly, and preserves the `?q=` search param
  - A partner user manually navigating to `/projects` or `/cases` is redirected to `/`
  - Export CSV/PDF works from both the overview and full-list pages



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified project and case search for eligible users.
  * Added dedicated Projects and Cases result pages with filtering, pagination, and URL-persisted searches.
  * Added CSV and PDF export options for project and case results.
  * Added navigation from search results to project and case details.
  * Added project overview counters for active chats, required actions, and outstanding items.
* **Access**
  * Restricted these overview pages to non-partner users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->