### PR TITLE
[CSM Portal] case detail UX improvements, one-step linked SR creation, Set Fix ETA rework, project-scoped creation gating

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1993,56 +1993,13 @@ func TestRemoveCaseTag(t *testing.T) {
 	})
 }
 
-func TestPatchCaseFixEta(t *testing.T) {
-	// Item 3: fixEta is a pure pass-through single-field PATCH variant. It does not
-	// trip the state/workState peek, so patchCaseFn is invoked directly with the raw
-	// body and the upstream response passes through unchanged.
-	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"fixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","fixEta":"2026-08-01T00:00:00Z"}}`
-
-	var capturedBody []byte
-	client := &mockEntityCaseClient{
-		patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
-			capturedBody = body
-			return []byte(upstream), nil
-		},
-	}
-	h := NewCaseHandler(client)
-	r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(reqBody)))
-	r.SetPathValue("id", testCaseID)
-	w := httptest.NewRecorder()
-	h.PatchCase(w, r)
-
-	assertStatus(t, w, http.StatusOK)
-	assertContentType(t, w, "application/json")
-
-	if string(capturedBody) != reqBody {
-		t.Errorf("upstream received body %s, want %s (must forward verbatim)", capturedBody, reqBody)
-	}
-
-	var wrapper struct {
-		Case struct {
-			FixEta string `json:"fixEta"`
-		} `json:"case"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
-		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
-	}
-	if wrapper.Case.FixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.fixEta = %q, want %q", wrapper.Case.FixEta, "2026-08-01T00:00:00Z")
-	}
-}
-
-func TestGetCasePassesThroughFixEtaAndTags(t *testing.T) {
-	// Item 3 (read) + item 8 (read): fixEta and tags are additive entity-response
-	// fields with zero BFF handling — GetCase's injectNextStates merge must not drop
-	// or alter them.
+func TestGetCasePassesThroughTags(t *testing.T) {
+	// Item 8 (read): tags are an additive entity-response field with zero BFF
+	// handling — GetCase's injectNextStates merge must not drop or alter them.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
 	const upstreamBody = `{
 		"id":"` + testCaseID + `",
 		"state":"open",
-		"fixEta":"2026-08-01T00:00:00Z",
 		"tags":[{"id":"33333333-3333-3333-3333-333333333333","label":"micro-gw","color":"#FF6600"}]
 	}`
 	client := &mockEntityCaseClient{
@@ -2064,14 +2021,10 @@ func TestGetCasePassesThroughFixEtaAndTags(t *testing.T) {
 		Color *string `json:"color"`
 	}
 	type resp struct {
-		FixEta string `json:"fixEta"`
-		Tags   []tag  `json:"tags"`
+		Tags []tag `json:"tags"`
 	}
 	got := decodeJSON[resp](t, w)
 
-	if got.FixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("fixEta = %q, want 2026-08-01T00:00:00Z", got.FixEta)
-	}
 	if len(got.Tags) != 1 || got.Tags[0].Label != "micro-gw" || got.Tags[0].Color == nil || *got.Tags[0].Color != "#FF6600" {
 		t.Errorf("tags = %+v, want a single micro-gw/#FF6600 entry", got.Tags)
 	}
@@ -2105,8 +2058,8 @@ func TestPatchCaseBestCaseFixEta(t *testing.T) {
 	// patchCaseFn is invoked directly with the raw body and the upstream response
 	// passes through unchanged.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"bestCaseFixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","bestCaseFixEta":"2026-08-01T00:00:00Z"}}`
+	const reqBody = `{"bestCaseFixEta":"2026-08-01"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","bestCaseFixEta":"2026-08-01"}}`
 
 	var capturedBody []byte
 	client := &mockEntityCaseClient{
@@ -2136,8 +2089,8 @@ func TestPatchCaseBestCaseFixEta(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
 	}
-	if wrapper.Case.BestCaseFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.bestCaseFixEta = %q, want %q", wrapper.Case.BestCaseFixEta, "2026-08-01T00:00:00Z")
+	if wrapper.Case.BestCaseFixEta != "2026-08-01" {
+		t.Errorf("case.bestCaseFixEta = %q, want %q", wrapper.Case.BestCaseFixEta, "2026-08-01")
 	}
 }
 
@@ -2145,8 +2098,8 @@ func TestPatchCaseMostLikelyFixEta(t *testing.T) {
 	// mostLikelyFixEta is a pure pass-through single-field PATCH variant, same
 	// shape as the existing fixEta test.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"mostLikelyFixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","mostLikelyFixEta":"2026-08-01T00:00:00Z"}}`
+	const reqBody = `{"mostLikelyFixEta":"2026-08-01"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","mostLikelyFixEta":"2026-08-01"}}`
 
 	var capturedBody []byte
 	client := &mockEntityCaseClient{
@@ -2176,8 +2129,8 @@ func TestPatchCaseMostLikelyFixEta(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
 	}
-	if wrapper.Case.MostLikelyFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.mostLikelyFixEta = %q, want %q", wrapper.Case.MostLikelyFixEta, "2026-08-01T00:00:00Z")
+	if wrapper.Case.MostLikelyFixEta != "2026-08-01" {
+		t.Errorf("case.mostLikelyFixEta = %q, want %q", wrapper.Case.MostLikelyFixEta, "2026-08-01")
 	}
 }
 
@@ -2185,8 +2138,8 @@ func TestPatchCaseWorstCaseFixEta(t *testing.T) {
 	// worstCaseFixEta is a pure pass-through single-field PATCH variant, same
 	// shape as the existing fixEta test.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"worstCaseFixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","worstCaseFixEta":"2026-08-01T00:00:00Z"}}`
+	const reqBody = `{"worstCaseFixEta":"2026-08-01"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","worstCaseFixEta":"2026-08-01"}}`
 
 	var capturedBody []byte
 	client := &mockEntityCaseClient{
@@ -2216,8 +2169,8 @@ func TestPatchCaseWorstCaseFixEta(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
 	}
-	if wrapper.Case.WorstCaseFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.worstCaseFixEta = %q, want %q", wrapper.Case.WorstCaseFixEta, "2026-08-01T00:00:00Z")
+	if wrapper.Case.WorstCaseFixEta != "2026-08-01" {
+		t.Errorf("case.worstCaseFixEta = %q, want %q", wrapper.Case.WorstCaseFixEta, "2026-08-01")
 	}
 }
 
@@ -2229,9 +2182,9 @@ func TestGetCasePassesThroughNewFixEtaFields(t *testing.T) {
 	const upstreamBody = `{
 		"id":"` + testCaseID + `",
 		"state":"open",
-		"bestCaseFixEta":"2026-07-28T00:00:00Z",
-		"mostLikelyFixEta":"2026-08-01T00:00:00Z",
-		"worstCaseFixEta":"2026-08-15T00:00:00Z"
+		"bestCaseFixEta":"2026-07-28",
+		"mostLikelyFixEta":"2026-08-01",
+		"worstCaseFixEta":"2026-08-15"
 	}`
 	client := &mockEntityCaseClient{
 		getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
@@ -2253,21 +2206,21 @@ func TestGetCasePassesThroughNewFixEtaFields(t *testing.T) {
 	}
 	got := decodeJSON[resp](t, w)
 
-	if got.BestCaseFixEta != "2026-07-28T00:00:00Z" {
-		t.Errorf("bestCaseFixEta = %q, want 2026-07-28T00:00:00Z", got.BestCaseFixEta)
+	if got.BestCaseFixEta != "2026-07-28" {
+		t.Errorf("bestCaseFixEta = %q, want 2026-07-28", got.BestCaseFixEta)
 	}
-	if got.MostLikelyFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01T00:00:00Z", got.MostLikelyFixEta)
+	if got.MostLikelyFixEta != "2026-08-01" {
+		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01", got.MostLikelyFixEta)
 	}
-	if got.WorstCaseFixEta != "2026-08-15T00:00:00Z" {
-		t.Errorf("worstCaseFixEta = %q, want 2026-08-15T00:00:00Z", got.WorstCaseFixEta)
+	if got.WorstCaseFixEta != "2026-08-15" {
+		t.Errorf("worstCaseFixEta = %q, want 2026-08-15", got.WorstCaseFixEta)
 	}
 }
 
 func TestSearchCasesPassesThroughNewFixEtaFields(t *testing.T) {
 	// Item: the 3 new fix-ETA fields flow through SearchCases's response verbatim,
 	// same zero-BFF-handling pattern as fixEta/tags on GetCase.
-	const upstream = `{"cases":[{"id":"11111111-1111-1111-1111-111111111111","bestCaseFixEta":"2026-07-28T00:00:00Z","mostLikelyFixEta":"2026-08-01T00:00:00Z","worstCaseFixEta":"2026-08-15T00:00:00Z"}],"total":1}`
+	const upstream = `{"cases":[{"id":"11111111-1111-1111-1111-111111111111","bestCaseFixEta":"2026-07-28","mostLikelyFixEta":"2026-08-01","worstCaseFixEta":"2026-08-15"}],"total":1}`
 	client := &mockEntityCaseClient{
 		searchCasesFn: func(_ context.Context, _ []byte) ([]byte, error) {
 			return []byte(upstream), nil
@@ -2291,14 +2244,14 @@ func TestSearchCasesPassesThroughNewFixEtaFields(t *testing.T) {
 	if len(got.Cases) != 1 {
 		t.Fatalf("cases = %+v, want 1 entry", got.Cases)
 	}
-	if got.Cases[0].BestCaseFixEta != "2026-07-28T00:00:00Z" {
-		t.Errorf("bestCaseFixEta = %q, want 2026-07-28T00:00:00Z", got.Cases[0].BestCaseFixEta)
+	if got.Cases[0].BestCaseFixEta != "2026-07-28" {
+		t.Errorf("bestCaseFixEta = %q, want 2026-07-28", got.Cases[0].BestCaseFixEta)
 	}
-	if got.Cases[0].MostLikelyFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01T00:00:00Z", got.Cases[0].MostLikelyFixEta)
+	if got.Cases[0].MostLikelyFixEta != "2026-08-01" {
+		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01", got.Cases[0].MostLikelyFixEta)
 	}
-	if got.Cases[0].WorstCaseFixEta != "2026-08-15T00:00:00Z" {
-		t.Errorf("worstCaseFixEta = %q, want 2026-08-15T00:00:00Z", got.Cases[0].WorstCaseFixEta)
+	if got.Cases[0].WorstCaseFixEta != "2026-08-15" {
+		t.Errorf("worstCaseFixEta = %q, want 2026-08-15", got.Cases[0].WorstCaseFixEta)
 	}
 }
 

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -130,7 +130,7 @@ paths:
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
         `workState`, `watchList`, `assigneeEmail`, `parentId`, `subject`, `description`,
-        `deploymentId`, `deployedProductId`, `relatedCaseId`, `autocloseHoldUntil`, `fixEta`,
+        `deploymentId`, `deployedProductId`, `relatedCaseId`, `autocloseHoldUntil`,
         `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`.
         `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are supported only when
         the ServiceNow data source is active.
@@ -4419,7 +4419,7 @@ components:
       description: |
         Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`, `parentId`,
         `subject`, `description`, `deploymentId`, `deployedProductId`, `relatedCaseId`,
-        `autocloseHoldUntil`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`
+        `autocloseHoldUntil`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`
         must be provided. `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are
         supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional resolution fields that may only be
@@ -4437,7 +4437,6 @@ components:
         - required: [deployedProductId]
         - required: [relatedCaseId]
         - required: [autocloseHoldUntil]
-        - required: [fixEta]
         - required: [bestCaseFixEta]
         - required: [mostLikelyFixEta]
         - required: [worstCaseFixEta]
@@ -4515,27 +4514,24 @@ components:
             until this date, mirroring the real ServiceNow UX (an engineer picks a hold-until
             date). This is the only supported write against that sequence — the raw
             `autoclosureStep` state is not directly settable (ServiceNow only).
-        fixEta:
-          type: string
-          format: date-time
-          description: >
-            Sets the customer-facing fix-commitment date/time for the case. This is the only
-            fix-ETA field exposed by this API; internal-only estimates are not surfaced.
         bestCaseFixEta:
           type: string
-          format: date-time
-          nullable: true
-          description: Sets the best-case fix-commitment date/time estimate for the case.
+          format: date
+          description: >
+            Sets the internal-only best-case fix-commitment date estimate for the case
+            (date-only, YYYY-MM-DD). Never surfaced to the customer.
         mostLikelyFixEta:
           type: string
-          format: date-time
-          nullable: true
-          description: Sets the most-likely fix-commitment date/time estimate for the case.
+          format: date
+          description: >
+            Sets the internal-only most-likely fix-commitment date estimate for the case
+            (date-only, YYYY-MM-DD). Never surfaced to the customer.
         worstCaseFixEta:
           type: string
-          format: date-time
-          nullable: true
-          description: Sets the worst-case fix-commitment date/time estimate for the case.
+          format: date
+          description: >
+            Sets the internal-only worst-case fix-commitment date estimate for the case
+            (date-only, YYYY-MM-DD). Never surfaced to the customer.
 
     UpdateCaseResponse:
       type: object
@@ -4603,11 +4599,27 @@ components:
         parentCase:
           $ref: '#/components/schemas/CaseNumberRef'
           description: Present when the update set parentId, identifying the case, incident, change request, or problem this case is now linked to as its parent.
-        fixEta:
+        bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Echoes the updated customer-facing fix-commitment date/time. Present when the update set fixEta.
+          description: >-
+            Echoes the updated internal-only best-case fix-commitment date back (date-only,
+            YYYY-MM-DD). Present when the update set bestCaseFixEta.
+        mostLikelyFixEta:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Echoes the updated internal-only most-likely fix-commitment date back (date-only,
+            YYYY-MM-DD). Present when the update set mostLikelyFixEta.
+        worstCaseFixEta:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Echoes the updated internal-only worst-case fix-commitment date back (date-only,
+            YYYY-MM-DD). Present when the update set worstCaseFixEta.
 
     CaseResolutionCode:
       type: string
@@ -5261,28 +5273,27 @@ components:
           description: >-
             Service-request cases whose parent points to this case. Populated on every
             case detail response, not just high-severity cases.
-        fixEta:
-          type: string
-          format: date-time
-          nullable: true
-          description: >-
-            The single customer-facing fix-commitment date/time for the case. This is the
-            only fix-ETA field exposed by this API; internal-only estimates are not surfaced.
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Best-case fix-commitment date/time estimate for the case.
+          description: >-
+            Internal-only best-case fix-commitment date estimate for the case (date-only,
+            YYYY-MM-DD). Never surfaced to the customer.
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Most-likely fix-commitment date/time estimate for the case.
+          description: >-
+            Internal-only most-likely fix-commitment date estimate for the case (date-only,
+            YYYY-MM-DD). Never surfaced to the customer.
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Worst-case fix-commitment date/time estimate for the case.
+          description: >-
+            Internal-only worst-case fix-commitment date estimate for the case (date-only,
+            YYYY-MM-DD). Never surfaced to the customer.
         tags:
           type: array
           nullable: true

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -326,25 +326,21 @@ export interface BeCaseView {
    */
   autoclosureStateTime?: string | null;
   /**
-   * The customer-facing fix-commitment date/time for the case — the shared
-   * commitment shown to the customer. Settable via `PATCH /cases/{id}`
-   * (`fixEta`). Distinct from the three internal-only estimates below, which
-   * are never shared with the customer.
-   */
-  fixEta?: string | null;
-  /**
-   * Internal-only best-case fix estimate. Settable via `PATCH /cases/{id}`
-   * (`bestCaseFixEta`). Never surfaced to the customer.
+   * Internal-only best-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string. Settable via `PATCH /cases/{id}` (`bestCaseFixEta`). Never
+   * surfaced to the customer.
    */
   bestCaseFixEta?: string | null;
   /**
-   * Internal-only most-likely fix estimate. Settable via `PATCH /cases/{id}`
-   * (`mostLikelyFixEta`). Never surfaced to the customer.
+   * Internal-only most-likely fix estimate, as a date-only "YYYY-MM-DD"
+   * string. Settable via `PATCH /cases/{id}` (`mostLikelyFixEta`). Never
+   * surfaced to the customer.
    */
   mostLikelyFixEta?: string | null;
   /**
-   * Internal-only worst-case fix estimate. Settable via `PATCH /cases/{id}`
-   * (`worstCaseFixEta`). Never surfaced to the customer.
+   * Internal-only worst-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string. Settable via `PATCH /cases/{id}` (`worstCaseFixEta`). Never
+   * surfaced to the customer.
    */
   worstCaseFixEta?: string | null;
   /** Free-text labels attached to the case. Null/absent when none are set. */
@@ -541,7 +537,6 @@ interface BeCaseUpdateNever {
   deployedProductId?: never;
   relatedCaseId?: never;
   autocloseHoldUntil?: never;
-  fixEta?: never;
   bestCaseFixEta?: never;
   mostLikelyFixEta?: never;
   worstCaseFixEta?: never;
@@ -551,7 +546,7 @@ interface BeCaseUpdateNever {
  * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
  * **Exactly one** of `state` / `severity` / `workState` / `assigneeEmail` /
  * `watchList` / `parentId` / `subject` / `description` / `deploymentId` /
- * `deployedProductId` / `relatedCaseId` / `autocloseHoldUntil` / `fixEta` /
+ * `deployedProductId` / `relatedCaseId` / `autocloseHoldUntil` /
  * `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` is sent per call —
  * the backend rejects zero or more than one. Encoded as a discriminated union
  * (each variant carries every other field as `never`, via
@@ -560,7 +555,7 @@ interface BeCaseUpdateNever {
  * and `autocloseHoldUntil` are supported **only** for the ServiceNow data
  * source. `workState` is only accepted while the case is `work_in_progress`.
  * `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` are internal-only
- * estimates, independent of the customer-facing `fixEta`.
+ * estimates, never shared with the customer.
  */
 export type BeCaseUpdatePayload =
   | (Omit<BeCaseUpdateNever, "state"> & {
@@ -599,16 +594,11 @@ export type BeCaseUpdatePayload =
    * `autoclosureStep` is not directly settable.
    */
   | (Omit<BeCaseUpdateNever, "autocloseHoldUntil"> & { autocloseHoldUntil: string })
-  /**
-   * Sets the customer-facing fix-commitment date/time for the case (ISO
-   * date-time).
-   */
-  | (Omit<BeCaseUpdateNever, "fixEta"> & { fixEta: string })
-  /** Sets the internal-only best-case fix estimate (ISO date-time). */
+  /** Sets the internal-only best-case fix estimate (date-only, "YYYY-MM-DD"). */
   | (Omit<BeCaseUpdateNever, "bestCaseFixEta"> & { bestCaseFixEta: string })
-  /** Sets the internal-only most-likely fix estimate (ISO date-time). */
+  /** Sets the internal-only most-likely fix estimate (date-only, "YYYY-MM-DD"). */
   | (Omit<BeCaseUpdateNever, "mostLikelyFixEta"> & { mostLikelyFixEta: string })
-  /** Sets the internal-only worst-case fix estimate (ISO date-time). */
+  /** Sets the internal-only worst-case fix estimate (date-only, "YYYY-MM-DD"). */
   | (Omit<BeCaseUpdateNever, "worstCaseFixEta"> & { worstCaseFixEta: string });
 
 /** A user in the case watch list, as echoed by `PATCH /cases/{id}`. */
@@ -631,8 +621,6 @@ export interface BeUpdatedCase {
   assignedTo?: BeEntityRef | null;
   /** Present when the update set `parentId` — the record this case is now linked to as its parent. */
   parentCase?: BeCaseNumberRef | null;
-  /** Echoes the updated customer-facing fix-commitment date/time. Present when the update set `fixEta`. */
-  fixEta?: string | null;
   /** Echoes the updated internal-only best-case fix estimate. Present when the update set `bestCaseFixEta`. */
   bestCaseFixEta?: string | null;
   /** Echoes the updated internal-only most-likely fix estimate. Present when the update set `mostLikelyFixEta`. */

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -411,6 +411,14 @@ export interface BeServiceRequestCreatePayload {
   catalogId: string;
   catalogItemId: string;
   variables: BeCaseVariable[];
+  /**
+   * UUID of the case this service request is linked to as its parent, when
+   * created from a case's "Create service request" action. Mirrors
+   * {@link BeCaseCreatePayload.relatedCaseId}, but for a service request the
+   * link is to the (typically still-open) originating case rather than a
+   * closed case within a reopen window.
+   */
+  relatedCaseId?: string;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/components/CreateFromProjectRequiredDialog.tsx
+++ b/apps/csm-portal/webapp/src/components/CreateFromProjectRequiredDialog.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type JSX } from "react";
+import { useNavTransition } from "@hooks/useNavTransition";
+
+export interface CreateFromProjectRequiredDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /**
+   * Singular noun for the entity being created ("case", "service request",
+   * "security report", "engagement") — used to phrase the dialog copy so it
+   * reads naturally regardless of which listing page it was opened from.
+   */
+  entityNoun: string;
+  onClose: () => void;
+}
+
+/**
+ * Shared guardrail dialog for every "Create X" button on a cross-project
+ * listing page (Cases, Service Requests, Security Reports, Engagements).
+ * Creating directly from a listing risks picking the wrong project — there is
+ * no project already in context — so this steers the engineer to open the
+ * correct project first and create from there instead, where a locked-to-that-
+ * project create action is available.
+ */
+export default function CreateFromProjectRequiredDialog({
+  open,
+  entityNoun,
+  onClose,
+}: CreateFromProjectRequiredDialogProps): JSX.Element {
+  const navigate = useNavTransition();
+
+  const handleGoToProjects = (): void => {
+    onClose();
+    navigate("/customers/projects");
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Create from the project instead</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary">
+          Creating a {entityNoun} from this list risks picking the wrong
+          project. Open the customer&apos;s project first — from Customers →
+          the account → the project — and create the {entityNoun} from its
+          Project details page instead, where the project is already locked
+          in.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleGoToProjects}>
+          Go to projects
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -134,7 +134,6 @@ function detailFromBeCase(
     audit: [],
     attachments: [],
     isWatching: watchers.some((w) => w.isMe),
-    fixEta: c.fixEta ?? null,
     bestCaseFixEta: c.bestCaseFixEta ?? null,
     mostLikelyFixEta: c.mostLikelyFixEta ?? null,
     worstCaseFixEta: c.worstCaseFixEta ?? null,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -210,7 +210,8 @@ interface SecondaryItem {
  *                                       Kept here even though a Tasks tab exists: that tab is
  *                                       still `hidden` in CsmCaseDetailPage's TAB_DEFS, so this
  *                                       menu item is the only reachable entry point today.
- *   - Set fix ETA                    → PATCH /cases/{id} { fixEta }, see SetFixEtaDialog.tsx
+ *   - Set fix ETA                    → PATCH /cases/{id} { bestCaseFixEta | mostLikelyFixEta |
+ *                                       worstCaseFixEta }, see SetFixEtaDialog.tsx
  *   - Log time                       → ISSU-017
  *   - Change severity                → PATCH /cases/{id} { severity }, already fully
  *                                       backend-supported (see ChangeSeverityDialog.tsx)

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -190,9 +190,7 @@ export default function CaseMetaBand({
   // case stay visible.
   const collapsedSummary = [
     c.projectName,
-    product.deployment,
-    product.product,
-    c.assignee,
+    ...(isAnnouncement ? [] : [product.deployment, product.product, c.assignee]),
   ]
     .filter(Boolean)
     .join(" · ");

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -25,7 +25,7 @@ import DeploymentDetailsDialog from "@features/csm-projects/components/Deploymen
 import type { BeDeploymentType } from "@api/backend/types";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
-import { formatAbsoluteForUser } from "@utils/dateTime";
+import { formatDateOnlyForDisplay } from "@utils/dateTime";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
@@ -356,29 +356,21 @@ export default function CaseMetaBand({
                   )}
                 </Typography>
               </Cell>
-              {(c.fixEta ||
-                c.bestCaseFixEta ||
-                c.mostLikelyFixEta ||
-                c.worstCaseFixEta) && (
+              {(c.bestCaseFixEta || c.mostLikelyFixEta || c.worstCaseFixEta) && (
                 <>
-                  <Cell label="Fix ETA">
-                    <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.fixEta) ?? "—"}
-                    </Typography>
-                  </Cell>
                   <Cell label="Best case fix ETA">
                     <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.bestCaseFixEta) ?? "—"}
+                      {formatDateOnlyForDisplay(c.bestCaseFixEta) ?? "—"}
                     </Typography>
                   </Cell>
                   <Cell label="Most likely fix ETA">
                     <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.mostLikelyFixEta) ?? "—"}
+                      {formatDateOnlyForDisplay(c.mostLikelyFixEta) ?? "—"}
                     </Typography>
                   </Cell>
                   <Cell label="Worst case fix ETA">
                     <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.worstCaseFixEta) ?? "—"}
+                      {formatDateOnlyForDisplay(c.worstCaseFixEta) ?? "—"}
                     </Typography>
                   </Cell>
                 </>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -186,8 +186,14 @@ export default function CaseMetaBand({
   // until the backend exposes it as a first-class field.
   const projectType = c.projectName?.split(" - ")[1]?.trim() || "—";
   // One-line digest shown when the band is collapsed, so collapsing doesn't
-  // hide every triage fact — account, tier, and who owns the case stay visible.
-  const collapsedSummary = [c.customer, tierLabel(tier), c.assignee]
+  // hide every triage fact — project, deployment, product, and who owns the
+  // case stay visible.
+  const collapsedSummary = [
+    c.projectName,
+    product.deployment,
+    product.product,
+    c.assignee,
+  ]
     .filter(Boolean)
     .join(" · ");
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -61,7 +61,7 @@ const ROLE_LABEL: Record<CsmCommentAuthorRole, string> = {
   customer: "Customer",
   wso2_engineer: "WSO2",
   system: "System",
-  chatbot: "Chatbot",
+  chatbot: "AI Agent",
 };
 
 const ROLE_COLOR: Record<

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.test.tsx
@@ -19,53 +19,51 @@ import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import SetFixEtaDialog from "@features/csm-cases/components/SetFixEtaDialog";
 
-describe("SetFixEtaDialog — four independent fields", () => {
-  it("renders one Save button per field, each disabled until a date/time is picked", () => {
+describe("SetFixEtaDialog — three independent internal-only fields", () => {
+  it("renders one Save button per field, each disabled until a date is picked", () => {
     render(
       <SetFixEtaDialog isSaving={false} onClose={() => {}} onSave={() => {}} />,
     );
     const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
-    expect(saveButtons).toHaveLength(4);
+    expect(saveButtons).toHaveLength(3);
     saveButtons.forEach((btn) => expect(btn).toBeDisabled());
   });
 
   it("seeds each field from its current value and enables that field's Save immediately", () => {
     render(
       <SetFixEtaDialog
-        currentFixEta="2099-06-15T10:30:00.000Z"
-        currentBestCaseFixEta="2099-06-16T10:30:00.000Z"
-        currentMostLikelyFixEta="2099-06-17T10:30:00.000Z"
-        currentWorstCaseFixEta="2099-06-18T10:30:00.000Z"
+        currentBestCaseFixEta="2099-06-16"
+        currentMostLikelyFixEta="2099-06-17"
+        currentWorstCaseFixEta="2099-06-18"
         isSaving={false}
         onClose={() => {}}
         onSave={() => {}}
       />,
     );
     const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
-    expect(saveButtons).toHaveLength(4);
+    expect(saveButtons).toHaveLength(3);
     saveButtons.forEach((btn) => expect(btn).toBeEnabled());
   });
 
-  it("saves only the fixEta field with a UTC ISO string, independent of the other three", () => {
+  it("saves only the bestCaseFixEta field as a date-only string, independent of the other two", () => {
     const onSave = vi.fn();
     render(
       <SetFixEtaDialog
-        currentFixEta="2099-06-15T10:30:00.000Z"
+        currentBestCaseFixEta="2099-06-16"
         isSaving={false}
         onClose={() => {}}
         onSave={onSave}
       />,
     );
     const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
-    // The fixEta row is the only one seeded, so it's the only enabled Save.
+    // The bestCaseFixEta row is the only one seeded, so it's the only enabled Save.
     const enabled = saveButtons.filter((btn) => !btn.hasAttribute("disabled"));
     expect(enabled).toHaveLength(1);
     fireEvent.click(enabled[0]);
     expect(onSave).toHaveBeenCalledTimes(1);
     const [field, arg] = onSave.mock.calls[0] as [string, string];
-    expect(field).toBe("fixEta");
-    expect(() => new Date(arg).toISOString()).not.toThrow();
-    expect(new Date(arg).getUTCFullYear()).toBe(2099);
+    expect(field).toBe("bestCaseFixEta");
+    expect(arg).toBe("2099-06-16");
   });
 
   it("calls onClose on Close without calling onSave", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.tsx
@@ -23,44 +23,31 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   Typography,
 } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
-import {
-  formatDateTimeLocal,
-  parseDateTimeLocal,
-  resolveDisplayTimeZone,
-  zonedInputToUtcIso,
-} from "@utils/dateTime";
+import { formatDateOnly, parseDateOnly } from "@utils/dateTime";
 
-const { DateTimePicker, LocalizationProvider } = DatePickers;
+const { DesktopDatePicker: DatePicker, LocalizationProvider } = DatePickers;
 
-/** One of the four independent fix-ETA fields this dialog can set. */
-export type FixEtaField =
-  | "fixEta"
-  | "bestCaseFixEta"
-  | "mostLikelyFixEta"
-  | "worstCaseFixEta";
+/** One of the three independent internal-only fix-ETA estimate fields this dialog can set. */
+export type FixEtaField = "bestCaseFixEta" | "mostLikelyFixEta" | "worstCaseFixEta";
 
 interface SetFixEtaDialogProps {
-  /** Current customer-facing fix-commitment date/time, if any (ISO). */
-  currentFixEta?: string | null;
-  /** Current internal-only best-case estimate, if any (ISO). */
+  /** Current internal-only best-case estimate, if any (date-only "YYYY-MM-DD"). */
   currentBestCaseFixEta?: string | null;
-  /** Current internal-only most-likely estimate, if any (ISO). */
+  /** Current internal-only most-likely estimate, if any (date-only "YYYY-MM-DD"). */
   currentMostLikelyFixEta?: string | null;
-  /** Current internal-only worst-case estimate, if any (ISO). */
+  /** Current internal-only worst-case estimate, if any (date-only "YYYY-MM-DD"). */
   currentWorstCaseFixEta?: string | null;
-  /** True while any of the four PATCHes is in flight; disables every field's Save. */
+  /** True while any of the three PATCHes is in flight; disables every field's Save. */
   isSaving: boolean;
   onClose: () => void;
-  /** Apply one field's new value (`PATCH { [field]: valueIso }`), as a UTC ISO string. */
-  onSave: (field: FixEtaField, valueIso: string) => void;
+  /** Apply one field's new value (`PATCH { [field]: "YYYY-MM-DD" }`). */
+  onSave: (field: FixEtaField, valueDateOnly: string) => void;
 }
 
 const FIELD_LABEL: Record<FixEtaField, string> = {
-  fixEta: "Fix ETA",
   bestCaseFixEta: "Best case",
   mostLikelyFixEta: "Most likely",
   worstCaseFixEta: "Worst case",
@@ -69,46 +56,42 @@ const FIELD_LABEL: Record<FixEtaField, string> = {
 interface FixEtaFieldRowProps {
   field: FixEtaField;
   currentValue?: string | null;
-  timeZone: string;
   isSaving: boolean;
-  onSave: (field: FixEtaField, valueIso: string) => void;
+  onSave: (field: FixEtaField, valueDateOnly: string) => void;
 }
 
 /**
- * One independently-saved date/time field. Each row owns its own draft value
- * and Save action — the four fields are unrelated PATCH variants (see
- * `BeCaseUpdatePayload`), so saving one never requires the others to be filled.
+ * One independently-saved date field. Each row owns its own draft value and
+ * Save action — the three fields are unrelated PATCH variants (see
+ * `BeCaseUpdatePayload`), so saving one never requires the others to be
+ * filled. Date-only, no time-of-day component, matching this codebase's
+ * `SetAutocloseHoldDialog` picker convention.
  */
 function FixEtaFieldRow({
   field,
   currentValue,
-  timeZone,
   isSaving,
   onSave,
 }: FixEtaFieldRowProps): JSX.Element {
-  const [value, setValue] = useState<string>(
-    currentValue ? formatDateTimeLocal(new Date(currentValue)) : "",
-  );
-  const parsed = parseDateTimeLocal(value);
+  const [value, setValue] = useState<string>(currentValue ?? "");
+  const parsed = parseDateOnly(value);
   const canSubmit = !!parsed;
 
   const handleSave = (): void => {
-    if (!canSubmit) return;
-    const iso = zonedInputToUtcIso(value, timeZone);
-    if (!iso) return;
-    onSave(field, iso);
+    if (!canSubmit || !value) return;
+    onSave(field, value);
   };
 
   return (
     <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
       <LocalizationProvider dateAdapter={AdapterDateFns}>
-        <DateTimePicker
-          label={`${FIELD_LABEL[field]} (${timeZone})`}
+        <DatePicker
+          label={FIELD_LABEL[field]}
           value={parsed}
           onChange={(next) =>
             setValue(
               next instanceof Date && !Number.isNaN(next.getTime())
-                ? formatDateTimeLocal(next)
+                ? formatDateOnly(next)
                 : "",
             )
           }
@@ -134,16 +117,14 @@ function FixEtaFieldRow({
 }
 
 /**
- * Set the case's four independent fix-ETA fields: the single customer-facing
- * commitment (`fixEta` on `PATCH /cases/{id}`) plus three internal-only
- * estimates (`bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta`) never
- * shared with the customer. Each field is its own single-field PATCH variant
- * (see `BeCaseUpdatePayload`), so every row saves independently — filling in
- * one estimate never requires the others. ServiceNow-source only for
- * `fixEta`; the caller surfaces a rejection on another source.
+ * Set the case's three independent internal-only fix-ETA estimates
+ * (`bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta`), never shared
+ * with the customer. Each field is its own single-field, date-only PATCH
+ * variant (see `BeCaseUpdatePayload`), so every row saves independently —
+ * filling in one estimate never requires the others. ServiceNow-source only;
+ * the caller surfaces a rejection on another source.
  */
 export default function SetFixEtaDialog({
-  currentFixEta,
   currentBestCaseFixEta,
   currentMostLikelyFixEta,
   currentWorstCaseFixEta,
@@ -151,58 +132,32 @@ export default function SetFixEtaDialog({
   onClose,
   onSave,
 }: SetFixEtaDialogProps): JSX.Element {
-  const timeZone = resolveDisplayTimeZone();
-
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Set fix ETA</DialogTitle>
       <DialogContent>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
           <Typography variant="body2" color="text.secondary">
-            Each field below is saved independently — you don't need to fill
-            in every estimate to save one.
-          </Typography>
-
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
-            <Typography variant="caption" color="text.secondary">
-              Customer-facing fix-commitment date/time. Shared with the
-              customer — distinct from the backend-computed SLA clocks shown
-              on the SLAs tab.
-            </Typography>
-            <FixEtaFieldRow
-              field="fixEta"
-              currentValue={currentFixEta}
-              timeZone={timeZone}
-              isSaving={isSaving}
-              onSave={onSave}
-            />
-          </Box>
-
-          <Divider />
-
-          <Typography variant="subtitle2">Internal-only estimates</Typography>
-          <Typography variant="caption" color="text.secondary" sx={{ mt: -1.5 }}>
-            Never shared with the customer.
+            Internal-only estimates, never shared with the customer. Each
+            field below is saved independently — you don't need to fill in
+            every estimate to save one.
           </Typography>
 
           <FixEtaFieldRow
             field="bestCaseFixEta"
             currentValue={currentBestCaseFixEta}
-            timeZone={timeZone}
             isSaving={isSaving}
             onSave={onSave}
           />
           <FixEtaFieldRow
             field="mostLikelyFixEta"
             currentValue={currentMostLikelyFixEta}
-            timeZone={timeZone}
             isSaving={isSaving}
             onSave={onSave}
           />
           <FixEtaFieldRow
             field="worstCaseFixEta"
             currentValue={currentWorstCaseFixEta}
-            timeZone={timeZone}
             isSaving={isSaving}
             onSave={onSave}
           />

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1282,7 +1282,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
             : { worstCaseFixEta: valueDateOnly };
       patchCase.mutate(payload, {
         onSuccess: () => {
-          setFixEtaOpen(false);
           setFeedback({
             message: "Fix ETA updated.",
             severity: "success",

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -94,7 +94,9 @@ import LinkIncidentDialog from "@features/csm-cases/components/LinkIncidentDialo
 import LinkCaseDialog, {
   type CaseLinkType,
 } from "@features/csm-cases/components/LinkCaseDialog";
-import SetFixEtaDialog from "@features/csm-cases/components/SetFixEtaDialog";
+import SetFixEtaDialog, {
+  type FixEtaField,
+} from "@features/csm-cases/components/SetFixEtaDialog";
 import CreateTaskDialog from "@features/csm-cases/components/CreateTaskDialog";
 import AddTagDialog from "@features/csm-cases/components/AddTagDialog";
 import { useCreateCaseTask } from "@features/csm-cases/api/useCreateCaseTask";
@@ -1271,21 +1273,24 @@ export default function CsmCaseDetailPage(): JSX.Element {
   );
 
   const onSetFixEta = useCallback(
-    (fixEtaIso: string) => {
-      patchCase.mutate(
-        { fixEta: fixEtaIso },
-        {
-          onSuccess: () => {
-            setFixEtaOpen(false);
-            setFeedback({
-              message: "Fix ETA updated.",
-              severity: "success",
-              sticky: false,
-            });
-          },
-          onError: (err) => showError("Could not set the fix ETA.", err),
+    (field: FixEtaField, valueDateOnly: string) => {
+      const payload: BeCaseUpdatePayload =
+        field === "bestCaseFixEta"
+          ? { bestCaseFixEta: valueDateOnly }
+          : field === "mostLikelyFixEta"
+            ? { mostLikelyFixEta: valueDateOnly }
+            : { worstCaseFixEta: valueDateOnly };
+      patchCase.mutate(payload, {
+        onSuccess: () => {
+          setFixEtaOpen(false);
+          setFeedback({
+            message: "Fix ETA updated.",
+            severity: "success",
+            sticky: false,
+          });
         },
-      );
+        onError: (err) => showError("Could not set the fix ETA.", err),
+      });
     },
     [patchCase, showError],
   );
@@ -2187,7 +2192,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
       {fixEtaOpen && (
         <SetFixEtaDialog
-          currentFixEta={c.fixEta}
+          currentBestCaseFixEta={c.bestCaseFixEta}
+          currentMostLikelyFixEta={c.mostLikelyFixEta}
+          currentWorstCaseFixEta={c.worstCaseFixEta}
           isSaving={patchCase.isPending}
           onClose={() => setFixEtaOpen(false)}
           onSave={onSetFixEta}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -43,6 +43,7 @@ import {
   Paperclip,
   PauseCircle,
   Phone,
+  Plus,
   Users,
   X,
 } from "@wso2/oxygen-ui-icons-react";
@@ -149,6 +150,7 @@ import type {
   CaseWatcher,
   CreateIncidentFromCaseNavState,
   CreateRelatedCaseNavState,
+  CreateServiceRequestFromCaseNavState,
 } from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 import { useNavTransition } from "@hooks/useNavTransition";
@@ -1975,16 +1977,35 @@ export default function CsmCaseDetailPage(): JSX.Element {
         >
           <ChildCasesWidget caseId={c.id} />
           <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1, flexWrap: "wrap" }}>
               <Typography variant="subtitle2">Linked service requests</Typography>
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<LinkIcon size={14} />}
-                onClick={() => setLinkCaseOpen(true)}
-              >
-                Link to another case
-              </Button>
+              <Box sx={{ display: "flex", gap: 1 }}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<Plus size={14} />}
+                  onClick={() => {
+                    const navState: CreateServiceRequestFromCaseNavState = {
+                      projectId: c.projectId,
+                      relatedCaseId: c.id,
+                      relatedCaseNumber: c.caseNumber,
+                      deploymentId: c.productContext.deploymentId,
+                      deployedProductId: c.productContext.deployedProductId,
+                    };
+                    navigate("/operations/service-requests/new", { state: navState });
+                  }}
+                >
+                  Create service request
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<LinkIcon size={14} />}
+                  onClick={() => setLinkCaseOpen(true)}
+                >
+                  Link to another case
+                </Button>
+              </Box>
             </Box>
             {c.linkedServiceRequests && c.linkedServiceRequests.length > 0 ? (
               <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -16,36 +16,43 @@
 
 import { Button } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { type JSX } from "react";
+import { useState, type JSX } from "react";
 
+import CreateFromProjectRequiredDialog from "@components/CreateFromProjectRequiredDialog";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
-import { useNavTransition } from "@hooks/useNavTransition";
 
 /** All-cases list — the shared issues view across every case type. */
 export default function CsmCasesPage(): JSX.Element {
-  const navigate = useNavTransition();
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
 
   return (
-    <CsmIssuesView
-      title="Cases"
-      entityNoun="cases"
-      // Cases list is support cases only. The other issue types have dedicated
-      // homes — service requests under Operations, engagements under
-      // Engagements, security reports under Security Center — so they're locked
-      // out here (and the type filter is hidden since it's fixed to `case`).
-      lockedFilters={{ caseTypes: ["case"] }}
-      hideTypeFilter
-      actions={
-        <Button
-          variant="contained"
-          color="primary"
-          size="small"
-          startIcon={<Plus size={16} />}
-          onClick={() => navigate("/cases/new")}
-        >
-          Create case
-        </Button>
-      }
-    />
+    <>
+      <CsmIssuesView
+        title="Cases"
+        entityNoun="cases"
+        // Cases list is support cases only. The other issue types have dedicated
+        // homes — service requests under Operations, engagements under
+        // Engagements, security reports under Security Center — so they're locked
+        // out here (and the type filter is hidden since it's fixed to `case`).
+        lockedFilters={{ caseTypes: ["case"] }}
+        hideTypeFilter
+        actions={
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            startIcon={<Plus size={16} />}
+            onClick={() => setShowCreateDialog(true)}
+          >
+            Create case
+          </Button>
+        }
+      />
+      <CreateFromProjectRequiredDialog
+        open={showCreateDialog}
+        entityNoun="case"
+        onClose={() => setShowCreateDialog(false)}
+      />
+    </>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -379,6 +379,26 @@ export interface CreateRelatedCaseNavState {
 
 /**
  * Router (`navigate(..., { state })`) payload carried from a case's "Create
+ * service request" action (Related tab, Linked service requests card) to
+ * `/operations/service-requests/new`, so the create-service-request form can
+ * prefill from the originating case and file the new SR as linked to it in
+ * one step — no separate create-then-link round trip. `projectId` seeds the
+ * form's Project field locked read-only (mirrors
+ * {@link CreateRelatedCaseNavState} / CsmCaseCreatePage.tsx); `deploymentId` /
+ * `deployedProductId` are just starting values and stay fully editable. See
+ * CsmCaseDetailPage.tsx's "Create service request" button and
+ * CreateServiceRequestPage.tsx's read of `useLocation().state`.
+ */
+export interface CreateServiceRequestFromCaseNavState {
+  projectId: string;
+  relatedCaseId: string;
+  relatedCaseNumber?: string;
+  deploymentId?: string;
+  deployedProductId?: string;
+}
+
+/**
+ * Router (`navigate(..., { state })`) payload carried from a case's "Create
  * incident from case…" action to `/operations/incidents/new`, so the
  * create-incident form can prefill from the originating case without a
  * query-string round trip or a full page load. `caseId` seeds the incident's

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -462,18 +462,21 @@ export interface CsmCaseDetail extends CsmCaseRow {
   /** When the auto-closure sequence next advances (ServiceNow only). Read-only. */
   autoclosureStateTime?: string;
   /**
-   * The customer-facing fix-commitment date/time for the case; `null`/absent
-   * when not set. Distinct from the backend-computed SLA clocks shown in
-   * {@link CaseSla} — this is a settable commitment, not a derived clock. Also
-   * distinct from the three internal-only estimates below, which are never
-   * shared with the customer.
+   * Internal-only best-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string; `null`/absent when not set. Never shared with the customer.
+   * Distinct from the backend-computed SLA clocks shown in {@link CaseSla} —
+   * these are settable commitments, not derived clocks.
    */
-  fixEta?: string | null;
-  /** Internal-only best-case fix estimate; `null`/absent when not set. */
   bestCaseFixEta?: string | null;
-  /** Internal-only most-likely fix estimate; `null`/absent when not set. */
+  /**
+   * Internal-only most-likely fix estimate, as a date-only "YYYY-MM-DD"
+   * string; `null`/absent when not set.
+   */
   mostLikelyFixEta?: string | null;
-  /** Internal-only worst-case fix estimate; `null`/absent when not set. */
+  /**
+   * Internal-only worst-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string; `null`/absent when not set.
+   */
   worstCaseFixEta?: string | null;
   /** Display name of the person who opened the case. */
   createdBy?: string;

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -30,7 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
-import { useLocation } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 
 import { BackendApiError } from "@api/backend/client";
 import AttachmentsField from "@components/attachments/AttachmentsField";
@@ -75,7 +75,15 @@ export default function CreateServiceRequestPage(): JSX.Element {
     | CreateServiceRequestFromCaseNavState
     | undefined;
 
-  const lockedProjectId = relatedCaseState?.projectId ?? "";
+  // When opened from a project's page
+  // (`/operations/service-requests/new?projectId=…`), the project is fixed
+  // and shown read-only, mirroring CsmCaseCreatePage's `?projectId=` lock —
+  // the engineer can't accidentally file against the wrong project. Opened
+  // without either source (the operations-list entry), the searchable picker
+  // is shown.
+  const [searchParams] = useSearchParams();
+  const lockedProjectId =
+    searchParams.get("projectId") ?? relatedCaseState?.projectId ?? "";
   const isProjectLocked = !!lockedProjectId;
   const relatedCaseId = relatedCaseState?.relatedCaseId;
   const relatedCaseNumber = relatedCaseState?.relatedCaseNumber;
@@ -93,7 +101,9 @@ export default function CreateServiceRequestPage(): JSX.Element {
 
   // Details for the locked project — gives the display name for the
   // read-only field (mirrors CsmCaseCreatePage.tsx).
-  const selectedProject = useGetProject(projectId || undefined);
+  const selectedProject = useGetProject(
+    isProjectLocked ? lockedProjectId : undefined,
+  );
   const lockedProjectLabel = selectedProject.data?.name
     ? selectedProject.data.name
     : selectedProject.isLoading

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -25,10 +25,12 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
+import { useLocation } from "react-router";
 
 import { BackendApiError } from "@api/backend/client";
 import AttachmentsField from "@components/attachments/AttachmentsField";
@@ -38,6 +40,7 @@ import {
 } from "@components/attachments/encodeAttachment";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
+import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
@@ -55,19 +58,47 @@ import {
   getUserEditableVariables,
   isAttachmentField,
 } from "@features/csm-operations/utils/catalogVariables";
+import type { CreateServiceRequestFromCaseNavState } from "@features/csm-cases/types/csmCases";
 
 export default function CreateServiceRequestPage(): JSX.Element {
   const navigate = useNavTransition();
   const { showError } = useErrorBanner();
 
-  const [projectId, setProjectId] = useState("");
-  const [deploymentId, setDeploymentId] = useState("");
-  const [deployedProductId, setDeployedProductId] = useState("");
+  // Set when opened from a case's "Create service request" action (Related
+  // tab, Linked service requests card), which navigates here with router
+  // state (not query params) so the case's project/deployment/product carry
+  // over and the new SR is filed linked to that case in one step. See
+  // CsmCaseDetailPage.tsx's "Create service request" button and
+  // CreateRelatedCaseNavState's read in CsmCaseCreatePage.tsx for the
+  // analogous case-create pattern.
+  const relatedCaseState = useLocation().state as
+    | CreateServiceRequestFromCaseNavState
+    | undefined;
+
+  const lockedProjectId = relatedCaseState?.projectId ?? "";
+  const isProjectLocked = !!lockedProjectId;
+  const relatedCaseId = relatedCaseState?.relatedCaseId;
+  const relatedCaseNumber = relatedCaseState?.relatedCaseNumber;
+
+  const [projectId, setProjectId] = useState(lockedProjectId);
+  const [deploymentId, setDeploymentId] = useState(relatedCaseState?.deploymentId ?? "");
+  const [deployedProductId, setDeployedProductId] = useState(
+    relatedCaseState?.deployedProductId ?? "",
+  );
   const [catalogId, setCatalogId] = useState("");
   const [catalogItemId, setCatalogItemId] = useState("");
   // Variable answers, keyed by variable id.
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [attachments, setAttachments] = useState<EncodedAttachment[]>([]);
+
+  // Details for the locked project — gives the display name for the
+  // read-only field (mirrors CsmCaseCreatePage.tsx).
+  const selectedProject = useGetProject(projectId || undefined);
+  const lockedProjectLabel = selectedProject.data?.name
+    ? selectedProject.data.name
+    : selectedProject.isLoading
+      ? "Loading project…"
+      : lockedProjectId;
 
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
@@ -192,6 +223,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
         catalogId,
         catalogItemId,
         variables: variablePayload,
+        relatedCaseId,
       });
       // The create endpoint doesn't attach files for service requests, so upload
       // them to the new case afterwards. A partial failure still lands the case.
@@ -228,9 +260,14 @@ export default function CreateServiceRequestPage(): JSX.Element {
       >
         Back to operations
       </Button>
-      <Typography variant="h5" sx={{ mb: 2 }}>
+      <Typography variant="h5" sx={{ mb: relatedCaseId ? 0.5 : 2 }}>
         New service request
       </Typography>
+      {relatedCaseId && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Creating a service request linked to case {relatedCaseNumber ?? "the case"} — its id is carried through automatically.
+        </Typography>
+      )}
 
       <Card variant="outlined" sx={{ p: 3 }}>
         {hasOptionsError && (
@@ -254,11 +291,31 @@ export default function CreateServiceRequestPage(): JSX.Element {
 
         <Grid container spacing={2.5}>
           <Grid size={{ xs: 12, md: 4 }}>
-            <AsyncProjectSelect
-              value={projectId}
-              onChange={onProjectChange}
-              required
-            />
+            {isProjectLocked ? (
+              <TextField
+                fullWidth
+                size="small"
+                label="Project"
+                required
+                value={lockedProjectLabel}
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    endAdornment: (
+                      <Lock size={16} aria-hidden style={{ opacity: 0.6 }} />
+                    ),
+                  },
+                  htmlInput: { "aria-readonly": true },
+                }}
+                helperText="Locked to the project you opened this from. To file against another project, open that project first."
+              />
+            ) : (
+              <AsyncProjectSelect
+                value={projectId}
+                onChange={onProjectChange}
+                required
+              />
+            )}
           </Grid>
 
           <Grid size={{ xs: 12, md: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -16,13 +16,13 @@
 
 import { Box, Button, Typography } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { type JSX } from "react";
+import { useState, type JSX } from "react";
+import CreateFromProjectRequiredDialog from "@components/CreateFromProjectRequiredDialog";
 import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ChangeRequestsTab from "@features/csm-operations/components/ChangeRequestsTab";
 import IncidentsTab from "@features/csm-operations/components/IncidentsTab";
 import ProblemsTab from "@features/csm-operations/components/ProblemsTab";
-import { useNavTransition } from "@hooks/useNavTransition";
 import { useQueryTabs } from "@hooks/useSectionTabs";
 
 /**
@@ -35,11 +35,11 @@ import { useQueryTabs } from "@hooks/useSectionTabs";
  * one through `CSM_PORTAL_FEATURE_OVERRIDES` without touching this page.
  */
 export default function OperationsPage(): JSX.Element {
-  const navigate = useNavTransition();
   // Active tab lives in the URL (`?tab=`) so the change-request detail page can
   // link back to the right tab, and the tab survives a refresh / share.
   const tabs = useQueryTabs("operations");
   const activeTab = tabs.activeKey;
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -64,7 +64,7 @@ export default function OperationsPage(): JSX.Element {
               color="primary"
               size="small"
               startIcon={<Plus size={16} />}
-              onClick={() => navigate("/operations/service-requests/new")}
+              onClick={() => setShowCreateDialog(true)}
             >
               Create service request
             </Button>
@@ -77,6 +77,12 @@ export default function OperationsPage(): JSX.Element {
       {activeTab === "incidents" && <IncidentsTab />}
 
       {activeTab === "problems" && <ProblemsTab />}
+
+      <CreateFromProjectRequiredDialog
+        open={showCreateDialog}
+        entityNoun="service request"
+        onClose={() => setShowCreateDialog(false)}
+      />
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -19,13 +19,15 @@ import {
   Button,
   Card,
   Chip,
+  Menu,
+  MenuItem,
   Skeleton,
   Tab,
   Tabs,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
-import { useState, type JSX, type ReactNode } from "react";
+import { ArrowLeft, ChevronDown, Plus } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX, type MouseEvent, type ReactNode } from "react";
 import { Link as RouterLink, useParams } from "react-router";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
@@ -128,6 +130,9 @@ export default function CsmProjectDetailPage(): JSX.Element {
   const navigate = useNavTransition();
   const { data, isLoading, isError } = useGetProject(id);
   const [activeTab, setActiveTab] = useState<ProjectTabId>("overview");
+  const [createMenuAnchor, setCreateMenuAnchor] = useState<HTMLElement | null>(
+    null,
+  );
 
   if (isLoading) {
     return (
@@ -189,16 +194,57 @@ export default function CsmProjectDetailPage(): JSX.Element {
             {p.key}
           </Typography>
         </Box>
-        {/* File a case already scoped to this project — the create form locks the
-            project field, so it can't be filed against the wrong one. */}
+        {/* File any issue type already scoped to this project — every create
+            form below locks the project field, so it can't be filed against
+            the wrong one.
+            FOLLOW-UP: no "Create engagement" entry here — there is no
+            create-engagement page/route in the FE, and `POST /cases`'s
+            request contract (`BeCaseCreateBody`) has no engagement variant,
+            so this needs a BE/entity-service addition before it can be
+            wired up. */}
         <Button
           variant="contained"
           startIcon={<Plus size={16} />}
-          onClick={() => navigate(`/cases/new?projectId=${encodeURIComponent(p.id)}`)}
+          endIcon={<ChevronDown size={16} />}
+          onClick={(e: MouseEvent<HTMLElement>) => setCreateMenuAnchor(e.currentTarget)}
           sx={{ flexShrink: 0 }}
         >
-          Create case
+          Create
         </Button>
+        <Menu
+          anchorEl={createMenuAnchor}
+          open={!!createMenuAnchor}
+          onClose={() => setCreateMenuAnchor(null)}
+        >
+          <MenuItem
+            onClick={() => {
+              setCreateMenuAnchor(null);
+              navigate(`/cases/new?projectId=${encodeURIComponent(p.id)}`);
+            }}
+          >
+            Create case
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setCreateMenuAnchor(null);
+              navigate(
+                `/operations/service-requests/new?projectId=${encodeURIComponent(p.id)}`,
+              );
+            }}
+          >
+            Create service request
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setCreateMenuAnchor(null);
+              navigate(
+                `/security-center/reports/new?projectId=${encodeURIComponent(p.id)}`,
+              );
+            }}
+          >
+            Create security report
+          </MenuItem>
+        </Menu>
       </Box>
 
       <Box sx={{ borderBottom: 1, borderColor: "divider" }}>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -27,8 +27,9 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
+import { useSearchParams } from "react-router";
 
 import { BackendApiError } from "@api/backend/client";
 import Editor from "@components/rich-text-editor/Editor";
@@ -39,6 +40,7 @@ import {
 } from "@components/attachments/encodeAttachment";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
+import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
@@ -66,7 +68,16 @@ export default function CreateSecurityReportPage(): JSX.Element {
   const navigate = useNavTransition();
   const { showError } = useErrorBanner();
 
-  const [projectId, setProjectId] = useState("");
+  // When opened from a project's page (`/security-center/reports/new?projectId=…`),
+  // the project is fixed and shown read-only, mirroring CsmCaseCreatePage's
+  // `?projectId=` lock — the engineer can't accidentally file against the
+  // wrong project. Opened without the param (the Security Center list entry),
+  // the searchable picker is shown.
+  const [searchParams] = useSearchParams();
+  const lockedProjectId = searchParams.get("projectId") ?? "";
+  const isProjectLocked = !!lockedProjectId;
+
+  const [projectId, setProjectId] = useState(lockedProjectId);
   const [deploymentId, setDeploymentId] = useState("");
   const [deployedProductId, setDeployedProductId] = useState("");
   const [subject, setSubject] = useState("");
@@ -75,6 +86,17 @@ export default function CreateSecurityReportPage(): JSX.Element {
   const [subjectEdited, setSubjectEdited] = useState(false);
   const [description, setDescription] = useState("");
   const [attachments, setAttachments] = useState<EncodedAttachment[]>([]);
+
+  // Details for the locked project. Gives the display name for the locked
+  // read-only field (falls back to the raw id while loading).
+  const selectedProject = useGetProject(
+    isProjectLocked ? lockedProjectId : undefined,
+  );
+  const lockedProjectLabel = selectedProject.data?.name
+    ? selectedProject.data.name
+    : selectedProject.isLoading
+      ? "Loading project…"
+      : lockedProjectId;
 
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
@@ -207,11 +229,31 @@ export default function CreateSecurityReportPage(): JSX.Element {
 
         <Grid container spacing={2.5}>
           <Grid size={{ xs: 12, md: 4 }}>
-            <AsyncProjectSelect
-              value={projectId}
-              onChange={onProjectChange}
-              required
-            />
+            {isProjectLocked ? (
+              <TextField
+                fullWidth
+                size="small"
+                label="Project"
+                required
+                value={lockedProjectLabel}
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    endAdornment: (
+                      <Lock size={16} aria-hidden style={{ opacity: 0.6 }} />
+                    ),
+                  },
+                  htmlInput: { "aria-readonly": true },
+                }}
+                helperText="Locked to the project you opened this from. To file against another project, open that project first."
+              />
+            ) : (
+              <AsyncProjectSelect
+                value={projectId}
+                onChange={onProjectChange}
+                required
+              />
+            )}
           </Grid>
 
           <Grid size={{ xs: 12, md: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -16,11 +16,11 @@
 
 import { Box, Button, Typography } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { type JSX } from "react";
+import { useState, type JSX } from "react";
+import CreateFromProjectRequiredDialog from "@components/CreateFromProjectRequiredDialog";
 import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ProductVulnerabilitiesTab from "@features/csm-security-center/components/ProductVulnerabilitiesTab";
-import { useNavTransition } from "@hooks/useNavTransition";
 import { useQueryTabs } from "@hooks/useSectionTabs";
 
 /**
@@ -33,9 +33,9 @@ import { useQueryTabs } from "@hooks/useSectionTabs";
  * one through `CSM_PORTAL_FEATURE_OVERRIDES` without touching this page.
  */
 export default function CsmSecurityCenterPage(): JSX.Element {
-  const navigate = useNavTransition();
   const tabs = useQueryTabs("security-center");
   const activeTab = tabs.activeKey;
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -60,7 +60,7 @@ export default function CsmSecurityCenterPage(): JSX.Element {
               color="primary"
               size="small"
               startIcon={<Plus size={16} />}
-              onClick={() => navigate("/security-center/reports/new")}
+              onClick={() => setShowCreateDialog(true)}
             >
               New security report
             </Button>
@@ -69,6 +69,12 @@ export default function CsmSecurityCenterPage(): JSX.Element {
       )}
 
       {activeTab === "vulnerabilities" && <ProductVulnerabilitiesTab />}
+
+      <CreateFromProjectRequiredDialog
+        open={showCreateDialog}
+        entityNoun="security report"
+        onClose={() => setShowCreateDialog(false)}
+      />
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.ts
@@ -341,6 +341,26 @@ export function parseDateOnly(value: string): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/**
+ * "YYYY-MM-DD" to a human-readable date string (e.g. "Aug 1, 2026"), for
+ * read-only display of a date-only field. Uses {@link parseDateOnly}'s
+ * local-midnight parse rather than {@link formatAbsoluteForUser}'s UTC parse,
+ * so the displayed day never shifts depending on the viewer's timezone.
+ * Returns `null` when the input is empty or unparseable.
+ */
+export function formatDateOnlyForDisplay(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  const date = parseDateOnly(value);
+  if (!date) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
 /** Local-midnight Date back to "YYYY-MM-DD", the inverse of {@link parseDateOnly}. */
 export function formatDateOnly(date: Date): string {
   const y = date.getFullYear();

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1070,18 +1070,18 @@ type CaseView struct {
 	// AutoclosureStateTime is when the auto-closure sequence next advances (e.g. the
 	// "eligible again after" date for a held case). Read-only (ServiceNow data source only).
 	AutoclosureStateTime *time.Time `json:"autoclosureStateTime,omitempty"`
-	// FixEta is the single customer-facing fix-commitment date/time
-	// (ServiceNow u_fix_eta_shared).
-	FixEta *time.Time `json:"fixEta"`
-	// BestCaseFixEta is the internal-only best-case fix-commitment date
-	// (ServiceNow u_best_case_fix_eta). CSM-engineer-facing only.
-	BestCaseFixEta *time.Time `json:"bestCaseFixEta"`
-	// MostLikelyFixEta is the internal-only most-likely fix-commitment date
-	// (ServiceNow u_most_likely_fix_eta). CSM-engineer-facing only.
-	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta"`
-	// WorstCaseFixEta is the internal-only worst-case fix-commitment date
-	// (ServiceNow u_worst_case_fix_eta). CSM-engineer-facing only.
-	WorstCaseFixEta *time.Time `json:"worstCaseFixEta"`
+	// BestCaseFixEta is the internal-only best-case fix-commitment date, as a
+	// date-only "YYYY-MM-DD" string (ServiceNow u_best_case_fix_eta).
+	// CSM-engineer-facing only, never shared with the customer.
+	BestCaseFixEta *string `json:"bestCaseFixEta"`
+	// MostLikelyFixEta is the internal-only most-likely fix-commitment date, as
+	// a date-only "YYYY-MM-DD" string (ServiceNow u_most_likely_fix_eta).
+	// CSM-engineer-facing only, never shared with the customer.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta is the internal-only worst-case fix-commitment date, as a
+	// date-only "YYYY-MM-DD" string (ServiceNow u_worst_case_fix_eta).
+	// CSM-engineer-facing only, never shared with the customer.
+	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 	// Tags are the free-text labels attached to the case via ServiceNow's generic
 	// platform label/label_entry mechanism (not a case-specific column).
 	//
@@ -1180,10 +1180,10 @@ type SearchCasesResponse struct {
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
 // Exactly one of State, Severity, WorkState, WatchList, AssigneeEmail, ParentID, RelatedCaseID,
-// AutocloseHoldUntil, Subject, Description, DeploymentID, DeployedProductID, FixEta,
+// AutocloseHoldUntil, Subject, Description, DeploymentID, DeployedProductID,
 // BestCaseFixEta, MostLikelyFixEta, or WorstCaseFixEta must be provided.
 // WatchList, AssigneeEmail, ParentID, RelatedCaseID, AutocloseHoldUntil, Subject, Description,
-// DeploymentID, DeployedProductID, FixEta, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta
+// DeploymentID, DeployedProductID, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta
 // are only supported for the ServiceNow data source.
 // ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
 // State is closed or solution_proposed.
@@ -1224,22 +1224,18 @@ type UpdateCaseRequest struct {
 	// converted to the backing data source's internal id before dispatch (ServiceNow data
 	// source only).
 	DeployedProductID *string `json:"deployedProductId"`
-	// FixEta sets the customer-facing fix-commitment date/time (ServiceNow
-	// u_fix_eta_shared). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists yet
-	// for this field — see snUpdateCasePayload.FixEta in sn_case_service.go.
-	FixEta *time.Time `json:"fixEta"`
-	// BestCaseFixEta sets the internal-only best-case fix-commitment date (ServiceNow
-	// u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists
-	// yet for this field — see snUpdateCasePayload.BestCaseFixEta in sn_case_service.go.
-	BestCaseFixEta *time.Time `json:"bestCaseFixEta"`
-	// MostLikelyFixEta sets the internal-only most-likely fix-commitment date (ServiceNow
-	// u_most_likely_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support
-	// exists yet for this field — see snUpdateCasePayload.MostLikelyFixEta in sn_case_service.go.
-	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta"`
-	// WorstCaseFixEta sets the internal-only worst-case fix-commitment date (ServiceNow
-	// u_worst_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists
-	// yet for this field — see snUpdateCasePayload.WorstCaseFixEta in sn_case_service.go.
-	WorstCaseFixEta *time.Time `json:"worstCaseFixEta"`
+	// BestCaseFixEta sets the internal-only best-case fix-commitment date
+	// (ServiceNow u_best_case_fix_eta), as a date-only "YYYY-MM-DD" string —
+	// see snUpdateCasePayload.BestCaseFixEta in sn_case_service.go.
+	BestCaseFixEta *string `json:"bestCaseFixEta"`
+	// MostLikelyFixEta sets the internal-only most-likely fix-commitment date
+	// (ServiceNow u_most_likely_fix_eta), as a date-only "YYYY-MM-DD" string —
+	// see snUpdateCasePayload.MostLikelyFixEta in sn_case_service.go.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta sets the internal-only worst-case fix-commitment date
+	// (ServiceNow u_worst_case_fix_eta), as a date-only "YYYY-MM-DD" string —
+	// see snUpdateCasePayload.WorstCaseFixEta in sn_case_service.go.
+	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -1269,25 +1265,20 @@ type UpdatedCase struct {
 	CloseNotes     *string              `json:"closeNotes,omitempty"`
 	ResolvedOn     *time.Time           `json:"resolvedOn,omitempty"`
 	ParentCase     *CaseNumberRef       `json:"parentCase,omitempty"`
-	// FixEta echoes the updated customer-facing fix-commitment date/time
-	// (u_fix_eta_shared) back on a successful PATCH. Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.FixEta doc comment; always nil until Ballerina supports the write.
-	FixEta *time.Time `json:"fixEta,omitempty"`
-	// BestCaseFixEta echoes the updated internal-only best-case fix-commitment date
-	// (u_best_case_fix_eta) back on a successful PATCH. Ballerina support added on
-	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.BestCaseFixEta doc comment; always nil until Ballerina supports the write.
-	BestCaseFixEta *time.Time `json:"bestCaseFixEta,omitempty"`
-	// MostLikelyFixEta echoes the updated internal-only most-likely fix-commitment date
-	// (u_most_likely_fix_eta) back on a successful PATCH. Ballerina support added on
-	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.MostLikelyFixEta doc comment; always nil until Ballerina supports the write.
-	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta,omitempty"`
-	// WorstCaseFixEta echoes the updated internal-only worst-case fix-commitment date
-	// (u_worst_case_fix_eta) back on a successful PATCH. Ballerina support added on
-	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.WorstCaseFixEta doc comment; always nil until Ballerina supports the write.
-	WorstCaseFixEta *time.Time `json:"worstCaseFixEta,omitempty"`
+	// BestCaseFixEta echoes the updated internal-only best-case fix-commitment
+	// date (u_best_case_fix_eta) back on a successful PATCH, as a date-only
+	// "YYYY-MM-DD" string. Present only when the update set bestCaseFixEta.
+	BestCaseFixEta *string `json:"bestCaseFixEta,omitempty"`
+	// MostLikelyFixEta echoes the updated internal-only most-likely
+	// fix-commitment date (u_most_likely_fix_eta) back on a successful PATCH,
+	// as a date-only "YYYY-MM-DD" string. Present only when the update set
+	// mostLikelyFixEta.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta,omitempty"`
+	// WorstCaseFixEta echoes the updated internal-only worst-case
+	// fix-commitment date (u_worst_case_fix_eta) back on a successful PATCH,
+	// as a date-only "YYYY-MM-DD" string. Present only when the update set
+	// worstCaseFixEta.
+	WorstCaseFixEta *string `json:"worstCaseFixEta,omitempty"`
 }
 
 // WatchListUser is a compact user reference within the watch list.

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -292,10 +292,11 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}
-	if len(req.WatchList) > 0 || req.AssigneeEmail != nil || req.FixEta != nil ||
+	if len(req.WatchList) > 0 || req.AssigneeEmail != nil ||
 		req.RelatedCaseID != nil || req.ParentID != nil || req.AutocloseHoldUntil != nil ||
-		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, fixEta, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, and deployedProductId are only supported for the ServiceNow data source"}
+		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil ||
+		req.BestCaseFixEta != nil || req.MostLikelyFixEta != nil || req.WorstCaseFixEta != nil {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, bestCaseFixEta, mostLikelyFixEta, and worstCaseFixEta are only supported for the ServiceNow data source"}
 	}
 	fieldCount := 0
 	if req.State != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -182,10 +182,10 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
-	// UpdateCase updates the state, severity, watch list, assignee, or fix ETA (customer-facing
-	// or internal best-case/most-likely/worst-case) of a case.
+	// UpdateCase updates the state, severity, watch list, assignee, or internal-only
+	// fix-ETA estimate (best-case/most-likely/worst-case) of a case.
 	// A ValidationError is returned for invalid values or malformed UUID; a NotFoundError if no case matches.
-	// WatchList, AssigneeEmail, FixEta, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta are
+	// WatchList, AssigneeEmail, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta are
 	// only supported for the ServiceNow data source.
 	// Transitioning State to closed is rejected with a ValidationError if the case has any
 	// open task that is visible to the customer (the authoritative case-close gate).

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -93,12 +93,6 @@ type snCase struct {
 	// AutoclosureStateTime is when the auto-closure sequence next advances (e.g. the
 	// "eligible again after" date for a held case).
 	AutoclosureStateTime *string `json:"autoclosureStateTime"`
-	// FixEta is the single customer-facing fix-commitment date/time
-	// (u_fix_eta_shared). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
-	// surfaces this — the Choreo GET /cases/{id} response does not include a
-	// "fixEta" key today, so this always unmarshals to nil. Ask: add a
-	// "fixEta" (glide_date_time) field to servicenow:CaseResponse.
-	FixEta *string `json:"fixEta"`
 	// BestCaseFixEta is the internal-only best-case fix-commitment date
 	// (u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
 	// surfaces this — the Choreo GET /cases/{id} response does not include a
@@ -382,6 +376,18 @@ func formatSNDateOnly(t *time.Time) string {
 		return ""
 	}
 	return t.UTC().Format(snDateOnlyLayout)
+}
+
+// validateDateOnly rejects a wire value that is not a strict "YYYY-MM-DD" date. Used
+// for fields (bestCaseFixEta, mostLikelyFixEta, worstCaseFixEta) whose contract with
+// the integration service is a plain date string, not an RFC3339 datetime — unlike
+// AutocloseHoldUntil, these arrive as *string already, so there is no JSON-time-based
+// parse to lean on; the format must be checked explicitly before it is forwarded.
+func validateDateOnly(field, value string) error {
+	if _, err := time.Parse(snDateOnlyLayout, value); err != nil {
+		return &apierror.ValidationError{Msg: field + " must be a date in YYYY-MM-DD format"}
+	}
+	return nil
 }
 
 type snCaseService struct {
@@ -717,41 +723,18 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.AutoclosureStateTime = &autoclosureStateTime
 	}
-	// FixEta passes through once Ballerina's matching field (see snCase.FixEta doc
-	// comment) lands; until then this is always nil.
-	if c.FixEta != nil && *c.FixEta != "" {
-		fixEta, err := time.Parse(snCreatedOnLayout, *c.FixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse fixEta %q: %w", *c.FixEta, err)
-		}
-		cv.FixEta = &fixEta
-	}
-	// BestCaseFixEta passes through once Ballerina's matching field (see
-	// snCase.BestCaseFixEta doc comment) lands; until then this is always nil.
+	// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta are already date-only
+	// "YYYY-MM-DD" strings on both sides, so no parsing/reformatting is
+	// needed — pass through once Ballerina's matching read fields (see
+	// snCase doc comments) land; until then these are always nil.
 	if c.BestCaseFixEta != nil && *c.BestCaseFixEta != "" {
-		bestCaseFixEta, err := time.Parse(snCreatedOnLayout, *c.BestCaseFixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse bestCaseFixEta %q: %w", *c.BestCaseFixEta, err)
-		}
-		cv.BestCaseFixEta = &bestCaseFixEta
+		cv.BestCaseFixEta = c.BestCaseFixEta
 	}
-	// MostLikelyFixEta passes through once Ballerina's matching field (see
-	// snCase.MostLikelyFixEta doc comment) lands; until then this is always nil.
 	if c.MostLikelyFixEta != nil && *c.MostLikelyFixEta != "" {
-		mostLikelyFixEta, err := time.Parse(snCreatedOnLayout, *c.MostLikelyFixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse mostLikelyFixEta %q: %w", *c.MostLikelyFixEta, err)
-		}
-		cv.MostLikelyFixEta = &mostLikelyFixEta
+		cv.MostLikelyFixEta = c.MostLikelyFixEta
 	}
-	// WorstCaseFixEta passes through once Ballerina's matching field (see
-	// snCase.WorstCaseFixEta doc comment) lands; until then this is always nil.
 	if c.WorstCaseFixEta != nil && *c.WorstCaseFixEta != "" {
-		worstCaseFixEta, err := time.Parse(snCreatedOnLayout, *c.WorstCaseFixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse worstCaseFixEta %q: %w", *c.WorstCaseFixEta, err)
-		}
-		cv.WorstCaseFixEta = &worstCaseFixEta
+		cv.WorstCaseFixEta = c.WorstCaseFixEta
 	}
 	// Tags are not populated: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see CaseView.Tags doc comment.
 	// cv.Tags is left nil.
@@ -969,24 +952,18 @@ type snUpdateCasePayload struct {
 	Description       *string `json:"description,omitempty"`
 	DeploymentID      *string `json:"deploymentId,omitempty"`
 	DeployedProductID *string `json:"deployedProductId,omitempty"`
-	// FixEta writes the customer-facing fix-commitment date/time (u_fix_eta_shared).
-	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field exists yet for this — ask:
-	// add a "fixEta" field to servicenow:CaseUpdatePayload backed by u_fix_eta_shared.
-	FixEta *string `json:"fixEta,omitempty"`
 	// BestCaseFixEta writes the internal-only best-case fix-commitment date
-	// (u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field exists
-	// yet for this — ask: add a "bestCaseFixEta" field to servicenow:CaseUpdatePayload
-	// backed by u_best_case_fix_eta.
+	// (u_best_case_fix_eta) as a date-only "YYYY-MM-DD" string. Confirmed live
+	// against the existing case-update resource — same single-field PATCH
+	// pathway as AutocloseHoldUntil/Title/Description above.
 	BestCaseFixEta *string `json:"bestCaseFixEta,omitempty"`
-	// MostLikelyFixEta writes the internal-only most-likely fix-commitment date
-	// (u_most_likely_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field
-	// exists yet for this — ask: add a "mostLikelyFixEta" field to
-	// servicenow:CaseUpdatePayload backed by u_most_likely_fix_eta.
+	// MostLikelyFixEta writes the internal-only most-likely fix-commitment
+	// date (u_most_likely_fix_eta) as a date-only "YYYY-MM-DD" string. Same
+	// pathway as BestCaseFixEta above.
 	MostLikelyFixEta *string `json:"mostLikelyFixEta,omitempty"`
 	// WorstCaseFixEta writes the internal-only worst-case fix-commitment date
-	// (u_worst_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field
-	// exists yet for this — ask: add a "worstCaseFixEta" field to
-	// servicenow:CaseUpdatePayload backed by u_worst_case_fix_eta.
+	// (u_worst_case_fix_eta) as a date-only "YYYY-MM-DD" string. Same pathway
+	// as BestCaseFixEta above.
 	WorstCaseFixEta *string `json:"worstCaseFixEta,omitempty"`
 }
 
@@ -1111,17 +1088,12 @@ type snUpdateCaseResponse struct {
 		CloseNotes *string    `json:"closeNotes"`
 		ResolvedOn *string    `json:"resolvedOn"`
 		ParentCase *snCaseRef `json:"parentCase"`
-		// FixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see snUpdateCasePayload.FixEta doc comment.
-		FixEta *string `json:"fixEta"`
-		// BestCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-		// snUpdateCasePayload.BestCaseFixEta doc comment.
-		BestCaseFixEta *string `json:"bestCaseFixEta"`
-		// MostLikelyFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-		// snUpdateCasePayload.MostLikelyFixEta doc comment.
+		// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta echo back the
+		// updated date-only estimate when that field was the one PATCHed —
+		// see snUpdateCasePayload doc comments.
+		BestCaseFixEta   *string `json:"bestCaseFixEta"`
 		MostLikelyFixEta *string `json:"mostLikelyFixEta"`
-		// WorstCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-		// snUpdateCasePayload.WorstCaseFixEta doc comment.
-		WorstCaseFixEta *string `json:"worstCaseFixEta"`
+		WorstCaseFixEta  *string `json:"worstCaseFixEta"`
 	} `json:"case"`
 }
 
@@ -1169,9 +1141,6 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.DeployedProductID != nil {
 		fieldCount++
 	}
-	if req.FixEta != nil {
-		fieldCount++
-	}
 	if req.BestCaseFixEta != nil {
 		fieldCount++
 	}
@@ -1182,7 +1151,7 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		fieldCount++
 	}
 	const fieldList = "state, severity, workState, watchList, assigneeEmail, parentId, relatedCaseId, " +
-		"autocloseHoldUntil, subject, description, deploymentId, deployedProductId, fixEta, " +
+		"autocloseHoldUntil, subject, description, deploymentId, deployedProductId, " +
 		"bestCaseFixEta, mostLikelyFixEta, or worstCaseFixEta"
 	if fieldCount == 0 {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of " + fieldList + " must be provided"}
@@ -1296,21 +1265,23 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		sysid := uuidToSysid(*req.DeployedProductID)
 		payload.DeployedProductID = &sysid
 	}
-	if req.FixEta != nil {
-		fixEta := formatSNDate(req.FixEta)
-		payload.FixEta = &fixEta
-	}
 	if req.BestCaseFixEta != nil {
-		bestCaseFixEta := formatSNDate(req.BestCaseFixEta)
-		payload.BestCaseFixEta = &bestCaseFixEta
+		if err := validateDateOnly("bestCaseFixEta", *req.BestCaseFixEta); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		payload.BestCaseFixEta = req.BestCaseFixEta
 	}
 	if req.MostLikelyFixEta != nil {
-		mostLikelyFixEta := formatSNDate(req.MostLikelyFixEta)
-		payload.MostLikelyFixEta = &mostLikelyFixEta
+		if err := validateDateOnly("mostLikelyFixEta", *req.MostLikelyFixEta); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		payload.MostLikelyFixEta = req.MostLikelyFixEta
 	}
 	if req.WorstCaseFixEta != nil {
-		worstCaseFixEta := formatSNDate(req.WorstCaseFixEta)
-		payload.WorstCaseFixEta = &worstCaseFixEta
+		if err := validateDateOnly("worstCaseFixEta", *req.WorstCaseFixEta); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		payload.WorstCaseFixEta = req.WorstCaseFixEta
 	}
 
 	// Close-gate: reject closing a case that still has an open, customer-visible task.
@@ -1400,44 +1371,17 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		}
 		resp.Case.ResolvedOn = &resolvedOn
 	}
-	// FixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see snUpdateCasePayload.FixEta doc comment;
-	// snResp.Case.FixEta is always nil until Ballerina echoes it back.
-	if snResp.Case.FixEta != nil && *snResp.Case.FixEta != "" {
-		fixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.FixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse fixEta %q: %w", *snResp.Case.FixEta, err)
-		}
-		resp.Case.FixEta = &fixEta
-	}
-	// BestCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-	// snUpdateCasePayload.BestCaseFixEta doc comment; snResp.Case.BestCaseFixEta is always
-	// nil until Ballerina echoes it back.
+	// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta echo back verbatim — the
+	// wire and domain types are both date-only "YYYY-MM-DD" strings, so no
+	// parsing/reformatting is needed here.
 	if snResp.Case.BestCaseFixEta != nil && *snResp.Case.BestCaseFixEta != "" {
-		bestCaseFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.BestCaseFixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse bestCaseFixEta %q: %w", *snResp.Case.BestCaseFixEta, err)
-		}
-		resp.Case.BestCaseFixEta = &bestCaseFixEta
+		resp.Case.BestCaseFixEta = snResp.Case.BestCaseFixEta
 	}
-	// MostLikelyFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-	// snUpdateCasePayload.MostLikelyFixEta doc comment; snResp.Case.MostLikelyFixEta is
-	// always nil until Ballerina echoes it back.
 	if snResp.Case.MostLikelyFixEta != nil && *snResp.Case.MostLikelyFixEta != "" {
-		mostLikelyFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.MostLikelyFixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse mostLikelyFixEta %q: %w", *snResp.Case.MostLikelyFixEta, err)
-		}
-		resp.Case.MostLikelyFixEta = &mostLikelyFixEta
+		resp.Case.MostLikelyFixEta = snResp.Case.MostLikelyFixEta
 	}
-	// WorstCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-	// snUpdateCasePayload.WorstCaseFixEta doc comment; snResp.Case.WorstCaseFixEta is always
-	// nil until Ballerina echoes it back.
 	if snResp.Case.WorstCaseFixEta != nil && *snResp.Case.WorstCaseFixEta != "" {
-		worstCaseFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.WorstCaseFixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse worstCaseFixEta %q: %w", *snResp.Case.WorstCaseFixEta, err)
-		}
-		resp.Case.WorstCaseFixEta = &worstCaseFixEta
+		resp.Case.WorstCaseFixEta = snResp.Case.WorstCaseFixEta
 	}
 
 	return resp, nil

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -420,12 +420,12 @@ const (
 	testTaskSysid = "33333333333333333333333333333333"
 )
 
-// --- UpdateCase: field-count union (including the new fixEta variant) ---
+// --- UpdateCase: field-count union (including the internal fix-ETA date variants) ---
 
 func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
 	svc := NewServiceNowCaseService(nil, nil)
 	closed := domain.CaseStateClosed
-	fixEta := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	bestCase := "2026-08-01"
 
 	tests := []struct {
 		name string
@@ -436,8 +436,8 @@ func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
 			req:  domain.UpdateCaseRequest{ID: testCaseUUID},
 		},
 		{
-			name: "state and fixEta both provided",
-			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, FixEta: &fixEta},
+			name: "state and bestCaseFixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, BestCaseFixEta: &bestCase},
 		},
 	}
 
@@ -520,61 +520,6 @@ func TestSNCaseService_UpdateCase_CloseGate_AllowsWhenNoVisibleOpenTask(t *testi
 	}
 	if !patchCalled {
 		t.Fatalf("expected PATCH /cases/{id} to be called when no visible open task blocks the close")
-	}
-}
-
-// --- FixEta read/write mapping ---
-
-func TestSNCaseService_GetCaseByID_MapsFixEta(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id": testCaseSysid, "internalId": "INT-1", "number": "CS0001",
-			"title": "t", "description": "d",
-			"createdOn": "2026-01-01 00:00:00", "createdBy": "a@example.com",
-			"project":         map[string]any{"id": "", "name": ""},
-			"deployment":      map[string]any{"id": "", "name": ""},
-			"deployedProduct": map[string]any{"id": "", "name": "", "version": ""},
-			"fixEta":          "2026-02-15 10:30:00",
-		})
-	})
-
-	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil)
-
-	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cv.FixEta == nil {
-		t.Fatalf("expected FixEta to be populated, got nil")
-	}
-	want := time.Date(2026, 2, 15, 10, 30, 0, 0, time.UTC)
-	if !cv.FixEta.Equal(want) {
-		t.Fatalf("FixEta = %v, want %v", cv.FixEta, want)
-	}
-}
-
-func TestSNCaseService_UpdateCase_FixEta_SendsFormattedDate(t *testing.T) {
-	var gotBody map[string]any
-	mux := http.NewServeMux()
-	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
-		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
-	})
-
-	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil)
-
-	fixEta := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
-	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, FixEta: &fixEta})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	got, _ := gotBody["fixEta"].(string)
-	want := "2026-03-01 12:00:00"
-	if got != want {
-		t.Fatalf("fixEta sent = %q, want %q", got, want)
 	}
 }
 
