### PR TITLE
[CSM Portal] don't offer Request approval when the change request has no assigned team

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -88,6 +88,7 @@ const BASE_CR: BeChangeRequestDetail = {
   createdOn: "2026-01-01T00:00:00Z",
   state: "new",
   type: "normal",
+  assignedTeam: { id: "team-1", name: "Platform" },
 };
 
 function mockQueryResult(
@@ -146,6 +147,27 @@ describe("CsmChangeRequestDetailPage — Request approval (New -> Assess)", () =
     expect(
       screen.queryByRole("button", { name: /request approval/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a disabled Request approval button when the state allows it but there is no assigned team", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, legalNextStates: ["assess"], assignedTeam: null },
+    });
+    render(<CsmChangeRequestDetailPage />);
+    const button = screen.getByRole("button", { name: /request approval/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(patchMutateMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves Request approval enabled when both the state and the assigned team allow it", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, legalNextStates: ["assess"], assignedTeam: { id: "team-1", name: "Platform" } },
+    });
+    render(<CsmChangeRequestDetailPage />);
+    expect(
+      screen.getByRole("button", { name: /request approval/i }),
+    ).toBeEnabled();
   });
 
   it("PATCHes { requestApproval: true } for this CR when clicked", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   Card,
   Chip,
   Skeleton,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, Check, MessageSquarePlus, Pencil, Send, X } from "@wso2/oxygen-ui-icons-react";
@@ -237,7 +238,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   // ever modeled today (New -> Assess), but this checks membership rather
   // than hardcoding `cr.state === "new"` so a backend-added transition needs
   // no FE change to show up.
-  const canRequestApproval = !!cr.legalNextStates?.includes("assess");
+  // The state machine alone isn't sufficient: the backing data source also
+  // enforces that an assigned team is set before this transition is allowed,
+  // so require `assignedTeam` too or the request round-trips and fails there.
+  const stateAllowsRequestApproval = !!cr.legalNextStates?.includes("assess");
+  const requestApprovalBlockedReason = stateAllowsRequestApproval && !cr.assignedTeam
+    ? "Set an assigned team before requesting approval"
+    : null;
 
   const requestApproval = (): void => {
     patchCr.mutate(
@@ -277,25 +284,42 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               label={`${changeRequestImpactLabel(cr.impact)} impact`}
             />
           )}
-          {canRequestApproval && (
-            <Button
-              variant="contained"
-              color="primary"
-              size="small"
-              startIcon={<Send size={14} />}
-              onClick={requestApproval}
-              loading={patchCr.isPending}
-              sx={{ ml: "auto", flexShrink: 0 }}
-            >
-              Request approval
-            </Button>
+          {stateAllowsRequestApproval && (
+            requestApprovalBlockedReason ? (
+              <Tooltip title={requestApprovalBlockedReason}>
+                <Box component="span" sx={{ ml: "auto", flexShrink: 0 }}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    startIcon={<Send size={14} />}
+                    disabled
+                    sx={{ flexShrink: 0 }}
+                  >
+                    Request approval
+                  </Button>
+                </Box>
+              </Tooltip>
+            ) : (
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                startIcon={<Send size={14} />}
+                onClick={requestApproval}
+                loading={patchCr.isPending}
+                sx={{ ml: "auto", flexShrink: 0 }}
+              >
+                Request approval
+              </Button>
+            )
           )}
           <Button
             variant="outlined"
             size="small"
             startIcon={<Pencil size={14} />}
             onClick={() => setEditOpen(true)}
-            sx={{ ml: canRequestApproval ? 0 : "auto", flexShrink: 0 }}
+            sx={{ ml: stateAllowsRequestApproval ? 0 : "auto", flexShrink: 0 }}
           >
             Edit
           </Button>


### PR DESCRIPTION
## Purpose
On a change request's detail page, clicking "Request approval" could still round-trip all the way to the backing data source and fail there, even though the frontend already has a client-side gate. The existing gate only checked the generic state-machine transition list (`legalNextStates`), which reflects the structural New -> Assess move being legal — but the backing data source separately enforces a precondition not captured by that list: the change request must also have an assignment group/team set, or the transition is rejected server-side.

## Goals
Extend the client-side gate so a CS engineer can't trigger a request that is guaranteed to fail: require an assigned team in addition to the existing state check before treating "Request approval" as available.

## Approach
- `canRequestApproval`-equivalent logic now requires `cr.assignedTeam` to be set in addition to `legalNextStates` including `"assess"`.
- When the transition is otherwise legal but no team is assigned, the button is now shown disabled with a tooltip ("Set an assigned team before requesting approval") instead of being silently hidden, mirroring the existing disabled+tooltip pattern used elsewhere in this app (case detail's action bar) for actions blocked by a nameable, specific reason.
- Updated/added unit tests covering: button enabled (state ok + team set), button disabled (state ok + no team, click is a no-op), and existing hide/show-by-state cases.

## User stories
As a CS engineer, when I open a change request that's eligible for approval but has no assigned team yet, I see why the Request approval action isn't available instead of hitting a failed request after clicking it.

## Release note
Fix: the change request detail page no longer offers "Request approval" when the change request has no assigned team, preventing a request that was guaranteed to fail once it reached the backing data source. The button is now shown disabled with an explanatory tooltip in that case.

## Documentation
N/A — internal client-side validation change, no user-facing product documentation to update.

## Training
N/A — no training content is affected by this change.

## Certification
N/A — no certification exam content is affected by this change.

## Marketing
N/A — internal bug fix, no marketing impact.

## Automation tests
 - Unit tests
   > Updated `CsmChangeRequestDetailPage.test.tsx`: added a case asserting the button is disabled (and clicking it is a no-op) when the state allows the transition but no team is assigned, and a case asserting it stays enabled when both conditions are met. All 11 tests in the file pass (`npx vitest run`).
 - Integration tests
   > N/A — no integration test suite covers this page; covered by the unit tests above plus a full `pnpm build`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend; ran `npx eslint` and `npx tsc -b` clean instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code affected.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Node.js + pnpm, local build via `npx tsc -b`, `npx eslint`, `npx vitest run`, and `pnpm build` (all passing).

## Learning
N/A — root cause was already confirmed prior to this change; followed the existing disabled+tooltip pattern already established in this codebase (case detail action bar) rather than inventing a new one.
