### PR TITLE
[Entity-Service] add SF ID to ServiceNow-backed account mapping

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -230,6 +230,7 @@ type SNAccountView struct {
 	Name             string     `json:"name"`
 	Classification   string     `json:"classification"`
 	Pod              *string    `json:"pod"`
+	SfID             *string    `json:"sfId"`
 	Region           *string    `json:"region"`
 	SupportTier      *string    `json:"supportTier"`
 	ArrToday         *string    `json:"arrToday"`
@@ -266,6 +267,7 @@ type SNAccountDetail struct {
 	Name             string            `json:"name"`
 	Classification   string            `json:"classification"`
 	Pod              *string           `json:"pod"`
+	SfID             *string           `json:"sfId"`
 	Region           *string           `json:"region"`
 	SupportTier      *SNSupportTierRef `json:"supportTier"`
 	ArrToday         *string           `json:"arrToday"`

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -50,6 +50,7 @@ type snAccount struct {
 	SupportTier      *snSupportTier `json:"supportTier"`
 	Classification   string         `json:"classification"`
 	Pod              *string        `json:"pod"`
+	SfID             *string        `json:"sfId"`
 	Region           *string        `json:"region"`
 	ArrToday         *string        `json:"arrToday"`
 	ActivationDate   string         `json:"activationDate"`
@@ -180,6 +181,7 @@ func snAccountToDomain(a snAccount) domain.SNAccountView {
 		Name:             a.Name,
 		Classification:   a.Classification,
 		Pod:              nilIfEmpty(a.Pod),
+		SfID:             nilIfEmpty(a.SfID),
 		Region:           nilIfEmpty(a.Region),
 		SupportTier:      supportTier,
 		ArrToday:         nilIfEmpty(a.ArrToday),
@@ -211,6 +213,7 @@ func snAccountToDetail(a snAccount) domain.SNAccountDetail {
 		Name:             a.Name,
 		Classification:   a.Classification,
 		Pod:              nilIfEmpty(a.Pod),
+		SfID:             nilIfEmpty(a.SfID),
 		Region:           nilIfEmpty(a.Region),
 		SupportTier:      supportTier,
 		ArrToday:         nilIfEmpty(a.ArrToday),

--- a/entity-service/internal/service/sn_account_service_test.go
+++ b/entity-service/internal/service/sn_account_service_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"net/http"
+	"testing"
+)
+
+// snAccountJSON is a minimal ServiceNow account payload, with placeholders for
+// the id and sfId under test.
+func snAccountJSON(id, sfID string) string {
+	body := `{
+		"id": "` + id + `",
+		"name": "Acme",
+		"classification": "enterprise",
+		"pod": "US - WEST",
+		"activationDate": "2026-01-01 00:00:00",
+		"hasAgent": false,
+		"hasKbReferences": false,
+		"createdOn": "2026-01-01 00:00:00",
+		"updatedOn": "2026-01-01 00:00:00"`
+	if sfID != "" {
+		body += `, "sfId": "` + sfID + `"`
+	}
+	body += `}`
+	return body
+}
+
+// TestSNAccountService_GetAccountByID_SfIDRoundTrips verifies that the SF ID
+// ServiceNow's AccountUtils now emits (u_account_id, surfaced as sfId) survives
+// the SN JSON -> domain.SNAccountDetail conversion in GetAccountByID.
+func TestSNAccountService_GetAccountByID_SfIDRoundTrips(t *testing.T) {
+	const wantSfID = "001E2000014mQ2hIAE"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/"+testAccountSysid, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(snAccountJSON(testAccountSysid, wantSfID)))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowAccountService(client)
+
+	got, err := svc.GetAccountByID(contextWithUserIDToken("token"), sysidToUUID(testAccountSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.SfID == nil || *got.SfID != wantSfID {
+		t.Fatalf("SfID = %v, want %q", got.SfID, wantSfID)
+	}
+}
+
+// TestSNAccountService_GetAccountByID_SfIDAbsent verifies that an account with
+// no linked Salesforce ID surfaces a nil SfID rather than an empty string, so
+// FE consumers can distinguish "not linked" from "linked, empty" the same way
+// they already do for pod/region.
+func TestSNAccountService_GetAccountByID_SfIDAbsent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/"+testAccountSysid, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(snAccountJSON(testAccountSysid, "")))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowAccountService(client)
+
+	got, err := svc.GetAccountByID(contextWithUserIDToken("token"), sysidToUUID(testAccountSysid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.SfID != nil {
+		t.Fatalf("SfID = %v, want nil", *got.SfID)
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2852,6 +2852,10 @@ components:
         pod:
           type: string
           nullable: true
+        sfId:
+          type: string
+          nullable: true
+          description: Salesforce account ID linked to this account, if any.
         region:
           type: string
           nullable: true
@@ -2909,6 +2913,10 @@ components:
         pod:
           type: string
           nullable: true
+        sfId:
+          type: string
+          nullable: true
+          description: Salesforce account ID linked to this account, if any.
         region:
           type: string
           nullable: true


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The CSM portal's Account pages show a blank SF ID even though the backing
data source already provides it and it is well populated (a large majority
of sampled accounts carry a real value). The gap was upstream of this
service: the backing data source's account-summary mapping never forwarded
that field at all, so this service's account types had nothing to carry it
even though the shape supports it.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Add the field the backing data source now provides so it flows through
`GET /accounts/{id}` and `POST /accounts/search` to CSM portal consumers.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `internal/service/sn_account_service.go`: added `SfID *string \`json:"sfId"\`` to
  the `snAccount` wire struct (matching the existing `pod`/`region` nullable-pointer
  convention), wired into both `snAccountToDomain` and `snAccountToDetail` via the
  existing `nilIfEmpty` helper.
- `internal/domain/entity.go`: added `SfID *string \`json:"sfId"\`` to
  `SNAccountView` and `SNAccountDetail`, next to `Pod`, mirroring the naming
  convention of the existing Postgres-path `Account.SfID string \`json:"sfId"\`` field
  (nullable here since it's sourced from the backing data source rather than
  Postgres).
- `openapi.yaml`: documented `sfId` on both `SNAccountView` and `SNAccountDetail`.

No handler/repository changes were needed — both mapping functions already
pass every other pointer field straight through the same way.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I want to see an account's SF ID on its detail/search
views so I can cross-reference it against Salesforce.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Account detail and search responses now include `sfId` when the backing data
source has a linked Salesforce ID for the account.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal API field addition documented inline in `openapi.yaml`.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal API field addition, not user-facing marketing content.

## Automation tests
 - Unit tests
   > Added `internal/service/sn_account_service_test.go`: asserts `sfId` round-trips
   from the backing data source's JSON response into `SNAccountDetail` via
   `GetAccountByID` (both when present and when absent, confirming `nil` rather
   than an empty string). `go build ./...`, `go vet ./...`, and `go test ./...`
   all pass in `entity-service/`.
 - Integration tests
   > None added; covered by the unit test above plus manual verification against
   the backing data source directly (upstream change).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go codebase; `go vet ./...` ran clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code affected.

## Related PRs
A corresponding Ballerina entity-service change (private repo) adds the
matching field upstream so it reaches this service's account responses.

## Migrations (if applicable)
N/A — no data migration required.

## Test environment
Go 1.x (per `go.mod`), macOS, local `go test` run.

## Learning
N/A.