@@ -672,10 +617,9 @@ func TestSNCaseService_RemoveCaseTag_Success(t *testing.T) {
 func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t *testing.T) {
 	svc := NewServiceNowCaseService(nil, nil)
 	closed := domain.CaseStateClosed
-	fixEta := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
-	bestCase := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
-	mostLikely := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
-	worstCase := time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC)
+	bestCase := "2026-08-02"
+	mostLikely := "2026-08-03"
+	worstCase := "2026-08-04"
 
 	tests := []struct {
 		name string
@@ -686,8 +630,8 @@ func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t 
 			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, BestCaseFixEta: &bestCase},
 		},
 		{
-			name: "fixEta and mostLikelyFixEta both provided",
-			req:  domain.UpdateCaseRequest{ID: testCaseUUID, FixEta: &fixEta, MostLikelyFixEta: &mostLikely},
+			name: "mostLikelyFixEta and worstCaseFixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: &mostLikely, WorstCaseFixEta: &worstCase},
 		},
 		{
 			name: "bestCaseFixEta and worstCaseFixEta both provided",
@@ -708,27 +652,27 @@ func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t 
 func TestSNCaseService_UpdateCase_InternalFixEtaVariants_EachIndependentlySettable(t *testing.T) {
 	tests := []struct {
 		name    string
-		req     func(t time.Time) domain.UpdateCaseRequest
+		req     func(v string) domain.UpdateCaseRequest
 		bodyKey string
 	}{
 		{
 			name: "bestCaseFixEta",
-			req: func(t time.Time) domain.UpdateCaseRequest {
-				return domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &t}
+			req: func(v string) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &v}
 			},
 			bodyKey: "bestCaseFixEta",
 		},
 		{
 			name: "mostLikelyFixEta",
-			req: func(t time.Time) domain.UpdateCaseRequest {
-				return domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: &t}
+			req: func(v string) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: &v}
 			},
 			bodyKey: "mostLikelyFixEta",
 		},
 		{
 			name: "worstCaseFixEta",
-			req: func(t time.Time) domain.UpdateCaseRequest {
-				return domain.UpdateCaseRequest{ID: testCaseUUID, WorstCaseFixEta: &t}
+			req: func(v string) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, WorstCaseFixEta: &v}
 			},
 			bodyKey: "worstCaseFixEta",
 		},
