### PR TITLE
[Customer Portal][Webapp] Revert stat count colors in the user projects overview

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
@@ -34,7 +34,6 @@ import {
   TableRow,
   TextField,
   Typography,
-  colors,
 } from "@wso2/oxygen-ui";
 import { ChevronDown, Download, FileText, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type MouseEvent, useCallback, useRef, useState } from "react";
@@ -394,17 +393,17 @@ export default function UserGlobalSearch(): JSX.Element {
                           />
                         </TableCell>
                         <TableCell align="right">
-                          <Typography variant="body2" color="warning.main">
+                          <Typography variant="body2">
                             {project.actionRequiredCount ?? 0}
                           </Typography>
                         </TableCell>
                         <TableCell align="right">
-                          <Typography variant="body2" color="primary">
+                          <Typography variant="body2">
                             {project.outstandingCount ?? 0}
                           </Typography>
                         </TableCell>
                         <TableCell align="right">
-                          <Typography variant="body2" color={colors.blue[500]}>
+                          <Typography variant="body2">
                             {project.activeChatsCount ?? 0}
                           </Typography>
                         </TableCell>

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
@@ -35,7 +35,6 @@ import {
   TableRow,
   TextField,
   Typography,
-  colors,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, ChevronDown, Download, FolderOpen, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { type ChangeEvent, type JSX, type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
@@ -367,17 +366,17 @@ export default function UserProjectsPage(): JSX.Element {
                         />
                       </TableCell>
                       <TableCell align="right">
-                        <Typography variant="body2" color="warning.main">
+                        <Typography variant="body2">
                           {project.actionRequiredCount ?? 0}
                         </Typography>
                       </TableCell>
                       <TableCell align="right">
-                        <Typography variant="body2" color="primary">
+                        <Typography variant="body2">
                           {project.outstandingCount ?? 0}
                         </Typography>
                       </TableCell>
                       <TableCell align="right">
-                        <Typography variant="body2" color={colors.blue[500]}>
+                        <Typography variant="body2">
                           {project.activeChatsCount ?? 0}
                         </Typography>
                       </TableCell>


### PR DESCRIPTION
## Summary
- Reverts the earlier color styling (warning/primary/blue) applied to Action Required, Outstanding, and Active Chats counts in the Projects table.
- These counts are back to plain body text in both `UserGlobalSearch.tsx` (dashboard overview) and `UserProjectsPage.tsx` (full projects list), matching how they looked before.
- Removed the now-unused `colors` import from both files.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean
- [ ] Manually verify in browser: Action Required/Outstanding/Active Chats counts render as plain text (no color) in both the overview and full projects list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated project table count columns to use the standard text styling.
  * Removed custom colors from “Action Required,” “Outstanding,” and “Active Chats” counts.
  * Existing count values and zero fallbacks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->