### PR TITLE
Give attachment uploads their own size cap instead of the generic 1 MiB default

### DIFF
--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -28,6 +28,13 @@ import (
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
 )
 
+// maxAttachmentBodySize caps the CreateCaseAttachment JSON body at 15 MiB,
+// matching the csm-portal backend's own maxAttachmentBodyBytes ceiling: a 10
+// MB file becomes ~13.3 MB once base64-encoded, plus JSON envelope overhead.
+// The generic maxRequestBodySize (1 MiB) is far too small for this endpoint
+// and rejects legitimate small attachments (e.g. a 2 MB file).
+const maxAttachmentBodySize = int64(15 << 20)
+
 // safeAttachmentTypes is the allowlist of Content-Type values that may be
 // forwarded as-is. Anything not in this set is coerced to application/octet-stream
 // to prevent a stored-XSS attack via a crafted upstream Content-Type (e.g. text/html).
@@ -170,7 +177,7 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 // CreateCaseAttachment handles POST /attachments.
 func (h *CaseHandler) CreateCaseAttachment(w http.ResponseWriter, r *http.Request) {
 	var req domain.CreateAttachmentRequest
-	if !decodeRequest(w, r, &req) {
+	if !decodeRequestWithLimit(w, r, &req, maxAttachmentBodySize, "attachment exceeds the maximum allowed size of 10 MB") {
 		return
 	}
 	resp, err := h.svc.CreateCaseAttachment(r.Context(), req)

--- a/entity-service/internal/handler/case_handler_test.go
+++ b/entity-service/internal/handler/case_handler_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// stubCaseService embeds the service.CaseService interface so tests only need
+// to implement the method(s) under test; any call to an unimplemented method
+// panics on the nil embedded interface, which is fine since these tests never
+// reach them.
+type stubCaseService struct {
+	service.CaseService
+	createAttachmentCalled bool
+	createAttachmentResp   domain.CreateAttachmentResponse
+	createAttachmentErr    error
+}
+
+func (s *stubCaseService) CreateCaseAttachment(_ context.Context, _ domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
+	s.createAttachmentCalled = true
+	return s.createAttachmentResp, s.createAttachmentErr
+}
+
+// attachmentRequestBody builds a valid CreateAttachmentRequest JSON body whose
+// base64 "file" field is padded to approximately targetBytes total size, so
+// tests can exercise the size cap without depending on a real file.
+func attachmentRequestBody(t *testing.T, targetBytes int) []byte {
+	t.Helper()
+	// Reserve room for the JSON envelope; pad only the base64 payload.
+	const envelopeOverhead = 512
+	payloadBytes := targetBytes - envelopeOverhead
+	if payloadBytes < 0 {
+		payloadBytes = 0
+	}
+	raw := make([]byte, payloadBytes)
+	encoded := base64.StdEncoding.EncodeToString(raw)
+
+	req := domain.CreateAttachmentRequest{
+		ReferenceID:   "11111111-1111-1111-1111-111111111111",
+		ReferenceType: domain.ReferenceTypeCase,
+		Name:          "test-file.bin",
+		Type:          "application/octet-stream",
+		File:          encoded,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	return body
+}
+
+// TestCreateCaseAttachment_UnderNewLimit_OverOldLimit verifies a body larger
+// than the old generic 1 MiB cap, but under the new 15 MiB attachment cap,
+// is no longer rejected at the decode stage (this is the QA regression: a
+// 2 MB attachment used to fail with "request body too large").
+func TestCreateCaseAttachment_UnderNewLimit_OverOldLimit(t *testing.T) {
+	body := attachmentRequestBody(t, 2<<20) // ~2 MiB, matches QA's repro size.
+	if int64(len(body)) <= maxRequestBodySize {
+		t.Fatalf("test body (%d bytes) must exceed the old 1 MiB limit (%d) to be meaningful", len(body), maxRequestBodySize)
+	}
+	if int64(len(body)) >= maxAttachmentBodySize {
+		t.Fatalf("test body (%d bytes) must stay under the new attachment limit (%d)", len(body), maxAttachmentBodySize)
+	}
+
+	stub := &stubCaseService{
+		createAttachmentResp: domain.CreateAttachmentResponse{Message: "created"},
+	}
+	h := NewCaseHandler(stub)
+
+	req := httptest.NewRequest(http.MethodPost, "/attachments", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+
+	h.CreateCaseAttachment(rec, req)
+
+	if !stub.createAttachmentCalled {
+		t.Fatalf("expected CreateCaseAttachment to reach the service layer, got status %d body %q", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 Created, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCreateCaseAttachment_OverNewLimit verifies a body over the new 15 MiB
+// attachment cap is still rejected, with the attachment-specific message.
+func TestCreateCaseAttachment_OverNewLimit(t *testing.T) {
+	body := attachmentRequestBody(t, 16<<20) // ~16 MiB, over the 15 MiB cap.
+
+	stub := &stubCaseService{}
+	h := NewCaseHandler(stub)
+
+	req := httptest.NewRequest(http.MethodPost, "/attachments", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+
+	h.CreateCaseAttachment(rec, req)
+
+	if stub.createAttachmentCalled {
+		t.Fatalf("expected the request to be rejected before reaching the service layer")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "attachment exceeds the maximum allowed size of 10 MB") {
+		t.Fatalf("expected the attachment-specific too-large message, got: %s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "request body too large") {
+		t.Fatalf("expected the generic message to be replaced by the attachment-specific one, got: %s", rec.Body.String())
+	}
+}

--- a/entity-service/internal/handler/decode.go
+++ b/entity-service/internal/handler/decode.go
@@ -38,11 +38,20 @@ var sanitizeLog = strings.NewReplacer("\n", `\n`, "\r", `\r`).Replace
 // rejection, a 1 MiB body cap, and no trailing data after the JSON object.
 // Returns false and writes the error response if decoding fails.
 func decodeRequest[T any](w http.ResponseWriter, r *http.Request, dst *T) bool {
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	return decodeRequestWithLimit(w, r, dst, maxRequestBodySize, "request body too large")
+}
+
+// decodeRequestWithLimit is the same as decodeRequest but allows the caller to
+// override the default 1 MiB body cap and the message returned when that cap
+// is exceeded. Use this for endpoints whose payload is legitimately larger
+// than the generic JSON body (e.g. base64-encoded file uploads) instead of
+// changing the default for every other endpoint.
+func decodeRequestWithLimit[T any](w http.ResponseWriter, r *http.Request, dst *T, limit int64, tooLargeMsg string) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(dst); err != nil {
-		apierror.WriteJSON(w, http.StatusBadRequest, decodeErrMsg(err))
+		apierror.WriteJSON(w, http.StatusBadRequest, decodeErrMsgWithLimit(err, tooLargeMsg))
 		return false
 	}
 	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
@@ -56,9 +65,17 @@ func decodeRequest[T any](w http.ResponseWriter, r *http.Request, dst *T) bool {
 // is safe to return to the caller. Infrastructure details (e.g. raw Go type
 // names) are replaced with user-friendly descriptions.
 func decodeErrMsg(err error) string {
+	return decodeErrMsgWithLimit(err, "request body too large")
+}
+
+// decodeErrMsgWithLimit behaves like decodeErrMsg but lets the caller supply
+// an endpoint-specific message for the body-too-large case, so a handler with
+// a raised size cap (see decodeRequestWithLimit) can tell the caller what the
+// actual limit is instead of the generic message.
+func decodeErrMsgWithLimit(err error, tooLargeMsg string) string {
 	var maxBytes *http.MaxBytesError
 	if errors.As(err, &maxBytes) {
-		return "request body too large"
+		return tooLargeMsg
 	}
 	var syntaxErr *json.SyntaxError
 	if errors.As(err, &syntaxErr) {


### PR DESCRIPTION
## Purpose
Attachment uploads fail with `400 "request body too large"` for any file over ~1 MiB, including small legitimate files well under every advertised limit (client-side check and downstream service cap both allow far larger uploads). Reported by QA on 2026-07-12 (2 MB attachment repro), retested and confirmed still broken on 2026-07-14.

Root cause: `CreateCaseAttachment` in `entity-service/internal/handler/case_handler.go` decoded its body through the generic `decodeRequest` helper, which applies a blanket 1 MiB cap (`maxRequestBodySize`) intended for small structured JSON payloads to every endpoint, including this one. The attachment payload is a base64-encoded file plus JSON envelope, which is legitimately much larger than 1 MiB for ordinary attachments.

## Goals
Give attachment uploads their own size cap, sized to actually accommodate the file sizes the rest of the stack already allows, without loosening the cap for any other endpoint.

## Approach
- Added `decodeRequestWithLimit`, a generic variant of the existing `decodeRequest` helper that accepts a caller-supplied byte limit and too-large message, instead of always applying the package-wide default.
- `CreateCaseAttachment` now calls `decodeRequestWithLimit` with a new `maxAttachmentBodySize` constant of 15 MiB, matching the size ceiling already used one layer up in the request path for this same payload (a 10 MB file becomes ~13.3 MB once base64-encoded, plus JSON envelope overhead, so 15 MiB is the intended safe ceiling for the encoded body).
- All other endpoints continue to use `decodeRequest` and the unchanged 1 MiB default — this is a scoped override for one handler, not a global change.
- The body-too-large error message for this endpoint now states the actual limit (10 MB, the underlying file-size ceiling) instead of the generic "request body too large" string, so any bypass of the client-side check surfaces something concrete.

## User stories
As a CS engineer, I can upload a legitimate attachment to a case (e.g. a 2 MB screenshot or log file) without it being rejected for being "too large" when it isn't.

## Release note
Fixed a bug where attaching a file over ~1 MiB to a case failed with a generic "request body too large" error, even for small files well under the platform's advertised upload limits.

## Documentation
N/A — internal API behavior fix, no user-facing documentation to update.

## Training
N/A — not training content.

## Certification
N/A — no certification impact.

## Marketing
N/A — bug fix, not a feature.

## Automation tests
- Unit tests
  - Added `entity-service/internal/handler/case_handler_test.go` covering `CreateCaseAttachment`:
    - a body over the old 1 MiB cap but under the new 15 MiB cap now reaches the service layer and returns 201 (previously rejected at decode).
    - a body over the new 15 MiB cap is still rejected, with the attachment-specific error message.
  - Full suite: `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Integration tests
  - None added; this is a handler-level fix isolated with a stub service implementation.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go component) — ran `go vet ./...` clean instead.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Local Go toolchain (go 1.26.3), macOS.

## Learning
N/A