@@ -746,15 +690,45 @@ func TestSNCaseService_UpdateCase_InternalFixEtaVariants_EachIndependentlySettab
 			client := newTestSNClient(t, mux)
 			svc := NewServiceNowCaseService(client, nil)
 
-			value := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+			value := "2026-03-01"
 			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req(value))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			got, _ := gotBody[tt.bodyKey].(string)
-			want := "2026-03-01 12:00:00"
+			want := "2026-03-01"
 			if got != want {
 				t.Fatalf("%s sent = %q, want %q", tt.bodyKey, got, want)
+			}
+		})
+	}
+}
+
+func TestSNCaseService_UpdateCase_InternalFixEtaVariants_RejectsMalformedDate(t *testing.T) {
+	tests := []struct {
+		name string
+		req  domain.UpdateCaseRequest
+	}{
+		{
+			name: "bestCaseFixEta not YYYY-MM-DD",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: strPtr("2026-08-01T00:00:00Z")},
+		},
+		{
+			name: "mostLikelyFixEta not a date",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: strPtr("not-a-date")},
+		},
+		{
+			name: "worstCaseFixEta empty string",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, WorstCaseFixEta: strPtr("")},
+		},
+	}
+
+	svc := NewServiceNowCaseService(nil, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
 			}
 		})
 	}
