### PR TITLE
[CSM Portal] add 3 date-only fix-ETA estimates, replace dead fixEta field

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1993,56 +1993,13 @@ func TestRemoveCaseTag(t *testing.T) {
 	})
 }
 
-func TestPatchCaseFixEta(t *testing.T) {
-	// Item 3: fixEta is a pure pass-through single-field PATCH variant. It does not
-	// trip the state/workState peek, so patchCaseFn is invoked directly with the raw
-	// body and the upstream response passes through unchanged.
-	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"fixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","fixEta":"2026-08-01T00:00:00Z"}}`
-
-	var capturedBody []byte
-	client := &mockEntityCaseClient{
-		patchCaseFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
-			capturedBody = body
-			return []byte(upstream), nil
-		},
-	}
-	h := NewCaseHandler(client)
-	r := withUser(httptest.NewRequest(http.MethodPatch, "/cases/"+testCaseID, strings.NewReader(reqBody)))
-	r.SetPathValue("id", testCaseID)
-	w := httptest.NewRecorder()
-	h.PatchCase(w, r)
-
-	assertStatus(t, w, http.StatusOK)
-	assertContentType(t, w, "application/json")
-
-	if string(capturedBody) != reqBody {
-		t.Errorf("upstream received body %s, want %s (must forward verbatim)", capturedBody, reqBody)
-	}
-
-	var wrapper struct {
-		Case struct {
-			FixEta string `json:"fixEta"`
-		} `json:"case"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
-		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
-	}
-	if wrapper.Case.FixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.fixEta = %q, want %q", wrapper.Case.FixEta, "2026-08-01T00:00:00Z")
-	}
-}
-
-func TestGetCasePassesThroughFixEtaAndTags(t *testing.T) {
-	// Item 3 (read) + item 8 (read): fixEta and tags are additive entity-response
-	// fields with zero BFF handling — GetCase's injectNextStates merge must not drop
-	// or alter them.
+func TestGetCasePassesThroughTags(t *testing.T) {
+	// Item 8 (read): tags are an additive entity-response field with zero BFF
+	// handling — GetCase's injectNextStates merge must not drop or alter them.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
 	const upstreamBody = `{
 		"id":"` + testCaseID + `",
 		"state":"open",
-		"fixEta":"2026-08-01T00:00:00Z",
 		"tags":[{"id":"33333333-3333-3333-3333-333333333333","label":"micro-gw","color":"#FF6600"}]
 	}`
 	client := &mockEntityCaseClient{
@@ -2064,14 +2021,10 @@ func TestGetCasePassesThroughFixEtaAndTags(t *testing.T) {
 		Color *string `json:"color"`
 	}
 	type resp struct {
-		FixEta string `json:"fixEta"`
-		Tags   []tag  `json:"tags"`
+		Tags []tag `json:"tags"`
 	}
 	got := decodeJSON[resp](t, w)
 
-	if got.FixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("fixEta = %q, want 2026-08-01T00:00:00Z", got.FixEta)
-	}
 	if len(got.Tags) != 1 || got.Tags[0].Label != "micro-gw" || got.Tags[0].Color == nil || *got.Tags[0].Color != "#FF6600" {
 		t.Errorf("tags = %+v, want a single micro-gw/#FF6600 entry", got.Tags)
 	}
@@ -2105,8 +2058,8 @@ func TestPatchCaseBestCaseFixEta(t *testing.T) {
 	// patchCaseFn is invoked directly with the raw body and the upstream response
 	// passes through unchanged.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"bestCaseFixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","bestCaseFixEta":"2026-08-01T00:00:00Z"}}`
+	const reqBody = `{"bestCaseFixEta":"2026-08-01"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","bestCaseFixEta":"2026-08-01"}}`
 
 	var capturedBody []byte
 	client := &mockEntityCaseClient{
@@ -2136,8 +2089,8 @@ func TestPatchCaseBestCaseFixEta(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
 	}
-	if wrapper.Case.BestCaseFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.bestCaseFixEta = %q, want %q", wrapper.Case.BestCaseFixEta, "2026-08-01T00:00:00Z")
+	if wrapper.Case.BestCaseFixEta != "2026-08-01" {
+		t.Errorf("case.bestCaseFixEta = %q, want %q", wrapper.Case.BestCaseFixEta, "2026-08-01")
 	}
 }
 
@@ -2145,8 +2098,8 @@ func TestPatchCaseMostLikelyFixEta(t *testing.T) {
 	// mostLikelyFixEta is a pure pass-through single-field PATCH variant, same
 	// shape as the existing fixEta test.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"mostLikelyFixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","mostLikelyFixEta":"2026-08-01T00:00:00Z"}}`
+	const reqBody = `{"mostLikelyFixEta":"2026-08-01"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","mostLikelyFixEta":"2026-08-01"}}`
 
 	var capturedBody []byte
 	client := &mockEntityCaseClient{
@@ -2176,8 +2129,8 @@ func TestPatchCaseMostLikelyFixEta(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
 	}
-	if wrapper.Case.MostLikelyFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.mostLikelyFixEta = %q, want %q", wrapper.Case.MostLikelyFixEta, "2026-08-01T00:00:00Z")
+	if wrapper.Case.MostLikelyFixEta != "2026-08-01" {
+		t.Errorf("case.mostLikelyFixEta = %q, want %q", wrapper.Case.MostLikelyFixEta, "2026-08-01")
 	}
 }
 
@@ -2185,8 +2138,8 @@ func TestPatchCaseWorstCaseFixEta(t *testing.T) {
 	// worstCaseFixEta is a pure pass-through single-field PATCH variant, same
 	// shape as the existing fixEta test.
 	const testCaseID = "11111111-1111-1111-1111-111111111111"
-	const reqBody = `{"worstCaseFixEta":"2026-08-01T00:00:00Z"}`
-	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","worstCaseFixEta":"2026-08-01T00:00:00Z"}}`
+	const reqBody = `{"worstCaseFixEta":"2026-08-01"}`
+	const upstream = `{"message":"Case updated successfully","case":{"id":"` + testCaseID + `","updatedOn":"2026-07-23T10:00:00Z","worstCaseFixEta":"2026-08-01"}}`
 
 	var capturedBody []byte
 	client := &mockEntityCaseClient{
@@ -2216,8 +2169,8 @@ func TestPatchCaseWorstCaseFixEta(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
 	}
-	if wrapper.Case.WorstCaseFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("case.worstCaseFixEta = %q, want %q", wrapper.Case.WorstCaseFixEta, "2026-08-01T00:00:00Z")
+	if wrapper.Case.WorstCaseFixEta != "2026-08-01" {
+		t.Errorf("case.worstCaseFixEta = %q, want %q", wrapper.Case.WorstCaseFixEta, "2026-08-01")
 	}
 }
 
@@ -2229,9 +2182,9 @@ func TestGetCasePassesThroughNewFixEtaFields(t *testing.T) {
 	const upstreamBody = `{
 		"id":"` + testCaseID + `",
 		"state":"open",
-		"bestCaseFixEta":"2026-07-28T00:00:00Z",
-		"mostLikelyFixEta":"2026-08-01T00:00:00Z",
-		"worstCaseFixEta":"2026-08-15T00:00:00Z"
+		"bestCaseFixEta":"2026-07-28",
+		"mostLikelyFixEta":"2026-08-01",
+		"worstCaseFixEta":"2026-08-15"
 	}`
 	client := &mockEntityCaseClient{
 		getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
@@ -2253,21 +2206,21 @@ func TestGetCasePassesThroughNewFixEtaFields(t *testing.T) {
 	}
 	got := decodeJSON[resp](t, w)
 
-	if got.BestCaseFixEta != "2026-07-28T00:00:00Z" {
-		t.Errorf("bestCaseFixEta = %q, want 2026-07-28T00:00:00Z", got.BestCaseFixEta)
+	if got.BestCaseFixEta != "2026-07-28" {
+		t.Errorf("bestCaseFixEta = %q, want 2026-07-28", got.BestCaseFixEta)
 	}
-	if got.MostLikelyFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01T00:00:00Z", got.MostLikelyFixEta)
+	if got.MostLikelyFixEta != "2026-08-01" {
+		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01", got.MostLikelyFixEta)
 	}
-	if got.WorstCaseFixEta != "2026-08-15T00:00:00Z" {
-		t.Errorf("worstCaseFixEta = %q, want 2026-08-15T00:00:00Z", got.WorstCaseFixEta)
+	if got.WorstCaseFixEta != "2026-08-15" {
+		t.Errorf("worstCaseFixEta = %q, want 2026-08-15", got.WorstCaseFixEta)
 	}
 }
 
 func TestSearchCasesPassesThroughNewFixEtaFields(t *testing.T) {
 	// Item: the 3 new fix-ETA fields flow through SearchCases's response verbatim,
 	// same zero-BFF-handling pattern as fixEta/tags on GetCase.
-	const upstream = `{"cases":[{"id":"11111111-1111-1111-1111-111111111111","bestCaseFixEta":"2026-07-28T00:00:00Z","mostLikelyFixEta":"2026-08-01T00:00:00Z","worstCaseFixEta":"2026-08-15T00:00:00Z"}],"total":1}`
+	const upstream = `{"cases":[{"id":"11111111-1111-1111-1111-111111111111","bestCaseFixEta":"2026-07-28","mostLikelyFixEta":"2026-08-01","worstCaseFixEta":"2026-08-15"}],"total":1}`
 	client := &mockEntityCaseClient{
 		searchCasesFn: func(_ context.Context, _ []byte) ([]byte, error) {
 			return []byte(upstream), nil
@@ -2291,14 +2244,14 @@ func TestSearchCasesPassesThroughNewFixEtaFields(t *testing.T) {
 	if len(got.Cases) != 1 {
 		t.Fatalf("cases = %+v, want 1 entry", got.Cases)
 	}
-	if got.Cases[0].BestCaseFixEta != "2026-07-28T00:00:00Z" {
-		t.Errorf("bestCaseFixEta = %q, want 2026-07-28T00:00:00Z", got.Cases[0].BestCaseFixEta)
+	if got.Cases[0].BestCaseFixEta != "2026-07-28" {
+		t.Errorf("bestCaseFixEta = %q, want 2026-07-28", got.Cases[0].BestCaseFixEta)
 	}
-	if got.Cases[0].MostLikelyFixEta != "2026-08-01T00:00:00Z" {
-		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01T00:00:00Z", got.Cases[0].MostLikelyFixEta)
+	if got.Cases[0].MostLikelyFixEta != "2026-08-01" {
+		t.Errorf("mostLikelyFixEta = %q, want 2026-08-01", got.Cases[0].MostLikelyFixEta)
 	}
-	if got.Cases[0].WorstCaseFixEta != "2026-08-15T00:00:00Z" {
-		t.Errorf("worstCaseFixEta = %q, want 2026-08-15T00:00:00Z", got.Cases[0].WorstCaseFixEta)
+	if got.Cases[0].WorstCaseFixEta != "2026-08-15" {
+		t.Errorf("worstCaseFixEta = %q, want 2026-08-15", got.Cases[0].WorstCaseFixEta)
 	}
 }
 

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -130,7 +130,7 @@ paths:
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
         `workState`, `watchList`, `assigneeEmail`, `parentId`, `subject`, `description`,
-        `deploymentId`, `deployedProductId`, `relatedCaseId`, `autocloseHoldUntil`, `fixEta`,
+        `deploymentId`, `deployedProductId`, `relatedCaseId`, `autocloseHoldUntil`,
         `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`.
         `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are supported only when
         the ServiceNow data source is active.
@@ -4419,7 +4419,7 @@ components:
       description: |
         Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`, `parentId`,
         `subject`, `description`, `deploymentId`, `deployedProductId`, `relatedCaseId`,
-        `autocloseHoldUntil`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`
+        `autocloseHoldUntil`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`
         must be provided. `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are
         supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional resolution fields that may only be
@@ -4437,7 +4437,6 @@ components:
         - required: [deployedProductId]
         - required: [relatedCaseId]
         - required: [autocloseHoldUntil]
-        - required: [fixEta]
         - required: [bestCaseFixEta]
         - required: [mostLikelyFixEta]
         - required: [worstCaseFixEta]
@@ -4515,27 +4514,24 @@ components:
             until this date, mirroring the real ServiceNow UX (an engineer picks a hold-until
             date). This is the only supported write against that sequence — the raw
             `autoclosureStep` state is not directly settable (ServiceNow only).
-        fixEta:
-          type: string
-          format: date-time
-          description: >
-            Sets the customer-facing fix-commitment date/time for the case. This is the only
-            fix-ETA field exposed by this API; internal-only estimates are not surfaced.
         bestCaseFixEta:
           type: string
-          format: date-time
-          nullable: true
-          description: Sets the best-case fix-commitment date/time estimate for the case.
+          format: date
+          description: >
+            Sets the internal-only best-case fix-commitment date estimate for the case
+            (date-only, YYYY-MM-DD). Never surfaced to the customer.
         mostLikelyFixEta:
           type: string
-          format: date-time
-          nullable: true
-          description: Sets the most-likely fix-commitment date/time estimate for the case.
+          format: date
+          description: >
+            Sets the internal-only most-likely fix-commitment date estimate for the case
+            (date-only, YYYY-MM-DD). Never surfaced to the customer.
         worstCaseFixEta:
           type: string
-          format: date-time
-          nullable: true
-          description: Sets the worst-case fix-commitment date/time estimate for the case.
+          format: date
+          description: >
+            Sets the internal-only worst-case fix-commitment date estimate for the case
+            (date-only, YYYY-MM-DD). Never surfaced to the customer.
 
     UpdateCaseResponse:
       type: object
@@ -4603,11 +4599,27 @@ components:
         parentCase:
           $ref: '#/components/schemas/CaseNumberRef'
           description: Present when the update set parentId, identifying the case, incident, change request, or problem this case is now linked to as its parent.
-        fixEta:
+        bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Echoes the updated customer-facing fix-commitment date/time. Present when the update set fixEta.
+          description: >-
+            Echoes the updated internal-only best-case fix-commitment date back (date-only,
+            YYYY-MM-DD). Present when the update set bestCaseFixEta.
+        mostLikelyFixEta:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Echoes the updated internal-only most-likely fix-commitment date back (date-only,
+            YYYY-MM-DD). Present when the update set mostLikelyFixEta.
+        worstCaseFixEta:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Echoes the updated internal-only worst-case fix-commitment date back (date-only,
+            YYYY-MM-DD). Present when the update set worstCaseFixEta.
 
     CaseResolutionCode:
       type: string
@@ -5261,28 +5273,27 @@ components:
           description: >-
             Service-request cases whose parent points to this case. Populated on every
             case detail response, not just high-severity cases.
-        fixEta:
-          type: string
-          format: date-time
-          nullable: true
-          description: >-
-            The single customer-facing fix-commitment date/time for the case. This is the
-            only fix-ETA field exposed by this API; internal-only estimates are not surfaced.
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Best-case fix-commitment date/time estimate for the case.
+          description: >-
+            Internal-only best-case fix-commitment date estimate for the case (date-only,
+            YYYY-MM-DD). Never surfaced to the customer.
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Most-likely fix-commitment date/time estimate for the case.
+          description: >-
+            Internal-only most-likely fix-commitment date estimate for the case (date-only,
+            YYYY-MM-DD). Never surfaced to the customer.
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
-          description: Worst-case fix-commitment date/time estimate for the case.
+          description: >-
+            Internal-only worst-case fix-commitment date estimate for the case (date-only,
+            YYYY-MM-DD). Never surfaced to the customer.
         tags:
           type: array
           nullable: true

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -326,25 +326,21 @@ export interface BeCaseView {
    */
   autoclosureStateTime?: string | null;
   /**
-   * The customer-facing fix-commitment date/time for the case — the shared
-   * commitment shown to the customer. Settable via `PATCH /cases/{id}`
-   * (`fixEta`). Distinct from the three internal-only estimates below, which
-   * are never shared with the customer.
-   */
-  fixEta?: string | null;
-  /**
-   * Internal-only best-case fix estimate. Settable via `PATCH /cases/{id}`
-   * (`bestCaseFixEta`). Never surfaced to the customer.
+   * Internal-only best-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string. Settable via `PATCH /cases/{id}` (`bestCaseFixEta`). Never
+   * surfaced to the customer.
    */
   bestCaseFixEta?: string | null;
   /**
-   * Internal-only most-likely fix estimate. Settable via `PATCH /cases/{id}`
-   * (`mostLikelyFixEta`). Never surfaced to the customer.
+   * Internal-only most-likely fix estimate, as a date-only "YYYY-MM-DD"
+   * string. Settable via `PATCH /cases/{id}` (`mostLikelyFixEta`). Never
+   * surfaced to the customer.
    */
   mostLikelyFixEta?: string | null;
   /**
-   * Internal-only worst-case fix estimate. Settable via `PATCH /cases/{id}`
-   * (`worstCaseFixEta`). Never surfaced to the customer.
+   * Internal-only worst-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string. Settable via `PATCH /cases/{id}` (`worstCaseFixEta`). Never
+   * surfaced to the customer.
    */
   worstCaseFixEta?: string | null;
   /** Free-text labels attached to the case. Null/absent when none are set. */
@@ -533,7 +529,6 @@ interface BeCaseUpdateNever {
   deployedProductId?: never;
   relatedCaseId?: never;
   autocloseHoldUntil?: never;
-  fixEta?: never;
   bestCaseFixEta?: never;
   mostLikelyFixEta?: never;
   worstCaseFixEta?: never;
@@ -543,7 +538,7 @@ interface BeCaseUpdateNever {
  * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
  * **Exactly one** of `state` / `severity` / `workState` / `assigneeEmail` /
  * `watchList` / `parentId` / `subject` / `description` / `deploymentId` /
- * `deployedProductId` / `relatedCaseId` / `autocloseHoldUntil` / `fixEta` /
+ * `deployedProductId` / `relatedCaseId` / `autocloseHoldUntil` /
  * `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` is sent per call —
  * the backend rejects zero or more than one. Encoded as a discriminated union
  * (each variant carries every other field as `never`, via
@@ -552,7 +547,7 @@ interface BeCaseUpdateNever {
  * and `autocloseHoldUntil` are supported **only** for the ServiceNow data
  * source. `workState` is only accepted while the case is `work_in_progress`.
  * `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` are internal-only
- * estimates, independent of the customer-facing `fixEta`.
+ * estimates, never shared with the customer.
  */
 export type BeCaseUpdatePayload =
   | (Omit<BeCaseUpdateNever, "state"> & {
@@ -591,16 +586,11 @@ export type BeCaseUpdatePayload =
    * `autoclosureStep` is not directly settable.
    */
   | (Omit<BeCaseUpdateNever, "autocloseHoldUntil"> & { autocloseHoldUntil: string })
-  /**
-   * Sets the customer-facing fix-commitment date/time for the case (ISO
-   * date-time).
-   */
-  | (Omit<BeCaseUpdateNever, "fixEta"> & { fixEta: string })
-  /** Sets the internal-only best-case fix estimate (ISO date-time). */
+  /** Sets the internal-only best-case fix estimate (date-only, "YYYY-MM-DD"). */
   | (Omit<BeCaseUpdateNever, "bestCaseFixEta"> & { bestCaseFixEta: string })
-  /** Sets the internal-only most-likely fix estimate (ISO date-time). */
+  /** Sets the internal-only most-likely fix estimate (date-only, "YYYY-MM-DD"). */
   | (Omit<BeCaseUpdateNever, "mostLikelyFixEta"> & { mostLikelyFixEta: string })
-  /** Sets the internal-only worst-case fix estimate (ISO date-time). */
+  /** Sets the internal-only worst-case fix estimate (date-only, "YYYY-MM-DD"). */
   | (Omit<BeCaseUpdateNever, "worstCaseFixEta"> & { worstCaseFixEta: string });
 
 /** A user in the case watch list, as echoed by `PATCH /cases/{id}`. */
@@ -623,8 +613,6 @@ export interface BeUpdatedCase {
   assignedTo?: BeEntityRef | null;
   /** Present when the update set `parentId` — the record this case is now linked to as its parent. */
   parentCase?: BeCaseNumberRef | null;
-  /** Echoes the updated customer-facing fix-commitment date/time. Present when the update set `fixEta`. */
-  fixEta?: string | null;
   /** Echoes the updated internal-only best-case fix estimate. Present when the update set `bestCaseFixEta`. */
   bestCaseFixEta?: string | null;
   /** Echoes the updated internal-only most-likely fix estimate. Present when the update set `mostLikelyFixEta`. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -134,7 +134,6 @@ function detailFromBeCase(
     audit: [],
     attachments: [],
     isWatching: watchers.some((w) => w.isMe),
-    fixEta: c.fixEta ?? null,
     bestCaseFixEta: c.bestCaseFixEta ?? null,
     mostLikelyFixEta: c.mostLikelyFixEta ?? null,
     worstCaseFixEta: c.worstCaseFixEta ?? null,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -210,7 +210,8 @@ interface SecondaryItem {
  *                                       Kept here even though a Tasks tab exists: that tab is
  *                                       still `hidden` in CsmCaseDetailPage's TAB_DEFS, so this
  *                                       menu item is the only reachable entry point today.
- *   - Set fix ETA                    → PATCH /cases/{id} { fixEta }, see SetFixEtaDialog.tsx
+ *   - Set fix ETA                    → PATCH /cases/{id} { bestCaseFixEta | mostLikelyFixEta |
+ *                                       worstCaseFixEta }, see SetFixEtaDialog.tsx
  *   - Log time                       → ISSU-017
  *   - Change severity                → PATCH /cases/{id} { severity }, already fully
  *                                       backend-supported (see ChangeSeverityDialog.tsx)

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -25,7 +25,7 @@ import DeploymentDetailsDialog from "@features/csm-projects/components/Deploymen
 import type { BeDeploymentType } from "@api/backend/types";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
-import { formatAbsoluteForUser } from "@utils/dateTime";
+import { formatDateOnlyForDisplay } from "@utils/dateTime";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
@@ -350,29 +350,21 @@ export default function CaseMetaBand({
                   )}
                 </Typography>
               </Cell>
-              {(c.fixEta ||
-                c.bestCaseFixEta ||
-                c.mostLikelyFixEta ||
-                c.worstCaseFixEta) && (
+              {(c.bestCaseFixEta || c.mostLikelyFixEta || c.worstCaseFixEta) && (
                 <>
-                  <Cell label="Fix ETA">
-                    <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.fixEta) ?? "—"}
-                    </Typography>
-                  </Cell>
                   <Cell label="Best case fix ETA">
                     <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.bestCaseFixEta) ?? "—"}
+                      {formatDateOnlyForDisplay(c.bestCaseFixEta) ?? "—"}
                     </Typography>
                   </Cell>
                   <Cell label="Most likely fix ETA">
                     <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.mostLikelyFixEta) ?? "—"}
+                      {formatDateOnlyForDisplay(c.mostLikelyFixEta) ?? "—"}
                     </Typography>
                   </Cell>
                   <Cell label="Worst case fix ETA">
                     <Typography variant="body2" noWrap>
-                      {formatAbsoluteForUser(c.worstCaseFixEta) ?? "—"}
+                      {formatDateOnlyForDisplay(c.worstCaseFixEta) ?? "—"}
                     </Typography>
                   </Cell>
                 </>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.test.tsx
@@ -19,53 +19,51 @@ import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import SetFixEtaDialog from "@features/csm-cases/components/SetFixEtaDialog";
 
-describe("SetFixEtaDialog — four independent fields", () => {
-  it("renders one Save button per field, each disabled until a date/time is picked", () => {
+describe("SetFixEtaDialog — three independent internal-only fields", () => {
+  it("renders one Save button per field, each disabled until a date is picked", () => {
     render(
       <SetFixEtaDialog isSaving={false} onClose={() => {}} onSave={() => {}} />,
     );
     const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
-    expect(saveButtons).toHaveLength(4);
+    expect(saveButtons).toHaveLength(3);
     saveButtons.forEach((btn) => expect(btn).toBeDisabled());
   });
 
   it("seeds each field from its current value and enables that field's Save immediately", () => {
     render(
       <SetFixEtaDialog
-        currentFixEta="2099-06-15T10:30:00.000Z"
-        currentBestCaseFixEta="2099-06-16T10:30:00.000Z"
-        currentMostLikelyFixEta="2099-06-17T10:30:00.000Z"
-        currentWorstCaseFixEta="2099-06-18T10:30:00.000Z"
+        currentBestCaseFixEta="2099-06-16"
+        currentMostLikelyFixEta="2099-06-17"
+        currentWorstCaseFixEta="2099-06-18"
         isSaving={false}
         onClose={() => {}}
         onSave={() => {}}
       />,
     );
     const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
-    expect(saveButtons).toHaveLength(4);
+    expect(saveButtons).toHaveLength(3);
     saveButtons.forEach((btn) => expect(btn).toBeEnabled());
   });
 
-  it("saves only the fixEta field with a UTC ISO string, independent of the other three", () => {
+  it("saves only the bestCaseFixEta field as a date-only string, independent of the other two", () => {
     const onSave = vi.fn();
     render(
       <SetFixEtaDialog
-        currentFixEta="2099-06-15T10:30:00.000Z"
+        currentBestCaseFixEta="2099-06-16"
         isSaving={false}
         onClose={() => {}}
         onSave={onSave}
       />,
     );
     const saveButtons = screen.getAllByRole("button", { name: /^save$/i });
-    // The fixEta row is the only one seeded, so it's the only enabled Save.
+    // The bestCaseFixEta row is the only one seeded, so it's the only enabled Save.
     const enabled = saveButtons.filter((btn) => !btn.hasAttribute("disabled"));
     expect(enabled).toHaveLength(1);
     fireEvent.click(enabled[0]);
     expect(onSave).toHaveBeenCalledTimes(1);
     const [field, arg] = onSave.mock.calls[0] as [string, string];
-    expect(field).toBe("fixEta");
-    expect(() => new Date(arg).toISOString()).not.toThrow();
-    expect(new Date(arg).getUTCFullYear()).toBe(2099);
+    expect(field).toBe("bestCaseFixEta");
+    expect(arg).toBe("2099-06-16");
   });
 
   it("calls onClose on Close without calling onSave", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/SetFixEtaDialog.tsx
@@ -23,44 +23,31 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   Typography,
 } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
-import {
-  formatDateTimeLocal,
-  parseDateTimeLocal,
-  resolveDisplayTimeZone,
-  zonedInputToUtcIso,
-} from "@utils/dateTime";
+import { formatDateOnly, parseDateOnly } from "@utils/dateTime";
 
-const { DateTimePicker, LocalizationProvider } = DatePickers;
+const { DesktopDatePicker: DatePicker, LocalizationProvider } = DatePickers;
 
-/** One of the four independent fix-ETA fields this dialog can set. */
-export type FixEtaField =
-  | "fixEta"
-  | "bestCaseFixEta"
-  | "mostLikelyFixEta"
-  | "worstCaseFixEta";
+/** One of the three independent internal-only fix-ETA estimate fields this dialog can set. */
+export type FixEtaField = "bestCaseFixEta" | "mostLikelyFixEta" | "worstCaseFixEta";
 
 interface SetFixEtaDialogProps {
-  /** Current customer-facing fix-commitment date/time, if any (ISO). */
-  currentFixEta?: string | null;
-  /** Current internal-only best-case estimate, if any (ISO). */
+  /** Current internal-only best-case estimate, if any (date-only "YYYY-MM-DD"). */
   currentBestCaseFixEta?: string | null;
-  /** Current internal-only most-likely estimate, if any (ISO). */
+  /** Current internal-only most-likely estimate, if any (date-only "YYYY-MM-DD"). */
   currentMostLikelyFixEta?: string | null;
-  /** Current internal-only worst-case estimate, if any (ISO). */
+  /** Current internal-only worst-case estimate, if any (date-only "YYYY-MM-DD"). */
   currentWorstCaseFixEta?: string | null;
-  /** True while any of the four PATCHes is in flight; disables every field's Save. */
+  /** True while any of the three PATCHes is in flight; disables every field's Save. */
   isSaving: boolean;
   onClose: () => void;
-  /** Apply one field's new value (`PATCH { [field]: valueIso }`), as a UTC ISO string. */
-  onSave: (field: FixEtaField, valueIso: string) => void;
+  /** Apply one field's new value (`PATCH { [field]: "YYYY-MM-DD" }`). */
+  onSave: (field: FixEtaField, valueDateOnly: string) => void;
 }
 
 const FIELD_LABEL: Record<FixEtaField, string> = {
-  fixEta: "Fix ETA",
   bestCaseFixEta: "Best case",
   mostLikelyFixEta: "Most likely",
   worstCaseFixEta: "Worst case",
@@ -69,46 +56,42 @@ const FIELD_LABEL: Record<FixEtaField, string> = {
 interface FixEtaFieldRowProps {
   field: FixEtaField;
   currentValue?: string | null;
-  timeZone: string;
   isSaving: boolean;
-  onSave: (field: FixEtaField, valueIso: string) => void;
+  onSave: (field: FixEtaField, valueDateOnly: string) => void;
 }
 
 /**
- * One independently-saved date/time field. Each row owns its own draft value
- * and Save action — the four fields are unrelated PATCH variants (see
- * `BeCaseUpdatePayload`), so saving one never requires the others to be filled.
+ * One independently-saved date field. Each row owns its own draft value and
+ * Save action — the three fields are unrelated PATCH variants (see
+ * `BeCaseUpdatePayload`), so saving one never requires the others to be
+ * filled. Date-only, no time-of-day component, matching this codebase's
+ * `SetAutocloseHoldDialog` picker convention.
  */
 function FixEtaFieldRow({
   field,
   currentValue,
-  timeZone,
   isSaving,
   onSave,
 }: FixEtaFieldRowProps): JSX.Element {
-  const [value, setValue] = useState<string>(
-    currentValue ? formatDateTimeLocal(new Date(currentValue)) : "",
-  );
-  const parsed = parseDateTimeLocal(value);
+  const [value, setValue] = useState<string>(currentValue ?? "");
+  const parsed = parseDateOnly(value);
   const canSubmit = !!parsed;
 
   const handleSave = (): void => {
-    if (!canSubmit) return;
-    const iso = zonedInputToUtcIso(value, timeZone);
-    if (!iso) return;
-    onSave(field, iso);
+    if (!canSubmit || !value) return;
+    onSave(field, value);
   };
 
   return (
     <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
       <LocalizationProvider dateAdapter={AdapterDateFns}>
-        <DateTimePicker
-          label={`${FIELD_LABEL[field]} (${timeZone})`}
+        <DatePicker
+          label={FIELD_LABEL[field]}
           value={parsed}
           onChange={(next) =>
             setValue(
               next instanceof Date && !Number.isNaN(next.getTime())
-                ? formatDateTimeLocal(next)
+                ? formatDateOnly(next)
                 : "",
             )
           }
@@ -134,16 +117,14 @@ function FixEtaFieldRow({
 }
 
 /**
- * Set the case's four independent fix-ETA fields: the single customer-facing
- * commitment (`fixEta` on `PATCH /cases/{id}`) plus three internal-only
- * estimates (`bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta`) never
- * shared with the customer. Each field is its own single-field PATCH variant
- * (see `BeCaseUpdatePayload`), so every row saves independently — filling in
- * one estimate never requires the others. ServiceNow-source only for
- * `fixEta`; the caller surfaces a rejection on another source.
+ * Set the case's three independent internal-only fix-ETA estimates
+ * (`bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta`), never shared
+ * with the customer. Each field is its own single-field, date-only PATCH
+ * variant (see `BeCaseUpdatePayload`), so every row saves independently —
+ * filling in one estimate never requires the others. ServiceNow-source only;
+ * the caller surfaces a rejection on another source.
  */
 export default function SetFixEtaDialog({
-  currentFixEta,
   currentBestCaseFixEta,
   currentMostLikelyFixEta,
   currentWorstCaseFixEta,
@@ -151,58 +132,32 @@ export default function SetFixEtaDialog({
   onClose,
   onSave,
 }: SetFixEtaDialogProps): JSX.Element {
-  const timeZone = resolveDisplayTimeZone();
-
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Set fix ETA</DialogTitle>
       <DialogContent>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
           <Typography variant="body2" color="text.secondary">
-            Each field below is saved independently — you don't need to fill
-            in every estimate to save one.
-          </Typography>
-
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
-            <Typography variant="caption" color="text.secondary">
-              Customer-facing fix-commitment date/time. Shared with the
-              customer — distinct from the backend-computed SLA clocks shown
-              on the SLAs tab.
-            </Typography>
-            <FixEtaFieldRow
-              field="fixEta"
-              currentValue={currentFixEta}
-              timeZone={timeZone}
-              isSaving={isSaving}
-              onSave={onSave}
-            />
-          </Box>
-
-          <Divider />
-
-          <Typography variant="subtitle2">Internal-only estimates</Typography>
-          <Typography variant="caption" color="text.secondary" sx={{ mt: -1.5 }}>
-            Never shared with the customer.
+            Internal-only estimates, never shared with the customer. Each
+            field below is saved independently — you don't need to fill in
+            every estimate to save one.
           </Typography>
 
           <FixEtaFieldRow
             field="bestCaseFixEta"
             currentValue={currentBestCaseFixEta}
-            timeZone={timeZone}
             isSaving={isSaving}
             onSave={onSave}
           />
           <FixEtaFieldRow
             field="mostLikelyFixEta"
             currentValue={currentMostLikelyFixEta}
-            timeZone={timeZone}
             isSaving={isSaving}
             onSave={onSave}
           />
           <FixEtaFieldRow
             field="worstCaseFixEta"
             currentValue={currentWorstCaseFixEta}
-            timeZone={timeZone}
             isSaving={isSaving}
             onSave={onSave}
           />

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -93,7 +93,9 @@ import LinkIncidentDialog from "@features/csm-cases/components/LinkIncidentDialo
 import LinkCaseDialog, {
   type CaseLinkType,
 } from "@features/csm-cases/components/LinkCaseDialog";
-import SetFixEtaDialog from "@features/csm-cases/components/SetFixEtaDialog";
+import SetFixEtaDialog, {
+  type FixEtaField,
+} from "@features/csm-cases/components/SetFixEtaDialog";
 import CreateTaskDialog from "@features/csm-cases/components/CreateTaskDialog";
 import AddTagDialog from "@features/csm-cases/components/AddTagDialog";
 import { useCreateCaseTask } from "@features/csm-cases/api/useCreateCaseTask";
@@ -1269,21 +1271,24 @@ export default function CsmCaseDetailPage(): JSX.Element {
   );
 
   const onSetFixEta = useCallback(
-    (fixEtaIso: string) => {
-      patchCase.mutate(
-        { fixEta: fixEtaIso },
-        {
-          onSuccess: () => {
-            setFixEtaOpen(false);
-            setFeedback({
-              message: "Fix ETA updated.",
-              severity: "success",
-              sticky: false,
-            });
-          },
-          onError: (err) => showError("Could not set the fix ETA.", err),
+    (field: FixEtaField, valueDateOnly: string) => {
+      const payload: BeCaseUpdatePayload =
+        field === "bestCaseFixEta"
+          ? { bestCaseFixEta: valueDateOnly }
+          : field === "mostLikelyFixEta"
+            ? { mostLikelyFixEta: valueDateOnly }
+            : { worstCaseFixEta: valueDateOnly };
+      patchCase.mutate(payload, {
+        onSuccess: () => {
+          setFixEtaOpen(false);
+          setFeedback({
+            message: "Fix ETA updated.",
+            severity: "success",
+            sticky: false,
+          });
         },
-      );
+        onError: (err) => showError("Could not set the fix ETA.", err),
+      });
     },
     [patchCase, showError],
   );
@@ -2166,7 +2171,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
       {fixEtaOpen && (
         <SetFixEtaDialog
-          currentFixEta={c.fixEta}
+          currentBestCaseFixEta={c.bestCaseFixEta}
+          currentMostLikelyFixEta={c.mostLikelyFixEta}
+          currentWorstCaseFixEta={c.worstCaseFixEta}
           isSaving={patchCase.isPending}
           onClose={() => setFixEtaOpen(false)}
           onSave={onSetFixEta}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -442,18 +442,21 @@ export interface CsmCaseDetail extends CsmCaseRow {
   /** When the auto-closure sequence next advances (ServiceNow only). Read-only. */
   autoclosureStateTime?: string;
   /**
-   * The customer-facing fix-commitment date/time for the case; `null`/absent
-   * when not set. Distinct from the backend-computed SLA clocks shown in
-   * {@link CaseSla} — this is a settable commitment, not a derived clock. Also
-   * distinct from the three internal-only estimates below, which are never
-   * shared with the customer.
+   * Internal-only best-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string; `null`/absent when not set. Never shared with the customer.
+   * Distinct from the backend-computed SLA clocks shown in {@link CaseSla} —
+   * these are settable commitments, not derived clocks.
    */
-  fixEta?: string | null;
-  /** Internal-only best-case fix estimate; `null`/absent when not set. */
   bestCaseFixEta?: string | null;
-  /** Internal-only most-likely fix estimate; `null`/absent when not set. */
+  /**
+   * Internal-only most-likely fix estimate, as a date-only "YYYY-MM-DD"
+   * string; `null`/absent when not set.
+   */
   mostLikelyFixEta?: string | null;
-  /** Internal-only worst-case fix estimate; `null`/absent when not set. */
+  /**
+   * Internal-only worst-case fix estimate, as a date-only "YYYY-MM-DD"
+   * string; `null`/absent when not set.
+   */
   worstCaseFixEta?: string | null;
   /** Display name of the person who opened the case. */
   createdBy?: string;

--- a/apps/csm-portal/webapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.ts
@@ -341,6 +341,26 @@ export function parseDateOnly(value: string): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/**
+ * "YYYY-MM-DD" to a human-readable date string (e.g. "Aug 1, 2026"), for
+ * read-only display of a date-only field. Uses {@link parseDateOnly}'s
+ * local-midnight parse rather than {@link formatAbsoluteForUser}'s UTC parse,
+ * so the displayed day never shifts depending on the viewer's timezone.
+ * Returns `null` when the input is empty or unparseable.
+ */
+export function formatDateOnlyForDisplay(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  const date = parseDateOnly(value);
+  if (!date) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
 /** Local-midnight Date back to "YYYY-MM-DD", the inverse of {@link parseDateOnly}. */
 export function formatDateOnly(date: Date): string {
   const y = date.getFullYear();

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1070,18 +1070,18 @@ type CaseView struct {
 	// AutoclosureStateTime is when the auto-closure sequence next advances (e.g. the
 	// "eligible again after" date for a held case). Read-only (ServiceNow data source only).
 	AutoclosureStateTime *time.Time `json:"autoclosureStateTime,omitempty"`
-	// FixEta is the single customer-facing fix-commitment date/time
-	// (ServiceNow u_fix_eta_shared).
-	FixEta *time.Time `json:"fixEta"`
-	// BestCaseFixEta is the internal-only best-case fix-commitment date
-	// (ServiceNow u_best_case_fix_eta). CSM-engineer-facing only.
-	BestCaseFixEta *time.Time `json:"bestCaseFixEta"`
-	// MostLikelyFixEta is the internal-only most-likely fix-commitment date
-	// (ServiceNow u_most_likely_fix_eta). CSM-engineer-facing only.
-	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta"`
-	// WorstCaseFixEta is the internal-only worst-case fix-commitment date
-	// (ServiceNow u_worst_case_fix_eta). CSM-engineer-facing only.
-	WorstCaseFixEta *time.Time `json:"worstCaseFixEta"`
+	// BestCaseFixEta is the internal-only best-case fix-commitment date, as a
+	// date-only "YYYY-MM-DD" string (ServiceNow u_best_case_fix_eta).
+	// CSM-engineer-facing only, never shared with the customer.
+	BestCaseFixEta *string `json:"bestCaseFixEta"`
+	// MostLikelyFixEta is the internal-only most-likely fix-commitment date, as
+	// a date-only "YYYY-MM-DD" string (ServiceNow u_most_likely_fix_eta).
+	// CSM-engineer-facing only, never shared with the customer.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta is the internal-only worst-case fix-commitment date, as a
+	// date-only "YYYY-MM-DD" string (ServiceNow u_worst_case_fix_eta).
+	// CSM-engineer-facing only, never shared with the customer.
+	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 	// Tags are the free-text labels attached to the case via ServiceNow's generic
 	// platform label/label_entry mechanism (not a case-specific column).
 	//
@@ -1180,10 +1180,10 @@ type SearchCasesResponse struct {
 
 // UpdateCaseRequest is the input for PATCH /cases/{id}.
 // Exactly one of State, Severity, WorkState, WatchList, AssigneeEmail, ParentID, RelatedCaseID,
-// AutocloseHoldUntil, Subject, Description, DeploymentID, DeployedProductID, FixEta,
+// AutocloseHoldUntil, Subject, Description, DeploymentID, DeployedProductID,
 // BestCaseFixEta, MostLikelyFixEta, or WorstCaseFixEta must be provided.
 // WatchList, AssigneeEmail, ParentID, RelatedCaseID, AutocloseHoldUntil, Subject, Description,
-// DeploymentID, DeployedProductID, FixEta, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta
+// DeploymentID, DeployedProductID, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta
 // are only supported for the ServiceNow data source.
 // ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
 // State is closed or solution_proposed.
@@ -1224,22 +1224,18 @@ type UpdateCaseRequest struct {
 	// converted to the backing data source's internal id before dispatch (ServiceNow data
 	// source only).
 	DeployedProductID *string `json:"deployedProductId"`
-	// FixEta sets the customer-facing fix-commitment date/time (ServiceNow
-	// u_fix_eta_shared). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists yet
-	// for this field — see snUpdateCasePayload.FixEta in sn_case_service.go.
-	FixEta *time.Time `json:"fixEta"`
-	// BestCaseFixEta sets the internal-only best-case fix-commitment date (ServiceNow
-	// u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists
-	// yet for this field — see snUpdateCasePayload.BestCaseFixEta in sn_case_service.go.
-	BestCaseFixEta *time.Time `json:"bestCaseFixEta"`
-	// MostLikelyFixEta sets the internal-only most-likely fix-commitment date (ServiceNow
-	// u_most_likely_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support
-	// exists yet for this field — see snUpdateCasePayload.MostLikelyFixEta in sn_case_service.go.
-	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta"`
-	// WorstCaseFixEta sets the internal-only worst-case fix-commitment date (ServiceNow
-	// u_worst_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write support exists
-	// yet for this field — see snUpdateCasePayload.WorstCaseFixEta in sn_case_service.go.
-	WorstCaseFixEta *time.Time `json:"worstCaseFixEta"`
+	// BestCaseFixEta sets the internal-only best-case fix-commitment date
+	// (ServiceNow u_best_case_fix_eta), as a date-only "YYYY-MM-DD" string —
+	// see snUpdateCasePayload.BestCaseFixEta in sn_case_service.go.
+	BestCaseFixEta *string `json:"bestCaseFixEta"`
+	// MostLikelyFixEta sets the internal-only most-likely fix-commitment date
+	// (ServiceNow u_most_likely_fix_eta), as a date-only "YYYY-MM-DD" string —
+	// see snUpdateCasePayload.MostLikelyFixEta in sn_case_service.go.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta sets the internal-only worst-case fix-commitment date
+	// (ServiceNow u_worst_case_fix_eta), as a date-only "YYYY-MM-DD" string —
+	// see snUpdateCasePayload.WorstCaseFixEta in sn_case_service.go.
+	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -1269,25 +1265,20 @@ type UpdatedCase struct {
 	CloseNotes     *string              `json:"closeNotes,omitempty"`
 	ResolvedOn     *time.Time           `json:"resolvedOn,omitempty"`
 	ParentCase     *CaseNumberRef       `json:"parentCase,omitempty"`
-	// FixEta echoes the updated customer-facing fix-commitment date/time
-	// (u_fix_eta_shared) back on a successful PATCH. Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.FixEta doc comment; always nil until Ballerina supports the write.
-	FixEta *time.Time `json:"fixEta,omitempty"`
-	// BestCaseFixEta echoes the updated internal-only best-case fix-commitment date
-	// (u_best_case_fix_eta) back on a successful PATCH. Ballerina support added on
-	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.BestCaseFixEta doc comment; always nil until Ballerina supports the write.
-	BestCaseFixEta *time.Time `json:"bestCaseFixEta,omitempty"`
-	// MostLikelyFixEta echoes the updated internal-only most-likely fix-commitment date
-	// (u_most_likely_fix_eta) back on a successful PATCH. Ballerina support added on
-	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.MostLikelyFixEta doc comment; always nil until Ballerina supports the write.
-	MostLikelyFixEta *time.Time `json:"mostLikelyFixEta,omitempty"`
-	// WorstCaseFixEta echoes the updated internal-only worst-case fix-commitment date
-	// (u_worst_case_fix_eta) back on a successful PATCH. Ballerina support added on
-	// ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main) — see
-	// UpdateCaseRequest.WorstCaseFixEta doc comment; always nil until Ballerina supports the write.
-	WorstCaseFixEta *time.Time `json:"worstCaseFixEta,omitempty"`
+	// BestCaseFixEta echoes the updated internal-only best-case fix-commitment
+	// date (u_best_case_fix_eta) back on a successful PATCH, as a date-only
+	// "YYYY-MM-DD" string. Present only when the update set bestCaseFixEta.
+	BestCaseFixEta *string `json:"bestCaseFixEta,omitempty"`
+	// MostLikelyFixEta echoes the updated internal-only most-likely
+	// fix-commitment date (u_most_likely_fix_eta) back on a successful PATCH,
+	// as a date-only "YYYY-MM-DD" string. Present only when the update set
+	// mostLikelyFixEta.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta,omitempty"`
+	// WorstCaseFixEta echoes the updated internal-only worst-case
+	// fix-commitment date (u_worst_case_fix_eta) back on a successful PATCH,
+	// as a date-only "YYYY-MM-DD" string. Present only when the update set
+	// worstCaseFixEta.
+	WorstCaseFixEta *string `json:"worstCaseFixEta,omitempty"`
 }
 
 // WatchListUser is a compact user reference within the watch list.

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -292,10 +292,11 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}
-	if len(req.WatchList) > 0 || req.AssigneeEmail != nil || req.FixEta != nil ||
+	if len(req.WatchList) > 0 || req.AssigneeEmail != nil ||
 		req.RelatedCaseID != nil || req.ParentID != nil || req.AutocloseHoldUntil != nil ||
-		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, fixEta, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, and deployedProductId are only supported for the ServiceNow data source"}
+		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil ||
+		req.BestCaseFixEta != nil || req.MostLikelyFixEta != nil || req.WorstCaseFixEta != nil {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "watchList, assigneeEmail, relatedCaseId, parentId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, bestCaseFixEta, mostLikelyFixEta, and worstCaseFixEta are only supported for the ServiceNow data source"}
 	}
 	fieldCount := 0
 	if req.State != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -182,10 +182,10 @@ type CaseService interface {
 	// SearchCaseComments returns a paginated list of comments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseComments(ctx context.Context, req domain.SearchCaseCommentsRequest) (domain.SearchCaseCommentsResponse, error)
-	// UpdateCase updates the state, severity, watch list, assignee, or fix ETA (customer-facing
-	// or internal best-case/most-likely/worst-case) of a case.
+	// UpdateCase updates the state, severity, watch list, assignee, or internal-only
+	// fix-ETA estimate (best-case/most-likely/worst-case) of a case.
 	// A ValidationError is returned for invalid values or malformed UUID; a NotFoundError if no case matches.
-	// WatchList, AssigneeEmail, FixEta, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta are
+	// WatchList, AssigneeEmail, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta are
 	// only supported for the ServiceNow data source.
 	// Transitioning State to closed is rejected with a ValidationError if the case has any
 	// open task that is visible to the customer (the authoritative case-close gate).

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -93,12 +93,6 @@ type snCase struct {
 	// AutoclosureStateTime is when the auto-closure sequence next advances (e.g. the
 	// "eligible again after" date for a held case).
 	AutoclosureStateTime *string `json:"autoclosureStateTime"`
-	// FixEta is the single customer-facing fix-commitment date/time
-	// (u_fix_eta_shared). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
-	// surfaces this — the Choreo GET /cases/{id} response does not include a
-	// "fixEta" key today, so this always unmarshals to nil. Ask: add a
-	// "fixEta" (glide_date_time) field to servicenow:CaseResponse.
-	FixEta *string `json:"fixEta"`
 	// BestCaseFixEta is the internal-only best-case fix-commitment date
 	// (u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina field currently
 	// surfaces this — the Choreo GET /cases/{id} response does not include a
@@ -382,6 +376,18 @@ func formatSNDateOnly(t *time.Time) string {
 		return ""
 	}
 	return t.UTC().Format(snDateOnlyLayout)
+}
+
+// validateDateOnly rejects a wire value that is not a strict "YYYY-MM-DD" date. Used
+// for fields (bestCaseFixEta, mostLikelyFixEta, worstCaseFixEta) whose contract with
+// the integration service is a plain date string, not an RFC3339 datetime — unlike
+// AutocloseHoldUntil, these arrive as *string already, so there is no JSON-time-based
+// parse to lean on; the format must be checked explicitly before it is forwarded.
+func validateDateOnly(field, value string) error {
+	if _, err := time.Parse(snDateOnlyLayout, value); err != nil {
+		return &apierror.ValidationError{Msg: field + " must be a date in YYYY-MM-DD format"}
+	}
+	return nil
 }
 
 type snCaseService struct {
@@ -717,41 +723,18 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.AutoclosureStateTime = &autoclosureStateTime
 	}
-	// FixEta passes through once Ballerina's matching field (see snCase.FixEta doc
-	// comment) lands; until then this is always nil.
-	if c.FixEta != nil && *c.FixEta != "" {
-		fixEta, err := time.Parse(snCreatedOnLayout, *c.FixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse fixEta %q: %w", *c.FixEta, err)
-		}
-		cv.FixEta = &fixEta
-	}
-	// BestCaseFixEta passes through once Ballerina's matching field (see
-	// snCase.BestCaseFixEta doc comment) lands; until then this is always nil.
+	// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta are already date-only
+	// "YYYY-MM-DD" strings on both sides, so no parsing/reformatting is
+	// needed — pass through once Ballerina's matching read fields (see
+	// snCase doc comments) land; until then these are always nil.
 	if c.BestCaseFixEta != nil && *c.BestCaseFixEta != "" {
-		bestCaseFixEta, err := time.Parse(snCreatedOnLayout, *c.BestCaseFixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse bestCaseFixEta %q: %w", *c.BestCaseFixEta, err)
-		}
-		cv.BestCaseFixEta = &bestCaseFixEta
+		cv.BestCaseFixEta = c.BestCaseFixEta
 	}
-	// MostLikelyFixEta passes through once Ballerina's matching field (see
-	// snCase.MostLikelyFixEta doc comment) lands; until then this is always nil.
 	if c.MostLikelyFixEta != nil && *c.MostLikelyFixEta != "" {
-		mostLikelyFixEta, err := time.Parse(snCreatedOnLayout, *c.MostLikelyFixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse mostLikelyFixEta %q: %w", *c.MostLikelyFixEta, err)
-		}
-		cv.MostLikelyFixEta = &mostLikelyFixEta
+		cv.MostLikelyFixEta = c.MostLikelyFixEta
 	}
-	// WorstCaseFixEta passes through once Ballerina's matching field (see
-	// snCase.WorstCaseFixEta doc comment) lands; until then this is always nil.
 	if c.WorstCaseFixEta != nil && *c.WorstCaseFixEta != "" {
-		worstCaseFixEta, err := time.Parse(snCreatedOnLayout, *c.WorstCaseFixEta)
-		if err != nil {
-			return domain.CaseView{}, fmt.Errorf("sn get case: parse worstCaseFixEta %q: %w", *c.WorstCaseFixEta, err)
-		}
-		cv.WorstCaseFixEta = &worstCaseFixEta
+		cv.WorstCaseFixEta = c.WorstCaseFixEta
 	}
 	// Tags are not populated: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see CaseView.Tags doc comment.
 	// cv.Tags is left nil.
@@ -969,24 +952,18 @@ type snUpdateCasePayload struct {
 	Description       *string `json:"description,omitempty"`
 	DeploymentID      *string `json:"deploymentId,omitempty"`
 	DeployedProductID *string `json:"deployedProductId,omitempty"`
-	// FixEta writes the customer-facing fix-commitment date/time (u_fix_eta_shared).
-	// Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field exists yet for this — ask:
-	// add a "fixEta" field to servicenow:CaseUpdatePayload backed by u_fix_eta_shared.
-	FixEta *string `json:"fixEta,omitempty"`
 	// BestCaseFixEta writes the internal-only best-case fix-commitment date
-	// (u_best_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field exists
-	// yet for this — ask: add a "bestCaseFixEta" field to servicenow:CaseUpdatePayload
-	// backed by u_best_case_fix_eta.
+	// (u_best_case_fix_eta) as a date-only "YYYY-MM-DD" string. Confirmed live
+	// against the existing case-update resource — same single-field PATCH
+	// pathway as AutocloseHoldUntil/Title/Description above.
 	BestCaseFixEta *string `json:"bestCaseFixEta,omitempty"`
-	// MostLikelyFixEta writes the internal-only most-likely fix-commitment date
-	// (u_most_likely_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field
-	// exists yet for this — ask: add a "mostLikelyFixEta" field to
-	// servicenow:CaseUpdatePayload backed by u_most_likely_fix_eta.
+	// MostLikelyFixEta writes the internal-only most-likely fix-commitment
+	// date (u_most_likely_fix_eta) as a date-only "YYYY-MM-DD" string. Same
+	// pathway as BestCaseFixEta above.
 	MostLikelyFixEta *string `json:"mostLikelyFixEta,omitempty"`
 	// WorstCaseFixEta writes the internal-only worst-case fix-commitment date
-	// (u_worst_case_fix_eta). Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main): no Ballerina write field
-	// exists yet for this — ask: add a "worstCaseFixEta" field to
-	// servicenow:CaseUpdatePayload backed by u_worst_case_fix_eta.
+	// (u_worst_case_fix_eta) as a date-only "YYYY-MM-DD" string. Same pathway
+	// as BestCaseFixEta above.
 	WorstCaseFixEta *string `json:"worstCaseFixEta,omitempty"`
 }
 
@@ -1111,17 +1088,12 @@ type snUpdateCaseResponse struct {
 		CloseNotes *string    `json:"closeNotes"`
 		ResolvedOn *string    `json:"resolvedOn"`
 		ParentCase *snCaseRef `json:"parentCase"`
-		// FixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see snUpdateCasePayload.FixEta doc comment.
-		FixEta *string `json:"fixEta"`
-		// BestCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-		// snUpdateCasePayload.BestCaseFixEta doc comment.
-		BestCaseFixEta *string `json:"bestCaseFixEta"`
-		// MostLikelyFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-		// snUpdateCasePayload.MostLikelyFixEta doc comment.
+		// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta echo back the
+		// updated date-only estimate when that field was the one PATCHed —
+		// see snUpdateCasePayload doc comments.
+		BestCaseFixEta   *string `json:"bestCaseFixEta"`
 		MostLikelyFixEta *string `json:"mostLikelyFixEta"`
-		// WorstCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-		// snUpdateCasePayload.WorstCaseFixEta doc comment.
-		WorstCaseFixEta *string `json:"worstCaseFixEta"`
+		WorstCaseFixEta  *string `json:"worstCaseFixEta"`
 	} `json:"case"`
 }
 
@@ -1169,9 +1141,6 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.DeployedProductID != nil {
 		fieldCount++
 	}
-	if req.FixEta != nil {
-		fieldCount++
-	}
 	if req.BestCaseFixEta != nil {
 		fieldCount++
 	}
@@ -1182,7 +1151,7 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		fieldCount++
 	}
 	const fieldList = "state, severity, workState, watchList, assigneeEmail, parentId, relatedCaseId, " +
-		"autocloseHoldUntil, subject, description, deploymentId, deployedProductId, fixEta, " +
+		"autocloseHoldUntil, subject, description, deploymentId, deployedProductId, " +
 		"bestCaseFixEta, mostLikelyFixEta, or worstCaseFixEta"
 	if fieldCount == 0 {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of " + fieldList + " must be provided"}
@@ -1296,21 +1265,23 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		sysid := uuidToSysid(*req.DeployedProductID)
 		payload.DeployedProductID = &sysid
 	}
-	if req.FixEta != nil {
-		fixEta := formatSNDate(req.FixEta)
-		payload.FixEta = &fixEta
-	}
 	if req.BestCaseFixEta != nil {
-		bestCaseFixEta := formatSNDate(req.BestCaseFixEta)
-		payload.BestCaseFixEta = &bestCaseFixEta
+		if err := validateDateOnly("bestCaseFixEta", *req.BestCaseFixEta); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		payload.BestCaseFixEta = req.BestCaseFixEta
 	}
 	if req.MostLikelyFixEta != nil {
-		mostLikelyFixEta := formatSNDate(req.MostLikelyFixEta)
-		payload.MostLikelyFixEta = &mostLikelyFixEta
+		if err := validateDateOnly("mostLikelyFixEta", *req.MostLikelyFixEta); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		payload.MostLikelyFixEta = req.MostLikelyFixEta
 	}
 	if req.WorstCaseFixEta != nil {
-		worstCaseFixEta := formatSNDate(req.WorstCaseFixEta)
-		payload.WorstCaseFixEta = &worstCaseFixEta
+		if err := validateDateOnly("worstCaseFixEta", *req.WorstCaseFixEta); err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		payload.WorstCaseFixEta = req.WorstCaseFixEta
 	}
 
 	// Close-gate: reject closing a case that still has an open, customer-visible task.
@@ -1400,44 +1371,17 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		}
 		resp.Case.ResolvedOn = &resolvedOn
 	}
-	// FixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see snUpdateCasePayload.FixEta doc comment;
-	// snResp.Case.FixEta is always nil until Ballerina echoes it back.
-	if snResp.Case.FixEta != nil && *snResp.Case.FixEta != "" {
-		fixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.FixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse fixEta %q: %w", *snResp.Case.FixEta, err)
-		}
-		resp.Case.FixEta = &fixEta
-	}
-	// BestCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-	// snUpdateCasePayload.BestCaseFixEta doc comment; snResp.Case.BestCaseFixEta is always
-	// nil until Ballerina echoes it back.
+	// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta echo back verbatim — the
+	// wire and domain types are both date-only "YYYY-MM-DD" strings, so no
+	// parsing/reformatting is needed here.
 	if snResp.Case.BestCaseFixEta != nil && *snResp.Case.BestCaseFixEta != "" {
-		bestCaseFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.BestCaseFixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse bestCaseFixEta %q: %w", *snResp.Case.BestCaseFixEta, err)
-		}
-		resp.Case.BestCaseFixEta = &bestCaseFixEta
+		resp.Case.BestCaseFixEta = snResp.Case.BestCaseFixEta
 	}
-	// MostLikelyFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-	// snUpdateCasePayload.MostLikelyFixEta doc comment; snResp.Case.MostLikelyFixEta is
-	// always nil until Ballerina echoes it back.
 	if snResp.Case.MostLikelyFixEta != nil && *snResp.Case.MostLikelyFixEta != "" {
-		mostLikelyFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.MostLikelyFixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse mostLikelyFixEta %q: %w", *snResp.Case.MostLikelyFixEta, err)
-		}
-		resp.Case.MostLikelyFixEta = &mostLikelyFixEta
+		resp.Case.MostLikelyFixEta = snResp.Case.MostLikelyFixEta
 	}
-	// WorstCaseFixEta: Ballerina support added on ballerina-tasks-fixeta-tags (not yet merged to digiops-cs main), see
-	// snUpdateCasePayload.WorstCaseFixEta doc comment; snResp.Case.WorstCaseFixEta is always
-	// nil until Ballerina echoes it back.
 	if snResp.Case.WorstCaseFixEta != nil && *snResp.Case.WorstCaseFixEta != "" {
-		worstCaseFixEta, err := time.Parse(snCreatedOnLayout, *snResp.Case.WorstCaseFixEta)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse worstCaseFixEta %q: %w", *snResp.Case.WorstCaseFixEta, err)
-		}
-		resp.Case.WorstCaseFixEta = &worstCaseFixEta
+		resp.Case.WorstCaseFixEta = snResp.Case.WorstCaseFixEta
 	}
 
 	return resp, nil

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -420,12 +420,12 @@ const (
 	testTaskSysid = "33333333333333333333333333333333"
 )
 
-// --- UpdateCase: field-count union (including the new fixEta variant) ---
+// --- UpdateCase: field-count union (including the internal fix-ETA date variants) ---
 
 func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
 	svc := NewServiceNowCaseService(nil, nil)
 	closed := domain.CaseStateClosed
-	fixEta := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	bestCase := "2026-08-01"
 
 	tests := []struct {
 		name string
@@ -436,8 +436,8 @@ func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
 			req:  domain.UpdateCaseRequest{ID: testCaseUUID},
 		},
 		{
-			name: "state and fixEta both provided",
-			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, FixEta: &fixEta},
+			name: "state and bestCaseFixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, BestCaseFixEta: &bestCase},
 		},
 	}
 
@@ -520,61 +520,6 @@ func TestSNCaseService_UpdateCase_CloseGate_AllowsWhenNoVisibleOpenTask(t *testi
 	}
 	if !patchCalled {
 		t.Fatalf("expected PATCH /cases/{id} to be called when no visible open task blocks the close")
-	}
-}
-
-// --- FixEta read/write mapping ---
-
-func TestSNCaseService_GetCaseByID_MapsFixEta(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id": testCaseSysid, "internalId": "INT-1", "number": "CS0001",
-			"title": "t", "description": "d",
-			"createdOn": "2026-01-01 00:00:00", "createdBy": "a@example.com",
-			"project":         map[string]any{"id": "", "name": ""},
-			"deployment":      map[string]any{"id": "", "name": ""},
-			"deployedProduct": map[string]any{"id": "", "name": "", "version": ""},
-			"fixEta":          "2026-02-15 10:30:00",
-		})
-	})
-
-	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil)
-
-	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cv.FixEta == nil {
-		t.Fatalf("expected FixEta to be populated, got nil")
-	}
-	want := time.Date(2026, 2, 15, 10, 30, 0, 0, time.UTC)
-	if !cv.FixEta.Equal(want) {
-		t.Fatalf("FixEta = %v, want %v", cv.FixEta, want)
-	}
-}
-
-func TestSNCaseService_UpdateCase_FixEta_SendsFormattedDate(t *testing.T) {
-	var gotBody map[string]any
-	mux := http.NewServeMux()
-	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
-		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
-	})
-
-	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil)
-
-	fixEta := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
-	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, FixEta: &fixEta})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	got, _ := gotBody["fixEta"].(string)
-	want := "2026-03-01 12:00:00"
-	if got != want {
-		t.Fatalf("fixEta sent = %q, want %q", got, want)
 	}
 }
 
