### PR TITLE
[CSM Portal Microapp] Fix translucent tab bars and content overlapping the bottom bar

### DIFF
--- a/apps/csm-portal/microapp/src/components/layout/MainLayout.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/MainLayout.tsx
@@ -26,7 +26,7 @@ export default function MainLayout() {
   return (
     <>
       <TopBar />
-      <Box component="main" flexGrow={1} p={2} pb={15}>
+      <Box component="main" flexGrow={1} p={2} pb="calc(var(--tab-bar-height, 120px) + 24px)">
         <Outlet />
       </Box>
       <TabBar />

--- a/apps/csm-portal/microapp/src/components/layout/TabBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TabBar.tsx
@@ -51,7 +51,6 @@ export function TabBar() {
     <Box
       ref={ref}
       position="fixed"
-      bgcolor="background.paper"
       bottom={0}
       left={0}
       right={0}
@@ -61,6 +60,13 @@ export function TabBar() {
       // reason as TopBar.tsx's fixed pt.
       pb={4}
       sx={{
+        // Solid, not the theme's `background.paper` token — that token is deliberately
+        // semi-transparent in the shared Acrylic theme (#ffffffe1 / #000000b8, for glass-style
+        // Paper/Card surfaces), which reads as visibly translucent on a fixed bar with page
+        // content scrolling underneath it. Matches the customer-portal microapp's own TabBar,
+        // which hardcodes solid black/white for the same reason (its own ThemeModeContext there
+        // does the same job as `theme.palette.mode` does here).
+        backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#000000" : "#ffffff"),
         borderTop: "1px solid",
         borderColor: "divider",
       }}

--- a/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
@@ -32,7 +32,6 @@ export function TopBar() {
     <Box
       position="sticky"
       top={0}
-      bgcolor="background.paper"
       display="flex"
       alignItems="center"
       px={2}
@@ -44,6 +43,9 @@ export function TopBar() {
         // correct for whatever inset it was tuned against; on a Dynamic Island phone (~59px inset)
         // it undershoots and the pill visually overflows into the page content below it.
         pt: "calc(var(--safe-top, 44px) + 40px)",
+        // Solid, not the theme's `background.paper` token — see TabBar.tsx's identical comment.
+        // Matches the customer-portal microapp's own AppBar, which hardcodes solid black/white.
+        backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#000000" : "#ffffff"),
         borderBottom: "1px solid",
         borderColor: "divider",
         zIndex: (theme) => theme.zIndex.appBar,


### PR DESCRIPTION
## Summary
- `TopBar.tsx`/`TabBar.tsx` used `bgcolor="background.paper"`, an MUI theme token that's deliberately semi-transparent in the shared "Acrylic" theme (`#ffffffe1` light / `#000000b8` dark) — makes both fixed bars look translucent with page content scrolling underneath. Switched both to a solid color keyed off `theme.palette.mode`, matching the customer-portal microapp's own bars (which hardcode solid black/white instead of using the token).
- `MainLayout.tsx`'s content area used a static `pb={15}` guess for tab-bar clearance. On a long page (e.g. the new Create Incident form), the tail of the content could end up rendering underneath the fixed `TabBar` instead of clearing it — previously masked by the translucency, now visible once the bar is opaque. Tied the padding to the live-measured `--tab-bar-height` CSS variable instead (already tracked by `TabBar.tsx`'s own `ResizeObserver` and used the same way for Fab positioning elsewhere in the app).

## Test plan
- [x] `tsc -b --noEmit` passes
- [x] `eslint` passes on all changed files
- [x] Verified in the iOS simulator: both bars render solid/opaque, and scrolling a long form (Create Incident) no longer shows content overlapping the bottom tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout spacing so content remains visible above the bottom tab bar.
  * Updated the top and bottom navigation bars to use solid backgrounds in light and dark themes, preventing unwanted transparency effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->