### PR TITLE
[CSM Portal] Rename Account owner to accountManager, add renewalAccountManager + email

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -976,7 +976,8 @@ paths:
       description: >
         Returns full account detail. The response takes one of two shapes:
         Account, or AccountDetail (supportTier as an {id, label} object,
-        owner/technicalOwner as {id, name} references).
+        accountManager/technicalOwner/renewalAccountManager as {id, name, email}
+        references).
       operationId: getAccountsId
       parameters:
         - name: id
@@ -1031,8 +1032,8 @@ paths:
       description: >
         Returns a paginated list of accounts. The response takes one of two
         shapes: AccountSearchResponse, or AccountViewSearchResponse
-        (supportTier as a plain label string, owner/technicalOwner as
-        {id, name} references).
+        (supportTier as a plain label string, accountManager/technicalOwner/
+        renewalAccountManager as {id, name, email} references).
       operationId: postAccountsSearch
       requestBody:
         description: Account search payload
@@ -5056,6 +5057,19 @@ components:
         name:
           type: string
 
+    PersonRef:
+      description: A reference to a person, including their email (unlike EntityRef, which is used for non-person references).
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        email:
+          type: string
+          nullable: true
+
     DeployedProductRef:
       type: object
       properties:
@@ -5739,14 +5753,18 @@ components:
         arrToday:
           type: string
           nullable: true
-        owner:
+        accountManager:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
+            - $ref: '#/components/schemas/PersonRef'
         technicalOwner:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
+            - $ref: '#/components/schemas/PersonRef'
+        renewalAccountManager:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/PersonRef'
         activationDate:
           type: string
         deactivationDate:
@@ -5797,14 +5815,18 @@ components:
         arrToday:
           type: string
           nullable: true
-        owner:
+        accountManager:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
+            - $ref: '#/components/schemas/PersonRef'
         technicalOwner:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
