### PR TITLE
[Entity-Service] stop leaking internal error tags into user-facing messages

### DIFF
--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -24,14 +24,39 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 )
+
+// sanitizeLog strips CR/LF characters from a string to prevent log injection.
+// Apply to every downstream-derived operand before passing it to a log call.
+var sanitizeLog = strings.NewReplacer("\n", `\n`, "\r", `\r`).Replace
+
+// internalErrorTagPattern matches a leading bracketed all-caps tag (e.g.
+// "[SERVICENOW_ERROR] ") that a downstream service prepends to its error
+// messages to identify which internal layer raised the error. The tag is
+// useful for correlating log lines with the originating layer, but it is an
+// implementation detail that must never reach the client-facing message.
+var internalErrorTagPattern = regexp.MustCompile(`^\[[A-Z][A-Z0-9_]*\]\s*`)
+
+// stripInternalErrorTag splits msg into the client-safe message with any
+// leading internal tag removed, and the tag itself (empty if msg carried no
+// tag). Only the client-safe message should ever be placed in a field the
+// caller can see; the tag, if present, belongs in logs only.
+func stripInternalErrorTag(msg string) (clientMsg string, tag string) {
+	loc := internalErrorTagPattern.FindStringIndex(msg)
+	if loc == nil {
+		return msg, ""
+	}
+	return msg[loc[1]:], strings.TrimSpace(msg[loc[0]:loc[1]])
+}
 
 // ClientCredentialsConfig holds the OAuth2 client credentials used to obtain
 // a bearer token for service-to-service calls to the Choreo API.