@@ -770,9 +744,9 @@ func TestSNCaseService_GetCaseByID_MapsInternalFixEtaFields(t *testing.T) {
 			"project":          map[string]any{"id": "", "name": ""},
 			"deployment":       map[string]any{"id": "", "name": ""},
 			"deployedProduct":  map[string]any{"id": "", "name": "", "version": ""},
-			"bestCaseFixEta":   "2026-02-10 00:00:00",
-			"mostLikelyFixEta": "2026-02-15 00:00:00",
-			"worstCaseFixEta":  "2026-02-20 00:00:00",
+			"bestCaseFixEta":   "2026-02-10",
+			"mostLikelyFixEta": "2026-02-15",
+			"worstCaseFixEta":  "2026-02-20",
 		})
 	})
 
@@ -784,17 +758,14 @@ func TestSNCaseService_GetCaseByID_MapsInternalFixEtaFields(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	wantBestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
-	if cv.BestCaseFixEta == nil || !cv.BestCaseFixEta.Equal(wantBestCase) {
-		t.Fatalf("BestCaseFixEta = %v, want %v", cv.BestCaseFixEta, wantBestCase)
+	if cv.BestCaseFixEta == nil || *cv.BestCaseFixEta != "2026-02-10" {
+		t.Fatalf("BestCaseFixEta = %v, want 2026-02-10", cv.BestCaseFixEta)
 	}
-	wantMostLikely := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
-	if cv.MostLikelyFixEta == nil || !cv.MostLikelyFixEta.Equal(wantMostLikely) {
-		t.Fatalf("MostLikelyFixEta = %v, want %v", cv.MostLikelyFixEta, wantMostLikely)
+	if cv.MostLikelyFixEta == nil || *cv.MostLikelyFixEta != "2026-02-15" {
+		t.Fatalf("MostLikelyFixEta = %v, want 2026-02-15", cv.MostLikelyFixEta)
 	}
-	wantWorstCase := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
-	if cv.WorstCaseFixEta == nil || !cv.WorstCaseFixEta.Equal(wantWorstCase) {
-		t.Fatalf("WorstCaseFixEta = %v, want %v", cv.WorstCaseFixEta, wantWorstCase)
+	if cv.WorstCaseFixEta == nil || *cv.WorstCaseFixEta != "2026-02-20" {
+		t.Fatalf("WorstCaseFixEta = %v, want 2026-02-20", cv.WorstCaseFixEta)
 	}
 }
 
@@ -805,9 +776,9 @@ func TestSNCaseService_UpdateCase_EchoesInternalFixEtaFieldsBack(t *testing.T) {
 			"message": "ok",
 			"case": map[string]any{
 				"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00",
-				"bestCaseFixEta":   "2026-02-10 00:00:00",
-				"mostLikelyFixEta": "2026-02-15 00:00:00",
-				"worstCaseFixEta":  "2026-02-20 00:00:00",
+				"bestCaseFixEta":   "2026-02-10",
+				"mostLikelyFixEta": "2026-02-15",
+				"worstCaseFixEta":  "2026-02-20",
 			},
 		})
 	})