@@ -672,10 +617,9 @@ func TestSNCaseService_RemoveCaseTag_Success(t *testing.T) {
 func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t *testing.T) {
 	svc := NewServiceNowCaseService(nil, nil)
 	closed := domain.CaseStateClosed
-	fixEta := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
-	bestCase := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
-	mostLikely := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
-	worstCase := time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC)
+	bestCase := "2026-08-02"
+	mostLikely := "2026-08-03"
+	worstCase := "2026-08-04"
 
 	tests := []struct {
 		name string
@@ -686,8 +630,8 @@ func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t 
 			req:  domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed, BestCaseFixEta: &bestCase},
 		},
 		{
-			name: "fixEta and mostLikelyFixEta both provided",
-			req:  domain.UpdateCaseRequest{ID: testCaseUUID, FixEta: &fixEta, MostLikelyFixEta: &mostLikely},
+			name: "mostLikelyFixEta and worstCaseFixEta both provided",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: &mostLikely, WorstCaseFixEta: &worstCase},
 		},
 		{
 			name: "bestCaseFixEta and worstCaseFixEta both provided",
@@ -708,27 +652,27 @@ func TestSNCaseService_UpdateCase_FieldCountValidation_InternalFixEtaVariants(t 
 func TestSNCaseService_UpdateCase_InternalFixEtaVariants_EachIndependentlySettable(t *testing.T) {
 	tests := []struct {
 		name    string
-		req     func(t time.Time) domain.UpdateCaseRequest
+		req     func(v string) domain.UpdateCaseRequest
 		bodyKey string
 	}{
 		{
 			name: "bestCaseFixEta",
-			req: func(t time.Time) domain.UpdateCaseRequest {
-				return domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &t}
+			req: func(v string) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &v}
 			},
 			bodyKey: "bestCaseFixEta",
 		},
 		{
 			name: "mostLikelyFixEta",
-			req: func(t time.Time) domain.UpdateCaseRequest {
-				return domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: &t}
+			req: func(v string) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: &v}
 			},
 			bodyKey: "mostLikelyFixEta",
 		},
 		{
 			name: "worstCaseFixEta",
-			req: func(t time.Time) domain.UpdateCaseRequest {
-				return domain.UpdateCaseRequest{ID: testCaseUUID, WorstCaseFixEta: &t}
+			req: func(v string) domain.UpdateCaseRequest {
+				return domain.UpdateCaseRequest{ID: testCaseUUID, WorstCaseFixEta: &v}
 			},
 			bodyKey: "worstCaseFixEta",
 		},
@@ -746,15 +690,45 @@ func TestSNCaseService_UpdateCase_InternalFixEtaVariants_EachIndependentlySettab
 			client := newTestSNClient(t, mux)
 			svc := NewServiceNowCaseService(client, nil)
 
-			value := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+			value := "2026-03-01"
 			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req(value))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			got, _ := gotBody[tt.bodyKey].(string)