+            - $ref: '#/components/schemas/PersonRef'
+        renewalAccountManager:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/PersonRef'
         activationDate:
           type: string
         deactivationDate:

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -226,22 +226,23 @@ type SearchAccountsResponse struct {
 // Timestamp fields are kept as strings to accommodate empty values from ServiceNow.
 // SupportTier is returned as a plain label string (no ID).
 type SNAccountView struct {
-	ID               string     `json:"id"`
-	Name             string     `json:"name"`
-	Classification   string     `json:"classification"`
-	Pod              *string    `json:"pod"`
-	Region           *string    `json:"region"`
-	SupportTier      *string    `json:"supportTier"`
-	ArrToday         *string    `json:"arrToday"`
-	TechnicalOwner   *EntityRef `json:"technicalOwner"`
-	Owner            *EntityRef `json:"owner"`
-	ActivationDate   string     `json:"activationDate"`
-	DeactivationDate *string    `json:"deactivationDate"`
-	HasAgent         bool       `json:"hasAgent"`
-	HasKbReferences  bool       `json:"hasKbReferences"`
-	CreatedOn        string     `json:"createdOn"`
-	CreatedBy        *string    `json:"createdBy"`
-	UpdatedOn        string     `json:"updatedOn"`
+	ID                    string     `json:"id"`
+	Name                  string     `json:"name"`
+	Classification        string     `json:"classification"`
+	Pod                   *string    `json:"pod"`
+	Region                *string    `json:"region"`
+	SupportTier           *string    `json:"supportTier"`
+	ArrToday              *string    `json:"arrToday"`
+	TechnicalOwner        *PersonRef `json:"technicalOwner"`
+	AccountManager        *PersonRef `json:"accountManager"`
+	RenewalAccountManager *PersonRef `json:"renewalAccountManager"`
+	ActivationDate        string     `json:"activationDate"`
+	DeactivationDate      *string    `json:"deactivationDate"`
+	HasAgent              bool       `json:"hasAgent"`
+	HasKbReferences       bool       `json:"hasKbReferences"`
+	CreatedOn             string     `json:"createdOn"`
+	CreatedBy             *string    `json:"createdBy"`
+	UpdatedOn             string     `json:"updatedOn"`
 }
 
 // SearchSNAccountsResponse is the paginated result of a ServiceNow account search.
@@ -262,22 +263,23 @@ type SNSupportTierRef struct {
 // SNAccountDetail is the full account detail returned by the ServiceNow data source
 // for GET /accounts/{id}. SupportTier is returned as an {id, label} object.
 type SNAccountDetail struct {
-	ID               string            `json:"id"`
-	Name             string            `json:"name"`
-	Classification   string            `json:"classification"`
-	Pod              *string           `json:"pod"`
-	Region           *string           `json:"region"`
-	SupportTier      *SNSupportTierRef `json:"supportTier"`
-	ArrToday         *string           `json:"arrToday"`
-	TechnicalOwner   *EntityRef        `json:"technicalOwner"`
-	Owner            *EntityRef        `json:"owner"`
-	ActivationDate   string            `json:"activationDate"`
-	DeactivationDate *string           `json:"deactivationDate"`
-	HasAgent         bool              `json:"hasAgent"`
-	HasKbReferences  bool              `json:"hasKbReferences"`
-	CreatedOn        string            `json:"createdOn"`
-	CreatedBy        *string           `json:"createdBy"`
-	UpdatedOn        string            `json:"updatedOn"`
+	ID                    string            `json:"id"`
+	Name                  string            `json:"name"`
+	Classification        string            `json:"classification"`
+	Pod                   *string           `json:"pod"`
+	Region                *string           `json:"region"`
+	SupportTier           *SNSupportTierRef `json:"supportTier"`
+	ArrToday              *string           `json:"arrToday"`
+	TechnicalOwner        *PersonRef        `json:"technicalOwner"`
+	AccountManager        *PersonRef        `json:"accountManager"`
+	RenewalAccountManager *PersonRef        `json:"renewalAccountManager"`
+	ActivationDate        string            `json:"activationDate"`
+	DeactivationDate      *string           `json:"deactivationDate"`
+	HasAgent              bool              `json:"hasAgent"`
+	HasKbReferences       bool              `json:"hasKbReferences"`
+	CreatedOn             string            `json:"createdOn"`
+	CreatedBy             *string           `json:"createdBy"`
+	UpdatedOn             string            `json:"updatedOn"`
 }
 
 // SubscriptionType classifies the subscription type of a project.
@@ -999,6 +1001,17 @@ type UserIDEmailRef struct {
 type EntityRef struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+// PersonRef is a compact reference to a person (e.g. an account's manager or
+// technical owner), carrying an optional email alongside id/name. Kept
+// separate from EntityRef because EntityRef is also used for many
+// non-person references (projects, deployments, products, catalogs, ...)
+// where an email field would be semantically meaningless.
+type PersonRef struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Email *string `json:"email"`
 }
 
 // DeployedProductRef is a compact reference to a deployed product with a

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -40,8 +40,9 @@ type snSupportTier struct {
 }
 
 type snPersonRef struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Email *string `json:"email"`
 }
 
 type snAccount struct {
@@ -55,12 +56,16 @@ type snAccount struct {
 	ActivationDate   string         `json:"activationDate"`
 	DeactivationDate *string        `json:"deactivationDate"`
 	TechnicalOwner   *snPersonRef   `json:"technicalOwner"`
-	Owner            *snPersonRef   `json:"owner"`
-	HasAgent         bool           `json:"hasAgent"`
-	HasKbReferences  bool           `json:"hasKbReferences"`
-	CreatedOn        string         `json:"createdOn"`
-	CreatedBy        *string        `json:"createdBy"`
-	UpdatedOn        string         `json:"updatedOn"`
+	// Owner is Ballerina's own wire key and stays "owner" on the wire even
+	// though the entity-service's own output renames this concept to
+	// "accountManager" (see snAccountCommonFields / snAccountToDomain).
+	Owner                 *snPersonRef `json:"owner"`
+	RenewalAccountManager *snPersonRef `json:"renewalAccountManager"`
+	HasAgent              bool         `json:"hasAgent"`
+	HasKbReferences       bool         `json:"hasKbReferences"`
+	CreatedOn             string       `json:"createdOn"`
+	CreatedBy             *string      `json:"createdBy"`
+	UpdatedOn             string       `json:"updatedOn"`
 }
 
 // snAccountSearchPayload is the Choreo POST /accounts/search request body.
@@ -156,19 +161,22 @@ func nilIfEmpty(s *string) *string {
 	return s
 }
 
-func snAccountCommonFields(a snAccount) (deactivationDate *string, technicalOwner, owner *domain.EntityRef) {
+func snAccountCommonFields(a snAccount) (deactivationDate *string, technicalOwner, accountManager, renewalAccountManager *domain.PersonRef) {
 	deactivationDate = nilIfEmpty(a.DeactivationDate)
 	if a.TechnicalOwner != nil && a.TechnicalOwner.ID != "" {
-		technicalOwner = &domain.EntityRef{ID: sysidToUUID(a.TechnicalOwner.ID), Name: a.TechnicalOwner.Name}
+		technicalOwner = &domain.PersonRef{ID: sysidToUUID(a.TechnicalOwner.ID), Name: a.TechnicalOwner.Name, Email: a.TechnicalOwner.Email}
 	}
 	if a.Owner != nil && a.Owner.ID != "" {
-		owner = &domain.EntityRef{ID: sysidToUUID(a.Owner.ID), Name: a.Owner.Name}
+		accountManager = &domain.PersonRef{ID: sysidToUUID(a.Owner.ID), Name: a.Owner.Name, Email: a.Owner.Email}
+	}
+	if a.RenewalAccountManager != nil && a.RenewalAccountManager.ID != "" {
+		renewalAccountManager = &domain.PersonRef{ID: sysidToUUID(a.RenewalAccountManager.ID), Name: a.RenewalAccountManager.Name, Email: a.RenewalAccountManager.Email}
 	}
 	return
 }
 
 func snAccountToDomain(a snAccount) domain.SNAccountView {
-	deactivationDate, technicalOwner, owner := snAccountCommonFields(a)
+	deactivationDate, technicalOwner, accountManager, renewalAccountManager := snAccountCommonFields(a)
 
 	var supportTier *string
 	if a.SupportTier != nil && a.SupportTier.Label != "" {
@@ -176,27 +184,28 @@ func snAccountToDomain(a snAccount) domain.SNAccountView {
 	}
 
 	return domain.SNAccountView{
-		ID:               sysidToUUID(a.ID),
-		Name:             a.Name,
-		Classification:   a.Classification,
-		Pod:              nilIfEmpty(a.Pod),
-		Region:           nilIfEmpty(a.Region),
-		SupportTier:      supportTier,
-		ArrToday:         nilIfEmpty(a.ArrToday),
-		TechnicalOwner:   technicalOwner,
-		Owner:            owner,
-		ActivationDate:   a.ActivationDate,
-		DeactivationDate: deactivationDate,
-		HasAgent:         a.HasAgent,
-		HasKbReferences:  a.HasKbReferences,
-		CreatedOn:        a.CreatedOn,
-		CreatedBy:        nilIfEmpty(a.CreatedBy),
-		UpdatedOn:        a.UpdatedOn,
+		ID:                    sysidToUUID(a.ID),
+		Name:                  a.Name,
+		Classification:        a.Classification,
+		Pod:                   nilIfEmpty(a.Pod),
+		Region:                nilIfEmpty(a.Region),
+		SupportTier:           supportTier,
+		ArrToday:              nilIfEmpty(a.ArrToday),
+		TechnicalOwner:        technicalOwner,
+		AccountManager:        accountManager,
+		RenewalAccountManager: renewalAccountManager,
+		ActivationDate:        a.ActivationDate,
+		DeactivationDate:      deactivationDate,
+		HasAgent:              a.HasAgent,
+		HasKbReferences:       a.HasKbReferences,
+		CreatedOn:             a.CreatedOn,
+		CreatedBy:             nilIfEmpty(a.CreatedBy),
+		UpdatedOn:             a.UpdatedOn,
 	}
 }
 
 func snAccountToDetail(a snAccount) domain.SNAccountDetail {
-	deactivationDate, technicalOwner, owner := snAccountCommonFields(a)
+	deactivationDate, technicalOwner, accountManager, renewalAccountManager := snAccountCommonFields(a)
 
 	var supportTier *domain.SNSupportTierRef
 	if a.SupportTier != nil && a.SupportTier.ID != "" {
@@ -207,22 +216,23 @@ func snAccountToDetail(a snAccount) domain.SNAccountDetail {
 	}
 
 	return domain.SNAccountDetail{
-		ID:               sysidToUUID(a.ID),
-		Name:             a.Name,
-		Classification:   a.Classification,
-		Pod:              nilIfEmpty(a.Pod),
-		Region:           nilIfEmpty(a.Region),
-		SupportTier:      supportTier,
-		ArrToday:         nilIfEmpty(a.ArrToday),
-		TechnicalOwner:   technicalOwner,
-		Owner:            owner,
-		ActivationDate:   a.ActivationDate,
-		DeactivationDate: deactivationDate,
-		HasAgent:         a.HasAgent,
-		HasKbReferences:  a.HasKbReferences,
-		CreatedOn:        a.CreatedOn,
-		CreatedBy:        nilIfEmpty(a.CreatedBy),
-		UpdatedOn:        a.UpdatedOn,
+		ID:                    sysidToUUID(a.ID),
+		Name:                  a.Name,
+		Classification:        a.Classification,
+		Pod:                   nilIfEmpty(a.Pod),
+		Region:                nilIfEmpty(a.Region),
+		SupportTier:           supportTier,
+		ArrToday:              nilIfEmpty(a.ArrToday),
+		TechnicalOwner:        technicalOwner,
+		AccountManager:        accountManager,
+		RenewalAccountManager: renewalAccountManager,
+		ActivationDate:        a.ActivationDate,
+		DeactivationDate:      deactivationDate,
+		HasAgent:              a.HasAgent,
+		HasKbReferences:       a.HasKbReferences,
+		CreatedOn:             a.CreatedOn,
+		CreatedBy:             nilIfEmpty(a.CreatedBy),
+		UpdatedOn:             a.UpdatedOn,
 	}
 }
 

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -164,13 +164,13 @@ func nilIfEmpty(s *string) *string {
 func snAccountCommonFields(a snAccount) (deactivationDate *string, technicalOwner, accountManager, renewalAccountManager *domain.PersonRef) {
 	deactivationDate = nilIfEmpty(a.DeactivationDate)
 	if a.TechnicalOwner != nil && a.TechnicalOwner.ID != "" {
-		technicalOwner = &domain.PersonRef{ID: sysidToUUID(a.TechnicalOwner.ID), Name: a.TechnicalOwner.Name, Email: a.TechnicalOwner.Email}
+		technicalOwner = &domain.PersonRef{ID: sysidToUUID(a.TechnicalOwner.ID), Name: a.TechnicalOwner.Name, Email: nilIfEmpty(a.TechnicalOwner.Email)}
 	}
 	if a.Owner != nil && a.Owner.ID != "" {
-		accountManager = &domain.PersonRef{ID: sysidToUUID(a.Owner.ID), Name: a.Owner.Name, Email: a.Owner.Email}
+		accountManager = &domain.PersonRef{ID: sysidToUUID(a.Owner.ID), Name: a.Owner.Name, Email: nilIfEmpty(a.Owner.Email)}
 	}
 	if a.RenewalAccountManager != nil && a.RenewalAccountManager.ID != "" {
-		renewalAccountManager = &domain.PersonRef{ID: sysidToUUID(a.RenewalAccountManager.ID), Name: a.RenewalAccountManager.Name, Email: a.RenewalAccountManager.Email}
+		renewalAccountManager = &domain.PersonRef{ID: sysidToUUID(a.RenewalAccountManager.ID), Name: a.RenewalAccountManager.Name, Email: nilIfEmpty(a.RenewalAccountManager.Email)}
 	}
 	return
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2865,11 +2865,15 @@ components:
         technicalOwner:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
-        owner:
+            - $ref: '#/components/schemas/PersonRef'
+        accountManager:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
+            - $ref: '#/components/schemas/PersonRef'
+        renewalAccountManager:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/PersonRef'
         activationDate:
           type: string
         deactivationDate:
@@ -2922,11 +2926,15 @@ components:
         technicalOwner:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
-        owner:
+            - $ref: '#/components/schemas/PersonRef'
+        accountManager:
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/EntityRef'
+            - $ref: '#/components/schemas/PersonRef'
+        renewalAccountManager:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/PersonRef'
         activationDate:
           type: string
         deactivationDate:
@@ -4313,6 +4321,21 @@ components:
           format: uuid
         name:
           type: string
+
+    PersonRef:
+      type: object
+      description: >-
+        A compact reference to a person (e.g. an account's manager or
+        technical owner), carrying an optional email alongside id/name.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        email:
+          type: string
+          nullable: true
 
     DeployedProductRef:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

WSO2 calls this account role "Account Manager", not "Owner". The Account API's `owner` field is renamed to `accountManager` across the stack, and a previously-unexposed "renewal account manager" field is now surfaced, so the account detail/search views can show who owns the relationship and who owns renewal separately from the technical owner.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Entity-service: rename `owner` to `accountManager` on the Account API's output side (`SNAccountView`/`SNAccountDetail`), add a new `renewalAccountManager` field backed by a previously-unexposed source field, and add `email` to all three person references (`accountManager`, `technicalOwner`, `renewalAccountManager`). A corresponding ServiceNow and Ballerina entity-service change is tracked separately to supply the upstream data.
- BFF: update `openapi.yaml` documentation for `AccountView`/`AccountDetail` to match (docs only — the BFF is a byte-for-byte pass-through for accounts, with no Go code referencing these fields).

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Three layers, one combined PR:

1. **entity-service** (`entity-service/internal/domain/entity.go`, `entity-service/internal/service/sn_account_service.go`, `entity-service/openapi.yaml`): introduces a `PersonRef {id, name, email}` type, kept separate from the existing `EntityRef {id, name}` (used broadly for non-person references like project/deployment/product/catalog, where an email would be meaningless). `accountManager`, `technicalOwner`, and the new `renewalAccountManager` are all `PersonRef`. The upstream (ServiceNow-backed) wire key stays `owner` on the input side; the rename to `accountManager` happens in the output translation (`snAccountCommonFields`/`snAccountToDomain`/`snAccountToDetail`).
2. **BFF** (`apps/csm-portal/backend/openapi.yaml`): mirrors the same rename in `AccountView`/`AccountDetail` — `owner` → `accountManager`, both switched from `EntityRef` to a new `PersonRef` schema, plus the new `renewalAccountManager` property. Endpoint description text for `GET /accounts/{id}` and `POST /accounts/search` updated to match. Documentation only; confirmed there is no BFF Go code referencing `owner`/`technicalOwner` (the BFF passes the entity-service's account response through unchanged).
3. **webapp**: no code changes. The CSM portal's account search/detail feature (`apps/csm-portal/webapp/src/features/csm-accounts`) is built against a separate, simpler `Account` contract (`ownerId`/`technicalOwnerId` as plain ID strings, `sfId`, `tier`) that this change does not touch — it does not consume `AccountView`/`AccountDetail`'s `owner`/`technicalOwner`/`accountManager` object fields at all. There is nothing to rename or add UI for at this layer for this change.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I can see an account's account manager, technical owner, and renewal account manager, each with a name and email, instead of just an ambiguous "owner" reference with no contact info.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Renamed the Account API's `owner` field to `accountManager`, added a new `renewalAccountManager` field, and added `email` to all three account person references (`accountManager`, `technicalOwner`, `renewalAccountManager`).

## Documentation
N/A — internal API rename/addition, no external product documentation references the old field name.

## Training
N/A — no training content references this field.

## Certification
N/A — no certification questions reference this field.

## Marketing
N/A — internal API change, no customer-facing feature to promote.

## Automation tests
 - Unit tests
   > No existing unit tests covered the renamed/added fields; entity-service `go build`/`go vet` pass. No new tests added since this is a pass-through rename with no new business logic.
 - Integration tests
   > None added. BFF change is documentation-only (openapi.yaml); validated the YAML parses with `python3 -c "import yaml; yaml.safe_load(...)"`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go/TypeScript codebase; `go vet` (entity-service) ran clean, no webapp code changed
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples affected.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data migration; this is a field rename/addition on API output shaped from upstream data, no stored schema change in this repo.

## Test environment
Validated locally: `python3 -c "import yaml; yaml.safe_load(open('apps/csm-portal/backend/openapi.yaml'))"` for the BFF spec; `go build ./...` / `go vet ./...` for entity-service.

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Account details now distinguish between account manager, technical owner, and renewal account manager roles.
  - Person references now include `{ id, name, email }`, with `email` optional.
  - Account search and detail responses now return the updated ownership/management fields.

- **Documentation**
  - Updated API documentation and response schemas to reflect the new person-reference shape and the revised account manager fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->