@@ -815,23 +786,20 @@ func TestSNCaseService_UpdateCase_EchoesInternalFixEtaFieldsBack(t *testing.T) {
 	client := newTestSNClient(t, mux)
 	svc := NewServiceNowCaseService(client, nil)
 
-	bestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	bestCase := "2026-02-10"
 	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &bestCase})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	wantBestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
-	if resp.Case.BestCaseFixEta == nil || !resp.Case.BestCaseFixEta.Equal(wantBestCase) {
-		t.Fatalf("BestCaseFixEta = %v, want %v", resp.Case.BestCaseFixEta, wantBestCase)
+	if resp.Case.BestCaseFixEta == nil || *resp.Case.BestCaseFixEta != "2026-02-10" {
+		t.Fatalf("BestCaseFixEta = %v, want 2026-02-10", resp.Case.BestCaseFixEta)
 	}
-	wantMostLikely := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
-	if resp.Case.MostLikelyFixEta == nil || !resp.Case.MostLikelyFixEta.Equal(wantMostLikely) {
-		t.Fatalf("MostLikelyFixEta = %v, want %v", resp.Case.MostLikelyFixEta, wantMostLikely)
+	if resp.Case.MostLikelyFixEta == nil || *resp.Case.MostLikelyFixEta != "2026-02-15" {
+		t.Fatalf("MostLikelyFixEta = %v, want 2026-02-15", resp.Case.MostLikelyFixEta)
 	}
-	wantWorstCase := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
-	if resp.Case.WorstCaseFixEta == nil || !resp.Case.WorstCaseFixEta.Equal(wantWorstCase) {
-		t.Fatalf("WorstCaseFixEta = %v, want %v", resp.Case.WorstCaseFixEta, wantWorstCase)
+	if resp.Case.WorstCaseFixEta == nil || *resp.Case.WorstCaseFixEta != "2026-02-20" {
+		t.Fatalf("WorstCaseFixEta = %v, want 2026-02-20", resp.Case.WorstCaseFixEta)
 	}
 }
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -629,8 +629,8 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
-        `workState`, `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`,
-        or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`,
+        `workState`, `watchList`, `assigneeEmail`, `bestCaseFixEta`, `mostLikelyFixEta`,
+        or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `bestCaseFixEta`,
         `mostLikelyFixEta`, and `worstCaseFixEta` are supported only when the ServiceNow data
         source is active.
       operationId: patchCase
@@ -3752,9 +3752,9 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`, `fixEta`,
+        Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`,
         `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta` must be provided.
-        `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`, and
+        `watchList`, `assigneeEmail`, `bestCaseFixEta`, `mostLikelyFixEta`, and
         `worstCaseFixEta` are supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
         `state` when the state is `closed` or `solution_proposed`.
@@ -3764,7 +3764,6 @@ components:
         - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
-        - required: [fixEta]
         - required: [bestCaseFixEta]
         - required: [mostLikelyFixEta]
         - required: [worstCaseFixEta]
@@ -3845,28 +3844,24 @@ components:
         closeNotes:
           type: string
           description: Close notes. Only allowed when state is closed or solution_proposed.
-        fixEta:
-          type: string
-          format: date-time
-          description: The single customer-facing fix-commitment date/time (ServiceNow only).
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           description: >-
-            Internal-only best-case fix-commitment date, visible to CSM engineers only
-            (ServiceNow only).
+            Internal-only best-case fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only (ServiceNow only).
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           description: >-
-            Internal-only most-likely fix-commitment date, visible to CSM engineers only
-            (ServiceNow only).
+            Internal-only most-likely fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only (ServiceNow only).
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           description: >-
-            Internal-only worst-case fix-commitment date, visible to CSM engineers only
-            (ServiceNow only).
+            Internal-only worst-case fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only (ServiceNow only).
 
     UpdateCaseResponse:
       type: object
@@ -3970,34 +3965,27 @@ components:
           format: date-time
           nullable: true
           description: Timestamp when the case was resolved, present when state is closed or solution_proposed.
-        fixEta:
-          type: string
-          format: date-time
-          nullable: true
-          description: >-
-            Echoes the updated customer-facing fix-commitment date/time back, present when
-            fixEta was the field updated.
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Echoes the updated internal-only best-case fix-commitment date back, present when
-            bestCaseFixEta was the field updated.
+            Echoes the updated internal-only best-case fix-commitment date back (date-only,
+            YYYY-MM-DD), present when bestCaseFixEta was the field updated.
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Echoes the updated internal-only most-likely fix-commitment date back, present when
-            mostLikelyFixEta was the field updated.
+            Echoes the updated internal-only most-likely fix-commitment date back (date-only,
+            YYYY-MM-DD), present when mostLikelyFixEta was the field updated.
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Echoes the updated internal-only worst-case fix-commitment date back, present when
-            worstCaseFixEta was the field updated.
+            Echoes the updated internal-only worst-case fix-commitment date back (date-only,
+            YYYY-MM-DD), present when worstCaseFixEta was the field updated.
 
     CaseLabelRef:
       type: object
@@ -4502,34 +4490,27 @@ components:
           type: string
           nullable: true
           description: Free-text resolution/close notes. Populated for resolved/closed ServiceNow cases; null otherwise.
-        fixEta:
-          type: string
-          format: date-time
-          nullable: true
-          description: >-
-            The single customer-facing fix-commitment date/time. Populated for ServiceNow
-            cases; null otherwise.
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Internal-only best-case fix-commitment date, visible to CSM engineers only.
-            Populated for ServiceNow cases; null otherwise.
+            Internal-only best-case fix-commitment date (date-only, YYYY-MM-DD), visible to
+            CSM engineers only. Populated for ServiceNow cases; null otherwise.
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Internal-only most-likely fix-commitment date, visible to CSM engineers only.
-            Populated for ServiceNow cases; null otherwise.
+            Internal-only most-likely fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only. Populated for ServiceNow cases; null otherwise.
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Internal-only worst-case fix-commitment date, visible to CSM engineers only.
-            Populated for ServiceNow cases; null otherwise.
+            Internal-only worst-case fix-commitment date (date-only, YYYY-MM-DD), visible to
+            CSM engineers only. Populated for ServiceNow cases; null otherwise.
 
     CaseSearchView:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

A batch of CSM portal case/SR/CR workflow improvements, consolidated into this single PR to avoid triggering multiple separate CodeRabbit review cycles:

1. The automated-message chip next to the bot's comments in the Activities tab read "Chatbot" — generic/dated for what is actually an AI agent.
2. The Overview box, when collapsed, summarized a case as Account · Tier · Assignee — facts already visible elsewhere on the page — rather than the project/deployment/product/assignee context an engineer actually needs while triaging a list of cases.
3. Linking a case to a related service request required creating the SR separately first, then linking it — two steps for what is conceptually one action, and the new SR's project/deployment/product had to be re-entered by hand instead of inherited from the case it relates to.
4. "Set Fix ETA" only ever wrote a single legacy datetime field (`u_fix_eta_shared`) that had never been backed by real Ballerina support since it was introduced — the FE dialog silently failed to persist anything.
5. Case/SR/SRA creation could be started directly from their listing pages with no project context, making it easy to create the record against the wrong project. There was no equivalent creation entry point scoped to a specific project.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Rename the "Chatbot" chip to "AI Agent".
2. Change the collapsed Overview summary to show Project name, Deployment, Product, and Assignee instead of Account, Tier, and Assignee.
3. Add a "Create service request" action alongside "Link to another case" in the case detail page's Linked Service Requests card, pre-filling project/deployment/product from the current case (project locked, deployment/product editable) and passing the relation through at creation time.
4. Replace the single broken `fixEta` field with three real, working date-only estimates (`bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta`), plumbed end-to-end through entity-service, the csm-portal backend, and the FE dialog.
5. Gate direct "Create" actions on the case/SR/SRA listing pages behind a dialog that routes the user to pick a project first; add project-scoped "Create" entry points on the Project details page with the project field locked.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**AI Agent chip rename** — `CsmCaseCommentBubble.tsx`: `ROLE_LABEL.chatbot` changed from `"Chatbot"` to `"AI Agent"`. Label-only change; chip color/role and the underlying `authorRole` value are unchanged.

**Collapsed Overview summary** — `CaseMetaBand.tsx`: `collapsedSummary` now joins `projectName`, `product.deployment`, `product.product`, `assignee` instead of `customer`, `tierLabel(tier)`, `assignee`. The expanded view is unchanged. Falsy values are filtered before joining, so e.g. an announcement case (no deployment/product/assignee) degrades gracefully to just the project name.

**One-step linked SR creation** — new `CreateServiceRequestFromCaseNavState` type carries `projectId` / `relatedCaseId` / `relatedCaseNumber` / `deploymentId` / `deployedProductId` via router `location.state`. `CreateServiceRequestPage.tsx` reads it (or a `?projectId=` query param) and renders a locked, read-only Project field while leaving Deployment/Product editable and pre-seeded; shows a banner ("Creating a service request linked to case {number}"); passes `relatedCaseId` through to the existing `POST /cases` payload (already accepted server-side, no BE contract change needed for the link itself).

**Set Fix ETA rework** — the old `fixEta` field (`u_fix_eta_shared`, datetime, dead since PR #1219 — Ballerina support was never actually merged, so it always read back `nil`) is removed entirely across entity-service, the csm-portal backend, and the FE. Replaced with three independent date-only fields, `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` (`YYYY-MM-DD`), mapped to the corresponding ServiceNow fields already exposed via the existing Ballerina entity-service contract (confirmed present since PR #2509 — no Ballerina change required). `SetFixEtaDialog.tsx` now collects all three dates. This was live-verified end-to-end against SN DEV (case CS0440883) via a global-scope Script Include proxy (SN update set `1258-S1218-T88-CST-SajithE`) after two other options (clearing `sys_dictionary.read_only`, a scoped-code direct write) were ruled out by real SN permission constraints.

**Project-scoped creation gating** — `CsmCasesPage.tsx`, `OperationsPage.tsx`, `CsmSecurityCenterPage.tsx`: "Create X" buttons now open a shared `CreateFromProjectRequiredDialog` (parameterized by entity noun) instead of navigating directly; its primary action routes to `/customers/projects`. `CsmProjectDetailPage.tsx`: the single "Create case" button is replaced with a "Create ▾" menu offering Create case / Create service request / Create security report, each navigating with `?projectId=` set; `CreateSecurityReportPage.tsx` gained the corresponding `?projectId=` locking (new capability). No Create Engagement entry point exists anywhere in the stack yet (no backend contract support) — flagged as a follow-up, not built here.

## User stories
> Summary of user stories addressed by this change

- As a CS engineer, when I collapse a case's Overview box, I want to still see which project/deployment/product the case is against and who's assigned, so I can triage a list of cases without expanding each one.
- As a CS engineer looking at a case's linked service requests, I want to create a new related SR in one step, pre-filled from the case, instead of creating it separately and then linking it.
- As a CS engineer, I want Set Fix ETA to actually persist the dates I enter.
- As a CS engineer, I want to be steered toward the right project when creating a new case/SR/SRA, so I don't accidentally create it under the wrong project.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

- Renamed the automated-message chip from "Chatbot" to "AI Agent" in the case Activities feed.
- The collapsed case Overview summary now shows Project, Deployment, Product, and Assignee instead of Account, Tier, and Assignee.
- Added a "Create service request" action in a case's Linked Service Requests card that pre-fills the new SR's project/deployment/product from the current case.
- Fixed Set Fix ETA: replaced a non-functional legacy field with three working date-only estimates (best case / most likely / worst case).
- Case, service request, and security report creation from their listing pages now routes through project selection first; the Project details page gained project-scoped "Create" entry points with the project locked.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal CSM portal UI/workflow changes, no external-facing documentation to update.

## Training
N/A — no training content covers this internal portal.

## Certification
N/A — no certification exam covers this internal portal.

## Marketing
N/A — internal tooling change, not customer/market facing.

## Automation tests
 - Unit tests
   > `CsmCaseCommentBubble.test.tsx`, `CaseActionBar.test.tsx`, `SetFixEtaDialog.test.tsx` updated/passing; `entity-service`'s `sn_case_service_test.go` updated for the fix-ETA field rework; `apps/csm-portal/backend`'s `cases_test.go` updated for the mirrored contract change. `go test ./...`, `go vet ./...` clean on entity-service and the backend; `pnpm build`, `pnpm lint`, `npx vitest run` clean on the webapp.
 - Integration tests
   > N/A — no integration test harness exercises this page's DOM; Set Fix ETA was live-verified end-to-end against ServiceNow DEV (case CS0440883, read-back confirmed).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go/TypeScript project; ran `go vet` and `eslint` clean on the changed files instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None currently open — this PR previously absorbed the commits from #1269 and #1272 (both closed, superseded by this branch) to keep all related work under a single review.

## Migrations (if applicable)
N/A — no schema or data migration involved. The removed `fixEta` field was dead code with no live data ever written to it.

## Test environment
Verified with `go build ./...`, `go test ./...`, `go vet ./...` (entity-service and csm-portal backend), `pnpm build`, `pnpm lint`, `npx vitest run` (webapp), all on macOS/Node/Go local dev environment; Set Fix ETA additionally verified live against ServiceNow DEV (`wso2sndev.service-now.com`).

## Learning
N/A — implementation followed existing patterns in the codebase (locked-field create forms, dialog-based confirmation, entity-service field mapping).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Create dropdown on project pages for cases, service requests, and security reports.
  * Added modal guidance for creating items without selecting a project first.
  * Enabled creating service requests directly from a case, with related case and project details prefilled.
* **Improvements**
  * Updated case “Fix ETA” handling to manage best-, most-likely-, and worst-case dates using date-only formatting (removing the single customer-facing field from the UI).
  * Refined collapsed case summaries and updated the chatbot label to “AI Agent”.
  * Preserved case tags when viewing case details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->