### PR TITLE
[CSM Portal] give case watchers their own tab, separate from Related

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -35,6 +35,7 @@ import {
   ArrowLeft,
   CheckSquare,
   Clock,
+  Eye,
   Layers,
   Link as LinkIcon,
   ListChecks,
@@ -252,6 +253,7 @@ type CaseTabId =
   | "activities"
   | "details"
   | "related"
+  | "watchers"
   | "sla"
   | "attachments"
   | "time"
@@ -290,6 +292,7 @@ const TAB_DEFS: Array<{
   { id: "activities", label: "Activities", icon: <Activity size={16} /> },
   { id: "details", label: "Details", icon: <ListChecks size={16} /> },
   { id: "related", label: "Related", icon: <Users size={16} /> },
+  { id: "watchers", label: "Watchers", icon: <Eye size={16} /> },
   { id: "sla", label: "SLAs", icon: <Clock size={16} /> },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
   { id: "time", label: "Time tracking", icon: <Layers size={16} /> },
@@ -503,6 +506,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   if (
     isAnnouncement &&
     (activeTab === "related" ||
+      activeTab === "watchers" ||
       activeTab === "sla" ||
       activeTab === "time" ||
       activeTab === "call-requests" ||
@@ -795,10 +799,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
-      // Manage watchers jumps to the Related tab, which now edits the watch
+      // Manage watchers jumps to the Watchers tab, which edits the watch
       // list inline (add/remove chips) rather than opening a separate dialog.
       if (action.secondary === "manage_watchers") {
-        setActiveTab("related");
+        setActiveTab("watchers");
         return;
       }
 
@@ -1068,7 +1072,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     [patchCase, showError],
   );
 
-  // Watchers are edited inline in the Related tab (see WatchersWidget); the
+  // Watchers are edited inline in the Watchers tab (see WatchersWidget); the
   // backend has no add/remove-one endpoint, only a full-list-replace
   // `PATCH /cases/{id}` (`watchList`), and that PATCH is an array of emails
   // (ServiceNow's watch_list only round-trips as `EmailString[]`), so both add
@@ -1642,25 +1646,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
               !t.hidden &&
               (!isAnnouncement ||
                 (t.id !== "related" &&
+                  t.id !== "watchers" &&
                   t.id !== "sla" &&
                   t.id !== "time" &&
                   t.id !== "call-requests")),
           ).map((t) => {
             // Counts shown only where the tab IS the list (unambiguous). Not
-            // shown for "related" — it combines two lists (watchers + child
-            // cases), so a single count would be misleading.
+            // shown for "related" — ChildCasesWidget runs its own scoped
+            // query for the child-case list, so no count is available here
+            // without an extra fetch.
             const count =
-              t.id === "sla"
-                ? slaList?.count
-                : t.id === "attachments"
-                  ? attachmentList.length
-                  : t.id === "time"
-                    ? c.timeLogs.length
-                    : t.id === "call-requests"
-                      ? callRequests?.length
-                      : t.id === "tasks"
-                        ? caseTasks?.total
-                        : undefined;
+              t.id === "watchers"
+                ? c.watchers.length
+                : t.id === "sla"
+                  ? slaList?.count
+                  : t.id === "attachments"
+                    ? attachmentList.length
+                    : t.id === "time"
+                      ? c.timeLogs.length
+                      : t.id === "call-requests"
+                        ? callRequests?.length
+                        : t.id === "tasks"
+                          ? caseTasks?.total
+                          : undefined;
             return (
               <Tab
                 key={t.id}
@@ -1961,28 +1969,24 @@ export default function CsmCaseDetailPage(): JSX.Element {
       )}
 
       {activeTab === "related" && (
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: {
-              xs: "1fr",
-              md: "repeat(2, minmax(0, 1fr))",
-            },
-            alignItems: "start",
-          }}
-        >
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
+          <ChildCasesWidget caseId={c.id} />
+        </Box>
+      )}
+
+      {activeTab === "watchers" && (
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
           {/* Watchers list — moved off the (single-line) overview Cell so a
-              long watch list has room to wrap as chips. Add/remove are
-              inline here (no separate dialog); "Manage watchers…" in the
-              action bar just jumps to this tab. */}
+              long watch list has room to wrap as chips, and given its own
+              tab (split out of "Related") since it's not actually related
+              content. Add/remove are inline here (no separate dialog);
+              "Manage watchers…" in the action bar just jumps to this tab. */}
           <WatchersWidget
             watchers={c.watchers}
             onAdd={onAddWatcher}
             onRemove={onRemoveWatcher}
             isSaving={patchCase.isPending}
           />
-          <ChildCasesWidget caseId={c.id} />
         </Box>
       )}
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The case-detail "Related" tab currently combines two unrelated concerns in one screen: the watch list (who gets notified on case updates) and child cases. Watchers aren't actually "related case" content, and cramming them into the same tab as child cases makes both harder to scan and prevents showing an unambiguous watcher count on the tab bar.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Give Watchers its own top-level tab, matching the existing pattern used by the SLAs tab, so it's independently discoverable and can carry its own count in the tab label.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

In `CsmCaseDetailPage.tsx`:
- Added a new `"watchers"` tab id, positioned between "Related" and "SLAs" in the tab bar, with an `Eye` icon (already used elsewhere in this webapp for view/visibility affordances) to keep it visually distinct from the other icons on this tab bar.
- Moved the `WatchersWidget` render out of the "Related" tab's content block into its own `{activeTab === "watchers" && ...}` block. The widget itself, its inline add/remove chip behavior, and the `onAddWatcher`/`onRemoveWatcher` handlers are unchanged — only relocated.
- The "Related" tab now renders only `ChildCasesWidget` and switches from the previous 2-column grid to a single-column layout, since it's no longer combining two widgets.
- Added a watcher count to the new tab's label (`c.watchers.length`), consistent with how SLAs/Attachments/Time/Call requests/Tasks already show counts. "Related" still shows no count (its widget runs its own scoped data fetch, so no count is available at this level without an extra query).
- The action bar's "Manage watchers" item now jumps to the new "watchers" tab instead of "related".
- Added "watchers" to the same announcement-only tab-hiding logic that already excludes "related"/"sla"/"time"/"call-requests" (announcements have no watch list), in both places that gate: the tab-bar filter and the render-time fallback-to-Activities guard.

No changes to `WatchersWidget`, `WatcherAddPicker`, or any backend/entity-service code.

## User stories
> Summary of user stories addressed by this change

As a CS engineer viewing a case, I want Watchers to have its own tab, so I can find and manage the watch list without it being mixed in with child-case information.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Case detail: Watchers now has its own tab, separate from Related.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal CSM-portal UI reorganization, no external-facing product documentation covers this screen.

## Automation tests
 - Unit tests
   > Code coverage information

Existing `CaseDetailWidgets.test.tsx` (WatchersWidget unit tests) and `CaseActionBar.test.tsx` (secondary-action dispatch tests, including "manage watchers") pass unchanged — the tab move doesn't affect either component's own test surface. Manually verified `tsc -b`, `eslint`, and `pnpm build` are clean.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/React change; ran `eslint` clean instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A — no sample code shipped with this change.

## Related PRs
> None.

## Migrations (if applicable)
> N/A — no data or schema migration involved.

## Test environment
> Verified locally with `tsc -b`, `eslint`, `vitest`, and `pnpm build` (Node/pnpm toolchain per repo `package.json`).

## Learning
> N/A — straightforward tab-bar reorganization following the existing SLAs-tab pattern already present in the file.