@@ -298,6 +323,13 @@ func (c *Client) Post(ctx context.Context, path string, userIDToken string, payl
 // extractDownstreamMessage attempts to parse a "message" field from the JSON
 // error body returned by the downstream service. Falls back to defaultMsg if
 // the body is empty, not JSON, or has no "message" field.
+//
+// The downstream service sometimes prefixes its message with an internal
+// bracketed tag identifying which layer raised it (e.g.
+// "[SERVICENOW_ERROR] State transition rejected"). That tag is logged here
+// for correlation but stripped from the returned string, since the returned
+// string is used verbatim as the client-facing apierror Msg — it must never
+// carry backend/vendor implementation detail.
 func extractDownstreamMessage(body []byte, defaultMsg string) string {
 	if len(body) == 0 {
 		return defaultMsg
@@ -306,7 +338,11 @@ func extractDownstreamMessage(body []byte, defaultMsg string) string {
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(body, &payload); err == nil && payload.Message != "" {
-		return payload.Message
+		clientMsg, tag := stripInternalErrorTag(payload.Message)
+		if tag != "" {
+			log.Printf("snclient: downstream error tagged %s: %s", sanitizeLog(tag), sanitizeLog(clientMsg)) // #nosec G706 -- tag and message sanitized
+		}
+		return clientMsg
 	}
 	return defaultMsg
 }

--- a/entity-service/internal/servicenow-integration-service/client_test.go
+++ b/entity-service/internal/servicenow-integration-service/client_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package integrationservice
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+)
+
+func TestStripInternalErrorTag(t *testing.T) {
+	tests := []struct {
+		name          string
+		in            string
+		wantClientMsg string
+		wantTag       string
+	}{
+		{
+			name:          "servicenow tag stripped",
+			in:            "[SERVICENOW_ERROR] State transition rejected",
+			wantClientMsg: "State transition rejected",
+			wantTag:       "[SERVICENOW_ERROR]",
+		},
+		{
+			name:          "other bracket tag stripped",
+			in:            "[ENTITY_SERVICE_ERROR] duplicate key",
+			wantClientMsg: "duplicate key",
+			wantTag:       "[ENTITY_SERVICE_ERROR]",
+		},
+		{
+			name:          "no tag left untouched",
+			in:            "State transition rejected",
+			wantClientMsg: "State transition rejected",
+			wantTag:       "",
+		},
+		{
+			name:          "lowercase bracket content is not treated as a tag",
+			in:            "[case 123] rejected",
+			wantClientMsg: "[case 123] rejected",
+			wantTag:       "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMsg, gotTag := stripInternalErrorTag(tc.in)
+			if gotMsg != tc.wantClientMsg {
+				t.Errorf("clientMsg = %q, want %q", gotMsg, tc.wantClientMsg)
+			}
+			if gotTag != tc.wantTag {
+				t.Errorf("tag = %q, want %q", gotTag, tc.wantTag)
+			}
+		})
+	}
+}
+
+// TestClient_TaggedDownstreamMessage_NotLeakedToClient reproduces the
+// production observation: the downstream service returns a 409 body whose
+// "message" field carries a "[SERVICENOW_ERROR]" prefix. The error returned
+// to the caller (and ultimately serialized into the HTTP response the FE
+// sees) must have the tag stripped while keeping the rest of the message.
+func TestClient_TaggedDownstreamMessage_NotLeakedToClient(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 3600})
+	})
+	mux.HandleFunc("/cases/abc", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "[SERVICENOW_ERROR] State transition rejected",
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := New(srv.URL, ClientCredentialsConfig{
+		TokenURL:     srv.URL + "/oauth2/token",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Patch(context.Background(), "/cases/abc", "test-id-token", map[string]any{"workState": "ongoing"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+
+	ce, ok := err.(*apierror.ConflictError)
+	if !ok {
+		t.Fatalf("expected *apierror.ConflictError, got %T: %v", err, err)
+	}
+
+	const wantMsg = "State transition rejected"
+	if ce.Msg != wantMsg {
+		t.Errorf("ConflictError.Msg = %q, want %q (internal tag must not reach the client-facing message)", ce.Msg, wantMsg)
+	}
+}


### PR DESCRIPTION
## Purpose
> `customer-entity-service` sometimes returns a client-facing error `message` with a literal internal tag prefix, e.g. `{"message":"[SERVICENOW_ERROR] State transition rejected"}`. The tag is meant to identify which internal/downstream layer raised the error for log correlation, but it was flowing straight through into the field the CSM portal FE displays to CS engineers. Not a security issue (internal-only audience, no secrets/PII in the tag), but it leaks backend/vendor implementation detail and reads as an unhandled bug.

## Goals
> Strip the leading bracketed internal tag (e.g. `[SERVICENOW_ERROR]`, `[ENTITY_SERVICE_ERROR]`) from any downstream error message before it is placed into the client-facing error response, while still logging the tag server-side for correlation, and without losing the useful text that follows the tag (e.g. "State transition rejected" still reaches the client).

## Approach
> Root cause: `extractDownstreamMessage` in `entity-service/internal/servicenow-integration-service/client.go` pulls the `message` field straight out of the downstream error body and uses it verbatim as the `Msg` on the returned `apierror.*` type. That same `Msg` is both logged and written to the HTTP response body in `writeServiceError` (`internal/handler/decode.go`), so any tag baked into the downstream message reached the client unfiltered.
>
> Fix, localized to `client.go` (the single choke point all `sn_*.go` service calls funnel through via `Client.Get/Patch/Post/Delete`):
> - Added `stripInternalErrorTag`, which splits a message into a client-safe string (tag removed) and the tag itself (empty if none was present), matching a generic `^\[[A-Z][A-Z0-9_]*\]\s*` pattern rather than hardcoding one tag name.
> - `extractDownstreamMessage` now uses this to build two things from the one input: it `log.Printf`s the tag + message for correlation, and returns only the tag-stripped message — the value that becomes the client-facing `Msg`.
> - No behavior change when no tag is present.

## User stories
> N/A — internal error-handling correctness fix, no user-facing feature.

## Release note
> Fix: error messages returned to the CSM portal no longer carry an internal `[SOMETHING_ERROR]`-style tag prefix; the underlying error text is preserved, the tag is now logged server-side only.

## Documentation
> N/A — internal error-handling implementation detail, no public API contract change.

## Automation tests
 - Unit tests
   > Added `entity-service/internal/servicenow-integration-service/client_test.go`: table-driven tests for `stripInternalErrorTag` (tag stripped, no-tag passthrough, lowercase-bracket non-tag left alone), plus an end-to-end test that spins up an `httptest` server returning a 409 with a `[SERVICENOW_ERROR]`-tagged message and asserts the `apierror.ConflictError.Msg` the client receives is tag-free.
 - Integration tests
   > N/A — covered by the unit test exercising the real HTTP round trip through `Client.Patch`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go component; ran `go vet ./...` clean instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> None

## Migrations (if applicable)
> N/A — no schema or data change.

## Test environment
> Go (per `entity-service/go.mod`), macOS, `go build ./...`, `go vet ./...`, `go test ./...` — all pass.

## Learning
> N/A
