### PR TITLE
fix(customer-portal): reset last-selected project on sign-out

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/utils/settingsStorage.ts
+++ b/apps/customer-portal/webapp/src/features/settings/utils/settingsStorage.ts
@@ -144,6 +144,20 @@ export function clearLastSelectedProject(): void {
   }
 }
 
+// Clear it again on sign-out. Registered once at module load, not tied to
+// any component, so it fires reliably regardless of where in the tree
+// sign-out is triggered (mirrors csm-portal's useRecentViews.ts). Without
+// this, the id survives both an explicit "Log out" and an idle-timeout auto
+// sign-out, so the next sign-in — even a different user on the same browser
+// — gets redirected straight back into the stale project instead of landing
+// on the Project Hub. "app:signing-out" is dispatched ONLY by the manual
+// "Log out" action (UserProfile.tsx) and the idle-timeout auto sign-out
+// (IdleTimeoutProvider.tsx) — never by a silent re-auth/token-refresh — so
+// this never clears data out from under a user who is still signed in.
+if (typeof window !== "undefined") {
+  window.addEventListener("app:signing-out", clearLastSelectedProject);
+}
+
 /**
  * Reads whether Novera chat is enabled from localStorage.
  *


### PR DESCRIPTION
## Summary
- The app remembers the last project a user opened and auto-navigates there on the next visit. That memory wasn't being cleared on sign-out (neither the manual "Log out" action nor the idle-timeout auto sign-out), so the next sign-in could land straight back in a stale project instead of the Project Hub.
- Now clears it on the existing `"app:signing-out"` event, which both sign-out paths already dispatch — mirrors the same pattern already used in csm-portal's `useRecentViews.ts`.

## Test plan
- [x] `tsc -b` passes
- [x] `eslint` clean
- [x] `vite build` succeeds
- [x] Manually verify: open a project, sign out (via "Log out"), sign back in — should land on the Project Hub, not the previous project
- [ ] Manually verify: same, but via idle-timeout auto sign-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)