### PR TITLE
[CSM Portal Microapp] Add Create Incident to the microapp

### DIFF
--- a/apps/csm-portal/microapp/src/App.tsx
+++ b/apps/csm-portal/microapp/src/App.tsx
@@ -27,6 +27,7 @@ import NewCasePage from "@pages/NewCasePage";
 import OperationsPage from "@pages/OperationsPage";
 import NewChangeRequestPage from "@pages/NewChangeRequestPage";
 import NewServiceRequestPage from "@pages/NewServiceRequestPage";
+import NewIncidentPage from "@pages/NewIncidentPage";
 import ChangeRequestDetailPage from "@pages/ChangeRequestDetailPage";
 import IncidentDetailPage from "@pages/IncidentDetailPage";
 import MorePage from "@pages/MorePage";
@@ -77,6 +78,7 @@ export default function App() {
           <Route path="/operations/change-requests/new" element={<NewChangeRequestPage />} />
           <Route path="/operations/service-requests/new" element={<NewServiceRequestPage />} />
           <Route path="/operations/change-requests/:id" element={<ChangeRequestDetailPage />} />
+          <Route path="/operations/incidents/new" element={<NewIncidentPage />} />
           <Route path="/operations/incidents/:id" element={<IncidentDetailPage />} />
           <Route path="/more" element={<MorePage />} />
           <Route path="/more/announcements" element={<AnnouncementsPage />} />

--- a/apps/csm-portal/microapp/src/components/operations/AsyncEntityMultiSelect.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/AsyncEntityMultiSelect.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState } from "react";
+import { Autocomplete, Chip, TextField } from "@wso2/oxygen-ui";
+import { useQuery } from "@tanstack/react-query";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+import type { EntityOption } from "@src/services/changeRequestLookups";
+
+interface AsyncEntityMultiSelectProps {
+  label: string;
+  placeholder?: string;
+  value: EntityOption[];
+  onChange: (next: EntityOption[]) => void;
+  disabled?: boolean;
+  helperText?: string;
+  search: (query: string, extra?: string) => Promise<EntityOption[]>;
+  searchExtra?: string;
+}
+
+// Multi-select counterpart of AsyncEntitySelect.tsx, for the incident create form's Watch list
+// field — the only multi-value lookup in this app so far. Kept as its own small component rather
+// than adding a `multiple` variant to AsyncEntitySelect's props, so that component's five existing
+// single-select usages stay untouched.
+export function AsyncEntityMultiSelect({
+  label,
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  helperText,
+  search,
+  searchExtra,
+}: AsyncEntityMultiSelectProps) {
+  const [inputValue, setInputValue] = useState("");
+  const debouncedQuery = useDebouncedValue(inputValue, 300);
+  const query = debouncedQuery.trim();
+  const { data, isFetching, isError } = useQuery({
+    queryKey: ["async-entity-multi-select", label, query, searchExtra ?? ""],
+    queryFn: () => search(query, searchExtra),
+    enabled: query.length > 0,
+    staleTime: 60_000,
+  });
+
+  const options = useMemo(() => {
+    const results = data ?? [];
+    const missingSelected = value.filter((v) => !results.some((o) => o.id === v.id));
+    return [...missingSelected, ...results];
+  }, [data, value]);
+
+  return (
+    <Autocomplete
+      multiple
+      options={options}
+      value={value}
+      loading={isFetching}
+      disabled={disabled}
+      fullWidth
+      size="small"
+      getOptionLabel={(option) => option.label}
+      isOptionEqualToValue={(option, val) => option.id === val.id}
+      onChange={(_, next) => onChange(next)}
+      onInputChange={(_, next) => setInputValue(next)}
+      noOptionsText={
+        query.length === 0 ? "Type to search…" : isError ? "Search failed. Try again." : "No matches found"
+      }
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip {...getTagProps({ index })} key={option.id} label={option.label} size="small" />
+        ))
+      }
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={value.length === 0 ? placeholder : undefined}
+          error={isError}
+          helperText={isError ? "Search failed." : helperText}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/microapp/src/components/operations/IncidentsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/IncidentsTab.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
-import { Badge, Chip, IconButton, Stack } from "@wso2/oxygen-ui";
-import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "react-router-dom";
+import { Badge, Chip, Fab, IconButton, Stack } from "@wso2/oxygen-ui";
+import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useQueryErrorResetBoundary, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { incidents } from "@src/services/incidents";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
@@ -35,9 +36,9 @@ import {
 } from "./incidentConfig";
 
 // Mirrors the shape of ChangeRequestsTab.tsx's own list content (search + filter sheet + infinite
