### PR TITLE
fix(customer-portal): global search dropdown parity and loading-state polish

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/PartnerGlobalSearch.tsx
@@ -461,7 +461,7 @@ export default function PartnerGlobalSearch(): JSX.Element {
                           gap: 1.5,
                           px: 2,
                           py: 1.25,
-                          "&:hover": { bgcolor: "action.hover" },
+                          ...(casePath ? { "&:hover": { bgcolor: "action.hover" } } : {}),
                         }}
                       >
                         <Box

--- a/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
@@ -20,6 +20,7 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Divider,
   IconButton,
   InputAdornment,
   Menu,
@@ -63,6 +64,7 @@ type ExportFormat = "csv" | "pdf";
 
 const SUMMARY_PAGE_SIZE = 5;
 const SKELETON_ROW_COUNT = 5;
+const DROPDOWN_RESULT_LIMIT = 5;
 
 function SkeletonRows({ cols }: { cols: number }): JSX.Element {
   return (
@@ -80,6 +82,22 @@ function SkeletonRows({ cols }: { cols: number }): JSX.Element {
   );
 }
 
+/** Bolds the matched substring — mirrors PartnerGlobalSearch's dropdown. */
+function highlightMatch(text: string, query: string): JSX.Element {
+  if (!query.trim()) return <>{text}</>;
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase().trim();
+  const idx = lowerText.indexOf(lowerQuery);
+  if (idx === -1) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <strong>{text.slice(idx, idx + lowerQuery.length)}</strong>
+      {text.slice(idx + lowerQuery.length)}
+    </>
+  );
+}
+
 /**
  * Home overview for users with more than one project.
  * Same layout as the partner global search page — Projects and Cases table
@@ -92,6 +110,8 @@ export default function UserGlobalSearch(): JSX.Element {
   const { showError } = useErrorBanner();
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearchQuery = useDebouncedValue(searchQuery, PROJECT_HUB_SEARCH_DEBOUNCE_MS);
+
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
   const isExportingRef = useRef(false);
@@ -195,6 +215,25 @@ export default function UserGlobalSearch(): JSX.Element {
   const projectsMoreCount = Math.max(0, projectsTotal - projects.length);
   const casesMoreCount = Math.max(0, casesTotal - cases.length);
 
+  // Dropdown query — filtered by the live search query, same pattern as
+  // PartnerGlobalSearch's dropdown (only enabled once there's a query).
+  const { data: dropdownData, isLoading: isLoadingDropdown } = useGetGlobalSearch(
+    {
+      filters: debouncedSearchQuery ? { searchQuery: debouncedSearchQuery } : undefined,
+      projectsPagination: { offset: 0, limit: DROPDOWN_RESULT_LIMIT },
+      casesPagination: { offset: 0, limit: DROPDOWN_RESULT_LIMIT },
+    },
+    { enabled: Boolean(debouncedSearchQuery) },
+  );
+
+  const isDebouncing = searchQuery.trim() !== debouncedSearchQuery.trim();
+  const dropdownProjects: GlobalSearchProject[] = isDebouncing || isLoadingDropdown
+    ? []
+    : (dropdownData?.projects ?? []).slice(0, DROPDOWN_RESULT_LIMIT);
+  const dropdownCases: GlobalSearchCase[] = isDebouncing || isLoadingDropdown
+    ? []
+    : (dropdownData?.cases ?? []).slice(0, DROPDOWN_RESULT_LIMIT);
+
   return (
     <Box
       sx={{
@@ -219,7 +258,7 @@ export default function UserGlobalSearch(): JSX.Element {
           textAlign: "center",
         }}
       >
-        <Box sx={{ maxWidth: 560, width: "100%" }}>
+        <Box sx={{ maxWidth: 560, position: "relative", width: "100%" }}>
           <TextField
             fullWidth
             inputProps={{ autoComplete: "off" }}
@@ -229,7 +268,10 @@ export default function UserGlobalSearch(): JSX.Element {
                   <IconButton
                     aria-label="Clear search"
                     edge="end"
-                    onClick={() => setSearchQuery("")}
+                    onClick={() => {
+                      setSearchQuery("");
+                      setDropdownOpen(false);
+                    }}
                     size="small"
                   >
                     <X size={16} />
@@ -238,7 +280,17 @@ export default function UserGlobalSearch(): JSX.Element {
               ) : undefined,
               startAdornment: <Search size={20} style={{ marginRight: 8 }} />,
             }}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onBlur={() => setDropdownOpen(false)}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setDropdownOpen(Boolean(e.target.value.trim()));
+            }}
+            onFocus={() => {
+              if (searchQuery.trim()) setDropdownOpen(true);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setDropdownOpen(false);
+            }}
             placeholder="Search projects and cases..."
             size="small"
             sx={{
@@ -251,7 +303,7 @@ export default function UserGlobalSearch(): JSX.Element {
             }}
             value={searchQuery}
           />
-          {debouncedSearchQuery.trim() && !isLoadingProjects && !isLoadingCases && (
+          {!dropdownOpen && debouncedSearchQuery.trim() && !isLoadingProjects && !isLoadingCases && (
             <Typography
               color="text.secondary"
               sx={{ display: "block", mt: 1, textAlign: "left" }}
@@ -259,6 +311,209 @@ export default function UserGlobalSearch(): JSX.Element {
             >
               Showing results for &ldquo;{debouncedSearchQuery.trim()}&rdquo;
             </Typography>
+          )}
+          {dropdownOpen && (
+            <Paper
+              elevation={4}
+              onMouseDown={(e) => e.preventDefault()}
+              sx={{
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+                left: 0,
+                maxHeight: 400,
+                mt: 0.5,
+                overflowY: "auto",
+                position: "absolute",
+                right: 0,
+                textAlign: "left",
+                top: "100%",
+                zIndex: 1300,
+              }}
+            >
+              {/* Projects section */}
+              {(isDebouncing || isLoadingDropdown || dropdownProjects.length > 0) && (
+                <>
+                  {isDebouncing || isLoadingDropdown ? (
+                    [1, 2, 3].map((i) => (
+                      <Box
+                        key={i}
+                        sx={{
+                          alignItems: "center",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1,
+                        }}
+                      >
+                        <Skeleton height={36} variant="circular" width={36} />
+                        <Box sx={{ flex: 1 }}>
+                          <Skeleton variant="text" width="70%" />
+                          <Skeleton variant="text" width="30%" />
+                        </Box>
+                      </Box>
+                    ))
+                  ) : (
+                    dropdownProjects.map((project) => (
+                      <Box
+                        key={project.id}
+                        onClick={() => {
+                          setDropdownOpen(false);
+                          navigate(`/projects/${project.id}/dashboard`);
+                        }}
+                        sx={{
+                          alignItems: "center",
+                          cursor: "pointer",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1.25,
+                          "&:hover": { bgcolor: "action.hover" },
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            alignItems: "center",
+                            bgcolor: "primary.main",
+                            borderRadius: "50%",
+                            color: "primary.contrastText",
+                            display: "flex",
+                            flexShrink: 0,
+                            height: 36,
+                            justifyContent: "center",
+                            width: 36,
+                          }}
+                        >
+                          <FolderOpen size={16} />
+                        </Box>
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography noWrap variant="body2">
+                            {highlightMatch(
+                              project.key
+                                ? `${project.key} · ${project.name}`
+                                : project.name,
+                              debouncedSearchQuery,
+                            )}
+                          </Typography>
+                          <Typography color="text.secondary" variant="caption">
+                            Project
+                          </Typography>
+                        </Box>
+                      </Box>
+                    ))
+                  )}
+                </>
+              )}
+
+              {/* Divider between sections — only when both have results */}
+              {!isDebouncing &&
+                !isLoadingDropdown &&
+                dropdownProjects.length > 0 &&
+                dropdownCases.length > 0 && <Divider />}
+
+              {/* Cases section */}
+              {(isDebouncing || isLoadingDropdown || dropdownCases.length > 0) && (
+                <>
+                  {isDebouncing || isLoadingDropdown ? (
+                    [1, 2, 3].map((i) => (
+                      <Box
+                        key={i}
+                        sx={{
+                          alignItems: "center",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1,
+                        }}
+                      >
+                        <Skeleton height={36} variant="circular" width={36} />
+                        <Box sx={{ flex: 1 }}>
+                          <Skeleton variant="text" width="70%" />
+                          <Skeleton variant="text" width="30%" />
+                        </Box>
+                      </Box>
+                    ))
+                  ) : (
+                    dropdownCases.map((c) => {
+                      const casePath = getCaseNavigationPath(c);
+                      const { color: caseTypeColor, displayLabel: caseTypeLabel } = getCaseTypeChipProps(c.caseType?.label);
+                      return (
+                      <Box
+                        key={c.id}
+                        onClick={casePath ? () => {
+                          setDropdownOpen(false);
+                          navigate(casePath, { state: { returnTo: "/" } });
+                        } : undefined}
+                        sx={{
+                          alignItems: "center",
+                          cursor: casePath ? "pointer" : "default",
+                          display: "flex",
+                          gap: 1.5,
+                          px: 2,
+                          py: 1.25,
+                          "&:hover": { bgcolor: "action.hover" },
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            alignItems: "center",
+                            bgcolor: alpha(caseTypeColor, 0.15),
+                            borderRadius: "50%",
+                            color: caseTypeColor,
+                            display: "flex",
+                            flexShrink: 0,
+                            height: 36,
+                            justifyContent: "center",
+                            width: 36,
+                          }}
+                        >
+                          <FileText size={16} />
+                        </Box>
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography noWrap variant="body2">
+                            {highlightMatch(c.title ?? "--", debouncedSearchQuery)}
+                          </Typography>
+                          <Box sx={{ alignItems: "center", display: "flex", gap: 0.75, mt: 0.25 }}>
+                            <Typography color="text.secondary" noWrap variant="caption">
+                              {formatCasesTableCaseIdentifier(c.number, c.internalId)}
+                            </Typography>
+                            <Chip
+                              label={caseTypeLabel}
+                              size="small"
+                              variant="outlined"
+                              sx={(theme) => ({
+                                bgcolor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.05 : 0.1),
+                                borderColor: alpha(caseTypeColor, theme.palette.mode === "dark" ? 0.18 : 0.3),
+                                color: caseTypeColor,
+                                flexShrink: 0,
+                                fontSize: "0.65rem",
+                                fontWeight: 500,
+                                height: 16,
+                                px: 0,
+                                "& .MuiChip-label": { pl: "5px", pr: "5px" },
+                              })}
+                            />
+                          </Box>
+                        </Box>
+                      </Box>
+                      );
+                    })
+                  )}
+                </>
+              )}
+
+              {/* No results */}
+              {!isDebouncing &&
+                !isLoadingDropdown &&
+                dropdownProjects.length === 0 &&
+                dropdownCases.length === 0 && (
+                  <Box sx={{ px: 2, py: 2, textAlign: "center" }}>
+                    <Typography color="text.secondary" variant="body2">
+                      No results found.
+                    </Typography>
+                  </Box>
+                )}
+            </Paper>
           )}
         </Box>
       </Box>

