### PR TITLE
[Customer Portal][Webapp]Restrict case de-escalation eligibility at EL4/EL5

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -42,6 +42,7 @@ import {
 } from "@features/support/utils/support";
 import {
   CALL_SCHEDULABLE_CASE_STATUSES,
+  ESCALATION_DEESCALATE_ADMIN_LEAD_ONLY_LEVELS,
   type CaseStatus,
 } from "@features/support/constants/supportConstants";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
@@ -212,9 +213,9 @@ export default function CaseDetailsContent({
         )?.isLead
       : undefined;
 
-  // De-escalation is allowed for customer admins, leads, and users who created
-  // at least one escalation on this case (matched by email against the
-  // escalation history's createdBy).
+  // De-escalation is allowed at any level (EL1-EL5). At EL4/EL5, only customer
+  // admins and project leads are eligible. At EL1-EL3, users who created an
+  // escalation on this case are also eligible, in addition to admins/leads.
   const isCurrentUserCsAdmin: boolean | undefined = isUserDetailsLoading
     ? undefined
     : (userDetails?.roles ?? []).includes(SETTINGS_CUSTOMER_ADMIN_ROLE);
@@ -226,7 +227,8 @@ export default function CaseDetailsContent({
   const canDeescalate =
     isCurrentUserCsAdmin === true ||
     isCurrentUserLead === true ||
-    hasCreatedEscalation;
+    (!ESCALATION_DEESCALATE_ADMIN_LEAD_ONLY_LEVELS.has(escalationLevelId) &&
+      hasCreatedEscalation);
 
   const visibleTabs = useMemo(
     () => [

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/details-tab/CaseDetailsContent.tsx
@@ -42,7 +42,7 @@ import {
 } from "@features/support/utils/support";
 import {
   CALL_SCHEDULABLE_CASE_STATUSES,
-  ESCALATION_DEESCALATE_ADMIN_LEAD_ONLY_LEVELS,
+  ESCALATION_DEESCALATE_CREATOR_ELIGIBLE_LEVELS,
   type CaseStatus,
 } from "@features/support/constants/supportConstants";
 import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
@@ -227,7 +227,7 @@ export default function CaseDetailsContent({
   const canDeescalate =
     isCurrentUserCsAdmin === true ||
     isCurrentUserLead === true ||
-    (!ESCALATION_DEESCALATE_ADMIN_LEAD_ONLY_LEVELS.has(escalationLevelId) &&
+    (ESCALATION_DEESCALATE_CREATOR_ELIGIBLE_LEVELS.has(escalationLevelId) &&
       hasCreatedEscalation);
 
   const visibleTabs = useMemo(

--- a/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-details/header/CaseDetailsActionRow.tsx
@@ -52,7 +52,7 @@ import { TriangleAlert } from "@wso2/oxygen-ui-icons-react";
 
 const ACTION_BUTTON_ICON_SIZE = 12;
 const DEESCALATE_PERMISSION_TOOLTIP =
-  "Only customer admins, project leads, or the user who created an escalation on this case can de-escalate it.";
+  "Only customer admins, project leads, or (at escalation level 1-3) the user who created the escalation can de-escalate this case.";
 
 function getActionButtonSx(
   theme: Theme,

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -337,6 +337,10 @@ export const ESCALATION_MAX_LEVEL_ID = "5";
 // Escalation levels that require the user to have isLead: true (EL3→EL4 and EL4→EL5).
 export const ESCALATION_LEAD_REQUIRED_FROM_LEVEL = new Set(["3", "4"]);
 
+// At these escalation levels, only customer admins and project leads may
+// de-escalate — the user who created the escalation is not eligible.
+export const ESCALATION_DEESCALATE_ADMIN_LEAD_ONLY_LEVELS = new Set(["4", "5"]);
+
 export const ESCALATION_NEXT_LEVEL: Record<
   string,
   { nextId: string; nextLabel: string; notifiedLabel: string }

--- a/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/supportConstants.ts
@@ -337,9 +337,14 @@ export const ESCALATION_MAX_LEVEL_ID = "5";
 // Escalation levels that require the user to have isLead: true (EL3→EL4 and EL4→EL5).
 export const ESCALATION_LEAD_REQUIRED_FROM_LEVEL = new Set(["3", "4"]);
 
-// At these escalation levels, only customer admins and project leads may
-// de-escalate — the user who created the escalation is not eligible.
-export const ESCALATION_DEESCALATE_ADMIN_LEAD_ONLY_LEVELS = new Set(["4", "5"]);
+// Only at these escalation levels is the user who created the escalation
+// (in addition to customer admins and project leads) eligible to de-escalate.
+// Any other/unknown level (including EL4/EL5) fails closed to admins/leads only.
+export const ESCALATION_DEESCALATE_CREATOR_ELIGIBLE_LEVELS = new Set([
+  "1",
+  "2",
+  "3",
+]);
 
 export const ESCALATION_NEXT_LEVEL: Record<
   string,


### PR DESCRIPTION
## Summary
- At escalation level 4 or 5, only customer admins and project leads can de-escalate a case
- At EL1-EL3, the user who created the escalation remains eligible to de-escalate, alongside admins/leads
- Updated the de-escalate button's disabled tooltip to reflect the level-dependent eligibility rule

## Test plan
- [ ] As a non-admin/non-lead user who created an escalation, verify de-escalate is enabled at EL1-EL3
- [ ] As that same user, verify de-escalate is disabled (with updated tooltip) once the case is at EL4 or EL5
- [ ] As a customer admin or project lead, verify de-escalate is enabled at every level (EL1-EL5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated case de-escalation permissions to apply escalation-level rules consistently.
  * Escalation creators can de-escalate cases at levels 1–3.
  * At levels 4–5, only customer admins and project leads can de-escalate.
  * Updated permission guidance to clearly explain these restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->