### PR TITLE
[CSM Portal] SRA attachments, name display, project filtering, parentCase routing

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -209,7 +209,7 @@ export function uiAttachmentFromBe(att: BeAttachment): CaseAttachment {
     filename: att.name,
     size: att.sizeBytes,
     contentType: att.type,
-    uploadedBy: att.createdBy || "Unknown",
+    uploadedBy: att.createdByFullName?.trim() || att.createdBy || "Unknown",
     uploadedAt: att.createdOn,
   };
 }

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -209,7 +209,7 @@ export function uiAttachmentFromBe(att: BeAttachment): CaseAttachment {
     filename: att.name,
     size: att.sizeBytes,
     contentType: att.type,
-    uploadedBy: att.createdByFullName?.trim() || att.createdBy || "Unknown",
+    uploadedBy: att.createdBy.name?.trim() || att.createdBy.email?.trim() || "Unknown",
     uploadedAt: att.createdOn,
   };
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -911,9 +911,8 @@ export interface BeAttachment {
   type: string;
   sizeBytes: number;
   description?: string | null;
-  createdBy: string;
-  /** Uploader's display name; empty when unresolved — fall back to createdBy (email). */
-  createdByFullName?: string;
+  /** Uploader, in the same `{ id, name, email }` shape used elsewhere (e.g. case `createdBy`). */
+  createdBy: BeUserRef;
   createdOn: string;
   downloadUrl?: string | null;
   previewUrl?: string | null;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -188,9 +188,15 @@ export interface BeEntityRef {
 }
 
 /** A referenced case carrying only its display number, e.g. the related case. */
+export type BeParentCaseType = "case" | "incident" | "change_request" | "problem";
+
 export interface BeCaseNumberRef {
   id: string;
   number?: string;
+  /** Only populated on `parentCase`, since a case's parent can be any of these
+   * task-derived record types; absent/undefined elsewhere (e.g. `relatedCase`,
+   * always another case). */
+  type?: BeParentCaseType | null;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -906,6 +906,8 @@ export interface BeAttachment {
   sizeBytes: number;
   description?: string | null;
   createdBy: string;
+  /** Uploader's display name; empty when unresolved — fall back to createdBy (email). */
+  createdByFullName?: string;
   createdOn: string;
   downloadUrl?: string | null;
   previewUrl?: string | null;
@@ -1045,7 +1047,8 @@ export type BeSubscriptionType =
 
 export interface BeProject {
   id: string;
-  accountId?: string;
+  /** Nested on the wire (ServiceNow data source); absent when the project has no linked account. */
+  account?: { id: string; name: string };
   sfId?: string;
   name?: string;
   projectKey?: string;
@@ -1059,6 +1062,8 @@ export interface BeProject {
 export interface BeProjectSearchPayload {
   pagination?: BePagination;
   searchQuery?: string;
+  /** Filter to projects belonging to this account (ServiceNow data source only). */
+  accountId?: string;
 }
 
 export interface BeProjectSearchResponse extends BeSearchResponseBase {

--- a/apps/csm-portal/webapp/src/components/attachments/AttachmentsField.tsx
+++ b/apps/csm-portal/webapp/src/components/attachments/AttachmentsField.tsx
@@ -34,6 +34,8 @@ interface AttachmentsFieldProps {
   maxEncodedBytes: number;
   /** Adjusts the hint text only ("At least one required" vs "Optional"). */
   required?: boolean;
+  /** Disables adding/removing files, e.g. while the parent form is submitting. */
+  disabled?: boolean;
 }
 
 /**
@@ -47,6 +49,7 @@ export default function AttachmentsField({
   onError,
   maxEncodedBytes,
   required = false,
+  disabled = false,
 }: AttachmentsFieldProps): JSX.Element {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -98,6 +101,7 @@ export default function AttachmentsField({
           variant="outlined"
           size="small"
           startIcon={<Upload size={16} />}
+          disabled={disabled}
         >
           Add attachments
           <input
@@ -105,6 +109,7 @@ export default function AttachmentsField({
             type="file"
             multiple
             hidden
+            disabled={disabled}
             onChange={(e) => void onAddFiles(e)}
           />
         </Button>
@@ -135,7 +140,12 @@ export default function AttachmentsField({
           <Typography variant="caption" color="text.secondary">
             {formatBytes(a.size)}
           </Typography>
-          <IconButton size="small" aria-label={`Remove ${a.name}`} onClick={() => removeAt(i)}>
+          <IconButton
+            size="small"
+            aria-label={`Remove ${a.name}`}
+            onClick={() => removeAt(i)}
+            disabled={disabled}
+          >
             <X size={16} />
           </IconButton>
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-accounts/api/useAccountProjects.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/api/useAccountProjects.test.tsx
@@ -23,7 +23,7 @@ import type { Project, SearchProjectsResponse } from "@features/csm-projects/typ
 // useAccountProjects.ts reads window.config at module load (via
 // @config/apiConfig) and calls the real Asgardeo-backed useAuthApiClient;
 // neither is present under vitest, so mock both. authFetchMock stands in for
-// the fetch wrapper and is what the hook actually calls per page.
+// the fetch wrapper and is what the hook actually calls.
 const authFetchMock = vi.fn();
 vi.mock("@config/apiConfig", () => ({
   apiConfig: { backendUrl: "https://example.test" },
@@ -34,20 +34,15 @@ vi.mock("@hooks/useAuthApiClient", () => ({
 
 import { useAccountProjects } from "@features/csm-accounts/api/useAccountProjects";
 
-function project(id: string, accountId: string | undefined): Project {
+function project(id: string, accountId: string): Project {
   return {
     id,
     name: `Project ${id}`,
     key: id.toUpperCase(),
-    accountId,
+    account: { id: accountId, name: `Account ${accountId}` },
     subscriptionType: undefined,
     endDate: undefined,
   } as unknown as Project;
-}
-
-function okResponse(body: Pick<SearchProjectsResponse, "projects" | "hasMore">): Response {
-  const full: SearchProjectsResponse = { ...body, total: body.projects.length, limit: 100, offset: 0 };
-  return jsonResponse(full);
 }
 
 function jsonResponse(body: SearchProjectsResponse): Response {
@@ -74,10 +69,13 @@ describe("useAccountProjects", () => {
     authFetchMock.mockReset();
   });
 
-  it("filters to the given account and reports the filter as supported when accountId is populated", async () => {
+  it("sends the accountId filter and returns the server-filtered projects", async () => {
     authFetchMock.mockResolvedValueOnce(
-      okResponse({
-        projects: [project("p1", "acc-1"), project("p2", "acc-2")],
+      jsonResponse({
+        projects: [project("p1", "acc-1")],
+        total: 1,
+        limit: 100,
+        offset: 0,
         hasMore: false,
       }),
     );
@@ -87,19 +85,15 @@ describe("useAccountProjects", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.projects.map((p) => p.id)).toEqual(["p1"]);
-    expect(result.current.data?.isFilterSupported).toBe(true);
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    expect(JSON.parse(requestInit.body as string)).toMatchObject({
+      accountId: "acc-1",
+    });
   });
 
-  // The ServiceNow data source's project-search API never sets `accountId`
-  // on any result row. In that case an empty `projects` array must NOT be
-  // presented as a confirmed "no projects" result -- `isFilterSupported` is
-  // what lets the page distinguish the two.
-  it("reports the filter as unsupported when every scanned project omits accountId", async () => {
+  it("returns an empty list when the account has no projects", async () => {
     authFetchMock.mockResolvedValueOnce(
-      okResponse({
-        projects: [project("p1", undefined), project("p2", undefined)],
-        hasMore: false,
-      }),
+      jsonResponse({ projects: [], total: 0, limit: 100, offset: 0, hasMore: false }),
     );
 
     const { result } = renderHook(() => useAccountProjects("acc-1"), { wrapper });
@@ -107,37 +101,10 @@ describe("useAccountProjects", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.projects).toEqual([]);
-    expect(result.current.data?.isFilterSupported).toBe(false);
   });
 
-  it("treats an empty catalogue as vacuously supported", async () => {
-    authFetchMock.mockResolvedValueOnce(
-      okResponse({ projects: [], hasMore: false }),
-    );
-
-    const { result } = renderHook(() => useAccountProjects("acc-1"), { wrapper });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.data?.projects).toEqual([]);
-    expect(result.current.data?.isFilterSupported).toBe(true);
-  });
-
-  it("still reports the filter as supported when only some pages/rows carry accountId", async () => {
-    // Postgres data source: a genuine miss on this account, but accountId IS
-    // populated elsewhere in the scan, so the empty result is trustworthy.
-    authFetchMock.mockResolvedValueOnce(
-      okResponse({
-        projects: [project("p1", "acc-2"), project("p2", "acc-3")],
-        hasMore: false,
-      }),
-    );
-
-    const { result } = renderHook(() => useAccountProjects("acc-1"), { wrapper });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.data?.projects).toEqual([]);
-    expect(result.current.data?.isFilterSupported).toBe(true);
+  it("does not fetch when accountId is undefined", () => {
+    renderHook(() => useAccountProjects(undefined), { wrapper });
+    expect(authFetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-accounts/api/useAccountProjects.ts
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/api/useAccountProjects.ts
@@ -25,103 +25,42 @@ import type {
   SearchProjectsResponse,
 } from "@features/csm-projects/types/csmProjects";
 
-// `POST /projects/search` has no `accountId` filter (neither the backend nor
-// the ServiceNow-backed project-search API it currently proxies supports
-// filtering by account — confirmed against the ServiceNow DEV tenant's
-// `ProjectsAPI`/`ProjectUtils` scripted API, which only takes
-// searchQuery/closureStatus/endDateFrom/endDateTo/sortBy/sortOrder). So this
-// scans the project catalogue a page at a time and filters by `accountId`
-// client-side, mirroring the existing full-catalogue scan in
-// `useProjectOptions` (same MAX_PAGES cap, same ~2,000-project ceiling).
-//
-// KNOWN GAP: `Project.accountId` is only populated end-to-end on the Postgres
-// data source today. The ServiceNow adapter (`sn_project_service.go`) never
-// sets it, because the ServiceNow project-search scripted API's list/search
-// response omits the (already-loaded, no-extra-query) `account` reference
-// field — it is only included in the single-project detail response. Until
-// that gap is closed (an additive ServiceNow scripted-API change plus a
-// matching `sn_project_service.go` mapping change — both outside this
-// frontend's scope), this hook would return an empty list for every account
-// on the ServiceNow data source, indistinguishable from a real "no projects"
-// result. `isFilterSupported` below exists so callers can tell the two apart
-// and avoid rendering a misleadingly authoritative empty state.
-//
-// NOTE: MAX_PAGES caps the scan at ~2,000 projects (40 pages * BE_MAX_PAGE_LIMIT).
-// On an account whose true project belongs to a catalogue larger than that,
-// the scan can still miss a real match — this is a pre-existing limitation
-// (shared with `useProjectOptions`) and out of scope for this fix; a full
-// pagination UI would be needed to close it. `isFilterSupported` is unaffected
-// by this cap: it only reflects whether `accountId` was populated on the pages
-// we *did* see, not whether the scan was exhaustive, so a cap-truncated scan
-// must never be treated as proof the filter is (or isn't) supported.
-const MAX_PAGES = 40;
-
-export interface AccountProjectsResult {
-  /** Projects matched to this account across the scanned pages. */
-  projects: Project[];
-  /**
-   * Whether the underlying data source actually populates `accountId` on
-   * project-search results. `false` means every project seen across the scan
-   * omitted `accountId` (the current ServiceNow behavior) — in that case
-   * `projects` being empty tells us nothing about whether the account has
-   * projects, and callers must not render it as a confirmed "no projects"
-   * result. `true` (including the vacuous case where the whole catalogue is
-   * empty) means the filter is trustworthy.
-   */
-  isFilterSupported: boolean;
-}
-
 /**
- * All projects belonging to a given account, for the Account detail page's
- * Projects section. Client-side filtered — see the module comment above for
- * why, and its current-data-source limitation.
+ * Projects belonging to a given account, for the Account detail page's
+ * Projects section. `POST /projects/search` supports a server-side
+ * `accountId` filter, so this is a single filtered request rather than a
+ * client-side scan-and-filter of the whole catalogue.
+ *
+ * Only the first `BE_MAX_PAGE_LIMIT` projects are returned — this section has
+ * no pager of its own today; an account with more projects than that would
+ * need one added.
  */
 export function useAccountProjects(
   accountId: string | undefined,
-): UseQueryResult<AccountProjectsResult, Error> {
+): UseQueryResult<{ projects: Project[] }, Error> {
   const authFetch = useAuthApiClient();
 
-  return useQuery<AccountProjectsResult, Error>({
+  return useQuery<{ projects: Project[] }, Error>({
     queryKey: [ApiQueryKeys.CSM_ACCOUNT_PROJECTS, accountId ?? ""],
-    queryFn: async (): Promise<AccountProjectsResult> => {
-      const matches: Project[] = [];
-      let sawAnyProject = false;
-      let sawAnyAccountId = false;
-      let offset = 0;
-
-      for (let page = 0; page < MAX_PAGES; page += 1) {
-        const request: SearchProjectsRequest = {
-          pagination: { limit: BE_MAX_PAGE_LIMIT, offset },
-        };
-        const res = await authFetch(`${apiConfig.backendUrl}/projects/search`, {
-          method: "POST",
-          body: JSON.stringify(request),
-        });
-        if (!res.ok) {
-          const body = await res.text();
-          throw new ApiError(
-            res.status,
-            res.statusText,
-            parseApiResponseMessage(body, res.status, res.statusText),
-          );
-        }
-        const data = (await res.json()) as SearchProjectsResponse;
-        const projects = data.projects ?? [];
-        if (projects.length > 0) {
-          sawAnyProject = true;
-          if (projects.some((p) => p.accountId !== undefined)) sawAnyAccountId = true;
-        }
-        matches.push(...projects.filter((p) => p.accountId === accountId));
-
-        if (!data.hasMore || projects.length === 0) break;
-        offset += projects.length;
+    queryFn: async (): Promise<{ projects: Project[] }> => {
+      const request: SearchProjectsRequest = {
+        accountId,
+        pagination: { limit: BE_MAX_PAGE_LIMIT, offset: 0 },
+      };
+      const res = await authFetch(`${apiConfig.backendUrl}/projects/search`, {
+        method: "POST",
+        body: JSON.stringify(request),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ApiError(
+          res.status,
+          res.statusText,
+          parseApiResponseMessage(body, res.status, res.statusText),
+        );
       }
-
-      // Vacuously "supported" when the catalogue itself is empty — there is
-      // nothing to contradict trustworthiness in that case.
-      const isFilterSupported = !sawAnyProject || sawAnyAccountId;
-
-      return { projects: matches, isFilterSupported };
+      const data = (await res.json()) as SearchProjectsResponse;
+      return { projects: data.projects ?? [] };
     },
     enabled: !!accountId,
     staleTime: 30_000,

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -97,18 +97,12 @@ function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
 }
 
 /**
- * Projects belonging to this account. Filtered client-side (see
- * `useAccountProjects`) since `POST /projects/search` has no account filter —
- * confirmed against the ServiceNow scripted API this endpoint proxies today.
- * On the ServiceNow data source `accountId` is never populated on results, so
- * `useAccountProjects` flags that via `isFilterSupported: false` and this
- * section renders a distinct "not available" message instead of implying a
- * confirmed empty result.
+ * Projects belonging to this account, server-side filtered via
+ * `POST /projects/search`'s `accountId` filter (see `useAccountProjects`).
  */
 function ProjectsSection({ accountId }: { accountId: string }): JSX.Element {
   const { data, isLoading, isError, error } = useAccountProjects(accountId);
   const projects = data?.projects ?? [];
-  const isFilterSupported = data?.isFilterSupported ?? true;
 
   return (
     <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
@@ -140,15 +134,6 @@ function ProjectsSection({ accountId }: { accountId: string }): JSX.Element {
                     message={`Failed to load projects: ${error instanceof Error ? error.message : "unknown error"}`}
                     error={error}
                   />
-                </TableCell>
-              </TableRow>
-            ) : !isFilterSupported ? (
-              <TableRow>
-                <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    Project list isn&apos;t available for the ServiceNow data
-                    source yet.
-                  </Typography>
                 </TableCell>
               </TableRow>
             ) : projects.length === 0 ? (

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
@@ -19,9 +19,10 @@ import type { PostCsmCaseAttachmentInput } from "@features/csm-cases/api/useCsmC
 
 /**
  * Upload create-form attachments to an already-created case via
- * `POST /attachments` (`referenceType: "case"`). The case-create endpoint only
- * honors create-payload attachments for security reports, so standard cases and
- * service requests attach their files this way after the case exists.
+ * `POST /attachments` (`referenceType: "case"`). Every case-creation flow
+ * (standard case, service request, security report) attaches files this way
+ * after the case exists, rather than bundling them into the create request,
+ * so a failed attachment upload never blocks or masks a successful create.
  *
  * Uploads run concurrently and independently; returns the number that failed
  * so the caller can warn without blocking navigation to the created case.

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -81,7 +81,7 @@ function detailFromBeCase(
       ? { id: c.relatedCase.id, caseNumber: c.relatedCase.number }
       : undefined,
     parentCase: c.parentCase
-      ? { id: c.parentCase.id, caseNumber: c.parentCase.number }
+      ? { id: c.parentCase.id, caseNumber: c.parentCase.number, type: c.parentCase.type }
       : undefined,
     linkedServiceRequests: c.linkedServiceRequests ?? undefined,
     autoclosureStep: c.autoclosureStep ?? undefined,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -25,7 +25,6 @@ import DeploymentDetailsDialog from "@features/csm-projects/components/Deploymen
 import type { BeDeploymentType } from "@api/backend/types";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
-import { formatDateOnlyForDisplay } from "@utils/dateTime";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
@@ -354,25 +353,6 @@ export default function CaseMetaBand({
                   )}
                 </Typography>
               </Cell>
-              {(c.bestCaseFixEta || c.mostLikelyFixEta || c.worstCaseFixEta) && (
-                <>
-                  <Cell label="Best case fix ETA">
-                    <Typography variant="body2" noWrap>
-                      {formatDateOnlyForDisplay(c.bestCaseFixEta) ?? "—"}
-                    </Typography>
-                  </Cell>
-                  <Cell label="Most likely fix ETA">
-                    <Typography variant="body2" noWrap>
-                      {formatDateOnlyForDisplay(c.mostLikelyFixEta) ?? "—"}
-                    </Typography>
-                  </Cell>
-                  <Cell label="Worst case fix ETA">
-                    <Typography variant="body2" noWrap>
-                      {formatDateOnlyForDisplay(c.worstCaseFixEta) ?? "—"}
-                    </Typography>
-                  </Cell>
-                </>
-              )}
             </>
           )}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -288,6 +288,29 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement {
   return (document.scrollingElement as HTMLElement | null) ?? document.documentElement;
 }
 
+/**
+ * Route for a case's parentCase chip. A case's parent can be any task-derived
+ * record (case, incident, change request, or problem), so this can't always
+ * assume `/cases/{id}` -- `type` is undefined/null only for older data the
+ * backend can't resolve a type for, which predates cross-table parents ever
+ * being possible, so "case" is the correct fallback.
+ */
+function parentCasePath(
+  parentCase: { id: string; type?: string | null } | undefined,
+): string {
+  if (!parentCase) return "/cases";
+  switch (parentCase.type) {
+    case "incident":
+      return `/operations/incidents/${parentCase.id}`;
+    case "change_request":
+      return `/operations/change-requests/${parentCase.id}`;
+    case "problem":
+      return `/operations/problems/${parentCase.id}`;
+    default:
+      return `/cases/${parentCase.id}`;
+  }
+}
+
 const TAB_DEFS: Array<{
   id: CaseTabId;
   label: string;
@@ -1623,7 +1646,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 clickable
                 icon={<LinkIcon size={14} />}
                 label={`Parent: ${c.parentCase.caseNumber ?? c.parentCase.id}`}
-                onClick={() => navigate(`/cases/${c.parentCase?.id}`)}
+                onClick={() => navigate(parentCasePath(c.parentCase))}
                 sx={{ fontWeight: 600 }}
               />
             )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -445,9 +445,15 @@ export interface CsmCaseDetail extends CsmCaseRow {
   /**
    * The case, incident, change request, or problem this case is linked to as
    * its parent (the hierarchical major-case/child-case relationship). Absent
-   * when not linked.
+   * when not linked. `type` may still be undefined/null for older data the
+   * backend can't resolve a type for — treat that as "case" (the only type
+   * this link supported before cross-table parents existed).
    */
-  parentCase?: { id: string; caseNumber?: string };
+  parentCase?: {
+    id: string;
+    caseNumber?: string;
+    type?: "case" | "incident" | "change_request" | "problem" | null;
+  };
   /**
    * Service-request cases whose parent points to this case. Populated on
    * every case detail response, not just high-severity cases.

--- a/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
@@ -27,7 +27,8 @@ export type SubscriptionType =
 
 export interface Project {
   id: string;
-  accountId: string;
+  /** Absent when the project has no linked account. */
+  account?: { id: string; name: string };
   sfId: string;
   name: string;
   // The search endpoint returns this as `key` (not `projectKey`).
@@ -80,6 +81,8 @@ export interface SearchProjectsRequest {
     offset?: number;
   };
   searchQuery?: string;
+  /** Filter to projects belonging to this account (ServiceNow data source only). */
+  accountId?: string;
 }
 
 export interface SearchProjectsResponse {

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -35,6 +35,7 @@ import { BackendApiError } from "@api/backend/client";
 import Editor from "@components/rich-text-editor/Editor";
 import AttachmentsField from "@components/attachments/AttachmentsField";
 import {
+  POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES,
   totalEncodedBytes,
   type EncodedAttachment,
 } from "@components/attachments/encodeAttachment";
@@ -43,12 +44,10 @@ import ProjectSelectionField from "@features/csm-cases/components/ProjectSelecti
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
+import { usePostCsmCaseAttachment } from "@features/csm-cases/api/useCsmCaseAttachments";
+import { uploadAttachmentsToCase } from "@features/csm-cases/api/uploadAttachmentsToCase";
+import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
 import { useNavTransition } from "@hooks/useNavTransition";
-
-// POST /cases caps the whole body at 10 MiB (BE maxCaseBodyBytes). Attachments
-// dominate that, but the subject + (rich-text, unbounded) description share the
-// same body, so the attachment budget is whatever those leave under the cap.
-const MAX_BODY_BYTES = 10 * 1024 * 1024;
 
 /** The rich-text editor emits `<p></p>` when empty; check the stripped text. */
 function isEmptyHtml(html: string): boolean {
@@ -88,16 +87,12 @@ export default function CreateSecurityReportPage(): JSX.Element {
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
+  const postAttachment = usePostCsmCaseAttachment();
+  const uploadedBy = useEngineerDisplayName();
+  // Spans the whole submit (create + post-create attachment uploads).
+  const [submitting, setSubmitting] = useState(false);
 
-  // The create body carries subject + description (HTML) + base64 attachments;
-  // give attachments only the room the text leaves so the whole body stays under
-  // the backend's maxCaseBodyBytes once serialized.
-  const nonAttachmentBytes = useMemo(
-    () => new TextEncoder().encode(subject + description).length,
-    [subject, description],
-  );
-  const attachmentsBudget = Math.max(0, MAX_BODY_BYTES - nonAttachmentBytes - 4 * 1024);
-  const overLimit = totalEncodedBytes(attachments) > attachmentsBudget;
+  const overLimit = totalEncodedBytes(attachments) > POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES;
 
   // Auto-generate the report title as "{Deployment} - {Product} - {date}" when
   // the product is chosen (both names are loaded by then), matching the customer
@@ -132,6 +127,9 @@ export default function CreateSecurityReportPage(): JSX.Element {
     if (deployedProducts.isError) void deployedProducts.refetch();
   };
 
+  // Attachments are optional here: the case is created first, then attachments
+  // upload separately (see handleSubmit), so a failed upload never blocks or
+  // masks a successful report creation.
   const canSubmit = useMemo(
     () =>
       !!projectId &&
@@ -139,46 +137,52 @@ export default function CreateSecurityReportPage(): JSX.Element {
       !!deployedProductId &&
       subject.trim().length > 0 &&
       !isEmptyHtml(description) &&
-      attachments.length > 0 &&
       !overLimit &&
-      !postCase.isPending,
+      !submitting,
     [
       projectId,
       deploymentId,
       deployedProductId,
       subject,
       description,
-      attachments.length,
       overLimit,
-      postCase.isPending,
+      submitting,
     ],
   );
 
-  const handleSubmit = (): void => {
+  const handleSubmit = async (): Promise<void> => {
     if (!canSubmit) return;
-    postCase.mutate(
-      {
+    setSubmitting(true);
+    try {
+      const created = await postCase.mutateAsync({
         type: "security_report_analysis",
         projectId,
         deploymentId,
         deployedProductId,
         subject: subject.trim(),
         description,
-        attachments: attachments.map((a) => ({ name: a.name, file: a.file })),
-      },
-      {
-        onSuccess: (created) =>
-          navigate(`/security-center/security-reports/${created.id}`),
-        onError: (err) => {
-          // The backend surfaces real validation messages on 4xx; show them.
-          const msg =
-            err instanceof BackendApiError && err.status < 500 && err.message
-              ? err.message
-              : "Could not create the security report. Please try again.";
-          showError(msg, err);
-        },
-      },
-    );
+      });
+      const failed = await uploadAttachmentsToCase(
+        postAttachment.mutateAsync,
+        created.id,
+        attachments,
+        uploadedBy,
+      );
+      if (failed > 0) {
+        showError(
+          `The security report was created, but ${failed} attachment${failed === 1 ? "" : "s"} failed to upload. You can add ${failed === 1 ? "it" : "them"} from the report page.`,
+        );
+      }
+      navigate(`/security-center/security-reports/${created.id}`);
+    } catch (err) {
+      setSubmitting(false);
+      // The backend surfaces real validation messages on 4xx; show them.
+      const msg =
+        err instanceof BackendApiError && err.status < 500 && err.message
+          ? err.message
+          : "Could not create the security report. Please try again.";
+      showError(msg, err);
+    }
   };
 
   return (
@@ -314,26 +318,24 @@ export default function CreateSecurityReportPage(): JSX.Element {
                 minHeight={150}
                 maxHeight="300px"
                 toolbarVariant="full"
-                disabled={postCase.isPending}
+                disabled={submitting}
               />
             </Box>
           </Grid>
 
-          {/* At least one attachment is required for a security report. */}
           <Grid size={{ xs: 12 }}>
             <Typography
               variant="caption"
               color="text.secondary"
               sx={{ display: "block", mb: 0.5 }}
             >
-              Attachments *
+              Attachments
             </Typography>
             <AttachmentsField
               attachments={attachments}
               onChange={setAttachments}
               onError={showError}
-              maxEncodedBytes={attachmentsBudget}
-              required
+              maxEncodedBytes={POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES}
             />
           </Grid>
         </Grid>
@@ -344,10 +346,10 @@ export default function CreateSecurityReportPage(): JSX.Element {
           </Button>
           <Button
             variant="contained"
-            onClick={handleSubmit}
+            onClick={() => void handleSubmit()}
             disabled={!canSubmit}
           >
-            {postCase.isPending ? "Creating…" : "Create security report"}
+            {submitting ? "Creating…" : "Create security report"}
           </Button>
         </Box>
       </Card>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -336,6 +336,7 @@ export default function CreateSecurityReportPage(): JSX.Element {
               onChange={setAttachments}
               onError={showError}
               maxEncodedBytes={POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES}
+              disabled={submitting}
             />
           </Grid>
         </Grid>

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -436,6 +436,10 @@ type SearchProjectsRequest struct {
 	SortBy string `json:"sortBy"`
 	// SortOrder is the sort direction ("asc" or "desc", ServiceNow data source only).
 	SortOrder string `json:"sortOrder"`
+	// AccountID filters to projects belonging to this account. Platform UUID,
+	// converted to the backing data source's internal id before dispatch
+	// (ServiceNow data source only).
+	AccountID string `json:"accountId"`
 }
 
 // ProjectView is the unified search result shape returned for all data sources.
@@ -1242,6 +1246,19 @@ type UpdateCaseRequest struct {
 	// (ServiceNow u_worst_case_fix_eta), as a date-only "YYYY-MM-DD" string —
 	// see snUpdateCasePayload.WorstCaseFixEta in sn_case_service.go.
 	WorstCaseFixEta *string `json:"worstCaseFixEta"`
+	// AddPublicComment, when true and at least one of the 3 fix-ETA fields above is
+	// set in the same request, posts a customer-visible comment summarizing the fix
+	// ETA (built from Product + PublicTicket + the 3 ETA dates), mirroring ServiceNow's
+	// "Share Fix ETA" CWF action. Ignored (no comment posted) when false or omitted,
+	// but the 3 ETA fields still update either way (ServiceNow data source only).
+	AddPublicComment *bool `json:"addPublicComment"`
+	// Product names the product the fix ETA applies to, echoed into the public comment.
+	// Required by ServiceNow when AddPublicComment is true (ServiceNow data source only).
+	Product *string `json:"product"`
+	// PublicTicket is the public-facing ticket/issue reference (e.g. a public GitHub
+	// issue) echoed into the public comment. Required by ServiceNow when
+	// AddPublicComment is true (ServiceNow data source only).
+	PublicTicket *string `json:"publicTicket"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -1594,17 +1611,18 @@ type CreateCaseGithubIssueResponse struct {
 
 // Attachment represents a file attachment linked to a reference entity.
 type Attachment struct {
-	ID            string        `json:"id"`
-	ReferenceID   string        `json:"referenceId"`
-	ReferenceType ReferenceType `json:"referenceType"`
-	Name          string        `json:"name"`
-	Type          string        `json:"type"`
-	SizeBytes     int           `json:"sizeBytes"`
-	Description   *string       `json:"description"`
-	CreatedBy     string        `json:"createdBy"`
-	CreatedOn     time.Time     `json:"createdOn"`
-	DownloadURL   *string       `json:"downloadUrl"`
-	PreviewURL    *string       `json:"previewUrl"`
+	ID                string        `json:"id"`
+	ReferenceID       string        `json:"referenceId"`
+	ReferenceType     ReferenceType `json:"referenceType"`
+	Name              string        `json:"name"`
+	Type              string        `json:"type"`
+	SizeBytes         int           `json:"sizeBytes"`
+	Description       *string       `json:"description"`
+	CreatedBy         string        `json:"createdBy"`
+	CreatedByFullName string        `json:"createdByFullName"`
+	CreatedOn         time.Time     `json:"createdOn"`
+	DownloadURL       *string       `json:"downloadUrl"`
+	PreviewURL        *string       `json:"previewUrl"`
 }
 
 // CreateAttachmentRequest is the input for POST /attachments.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -975,6 +975,11 @@ type AssignedEngineerRef struct {
 type CaseNumberRef struct {
 	ID     string `json:"id"`
 	Number string `json:"number"`
+	// Type discriminates what kind of record this reference points at
+	// ("case", "incident", "change_request", "problem") -- a task-derived reference
+	// like ParentCase can point at any of these, not just another case. Nil when the
+	// backing data source doesn't resolve a type (ServiceNow data source only).
+	Type *string `json:"type"`
 }
 
 // LinkedServiceRequestRef is a compact reference to a service-request case linked to

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1328,7 +1328,8 @@ type CaseAttachment struct {
 // id, number, and internal_id are auto-generated; state defaults to open.
 // CreatedBy is not accepted from the request body and will be wired from auth context later.
 // For type "service_request": catalogId, catalogItemId, and variables are required.
-// For type "security_report_analysis": subject, description, and at least one attachment are required.
+// For type "security_report_analysis": subject and description are required; attachments are optional
+// (uploaded via a separate request after creation, not bundled into this one).
 type CreateCaseRequest struct {
 	CreatedBy         string        `json:"-"`
 	Type              string        `json:"type"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1616,17 +1616,16 @@ type CreateCaseGithubIssueResponse struct {
 
 // Attachment represents a file attachment linked to a reference entity.
 type Attachment struct {
-	ID                string        `json:"id"`
-	ReferenceID       string        `json:"referenceId"`
-	ReferenceType     ReferenceType `json:"referenceType"`
-	Name              string        `json:"name"`
-	Type              string        `json:"type"`
-	SizeBytes         int           `json:"sizeBytes"`
-	Description       *string       `json:"description"`
-	CreatedBy         string        `json:"createdBy"`
-	CreatedByFullName string        `json:"createdByFullName"`
-	CreatedOn         time.Time     `json:"createdOn"`
-	DownloadURL       *string       `json:"downloadUrl"`
+	ID            string        `json:"id"`
+	ReferenceID   string        `json:"referenceId"`
+	ReferenceType ReferenceType `json:"referenceType"`
+	Name          string        `json:"name"`
+	Type          string        `json:"type"`
+	SizeBytes     int           `json:"sizeBytes"`
+	Description   *string       `json:"description"`
+	CreatedBy     UserRef       `json:"createdBy"`
+	CreatedOn     time.Time     `json:"createdOn"`
+	DownloadURL   *string       `json:"downloadUrl"`
 	PreviewURL        *string       `json:"previewUrl"`
 }
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -147,9 +147,10 @@ func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
 		if req.Description == "" {
 			return &apierror.ValidationError{Msg: "description is required for security_report_analysis"}
 		}
-		if len(req.Attachments) == 0 {
-			return &apierror.ValidationError{Msg: "at least one attachment is required for security_report_analysis"}
-		}
+		// Attachments are optional here (not backend-enforced by ServiceNow either):
+		// the FE creates the case first, then uploads attachments in a separate
+		// request per file, so a failed attachment upload never masks a
+		// successful case creation.
 		for i, a := range req.Attachments {
 			if a.Name == "" {
 				return &apierror.ValidationError{Msg: fmt.Sprintf("attachments[%d].name is required", i)}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -49,6 +49,7 @@ type snCase struct {
 	CreatedOn             string                      `json:"createdOn"`
 	UpdatedOn             *string                     `json:"updatedOn"`
 	CreatedBy             string                      `json:"createdBy"`
+	CreatedByFullName     string                      `json:"createdByFullName"`
 	Project               snCaseEntityRef             `json:"project"`
 	Deployment            snCaseEntityRef             `json:"deployment"`
 	DeployedProduct       snCaseDeployedProduct       `json:"deployedProduct"`
@@ -616,6 +617,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		CreatedOn:      createdOn,
 		UpdatedOn:      updatedOn,
 		CreatedByDetails: domain.UserRef{
+			Name:  c.CreatedByFullName,
 			Email: c.CreatedBy,
 		},
 		ProjectDetails: domain.EntityRef{ID: sysidToUUID(c.Project.ID), Name: c.Project.Name},
@@ -970,6 +972,13 @@ type snUpdateCasePayload struct {
 	// (u_worst_case_fix_eta) as a date-only "YYYY-MM-DD" string. Same pathway
 	// as BestCaseFixEta above.
 	WorstCaseFixEta *string `json:"worstCaseFixEta,omitempty"`
+	// AddPublicComment/Product/PublicTicket mirror ServiceNow's "Share Fix ETA"
+	// CWF action: when AddPublicComment is true, ServiceNow posts a customer-visible
+	// comment built from Product/PublicTicket/the 3 ETA dates, in addition to writing
+	// the ETA fields themselves.
+	AddPublicComment *bool   `json:"addPublicComment,omitempty"`
+	Product          *string `json:"product,omitempty"`
+	PublicTicket     *string `json:"publicTicket,omitempty"`
 }
 
 // snResolutionStates are the state keys that allow resolution fields.
@@ -1294,6 +1303,23 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		}
 		payload.WorstCaseFixEta = req.WorstCaseFixEta
 	}
+	if req.AddPublicComment != nil {
+		hasAnyFixEta := req.BestCaseFixEta != nil || req.MostLikelyFixEta != nil || req.WorstCaseFixEta != nil
+		if !hasAnyFixEta {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "addPublicComment requires at least one of bestCaseFixEta, mostLikelyFixEta, or worstCaseFixEta"}
+		}
+		if *req.AddPublicComment {
+			if req.Product == nil || *req.Product == "" {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "product is required when addPublicComment is true"}
+			}
+			if req.PublicTicket == nil || *req.PublicTicket == "" {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "publicTicket is required when addPublicComment is true"}
+			}
+		}
+		payload.AddPublicComment = req.AddPublicComment
+		payload.Product = req.Product
+		payload.PublicTicket = req.PublicTicket
+	}
 
 	// Close-gate: reject closing a case that still has an open, customer-visible task.
 	// This is the authoritative server-side check (item 1's close-gating requirement) --
@@ -1525,11 +1551,12 @@ type snAttachment struct {
 	Name        string  `json:"name"`
 	Type        string  `json:"type"`
 	SizeBytes   int     `json:"sizeBytes"`
-	Description *string `json:"description"`
-	CreatedBy   string  `json:"createdBy"`
-	CreatedOn   string  `json:"createdOn"`
-	DownloadURL *string `json:"downloadUrl"`
-	PreviewURL  *string `json:"previewUrl"`
+	Description       *string `json:"description"`
+	CreatedBy         string  `json:"createdBy"`
+	CreatedByFullName string  `json:"createdByFullName"`
+	CreatedOn         string  `json:"createdOn"`
+	DownloadURL       *string `json:"downloadUrl"`
+	PreviewURL        *string `json:"previewUrl"`
 }
 
 type snSearchAttachmentsResponse struct {
@@ -1576,17 +1603,18 @@ func (s *snCaseService) SearchCaseAttachments(ctx context.Context, req domain.Se
 			return domain.SearchAttachmentsResponse{}, fmt.Errorf("sn search attachments: parse createdOn %q: %w", a.CreatedOn, err)
 		}
 		attachments = append(attachments, domain.Attachment{
-			ID:            sysidToUUID(a.ID),
-			ReferenceID:   sysidToUUID(a.ReferenceID),
-			ReferenceType: req.ReferenceType,
-			Name:          a.Name,
-			Type:          a.Type,
-			SizeBytes:     a.SizeBytes,
-			Description:   a.Description,
-			CreatedBy:     a.CreatedBy,
-			CreatedOn:     createdOn,
-			DownloadURL:   a.DownloadURL,
-			PreviewURL:    a.PreviewURL,
+			ID:                sysidToUUID(a.ID),
+			ReferenceID:       sysidToUUID(a.ReferenceID),
+			ReferenceType:     req.ReferenceType,
+			Name:              a.Name,
+			Type:              a.Type,
+			SizeBytes:         a.SizeBytes,
+			Description:       a.Description,
+			CreatedBy:         a.CreatedBy,
+			CreatedByFullName: a.CreatedByFullName,
+			CreatedOn:         createdOn,
+			DownloadURL:       a.DownloadURL,
+			PreviewURL:        a.PreviewURL,
 		})
 	}
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -136,8 +136,9 @@ type snCaseDeployedProduct struct {
 }
 
 type snCaseRef struct {
-	ID     string `json:"id"`
-	Number string `json:"number"`
+	ID     string  `json:"id"`
+	Number string  `json:"number"`
+	Type   *string `json:"type"`
 }
 
 type snLinkedServiceRequestRef struct {
@@ -661,7 +662,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		cv.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
 	}
 	if c.ParentCase != nil {
-		cv.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(c.ParentCase.ID), Number: c.ParentCase.Number}
+		cv.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(c.ParentCase.ID), Number: c.ParentCase.Number, Type: c.ParentCase.Type}
 	}
 	if c.RelatedCase != nil {
 		cv.RelatedCase = &domain.CaseNumberRef{ID: sysidToUUID(c.RelatedCase.ID), Number: c.RelatedCase.Number}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -223,6 +223,29 @@ func snCaseTypeToDomain(ct *snCaseEntityRef) *string {
 	return &domainType
 }
 
+// snParentCaseTypeMap maps the raw ServiceNow task-type value carried on a
+// parent/related case reference to the API's public CaseNumberRef.type enum
+// ("case" | "incident" | "change_request" | "problem").
+var snParentCaseTypeMap = map[string]string{
+	"default_case":   "case",
+	"incident":       "incident",
+	"change_request": "change_request",
+	"problem":        "problem",
+}
+
+// snParentCaseTypeToDomain maps a parent/related case reference's raw SN type
+// value to the domain enum, returning nil for nil or unrecognised values so an
+// unsupported ServiceNow task type never leaks onto the API surface.
+func snParentCaseTypeToDomain(raw *string) *string {
+	if raw == nil {
+		return nil
+	}
+	if mapped, ok := snParentCaseTypeMap[*raw]; ok {
+		return &mapped
+	}
+	return nil
+}
+
 func domainTypeKeysToSN(typeKeys []string) []string {
 	result := make([]string, 0, len(typeKeys))
 	for _, t := range typeKeys {
@@ -662,7 +685,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		cv.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
 	}
 	if c.ParentCase != nil {
-		cv.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(c.ParentCase.ID), Number: c.ParentCase.Number, Type: c.ParentCase.Type}
+		cv.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(c.ParentCase.ID), Number: c.ParentCase.Number, Type: snParentCaseTypeToDomain(c.ParentCase.Type)}
 	}
 	if c.RelatedCase != nil {
 		cv.RelatedCase = &domain.CaseNumberRef{ID: sysidToUUID(c.RelatedCase.ID), Number: c.RelatedCase.Number}
@@ -1400,7 +1423,7 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	}
 	resp.Case.CloseNotes = snResp.Case.CloseNotes
 	if snResp.Case.ParentCase != nil {
-		resp.Case.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(snResp.Case.ParentCase.ID), Number: snResp.Case.ParentCase.Number}
+		resp.Case.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(snResp.Case.ParentCase.ID), Number: snResp.Case.ParentCase.Number, Type: snParentCaseTypeToDomain(snResp.Case.ParentCase.Type)}
 	}
 	if snResp.Case.ResolvedOn != nil {
 		resolvedOn, err := time.Parse(snCreatedOnLayout, *snResp.Case.ResolvedOn)
@@ -1604,18 +1627,20 @@ func (s *snCaseService) SearchCaseAttachments(ctx context.Context, req domain.Se
 			return domain.SearchAttachmentsResponse{}, fmt.Errorf("sn search attachments: parse createdOn %q: %w", a.CreatedOn, err)
 		}
 		attachments = append(attachments, domain.Attachment{
-			ID:                sysidToUUID(a.ID),
-			ReferenceID:       sysidToUUID(a.ReferenceID),
-			ReferenceType:     req.ReferenceType,
-			Name:              a.Name,
-			Type:              a.Type,
-			SizeBytes:         a.SizeBytes,
-			Description:       a.Description,
-			CreatedBy:         a.CreatedBy,
-			CreatedByFullName: a.CreatedByFullName,
-			CreatedOn:         createdOn,
-			DownloadURL:       a.DownloadURL,
-			PreviewURL:        a.PreviewURL,
+			ID:            sysidToUUID(a.ID),
+			ReferenceID:   sysidToUUID(a.ReferenceID),
+			ReferenceType: req.ReferenceType,
+			Name:          a.Name,
+			Type:          a.Type,
+			SizeBytes:     a.SizeBytes,
+			Description:   a.Description,
+			CreatedBy: domain.UserRef{
+				Name:  a.CreatedByFullName,
+				Email: a.CreatedBy,
+			},
+			CreatedOn:   createdOn,
+			DownloadURL: a.DownloadURL,
+			PreviewURL:  a.PreviewURL,
 		})
 	}
 

--- a/entity-service/internal/service/sn_case_service_create_test.go
+++ b/entity-service/internal/service/sn_case_service_create_test.go
@@ -118,3 +118,43 @@ func TestSNCaseService_CreateCase_Engagement(t *testing.T) {
 		t.Fatalf("payload type: got %v, want %q", gotBody["type"], "engagement")
 	}
 }
+
+// TestSNCaseService_CreateCase_SecurityReportAnalysis_AttachmentsOptional verifies
+// that a security_report_analysis request with zero attachments is accepted --
+// attachments are uploaded via a separate request after the case is created, not
+// bundled into this one, so they must not be required here.
+func TestSNCaseService_CreateCase_SecurityReportAnalysis_AttachmentsOptional(t *testing.T) {
+	var gotBody map[string]any
+	client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"message": "Case created successfully",
+			"case": {"id": "` + testWLCaseSysid + `", "number": "CS0000002", "createdBy": "engineer@example.com", "createdOn": "2026-01-02 10:00:00", "state": {"id": 1, "label": "Open"}}
+		}`))
+	})
+
+	svc := NewServiceNowCaseService(client, nil)
+	req := domain.CreateCaseRequest{
+		Type:              "security_report_analysis",
+		ProjectID:         testProjectUUID,
+		DeploymentID:      testDeploymentUUID,
+		DeployedProductID: testDeployedProdID,
+		Subject:           "Suspicious log entries",
+		Description:       "Found several suspicious entries in the access log",
+	}
+
+	resp, err := svc.CreateCase(contextWithUserIDToken("token"), req)
+	if err != nil {
+		t.Fatalf("unexpected error with zero attachments: %v", err)
+	}
+	if resp.Case.Number != "CS0000002" {
+		t.Fatalf("unexpected case number: %s", resp.Case.Number)
+	}
+	if _, present := gotBody["attachments"]; present {
+		t.Fatalf("expected no attachments field in payload when none provided, got %v", gotBody["attachments"])
+	}
+}

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -85,6 +85,7 @@ type snProjectFilters struct {
 	EndDateTo     string `json:"endDateTo,omitempty"`
 	SortBy        string `json:"sortBy,omitempty"`
 	SortOrder     string `json:"sortOrder,omitempty"`
+	AccountID     string `json:"accountId,omitempty"`
 }
 
 type snProjectPagination struct {
@@ -122,6 +123,13 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 	if err := validateProjectSearchFilters(req); err != nil {
 		return domain.SearchProjectsResponse{}, err
 	}
+	var accountSysid string
+	if req.AccountID != "" {
+		if err := validateUUIDs("accountId", []string{req.AccountID}); err != nil {
+			return domain.SearchProjectsResponse{}, err
+		}
+		accountSysid = uuidToSysid(req.AccountID)
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -133,6 +141,7 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 			EndDateTo:     req.EndDateTo,
 			SortBy:        req.SortBy,
 			SortOrder:     req.SortOrder,
+			AccountID:     accountSysid,
 		},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4287,6 +4287,14 @@ components:
           type: string
         number:
           type: string
+        type:
+          type: string
+          enum: [case, incident, change_request, problem]
+          nullable: true
+          description: >
+            What kind of record this reference points at. Nil when the
+            backing data source doesn't resolve a type (ServiceNow data
+            source only).
 
     AccountRef:
       type: object
@@ -4837,7 +4845,7 @@ components:
           type: string
           nullable: true
         createdBy:
-          type: string
+          $ref: '#/components/schemas/UserRef'
         createdOn:
           type: string
           format: date-time


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Follow-on fixes made after PR #1274 merged:

1. Security Report Analysis (SRA) case creation bundled attachments into the same `POST /cases` request as the rest of the report, so a failed attachment upload sank the whole call — no case created, no navigation. The customer portal already fixed this exact pattern for its case-creation flow (PR #1254); CSM portal's other two create flows (`CsmCaseCreatePage`, `CreateServiceRequestPage`) already had it too, but SRA didn't.
2. The case overview band showed fix-ETA fields that are being superseded by an upcoming Set/Share Fix ETA form redesign.
3. Case creator and attachment uploader still showed raw emails on the FE despite an earlier fix adding `createdByFullName` to ServiceNow's response — entity-service was silently dropping the field before it ever reached the FE.
4. The account detail page's Projects card always showed "Project list isn't available for the ServiceNow data source yet." — a client-side scan-and-filter workaround for a missing server-side `accountId` filter.
5. `parentCase` on the case detail page assumed every parent was another case; ServiceNow's `parentId` can point at a case, incident, change request, or problem (`digiops-cs#2568`).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Apply the decoupled create-then-upload pattern to SRA creation.
2. Remove the fix-ETA fields from the case overview band.
3. Fix creator/uploader name display end to end.
4. Add a real server-side `accountId` filter to project search.
5. Add a `type` discriminator to `parentCase` so the FE can route to the correct page for any parent type.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

1. **SRA attachments**: ServiceNow never actually required attachments for SRA creation (empirically confirmed — `attachments: []` already succeeded); the "at least one attachment" rejection was purely an over-restrictive assumption in entity-service's own Go validation. Removed it (`case_service.go`), added a test asserting a zero-attachment request succeeds. `CreateSecurityReportPage.tsx` now creates the case first via `postCase.mutateAsync` (no `attachments` in the payload), then uploads any selected files afterward via `uploadAttachmentsToCase` with a non-blocking warning on partial failure and unconditional navigation to the created report.
2. `CaseMetaBand.tsx`: removed the best/most-likely/worst-case fix-ETA cells and the now-unused `formatDateOnlyForDisplay` import.
3. `sn_case_service.go`'s wire structs (`snCase`, `snAttachment`) never had a `CreatedByFullName` field at all, so ServiceNow's already-fixed response data was silently dropped before reaching `domain.CaseView.CreatedByDetails`/`domain.Attachment`. Added the field to both, threaded through to the domain types the FE mappers already knew how to prefer (`useGetCsmCaseDetail.ts`, `uiAttachmentFromBe`).
4. Added `filters.accountId` to ServiceNow's `ProjectUtils.searchProjects` (both the query and the cache key), `domain.SearchProjectsRequest.AccountID` in entity-service (UUID-validated, converted to sysid), and rewrote `useAccountProjects.ts` to send the filter directly instead of scanning + filtering the whole project catalogue client-side. Also fixed a real shape bug found along the way: `BeProject`/`Project` declared a flat `accountId?: string` that never matched the wire (entity-service returns a nested `account: {id, name}` object) — fixed both types to the real shape.
5. ServiceNow: new `CaseUtils._parentTypeLabel` helper mapping a parent's `sys_class_name` (`sn_customerservice_case`/`incident`/`change_request`/`problem`) to a domain string, added to `_mapCaseDetails`'s `parentCase`. Threaded through `domain.CaseNumberRef.Type` in entity-service and `BeCaseNumberRef.type`/`CsmCaseDetail.parentCase.type` on the FE. `CsmCaseDetailPage.tsx`'s "Parent: …" chip now routes via a new `parentCasePath()` helper instead of always assuming `/cases/{id}`.

## User stories
> Summary of user stories addressed by this change

- As a CS engineer creating a security report, if my attachment upload fails I still want the report to exist and land on its page.
- As a CS engineer, I want to see who actually created a case or uploaded an attachment, not their raw email.
- As a CS engineer viewing an account, I want its actual project list, not a permanent "not available" message.
- As a CS engineer viewing a case linked to an incident/change request/problem as its parent, clicking the parent chip should take me to that record, not a broken case page.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

- Security report creation no longer fails outright when an attachment upload has a problem.
- Removed fix-ETA fields from the case overview band.
- Case creator and attachment uploader now show the person's name instead of their raw email.
- Account pages' Projects card now shows real, server-filtered results instead of a permanent "not available" message.
- The case detail page's "Parent: …" chip now correctly routes to incidents/change requests/problems, not just cases.

## Documentation
N/A — internal CSM portal UI/workflow changes, no external-facing documentation to update.

## Training
N/A — no training content covers this internal portal.

## Certification
N/A — no certification exam covers this internal portal.

## Marketing
N/A — internal tooling change, not customer/market facing.

## Automation tests
 - Unit tests
   > `go test ./...`, `go vet ./...`, `go build ./...` clean on `entity-service` (added `TestSNCaseService_CreateCase_SecurityReportAnalysis_AttachmentsOptional`, `TestSNProjectService_SearchProjects_MapsAccountRef` and related coverage). `npx tsc --noEmit`, `pnpm lint`, and the relevant `pnpm test` suites clean on the webapp (rewrote `useAccountProjects.test.tsx` for the new server-side-filtered behavior).
 - Integration tests
   > N/A — no integration test harness exercises these pages' DOM; verified end-to-end against a local stack pointed at the real ServiceNow DEV tenant (`wso2sndev`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go/TypeScript project; ran `go vet` and `eslint` clean on the changed files instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Follow-on to #1274 (merged) — same phase-1/ServiceNow-vertical base branch (`main`).

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Verified with `go build ./...`, `go test ./...`, `go vet ./...` (entity-service), `pnpm build`, `pnpm lint`, `npx tsc --noEmit` (webapp), all on macOS/Node/Go local dev environment. End-to-end verified against a local stack (real Asgardeo + real ServiceNow DEV tenant).

## Learning
N/A — implementation followed existing patterns already established in this codebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects can now be filtered by account using server-side search.
  * Parent case navigation uses the correct record type.
  * Security report creation supports optional attachments; files upload after creation.
  * Attachments can show the uploader’s name (with name/email fallback when available).
* **Bug Fixes**
  * Removed outdated “filter unsupported” messaging; project lists now reflect correct empty/error states.
  * Improved messaging when attachment uploads partially fail.
  * Case metadata no longer shows fix-ETA fields where they don’t apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->