-			want := "2026-03-01 12:00:00"
+			want := "2026-03-01"
 			if got != want {
 				t.Fatalf("%s sent = %q, want %q", tt.bodyKey, got, want)
+			}
+		})
+	}
+}
+
+func TestSNCaseService_UpdateCase_InternalFixEtaVariants_RejectsMalformedDate(t *testing.T) {
+	tests := []struct {
+		name string
+		req  domain.UpdateCaseRequest
+	}{
+		{
+			name: "bestCaseFixEta not YYYY-MM-DD",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: strPtr("2026-08-01T00:00:00Z")},
+		},
+		{
+			name: "mostLikelyFixEta not a date",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, MostLikelyFixEta: strPtr("not-a-date")},
+		},
+		{
+			name: "worstCaseFixEta empty string",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, WorstCaseFixEta: strPtr("")},
+		},
+	}
+
+	svc := NewServiceNowCaseService(nil, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
 			}
 		})
 	}
@@ -770,9 +744,9 @@ func TestSNCaseService_GetCaseByID_MapsInternalFixEtaFields(t *testing.T) {
 			"project":          map[string]any{"id": "", "name": ""},
 			"deployment":       map[string]any{"id": "", "name": ""},
 			"deployedProduct":  map[string]any{"id": "", "name": "", "version": ""},
-			"bestCaseFixEta":   "2026-02-10 00:00:00",
-			"mostLikelyFixEta": "2026-02-15 00:00:00",
-			"worstCaseFixEta":  "2026-02-20 00:00:00",
+			"bestCaseFixEta":   "2026-02-10",
+			"mostLikelyFixEta": "2026-02-15",
+			"worstCaseFixEta":  "2026-02-20",
 		})
 	})
 
