### PR TITLE
[CSM][Web] Cache Accounts/Projects/Users search so tab switches don't refetch

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-accounts/api/useSearchAccounts.ts
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/api/useSearchAccounts.ts
@@ -44,5 +44,6 @@ export function useSearchAccounts(request: SearchAccountsRequest) {
       return (await res.json()) as SearchAccountsResponse;
     },
     placeholderData: keepPreviousData,
+    staleTime: 30_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjects.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjects.ts
@@ -44,5 +44,6 @@ export function useSearchProjects(request: SearchProjectsRequest) {
       return (await res.json()) as SearchProjectsResponse;
     },
     placeholderData: keepPreviousData,
+    staleTime: 30_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-users/api/useSearchUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/api/useSearchUsers.ts
@@ -53,5 +53,6 @@ export function useSearchUsers(request: SearchUsersRequest) {
     },
     select: normalizeUserSearchResponse,
     placeholderData: keepPreviousData,
+    staleTime: 30_000,
   });
 }


### PR DESCRIPTION
## Purpose
The Customers (Accounts/Projects) and Settings (Users) pages re-fetched their list data from the backend every time you switched tabs, unlike the rest of the app.

## Goals
- Switching between Accounts/Projects or the Settings Users tab shouldn't re-hit the backend if the data was just loaded.

## Approach
- Root cause: `useSearchAccounts`, `useSearchProjects`, and `useSearchUsers` were the only search hooks in the codebase with no `staleTime` set, so they fell back to TanStack Query's default of `0`. Customers/Settings tabs are real routes (`useRouteTabs`), so switching tabs unmounts/remounts the page component — with `staleTime: 0`, that remount always triggers a refetch.
- Every other search/list hook in the app already sets `staleTime: 30_000` (Operations' incidents/problems/change-requests, the Accounts/Projects *detail* hooks in these same features, csm-cases, csm-timecards, etc.), matching the same caching approach customer-portal uses. These three just never got it.
- Fix: added `staleTime: 30_000` to all three, bringing them in line with the rest of the app. No other behavior change.

## User stories
As a CSM engineer browsing Accounts, Projects, or Users, switching tabs and coming back doesn't re-fetch data I just loaded seconds ago.

## Release note
Fix Customers and Settings pages re-fetching on every tab switch.

## Documentation
N/A — internal CSM portal behavior fix, no external doc surface affected.

## Automation tests
- No existing automated coverage for these hooks' caching behavior.
- `tsc -b`, `eslint`, `vite build` all passing locally.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `tsc -b`, `eslint`, `vite build` passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Search results for accounts, projects, and users are now cached for 30 seconds, reducing unnecessary repeated requests and making repeated searches feel more responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->