-// scroll), scoped to incidents. Read-only for now — no create Fab (see the scope note on
-// OperationsPage.tsx).
+// scroll), scoped to incidents.
 export function IncidentsTab() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 300);
   const [filters, setFilters] = useState<IncidentFilters>(EMPTY_INCIDENT_FILTERS);
@@ -69,6 +70,17 @@ export function IncidentsTab() {
         filters={filters}
         onApply={setFilters}
       />
+
+      {/* Same floating create affordance as ChangeRequestsTab.tsx's own Fab. */}
+      <Fab
+        aria-label="Create incident"
+        size="medium"
+        color="primary"
+        onClick={() => navigate("/operations/incidents/new")}
+        sx={{ position: "fixed", right: 10, bottom: "calc(var(--tab-bar-height) + 60px)" }}
+      >
+        <Plus size={20} />
+      </Fab>
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/components/operations/incidentFormOptions.ts
+++ b/apps/csm-portal/microapp/src/components/operations/incidentFormOptions.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Direct port of the webapp's utils/incidentFormOptions.ts, used by NewIncidentPage.tsx.
+import type {
+  IncidentCategory,
+  IncidentContactType,
+  IncidentImpact,
+  IncidentPriority,
+  IncidentSubcategory,
+  IncidentUrgency,
+} from "@src/types";
+
+export const CATEGORY_OPTIONS: Array<{ value: IncidentCategory; label: string }> = [
+  { value: "INQUIRY", label: "Inquiry / Help" },
+  { value: "SERVICE_INTERRUPTION", label: "Service Interruption" },
+  { value: "SECURITY", label: "Security" },
+];
+
+export const IMPACT_OPTIONS: Array<{ value: IncidentImpact; label: string }> = [
+  { value: "HIGH", label: "High" },
+  { value: "MEDIUM", label: "Medium" },
+  { value: "LOW", label: "Low" },
+];
+
+export const URGENCY_OPTIONS: Array<{ value: IncidentUrgency; label: string }> = [
+  { value: "HIGH", label: "High" },
+  { value: "MEDIUM", label: "Medium" },
+  { value: "LOW", label: "Low" },
+];
+
+export const CONTACT_TYPE_OPTIONS: Array<{ value: IncidentContactType; label: string }> = [
+  { value: "SELF_SERVICE", label: "Self-service" },
+  { value: "EMAIL", label: "Email" },
+  { value: "WALK_IN", label: "Walk-in" },
+  { value: "AZURE", label: "Azure" },
+  { value: "EMAIL_INTERNAL", label: "Email Internal" },
+  { value: "SITE_247", label: "Site 24/7" },
+  { value: "DIRECT", label: "Direct" },
+  { value: "PHONE", label: "Phone" },
+  { value: "SENTINEL", label: "Sentinel" },
+  { value: "VIRTUAL_AGENT", label: "Virtual Agent" },
+  { value: "CHAT", label: "Chat" },
+  { value: "EMAIL_EXTERNAL", label: "Email External" },
+];
+
+/**
+ * Subcategory options, curated per category rather than one flat list — the backend's
+ * subcategory enum has more values than appear here, but the rest don't have an obvious home in
+ * Inquiry/Help, Service Interruption, or Security, so this curated picker doesn't surface them
+ * (same scope as the webapp's own picker).
+ */
+export const SUBCATEGORY_OPTIONS_BY_CATEGORY: Record<
+  IncidentCategory,
+  Array<{ value: IncidentSubcategory; label: string }>
+> = {
+  INQUIRY: [
+    { value: "CONFIG_CHANGE_REQUEST", label: "Config Change Request" },
+    { value: "INFORMATION_REQUEST", label: "Information Request" },
+  ],
+  SERVICE_INTERRUPTION: [
+    { value: "FULL_OUTAGE", label: "Full Outage" },
+    { value: "PARTIAL_OUTAGE", label: "Partial Outage" },
+    { value: "SLOWNESS", label: "Slowness" },
+  ],
+  SECURITY: [
+    { value: "DOS_DDOS", label: "DOS/DDOS" },
+    { value: "PRIVILEGE_ESCALATIONS", label: "Privilege Escalations" },
+    { value: "THREAT_INTELLIGENCE", label: "Threat Intelligence" },
+    { value: "SCANS_AND_PROBES", label: "Scans and Probes" },
+    { value: "APPLICATION_SECURITY", label: "Application Security" },
+    { value: "PRIVACY", label: "Privacy" },
+    { value: "DATA_BREACH", label: "Data Breach" },
+    { value: "SYSTEM_COMPROMISES", label: "System Compromises" },
+    { value: "MALWARE", label: "Malware" },
+    { value: "VULNERABILITY", label: "Vulnerability" },
+    { value: "UNAUTHORIZED_ACCESS", label: "Unauthorized Access" },
+    { value: "IDENTITY_PROTECTION", label: "Identity Protection" },
+    { value: "PHISHING", label: "Phishing" },
+    { value: "IMPROPER_CONFIGURATION", label: "Improper Configuration" },
+  ],
+};
+
+const PRIORITY_MATRIX: Record<IncidentImpact, Record<IncidentUrgency, IncidentPriority>> = {
+  HIGH: { HIGH: "CRITICAL", MEDIUM: "HIGH", LOW: "MODERATE" },
+  MEDIUM: { HIGH: "HIGH", MEDIUM: "MODERATE", LOW: "LOW" },
+  LOW: { HIGH: "MODERATE", MEDIUM: "LOW", LOW: "PLANNING" },
+};
+
+/**
+ * The standard ITIL impact × urgency → priority matrix (ServiceNow's own out-of-the-box default),
+ * used to show a live priority preview on the create form. This is purely a client-side preview —
+ * IncidentCreatePayloadDto has no `priority` field; the real value is computed server-side by
+ * ServiceNow from the impact/urgency actually submitted. Render the result with
+ * incidentPriorityLabel/incidentPriorityColor (./incidentConfig.ts) rather than duplicating a
+ * separate label/color map here.
+ */
+export function computeIncidentPriority(
+  impact: IncidentImpact | "",
+  urgency: IncidentUrgency | "",
+): IncidentPriority | null {
+  if (!impact || !urgency) return null;
+  return PRIORITY_MATRIX[impact][urgency];
+}

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -45,6 +45,7 @@ export const IT_SERVICES_SEARCH_ENDPOINT = "/services/search";
 export const SERVICE_OFFERINGS_SEARCH_ENDPOINT = "/service-offerings/search";
 export const CONFIGURATION_ITEMS_SEARCH_ENDPOINT = "/configuration-items/search";
 
+export const INCIDENTS_ENDPOINT = "/incidents";
 export const INCIDENTS_SEARCH_ENDPOINT = "/incidents/search";
 export const INCIDENT_ENDPOINT = (id: string) => `/incidents/${id}`;
 export const INCIDENT_COMMENTS_SEARCH_ENDPOINT = (id: string) => `/incidents/${id}/comments/search`;

--- a/apps/csm-portal/microapp/src/pages/NewIncidentPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewIncidentPage.tsx
@@ -1,0 +1,415 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { incidents } from "@src/services/incidents";
+import { changeRequestLookups, type EntityOption } from "@src/services/changeRequestLookups";
+import { users } from "@src/services/users";
+import type {
+  IncidentCategory,
+  IncidentContactType,
+  IncidentCreatePayloadDto,
+  IncidentImpact,
+  IncidentSubcategory,
+  IncidentUrgency,
+} from "@src/types";
+import { Logger } from "@utils/logger";
+import { incidentPriorityColor, incidentPriorityLabel } from "@components/operations/incidentConfig";
+import {
+  CATEGORY_OPTIONS,
+  CONTACT_TYPE_OPTIONS,
+  computeIncidentPriority,
+  IMPACT_OPTIONS,
+  SUBCATEGORY_OPTIONS_BY_CATEGORY,
+  URGENCY_OPTIONS,
+} from "@components/operations/incidentFormOptions";
+import { AsyncEntitySelect } from "@components/operations/AsyncEntitySelect";
+import { AsyncEntityMultiSelect } from "@components/operations/AsyncEntityMultiSelect";
+
+const UNSET = "";
+const SELECT_PLACEHOLDER = "-- Select --";
+
+// Ports the webapp's CreateIncidentPage.tsx, following this app's own NewChangeRequestPage.tsx for
+// structural conventions (plain useState per field, a renderSelect helper, a collapsed "More
+// options" Accordion for the less-common ServiceNow reference lookups). Unlike change requests,
+// most of incidents' core fields are actually required — the backend hard-requires
+// callerId/category/serviceId/impact/urgency/subject, and this form also requires
+// subcategory/contactType client-side, same as the webapp's own validation. There is deliberately
+// no priority or state field to fill in: priority is only ever a computed live preview
+// (impact × urgency → ITIL matrix), and every new incident starts at ServiceNow's default state.
+export default function NewIncidentPage() {
+  const navigate = useNavigate();
+
+  const [shortDescription, setShortDescription] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState<IncidentCategory | typeof UNSET>(UNSET);
+  const [subcategory, setSubcategory] = useState<IncidentSubcategory | typeof UNSET>(UNSET);
+  const [contactType, setContactType] = useState<IncidentContactType | typeof UNSET>(UNSET);
+  const [impact, setImpact] = useState<IncidentImpact | typeof UNSET>(UNSET);
+  const [urgency, setUrgency] = useState<IncidentUrgency | typeof UNSET>(UNSET);
+  const [caller, setCaller] = useState<EntityOption | null>(null);
+  const [service, setService] = useState<EntityOption | null>(null);
+  const [serviceOffering, setServiceOffering] = useState<EntityOption | null>(null);
+  const [configurationItem, setConfigurationItem] = useState<EntityOption | null>(null);
+  const [assignmentGroup, setAssignmentGroup] = useState<EntityOption | null>(null);
+  const [assignedEngineer, setAssignedEngineer] = useState<EntityOption | null>(null);
+  const [watchList, setWatchList] = useState<EntityOption[]>([]);
+  const [workNotes, setWorkNotes] = useState("");
+  const [parentId, setParentId] = useState("");
+  const [changeRequestId, setChangeRequestId] = useState("");
+  const [problemId, setProblemId] = useState("");
+  const [causedById, setCausedById] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Defaults "Caller" to the signed-in user, matching the webapp's own create form — the backend
+  // doesn't do this itself, and callerId is one of its hard-required fields. Fires once, when the
+  // current user first loads; a ref (not the field's own emptiness) gates it so manually clearing
+  // the field afterward sticks.
+  const { data: me } = useQuery(users.me());
+  const autoFilledCaller = useRef(false);
+  if (me?.id && !autoFilledCaller.current) {
+    autoFilledCaller.current = true;
+    setCaller({ id: me.id, label: me.fullName });
+  }
+
+  const createIncident = useMutation({ mutationFn: incidents.create });
+
+  const subcategoryOptions = category ? SUBCATEGORY_OPTIONS_BY_CATEGORY[category] : [];
+  const previewPriority = computeIncidentPriority(impact, urgency);
+
+  const handleCategoryChange = (next: IncidentCategory | typeof UNSET): void => {
+    setCategory(next);
+    // A subcategory only makes sense under its own category's curated list — drop it rather than
+    // leave a stale pairing.
+    setSubcategory(UNSET);
+  };
+
+  const canSubmit =
+    shortDescription.trim().length > 0 &&
+    !!category &&
+    !!subcategory &&
+    !!contactType &&
+    !!impact &&
+    !!urgency &&
+    !!caller &&
+    !!service &&
+    !createIncident.isPending;
+
+  const handleSubmit = (): void => {
+    if (!canSubmit || !category || !subcategory || !contactType || !impact || !urgency || !caller || !service) return;
+    setSubmitError(null);
+
+    const payload: IncidentCreatePayloadDto = {
+      subject: shortDescription.trim(),
+      category,
+      subcategory,
+      contactType,
+      impact,
+      urgency,
+      callerId: caller.id,
+      serviceId: service.id,
+    };
+    if (description.trim()) payload.additionalComments = description.trim();
+    if (serviceOffering) payload.serviceOfferingId = serviceOffering.id;
+    if (configurationItem) payload.configurationItemId = configurationItem.id;
+    if (assignmentGroup) payload.assignmentGroupId = assignmentGroup.id;
+    if (assignedEngineer) payload.assignedEngineerId = assignedEngineer.id;
+    if (watchList.length > 0) payload.watchList = watchList.map((w) => w.id);
+    if (workNotes.trim()) payload.workNotes = workNotes.trim();
+    if (parentId.trim()) payload.parentId = parentId.trim();
+    if (changeRequestId.trim()) payload.changeRequestId = changeRequestId.trim();
+    if (problemId.trim()) payload.problemId = problemId.trim();
+    if (causedById.trim()) payload.causedById = causedById.trim();
+
+    createIncident.mutate(payload, {
+      onSuccess: (created) => navigate(`/operations/incidents/${created.incident.id}`),
+      onError: (err) => {
+        Logger.warn("Could not create the incident", err);
+        setSubmitError("Could not create the incident. Please try again.");
+      },
+    });
+  };
+
+  // Shared renderer for a "-- Select --" dropdown.
+  const renderSelect = <T extends string>(
+    id: string,
+    label: string,
+    value: T | typeof UNSET,
+    onChange: (v: T | typeof UNSET) => void,
+    options: Array<{ value: T; label: string }>,
+    required = false,
+    disabled = false,
+  ) => (
+    <FormControl fullWidth size="small" required={required} disabled={createIncident.isPending || disabled}>
+      <InputLabel id={`${id}-label`} shrink>
+        {label}
+      </InputLabel>
+      <Select
+        labelId={`${id}-label`}
+        label={label}
+        value={value}
+        displayEmpty
+        onChange={(e) => onChange(e.target.value as T | typeof UNSET)}
+      >
+        <MenuItem value={UNSET}>
+          <Typography component="span" color="text.secondary">
+            {SELECT_PLACEHOLDER}
+          </Typography>
+        </MenuItem>
+        {options.map((o) => (
+          <MenuItem key={o.value} value={o.value}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="h6">New Incident</Typography>
+
+      <Stack gap={2}>
+        <TextField
+          label="Short description"
+          value={shortDescription}
+          onChange={(e) => setShortDescription(e.target.value)}
+          size="small"
+          fullWidth
+          required
+          disabled={createIncident.isPending}
+          placeholder="Brief summary of the incident"
+        />
+        <TextField
+          label="Description"
+          placeholder="More detail — visible to the customer"
+          size="small"
+          fullWidth
+          multiline
+          minRows={3}
+          disabled={createIncident.isPending}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          helperText="Visible to the customer — do not include internal-only details."
+        />
+
+        <Typography variant="subtitle2">Classification</Typography>
+
+        {renderSelect("incident-category", "Category", category, handleCategoryChange, CATEGORY_OPTIONS, true)}
+        {renderSelect(
+          "incident-subcategory",
+          "Subcategory",
+          subcategory,
+          setSubcategory,
+          subcategoryOptions,
+          true,
+          !category,
+        )}
+        {renderSelect("incident-contact-type", "Contact type", contactType, setContactType, CONTACT_TYPE_OPTIONS, true)}
+        {renderSelect("incident-impact", "Impact", impact, setImpact, IMPACT_OPTIONS, true)}
+        {renderSelect("incident-urgency", "Urgency", urgency, setUrgency, URGENCY_OPTIONS, true)}
+
+        <Stack direction="row" gap={1} alignItems="center">
+          <Typography variant="body2" color="text.secondary">
+            Priority
+          </Typography>
+          {previewPriority ? (
+            <Chip
+              size="small"
+              label={incidentPriorityLabel(previewPriority)}
+              color={incidentPriorityColor(previewPriority)}
+            />
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              Set Impact and Urgency to preview
+            </Typography>
+          )}
+          <Typography variant="caption" color="text.secondary">
+            (computed by ServiceNow on creation — not sent)
+          </Typography>
+        </Stack>
+
+        <Stack direction="row" gap={1} alignItems="center">
+          <Typography variant="body2" color="text.secondary">
+            State
+          </Typography>
+          <Chip size="small" label="New" />
+        </Stack>
+
+        <Typography variant="subtitle2">Requester &amp; service</Typography>
+
+        <AsyncEntitySelect
+          label="Caller"
+          placeholder="Search people…"
+          value={caller}
+          onChange={setCaller}
+          disabled={createIncident.isPending}
+          search={changeRequestLookups.users}
+          helperText="Defaults to you — clear it if this wasn't reported by you."
+        />
+        <AsyncEntitySelect
+          label="Service"
+          placeholder="Search services…"
+          value={service}
+          onChange={(next) => {
+            setService(next);
+            // A service offering only makes sense under its own service — drop it rather than
+            // leave a stale pairing.
+            setServiceOffering(null);
+          }}
+          disabled={createIncident.isPending}
+          search={changeRequestLookups.itServices}
+        />
+
+        {/* Everything below is optional and used less often at creation time — collapsed by
+            default so the form isn't dominated by fields most incidents won't need up front. */}
+        <Accordion disableGutters sx={{ "&:before": { display: "none" } }}>
+          <AccordionSummary expandIcon={<ChevronDown size={16} />}>
+            <Typography variant="body2" color="text.secondary">
+              More options (optional)
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <AsyncEntitySelect
+              label="Service offering"
+              placeholder="Search service offerings…"
+              value={serviceOffering}
+              onChange={setServiceOffering}
+              disabled={createIncident.isPending}
+              search={changeRequestLookups.serviceOfferings}
+              searchExtra={service?.id}
+              helperText={service ? undefined : "Narrows to a Service once one is picked."}
+            />
+            <AsyncEntitySelect
+              label="Configuration item"
+              placeholder="Search configuration items…"
+              value={configurationItem}
+              onChange={setConfigurationItem}
+              disabled={createIncident.isPending}
+              search={changeRequestLookups.configurationItems}
+            />
+            <AsyncEntitySelect
+              label="Assignment group"
+              placeholder="Search groups…"
+              value={assignmentGroup}
+              onChange={setAssignmentGroup}
+              disabled={createIncident.isPending}
+              search={changeRequestLookups.groups}
+            />
+            <AsyncEntitySelect
+              label="Assigned to"
+              placeholder="Search people…"
+              value={assignedEngineer}
+              onChange={setAssignedEngineer}
+              disabled={createIncident.isPending}
+              search={changeRequestLookups.users}
+            />
+            <AsyncEntityMultiSelect
+              label="Watch list"
+              placeholder="Search people…"
+              value={watchList}
+              onChange={setWatchList}
+              disabled={createIncident.isPending}
+              search={changeRequestLookups.users}
+            />
+            <TextField
+              label="Internal work note"
+              multiline
+              minRows={2}
+              size="small"
+              fullWidth
+              value={workNotes}
+              onChange={(e) => setWorkNotes(e.target.value)}
+              disabled={createIncident.isPending}
+              helperText="Internal only — never shown to the customer."
+            />
+
+            <Typography variant="body2" color="text.secondary">
+              Advanced linking
+            </Typography>
+            <TextField
+              label="Parent ID (case/incident/CR/problem)"
+              size="small"
+              fullWidth
+              value={parentId}
+              onChange={(e) => setParentId(e.target.value)}
+              disabled={createIncident.isPending}
+            />
+            <TextField
+              label="Change request ID"
+              size="small"
+              fullWidth
+              value={changeRequestId}
+              onChange={(e) => setChangeRequestId(e.target.value)}
+              disabled={createIncident.isPending}
+            />
+            <TextField
+              label="Problem ID"
+              size="small"
+              fullWidth
+              value={problemId}
+              onChange={(e) => setProblemId(e.target.value)}
+              disabled={createIncident.isPending}
+            />
+            <TextField
+              label="Caused by ID"
+              size="small"
+              fullWidth
+              value={causedById}
+              onChange={(e) => setCausedById(e.target.value)}
+              disabled={createIncident.isPending}
+            />
+          </AccordionDetails>
+        </Accordion>
+
+        {submitError && (
+          <Typography variant="body2" color="error.main">
+            {submitError}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={1} justifyContent="flex-end">
+          {/* navigate(-1) rather than a hardcoded /operations path — this app's Operations tab
+              state isn't URL-driven, so going back preserves whichever tab (Incidents) the Fab
+              was pressed from, same as NewChangeRequestPage.tsx's own Cancel button. */}
+          <Button onClick={() => navigate(-1)} disabled={createIncident.isPending}>
+            Cancel
+          </Button>
+          <Button variant="contained" disabled={!canSubmit} onClick={handleSubmit}>
+            {createIncident.isPending ? "Creating…" : "Create Incident"}
+          </Button>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/OperationsPage.tsx
@@ -32,11 +32,9 @@ const TABS: { id: OperationsTabId; label: string }[] = [
 // three tabs — Service requests (cases with type=service_request, reusing the Support page's own
 // list/pagination/filter infra, with its own "Create service request" Fab — see
 // ServiceRequestsTab.tsx), Change requests (its own list/detail/edit, with its own "Create change
-// request" Fab — see ChangeRequestsTab.tsx), and Incidents (list + read-only detail with comments
-// — see IncidentsTab.tsx/IncidentDetailPage.tsx). "Create incident" is deliberately out of scope
-// for this pass — it's its own form with an impact×urgency priority matrix and 34 ServiceNow
-// subcategories; incidents' Edit dialog (state transitions, watch list management) is similarly
-// out of scope.
+// request" Fab — see ChangeRequestsTab.tsx), and Incidents (list + detail with comments, with its
+// own "Create incident" Fab — see IncidentsTab.tsx/NewIncidentPage.tsx/IncidentDetailPage.tsx).
+// Incidents' Edit dialog (state transitions, watch list management) is still out of scope.
 export default function OperationsPage() {
   const [activeTab, setActiveTab] = useState<OperationsTabId>("service_requests");
 

--- a/apps/csm-portal/microapp/src/services/incidents.ts
+++ b/apps/csm-portal/microapp/src/services/incidents.ts
@@ -15,9 +15,16 @@
 // under the License.
 
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
-import { INCIDENTS_SEARCH_ENDPOINT, INCIDENT_COMMENTS_SEARCH_ENDPOINT, INCIDENT_ENDPOINT } from "@config/endpoints";
+import {
+  INCIDENTS_ENDPOINT,
+  INCIDENTS_SEARCH_ENDPOINT,
+  INCIDENT_COMMENTS_SEARCH_ENDPOINT,
+  INCIDENT_ENDPOINT,
+} from "@config/endpoints";
 import type {
   CaseCommentSearchResponseDto,
+  IncidentCreatePayloadDto,
+  IncidentCreateResponseDto,
   IncidentDetailDto,
   IncidentSearchPayloadDto,
   IncidentSearchResponseDto,
@@ -65,6 +72,11 @@ const getIncidentComments = async (id: string): Promise<Comment[]> => {
   return data.comments.map(toComment);
 };
 
+const createIncident = async (payload: IncidentCreatePayloadDto): Promise<IncidentCreateResponseDto> => {
+  const { data } = await apiClient.post<IncidentCreateResponseDto>(INCIDENTS_ENDPOINT, payload);
+  return data;
+};
+
 const INCIDENT_PAGE_LIMIT = 20;
 
 export const incidents = {
@@ -88,4 +100,6 @@ export const incidents = {
       queryKey: ["incident", id, "comments"],
       queryFn: () => getIncidentComments(id),
     }),
+
+  create: createIncident,
 };

--- a/apps/csm-portal/microapp/src/types/incident.dto.ts
+++ b/apps/csm-portal/microapp/src/types/incident.dto.ts
@@ -16,7 +16,6 @@
 
 // Incidents (ServiceNow data source only). Mirrors the webapp's BeIncident/BeIncidentDetail
 // (api/backend/types.ts). Unlike change requests, every enum here is UPPER_SNAKE_CASE on the wire.
-// Read-only in this app for now (no create/edit) — see IncidentsTab.tsx/IncidentDetailPage.tsx.
 
 import type { EntityRefDto } from "./case.dto";
 
@@ -98,4 +97,90 @@ export interface IncidentSearchResponseDto {
   total: number;
   limit: number;
   offset: number;
+}
+
+// Create-only enums (the detail response's category/subcategory/contactType/impact/urgency are
+// looser free-form strings, see IncidentDetailDto above) — mirrors the webapp's
+// BeIncidentCategory/Subcategory/ContactType/Impact/Urgency.
+export type IncidentCategory = "INQUIRY" | "SERVICE_INTERRUPTION" | "SECURITY";
+
+// Only the values the create form's curated picker offers (see incidentFormOptions.ts) — the
+// backend's validIncidentSubcategories enum has ~16 more values not surfaced there.
+export type IncidentSubcategory =
+  | "CONFIG_CHANGE_REQUEST"
+  | "INFORMATION_REQUEST"
+  | "FULL_OUTAGE"
+  | "PARTIAL_OUTAGE"
+  | "SLOWNESS"
+  | "DOS_DDOS"
+  | "PRIVILEGE_ESCALATIONS"
+  | "THREAT_INTELLIGENCE"
+  | "SCANS_AND_PROBES"
+  | "APPLICATION_SECURITY"
+  | "PRIVACY"
+  | "DATA_BREACH"
+  | "SYSTEM_COMPROMISES"
+  | "MALWARE"
+  | "VULNERABILITY"
+  | "UNAUTHORIZED_ACCESS"
+  | "IDENTITY_PROTECTION"
+  | "PHISHING"
+  | "IMPROPER_CONFIGURATION";
+
+export type IncidentContactType =
+  | "SELF_SERVICE"
+  | "EMAIL"
+  | "WALK_IN"
+  | "AZURE"
+  | "EMAIL_INTERNAL"
+  | "SITE_247"
+  | "DIRECT"
+  | "PHONE"
+  | "SENTINEL"
+  | "VIRTUAL_AGENT"
+  | "CHAT"
+  | "EMAIL_EXTERNAL";
+
+export type IncidentImpact = "HIGH" | "MEDIUM" | "LOW";
+
+export type IncidentUrgency = "HIGH" | "MEDIUM" | "LOW";
+
+/**
+ * `POST /incidents` body (ServiceNow data source only). Mirrors the webapp's
+ * BeCreateIncidentPayload. The backend hard-requires callerId/category/serviceId/impact/urgency/
+ * subject (`validateCreateIncidentBody`); subcategory/contactType are optional on the wire but
+ * treated as required by this app's form, same as the webapp's own create form. There is
+ * deliberately no `priority` or `state` field — ServiceNow computes priority server-side from
+ * impact/urgency, and every new incident starts at ServiceNow's default state ("New").
+ */
+export interface IncidentCreatePayloadDto {
+  callerId: string;
+  category: IncidentCategory;
+  subcategory?: IncidentSubcategory;
+  serviceId: string;
+  serviceOfferingId?: string;
+  configurationItemId?: string;
+  contactType?: IncidentContactType;
+  impact: IncidentImpact;
+  urgency: IncidentUrgency;
+  assignmentGroupId?: string;
+  assignedEngineerId?: string;
+  subject: string;
+  watchList?: string[];
+  additionalComments?: string;
+  workNotes?: string;
+  parentId?: string;
+  changeRequestId?: string;
+  problemId?: string;
+  causedById?: string;
+}
+
+export interface IncidentCreateResponseDto {
+  message: string;
+  incident: {
+    id: string;
+    number: string;
+    createdOn: string;
+    createdBy: string;
+  };
 }


### PR DESCRIPTION
## Summary
- Ports the webapp's `CreateIncidentPage` to the microapp as `NewIncidentPage.tsx`, following this app's own `NewChangeRequestPage.tsx` for structural conventions (plain `useState` per field, `renderSelect` helper, collapsed "More options" accordion).
- Adds `POST /incidents` support: `INCIDENTS_ENDPOINT`, `IncidentCreatePayloadDto`/`IncidentCreateResponseDto` and the create-only category/subcategory/contact-type/impact/urgency enums in `incident.dto.ts`, and `incidents.create` in `services/incidents.ts`.
- Adds `incidentFormOptions.ts` (category/subcategory/contact-type/impact/urgency option lists + the impact×urgency→priority preview matrix, matching the webapp's own curated picker).
- Adds `AsyncEntityMultiSelect.tsx` (multi-select counterpart of the existing `AsyncEntitySelect`) for the Watch list field, without touching the single-select component's five existing usages.
- Wires up the `/operations/incidents/new` route in `App.tsx` and a "Create incident" Fab on `IncidentsTab.tsx`, matching `ChangeRequestsTab.tsx`'s existing Fab pattern.

No `priority`/`state` field is submitted on create — ServiceNow computes priority server-side from impact/urgency, and every new incident starts at ServiceNow's default state ("New"), same as the webapp's behavior.

## Test plan
- [x] `tsc -b --noEmit` passes
- [x] `eslint` passes on all changed/new files
- [x] Verified in the iOS simulator: Incidents tab loads, "Create incident" Fab navigates to the new form
- [ ] Manually submit a real incident end-to-end against staging and confirm it appears in the Incidents list and detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)