--- a/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/components/UserGlobalSearch.tsx
@@ -451,7 +451,7 @@ export default function UserGlobalSearch(): JSX.Element {
                           gap: 1.5,
                           px: 2,
                           py: 1.25,
-                          "&:hover": { bgcolor: "action.hover" },
+                          ...(casePath ? { "&:hover": { bgcolor: "action.hover" } } : {}),
                         }}
                       >
                         <Box

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerCasesPage.tsx
@@ -22,7 +22,6 @@ import {
   CircularProgress,
   IconButton,
   InputAdornment,
-  LinearProgress,
   Menu,
   MenuItem,
   Paper,
@@ -57,7 +56,6 @@ import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const DEFAULT_ROWS_PER_PAGE = 10;
-const SKELETON_ROW_COUNT = 5;
 const COL_SPAN = 6;
 
 
@@ -275,14 +273,6 @@ export default function PartnerCasesPage(): JSX.Element {
         />
       </Box>
 
-      {/* Loading indicator */}
-      {isLoading && (
-        <LinearProgress
-          color="inherit"
-          sx={{ flexShrink: 0, height: 2, mx: 2 }}
-        />
-      )}
-
       {/* Scrollable table */}
       <Box
         sx={{
@@ -307,7 +297,7 @@ export default function PartnerCasesPage(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={`sk-${i}`}>
                     {Array.from({ length: COL_SPAN }).map((_, j) => (
                       <TableCell key={j}>

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/PartnerProjectsPage.tsx
@@ -19,7 +19,6 @@ import {
   Chip,
   IconButton,
   InputAdornment,
-  LinearProgress,
   Paper,
   Skeleton,
   Table,
@@ -41,7 +40,6 @@ import { PROJECT_HUB_SEARCH_DEBOUNCE_MS } from "@features/project-hub/constants/
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const DEFAULT_ROWS_PER_PAGE = 10;
-const SKELETON_ROW_COUNT = 5;
 const COL_SPAN = 5;
 
 const DATE_LOCALE = "en-US";
@@ -200,14 +198,6 @@ export default function PartnerProjectsPage(): JSX.Element {
         />
       </Box>
 
-      {/* Loading indicator */}
-      {isLoading && (
-        <LinearProgress
-          color="inherit"
-          sx={{ flexShrink: 0, height: 2, mx: 2 }}
-        />
-      )}
-
       {/* Scrollable table */}
       <Box
         sx={{
@@ -231,7 +221,7 @@ export default function PartnerProjectsPage(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={`sk-${i}`}>
                     {Array.from({ length: COL_SPAN }).map((_, j) => (
                       <TableCell key={j}>

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/ProjectHub.tsx
@@ -407,7 +407,7 @@ export default function ProjectHub(): JSX.Element {
               sx={{ width: "60%", maxWidth: 400, height: 2 }}
             />
             <Typography variant="body2" color="text.secondary">
-              Loading projects...
+              Loading...
             </Typography>
           </Box>
         );

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserCasesPage.tsx
@@ -22,7 +22,6 @@ import {
   CircularProgress,
   IconButton,
   InputAdornment,
-  LinearProgress,
   Menu,
   MenuItem,
   Paper,
@@ -57,7 +56,6 @@ import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const DEFAULT_ROWS_PER_PAGE = 10;
-const SKELETON_ROW_COUNT = 5;
 const COL_SPAN = 7;
 
 const DATE_LOCALE = "en-US";
@@ -287,14 +285,6 @@ export default function UserCasesPage(): JSX.Element {
         />
       </Box>
 
-      {/* Loading indicator */}
-      {isLoading && (
-        <LinearProgress
-          color="inherit"
-          sx={{ flexShrink: 0, height: 2, mx: 2 }}
-        />
-      )}
-
       {/* Scrollable table */}
       <Box
         sx={{
@@ -320,7 +310,7 @@ export default function UserCasesPage(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={`sk-${i}`}>
                     {Array.from({ length: COL_SPAN }).map((_, j) => (
                       <TableCell key={j}>

--- a/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/project-hub/pages/UserProjectsPage.tsx
@@ -21,7 +21,6 @@ import {
   CircularProgress,
   IconButton,
   InputAdornment,
-  LinearProgress,
   Menu,
   MenuItem,
   Paper,
@@ -52,7 +51,6 @@ import {
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const DEFAULT_ROWS_PER_PAGE = 10;
-const SKELETON_ROW_COUNT = 5;
 const COL_SPAN = 6;
 
 type ExportFormat = "csv" | "pdf";
@@ -271,14 +269,6 @@ export default function UserProjectsPage(): JSX.Element {
         />
       </Box>
 
-      {/* Loading indicator */}
-      {isLoading && (
-        <LinearProgress
-          color="inherit"
-          sx={{ flexShrink: 0, height: 2, mx: 2 }}
-        />
-      )}
-
       {/* Scrollable table */}
       <Box
         sx={{
@@ -303,7 +293,7 @@ export default function UserProjectsPage(): JSX.Element {
             </TableHead>
             <TableBody>
               {isLoading ? (
-                Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={`sk-${i}`}>
                     {Array.from({ length: COL_SPAN }).map((_, j) => (
                       <TableCell key={j}>

--- a/apps/customer-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/customer-portal/webapp/src/layouts/AppLayout.tsx
@@ -169,6 +169,12 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
   // Path Logic Constants
   const isProjectHub = location.pathname === "/" || location.pathname === "";
   const isPartnerPage = location.pathname.startsWith("/partner/");
+  // Home overview drill-down pages for non-partner users with multiple
+  // projects (see UserGlobalSearch's "View More" links) — same "no sidebar"
+  // treatment as the equivalent partner drill-down pages (/partner/projects,
+  // /partner/cases) above, which isPartnerPage already covers.
+  const isNonPartnerDrilldownPage =
+    location.pathname === "/projects" || location.pathname === "/cases";
 
   const isCaseDetailsPage =
     /\/(?:projects\/[^/]+|[^/]+)\/support\/cases\/[^/]+$/.test(
@@ -238,7 +244,11 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
             />
           }
           sidebar={
-            !isProjectHub && !isPartnerPage && !hasPortalAccessError && !isErrorPageDisplayed ? (
+            !isProjectHub &&
+            !isPartnerPage &&
+            !isNonPartnerDrilldownPage &&
+            !hasPortalAccessError &&
+            !isErrorPageDisplayed ? (
               <SideBar
                 collapsed={
                   isSidebarOverlay ? false : shellState.sidebarCollapsed


### PR DESCRIPTION
## Summary
Customers with more than one project are routed to a table-based global search overview (`UserGlobalSearch`), same as partner users, but it had drifted from `PartnerGlobalSearch` in a few ways:

- **No results dropdown while typing** — results only ever appeared in the static tables below, unlike the partner view's live dropdown. Ported the dropdown (query, skeleton rows, highlight-match) over from `PartnerGlobalSearch`.
- **Sidebar reappeared on customer drill-down pages** (`/projects`, `/cases`, reached via "View More") even though the equivalent partner pages (`/partner/projects`, `/partner/cases`) already suppress it in `AppLayout.tsx`.
- **Skeleton row count was hardcoded to 5** on all four drill-down pages (Cases/Projects × Partner/Customer), ignoring the selected rows-per-page (10/25/50).
- **Duplicate loading indicators** — a top `LinearProgress` bar and full skeleton rows both rendered simultaneously on those same four pages; dropped the redundant bar.
- **`ProjectHub`'s transient loading message** said "Loading projects..." while it's actually still deciding where to route (single project / partner search / multi-project search) — simplified to "Loading..." since the destination often includes cases too.

## Test plan
- [x] `tsc -b` passes
- [x] `eslint` clean on changed files (2 pre-existing, unrelated errors remain in `AppLayout.tsx`, confirmed present on `main` before this change)
- [x] `vite build` succeeds
- [x] Manually verify: typing in the customer-view global search shows a live results dropdown matching partner view
- [x] Manually verify: navigating to `/projects` or `/cases` via "View More" no longer shows the sidebar
- [x] Manually verify: changing rows-per-page on any of the four drill-down pages shows a matching number of skeleton rows while loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline global search dropdown for projects and cases, including highlighted matches, loading states, navigation, and empty results messaging.
  * Updated project and case drill-down pages with a simplified layout without the sidebar.

* **UI Improvements**
  * Replaced loading bars with table skeletons that match the selected page size.
  * Simplified project loading text to “Loading…”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->