### PR TITLE
[CSM Portal Microapp] Add Incidents page to the microapp

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -28,6 +28,7 @@ import OperationsPage from "@pages/OperationsPage";
 import NewChangeRequestPage from "@pages/NewChangeRequestPage";
 import NewServiceRequestPage from "@pages/NewServiceRequestPage";
 import ChangeRequestDetailPage from "@pages/ChangeRequestDetailPage";
+import IncidentDetailPage from "@pages/IncidentDetailPage";
 import MorePage from "@pages/MorePage";
 import AnnouncementsPage from "@pages/AnnouncementsPage";
 import TimeCardsPage from "@pages/TimeCardsPage";
@@ -76,6 +77,7 @@ export default function App() {
           <Route path="/operations/change-requests/new" element={<NewChangeRequestPage />} />
           <Route path="/operations/service-requests/new" element={<NewServiceRequestPage />} />
           <Route path="/operations/change-requests/:id" element={<ChangeRequestDetailPage />} />
+          <Route path="/operations/incidents/:id" element={<IncidentDetailPage />} />
           <Route path="/more" element={<MorePage />} />
           <Route path="/more/announcements" element={<AnnouncementsPage />} />
           <Route path="/more/time-cards" element={<TimeCardsPage />} />

--- a/apps/csm-portal/microapp/src/components/operations/IncidentCard.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/IncidentCard.tsx
@@ -34,16 +34,18 @@ export function IncidentCard({ item }: { item: IncidentSummary }) {
         <Typography variant="subtitle2" color="text.secondary">
           {item.number}
         </Typography>
-        <ChevronRight size={pxToRem(18)} color={theme.palette.text.secondary} />
+        {item.id && <ChevronRight size={pxToRem(18)} color={theme.palette.text.secondary} />}
       </Stack>
 
       <Typography variant="body1" color="text.primary" noWrap>
         {item.subject}
       </Typography>
 
-      <Typography variant="subtitle2" color="text.secondary" noWrap>
-        {item.caller?.name}
-      </Typography>
+      {item.caller?.name && (
+        <Typography variant="subtitle2" color="text.secondary" noWrap>
+          {item.caller.name}
+        </Typography>
+      )}
 
       <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
         {item.state && (

--- a/apps/csm-portal/microapp/src/components/operations/IncidentCard.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/IncidentCard.tsx
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Card, Chip, Skeleton, Stack, Typography, pxToRem, useTheme } from "@wso2/oxygen-ui";
+import { ChevronRight, Clock4 } from "@wso2/oxygen-ui-icons-react";
+import { Link } from "react-router-dom";
+import type { IncidentSummary } from "@src/types";
+import { fromNow } from "@utils/dateTime";
+import { incidentPriorityColor, incidentPriorityLabel, incidentStateColor, incidentStateLabel } from "./incidentConfig";
+
+// Mirrors ChangeRequestCard.tsx's layout exactly, swapping project name for caller and
+// change-request impact for incident priority. `item.id` is nullable (an edge case the backend's
+// type allows — see incident.dto.ts); when absent the card renders as plain, non-navigable content
+// instead of linking to "/operations/incidents/null".
+export function IncidentCard({ item }: { item: IncidentSummary }) {
+  const theme = useTheme();
+
+  const content = (
+    <Stack gap={0.75}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="subtitle2" color="text.secondary">
+          {item.number}
+        </Typography>
+        <ChevronRight size={pxToRem(18)} color={theme.palette.text.secondary} />
+      </Stack>
+
+      <Typography variant="body1" color="text.primary" noWrap>
+        {item.subject}
+      </Typography>
+
+      <Typography variant="subtitle2" color="text.secondary" noWrap>
+        {item.caller?.name}
+      </Typography>
+
+      <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+        {item.state && (
+          <Chip size="small" label={incidentStateLabel(item.state)} color={incidentStateColor(item.state)} />
+        )}
+        {item.priority && (
+          <Chip
+            size="small"
+            variant="outlined"
+            label={incidentPriorityLabel(item.priority)}
+            color={incidentPriorityColor(item.priority)}
+          />
+        )}
+      </Stack>
+
+      <Stack direction="row" alignItems="center" gap={0.5}>
+        <Clock4 size={pxToRem(13)} color={theme.palette.text.secondary} />
+        <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: pxToRem(12) }}>
+          Updated {item.updatedOn ? fromNow(item.updatedOn) : "—"}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+
+  if (!item.id) {
+    return <Card sx={{ p: 1.5 }}>{content}</Card>;
+  }
+
+  return (
+    <Card
+      component={Link}
+      to={`/operations/incidents/${item.id}`}
+      sx={{ textDecoration: "none", p: 1.5, display: "block" }}
+    >
+      {content}
+    </Card>
+  );
+}
+
+export function IncidentCardSkeleton() {
+  return (
+    <Card sx={{ p: 1.5 }}>
+      <Stack gap={0.75}>
+        <Stack direction="row" justifyContent="space-between">
+          <Skeleton variant="text" width={60} height={20} />
+          <Skeleton variant="circular" width={pxToRem(18)} height={pxToRem(18)} />
+        </Stack>
+        <Skeleton variant="text" width="80%" height={26} />
+        <Skeleton variant="text" width="40%" height={18} />
+        <Stack direction="row" gap={1}>
+          <Skeleton variant="rounded" width={70} height={24} sx={{ borderRadius: 1 }} />
+          <Skeleton variant="rounded" width={70} height={24} sx={{ borderRadius: 1 }} />
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/IncidentsFiltersSheet.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/IncidentsFiltersSheet.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import {
+  EMPTY_INCIDENT_FILTERS,
+  INCIDENT_PRIORITIES,
+  INCIDENT_PRIORITY_LABELS,
+  type IncidentFilters,
+} from "./incidentConfig";
+
+function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+interface IncidentsFiltersSheetProps {
+  open: boolean;
+  onClose: () => void;
+  filters: IncidentFilters;
+  onApply: (filters: IncidentFilters) => void;
+}
+
+// Mirrors ChangeRequestsFiltersSheet.tsx's bottom-sheet pattern, trimmed to the one filter
+// dimension the backend actually supports for incidents (priority — see incidentConfig.ts).
+export function IncidentsFiltersSheet({ open, onClose, filters, onApply }: IncidentsFiltersSheetProps) {
+  const [draft, setDraft] = useState<IncidentFilters>(filters);
+
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed on open
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        Filters
+        <IconButton size="small" aria-label="Close filters" onClick={onClose}>
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent>
+        <Stack gap={1}>
+          <Typography variant="subtitle2">Priority</Typography>
+          <Stack direction="row" gap={1} flexWrap="wrap">
+            {INCIDENT_PRIORITIES.map((priority) => {
+              const isSelected = draft.priorities.includes(priority);
+              return (
+                <Chip
+                  key={priority}
+                  label={INCIDENT_PRIORITY_LABELS[priority]}
+                  size="small"
+                  variant={isSelected ? "filled" : "outlined"}
+                  color={isSelected ? "primary" : "default"}
+                  onClick={() => setDraft({ ...draft, priorities: toggle(draft.priorities, priority) })}
+                />
+              );
+            })}
+          </Stack>
+        </Stack>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions>
+        <Button
+          onClick={() => {
+            setDraft(EMPTY_INCIDENT_FILTERS);
+            onApply(EMPTY_INCIDENT_FILTERS);
+            onClose();
+          }}
+        >
+          Clear all
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApply(draft);
+            onClose();
+          }}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/IncidentsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/IncidentsTab.tsx
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { Badge, Chip, IconButton, Stack } from "@wso2/oxygen-ui";
+import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { incidents } from "@src/services/incidents";
+import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { EmptyState } from "@components/support/EmptyState";
+import { ErrorState } from "@components/support/ErrorState";
+import { SearchBar } from "@components/support/SearchBar";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { IncidentCard, IncidentCardSkeleton } from "./IncidentCard";
+import { IncidentsFiltersSheet } from "./IncidentsFiltersSheet";
+import {
+  countActiveIncidentFilters,
+  EMPTY_INCIDENT_FILTERS,
+  INCIDENT_PRIORITY_LABELS,
+  toIncidentSearchFilters,
+  type IncidentFilters,
+} from "./incidentConfig";
+
+// Mirrors the shape of ChangeRequestsTab.tsx's own list content (search + filter sheet + infinite
+// scroll), scoped to incidents. Read-only for now — no create Fab (see the scope note on
+// OperationsPage.tsx).
+export function IncidentsTab() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [filters, setFilters] = useState<IncidentFilters>(EMPTY_INCIDENT_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const activeFilterCount = countActiveIncidentFilters(filters);
+
+  return (
+    <Stack gap={2}>
+      <Stack direction="row" gap={1} alignItems="center">
+        <SearchBar value={search} onChange={setSearch} placeholder="Search by incident #, subject…" />
+        <Badge badgeContent={activeFilterCount} color="primary" invisible={activeFilterCount === 0}>
+          <IconButton aria-label="Filters" onClick={() => setFiltersOpen(true)}>
+            <SlidersHorizontal size={18} />
+          </IconButton>
+        </Badge>
+      </Stack>
+
+      {activeFilterCount > 0 && <ActiveFiltersRow filters={filters} onChange={setFilters} />}
+
+      <IncidentListErrorBoundary>
+        <Suspense fallback={<IncidentListSkeleton />}>
+          <IncidentListContent search={debouncedSearch} filters={filters} />
+        </Suspense>
+      </IncidentListErrorBoundary>
+
+      <IncidentsFiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        filters={filters}
+        onApply={setFilters}
+      />
+    </Stack>
+  );
+}
+
+// One removable chip per active filter — mirrors ChangeRequestsTab.tsx's own ActiveFiltersRow.
+function ActiveFiltersRow({
+  filters,
+  onChange,
+}: {
+  filters: IncidentFilters;
+  onChange: (filters: IncidentFilters) => void;
+}) {
+  return (
+    <Stack direction="row" gap={1} flexWrap="wrap">
+      {filters.priorities.map((priority) => (
+        <Chip
+          key={`priority-${priority}`}
+          label={INCIDENT_PRIORITY_LABELS[priority]}
+          size="small"
+          onDelete={() => onChange({ ...filters, priorities: filters.priorities.filter((p) => p !== priority) })}
+        />
+      ))}
+    </Stack>
+  );
+}
+
+function IncidentListContent({ search, filters }: { search: string; filters: IncidentFilters }) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfiniteQuery(
+    incidents.infinite({ filters: toIncidentSearchFilters(search, filters) }),
+  );
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const items = data.pages.flatMap((page) => page.items);
+
+  if (items.length === 0) return <EmptyState message="No incidents found." />;
+
+  return (
+    <Stack gap={1.5}>
+      {items.map((item, index) => (
+        // item.id is nullable (see incident.dto.ts) — fall back to the index so multiple
+        // incidents with a null id (an edge case the type allows) still get distinct React keys.
+        <IncidentCard key={item.id ?? `incident-${index}`} item={item} />
+      ))}
+
+      <div ref={sentinelRef} style={{ height: 1 }} />
+
+      {isFetchingNextPage && <IncidentCardSkeleton />}
+    </Stack>
+  );
+}
+
+function IncidentListSkeleton() {
+  return (
+    <Stack gap={1.5}>
+      {[0, 1, 2].map((i) => (
+        <IncidentCardSkeleton key={i} />
+      ))}
+    </Stack>
+  );
+}
+
+function IncidentListErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/incidentConfig.ts
+++ b/apps/csm-portal/microapp/src/components/operations/incidentConfig.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ChipProps } from "@wso2/oxygen-ui";
+import type { IncidentPriority, IncidentSearchPayloadDto, IncidentState } from "@src/types";
+
+// Direct port of the webapp's utils/incidents.ts label/color maps
+// (apps/csm-portal/webapp/src/features/csm-operations/utils/incidents.ts).
+
+export const INCIDENT_STATE_LABELS: Record<IncidentState, string> = {
+  NEW: "New",
+  IN_PROGRESS: "In Progress",
+  ON_HOLD: "On Hold",
+  RESOLVED: "Resolved",
+  CLOSED: "Closed",
+  CANCELLED: "Cancelled",
+};
+
+// New is unstarted (default), in-progress/on-hold are in-flight (info/warning), resolved/closed
+// are terminal-good, cancelled is a terminal-problem state.
+export const INCIDENT_STATE_COLORS: Record<IncidentState, NonNullable<ChipProps["color"]>> = {
+  NEW: "default",
+  IN_PROGRESS: "info",
+  ON_HOLD: "warning",
+  RESOLVED: "success",
+  CLOSED: "success",
+  CANCELLED: "error",
+};
+
+export const INCIDENT_PRIORITY_LABELS: Record<IncidentPriority, string> = {
+  CRITICAL: "Critical",
+  HIGH: "High",
+  MODERATE: "Moderate",
+  LOW: "Low",
+  PLANNING: "Planning",
+};
+
+export const INCIDENT_PRIORITY_COLORS: Record<IncidentPriority, NonNullable<ChipProps["color"]>> = {
+  CRITICAL: "error",
+  HIGH: "error",
+  MODERATE: "warning",
+  LOW: "default",
+  PLANNING: "default",
+};
+
+function humanize(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+export function incidentStateLabel(state?: string | null): string {
+  if (!state) return "—";
+  return INCIDENT_STATE_LABELS[state as IncidentState] ?? humanize(state);
+}
+
+export function incidentStateColor(state?: string | null): NonNullable<ChipProps["color"]> {
+  if (!state) return "default";
+  return INCIDENT_STATE_COLORS[state as IncidentState] ?? "default";
+}
+
+export function incidentPriorityLabel(priority?: string | null): string {
+  if (!priority) return "—";
+  return INCIDENT_PRIORITY_LABELS[priority as IncidentPriority] ?? humanize(priority);
+}
+
+export function incidentPriorityColor(priority?: string | null): NonNullable<ChipProps["color"]> {
+  if (!priority) return "default";
+  return INCIDENT_PRIORITY_COLORS[priority as IncidentPriority] ?? "default";
+}
+
+/** All incident priorities, for the filter sheet. */
+export const INCIDENT_PRIORITIES: IncidentPriority[] = ["CRITICAL", "HIGH", "MODERATE", "LOW", "PLANNING"];
+
+// Deliberately just search + priority — the backend's IncidentSearchPayload.filters only supports
+// searchQuery, priorities, and parentIds (see incident.dto.ts); there's no server-side state
+// filter to build a control for (same gap the webapp's own IncidentsFilterBar documents).
+export interface IncidentFilters {
+  priorities: IncidentPriority[];
+}
+
+export const EMPTY_INCIDENT_FILTERS: IncidentFilters = {
+  priorities: [],
+};
+
+export function countActiveIncidentFilters(filters: IncidentFilters): number {
+  return filters.priorities.length > 0 ? 1 : 0;
+}
+
+export function toIncidentSearchFilters(search: string, filters: IncidentFilters): IncidentSearchPayloadDto["filters"] {
+  return {
+    ...(search.length > 0 && { searchQuery: search }),
+    ...(filters.priorities.length > 0 && { priorities: filters.priorities }),
+  };
+}

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -45,6 +45,10 @@ export const IT_SERVICES_SEARCH_ENDPOINT = "/services/search";
 export const SERVICE_OFFERINGS_SEARCH_ENDPOINT = "/service-offerings/search";
 export const CONFIGURATION_ITEMS_SEARCH_ENDPOINT = "/configuration-items/search";
 
+export const INCIDENTS_SEARCH_ENDPOINT = "/incidents/search";
+export const INCIDENT_ENDPOINT = (id: string) => `/incidents/${id}`;
+export const INCIDENT_COMMENTS_SEARCH_ENDPOINT = (id: string) => `/incidents/${id}/comments/search`;
+
 export const ACCOUNTS_SEARCH_ENDPOINT = "/accounts/search";
 export const ACCOUNT_ENDPOINT = (id: string) => `/accounts/${id}`;
 

--- a/apps/csm-portal/microapp/src/pages/IncidentDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/IncidentDetailPage.tsx
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Suspense, type ReactNode } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { incidents } from "@src/services/incidents";
+import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { ErrorState } from "@components/support/ErrorState";
+import { SectionCard } from "@components/case-detail/SectionCard";
+import { CaseActivityFeed } from "@components/case-detail/CaseActivityFeed";
+import {
+  incidentPriorityColor,
+  incidentPriorityLabel,
+  incidentStateColor,
+  incidentStateLabel,
+} from "@components/operations/incidentConfig";
+import { formatDate } from "@utils/dateTime";
+
+// Read-only counterpart of the webapp's CsmIncidentDetailPage.tsx (no Edit dialog, no comment
+// composer, no attachments — see the scope note on OperationsPage.tsx). Layout follows this app's
+// own ChangeRequestDetailPage.tsx: a stack of SectionCards with DetailRow/TextBlock fields rather
+// than the webapp's responsive MetaCell grid.
+export default function IncidentDetailPage() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <Stack gap={2} sx={{ mb: 10 }}>
+      <IncidentDetailErrorBoundary>
+        <Suspense fallback={<IncidentDetailSkeleton />}>
+          <IncidentDetailContent id={id ?? ""} />
+        </Suspense>
+      </IncidentDetailErrorBoundary>
+    </Stack>
+  );
+}
+
+function IncidentDetailContent({ id }: { id: string }) {
+  const { data: incident } = useSuspenseQuery(incidents.get(id));
+
+  const hasLinks = !!(incident.changeRequest || incident.problem || incident.causedBy);
+  const hasNotes = !!(incident.additionalComments || incident.workNotes);
+
+  return (
+    <>
+      <Stack gap={1}>
+        <Typography variant="subtitle2" color="text.secondary" noWrap>
+          {incident.number}
+        </Typography>
+
+        <Typography variant="h6">{incident.subject}</Typography>
+
+        <Stack direction="row" gap={1} flexWrap="wrap">
+          {incident.state && (
+            <Chip size="small" label={incidentStateLabel(incident.state)} color={incidentStateColor(incident.state)} />
+          )}
+          {incident.priority && (
+            <Chip
+              size="small"
+              variant="outlined"
+              label={incidentPriorityLabel(incident.priority)}
+              color={incidentPriorityColor(incident.priority)}
+            />
+          )}
+        </Stack>
+      </Stack>
+
+      <SectionCard title="Overview">
+        <Stack gap={1}>
+          <DetailRow label="Caller" value={incident.caller?.name} />
+          <DetailRow label="Category" value={incident.category} />
+          <DetailRow label="Subcategory" value={incident.subcategory} />
+          <DetailRow label="Contact Type" value={incident.contactType} />
+          <DetailRow label="Impact" value={incident.impact} />
+          <DetailRow label="Urgency" value={incident.urgency} />
+          <DetailRow label="Service" value={incident.service?.name} />
+          <DetailRow label="Service Offering" value={incident.serviceOffering?.name} />
+          <DetailRow label="Configuration Item" value={incident.configurationItem?.name} />
+          <DetailRow label="Assignment Group" value={incident.assignmentGroup?.name} />
+          <DetailRow label="Assigned To" value={incident.assignedTo?.name} />
+          <DetailRow label="Opened" value={incident.openedOn ? formatDate(incident.openedOn) : undefined} />
+          <DetailRow label="Created By" value={incident.createdBy} />
+          <DetailRow label="Created On" value={incident.createdOn ? formatDate(incident.createdOn) : undefined} />
+          <DetailRow label="Updated On" value={incident.updatedOn ? formatDate(incident.updatedOn) : undefined} />
+        </Stack>
+      </SectionCard>
+
+      {hasLinks && (
+        <SectionCard title="Linked records">
+          <Stack gap={1}>
+            <DetailRow label="Change Request" value={incident.changeRequest?.name} />
+            <DetailRow label="Problem" value={incident.problem?.name} />
+            {/* "Caused by" has no confirmed target record type (could be a change request, a
+                problem, or something else), same caveat the webapp's own detail page notes — left
+                as plain text rather than guessing a route. */}
+            <DetailRow label="Caused By" value={incident.causedBy?.name} />
+          </Stack>
+        </SectionCard>
+      )}
+
+      {hasNotes && (
+        <SectionCard title="Comments & notes">
+          <Stack gap={1.5}>
+            <TextBlock label="Additional comments (customer-visible)" value={incident.additionalComments} />
+            <TextBlock label="Internal work notes" value={incident.workNotes} />
+          </Stack>
+        </SectionCard>
+      )}
+
+      {incident.watchList.length > 0 && (
+        <SectionCard title="Watch list">
+          <Stack direction="row" gap={1} flexWrap="wrap">
+            {incident.watchList.map((w) => (
+              <Chip key={w.id} size="small" variant="outlined" label={w.name || w.email} />
+            ))}
+          </Stack>
+        </SectionCard>
+      )}
+
+      {incident.linkedServiceRequests.length > 0 && <LinkedServiceRequests items={incident.linkedServiceRequests} />}
+
+      <SectionCard title="Comments">
+        <IncidentCommentsSection incidentId={id} />
+      </SectionCard>
+    </>
+  );
+}
+
+function LinkedServiceRequests({ items }: { items: { id: string; number: string; name: string }[] }) {
+  const navigate = useNavigate();
+
+  return (
+    <SectionCard title="Linked service requests">
+      <Stack direction="row" gap={1} flexWrap="wrap">
+        {items.map((sr) => (
+          <Chip
+            key={sr.id}
+            size="small"
+            variant="outlined"
+            clickable
+            label={`${sr.number} — ${sr.name}`}
+            onClick={() => navigate(`/cases/${sr.id}`)}
+            sx={{ fontWeight: 600 }}
+          />
+        ))}
+      </Stack>
+    </SectionCard>
+  );
+}
+
+// Own Suspense/error boundary, mirroring CaseActivityFeed.tsx's own CaseActivitiesTab: comments
+// load independently of the rest of the detail page instead of blocking it.
+function IncidentCommentsSection({ incidentId }: { incidentId: string }) {
+  return (
+    <IncidentCommentsErrorBoundary>
+      <Suspense fallback={<Skeleton variant="rounded" height={56} />}>
+        <IncidentCommentsContent incidentId={incidentId} />
+      </Suspense>
+    </IncidentCommentsErrorBoundary>
+  );
+}
+
+function IncidentCommentsContent({ incidentId }: { incidentId: string }) {
+  const { data: comments } = useSuspenseQuery(incidents.comments(incidentId));
+  return <CaseActivityFeed comments={comments} audit={[]} attachments={[]} />;
+}
+
+function IncidentCommentsErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+
+  return (
+    <Stack direction="row" justifyContent="space-between" gap={2}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.primary" textAlign="right">
+        {value}
+      </Typography>
+    </Stack>
+  );
+}
+
+function TextBlock({ label, value }: { label: string; value?: string | null }) {
+  if (!value || value.trim().length === 0) return null;
+
+  return (
+    <Stack gap={0.25}>
+      <Typography variant="subtitle2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.primary" sx={{ whiteSpace: "pre-wrap" }}>
+        {value}
+      </Typography>
+    </Stack>
+  );
+}
+
+function IncidentDetailSkeleton() {
+  return (
+    <Stack gap={2}>
+      <Skeleton variant="text" width="40%" height={24} />
+      <Skeleton variant="text" width="80%" height={32} />
+      <Skeleton variant="rounded" height={200} />
+      <Skeleton variant="rounded" height={120} />
+    </Stack>
+  );
+}
+
+function IncidentDetailErrorBoundary({ children }: { children: ReactNode }) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      fallback={(_error, resetErrorBoundary) => (
+        <ErrorState
+          onRetry={() => {
+            reset();
+            resetErrorBoundary();
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
@@ -16,9 +16,9 @@
 
 import { useState } from "react";
 import { Stack, Tab, Tabs } from "@wso2/oxygen-ui";
-import { ComingSoonPage } from "@components/common/ComingSoonPage";
 import { ServiceRequestsTab } from "@components/operations/ServiceRequestsTab";
 import { ChangeRequestsTab } from "@components/operations/ChangeRequestsTab";
+import { IncidentsTab } from "@components/operations/IncidentsTab";
 
 type OperationsTabId = "service_requests" | "change_requests" | "incidents";
 
@@ -30,11 +30,13 @@ const TABS: { id: OperationsTabId; label: string }[] = [
 
 // Mirrors the webapp's OperationsPage (apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx):
 // three tabs — Service requests (cases with type=service_request, reusing the Support page's own
-// list/pagination/filter infra), Change requests (its own list/detail/edit, with its own "Create
-// change request" Fab — see ChangeRequestsTab.tsx), and Incidents (no backend endpoint exists yet,
-// in this repo or the webapp's — kept as a placeholder like the webapp's own
-// IssuesListUnavailable). "Create service request" is deliberately out of scope for this pass —
-// it's its own large form (cascading project/deployment/catalog selects with dynamic variables).
+// list/pagination/filter infra, with its own "Create service request" Fab — see
+// ServiceRequestsTab.tsx), Change requests (its own list/detail/edit, with its own "Create change
+// request" Fab — see ChangeRequestsTab.tsx), and Incidents (list + read-only detail with comments
+// — see IncidentsTab.tsx/IncidentDetailPage.tsx). "Create incident" is deliberately out of scope
+// for this pass — it's its own form with an impact×urgency priority matrix and 34 ServiceNow
+// subcategories; incidents' Edit dialog (state transitions, watch list management) is similarly
+// out of scope.
 export default function OperationsPage() {
   const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
 
@@ -48,13 +50,7 @@ export default function OperationsPage() {
 
       {activeTab === "service_requests" && <ServiceRequestsTab />}
       {activeTab === "change_requests" && <ChangeRequestsTab />}
-      {activeTab === "incidents" && (
-        <ComingSoonPage
-          title="Incidents"
-          description="Incident tracking is still under construction."
-          showTitle={false}
-        />
-      )}
+      {activeTab === "incidents" && <IncidentsTab />}
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/services/incidents.ts
+++ b/apps/csm-portal/microapp/src/services/incidents.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { INCIDENTS_SEARCH_ENDPOINT, INCIDENT_COMMENTS_SEARCH_ENDPOINT, INCIDENT_ENDPOINT } from "@config/endpoints";
+import type {
+  CaseCommentSearchResponseDto,
+  IncidentDetailDto,
+  IncidentSearchPayloadDto,
+  IncidentSearchResponseDto,
+} from "@src/types";
+import { toComment, toIncidentDetail, toIncidentSummary, type Comment, type IncidentSummary } from "@src/types";
+import apiClient from "./apiClient";
+
+export interface IncidentSearchResult {
+  items: IncidentSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+const searchIncidents = async (payload: IncidentSearchPayloadDto = {}): Promise<IncidentSearchResult> => {
+  const { data } = await apiClient.post<IncidentSearchResponseDto>(INCIDENTS_SEARCH_ENDPOINT, payload);
+  const items = data.incidents.map(toIncidentSummary);
+  // The search response has no `hasMore` field (unlike /cases/search) — derive it from
+  // offset/total, same defensive pattern as changeRequests.ts's searchChangeRequests.
+  return {
+    items,
+    total: data.total,
+    limit: data.limit,
+    offset: data.offset,
+    hasMore: items.length > 0 && data.offset + items.length < data.total,
+  };
+};
+
+const getIncident = async (id: string) => {
+  const { data } = await apiClient.get<IncidentDetailDto>(INCIDENT_ENDPOINT(id));
+  return toIncidentDetail(data);
+};
+
+// Matches cases.ts's COMMENTS_PAGE_LIMIT — the live entity service rejects the openapi-declared
+// 100 max with a 400. Reuses the exact same CaseCommentSearchResponseDto/toComment shape as case
+// comments: incidents' `/comments/search` endpoint returns the identical generic comment record,
+// just under a different reference path.
+const COMMENTS_PAGE_LIMIT = 50;
+
+const getIncidentComments = async (id: string): Promise<Comment[]> => {
+  const { data } = await apiClient.post<CaseCommentSearchResponseDto>(INCIDENT_COMMENTS_SEARCH_ENDPOINT(id), {
+    pagination: { limit: COMMENTS_PAGE_LIMIT },
+  });
+  return data.comments.map(toComment);
+};
+
+const INCIDENT_PAGE_LIMIT = 20;
+
+export const incidents = {
+  infinite: (payload: Omit<IncidentSearchPayloadDto, "pagination"> = {}) =>
+    infiniteQueryOptions({
+      queryKey: ["incidents", "infinite", payload],
+      queryFn: ({ pageParam }) =>
+        searchIncidents({ ...payload, pagination: { offset: pageParam, limit: INCIDENT_PAGE_LIMIT } }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
+    }),
+
+  get: (id: string) =>
+    queryOptions({
+      queryKey: ["incident", id],
+      queryFn: () => getIncident(id),
+    }),
+
+  comments: (id: string) =>
+    queryOptions({
+      queryKey: ["incident", id, "comments"],
+      queryFn: () => getIncidentComments(id),
+    }),
+};

--- a/apps/csm-portal/microapp/src/types/incident.dto.ts
+++ b/apps/csm-portal/microapp/src/types/incident.dto.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Incidents (ServiceNow data source only). Mirrors the webapp's BeIncident/BeIncidentDetail
+// (api/backend/types.ts). Unlike change requests, every enum here is UPPER_SNAKE_CASE on the wire.
+// Read-only in this app for now (no create/edit) — see IncidentsTab.tsx/IncidentDetailPage.tsx.
+
+import type { EntityRefDto } from "./case.dto";
+
+export type IncidentPriority = "CRITICAL" | "HIGH" | "MODERATE" | "LOW" | "PLANNING";
+
+export type IncidentState = "NEW" | "IN_PROGRESS" | "ON_HOLD" | "RESOLVED" | "CLOSED" | "CANCELLED";
+
+/** List-item shape for an incident (`POST /incidents/search`). */
+export interface IncidentSearchViewDto {
+  id: string | null;
+  number: string | null;
+  openedOn: string | null;
+  subject: string | null;
+  caller?: EntityRefDto | null;
+  priority: IncidentPriority | null;
+  state: IncidentState | null;
+  category: string | null;
+  parent?: EntityRefDto | null;
+  assignmentGroup?: EntityRefDto | null;
+  assignedTo?: EntityRefDto | null;
+  createdOn?: string;
+  createdBy?: string;
+  updatedOn?: string;
+  updatedBy?: string;
+}
+
+export interface IncidentWatchListItemDto {
+  id: string;
+  name: string;
+  email: string;
+}
+
+/** Service-request case linked to this incident (its `parent` case). */
+export interface LinkedServiceRequestRefDto {
+  id: string;
+  number: string;
+  name: string;
+}
+
+/**
+ * `GET /incidents/{id}` — the search view plus the fields only the detail endpoint returns.
+ * `category`/`subcategory`/`contactType`/`impact`/`urgency` are ServiceNow free-form/enum values
+ * rendered as plain text (no label map) — same as the webapp's own detail page.
+ */
+export interface IncidentDetailDto extends IncidentSearchViewDto {
+  subcategory?: string | null;
+  service?: EntityRefDto | null;
+  serviceOffering?: EntityRefDto | null;
+  configurationItem?: EntityRefDto | null;
+  contactType?: string | null;
+  impact?: string | null;
+  urgency?: string | null;
+  changeRequest?: EntityRefDto | null;
+  problem?: EntityRefDto | null;
+  causedBy?: EntityRefDto | null;
+  additionalComments?: string | null;
+  workNotes?: string | null;
+  watchList?: IncidentWatchListItemDto[];
+  linkedServiceRequests?: LinkedServiceRequestRefDto[] | null;
+}
+
+export interface IncidentSearchPayloadDto {
+  filters?: {
+    searchQuery?: string;
+    priorities?: IncidentPriority[];
+  };
+  sortBy?: {
+    field?: "createdOn" | "updatedOn" | "openedOn";
+    order?: "asc" | "desc";
+  };
+  pagination?: {
+    offset?: number;
+    limit?: number;
+  };
+}
+
+export interface IncidentSearchResponseDto {
+  incidents: IncidentSearchViewDto[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/csm-portal/microapp/src/types/incident.model.ts
+++ b/apps/csm-portal/microapp/src/types/incident.model.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { EntityRefDto } from "./case.dto";
+import type {
+  IncidentDetailDto,
+  IncidentPriority,
+  IncidentSearchViewDto,
+  IncidentState,
+  IncidentWatchListItemDto,
+  LinkedServiceRequestRefDto,
+} from "./incident.dto";
+import { parseOptionalBackendTimestamp } from "@utils/dateTime";
+
+export interface IncidentSummary {
+  id: string | null;
+  number: string;
+  subject: string;
+  openedOn: Date | null;
+  caller: EntityRefDto | null;
+  priority: IncidentPriority | null;
+  state: IncidentState | null;
+  category: string | null;
+  assignmentGroup: EntityRefDto | null;
+  assignedTo: EntityRefDto | null;
+  createdOn: Date | null;
+  updatedOn: Date | null;
+}
+
+export interface IncidentDetail extends IncidentSummary {
+  subcategory: string | null;
+  service: EntityRefDto | null;
+  serviceOffering: EntityRefDto | null;
+  configurationItem: EntityRefDto | null;
+  contactType: string | null;
+  impact: string | null;
+  urgency: string | null;
+  changeRequest: EntityRefDto | null;
+  problem: EntityRefDto | null;
+  causedBy: EntityRefDto | null;
+  createdBy: string | null;
+  additionalComments: string | null;
+  workNotes: string | null;
+  watchList: IncidentWatchListItemDto[];
+  linkedServiceRequests: LinkedServiceRequestRefDto[];
+}
+
+export function toIncidentSummary(dto: IncidentSearchViewDto): IncidentSummary {
+  return {
+    id: dto.id,
+    number: dto.number ?? "—",
+    subject: dto.subject ?? "(No subject)",
+    openedOn: parseOptionalBackendTimestamp(dto.openedOn),
+    caller: dto.caller ?? null,
+    priority: dto.priority,
+    state: dto.state,
+    category: dto.category,
+    assignmentGroup: dto.assignmentGroup ?? null,
+    assignedTo: dto.assignedTo ?? null,
+    createdOn: parseOptionalBackendTimestamp(dto.createdOn),
+    updatedOn: parseOptionalBackendTimestamp(dto.updatedOn),
+  };
+}
+
+export function toIncidentDetail(dto: IncidentDetailDto): IncidentDetail {
+  return {
+    ...toIncidentSummary(dto),
+    subcategory: dto.subcategory ?? null,
+    service: dto.service ?? null,
+    serviceOffering: dto.serviceOffering ?? null,
+    configurationItem: dto.configurationItem ?? null,
+    contactType: dto.contactType ?? null,
+    impact: dto.impact ?? null,
+    urgency: dto.urgency ?? null,
+    changeRequest: dto.changeRequest ?? null,
+    problem: dto.problem ?? null,
+    causedBy: dto.causedBy ?? null,
+    createdBy: dto.createdBy ?? null,
+    additionalComments: dto.additionalComments ?? null,
+    workNotes: dto.workNotes ?? null,
+    watchList: dto.watchList ?? [],
+    linkedServiceRequests: dto.linkedServiceRequests ?? [],
+  };
+}

--- a/apps/csm-portal/microapp/src/types/index.ts
+++ b/apps/csm-portal/microapp/src/types/index.ts
@@ -40,6 +40,8 @@ export * from "./timecard.model";
 export * from "./changeRequest.dto";
 export * from "./changeRequest.model";
 export * from "./changeRequestLookup.dto";
+export * from "./incident.dto";
+export * from "./incident.model";
 export * from "./updates.dto";
 export * from "./updates.model";
 export * from "./vulnerability.dto";


### PR DESCRIPTION
## Summary

Reconciliation PR against `main` for the Incidents feature (originally #1258, merged into `dev-app-csm-portal`).

**Context**: `dev-app-csm-portal` and `main` diverged — PR #1244 (create change request) ended up merged directly into `main`, while PR #1258 (this Incidents work) merged into `dev-app-csm-portal`. So `main` currently has service-request + change-request but not Incidents, and `dev-app-csm-portal` has service-request + Incidents but not change-request. Per @sajith (mentor), opening this fresh against `main` to reconcile.

This branch is the same 5 Incidents commits from #1258, cherry-picked cleanly onto current `main` (conflicts in `config/endpoints.ts`, `types/index.ts`, and `pages/OperationsPage.tsx` — all additive/comment-only — resolved so both change-request's and Incidents' additions coexist). No functional changes beyond what #1258 already had.

Adds a list + read-only detail view for Incidents to the CSM Portal microapp, replacing the "under construction" placeholder on the Operations page's Incidents tab. Ports the webapp's `IncidentsTab`/`CsmIncidentDetailPage`, scoped down per discussion (see Scope below).

- **List** (`IncidentsTab.tsx`): search + a priority filter sheet (the only filter dimension the backend's `IncidentSearchPayload.filters` actually supports for incidents) + infinite-scroll card list, mirroring `ChangeRequestsTab.tsx`'s own shape.
- **Detail** (`IncidentDetailPage.tsx`, read-only): Overview (caller, category/subcategory, contact type, impact/urgency, service/service offering/configuration item, assignment group/assigned to, dates), Linked records (change request/problem/caused by, shown only when present), Comments & notes (additional comments / internal work notes), Watch list, Linked service requests (tappable → jumps to the case), and a Comments feed reusing the existing `CaseActivityFeed` component.
- New supporting infra, none of which existed in the microapp before:
  - `types/incident.dto.ts` / `incident.model.ts` — ports the webapp's `BeIncident`/`BeIncidentDetail` shapes
  - `services/incidents.ts` — search/get/comments (comments reuse the same generic comment DTO/mapper as case comments, just pointed at `/incidents/{id}/comments`)
  - `components/operations/incidentConfig.ts` — state/priority labels + colors + filters, a direct port of the webapp's `utils/incidents.ts`
  - `components/operations/IncidentCard.tsx`, `IncidentsFiltersSheet.tsx`

## Scope

Discussed and deliberately trimmed given the webapp's Incidents feature is ~2,700 lines (list, detail, a 602-line create form with an impact×urgency priority matrix and 34 ServiceNow subcategories, and a 577-line Edit dialog):
- **In scope**: list + read-only detail with comments.
- **Out of scope for this pass**: create, the Edit dialog (state transitions, watch-list management), and attachments.

## Test plan

- [x] `tsc -b` passes with no errors on top of current `main`
- [x] `eslint`/`prettier` pass on all new/changed files
- [x] Verified in a headless browser: the Incidents tab renders, and the detail route renders without crashing
- [x] Diffed against `main` — the 12 changed files are exactly the Incidents feature, nothing else pulled in
- [ ] Manual end-to-end verification inside the native app shell — not possible from this environment, since the app requires the WSO2 native device-auth bridge to obtain a token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Incidents tab with searchable, filterable, infinitely scrolling incident lists.
  * Added incident cards displaying status, priority, caller, and update details.
  * Added read-only incident detail pages with overview information, linked records, watch lists, service requests, and comments.
  * Added priority filtering with active-filter indicators and clear/apply actions.
  * Added loading placeholders, empty states, and retryable error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->