### PR TITLE
[CSM Portal] expose project's linked account on project search results

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -450,6 +450,8 @@ type ProjectView struct {
 	// for this project (e.g. ServiceNow leaves it blank).
 	EndDate   *time.Time `json:"endDate"`
 	CreatedOn time.Time  `json:"createdOn"`
+	// Account is nil when the project has no linked account (ServiceNow data source only).
+	Account *EntityRef `json:"account"`
 	ProjectClosureFields
 }
 

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -51,16 +51,24 @@ type snProjectClosureFields struct {
 }
 
 type snProject struct {
-	ID        string        `json:"id"`
-	Name      string        `json:"name"`
-	Key       string        `json:"key"`
-	Type      snProjectType `json:"type"`
-	EndDate   string        `json:"endDate"`
-	CreatedOn string        `json:"createdOn"`
+	ID        string                  `json:"id"`
+	Name      string                  `json:"name"`
+	Key       string                  `json:"key"`
+	Type      snProjectType           `json:"type"`
+	EndDate   string                  `json:"endDate"`
+	CreatedOn string                  `json:"createdOn"`
+	Account   snProjectSummaryAccount `json:"account"`
 	snProjectClosureFields
 }
 
 type snProjectType struct {
+	Name string `json:"name"`
+}
+
+// snProjectSummaryAccount is the compact account reference embedded in each
+// search result. ID/Name are empty when the project has no linked account.
+type snProjectSummaryAccount struct {
+	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
@@ -156,6 +164,10 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 			}
 			endDate = &parsed
 		}
+		var account *domain.EntityRef
+		if p.Account.ID != "" {
+			account = &domain.EntityRef{ID: sysidToUUID(p.Account.ID), Name: p.Account.Name}
+		}
 		views = append(views, domain.ProjectView{
 			ID:               sysidToUUID(p.ID),
 			Name:             p.Name,
@@ -163,6 +175,7 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 			SubscriptionType: subType,
 			EndDate:          endDate,
 			CreatedOn:        createdOn,
+			Account:          account,
 			ProjectClosureFields: domain.ProjectClosureFields{
 				ClosureState:                    p.ClosureState,
 				EndDateClosureState:             p.EndDateClosureState,

--- a/entity-service/internal/service/sn_project_service_test.go
+++ b/entity-service/internal/service/sn_project_service_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestSNProjectService_SearchProjects_MapsAccountRef verifies that the account
+// reference newly added to ServiceNow's project search response is mapped into
+// domain.ProjectView.Account, and that a project with no linked account (blank
+// id/name) maps to a nil Account rather than a zero-valued ref.
+func TestSNProjectService_SearchProjects_MapsAccountRef(t *testing.T) {
+	const accountSysid = "4a6fc0623b16c31091404c6aa5e45a09"
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"projects": []map[string]any{
+				{
+					"id": "11111111111111111111111111111111", "name": "With account", "key": "WA",
+					"type": map[string]any{"name": "Subscription"},
+					"endDate": "", "createdOn": "2026-01-01 00:00:00",
+					"account": map[string]any{"id": accountSysid, "name": "Automation Test Customer Account"},
+				},
+				{
+					"id": "22222222222222222222222222222222", "name": "No account", "key": "NA",
+					"type": map[string]any{"name": "Subscription"},
+					"endDate": "", "createdOn": "2026-01-01 00:00:00",
+					"account": map[string]any{"id": "", "name": ""},
+				},
+			},
+			"totalRecords": 2, "offset": 0, "limit": 10,
+		})
+	}))
+
+	svc := NewServiceNowProjectService(client, nil)
+	resp, err := svc.SearchProjects(contextWithUserIDToken("token"), domain.SearchProjectsRequest{
+		Pagination: domain.Pagination{Limit: 10},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Projects) != 2 {
+		t.Fatalf("expected 2 projects, got %d", len(resp.Projects))
+	}
+
+	withAccount := resp.Projects[0]
+	if withAccount.Account == nil {
+		t.Fatalf("expected non-nil Account for project with a linked account")
+	}
+	if withAccount.Account.ID != sysidToUUID(accountSysid) || withAccount.Account.Name != "Automation Test Customer Account" {
+		t.Fatalf("unexpected Account: %+v", withAccount.Account)
+	}
+
+	noAccount := resp.Projects[1]
+	if noAccount.Account != nil {
+		t.Fatalf("expected nil Account for project with no linked account, got %+v", noAccount.Account)
+	}
+}


### PR DESCRIPTION
## Purpose
Project search results (`POST /projects/search`) had no way to identify which account a project belongs to — only the single-project detail endpoint (`GET /projects/{id}`) returned the linked account. This blocked account-scoped project filtering/display from the search path (the account detail page's project list currently has to fall back to a workaround because it can't rely on an account id being present in search results). The backing ServiceNow project-summary response now includes a compact account reference (change tracked separately); this PR carries it through the entity-service search path instead of silently dropping it.

## Goals
`POST /projects/search` results (`domain.ProjectView`) include an `account` field (`{id, name}`) mirroring what the detail endpoint already exposes, nil when the project has no linked account.

## Approach
Added `snProjectSummaryAccount` (compact `id`/`name`) to the `snProject` wire struct in `sn_project_service.go`, and `domain.ProjectView.Account *domain.EntityRef` (reusing the existing generic `EntityRef` id/name shape used elsewhere in this codebase). Mapped in `SearchProjects`: a blank account id from ServiceNow (no linked account) maps to a nil `Account` rather than a zero-valued ref.

## User stories
As a CS engineer viewing an account's page, project rows show which account they belong to without a separate lookup, and the FE can filter search results by account id.

## Release note
`POST /projects/search` results now include the project's linked account (`{id, name}`), matching what `GET /projects/{id}` already returned.

## Documentation
N/A — internal API behavior change, no external doc surface for entity-service.

## Automation tests
- Unit tests: added `TestSNProjectService_SearchProjects_MapsAccountRef` covering both a project with a linked account and one without. `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Integration tests: N/A, covered by unit tests against a mocked SN client.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go service — ran `go vet ./...` clean instead)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Go 1.x (per go.mod), tested against a mocked ServiceNow client (unit tests only); the corresponding live ServiceNow change was verified against the DEV tenant separately.

## Learning
N/A