### PR TITLE
[CSM][Web] Fix case-detail misrouting and align filter control heights

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -356,6 +356,10 @@ export default function App(): JSX.Element {
                     path="security-center/vulnerabilities/:id"
                     element={<ProductVulnerabilityDetailPage />}
                   />
+                  <Route
+                    path="security-center/security-reports/:caseId"
+                    element={<CsmCaseDetailPage />}
+                  />
                   <Route path="time-cards" element={<CsmTimeCardsPage />} />
                   <Route path="announcements" element={<CsmAnnouncementsPage />} />
                   <Route

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssigneeMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssigneeMultiSelect.tsx
@@ -146,7 +146,9 @@ export default function AsyncAssigneeMultiSelect({
       // Spinner only while the first page loads; later pages append on scroll.
       loading={isFetching && users.length === 0}
       disableCloseOnSelect
-      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" } }}
+      sx={{
+        "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap", minHeight: 40 },
+      }}
       // The backend already filtered by the typed term; don't re-filter locally
       // (that would also drop the manually-pinned "Me" option).
       filterOptions={(opts) => opts}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
@@ -128,7 +128,9 @@ export default function AsyncProjectMultiSelect({
       // Spinner only while the first page loads; later pages append on scroll.
       loading={isFetching && projects.length === 0}
       disableCloseOnSelect
-      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" } }}
+      sx={{
+        "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap", minHeight: 40 },
+      }}
       // The backend already filtered by the typed term; don't re-filter locally.
       filterOptions={(opts) => opts}
       getOptionLabel={(opt) => opt.name}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
@@ -67,7 +67,9 @@ export default function ProductNameMultiSelect({
       value={values}
       loading={isFetching && !data}
       disableCloseOnSelect
-      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" } }}
+      sx={{
+        "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap", minHeight: 40 },
+      }}
       getOptionLabel={(opt) => opt}
       isOptionEqualToValue={(opt, val) => opt === val}
       onChange={(_event, next) => onChange(next)}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -359,45 +359,27 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const isServiceRequest =
     isServiceRequestRoute || data?.caseType === "service_request";
   // Engagements, Announcements, Service Requests, and Security Reports each
-  // have a dedicated route; opening one of them under a mismatched route
-  // (e.g. a "Related case" link, which always points at /cases/:id) should
-  // redirect to its real destination rather than silently rendering under
-  // the wrong section.
-  const isMisroutedEngagement =
-    data?.caseType === "engagement" && !isEngagementRoute;
-  const isMisroutedAnnouncement =
-    data?.caseType === "announcement" && !isAnnouncementRoute;
-  const isMisroutedServiceRequest =
-    data?.caseType === "service_request" && !isServiceRequestRoute;
-  const isMisroutedSecurityReport =
-    data?.caseType === "security_report_analysis" && !isSecurityReportRoute;
-  const isMisrouted =
-    isMisroutedEngagement ||
-    isMisroutedAnnouncement ||
-    isMisroutedServiceRequest ||
-    isMisroutedSecurityReport;
+  // have a dedicated route; opening a case under any route other than its own
+  // canonical one (e.g. a "Related case" link, which always points at
+  // /cases/:id, or a dedicated route reached with a case of a different
+  // type) should redirect to its real destination rather than silently
+  // rendering under the wrong section.
+  const canonicalDetailPath =
+    data?.caseType === "engagement"
+      ? `/engagements/${caseId}`
+      : data?.caseType === "announcement"
+        ? `/announcements/${caseId}`
+        : data?.caseType === "service_request"
+          ? `/operations/service-requests/${caseId}`
+          : data?.caseType === "security_report_analysis"
+            ? `/security-center/security-reports/${caseId}`
+            : `/cases/${caseId}`;
+  const isMisrouted = !!data && detailPath !== canonicalDetailPath;
 
   useEffect(() => {
-    if (!caseId) return;
-    if (isMisroutedEngagement) {
-      navigate(`/engagements/${caseId}`, { replace: true });
-    } else if (isMisroutedAnnouncement) {
-      navigate(`/announcements/${caseId}`, { replace: true });
-    } else if (isMisroutedServiceRequest) {
-      navigate(`/operations/service-requests/${caseId}`, { replace: true });
-    } else if (isMisroutedSecurityReport) {
-      navigate(`/security-center/security-reports/${caseId}`, {
-        replace: true,
-      });
-    }
-  }, [
-    isMisroutedEngagement,
-    isMisroutedAnnouncement,
-    isMisroutedServiceRequest,
-    isMisroutedSecurityReport,
-    caseId,
-    navigate,
-  ]);
+    if (!caseId || !isMisrouted) return;
+    navigate(canonicalDetailPath, { replace: true });
+  }, [isMisrouted, canonicalDetailPath, caseId, navigate]);
 
   const {
     data: comments,

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -318,27 +318,36 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const isEngagementRoute = location.pathname.startsWith("/engagements/");
   const isServiceRequestRoute = location.pathname.startsWith("/operations/service-requests/");
   const isAnnouncementRoute = location.pathname.startsWith("/announcements/");
+  const isSecurityReportRoute = location.pathname.startsWith(
+    "/security-center/security-reports/",
+  );
   const backPath = isEngagementRoute
     ? "/engagements"
     : isServiceRequestRoute
       ? "/operations?tab=service_requests"
       : isAnnouncementRoute
         ? "/announcements"
-        : "/cases";
+        : isSecurityReportRoute
+          ? "/security-center?tab=security_reports"
+          : "/cases";
   const backLabel = isEngagementRoute
     ? "Back to engagements"
     : isServiceRequestRoute
       ? "Back to service requests"
       : isAnnouncementRoute
         ? "Back to announcements"
-        : "Back to cases";
+        : isSecurityReportRoute
+          ? "Back to security reports"
+          : "Back to cases";
   const detailPath = isEngagementRoute
     ? `/engagements/${caseId}`
     : isServiceRequestRoute
       ? `/operations/service-requests/${caseId}`
       : isAnnouncementRoute
         ? `/announcements/${caseId}`
-        : `/cases/${caseId}`;
+        : isSecurityReportRoute
+          ? `/security-center/security-reports/${caseId}`
+          : `/cases/${caseId}`;
   const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
   // The route alone isn't a reliable signal once data has loaded: a "Related
   // case" link always points at /cases/:id regardless of the target's actual
@@ -349,6 +358,47 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // severity, so combine the route with the loaded case's own caseType.
   const isServiceRequest =
     isServiceRequestRoute || data?.caseType === "service_request";
+  // Engagements, Announcements, Service Requests, and Security Reports each
+  // have a dedicated route; opening one of them under a mismatched route
+  // (e.g. a "Related case" link, which always points at /cases/:id) should
+  // redirect to its real destination rather than silently rendering under
+  // the wrong section.
+  const isMisroutedEngagement =
+    data?.caseType === "engagement" && !isEngagementRoute;
+  const isMisroutedAnnouncement =
+    data?.caseType === "announcement" && !isAnnouncementRoute;
+  const isMisroutedServiceRequest =
+    data?.caseType === "service_request" && !isServiceRequestRoute;
+  const isMisroutedSecurityReport =
+    data?.caseType === "security_report_analysis" && !isSecurityReportRoute;
+  const isMisrouted =
+    isMisroutedEngagement ||
+    isMisroutedAnnouncement ||
+    isMisroutedServiceRequest ||
+    isMisroutedSecurityReport;
+
+  useEffect(() => {
+    if (!caseId) return;
+    if (isMisroutedEngagement) {
+      navigate(`/engagements/${caseId}`, { replace: true });
+    } else if (isMisroutedAnnouncement) {
+      navigate(`/announcements/${caseId}`, { replace: true });
+    } else if (isMisroutedServiceRequest) {
+      navigate(`/operations/service-requests/${caseId}`, { replace: true });
+    } else if (isMisroutedSecurityReport) {
+      navigate(`/security-center/security-reports/${caseId}`, {
+        replace: true,
+      });
+    }
+  }, [
+    isMisroutedEngagement,
+    isMisroutedAnnouncement,
+    isMisroutedServiceRequest,
+    isMisroutedSecurityReport,
+    caseId,
+    navigate,
+  ]);
+
   const {
     data: comments,
     isLoading: isCommentsLoading,
@@ -1396,7 +1446,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     );
   }, [caseId, pendingDelete, deleteAttachment, showError]);
 
-  if (isLoading) {
+  if (isLoading || isMisrouted) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
         <Skeleton variant="rounded" height={32} width={240} />

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -180,7 +180,8 @@ export default function CreateSecurityReportPage(): JSX.Element {
         attachments: attachments.map((a) => ({ name: a.name, file: a.file })),
       },
       {
-        onSuccess: (created) => navigate(`/cases/${created.id}`),
+        onSuccess: (created) =>
+          navigate(`/security-center/security-reports/${created.id}`),
         onError: (err) => {
           // The backend surfaces real validation messages on 4xx; show them.
           const msg =

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -54,6 +54,7 @@ export default function CsmSecurityCenterPage(): JSX.Element {
           lockedFilters={{ caseTypes: ["security_report_analysis"] }}
           hideTypeFilter
           hideSeverityColumn
+          detailBasePath="/security-center/security-reports"
           actions={
             <Button
               variant="contained"


### PR DESCRIPTION
## Summary
- Announcement, Engagement, Service Request, and Security Report cases each have a dedicated route/page, but a generic link (e.g. a "Related case" chip, which always points at `/cases/:id`) could land the case on the wrong route/section. `CsmCaseDetailPage` now checks the loaded case's type and redirects to the correct destination when it doesn't match the current route — mirrors the customer-portal fix in #1190.
- Security report cases previously had no dedicated route and always opened at `/cases/:id`. Added a new `/security-center/security-reports/:caseId` route, and updated the security-reports list and the "New security report" create flow to link there directly.
- Fixed the Assignee/Project/Product filter controls (Autocomplete-based) rendering visibly shorter than the State/Work state controls (Select-based) in the cases filter bar — aligned their computed heights.

## Test plan
- [x] `tsc -b` passes
- [x] `eslint` clean on changed files (one pre-existing, unrelated warning in `CsmCaseDetailPage.tsx`)
- [x] Manually open a case-details URL for each type (`/cases/:id`, `/engagements/:id`, `/operations/service-requests/:id`, `/announcements/:id`) using an id belonging to a different type, and confirm it redirects to the correct page
- [ ] Create a new security report and confirm it lands on `/security-center/security-reports/:id`
- [x] Visually confirm the State/Work state/Assignee/Project/Product filter controls are the same height in the cases filter bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated detail pages and navigation for Security Center security reports.
  * Security report creation now opens the new security report detail view.
  * Added automatic routing to the correct case detail section when cases are opened through indirect links.

* **Style**
  * Improved multi-select field sizing for a more consistent 40px input height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->