### PR TITLE
[Customer Portal][Webapp] Color project stat counts in the user overview to match project cards

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
@@ -34,6 +34,7 @@ import {
   TableRow,
   TextField,
   Typography,
+  colors,
 } from "@wso2/oxygen-ui";
 import { ChevronDown, Download, FileText, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type MouseEvent, useCallback, useRef, useState } from "react";
@@ -393,17 +394,17 @@ export default function UserGlobalSearch(): JSX.Element {
                           />
                         </TableCell>
                         <TableCell align="right">
-                          <Typography variant="body2">
+                          <Typography variant="body2" color="warning.main">
                             {project.actionRequiredCount ?? 0}
                           </Typography>
                         </TableCell>
                         <TableCell align="right">
-                          <Typography variant="body2">
+                          <Typography variant="body2" color="primary">
                             {project.outstandingCount ?? 0}
                           </Typography>
                         </TableCell>
                         <TableCell align="right">
-                          <Typography variant="body2">
+                          <Typography variant="body2" color={colors.blue[500]}>
                             {project.activeChatsCount ?? 0}
                           </Typography>
                         </TableCell>

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
@@ -35,6 +35,7 @@ import {
   TableRow,
   TextField,
   Typography,
+  colors,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, ChevronDown, Download, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { type ChangeEvent, type JSX, type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
@@ -366,17 +367,17 @@ export default function UserProjectsPage(): JSX.Element {
                         />
                       </TableCell>
                       <TableCell align="right">
-                        <Typography variant="body2">
+                        <Typography variant="body2" color="warning.main">
                           {project.actionRequiredCount ?? 0}
                         </Typography>
                       </TableCell>
                       <TableCell align="right">
-                        <Typography variant="body2">
+                        <Typography variant="body2" color="primary">
                           {project.outstandingCount ?? 0}
                         </Typography>
                       </TableCell>
                       <TableCell align="right">
-                        <Typography variant="body2">
+                        <Typography variant="body2" color={colors.blue[500]}>
                           {project.activeChatsCount ?? 0}
                         </Typography>
                       </TableCell>


### PR DESCRIPTION
## Summary
- The Projects table in `UserGlobalSearch.tsx` (the non-partner multi-project overview) now colors the Action Required, Outstanding, and Active Chats counts instead of plain body text.
- Colors match the existing `ProjectCardStats` scheme: Action Required in `warning.main`, Outstanding in `primary`, Active Chats in `colors.blue[500]` — keeping the new table view visually consistent with the project-card view it replaces.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean
- [ ] Manually verify in browser: non-partner account with >1 project shows colored counts in the Projects table matching the colors previously seen on project cards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual clarity in the projects table by applying distinct semantic colors to “Action Required,” “Outstanding,” and “Active Chats” counts.
  * Updated count styling to better align with the application’s visual theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->