@@ -784,17 +758,14 @@ func TestSNCaseService_GetCaseByID_MapsInternalFixEtaFields(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	wantBestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
-	if cv.BestCaseFixEta == nil || !cv.BestCaseFixEta.Equal(wantBestCase) {
-		t.Fatalf("BestCaseFixEta = %v, want %v", cv.BestCaseFixEta, wantBestCase)
+	if cv.BestCaseFixEta == nil || *cv.BestCaseFixEta != "2026-02-10" {
+		t.Fatalf("BestCaseFixEta = %v, want 2026-02-10", cv.BestCaseFixEta)
 	}
-	wantMostLikely := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
-	if cv.MostLikelyFixEta == nil || !cv.MostLikelyFixEta.Equal(wantMostLikely) {
-		t.Fatalf("MostLikelyFixEta = %v, want %v", cv.MostLikelyFixEta, wantMostLikely)
+	if cv.MostLikelyFixEta == nil || *cv.MostLikelyFixEta != "2026-02-15" {
+		t.Fatalf("MostLikelyFixEta = %v, want 2026-02-15", cv.MostLikelyFixEta)
 	}
-	wantWorstCase := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
-	if cv.WorstCaseFixEta == nil || !cv.WorstCaseFixEta.Equal(wantWorstCase) {
-		t.Fatalf("WorstCaseFixEta = %v, want %v", cv.WorstCaseFixEta, wantWorstCase)
+	if cv.WorstCaseFixEta == nil || *cv.WorstCaseFixEta != "2026-02-20" {
+		t.Fatalf("WorstCaseFixEta = %v, want 2026-02-20", cv.WorstCaseFixEta)
 	}
 }
 
@@ -805,9 +776,9 @@ func TestSNCaseService_UpdateCase_EchoesInternalFixEtaFieldsBack(t *testing.T) {
 			"message": "ok",
 			"case": map[string]any{
 				"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00",
-				"bestCaseFixEta":   "2026-02-10 00:00:00",
-				"mostLikelyFixEta": "2026-02-15 00:00:00",
-				"worstCaseFixEta":  "2026-02-20 00:00:00",
+				"bestCaseFixEta":   "2026-02-10",
+				"mostLikelyFixEta": "2026-02-15",
+				"worstCaseFixEta":  "2026-02-20",
 			},
 		})
 	})
