### PR TITLE
[CSM Portal] minor fixes: strip internal error tags, gate CR approval on assigned team, split watchers into own tab

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -35,6 +35,7 @@ import {
   ArrowLeft,
   CheckSquare,
   Clock,
+  Eye,
   Layers,
   Link as LinkIcon,
   ListChecks,
@@ -255,6 +256,7 @@ type CaseTabId =
   | "activities"
   | "details"
   | "related"
+  | "watchers"
   | "sla"
   | "attachments"
   | "time"
@@ -293,6 +295,7 @@ const TAB_DEFS: Array<{
   { id: "activities", label: "Activities", icon: <Activity size={16} /> },
   { id: "details", label: "Details", icon: <ListChecks size={16} /> },
   { id: "related", label: "Related", icon: <Users size={16} /> },
+  { id: "watchers", label: "Watchers", icon: <Eye size={16} /> },
   { id: "sla", label: "SLAs", icon: <Clock size={16} /> },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
   { id: "time", label: "Time tracking", icon: <Layers size={16} /> },
@@ -508,6 +511,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   if (
     isAnnouncement &&
     (activeTab === "related" ||
+      activeTab === "watchers" ||
       activeTab === "sla" ||
       activeTab === "time" ||
       activeTab === "call-requests" ||
@@ -800,10 +804,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
-      // Manage watchers jumps to the Related tab, which now edits the watch
+      // Manage watchers jumps to the Watchers tab, which edits the watch
       // list inline (add/remove chips) rather than opening a separate dialog.
       if (action.secondary === "manage_watchers") {
-        setActiveTab("related");
+        setActiveTab("watchers");
         return;
       }
 
@@ -1100,7 +1104,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     [patchCase, showError],
   );
 
-  // Watchers are edited inline in the Related tab (see WatchersWidget); the
+  // Watchers are edited inline in the Watchers tab (see WatchersWidget); the
   // backend has no add/remove-one endpoint, only a full-list-replace
   // `PATCH /cases/{id}` (`watchList`), and that PATCH is an array of emails
   // (ServiceNow's watch_list only round-trips as `EmailString[]`), so both add
@@ -1694,25 +1698,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
               !t.hidden &&
               (!isAnnouncement ||
                 (t.id !== "related" &&
+                  t.id !== "watchers" &&
                   t.id !== "sla" &&
                   t.id !== "time" &&
                   t.id !== "call-requests")),
           ).map((t) => {
             // Counts shown only where the tab IS the list (unambiguous). Not
-            // shown for "related" — it combines two lists (watchers + child
-            // cases), so a single count would be misleading.
+            // shown for "related" — ChildCasesWidget runs its own scoped
+            // query for the child-case list, so no count is available here
+            // without an extra fetch.
             const count =
-              t.id === "sla"
-                ? slaList?.count
-                : t.id === "attachments"
-                  ? attachmentList.length
-                  : t.id === "time"
-                    ? c.timeLogs.length
-                    : t.id === "call-requests"
-                      ? callRequests?.length
-                      : t.id === "tasks"
-                        ? caseTasks?.total
-                        : undefined;
+              t.id === "watchers"
+                ? c.watchers.length
+                : t.id === "sla"
+                  ? slaList?.count
+                  : t.id === "attachments"
+                    ? attachmentList.length
+                    : t.id === "time"
+                      ? c.timeLogs.length
+                      : t.id === "call-requests"
+                        ? callRequests?.length
+                        : t.id === "tasks"
+                          ? caseTasks?.total
+                          : undefined;
             return (
               <Tab
                 key={t.id}
@@ -2013,28 +2021,24 @@ export default function CsmCaseDetailPage(): JSX.Element {
       )}
 
       {activeTab === "related" && (
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: {
-              xs: "1fr",
-              md: "repeat(2, minmax(0, 1fr))",
-            },
-            alignItems: "start",
-          }}
-        >
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
+          <ChildCasesWidget caseId={c.id} />
+        </Box>
+      )}
+
+      {activeTab === "watchers" && (
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
           {/* Watchers list — moved off the (single-line) overview Cell so a
-              long watch list has room to wrap as chips. Add/remove are
-              inline here (no separate dialog); "Manage watchers…" in the
-              action bar just jumps to this tab. */}
+              long watch list has room to wrap as chips, and given its own
+              tab (split out of "Related") since it's not actually related
+              content. Add/remove are inline here (no separate dialog);
+              "Manage watchers…" in the action bar just jumps to this tab. */}
           <WatchersWidget
             watchers={c.watchers}
             onAdd={onAddWatcher}
             onRemove={onRemoveWatcher}
             isSaving={patchCase.isPending}
           />
-          <ChildCasesWidget caseId={c.id} />
         </Box>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -88,6 +88,7 @@ const BASE_CR: BeChangeRequestDetail = {
   createdOn: "2026-01-01T00:00:00Z",
   state: "new",
   type: "normal",
+  assignedTeam: { id: "team-1", name: "Platform" },
 };
 
 function mockQueryResult(
@@ -146,6 +147,27 @@ describe("CsmChangeRequestDetailPage — Request approval (New -> Assess)", () =
     expect(
       screen.queryByRole("button", { name: /request approval/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a disabled Request approval button when the state allows it but there is no assigned team", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, legalNextStates: ["assess"], assignedTeam: null },
+    });
+    render(<CsmChangeRequestDetailPage />);
+    const button = screen.getByRole("button", { name: /request approval/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(patchMutateMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves Request approval enabled when both the state and the assigned team allow it", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, legalNextStates: ["assess"], assignedTeam: { id: "team-1", name: "Platform" } },
+    });
+    render(<CsmChangeRequestDetailPage />);
+    expect(
+      screen.getByRole("button", { name: /request approval/i }),
+    ).toBeEnabled();
   });
 
   it("PATCHes { requestApproval: true } for this CR when clicked", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -160,6 +160,20 @@ describe("CsmChangeRequestDetailPage — Request approval (New -> Assess)", () =
     expect(patchMutateMock).not.toHaveBeenCalled();
   });
 
+  it("exposes the blocked reason to keyboard users via a focusable, labeled wrapper", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, legalNextStates: ["assess"], assignedTeam: null },
+    });
+    render(<CsmChangeRequestDetailPage />);
+    const button = screen.getByRole("button", { name: /request approval/i });
+    const focusTarget = button.closest('[tabindex="0"]');
+    expect(focusTarget).not.toBeNull();
+    expect(focusTarget).toHaveAttribute(
+      "aria-label",
+      "Request approval: Set an assigned team before requesting approval",
+    );
+  });
+
   it("leaves Request approval enabled when both the state and the assigned team allow it", () => {
     mockQueryResult({
       data: { ...BASE_CR, legalNextStates: ["assess"], assignedTeam: { id: "team-1", name: "Platform" } },

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   Card,
   Chip,
   Skeleton,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, Check, MessageSquarePlus, Pencil, Send, X } from "@wso2/oxygen-ui-icons-react";
@@ -237,7 +238,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   // ever modeled today (New -> Assess), but this checks membership rather
   // than hardcoding `cr.state === "new"` so a backend-added transition needs
   // no FE change to show up.
-  const canRequestApproval = !!cr.legalNextStates?.includes("assess");
+  // The state machine alone isn't sufficient: the backing data source also
+  // enforces that an assigned team is set before this transition is allowed,
+  // so require `assignedTeam` too or the request round-trips and fails there.
+  const stateAllowsRequestApproval = !!cr.legalNextStates?.includes("assess");
+  const requestApprovalBlockedReason = stateAllowsRequestApproval && !cr.assignedTeam
+    ? "Set an assigned team before requesting approval"
+    : null;
 
   const requestApproval = (): void => {
     patchCr.mutate(
@@ -277,25 +284,42 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               label={`${changeRequestImpactLabel(cr.impact)} impact`}
             />
           )}
-          {canRequestApproval && (
-            <Button
-              variant="contained"
-              color="primary"
-              size="small"
-              startIcon={<Send size={14} />}
-              onClick={requestApproval}
-              loading={patchCr.isPending}
-              sx={{ ml: "auto", flexShrink: 0 }}
-            >
-              Request approval
-            </Button>
+          {stateAllowsRequestApproval && (
+            requestApprovalBlockedReason ? (
+              <Tooltip title={requestApprovalBlockedReason}>
+                <Box component="span" sx={{ ml: "auto", flexShrink: 0 }}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    startIcon={<Send size={14} />}
+                    disabled
+                    sx={{ flexShrink: 0 }}
+                  >
+                    Request approval
+                  </Button>
+                </Box>
+              </Tooltip>
+            ) : (
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                startIcon={<Send size={14} />}
+                onClick={requestApproval}
+                loading={patchCr.isPending}
+                sx={{ ml: "auto", flexShrink: 0 }}
+              >
+                Request approval
+              </Button>
+            )
           )}
           <Button
             variant="outlined"
             size="small"
             startIcon={<Pencil size={14} />}
             onClick={() => setEditOpen(true)}
-            sx={{ ml: canRequestApproval ? 0 : "auto", flexShrink: 0 }}
+            sx={{ ml: stateAllowsRequestApproval ? 0 : "auto", flexShrink: 0 }}
           >
             Edit
           </Button>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -287,7 +287,12 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
           {stateAllowsRequestApproval && (
             requestApprovalBlockedReason ? (
               <Tooltip title={requestApprovalBlockedReason}>
-                <Box component="span" sx={{ ml: "auto", flexShrink: 0 }}>
+                <Box
+                  component="span"
+                  tabIndex={0}
+                  aria-label={`Request approval: ${requestApprovalBlockedReason}`}
+                  sx={{ ml: "auto", flexShrink: 0 }}
+                >
                   <Button
                     variant="contained"
                     color="primary"

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -340,7 +340,13 @@ func extractDownstreamMessage(body []byte, defaultMsg string) string {
 	if err := json.Unmarshal(body, &payload); err == nil && payload.Message != "" {
 		clientMsg, tag := stripInternalErrorTag(payload.Message)
 		if tag != "" {
-			log.Printf("snclient: downstream error tagged %s: %s", sanitizeLog(tag), sanitizeLog(clientMsg)) // #nosec G706 -- tag and message sanitized
+			// Log only the tag, never the downstream-controlled message text —
+			// the message is attacker/upstream-influenced and must not be
+			// persisted verbatim per this repo's logging guidelines.
+			log.Printf("snclient: downstream error tagged %s", sanitizeLog(tag)) // #nosec G706 -- tag sanitized
+		}
+		if clientMsg == "" {
+			return defaultMsg
 		}
 		return clientMsg
 	}

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -24,14 +24,39 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 )
+
+// sanitizeLog strips CR/LF characters from a string to prevent log injection.
+// Apply to every downstream-derived operand before passing it to a log call.
+var sanitizeLog = strings.NewReplacer("\n", `\n`, "\r", `\r`).Replace
+
+// internalErrorTagPattern matches a leading bracketed all-caps tag (e.g.
+// "[SERVICENOW_ERROR] ") that a downstream service prepends to its error
+// messages to identify which internal layer raised the error. The tag is
+// useful for correlating log lines with the originating layer, but it is an
+// implementation detail that must never reach the client-facing message.
+var internalErrorTagPattern = regexp.MustCompile(`^\[[A-Z][A-Z0-9_]*\]\s*`)
+
+// stripInternalErrorTag splits msg into the client-safe message with any
+// leading internal tag removed, and the tag itself (empty if msg carried no
+// tag). Only the client-safe message should ever be placed in a field the
+// caller can see; the tag, if present, belongs in logs only.
+func stripInternalErrorTag(msg string) (clientMsg string, tag string) {
+	loc := internalErrorTagPattern.FindStringIndex(msg)
+	if loc == nil {
+		return msg, ""
+	}
+	return msg[loc[1]:], strings.TrimSpace(msg[loc[0]:loc[1]])
+}
 
 // ClientCredentialsConfig holds the OAuth2 client credentials used to obtain
 // a bearer token for service-to-service calls to the Choreo API.
@@ -298,6 +323,13 @@ func (c *Client) Post(ctx context.Context, path string, userIDToken string, payl
 // extractDownstreamMessage attempts to parse a "message" field from the JSON
 // error body returned by the downstream service. Falls back to defaultMsg if
 // the body is empty, not JSON, or has no "message" field.
+//
+// The downstream service sometimes prefixes its message with an internal
+// bracketed tag identifying which layer raised it (e.g.
+// "[SERVICENOW_ERROR] State transition rejected"). That tag is logged here
+// for correlation but stripped from the returned string, since the returned
+// string is used verbatim as the client-facing apierror Msg — it must never
+// carry backend/vendor implementation detail.
 func extractDownstreamMessage(body []byte, defaultMsg string) string {
 	if len(body) == 0 {
 		return defaultMsg
@@ -306,7 +338,11 @@ func extractDownstreamMessage(body []byte, defaultMsg string) string {
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(body, &payload); err == nil && payload.Message != "" {
-		return payload.Message
+		clientMsg, tag := stripInternalErrorTag(payload.Message)
+		if tag != "" {
+			log.Printf("snclient: downstream error tagged %s: %s", sanitizeLog(tag), sanitizeLog(clientMsg)) // #nosec G706 -- tag and message sanitized
+		}
+		return clientMsg
 	}
 	return defaultMsg
 }

--- a/entity-service/internal/servicenow-integration-service/client_test.go
+++ b/entity-service/internal/servicenow-integration-service/client_test.go
@@ -115,3 +115,16 @@ func TestClient_TaggedDownstreamMessage_NotLeakedToClient(t *testing.T) {
 		t.Errorf("ConflictError.Msg = %q, want %q (internal tag must not reach the client-facing message)", ce.Msg, wantMsg)
 	}
 }
+
+// TestExtractDownstreamMessage_TagOnly_FallsBackToDefault covers a downstream
+// payload whose "message" is nothing but the internal tag (no text after it).
+// Stripping the tag would otherwise leave an empty client-facing message.
+func TestExtractDownstreamMessage_TagOnly_FallsBackToDefault(t *testing.T) {
+	const defaultMsg = "request conflicts with current state of the resource"
+	body := []byte(`{"message":"[SERVICENOW_ERROR]"}`)
+
+	got := extractDownstreamMessage(body, defaultMsg)
+	if got != defaultMsg {
+		t.Errorf("extractDownstreamMessage() = %q, want fallback %q", got, defaultMsg)
+	}
+}

--- a/entity-service/internal/servicenow-integration-service/client_test.go
+++ b/entity-service/internal/servicenow-integration-service/client_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package integrationservice
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+)
+
+func TestStripInternalErrorTag(t *testing.T) {
+	tests := []struct {
+		name          string
+		in            string
+		wantClientMsg string
+		wantTag       string
+	}{
+		{
+			name:          "servicenow tag stripped",
+			in:            "[SERVICENOW_ERROR] State transition rejected",
+			wantClientMsg: "State transition rejected",
+			wantTag:       "[SERVICENOW_ERROR]",
+		},
+		{
+			name:          "other bracket tag stripped",
+			in:            "[ENTITY_SERVICE_ERROR] duplicate key",
+			wantClientMsg: "duplicate key",
+			wantTag:       "[ENTITY_SERVICE_ERROR]",
+		},
+		{
+			name:          "no tag left untouched",
+			in:            "State transition rejected",
+			wantClientMsg: "State transition rejected",
+			wantTag:       "",
+		},
+		{
+			name:          "lowercase bracket content is not treated as a tag",
+			in:            "[case 123] rejected",
+			wantClientMsg: "[case 123] rejected",
+			wantTag:       "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMsg, gotTag := stripInternalErrorTag(tc.in)
+			if gotMsg != tc.wantClientMsg {
+				t.Errorf("clientMsg = %q, want %q", gotMsg, tc.wantClientMsg)
+			}
+			if gotTag != tc.wantTag {
+				t.Errorf("tag = %q, want %q", gotTag, tc.wantTag)
+			}
+		})
+	}
+}
+
+// TestClient_TaggedDownstreamMessage_NotLeakedToClient reproduces the
+// production observation: the downstream service returns a 409 body whose
+// "message" field carries a "[SERVICENOW_ERROR]" prefix. The error returned
+// to the caller (and ultimately serialized into the HTTP response the FE
+// sees) must have the tag stripped while keeping the rest of the message.
+func TestClient_TaggedDownstreamMessage_NotLeakedToClient(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 3600})
+	})
+	mux.HandleFunc("/cases/abc", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "[SERVICENOW_ERROR] State transition rejected",
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := New(srv.URL, ClientCredentialsConfig{
+		TokenURL:     srv.URL + "/oauth2/token",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Patch(context.Background(), "/cases/abc", "test-id-token", map[string]any{"workState": "ongoing"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+
+	ce, ok := err.(*apierror.ConflictError)
+	if !ok {
+		t.Fatalf("expected *apierror.ConflictError, got %T: %v", err, err)
+	}
+
+	const wantMsg = "State transition rejected"
+	if ce.Msg != wantMsg {
+		t.Errorf("ConflictError.Msg = %q, want %q (internal tag must not reach the client-facing message)", ce.Msg, wantMsg)
+	}
+}


### PR DESCRIPTION
## Purpose
Consolidates three independent, unrelated-but-small fixes into one PR (each was originally opened separately as #1259/#1260/#1261; those are closed in favor of this one) to reduce review overhead. Each commit is self-contained and independently revertable, spanning entity-service (Go) and the CSM webapp (React).

## Goals
- Stop leaking internal `[SOMETHING_ERROR]`-style tags (e.g. `[SERVICENOW_ERROR]`) from the backing data source into user-facing error messages — confirmed live in production traffic on a change-request approval rejection.
- Stop "Request approval" on a change request from round-tripping to the backing data source and failing when the request lacks an assigned team — the existing state-based gate didn't check for this.
- Give case watchers their own detail tab instead of sharing the "Related" tab with child cases, matching the existing SLAs/Attachments/Time tracking tab pattern.

## Approach
Three independent commits, each addressing one issue in its own files with its own tests — see individual commit messages for detail. No shared code between them; a review can evaluate each commit in isolation.

## Release note
- Error messages from the backing data source no longer show an internal tag prefix.
- "Request approval" is now disabled (with an explanatory tooltip) instead of failing after a round trip, when a change request has no assigned team.
- Case watchers now live on their own tab.

## Documentation
N/A — internal bug fixes and a UX improvement, no contract/shape changes.

## Security checks
- Secure coding standards followed: yes
- FindSecurityBugs / static analysis: N/A for Go/TS — `go vet ./...` and `eslint`/`tsc` clean
- No secrets committed: yes

## Related PRs
Supersedes #1259, #1260, #1261 (closed in favor of this consolidated PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated **Watchers** tab to case details, including a live watcher count.
  - Watchers management now navigates directly to the **Watchers** tab.
- **Bug Fixes**
  - “Request approval” is now disabled unless the legal next state allows it *and* an assigned team exists, with an explanation shown via tooltip.
  - ServiceNow client errors no longer leak internal error tags and are sanitized for safer, clearer client-facing messaging.
- **Tests**
  - Added coverage for ServiceNow error tag stripping and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->