@@ -815,23 +786,20 @@ func TestSNCaseService_UpdateCase_EchoesInternalFixEtaFieldsBack(t *testing.T) {
 	client := newTestSNClient(t, mux)
 	svc := NewServiceNowCaseService(client, nil)
 
-	bestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	bestCase := "2026-02-10"
 	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, BestCaseFixEta: &bestCase})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	wantBestCase := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
-	if resp.Case.BestCaseFixEta == nil || !resp.Case.BestCaseFixEta.Equal(wantBestCase) {
-		t.Fatalf("BestCaseFixEta = %v, want %v", resp.Case.BestCaseFixEta, wantBestCase)
+	if resp.Case.BestCaseFixEta == nil || *resp.Case.BestCaseFixEta != "2026-02-10" {
+		t.Fatalf("BestCaseFixEta = %v, want 2026-02-10", resp.Case.BestCaseFixEta)
 	}
-	wantMostLikely := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
-	if resp.Case.MostLikelyFixEta == nil || !resp.Case.MostLikelyFixEta.Equal(wantMostLikely) {
-		t.Fatalf("MostLikelyFixEta = %v, want %v", resp.Case.MostLikelyFixEta, wantMostLikely)
+	if resp.Case.MostLikelyFixEta == nil || *resp.Case.MostLikelyFixEta != "2026-02-15" {
+		t.Fatalf("MostLikelyFixEta = %v, want 2026-02-15", resp.Case.MostLikelyFixEta)
 	}
-	wantWorstCase := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
-	if resp.Case.WorstCaseFixEta == nil || !resp.Case.WorstCaseFixEta.Equal(wantWorstCase) {
-		t.Fatalf("WorstCaseFixEta = %v, want %v", resp.Case.WorstCaseFixEta, wantWorstCase)
+	if resp.Case.WorstCaseFixEta == nil || *resp.Case.WorstCaseFixEta != "2026-02-20" {
+		t.Fatalf("WorstCaseFixEta = %v, want 2026-02-20", resp.Case.WorstCaseFixEta)
 	}
 }
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -629,8 +629,8 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
-        `workState`, `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`,
-        or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`,
+        `workState`, `watchList`, `assigneeEmail`, `bestCaseFixEta`, `mostLikelyFixEta`,
+        or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `bestCaseFixEta`,
         `mostLikelyFixEta`, and `worstCaseFixEta` are supported only when the ServiceNow data
         source is active.
       operationId: patchCase
@@ -3752,9 +3752,9 @@ components:
     UpdateCaseRequest:
       type: object
       description: |
-        Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`, `fixEta`,
+        Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`,
         `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta` must be provided.
-        `watchList`, `assigneeEmail`, `fixEta`, `bestCaseFixEta`, `mostLikelyFixEta`, and
+        `watchList`, `assigneeEmail`, `bestCaseFixEta`, `mostLikelyFixEta`, and
         `worstCaseFixEta` are supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
         `state` when the state is `closed` or `solution_proposed`.
@@ -3764,7 +3764,6 @@ components:
         - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
-        - required: [fixEta]
         - required: [bestCaseFixEta]
         - required: [mostLikelyFixEta]
         - required: [worstCaseFixEta]
@@ -3845,28 +3844,24 @@ components:
         closeNotes:
           type: string
           description: Close notes. Only allowed when state is closed or solution_proposed.
-        fixEta:
-          type: string
-          format: date-time
-          description: The single customer-facing fix-commitment date/time (ServiceNow only).
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           description: >-
-            Internal-only best-case fix-commitment date, visible to CSM engineers only
-            (ServiceNow only).
+            Internal-only best-case fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only (ServiceNow only).
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           description: >-
-            Internal-only most-likely fix-commitment date, visible to CSM engineers only
-            (ServiceNow only).
+            Internal-only most-likely fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only (ServiceNow only).
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           description: >-
-            Internal-only worst-case fix-commitment date, visible to CSM engineers only
-            (ServiceNow only).
+            Internal-only worst-case fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only (ServiceNow only).
 
     UpdateCaseResponse:
       type: object
@@ -3970,34 +3965,27 @@ components:
           format: date-time
           nullable: true
           description: Timestamp when the case was resolved, present when state is closed or solution_proposed.
-        fixEta:
-          type: string
-          format: date-time
-          nullable: true
-          description: >-
-            Echoes the updated customer-facing fix-commitment date/time back, present when
-            fixEta was the field updated.
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Echoes the updated internal-only best-case fix-commitment date back, present when
-            bestCaseFixEta was the field updated.
+            Echoes the updated internal-only best-case fix-commitment date back (date-only,
+            YYYY-MM-DD), present when bestCaseFixEta was the field updated.
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Echoes the updated internal-only most-likely fix-commitment date back, present when
-            mostLikelyFixEta was the field updated.
+            Echoes the updated internal-only most-likely fix-commitment date back (date-only,
+            YYYY-MM-DD), present when mostLikelyFixEta was the field updated.
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Echoes the updated internal-only worst-case fix-commitment date back, present when
-            worstCaseFixEta was the field updated.
+            Echoes the updated internal-only worst-case fix-commitment date back (date-only,
+            YYYY-MM-DD), present when worstCaseFixEta was the field updated.
 
     CaseLabelRef:
       type: object
@@ -4502,34 +4490,27 @@ components:
           type: string
           nullable: true
           description: Free-text resolution/close notes. Populated for resolved/closed ServiceNow cases; null otherwise.
-        fixEta:
-          type: string
-          format: date-time
-          nullable: true
-          description: >-
-            The single customer-facing fix-commitment date/time. Populated for ServiceNow
-            cases; null otherwise.
         bestCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Internal-only best-case fix-commitment date, visible to CSM engineers only.
-            Populated for ServiceNow cases; null otherwise.
+            Internal-only best-case fix-commitment date (date-only, YYYY-MM-DD), visible to
+            CSM engineers only. Populated for ServiceNow cases; null otherwise.
         mostLikelyFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Internal-only most-likely fix-commitment date, visible to CSM engineers only.
-            Populated for ServiceNow cases; null otherwise.
+            Internal-only most-likely fix-commitment date (date-only, YYYY-MM-DD), visible
+            to CSM engineers only. Populated for ServiceNow cases; null otherwise.
         worstCaseFixEta:
           type: string
-          format: date-time
+          format: date
           nullable: true
           description: >-
-            Internal-only worst-case fix-commitment date, visible to CSM engineers only.
-            Populated for ServiceNow cases; null otherwise.
+            Internal-only worst-case fix-commitment date (date-only, YYYY-MM-DD), visible to
+            CSM engineers only. Populated for ServiceNow cases; null otherwise.
 
     CaseSearchView:
       type: object


### PR DESCRIPTION
## Purpose
Adds Build Set Fix ETA support end-to-end: CSM engineers can record three independent, internal-only fix-commitment date estimates on a case — best case, most likely, and worst case — each a plain date (no time-of-day component).

An earlier, incomplete pass at this feature had added a single customer-facing `fixEta` field (backed by the data source's "shared with customer" fix-ETA field) alongside the three internal estimates, using full date-time values. That `fixEta` field's backing write path was never actually live, so it was dead code on every layer, and the three internal estimates were wired with the wrong date-time wire format. This PR replaces the broken `fixEta` field with the confirmed-working three-field contract and corrects the wire format to date-only.

## Goals
- Let a CSM engineer set/update best-case, most-likely, and worst-case fix-ETA dates on a case independently of one another.
- Consolidate on a single, working "fix ETA" concept instead of leaving a dead customer-facing field alongside the real internal-only one.
- Match the date-only wire contract the backing case-update resource actually expects (the same single-field-PATCH pathway already used for other case edits).

## Approach
- **entity-service**: `bestCaseFixEta` / `mostLikelyFixEta` / `worstCaseFixEta` on `UpdateCaseRequest` / `CaseView` / `UpdatedCase` are now `*string` date-only ("YYYY-MM-DD") fields instead of `*time.Time`, validated with a strict date-only parse before being forwarded. Removed the old single `fixEta` field and its now-dead read/write mapping. Fixed a gap where the Postgres-fallback path didn't reject these ServiceNow-only fields.
- **csm-portal-backend**: pure byte-passthrough handler, so only the OpenAPI spec needed updating to match (drop `fixEta`, correct the three estimates to `format: date`).
- **webapp**: `SetFixEtaDialog` now renders three date pickers (matching the existing `SetAutocloseHoldDialog` date-only picker convention) instead of four datetime pickers. Each field still saves independently via its own single-field PATCH. `CsmCaseDetailPage` now correctly passes all three current values into the dialog (previously only the unused `fixEta` value was wired) and maps `onSave(field, date)` to the matching PATCH payload variant. `CaseMetaBand` displays the three dates with a new date-only formatter so the viewer's timezone can't shift the displayed day.

## User stories
As a CSM engineer, I want to record best-case/most-likely/worst-case fix-ETA estimates on a case so the team has a shared, internal view of expected resolution timing, without exposing those estimates to the customer.

## Release note
CSM engineers can now set best-case, most-likely, and worst-case fix-ETA date estimates on a case from the "Set fix ETA…" action.

## Documentation
N/A — no customer-facing or admin-guide documentation exists for this internal CSM-portal action; the in-app dialog is self-explanatory.

## Automation tests
- Unit tests
  - entity-service: extended `sn_case_service_test.go` covering field-count validation, independent single-field PATCH per estimate, malformed-date rejection, and GET/PATCH read-back mapping for the three date-only fields.
  - csm-portal-backend: updated `cases_test.go` pass-through coverage for the three fields (date-only values) and removed the tests for the retired `fixEta` field.
  - webapp: rewrote `SetFixEtaDialog.test.tsx` for the three-field, date-only dialog.
- Integration tests
  - N/A — covered by the unit tests above; no dedicated integration suite exists for this endpoint.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go and TypeScript, not Java) — `go vet` and `eslint` both ran clean on all changed files
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A — this is the full, self-contained change across the three components in this repo. A corresponding change to the backing entity-service's data-source integration layer, adding write support for these three date fields, is tracked separately outside this repository.

## Migrations (if applicable)
N/A — no schema/data migration involved.

## Test environment
Verified locally: Go 1.x (entity-service and csm-portal-backend — `go build`, `go vet`, `go test`/`make test` all pass), Node/pnpm (webapp — `tsc -b`, `eslint`, `vitest`, `pnpm build` all pass).

## Learning
N/A
