### PR TITLE
[CSM Portal] build fix, crash-screen escape hatches, user-profile links, global quick-nav search, incident page revamp

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6623,6 +6623,14 @@ components:
           format: uuid
         number:
           type: string
+        type:
+          type: string
+          enum: [case, incident, change_request, problem]
+          nullable: true
+          description: >
+            What kind of record this reference points at. Nil when the
+            backing data source doesn't resolve a type (ServiceNow data
+            source only).
 
     LinkedServiceRequestRef:
       type: object

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -86,6 +86,9 @@ const CsmAdminLayout = lazy(
 const CsmUsersPage = lazy(
   () => import("@features/csm-users/pages/CsmUsersPage"),
 );
+const UserProfilePage = lazy(
+  () => import("@features/csm-users/pages/UserProfilePage"),
+);
 const CsmCustomersLayout = lazy(
   () => import("@features/csm-customers/pages/CsmCustomersLayout"),
 );
@@ -307,6 +310,15 @@ export default function App(): JSX.Element {
                       }
                     />
                   </Route>
+
+                  {/* Person profile — reachable by clicking any user reference
+                      (case creator, assignee, watchers, comment authors,
+                      attachment uploaders). Not admin-gated: any signed-in CS
+                      engineer can look up any user. */}
+                  <Route
+                    path="people/:email"
+                    element={<UserProfilePage />}
+                  />
 
                   <Route path="dashboard" element={<CsmDashboardPage />} />
                   <Route path="cases" element={<CsmCasesPage />} />

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -137,6 +137,18 @@ function commentAuthorName(comment: BeComment): string {
 }
 
 /**
+ * Best-effort email for a {@link BeComment}'s author, so the FE can link the
+ * author name to their profile page. The nested author block's `id` field IS
+ * the user's email (confirmed live: `{"createdBy":{"id":"rashmika@wso2.com",…}}`).
+ * The create-ack's bare-string `createdBy` carries no email, so this is
+ * `undefined` in that case.
+ */
+function commentAuthorEmail(comment: BeComment): string | undefined {
+  const cb = comment.createdBy;
+  return cb && typeof cb === "object" ? cb.id || undefined : undefined;
+}
+
+/**
  * Novera/bot sender detection — mirrors the customer portal's
  * `isNoveraOrBotSender`. Chat messages carry no role field, and the backend
  * normalizes `type` to `comment`/`work_note`/`activity` (a `bot` type never
@@ -189,6 +201,7 @@ export function uiCommentFromBe(
     id: comment.id,
     caseId: comment.referenceId ?? "",
     authorName: commentAuthorName(comment),
+    authorEmail: commentAuthorEmail(comment),
     // For a chatbot the body is Markdown; the bubble renders it as Markdown.
     // Otherwise it is rich-text HTML, sanitised on render.
     bodyHtml: comment.content ?? "",
@@ -210,6 +223,7 @@ export function uiAttachmentFromBe(att: BeAttachment): CaseAttachment {
     size: att.sizeBytes,
     contentType: att.type,
     uploadedBy: att.createdBy.name?.trim() || att.createdBy.email?.trim() || "Unknown",
+    uploadedByEmail: att.createdBy.email || undefined,
     uploadedAt: att.createdOn,
   };
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -438,7 +438,10 @@ export interface BeCaseAttachmentPayload {
 
 /**
  * Security report analysis (`type: "security_report_analysis"`). ServiceNow-only;
- * requires a subject, description, and at least one attachment.
+ * requires a subject and description. Attachments are optional here — the case
+ * is created first, then attachments upload separately via the post-case
+ * attachment endpoint (see `CreateSecurityReportPage.tsx`), so a failed upload
+ * never blocks or masks a successful report creation.
  */
 export interface BeSecurityReportCreatePayload {
   type: "security_report_analysis";
@@ -447,7 +450,7 @@ export interface BeSecurityReportCreatePayload {
   deployedProductId: string;
   subject: string;
   description: string;
-  attachments: BeCaseAttachmentPayload[];
+  attachments?: BeCaseAttachmentPayload[];
 }
 
 /**

--- a/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
@@ -43,7 +43,7 @@ describe("RelativeTime", () => {
     render(<RelativeTime iso={iso} href="#cmt-1001-2" />);
     expect(screen.getByRole("link")).toHaveAttribute("href", "#cmt-1001-2");
     expect(
-      screen.getByRole("button", { name: /copy link to this comment/i }),
+      screen.getByRole("button", { name: /copy link to this entry/i }),
     ).toBeInTheDocument();
   });
 
@@ -51,7 +51,7 @@ describe("RelativeTime", () => {
     render(<RelativeTime iso={iso} href="#cmt-1001-2" />);
 
     const button = screen.getByRole("button", {
-      name: /copy link to this comment/i,
+      name: /copy link to this entry/i,
     });
     fireEvent.click(button);
 
@@ -61,10 +61,41 @@ describe("RelativeTime", () => {
       );
     });
 
-    // Transient "Copied!" confirmation shows via the tooltip title immediately
-    // after copying (button stays in the document; label itself is static).
     await waitFor(() => {
-      expect(button).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
     });
+  });
+
+  it("does not mark the link copied when the clipboard write is rejected", async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    render(<RelativeTime iso={iso} href="#cmt-1001-2" />);
+
+    const button = screen.getByRole("button", {
+      name: /copy link to this entry/i,
+    });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    });
+
+    // Give the rejected promise a tick to settle, then confirm no "Copied"
+    // state was set — the button keeps its original label/icon.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(
+      screen.getByRole("button", { name: /copy link to this entry/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does nothing when the Clipboard API is unavailable", () => {
+    Object.assign(navigator, { clipboard: undefined });
+    render(<RelativeTime iso={iso} href="#cmt-1001-2" />);
+
+    const button = screen.getByRole("button", {
+      name: /copy link to this entry/i,
+    });
+    expect(() => fireEvent.click(button)).not.toThrow();
   });
 });

--- a/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import RelativeTime from "@components/RelativeTime";
+
+describe("RelativeTime", () => {
+  const iso = new Date(Date.now() - 60_000).toISOString();
+
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders plain (non-permalink) text with no copy button when href is absent", () => {
+    render(<RelativeTime iso={iso} />);
+    expect(
+      screen.queryByRole("button", { name: /copy link/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a permalink anchor and a copy-link button when href is provided", () => {
+    render(<RelativeTime iso={iso} href="#cmt-1001-2" />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "#cmt-1001-2");
+    expect(
+      screen.getByRole("button", { name: /copy link to this comment/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the absolute permalink URL to the clipboard and shows a transient confirmation", async () => {
+    render(<RelativeTime iso={iso} href="#cmt-1001-2" />);
+
+    const button = screen.getByRole("button", {
+      name: /copy link to this comment/i,
+    });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${window.location.origin}${window.location.pathname}#cmt-1001-2`,
+      );
+    });
+
+    // Transient "Copied!" confirmation shows via the tooltip title immediately
+    // after copying (button stays in the document; label itself is static).
+    await waitFor(() => {
+      expect(button).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/components/RelativeTime.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.tsx
@@ -46,21 +46,29 @@ function CopyPermalinkButton({ href }: { href: string }): JSX.Element {
 
   const handleCopy = (): void => {
     const url = `${window.location.origin}${window.location.pathname}${href}`;
-    void navigator.clipboard.writeText(url).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(url).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      },
+      () => {
+        // swallow — no toast surface available from this small button
+      },
+    );
   };
 
+  const label = copied ? "Copied" : "Copy link to this entry";
+
   return (
-    <Tooltip title={copied ? "Copied!" : "Copy link to this comment"} placement="top">
+    <Tooltip title={label} placement="top">
       <Button
         size="small"
         variant="text"
         color="inherit"
         onClick={handleCopy}
         sx={{ minWidth: 0, p: 0.5, color: "text.disabled" }}
-        aria-label="Copy link to this comment"
+        aria-label={label}
       >
         {copied ? <Check size={13} /> : <Link2 size={13} />}
       </Button>

--- a/apps/csm-portal/webapp/src/components/RelativeTime.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.tsx
@@ -14,8 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Tooltip } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import { Box, Button, Tooltip } from "@wso2/oxygen-ui";
+import { Check, Link2 } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 
@@ -33,9 +34,46 @@ interface RelativeTimeProps {
 }
 
 /**
+ * Small icon-button that copies the full absolute permalink URL for `href`
+ * to the clipboard, so the permalink affordance is discoverable even for
+ * someone who doesn't notice the timestamp itself is clickable. Follows the
+ * same Copy/Check + 2-second-reset pattern as {@link QueryErrorState}'s
+ * tracking-ID copy button, but rests on a chain-link icon to signal
+ * "permalink" rather than a generic copy action.
+ */
+function CopyPermalinkButton({ href }: { href: string }): JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (): void => {
+    const url = `${window.location.origin}${window.location.pathname}${href}`;
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Tooltip title={copied ? "Copied!" : "Copy link to this comment"} placement="top">
+      <Button
+        size="small"
+        variant="text"
+        color="inherit"
+        onClick={handleCopy}
+        sx={{ minWidth: 0, p: 0.5, color: "text.disabled" }}
+        aria-label="Copy link to this comment"
+      >
+        {copied ? <Check size={13} /> : <Link2 size={13} />}
+      </Button>
+    </Tooltip>
+  );
+}
+
+/**
  * Renders a relative timestamp ("7h ago") with the full absolute datetime
  * (in the user's preferred zone) shown on hover. If `href` is provided, the
- * text becomes a permalink to that entry.
+ * text becomes a permalink to that entry, and a copy-link icon-button follows
+ * it so the permalink affordance doesn't rely on someone noticing the
+ * timestamp itself is clickable.
  */
 export default function RelativeTime({
   iso,
@@ -71,9 +109,20 @@ export default function RelativeTime({
     </span>
   );
 
+  if (!href) {
+    return (
+      <Tooltip title={absolute} placement="top" arrow>
+        {inner}
+      </Tooltip>
+    );
+  }
+
   return (
-    <Tooltip title={absolute} placement="top" arrow>
-      {inner}
-    </Tooltip>
+    <Box component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
+      <Tooltip title={absolute} placement="top" arrow>
+        {inner}
+      </Tooltip>
+      <CopyPermalinkButton href={href} />
+    </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/components/UserRefLink.test.tsx
+++ b/apps/csm-portal/webapp/src/components/UserRefLink.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router";
+import UserRefLink from "@components/UserRefLink";
+
+describe("UserRefLink", () => {
+  it("renders a link to the profile page when an email is present", () => {
+    render(
+      <MemoryRouter>
+        <UserRefLink name="Jane Doe" email="jane.doe@example.com" />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: "Jane Doe" });
+    expect(link).toHaveAttribute(
+      "href",
+      `/people/${encodeURIComponent("jane.doe@example.com")}`,
+    );
+  });
+
+  it("URL-encodes the email in the href", () => {
+    render(
+      <MemoryRouter>
+        <UserRefLink name="Jane Doe" email="jane+test@example.com" />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: "Jane Doe" });
+    expect(link).toHaveAttribute(
+      "href",
+      "/people/jane%2Btest%40example.com",
+    );
+  });
+
+  it("renders plain text (no link) when there's no email", () => {
+    render(
+      <MemoryRouter>
+        <UserRefLink name="Jane Doe" />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("renders plain text when the email is an empty/whitespace string", () => {
+    render(
+      <MemoryRouter>
+        <UserRefLink name="Jane Doe" email="   " />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/UserRefLink.tsx
+++ b/apps/csm-portal/webapp/src/components/UserRefLink.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import { Link as RouterLink } from "react-router";
+
+interface UserRefLinkProps {
+  /** Display name shown as the link text (or plain text when there's no email). */
+  name: string;
+  /** The user's email, used to build the `/people/:email` link. Absent/empty
+   * renders plain text — a user with no email on file can't be looked up. */
+  email?: string;
+  /** Optional className passthrough for layout tweaks. */
+  className?: string;
+}
+
+/**
+ * Renders a person's name as a link to their profile page (`/people/:email`)
+ * when an email is available, with the same hover-underline treatment
+ * {@link RelativeTime} uses for its permalink anchor. Falls back to plain text
+ * when there's no email to look the user up by.
+ */
+export default function UserRefLink({
+  name,
+  email,
+  className,
+}: UserRefLinkProps): JSX.Element {
+  if (!email || !email.trim()) {
+    return <span className={className}>{name}</span>;
+  }
+
+  return (
+    <RouterLink
+      to={`/people/${encodeURIComponent(email)}`}
+      className={className}
+      style={{
+        color: "inherit",
+        textDecoration: "none",
+        cursor: "pointer",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLAnchorElement).style.textDecoration =
+          "underline";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLAnchorElement).style.textDecoration = "none";
+      }}
+    >
+      {name}
+    </RouterLink>
+  );
+}

--- a/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.test.tsx
+++ b/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.test.tsx
@@ -91,10 +91,9 @@ describe("AppErrorBoundary", () => {
     expect(copied).toContain("URL: https://csm.example.com/cases/1");
     expect(copied).toContain("Error: Error: boom");
     expect(copied).toContain("Component stack:");
+    expect(copied).toContain("Bomb");
     expect(copied).not.toContain("Correlation ID:");
 
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: /copy error details/i })).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText("Copied")).toBeInTheDocument());
   });
 });

--- a/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.test.tsx
+++ b/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import AppErrorBoundary from "@components/error/AppErrorBoundary";
+
+/** A component that always throws during render, to trip the boundary. */
+function Bomb(): never {
+  throw new Error("boom");
+}
+
+describe("AppErrorBoundary", () => {
+  const originalLocation = window.location;
+  const originalClipboard = navigator.clipboard;
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Silence the expected console.error from componentDidCatch and the
+    // "not implemented" jsdom navigation warning.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    // jsdom throws on direct window.location.href assignment; stub it out
+    // like the existing "Reload page" tests (via window.location.reload)
+    // would need to, so the click handler can be exercised safely.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, href: "https://csm.example.com/cases/1", reload: vi.fn() },
+    });
+
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+    vi.restoreAllMocks();
+  });
+
+  function renderCrashed(): void {
+    render(
+      <AppErrorBoundary>
+        <Bomb />
+      </AppErrorBoundary>,
+    );
+  }
+
+  it("shows the fallback UI once a descendant throws", () => {
+    renderCrashed();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("navigates to the app root when 'Go to home' is clicked", () => {
+    renderCrashed();
+    screen.getByRole("button", { name: /go to home/i }).click();
+    expect(window.location.href).toBe("/");
+  });
+
+  it("copies a plain-text error report including the component stack and URL", async () => {
+    renderCrashed();
+    screen.getByRole("button", { name: /copy error details/i }).click();
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0][0] as string;
+
+    expect(copied).toContain("CSM Portal error report");
+    expect(copied).toContain("URL: https://csm.example.com/cases/1");
+    expect(copied).toContain("Error: Error: boom");
+    expect(copied).toContain("Component stack:");
+    expect(copied).not.toContain("Correlation ID:");
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /copy error details/i })).toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
+++ b/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
@@ -89,13 +89,19 @@ export default class AppErrorBoundary extends Component<
       componentStack ?? "(unavailable)",
     ];
 
-    void navigator.clipboard.writeText(lines.join("\n")).then(() => {
-      this.setState({ copied: true });
-      if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
-      this.copyResetTimer = setTimeout(() => {
-        this.setState({ copied: false });
-      }, COPY_CONFIRMATION_MS);
-    });
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(lines.join("\n")).then(
+      () => {
+        this.setState({ copied: true });
+        if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
+        this.copyResetTimer = setTimeout(() => {
+          this.setState({ copied: false });
+        }, COPY_CONFIRMATION_MS);
+      },
+      () => {
+        // swallow — clipboard denied/unavailable; leave copied state untouched
+      },
+    );
   };
 
   /** Render the children, or the recovery screen once an error is caught. */

--- a/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
+++ b/apps/csm-portal/webapp/src/components/error/AppErrorBoundary.tsx
@@ -15,7 +15,9 @@
 // under the License.
 
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { Box, Button, Stack, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Stack, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { Check, Copy } from "@wso2/oxygen-ui-icons-react";
+import { getErrorReferenceId } from "@utils/correlationId";
 
 interface AppErrorBoundaryProps {
   children: ReactNode;
@@ -23,7 +25,13 @@ interface AppErrorBoundaryProps {
 
 interface AppErrorBoundaryState {
   hasError: boolean;
+  error: Error | null;
+  componentStack: string | null;
+  copied: boolean;
 }
+
+/** How long the "Copied!" confirmation stays visible after a successful copy. */
+const COPY_CONFIRMATION_MS = 2000;
 
 /**
  * Top-level error boundary so an uncaught render error degrades to a
@@ -36,17 +44,59 @@ export default class AppErrorBoundary extends Component<
   AppErrorBoundaryProps,
   AppErrorBoundaryState
 > {
-  state: AppErrorBoundaryState = { hasError: false };
+  state: AppErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    componentStack: null,
+    copied: false,
+  };
+
+  private copyResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Flip to the fallback UI when a descendant throws during render. */
-  static getDerivedStateFromError(): AppErrorBoundaryState {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): Partial<AppErrorBoundaryState> {
+    return { hasError: true, error };
   }
 
   /** Log the captured error and component stack to the console sink. */
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     console.error("Unhandled render error:", error, errorInfo.componentStack);
+    this.setState({ componentStack: errorInfo.componentStack ?? null });
   }
+
+  componentWillUnmount(): void {
+    if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
+  }
+
+  /** Navigate away from the dead error screen back to the app root. */
+  private handleGoHome = (): void => {
+    window.location.href = "/";
+  };
+
+  /** Build the plain-text error report and copy it to the clipboard. */
+  private handleCopyDetails = (): void => {
+    const { error, componentStack } = this.state;
+    if (!error) return;
+
+    const referenceId = getErrorReferenceId(error);
+    const lines = [
+      "CSM Portal error report",
+      `Time: ${new Date().toISOString()}`,
+      `URL: ${window.location.href}`,
+      `Error: ${error.name}: ${error.message}`,
+      ...(referenceId ? [`Correlation ID: ${referenceId}`] : []),
+      "Component stack:",
+      componentStack ?? "(unavailable)",
+    ];
+
+    void navigator.clipboard.writeText(lines.join("\n")).then(() => {
+      this.setState({ copied: true });
+      if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
+      this.copyResetTimer = setTimeout(() => {
+        this.setState({ copied: false });
+      }, COPY_CONFIRMATION_MS);
+    });
+  };
 
   /** Render the children, or the recovery screen once an error is caught. */
   render(): ReactNode {
@@ -69,9 +119,27 @@ export default class AppErrorBoundary extends Component<
             Something went wrong loading this page. Try reloading — your session
             will be kept.
           </Typography>
-          <Button variant="contained" onClick={() => window.location.reload()}>
-            Reload page
-          </Button>
+          <Stack direction="row" spacing={1.5}>
+            <Button variant="contained" onClick={() => window.location.reload()}>
+              Reload page
+            </Button>
+            <Button variant="outlined" onClick={this.handleGoHome}>
+              Go to home
+            </Button>
+          </Stack>
+          <Tooltip title={this.state.copied ? "Copied!" : "Copy error details"} placement="top">
+            <Button
+              size="small"
+              variant="text"
+              color="inherit"
+              onClick={this.handleCopyDetails}
+              startIcon={this.state.copied ? <Check size={14} /> : <Copy size={14} />}
+              sx={{ color: "text.disabled" }}
+              aria-label="Copy error details"
+            >
+              {this.state.copied ? "Copied" : "Copy error details"}
+            </Button>
+          </Tooltip>
         </Stack>
       </Box>
     );

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -88,6 +88,7 @@ function detailFromBeCase(
     autoclosureStateTime: c.autoclosureStateTime ?? undefined,
     assignee,
     assigneeName,
+    assigneeEmail,
     assigneeIsMe,
     slaClockType: "ack",
     minutesToBreach: 0,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.test.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useDecideChangeRequestApproval.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useQuickCaseSearch } from "@features/csm-cases/api/useQuickCaseSearch";
+import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useQuickCaseSearch", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ cases: [] });
+  });
+
+  it("requests every known case sub-type, not just the default 'case' type", async () => {
+    const { result } = renderHook(() => useQuickCaseSearch("ABC-123"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/search",
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          searchQuery: "ABC-123",
+          types: ALL_CASE_TYPES,
+        }),
+      }),
+    );
+    // Guards against the search silently regressing to only `case` hits again
+    // (the SRA-missing-from-quick-nav bug) if `ALL_CASE_TYPES` ever shrinks.
+    expect(ALL_CASE_TYPES).toEqual(
+      expect.arrayContaining([
+        "case",
+        "service_request",
+        "security_report_analysis",
+        "announcement",
+        "engagement",
+      ]),
+    );
+  });
+
+  it("does not fire a search until the query reaches the minimum length", () => {
+    renderHook(() => useQuickCaseSearch("a"), { wrapper });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -28,6 +28,7 @@ import type {
   CaseWorkState,
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
+import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
 
 /** Don't fire a search until the user has typed something searchable. */
 export const QUICK_CASE_MIN_QUERY_LEN = 2;
@@ -61,6 +62,11 @@ export interface QuickCaseHit {
  * cases list uses), so a CS/WSO2 case id — or any subject text — resolves to
  * matching cases the user can jump straight into.
  *
+ * Explicitly requests every known case sub-type ({@link ALL_CASE_TYPES}) —
+ * `entity-service`'s `/cases/search` defaults `filters.types` to `["case"]`
+ * only when the caller omits it, which silently hid Service Requests,
+ * Security Report Analyses, announcements, and engagements from this search.
+ *
  * The query is disabled until the trimmed text reaches
  * {@link QUICK_CASE_MIN_QUERY_LEN}, so opening the palette costs no network.
  */
@@ -77,7 +83,7 @@ export function useQuickCaseSearch(
         "/cases/search",
         {
           pagination: { offset: 0, limit: QUICK_CASE_LIMIT },
-          filters: { searchQuery: q },
+          filters: { searchQuery: q, types: ALL_CASE_TYPES },
         },
       );
       return (res.cases ?? []).map((c) => ({

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
@@ -14,12 +14,51 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useState, type ComponentProps, type JSX, type ReactElement } from "react";
+import { MemoryRouter } from "react-router";
 import "@testing-library/jest-dom/vitest";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import { formatAbsoluteForUser } from "@utils/dateTime";
-import type { CaseAuditEntry } from "@features/csm-cases/types/csmCases";
+import type {
+  CaseAttachment,
+  CaseAuditEntry,
+} from "@features/csm-cases/types/csmCases";
+
+// `UserRefLink` (used for the attachment uploader and the comment/lifecycle
+// actor) renders a `react-router` `Link`, so every render needs a Router
+// context even outside a full app render.
+function renderWithRouter(ui: ReactElement): ReturnType<typeof render> {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+// `previewTarget`/`onPreviewTargetChange` (part of the feed's `preview`
+// prop) are lifted to the parent page (see CsmCaseDetailPage) so the
+// preview dialog is shared with the Attachments tab's widget. This harness
+// owns that bit of state locally, standing in for the parent, and keeps the
+// flat `onGetPreviewContent` shape for individual tests below so only this
+// harness needs to know about the grouped `preview` prop.
+function CaseActivitiesFeedHarness({
+  onGetPreviewContent,
+  ...props
+}: Omit<ComponentProps<typeof CaseActivitiesFeed>, "preview"> & {
+  onGetPreviewContent?: (attachment: CaseAttachment) => Promise<Blob>;
+}): JSX.Element {
+  const [previewTarget, setPreviewTarget] = useState<CaseAttachment | null>(
+    null,
+  );
+  return (
+    <CaseActivitiesFeed
+      {...props}
+      preview={
+        onGetPreviewContent
+          ? { onGetPreviewContent, previewTarget, onPreviewTargetChange: setPreviewTarget }
+          : undefined
+      }
+    />
+  );
+}
 
 describe("CaseActivitiesFeed", () => {
   it("renders a field_change entry with old/new values", () => {
@@ -210,5 +249,111 @@ describe("CaseActivitiesFeed", () => {
     );
 
     expect(screen.getByText("Case moved to In Progress")).toBeInTheDocument();
+  });
+});
+
+describe("CaseActivitiesFeed — attachment preview affordance", () => {
+  const IMAGE_ATTACHMENT: CaseAttachment = {
+    id: "att-1",
+    filename: "screenshot.png",
+    size: 2048,
+    contentType: "image/png",
+    uploadedBy: "Jane Doe",
+    uploadedAt: "2026-01-01T00:00:00Z",
+  };
+  const ZIP_ATTACHMENT: CaseAttachment = {
+    id: "att-2",
+    filename: "logs.zip",
+    size: 8192,
+    contentType: "application/zip",
+    uploadedBy: "Jane Doe",
+    uploadedAt: "2026-01-02T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    // jsdom has no object-URL implementation; stub both so the preview
+    // dialog's blob -> object URL -> revoke lifecycle can run in tests.
+    globalThis.URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  it("shows Preview only for an image attachment, when a fetcher is supplied", () => {
+    renderWithRouter(
+      <CaseActivitiesFeedHarness
+        comments={[]}
+        audit={[]}
+        attachments={[IMAGE_ATTACHMENT, ZIP_ATTACHMENT]}
+        onGetPreviewContent={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: `Preview ${IMAGE_ATTACHMENT.filename}` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: `Preview ${ZIP_ATTACHMENT.filename}` }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides every Preview affordance when no fetcher is supplied", () => {
+    renderWithRouter(
+      <CaseActivitiesFeedHarness
+        comments={[]}
+        audit={[]}
+        attachments={[IMAGE_ATTACHMENT]}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /^preview /i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the fullscreen preview dialog with the fetched object URL and revokes it on close", async () => {
+    const fetchContent = vi
+      .fn()
+      .mockResolvedValue(new Blob(["fake"], { type: "image/png" }));
+    renderWithRouter(
+      <CaseActivitiesFeedHarness
+        comments={[]}
+        audit={[]}
+        attachments={[IMAGE_ATTACHMENT]}
+        onGetPreviewContent={fetchContent}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: `Preview ${IMAGE_ATTACHMENT.filename}` }),
+    );
+
+    expect(fetchContent).toHaveBeenCalledWith(IMAGE_ATTACHMENT);
+    await waitFor(() =>
+      expect(screen.getByAltText(IMAGE_ATTACHMENT.filename)).toBeInTheDocument(),
+    );
+    expect(screen.getByAltText(IMAGE_ATTACHMENT.filename)).toHaveAttribute(
+      "src",
+      "blob:mock-url",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /close preview/i }));
+    await waitFor(() =>
+      expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith(
+        "blob:mock-url",
+      ),
+    );
+  });
+
+  it("still shows Download for a non-previewable attachment", () => {
+    const onDownloadAttachment = vi.fn();
+    renderWithRouter(
+      <CaseActivitiesFeedHarness
+        comments={[]}
+        audit={[]}
+        attachments={[ZIP_ATTACHMENT]}
+        onDownloadAttachment={onDownloadAttachment}
+        onGetPreviewContent={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: `Download ${ZIP_ATTACHMENT.filename}` }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -45,6 +45,7 @@ import { useMemo, useState, type JSX } from "react";
 import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
 import ImageFullscreenModal from "@features/csm-cases/components/ImageFullscreenModal";
 import RelativeTime from "@components/RelativeTime";
+import UserRefLink from "@components/UserRefLink";
 import { formatBytes } from "@utils/formatBytes";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import {
@@ -404,7 +405,10 @@ export default function CaseActivitiesFeed({
                     }}
                   >
                     <Typography variant="subtitle2">
-                      {e.attachment.uploadedBy}
+                      <UserRefLink
+                        name={e.attachment.uploadedBy}
+                        email={e.attachment.uploadedByEmail}
+                      />
                     </Typography>
                     <Chip size="small" variant="outlined" label="Attachment" />
                     <Typography variant="caption" color="text.secondary">
@@ -499,7 +503,8 @@ export function AttachmentsList({
             </Typography>
             <Typography variant="caption" color="text.secondary">
               {formatBytes(a.size)} · {a.contentType} · uploaded by{" "}
-              {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />
+              <UserRefLink name={a.uploadedBy} email={a.uploadedByEmail} /> ·{" "}
+              <RelativeTime iso={a.uploadedAt} />
             </Typography>
           </Box>
         </Paper>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -33,6 +33,7 @@ import {
   ArrowUpRight,
   CheckCircle,
   Download,
+  Eye,
   Link as LinkIcon,
   ListFilter,
   Paperclip,
@@ -42,12 +43,14 @@ import {
   Users,
 } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
+import AttachmentPreviewDialog from "@features/csm-cases/components/AttachmentPreviewDialog";
 import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
 import ImageFullscreenModal from "@features/csm-cases/components/ImageFullscreenModal";
 import RelativeTime from "@components/RelativeTime";
 import UserRefLink from "@components/UserRefLink";
 import { formatBytes } from "@utils/formatBytes";
 import { formatAbsoluteForUser } from "@utils/dateTime";
+import { getAttachmentPreviewKind } from "@features/csm-cases/utils/attachmentPreview";
 import {
   compareFeedEntries,
   type FeedEntry,
@@ -64,6 +67,22 @@ interface CaseActivitiesFeedProps {
   attachments: CaseAttachment[];
   /** Download a file surfaced in the timeline. */
   onDownloadAttachment?: (attachment: CaseAttachment) => void;
+  /**
+   * Inline attachment preview for image/PDF attachments in the timeline.
+   * Mirrors the `AttachmentsWidget` preview prop (see `CaseDetailWidgets.tsx`)
+   * — all three fields are one feature, so omit the whole object to hide the
+   * per-row Preview affordance rather than supplying only some of the
+   * fields. `previewTarget`/`onPreviewTargetChange` are expected to be
+   * lifted to the parent page, shared with the Attachments tab's widget so
+   * there is exactly one dialog open at a time.
+   */
+  preview?: {
+    /** Fetch an attachment's raw bytes for inline preview. */
+    onGetPreviewContent: (attachment: CaseAttachment) => Promise<Blob>;
+    /** Attachment currently shown in the preview dialog. */
+    previewTarget: CaseAttachment | null;
+    onPreviewTargetChange: (attachment: CaseAttachment | null) => void;
+  };
 }
 
 const AUDIT_ICON: Record<CaseAuditEntry["kind"], JSX.Element> = {
@@ -128,6 +147,7 @@ export default function CaseActivitiesFeed({
   audit,
   attachments,
   onDownloadAttachment,
+  preview,
 }: CaseActivitiesFeedProps): JSX.Element {
   const [showWorkNotes, setShowWorkNotes] = useState(true);
   const [showLifecycle, setShowLifecycle] = useState(true);
@@ -439,18 +459,33 @@ export default function CaseActivitiesFeed({
                         {e.attachment.contentType}
                       </Typography>
                     </Box>
-                    {onDownloadAttachment && (
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<Download size={14} />}
-                        onClick={() => onDownloadAttachment(e.attachment)}
-                        aria-label={`Download ${e.attachment.filename}`}
-                        sx={{ flexShrink: 0 }}
-                      >
-                        Download
-                      </Button>
-                    )}
+                    <Box sx={{ display: "flex", gap: 1, flexShrink: 0 }}>
+                      {preview &&
+                        getAttachmentPreviewKind(e.attachment.contentType) && (
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            startIcon={<Eye size={14} />}
+                            onClick={() =>
+                              preview.onPreviewTargetChange(e.attachment)
+                            }
+                            aria-label={`Preview ${e.attachment.filename}`}
+                          >
+                            Preview
+                          </Button>
+                        )}
+                      {onDownloadAttachment && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<Download size={14} />}
+                          onClick={() => onDownloadAttachment(e.attachment)}
+                          aria-label={`Download ${e.attachment.filename}`}
+                        >
+                          Download
+                        </Button>
+                      )}
+                    </Box>
                   </Box>
                 </Paper>
               </Box>
@@ -467,6 +502,13 @@ export default function CaseActivitiesFeed({
           setFullscreenImageAlt(undefined);
         }}
       />
+      {preview && (
+        <AttachmentPreviewDialog
+          attachment={preview.previewTarget}
+          onClose={() => preview.onPreviewTargetChange(null)}
+          fetchContent={preview.onGetPreviewContent}
+        />
+      )}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -16,7 +16,8 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useState, type ComponentProps, type JSX } from "react";
+import { useState, type ComponentProps, type JSX, type ReactElement } from "react";
+import { MemoryRouter } from "react-router";
 import "@testing-library/jest-dom/vitest";
 import {
   AttachmentsWidget,
@@ -97,6 +98,13 @@ const WATCHERS: CaseWatcher[] = [
   { id: "w-2", name: "John Smith", isMe: true },
 ];
 
+// `WatchersWidget` links each watcher's name to their profile page via
+// `UserRefLink`, which renders a `react-router` `Link` — needs a Router
+// context even outside a full app render.
+function renderWithRouter(ui: ReactElement): ReturnType<typeof render> {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe("TagsWidget", () => {
   it("renders an empty state when there are no tags", () => {
     render(<TagsWidget tags={[]} />);
@@ -135,34 +143,34 @@ describe("TagsWidget", () => {
 
 describe("WatchersWidget", () => {
   it("renders an empty state when there are no watchers", () => {
-    render(<WatchersWidget watchers={[]} />);
+    renderWithRouter(<WatchersWidget watchers={[]} />);
     expect(
       screen.getByText("No one is watching this case."),
     ).toBeInTheDocument();
   });
 
   it("renders every watcher as a chip, marking the current user", () => {
-    render(<WatchersWidget watchers={WATCHERS} />);
+    renderWithRouter(<WatchersWidget watchers={WATCHERS} />);
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
     expect(screen.getByText("John Smith (you)")).toBeInTheDocument();
   });
 
   it("hides the Add watcher action when onAdd is omitted", () => {
-    render(<WatchersWidget watchers={WATCHERS} />);
+    renderWithRouter(<WatchersWidget watchers={WATCHERS} />);
     expect(
       screen.queryByRole("button", { name: /add watcher/i }),
     ).not.toBeInTheDocument();
   });
 
   it("omits the per-chip remove affordance when onRemove is omitted", () => {
-    render(<WatchersWidget watchers={WATCHERS} />);
+    renderWithRouter(<WatchersWidget watchers={WATCHERS} />);
     const chip = screen.getByText("Jane Doe").closest(".MuiChip-root");
     expect(chip?.querySelector(".MuiChip-deleteIcon")).toBeFalsy();
   });
 
   it("calls onRemove with the watcher when its chip delete icon is clicked", () => {
     const onRemove = vi.fn();
-    render(<WatchersWidget watchers={WATCHERS} onRemove={onRemove} />);
+    renderWithRouter(<WatchersWidget watchers={WATCHERS} onRemove={onRemove} />);
     const chip = screen.getByText("Jane Doe").closest(".MuiChip-root");
     const deleteIcon = chip?.querySelector(".MuiChip-deleteIcon");
     expect(deleteIcon).toBeTruthy();
@@ -173,7 +181,7 @@ describe("WatchersWidget", () => {
   it("opens an inline search panel on Add watcher and calls onAdd for a picked candidate — no dialog involved", () => {
     mockCandidates();
     const onAdd = vi.fn();
-    render(<WatchersWidget watchers={WATCHERS} onAdd={onAdd} />);
+    renderWithRouter(<WatchersWidget watchers={WATCHERS} onAdd={onAdd} />);
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /add watcher/i }));
@@ -185,7 +193,7 @@ describe("WatchersWidget", () => {
 
   it("closes the inline search panel when its cancel button is clicked", () => {
     mockCandidates();
-    render(<WatchersWidget watchers={WATCHERS} onAdd={() => {}} />);
+    renderWithRouter(<WatchersWidget watchers={WATCHERS} onAdd={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: /add watcher/i }));
     expect(
       screen.getByPlaceholderText(/search people to add/i),

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -75,6 +75,7 @@ import {
 import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
 import type { BeDeployment } from "@api/backend/types";
 import RelativeTime from "@components/RelativeTime";
+import UserRefLink from "@components/UserRefLink";
 
 // ---------------------------------------------------------------------------
 // Shared widget shell
@@ -546,7 +547,12 @@ export function WatchersWidget({
               size="small"
               variant="outlined"
               icon={<User size={14} />}
-              label={w.isMe ? `${w.name} (you)` : w.name}
+              label={
+                <UserRefLink
+                  name={w.isMe ? `${w.name} (you)` : w.name}
+                  email={w.email}
+                />
+              }
               disabled={isSaving}
               onDelete={
                 onRemove && w.email ? () => onRemove(w) : undefined
@@ -835,7 +841,8 @@ export function AttachmentsWidget({
                   )}
                   <Typography variant="caption" color="text.secondary" noWrap>
                     {formatBytes(a.size)} · {a.contentType} · uploaded by{" "}
-                    {a.uploadedBy} · <RelativeTime iso={a.uploadedAt} />
+                    <UserRefLink name={a.uploadedBy} email={a.uploadedByEmail} /> ·{" "}
+                    <RelativeTime iso={a.uploadedAt} />
                   </Typography>
                 </Box>
                 {preview &&

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -21,6 +21,7 @@ import { Link as RouterLink } from "react-router";
 import { tierLabel, tierColor } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import SemanticChip from "@components/SemanticChip";
+import UserRefLink from "@components/UserRefLink";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
 import type { BeDeploymentType } from "@api/backend/types";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
@@ -341,15 +342,20 @@ export default function CaseMetaBand({
               </Cell>
               <Cell label="Created by">
                 <Typography variant="body2" noWrap>
-                  {c.createdBy ?? c.customerContext.primaryContact ?? "—"}
+                  <UserRefLink
+                    name={c.createdBy ?? c.customerContext.primaryContact ?? "—"}
+                    email={c.createdByEmail}
+                  />
                 </Typography>
               </Cell>
               <Cell label="Assignee">
                 <Typography variant="body2" noWrap>
                   {c.assigneeIsMe ? (
-                    <strong>{c.assignee}</strong>
+                    <strong>
+                      <UserRefLink name={c.assignee} email={c.assigneeEmail} />
+                    </strong>
                   ) : (
-                    c.assignee
+                    <UserRefLink name={c.assignee} email={c.assigneeEmail} />
                   )}
                 </Typography>
               </Cell>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -19,6 +19,7 @@ import { Bot } from "@wso2/oxygen-ui-icons-react";
 import { useCallback, useEffect, useMemo, useRef, type JSX } from "react";
 import RelativeTime from "@components/RelativeTime";
 import SemanticChip from "@components/SemanticChip";
+import UserRefLink from "@components/UserRefLink";
 import { pickAccessibleText } from "@utils/contrastText";
 import { sanitizeRichTextHtml, stripLightModeInlineStyles } from "@utils/sanitizeHtml";
 import { useDarkMode } from "@utils/useDarkMode";
@@ -276,7 +277,9 @@ export default function CsmCaseCommentBubble({
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-          <Typography variant="subtitle2">{comment.authorName}</Typography>
+          <Typography variant="subtitle2">
+            <UserRefLink name={comment.authorName} email={comment.authorEmail} />
+          </Typography>
           {comment.authorRole !== "wso2_engineer" && (
             <Chip
               size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1931,6 +1931,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   audit={activityAudit ?? []}
                   attachments={attachmentList}
                   onDownloadAttachment={onDownloadAttachment}
+                  preview={{
+                    onGetPreviewContent: getAttachmentPreviewContent,
+                    previewTarget,
+                    onPreviewTargetChange: setPreviewTarget,
+                  }}
                 />
               </>
             )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -110,6 +110,9 @@ export interface CsmCaseComment {
   id: string;
   caseId: string;
   authorName: string;
+  /** Author's email, when the backend returns one — used to link the author
+   * name to their profile page. */
+  authorEmail?: string;
   authorRole: CsmCommentAuthorRole;
   bodyHtml: string;
   createdAt: string;
@@ -128,6 +131,9 @@ export interface CaseAttachment {
   size: number;
   contentType: string;
   uploadedBy: string;
+  /** Uploader's email, when the backend returns one — used to link the
+   * uploader name to their profile page. */
+  uploadedByEmail?: string;
   uploadedAt: string;
 }
 
@@ -495,6 +501,9 @@ export interface CsmCaseDetail extends CsmCaseRow {
    * against that fallback.
    */
   assigneeName?: string;
+  /** Email of the assigned engineer, when the data source returns one — used
+   * to link the assignee name to their profile page. */
+  assigneeEmail?: string;
   customerContext: CaseCustomerContext;
   productContext: CaseProductContext;
   watchers: CaseWatcher[];

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickChangeRequestSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickChangeRequestSearch.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeChangeRequestSearchPayload,
+  BeChangeRequestSearchResponse,
+} from "@api/backend/types";
+
+/** Don't fire a search until the user has typed something searchable. */
+export const QUICK_CHANGE_REQUEST_MIN_QUERY_LEN = 2;
+
+/** A small result page — the palette only shows the top few hits. */
+const QUICK_CHANGE_REQUEST_LIMIT = 5;
+
+/** One hit from the global-search change-request lookup, enough for the palette's result row. */
+export interface QuickChangeRequestHit {
+  id: string;
+  number?: string;
+  subject: string;
+  state?: string | null;
+  impact?: string | null;
+  assigneeName?: string;
+  updatedOn?: string;
+}
+
+/**
+ * Free-text change-request lookup for the global quick-nav palette. Calls
+ * `POST /change-requests/search` with the typed text as `searchQuery`
+ * (ServiceNow data source only) — same endpoint `useSearchChangeRequests`
+ * uses for the Operations tab's listing, just capped to a handful of hits and
+ * shaped for the palette instead of a paginated table.
+ *
+ * Disabled until the trimmed text reaches
+ * {@link QUICK_CHANGE_REQUEST_MIN_QUERY_LEN}, so opening the palette costs no
+ * network.
+ */
+export function useQuickChangeRequestSearch(
+  query: string,
+): UseQueryResult<QuickChangeRequestHit[], Error> {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<QuickChangeRequestHit[], Error>({
+    queryKey: [ApiQueryKeys.CHANGE_REQUESTS, "quick-search", q],
+    queryFn: async (): Promise<QuickChangeRequestHit[]> => {
+      const res = await api.post<
+        BeChangeRequestSearchPayload,
+        BeChangeRequestSearchResponse
+      >("/change-requests/search", {
+        pagination: { offset: 0, limit: QUICK_CHANGE_REQUEST_LIMIT },
+        filters: { searchQuery: q },
+      });
+      return (res.changeRequests ?? []).map((cr) => ({
+        id: cr.id,
+        number: cr.number,
+        subject: cr.subject ?? "(no subject)",
+        state: cr.state,
+        impact: cr.impact,
+        assigneeName: cr.assignedEngineer?.name,
+        updatedOn: cr.updatedOn,
+      }));
+    },
+    enabled: q.length >= QUICK_CHANGE_REQUEST_MIN_QUERY_LEN,
+    staleTime: 15_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickIncidentSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickIncidentSearch.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeIncidentSearchPayload,
+  BeIncidentSearchResponse,
+} from "@api/backend/types";
+
+/** Don't fire a search until the user has typed something searchable — mirrors {@link
+ * "@features/csm-cases/api/useQuickCaseSearch".QUICK_CASE_MIN_QUERY_LEN}. */
+export const QUICK_INCIDENT_MIN_QUERY_LEN = 2;
+
+/** A small result page — the palette only shows the top few hits. */
+const QUICK_INCIDENT_LIMIT = 5;
+
+/** One hit from the global-search incident lookup, enough for the palette's result row. */
+export interface QuickIncidentHit {
+  id: string;
+  number?: string | null;
+  subject: string;
+  state?: string | null;
+  priority?: string | null;
+  assigneeName?: string;
+  updatedOn?: string;
+}
+
+/**
+ * Free-text incident lookup for the global quick-nav palette. Calls
+ * `POST /incidents/search` with the typed text as `searchQuery` (ServiceNow
+ * data source only) — same endpoint `useSearchIncidents` uses for the
+ * Operations tab's listing, just capped to a handful of hits and shaped for
+ * the palette instead of a paginated table.
+ *
+ * Disabled until the trimmed text reaches {@link QUICK_INCIDENT_MIN_QUERY_LEN},
+ * so opening the palette costs no network.
+ */
+export function useQuickIncidentSearch(
+  query: string,
+): UseQueryResult<QuickIncidentHit[], Error> {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<QuickIncidentHit[], Error>({
+    queryKey: [ApiQueryKeys.INCIDENTS, "quick-search", q],
+    queryFn: async (): Promise<QuickIncidentHit[]> => {
+      const res = await api.post<BeIncidentSearchPayload, BeIncidentSearchResponse>(
+        "/incidents/search",
+        {
+          pagination: { offset: 0, limit: QUICK_INCIDENT_LIMIT },
+          filters: { searchQuery: q },
+        },
+      );
+      return (res.incidents ?? [])
+        .filter((i): i is typeof i & { id: string } => !!i.id)
+        .map((i) => ({
+          id: i.id,
+          number: i.number,
+          subject: i.subject ?? "(no subject)",
+          state: i.state,
+          priority: i.priority,
+          assigneeName: i.assignedTo?.name,
+          updatedOn: i.updatedOn,
+        }));
+    },
+    enabled: q.length >= QUICK_INCIDENT_MIN_QUERY_LEN,
+    staleTime: 15_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickProblemSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickProblemSearch.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeProblemSearchPayload,
+  BeProblemSearchResponse,
+} from "@api/backend/types";
+
+/** Don't fire a search until the user has typed something searchable. */
+export const QUICK_PROBLEM_MIN_QUERY_LEN = 2;
+
+/** A small result page — the palette only shows the top few hits. */
+const QUICK_PROBLEM_LIMIT = 5;
+
+/** One hit from the global-search problem lookup, enough for the palette's result row. */
+export interface QuickProblemHit {
+  id: string;
+  number?: string;
+  subject: string;
+  state?: string;
+  assigneeName?: string;
+}
+
+/**
+ * Free-text problem lookup for the global quick-nav palette. Calls
+ * `POST /problems/search` with the typed text as `searchQuery` (ServiceNow
+ * data source only) — same endpoint `useSearchProblems` uses for the
+ * Operations tab's listing, just capped to a handful of hits and shaped for
+ * the palette instead of a paginated table.
+ *
+ * Disabled until the trimmed text reaches {@link QUICK_PROBLEM_MIN_QUERY_LEN},
+ * so opening the palette costs no network.
+ */
+export function useQuickProblemSearch(
+  query: string,
+): UseQueryResult<QuickProblemHit[], Error> {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<QuickProblemHit[], Error>({
+    queryKey: [ApiQueryKeys.PROBLEMS, "quick-search", q],
+    queryFn: async (): Promise<QuickProblemHit[]> => {
+      const res = await api.post<BeProblemSearchPayload, BeProblemSearchResponse>(
+        "/problems/search",
+        {
+          pagination: { offset: 0, limit: QUICK_PROBLEM_LIMIT },
+          filters: { searchQuery: q },
+        },
+      );
+      return (res.problems ?? []).map((p) => ({
+        id: p.id,
+        number: p.number,
+        subject: p.subject ?? "(no subject)",
+        state: p.state,
+        assigneeName: p.assignedTo?.name,
+      }));
+    },
+    enabled: q.length >= QUICK_PROBLEM_MIN_QUERY_LEN,
+    staleTime: 15_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentActionBar.test.tsx
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import IncidentActionBar from "@features/csm-operations/components/IncidentActionBar";
+import type { BeIncidentDetail, BeIncidentState } from "@api/backend/types";
+
+function incidentInState(state: BeIncidentState): BeIncidentDetail {
+  return {
+    id: "inc-1",
+    number: "INC0012345",
+    openedOn: "2026-01-01T00:00:00Z",
+    subject: "Gateway 502s",
+    priority: null,
+    state,
+    category: null,
+  };
+}
+
+describe("IncidentActionBar — button set per state", () => {
+  it("NEW offers a single button per legal target (In Progress, Cancelled)", () => {
+    // NEW has two legal next states, so it renders the "Change state" menu.
+    render(
+      <IncidentActionBar incident={incidentInState("NEW")} isPending={false} onAction={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+    expect(screen.getByRole("menuitem", { name: /in progress/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /cancelled/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /^new$/i })).not.toBeInTheDocument();
+  });
+
+  it("IN_PROGRESS offers On Hold, Resolved, Cancelled via a Change-state menu", () => {
+    render(
+      <IncidentActionBar
+        incident={incidentInState("IN_PROGRESS")}
+        isPending={false}
+        onAction={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+    expect(screen.getByRole("menuitem", { name: /on hold/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /resolved/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /cancelled/i })).toBeInTheDocument();
+  });
+
+  it("ON_HOLD offers In Progress and Cancelled via a Change-state menu", () => {
+    render(
+      <IncidentActionBar
+        incident={incidentInState("ON_HOLD")}
+        isPending={false}
+        onAction={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+    expect(screen.getByRole("menuitem", { name: /in progress/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /cancelled/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /resolved/i })).not.toBeInTheDocument();
+  });
+
+  it("RESOLVED offers a single button: Closed (reopen is via the Edit dialog only)", () => {
+    render(
+      <IncidentActionBar
+        incident={incidentInState("RESOLVED")}
+        isPending={false}
+        onAction={() => {}}
+      />,
+    );
+    // Two legal targets (Closed, In Progress) -> Change-state menu.
+    fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+    expect(screen.getByRole("menuitem", { name: /^closed$/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /in progress/i })).toBeInTheDocument();
+  });
+
+  it("CLOSED renders nothing — terminal state", () => {
+    const { container } = render(
+      <IncidentActionBar
+        incident={incidentInState("CLOSED")}
+        isPending={false}
+        onAction={() => {}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("CANCELLED renders nothing — terminal state", () => {
+    const { container } = render(
+      <IncidentActionBar
+        incident={incidentInState("CANCELLED")}
+        isPending={false}
+        onAction={() => {}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("IncidentActionBar — dispatch", () => {
+  it("calls onAction with the target BeIncidentState when a menu item is clicked", () => {
+    const onAction = vi.fn();
+    render(
+      <IncidentActionBar incident={incidentInState("NEW")} isPending={false} onAction={onAction} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /in progress/i }));
+    expect(onAction).toHaveBeenCalledWith("IN_PROGRESS");
+  });
+
+  it("disables the primary/change-state button while a transition is pending", () => {
+    render(
+      <IncidentActionBar incident={incidentInState("NEW")} isPending={true} onAction={() => {}} />,
+    );
+    expect(screen.getByRole("button", { name: /change state/i })).toBeDisabled();
+  });
+});
+
+describe("IncidentActionBar — single-target rendering (no menu needed)", () => {
+  // None of today's real states happen to have exactly one legal next state
+  // (see incidents.test.ts), but the bar still supports it — exercise that
+  // branch directly by overriding the transition table for this test only.
+  it("renders one contained button (no 'Change state' menu) and dispatches on click", async () => {
+    vi.resetModules();
+    vi.doMock("@features/csm-operations/utils/incidents", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@features/csm-operations/utils/incidents")>();
+      return {
+        ...actual,
+        getLegalNextIncidentStates: () => ["NEW", "IN_PROGRESS"],
+      };
+    });
+    const { default: IsolatedIncidentActionBar } = await import(
+      "@features/csm-operations/components/IncidentActionBar"
+    );
+    const onAction = vi.fn();
+    render(
+      <IsolatedIncidentActionBar
+        incident={incidentInState("NEW")}
+        isPending={false}
+        onAction={onAction}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /change state/i })).not.toBeInTheDocument();
+    const button = screen.getByRole("button", { name: /in progress/i });
+    fireEvent.click(button);
+    expect(onAction).toHaveBeenCalledWith("IN_PROGRESS");
+    vi.doUnmock("@features/csm-operations/utils/incidents");
+    vi.resetModules();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentActionBar.test.tsx
@@ -18,7 +18,24 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import IncidentActionBar from "@features/csm-operations/components/IncidentActionBar";
+import { getLegalNextIncidentStates } from "@features/csm-operations/utils/incidents";
 import type { BeIncidentDetail, BeIncidentState } from "@api/backend/types";
+
+// Only `getLegalNextIncidentStates` is overridden (per-test, via
+// `mockReturnValueOnce` below) so the "single-target" branch — which none of
+// today's real states happen to exercise — can still be tested directly.
+// Everything else (icons, labels) uses the real module. Statically mocking
+// like this, instead of `vi.resetModules()` + a dynamic `import()` of the
+// component under test, avoids the risk of that reset also evicting React
+// itself from the module cache and re-evaluating a second copy.
+vi.mock("@features/csm-operations/utils/incidents", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@features/csm-operations/utils/incidents")>();
+  return {
+    ...actual,
+    getLegalNextIncidentStates: vi.fn(actual.getLegalNextIncidentStates),
+  };
+});
 
 function incidentInState(state: BeIncidentState): BeIncidentDetail {
   return {
@@ -131,32 +148,17 @@ describe("IncidentActionBar — dispatch", () => {
 describe("IncidentActionBar — single-target rendering (no menu needed)", () => {
   // None of today's real states happen to have exactly one legal next state
   // (see incidents.test.ts), but the bar still supports it — exercise that
-  // branch directly by overriding the transition table for this test only.
-  it("renders one contained button (no 'Change state' menu) and dispatches on click", async () => {
-    vi.resetModules();
-    vi.doMock("@features/csm-operations/utils/incidents", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("@features/csm-operations/utils/incidents")>();
-      return {
-        ...actual,
-        getLegalNextIncidentStates: () => ["NEW", "IN_PROGRESS"],
-      };
-    });
-    const { default: IsolatedIncidentActionBar } = await import(
-      "@features/csm-operations/components/IncidentActionBar"
-    );
+  // branch directly by overriding the transition table for this test only,
+  // via the hoisted mock above.
+  it("renders one contained button (no 'Change state' menu) and dispatches on click", () => {
+    vi.mocked(getLegalNextIncidentStates).mockReturnValueOnce(["NEW", "IN_PROGRESS"]);
     const onAction = vi.fn();
     render(
-      <IsolatedIncidentActionBar
-        incident={incidentInState("NEW")}
-        isPending={false}
-        onAction={onAction}
-      />,
+      <IncidentActionBar incident={incidentInState("NEW")} isPending={false} onAction={onAction} />,
     );
     expect(screen.queryByRole("button", { name: /change state/i })).not.toBeInTheDocument();
     const button = screen.getByRole("button", { name: /in progress/i });
     fireEvent.click(button);
     expect(onAction).toHaveBeenCalledWith("IN_PROGRESS");
-    vi.doUnmock("@features/csm-operations/utils/incidents");
-    vi.resetModules();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentActionBar.tsx
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Menu, MenuItem } from "@wso2/oxygen-ui";
+import {
+  ArrowRight,
+  Ban,
+  CheckCircle,
+  ChevronDown,
+  PauseCircle,
+  Play,
+} from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import { getLegalNextIncidentStates, incidentStateLabel } from "@features/csm-operations/utils/incidents";
+import type { BeIncidentDetail, BeIncidentState } from "@api/backend/types";
+
+/**
+ * Presentation for a transition *into* a given state. The button LABEL is
+ * never stored here — it always comes from `incidentStateLabel(target)`, same
+ * "no invented verbs" convention as `CaseActionBar`'s `TargetConfig`. Only the
+ * icon/colour live here.
+ */
+type TargetConfig = {
+  color: "primary" | "success" | "warning" | "error";
+  icon: JSX.Element;
+};
+
+const TARGET_CONFIG: Partial<Record<BeIncidentState, TargetConfig>> = {
+  IN_PROGRESS: { color: "primary", icon: <Play size={16} /> },
+  ON_HOLD: { color: "warning", icon: <PauseCircle size={16} /> },
+  RESOLVED: { color: "success", icon: <CheckCircle size={16} /> },
+  CLOSED: { color: "success", icon: <CheckCircle size={16} /> },
+  CANCELLED: { color: "error", icon: <Ban size={16} /> },
+};
+
+/**
+ * Presentation for a transition into a state this bar has no curated config
+ * for (e.g. a state added on the backend). Keeps the button renderable and
+ * safe to click — same fallback convention as `CaseActionBar`'s
+ * `DEFAULT_TARGET_CONFIG` — so a new backend state needs no FE change.
+ */
+const DEFAULT_TARGET_CONFIG: TargetConfig = {
+  color: "primary",
+  icon: <ArrowRight size={16} />,
+};
+
+interface IncidentActionBarProps {
+  incident: BeIncidentDetail;
+  /** True while a `PATCH /incidents/{id}` state transition is in flight. */
+  isPending: boolean;
+  /**
+   * Fired with the target state the engineer picked. The caller decides how
+   * to apply it — a direct `PATCH { state: target }` for most targets, or
+   * (for `RESOLVED`/`CLOSED`) opening a dialog to collect the
+   * `resolutionCode`/`resolutionNotes` ServiceNow requires for those two
+   * transitions (confirmed live — see `BeUpdateIncidentPayload`'s doc
+   * comment) — this bar has no opinion on that, same split of
+   * responsibility as `CaseActionBar` + `CsmCaseDetailPage.onAction`.
+   */
+  onAction: (target: BeIncidentState) => void;
+}
+
+/**
+ * Lifecycle action bar for the incident detail page. Buttons are driven
+ * directly by `getLegalNextIncidentStates` (a CSM-platform-only guardrail —
+ * ServiceNow itself enforces no old-state -> new-state legality for
+ * incidents in this org, only role-gating) so the button set always matches
+ * that single source of truth. Renders nothing once the incident is in a
+ * terminal state (`CLOSED`/`CANCELLED`).
+ */
+export default function IncidentActionBar({
+  incident,
+  isPending,
+  onAction,
+}: IncidentActionBarProps): JSX.Element | null {
+  const [stateMenuAnchor, setStateMenuAnchor] = useState<HTMLElement | null>(null);
+
+  const current = incident.state;
+  if (!current) return null;
+  const targets = getLegalNextIncidentStates(current).filter((s) => s !== current);
+  if (targets.length === 0) return null;
+
+  const buttons = targets.map((target) => ({
+    target,
+    label: incidentStateLabel(target),
+    ...(TARGET_CONFIG[target] ?? DEFAULT_TARGET_CONFIG),
+  }));
+
+  const dispatch = (target: BeIncidentState): void => {
+    setStateMenuAnchor(null);
+    onAction(target);
+  };
+
+  if (buttons.length === 1) {
+    const b = buttons[0];
+    return (
+      <Button
+        size="small"
+        variant="contained"
+        color={b.color}
+        startIcon={b.icon}
+        disabled={isPending}
+        onClick={() => dispatch(b.target)}
+      >
+        {b.label}
+      </Button>
+    );
+  }
+
+  return (
+    <Box sx={{ display: "flex" }}>
+      <Button
+        size="small"
+        variant="contained"
+        color="primary"
+        endIcon={<ChevronDown size={16} />}
+        disabled={isPending}
+        onClick={(e) => setStateMenuAnchor(e.currentTarget)}
+      >
+        Change state
+      </Button>
+      <Menu
+        anchorEl={stateMenuAnchor}
+        open={!!stateMenuAnchor}
+        onClose={() => setStateMenuAnchor(null)}
+      >
+        {buttons.map((b) => (
+          <MenuItem
+            key={b.target}
+            onClick={() => dispatch(b.target)}
+            sx={{ gap: 1.25, minHeight: 36 }}
+          >
+            <Box sx={{ color: `${b.color}.main`, display: "flex" }}>{b.icon}</Box>
+            {b.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentResolutionDialog.tsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import { incidentStateLabel } from "@features/csm-operations/utils/incidents";
+import type { BeIncidentState } from "@api/backend/types";
+
+interface IncidentResolutionDialogProps {
+  /** The transition this dialog is confirming — always RESOLVED or CLOSED. */
+  target: Extract<BeIncidentState, "RESOLVED" | "CLOSED">;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (fields: { resolutionCode: string; resolutionNotes: string }) => void;
+}
+
+/**
+ * Collects the resolution code + notes ServiceNow requires before an
+ * incident can move to `RESOLVED`/`CLOSED` — confirmed live: those two state
+ * values 500 without them (see `BeUpdateIncidentPayload`'s doc comment).
+ * Doubles as the confirmation step for these two transitions, same role
+ * `ResolutionDialog` plays for a case's close/propose-solution — there is no
+ * separate plain confirm dialog for them.
+ */
+export default function IncidentResolutionDialog({
+  target,
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: IncidentResolutionDialogProps): JSX.Element {
+  const [resolutionCode, setResolutionCode] = useState("");
+  const [resolutionNotes, setResolutionNotes] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  const hasCode = resolutionCode.trim().length > 0;
+  const hasNotes = resolutionNotes.trim().length > 0;
+  const canSubmit = hasCode && hasNotes && !isSubmitting;
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Move to {incidentStateLabel(target)}</DialogTitle>
+      <DialogContent dividers sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          ServiceNow requires a resolution to move this incident to{" "}
+          {incidentStateLabel(target)}.
+        </Typography>
+        <TextField
+          label="Resolution code"
+          required
+          size="small"
+          fullWidth
+          value={resolutionCode}
+          onChange={(e) => setResolutionCode(e.target.value)}
+          onBlur={() => setTouched(true)}
+          error={touched && !hasCode}
+          helperText={touched && !hasCode ? "Resolution code is required." : undefined}
+          disabled={isSubmitting}
+        />
+        <TextField
+          label="Resolution notes"
+          required
+          fullWidth
+          multiline
+          minRows={3}
+          value={resolutionNotes}
+          onChange={(e) => setResolutionNotes(e.target.value)}
+          onBlur={() => setTouched(true)}
+          error={touched && !hasNotes}
+          helperText={
+            touched && !hasNotes
+              ? "Resolution notes are required."
+              : "Describe the resolution…"
+          }
+          disabled={isSubmitting}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="success"
+          disabled={!canSubmit}
+          onClick={() => {
+            if (!hasCode || !hasNotes) {
+              setTouched(true);
+              return;
+            }
+            onSubmit({
+              resolutionCode: resolutionCode.trim(),
+              resolutionNotes: resolutionNotes.trim(),
+            });
+          }}
+        >
+          {isSubmitting ? "Saving…" : `Move to ${incidentStateLabel(target)}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -204,9 +204,9 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
     recordView({
       kind: "change_request",
       id: data.id,
-      title: data.number
-        ? `${data.number} · ${data.subject ?? ""}`.trim()
-        : (data.subject ?? "(no subject)"),
+      title:
+        [data.number, data.subject].filter((s): s is string => !!s?.trim()).join(" · ") ||
+        "(no subject)",
       subtitle: data.project?.name,
       href: `/operations/change-requests/${data.id}`,
     });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -37,13 +37,21 @@ import {
   Send,
   X,
 } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode, useCallback, useMemo, useState } from "react";
+import {
+  type JSX,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {  useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
+import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
 import { usePatchChangeRequest } from "@features/csm-operations/api/usePatchChangeRequest";
 import {
@@ -189,6 +197,20 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   const [composerOpen, setComposerOpen] = useState(false);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
+
+  const recordView = useRecordRecentView();
+  useEffect(() => {
+    if (!data?.id) return;
+    recordView({
+      kind: "change_request",
+      id: data.id,
+      title: data.number
+        ? `${data.number} · ${data.subject ?? ""}`.trim()
+        : (data.subject ?? "(no subject)"),
+      subtitle: data.project?.name,
+      href: `/operations/change-requests/${data.id}`,
+    });
+  }, [data, recordView]);
 
   const onUploadAttachment = useCallback(
     (file: File) => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -14,21 +14,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeIncidentDetail } from "@api/backend/types";
 
 const navigateMock = vi.fn();
 const useGetIncidentMock = vi.fn();
+const patchMutateMock = vi.fn();
+const showErrorMock = vi.fn();
 
 // The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
 // module load, which isn't present under vitest. The page imports
-// `BackendApiError` from it directly, so stub the module (same approach as
-// CsmAnnouncementsPage.test.tsx).
+// `BackendApiError` from it directly, so stub the module with a real class
+// (so `instanceof` still works) — same approach as
+// CsmChangeRequestDetailPage.test.tsx.
 vi.mock("@api/backend/client", () => ({
-  BackendApiError: class BackendApiError extends Error {},
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
   useBackendApi: () => ({ get: vi.fn(), patch: vi.fn() }),
 }));
 
@@ -42,10 +51,10 @@ vi.mock("@features/csm-operations/api/useGetIncident", () => ({
   useGetIncident: () => useGetIncidentMock(),
 }));
 vi.mock("@features/csm-operations/api/usePatchIncident", () => ({
-  usePatchIncident: () => ({ isPending: false, mutate: vi.fn() }),
+  usePatchIncident: () => ({ isPending: false, mutate: patchMutateMock }),
 }));
 vi.mock("@context/error-banner/ErrorBannerContext", () => ({
-  useErrorBanner: () => ({ showError: vi.fn() }),
+  useErrorBanner: () => ({ showError: showErrorMock }),
 }));
 vi.mock("@features/csm-operations/api/useCsmIncidentComments", () => ({
   useGetCsmIncidentComments: () => ({ data: [] }),
@@ -99,10 +108,46 @@ function clickChip(text: string): void {
     ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 }
 
-describe("CsmIncidentDetailPage", () => {
-  it("renders parent incident, change request, and problem as clickable references", () => {
+function goToTab(name: RegExp): void {
+  fireEvent.click(screen.getByRole("tab", { name }));
+}
+
+// `patchMutateMock`/`showErrorMock`/`navigateMock` are module-scoped `vi.fn()`s
+// shared across every test in this file — without a reset, a call recorded by
+// an earlier test (e.g. the direct-PATCH transition test) is still present
+// when a later test asserts `not.toHaveBeenCalled()`, failing on someone else's
+// call instead of its own.
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CsmIncidentDetailPage — tabs", () => {
+  it("renders all five tabs and defaults to Activities", () => {
     mockQueryResult({ data: BASE_INCIDENT });
     render(<CsmIncidentDetailPage />);
+
+    expect(screen.getByRole("tab", { name: /activities/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /details/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /related/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /watchers/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /attachments/i })).toBeInTheDocument();
+  });
+
+  it("switches to the Details tab and shows classification fields", () => {
+    mockQueryResult({ data: { ...BASE_INCIDENT, category: "INQUIRY" } });
+    render(<CsmIncidentDetailPage />);
+    goToTab(/details/i);
+    expect(screen.getByText("Classification")).toBeInTheDocument();
+    expect(screen.getByText("INQUIRY")).toBeInTheDocument();
+  });
+
+  it("renders parent incident, change request, and problem as clickable references under Related", () => {
+    mockQueryResult({ data: BASE_INCIDENT });
+    render(<CsmIncidentDetailPage />);
+    goToTab(/related/i);
 
     clickChip("INC0011111");
     expect(navigateMock).toHaveBeenCalledWith("/operations/incidents/inc-parent");
@@ -117,8 +162,99 @@ describe("CsmIncidentDetailPage", () => {
   it("renders 'Caused by' as plain, non-navigable text since its target type is unconfirmed", () => {
     mockQueryResult({ data: BASE_INCIDENT });
     render(<CsmIncidentDetailPage />);
+    goToTab(/related/i);
 
     const causedByText = screen.getByText("Some obscure record");
     expect(causedByText.closest('[role="button"]')).toBeNull();
+  });
+
+  it("shows the watch list under the Watchers tab", () => {
+    mockQueryResult({
+      data: {
+        ...BASE_INCIDENT,
+        watchList: [{ id: "u1", name: "Jane Doe", email: "jane.doe@example.com" }],
+      },
+    });
+    render(<CsmIncidentDetailPage />);
+    goToTab(/watchers/i);
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+});
+
+describe("CsmIncidentDetailPage — state-transition action bar", () => {
+  // IN_PROGRESS has three legal next states (ON_HOLD, RESOLVED, CANCELLED),
+  // so IncidentActionBar renders a "Change state" menu rather than a single
+  // button — open it first, same interaction as CaseActionBar's multi-target
+  // case.
+  function openChangeState(): void {
+    fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+  }
+
+  it("dispatches a direct PATCH for a simple transition (IN_PROGRESS -> ON_HOLD)", () => {
+    mockQueryResult({ data: { ...BASE_INCIDENT, state: "IN_PROGRESS" } });
+    render(<CsmIncidentDetailPage />);
+    openChangeState();
+    fireEvent.click(screen.getByRole("menuitem", { name: /on hold/i }));
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "inc-1", patch: { state: "ON_HOLD" } },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it("opens the resolution dialog for RESOLVED instead of PATCHing immediately", () => {
+    mockQueryResult({ data: { ...BASE_INCIDENT, state: "IN_PROGRESS" } });
+    render(<CsmIncidentDetailPage />);
+    openChangeState();
+    fireEvent.click(screen.getByRole("menuitem", { name: /resolved/i }));
+    expect(patchMutateMock).not.toHaveBeenCalled();
+    // The dialog title and its submit button both read "Move to Resolved" —
+    // scope to the heading so this doesn't trip over the multiple-match error
+    // a plain getByText(/move to resolved/i) would throw.
+    expect(screen.getByRole("heading", { name: /move to resolved/i })).toBeInTheDocument();
+  });
+
+  it("submits the resolution dialog with state + resolutionCode + resolutionNotes", () => {
+    mockQueryResult({ data: { ...BASE_INCIDENT, state: "IN_PROGRESS" } });
+    render(<CsmIncidentDetailPage />);
+    openChangeState();
+    fireEvent.click(screen.getByRole("menuitem", { name: /resolved/i }));
+
+    fireEvent.change(screen.getByLabelText(/resolution code/i), {
+      target: { value: "Solved" },
+    });
+    fireEvent.change(screen.getByLabelText(/resolution notes/i), {
+      target: { value: "Restarted the service." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^move to resolved$/i }));
+
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      {
+        id: "inc-1",
+        patch: {
+          state: "RESOLVED",
+          resolutionCode: "Solved",
+          resolutionNotes: "Restarted the service.",
+        },
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it("renders no state-transition buttons for a terminal incident (CLOSED)", () => {
+    mockQueryResult({ data: { ...BASE_INCIDENT, state: "CLOSED" } });
+    render(<CsmIncidentDetailPage />);
+    expect(screen.queryByRole("button", { name: /in progress/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /change state/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /cancelled/i })).not.toBeInTheDocument();
+  });
+
+  it("renders no state-transition buttons for a terminal incident (CANCELLED)", () => {
+    mockQueryResult({ data: { ...BASE_INCIDENT, state: "CANCELLED" } });
+    render(<CsmIncidentDetailPage />);
+    expect(screen.queryByRole("button", { name: /in progress/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /change state/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -64,6 +64,7 @@ vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
   useGetCsmCaseAttachments: () => ({ data: [] }),
   usePostCsmCaseAttachment: () => ({ isPending: false, mutate: vi.fn() }),
   useDownloadCsmCaseAttachment: () => vi.fn(),
+  useGetCsmCaseAttachmentContent: () => vi.fn(),
 }));
 vi.mock("@features/csm-cases/components/CaseActivitiesFeed", () => ({
   default: () => null,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -14,8 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
-import { ArrowLeft, MessageSquarePlus, Pencil } from "@wso2/oxygen-ui-icons-react";
+import { Box, Button, Card, Chip, Skeleton, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import {
+  Activity,
+  ArrowLeft,
+  Eye,
+  FileText,
+  Link as LinkIcon,
+  MessageSquarePlus,
+  Paperclip,
+  Pencil,
+} from "@wso2/oxygen-ui-icons-react";
 import {
   type JSX,
   type ReactNode,
@@ -38,6 +47,8 @@ import {
 } from "@features/csm-operations/api/useCsmIncidentComments";
 import EditIncidentDialog from "@features/csm-operations/components/EditIncidentDialog";
 import EntityRefLink from "@features/csm-operations/components/EntityRefLink";
+import IncidentActionBar from "@features/csm-operations/components/IncidentActionBar";
+import IncidentResolutionDialog from "@features/csm-operations/components/IncidentResolutionDialog";
 import {
   incidentCommentGateReason,
   incidentPriorityColor,
@@ -53,7 +64,12 @@ import {
   usePostCsmCaseAttachment,
   useDownloadCsmCaseAttachment,
 } from "@features/csm-cases/api/useCsmCaseAttachments";
-import type { BeEntityRef, BeIncidentDetail, BeUpdateIncidentPayload } from "@api/backend/types";
+import type {
+  BeEntityRef,
+  BeIncidentDetail,
+  BeIncidentState,
+  BeUpdateIncidentPayload,
+} from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 
 const OPERATIONS_INCIDENTS_PATH = "/operations?tab=incidents";
@@ -62,9 +78,9 @@ const OPERATIONS_INCIDENTS_PATH = "/operations?tab=incidents";
  * Two confirmed-live upstream limitations of `PATCH /incidents/{id}`
  * (entity-service/ServiceNow, not this BFF or the FE) — a third,
  * `state: RESOLVED`/`CLOSED` 500ing without a resolution, was fixed by
- * having `EditIncidentDialog` collect `resolutionCode`/`resolutionNotes`
- * (write-only fields, no read-side model — see `BeUpdateIncidentPayload`)
- * once the target state is one of those two:
+ * having `EditIncidentDialog`/`IncidentResolutionDialog` collect
+ * `resolutionCode`/`resolutionNotes` (write-only fields, no read-side model
+ * — see `BeUpdateIncidentPayload`) once the target state is one of those two:
  *  - `watchList` 404s ("The requested resource was not found!") for *any*
  *    id — confirmed with both an anonymous service account and a real, named
  *    person, so it isn't a bad-id problem on our side.
@@ -117,10 +133,26 @@ function RefText({ value }: { value?: BeEntityRef | null }): JSX.Element {
   return <Typography variant="body2">{value?.name || "—"}</Typography>;
 }
 
+type IncidentTabId = "activities" | "details" | "related" | "watchers" | "attachments";
+
+const TAB_DEFS: Array<{ id: IncidentTabId; label: string; icon: JSX.Element }> = [
+  { id: "activities", label: "Activities", icon: <Activity size={16} /> },
+  { id: "details", label: "Details", icon: <FileText size={16} /> },
+  { id: "related", label: "Related", icon: <LinkIcon size={16} /> },
+  { id: "watchers", label: "Watchers", icon: <Eye size={16} /> },
+  { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
+];
+
 /**
- * Detail for a single incident (`GET /incidents/{id}`), with an Edit dialog
- * (`PATCH /incidents/{id}`) mirroring the change-request detail page's
- * pattern.
+ * Detail for a single incident (`GET /incidents/{id}`), tabbed to match
+ * `CsmCaseDetailPage`'s structural pattern — Activities / Details / Related /
+ * Watchers / Attachments. Incidents have no call-requests, time-tracking, or
+ * tasks concept in this platform, so those case tabs are intentionally not
+ * carried over. State transitions (`PATCH /incidents/{id} { state }`) via
+ * `IncidentActionBar`; `RESOLVED`/`CLOSED` route through
+ * `IncidentResolutionDialog` first, since ServiceNow requires a resolution
+ * code/notes for those two (see `checkSilentlyDroppedNotes`'s doc comment
+ * for the related, already-handled `additionalComments`/`workNotes` quirk).
  */
 export default function CsmIncidentDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
@@ -129,6 +161,10 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   const { showError } = useErrorBanner();
   const patchIncident = usePatchIncident();
   const [editOpen, setEditOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<IncidentTabId>("activities");
+  const [resolutionTarget, setResolutionTarget] = useState<
+    Extract<BeIncidentState, "RESOLVED" | "CLOSED"> | null
+  >(null);
   const engineerName = useEngineerDisplayName();
 
   const { data: comments } = useGetCsmIncidentComments(id);
@@ -139,6 +175,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   const [composerOpen, setComposerOpen] = useState(false);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
+  const watchList = useMemo(() => data?.watchList ?? [], [data?.watchList]);
 
   const recordView = useRecordRecentView();
   useEffect(() => {
@@ -174,6 +211,55 @@ export default function CsmIncidentDetailPage(): JSX.Element {
       );
     },
     [downloadAttachment, showError],
+  );
+
+  /**
+   * Dispatch a state transition from `IncidentActionBar`. `RESOLVED`/`CLOSED`
+   * need the resolution dialog first (ServiceNow requires those fields — see
+   * the file-level doc comment); every other target PATCHes directly, same
+   * split of responsibility as `CaseActionBar` + `CsmCaseDetailPage.onAction`.
+   */
+  const onIncidentAction = useCallback(
+    (target: BeIncidentState) => {
+      if (!id) return;
+      if (target === "RESOLVED" || target === "CLOSED") {
+        setResolutionTarget(target);
+        return;
+      }
+      patchIncident.mutate(
+        { id, patch: { state: target } },
+        {
+          onError: (err) => {
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not update the incident's state. Please try again.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [id, patchIncident, showError],
+  );
+
+  const onResolutionSubmit = useCallback(
+    (fields: { resolutionCode: string; resolutionNotes: string }) => {
+      if (!id || !resolutionTarget) return;
+      patchIncident.mutate(
+        { id, patch: { state: resolutionTarget, ...fields } },
+        {
+          onSuccess: () => setResolutionTarget(null),
+          onError: (err) => {
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not update the incident's state. Please try again.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [id, patchIncident, resolutionTarget, showError],
   );
 
   const back = (): void => {
@@ -225,8 +311,9 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   }
 
   const incident = data;
-  const hasNotes = !!(incident.additionalComments || incident.workNotes);
   const hasLinks = !!(incident.parent || incident.changeRequest || incident.problem || incident.causedBy);
+  const hasLinkedServiceRequests =
+    !!incident.linkedServiceRequests && incident.linkedServiceRequests.length > 0;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
@@ -250,15 +337,21 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               label={incidentPriorityLabel(incident.priority)}
             />
           )}
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<Pencil size={14} />}
-            onClick={() => setEditOpen(true)}
-            sx={{ ml: "auto", flexShrink: 0 }}
-          >
-            Edit
-          </Button>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, ml: "auto", flexShrink: 0 }}>
+            <IncidentActionBar
+              incident={incident}
+              isPending={patchIncident.isPending}
+              onAction={onIncidentAction}
+            />
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<Pencil size={14} />}
+              onClick={() => setEditOpen(true)}
+            >
+              Edit
+            </Button>
+          </Box>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
           {incident.number || incident.id}
@@ -281,18 +374,9 @@ export default function CsmIncidentDetailPage(): JSX.Element {
           {(
             [
               { label: "Caller", render: () => <RefText value={incident.caller} /> },
-              { label: "Category", render: () => <Typography variant="body2">{incident.category || "—"}</Typography> },
-              { label: "Subcategory", render: () => <Typography variant="body2">{incident.subcategory || "—"}</Typography> },
-              { label: "Contact type", render: () => <Typography variant="body2">{incident.contactType || "—"}</Typography> },
-              { label: "Impact", render: () => <Typography variant="body2">{incident.impact || "—"}</Typography> },
-              { label: "Urgency", render: () => <Typography variant="body2">{incident.urgency || "—"}</Typography> },
-              { label: "Service", render: () => <RefText value={incident.service} /> },
-              { label: "Service offering", render: () => <RefText value={incident.serviceOffering} /> },
-              { label: "Configuration item", render: () => <RefText value={incident.configurationItem} /> },
               { label: "Assignment group", render: () => <RefText value={incident.assignmentGroup} /> },
               { label: "Assigned to", render: () => <RefText value={incident.assignedTo} /> },
               { label: "Opened", render: () => <Typography variant="body2">{formatDateTime(incident.openedOn)}</Typography> },
-              { label: "Created", render: () => <Typography variant="body2">{formatDateTime(incident.createdOn)}</Typography> },
               { label: "Created by", render: () => <Typography variant="body2">{incident.createdBy || "—"}</Typography> },
               { label: "Last updated", render: () => <Typography variant="body2">{formatDateTime(incident.updatedOn)}</Typography> },
             ] satisfies Array<{ label: string; render: () => JSX.Element }>
@@ -304,170 +388,278 @@ export default function CsmIncidentDetailPage(): JSX.Element {
         </Box>
       </Card>
 
-      {hasLinks && (
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, v) => setActiveTab(v as IncidentTabId)}
+          variant="scrollable"
+          scrollButtons="auto"
+        >
+          {TAB_DEFS.map((t) => {
+            const count =
+              t.id === "watchers"
+                ? watchList.length
+                : t.id === "attachments"
+                  ? attachmentList.length
+                  : undefined;
+            return (
+              <Tab
+                key={t.id}
+                value={t.id}
+                icon={t.icon}
+                iconPosition="start"
+                label={count ? `${t.label} (${count})` : t.label}
+                sx={{ minHeight: 44, textTransform: "none" }}
+              />
+            );
+          })}
+        </Tabs>
+      </Box>
+
+      {activeTab === "activities" && (
         <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-          <Typography variant="subtitle2">Linked records</Typography>
-          <Box
-            sx={{
-              display: "grid",
-              gap: 2,
-              gridTemplateColumns: {
-                xs: "1fr",
-                sm: "repeat(2, minmax(0, 1fr))",
-                md: "repeat(4, minmax(0, 1fr))",
-              },
-            }}
-          >
-            <MetaCell label="Parent incident">
-              <EntityRefLink value={incident.parent} routeBase="/operations/incidents" />
-            </MetaCell>
-            <MetaCell label="Change request">
-              <EntityRefLink value={incident.changeRequest} routeBase="/operations/change-requests" />
-            </MetaCell>
-            <MetaCell label="Problem">
-              <EntityRefLink value={incident.problem} routeBase="/operations/problems" />
-            </MetaCell>
-            {/* "Caused by" has no confirmed target record type (could be a
-                change request, a problem, or something else) — same caveat
-                as Problem.originCase — so it's left as plain text rather
-                than guessing a route. */}
-            <MetaCell label="Caused by"><RefText value={incident.causedBy} /></MetaCell>
-          </Box>
+          {composerOpen ? (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                <Typography variant="subtitle2">Reply</Typography>
+                <Button
+                  size="small"
+                  variant="text"
+                  color="inherit"
+                  onClick={() => setComposerOpen(false)}
+                >
+                  Cancel
+                </Button>
+              </Box>
+              <CsmCaseCommentInput
+                disabled={!id}
+                publicCommentDisabledReason={incidentCommentGateReason(incident.state)}
+                autoFocus
+                onSubmit={async (bodyHtml, internal, commentAttachments) => {
+                  if (!id) return;
+                  const hasText =
+                    bodyHtml.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length > 0;
+                  if (hasText) {
+                    await postComment.mutateAsync({
+                      incidentId: id,
+                      bodyHtml,
+                      internal,
+                    });
+                  }
+                  for (const { file, name } of commentAttachments) {
+                    await postAttachment.mutateAsync({
+                      caseId: id,
+                      file,
+                      name,
+                      uploadedBy: engineerName,
+                      referenceType: "incident",
+                    });
+                  }
+                  setComposerOpen(false);
+                }}
+              />
+            </Box>
+          ) : (
+            <Button
+              fullWidth
+              variant="outlined"
+              color="inherit"
+              startIcon={<MessageSquarePlus size={18} />}
+              onClick={() => setComposerOpen(true)}
+              sx={{ justifyContent: "flex-start", textTransform: "none", py: 1.5, px: 2 }}
+            >
+              Add a comment…
+            </Button>
+          )}
+          <CaseActivitiesFeed
+            comments={comments ?? []}
+            audit={[]}
+            attachments={[]}
+          />
         </Card>
       )}
 
-      {hasNotes && (
-        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
-          <Typography variant="subtitle2">Comments &amp; notes</Typography>
-          {incident.additionalComments && (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-              <Typography variant="body2" color="text.secondary">
-                Additional comments (customer-visible)
-              </Typography>
-              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                {incident.additionalComments}
-              </Typography>
+      {activeTab === "details" && (
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              md: "repeat(2, minmax(0, 1fr))",
+            },
+            alignItems: "start",
+          }}
+        >
+          <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Typography variant="subtitle2">Classification</Typography>
+            <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}>
+              <MetaCell label="Category">
+                <Typography variant="body2">{incident.category || "—"}</Typography>
+              </MetaCell>
+              <MetaCell label="Subcategory">
+                <Typography variant="body2">{incident.subcategory || "—"}</Typography>
+              </MetaCell>
+              <MetaCell label="Contact type">
+                <Typography variant="body2">{incident.contactType || "—"}</Typography>
+              </MetaCell>
+              <MetaCell label="Impact">
+                <Typography variant="body2">{incident.impact || "—"}</Typography>
+              </MetaCell>
+              <MetaCell label="Urgency">
+                <Typography variant="body2">{incident.urgency || "—"}</Typography>
+              </MetaCell>
+              <MetaCell label="Created">
+                <Typography variant="body2">{formatDateTime(incident.createdOn)}</Typography>
+              </MetaCell>
             </Box>
-          )}
-          {incident.workNotes && (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-              <Typography variant="body2" color="text.secondary">
-                Internal work notes
-              </Typography>
-              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                {incident.workNotes}
-              </Typography>
+          </Card>
+
+          <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Typography variant="subtitle2">Service &amp; configuration</Typography>
+            <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}>
+              <MetaCell label="Service"><RefText value={incident.service} /></MetaCell>
+              <MetaCell label="Service offering"><RefText value={incident.serviceOffering} /></MetaCell>
+              <MetaCell label="Configuration item"><RefText value={incident.configurationItem} /></MetaCell>
             </Box>
+          </Card>
+
+          {(incident.additionalComments || incident.workNotes) && (
+            <Card
+              sx={{
+                p: 2.5,
+                display: "flex",
+                flexDirection: "column",
+                gap: 2.5,
+                gridColumn: { xs: "auto", md: "1 / -1" },
+              }}
+            >
+              <Typography variant="subtitle2">Comments &amp; notes</Typography>
+              {incident.additionalComments && (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    Additional comments (customer-visible)
+                  </Typography>
+                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                    {incident.additionalComments}
+                  </Typography>
+                </Box>
+              )}
+              {incident.workNotes && (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    Internal work notes
+                  </Typography>
+                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                    {incident.workNotes}
+                  </Typography>
+                </Box>
+              )}
+            </Card>
           )}
-        </Card>
+        </Box>
       )}
 
-      {incident.watchList && incident.watchList.length > 0 && (
+      {activeTab === "related" && (
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              md: "repeat(2, minmax(0, 1fr))",
+            },
+            alignItems: "start",
+          }}
+        >
+          {hasLinks ? (
+            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+              <Typography variant="subtitle2">Linked records</Typography>
+              <Box
+                sx={{
+                  display: "grid",
+                  gap: 2,
+                  gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                }}
+              >
+                <MetaCell label="Parent incident">
+                  <EntityRefLink value={incident.parent} routeBase="/operations/incidents" />
+                </MetaCell>
+                <MetaCell label="Change request">
+                  <EntityRefLink value={incident.changeRequest} routeBase="/operations/change-requests" />
+                </MetaCell>
+                <MetaCell label="Problem">
+                  <EntityRefLink value={incident.problem} routeBase="/operations/problems" />
+                </MetaCell>
+                {/* "Caused by" has no confirmed target record type (could be a
+                    change request, a problem, or something else) — same caveat
+                    as Problem.originCase — so it's left as plain text rather
+                    than guessing a route. */}
+                <MetaCell label="Caused by"><RefText value={incident.causedBy} /></MetaCell>
+              </Box>
+            </Card>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No linked records for this incident.
+            </Typography>
+          )}
+
+          {hasLinkedServiceRequests && (
+            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <Typography variant="subtitle2">Linked service requests</Typography>
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                {incident.linkedServiceRequests?.map((sr) => (
+                  <Chip
+                    key={sr.id}
+                    size="small"
+                    variant="outlined"
+                    clickable
+                    label={`${sr.number} — ${sr.name}`}
+                    onClick={() => navigate(`/cases/${encodeURIComponent(sr.id)}`)}
+                    sx={{ fontWeight: 600 }}
+                  />
+                ))}
+              </Box>
+            </Card>
+          )}
+        </Box>
+      )}
+
+      {activeTab === "watchers" && (
         <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
           <Typography variant="subtitle2">Watch list</Typography>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-            {incident.watchList.map((w) => (
-              <Chip key={w.id} size="small" variant="outlined" label={w.name || w.email} />
-            ))}
-          </Box>
-        </Card>
-      )}
-
-      {incident.linkedServiceRequests && incident.linkedServiceRequests.length > 0 && (
-        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-          <Typography variant="subtitle2">Linked service requests</Typography>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-            {incident.linkedServiceRequests.map((sr) => (
-              <Chip
-                key={sr.id}
-                size="small"
-                variant="outlined"
-                clickable
-                label={`${sr.number} — ${sr.name}`}
-                onClick={() => navigate(`/cases/${encodeURIComponent(sr.id)}`)}
-                sx={{ fontWeight: 600 }}
-              />
-            ))}
-          </Box>
-        </Card>
-      )}
-
-      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-        <Typography variant="subtitle2">Comments</Typography>
-        {composerOpen ? (
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-              <Typography variant="subtitle2">Reply</Typography>
-              <Button
-                size="small"
-                variant="text"
-                color="inherit"
-                onClick={() => setComposerOpen(false)}
-              >
-                Cancel
-              </Button>
+          {watchList.length > 0 ? (
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+              {watchList.map((w) => (
+                <Chip key={w.id} size="small" variant="outlined" label={w.name || w.email} />
+              ))}
             </Box>
-            <CsmCaseCommentInput
-              disabled={!id}
-              publicCommentDisabledReason={incidentCommentGateReason(incident.state)}
-              autoFocus
-              onSubmit={async (bodyHtml, internal, commentAttachments) => {
-                if (!id) return;
-                const hasText =
-                  bodyHtml.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length > 0;
-                if (hasText) {
-                  await postComment.mutateAsync({
-                    incidentId: id,
-                    bodyHtml,
-                    internal,
-                  });
-                }
-                for (const { file, name } of commentAttachments) {
-                  await postAttachment.mutateAsync({
-                    caseId: id,
-                    file,
-                    name,
-                    uploadedBy: engineerName,
-                    referenceType: "incident",
-                  });
-                }
-                setComposerOpen(false);
-              }}
-            />
-          </Box>
-        ) : (
-          <Button
-            fullWidth
-            variant="outlined"
-            color="inherit"
-            startIcon={<MessageSquarePlus size={18} />}
-            onClick={() => setComposerOpen(true)}
-            sx={{ justifyContent: "flex-start", textTransform: "none", py: 1.5, px: 2 }}
-          >
-            Add a comment…
-          </Button>
-        )}
-        <CaseActivitiesFeed
-          comments={comments ?? []}
-          audit={[]}
-          attachments={[]}
-        />
-      </Card>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No one is watching this incident.
+            </Typography>
+          )}
+          <Typography variant="caption" color="text.secondary">
+            Edit the watch list from the Edit dialog above.
+          </Typography>
+        </Card>
+      )}
 
-      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-        <Typography variant="subtitle2">Attachments</Typography>
-        <AttachmentsWidget
-          attachments={attachmentList}
-          uploading={postAttachment.isPending}
-          uploadError={
-            postAttachment.isError
-              ? (postAttachment.error?.message ?? "Could not upload the attachment.")
-              : null
-          }
-          onUpload={onUploadAttachment}
-          onDownload={onDownloadAttachment}
-        />
-      </Card>
+      {activeTab === "attachments" && (
+        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+          <AttachmentsWidget
+            attachments={attachmentList}
+            uploading={postAttachment.isPending}
+            uploadError={
+              postAttachment.isError
+                ? (postAttachment.error?.message ?? "Could not upload the attachment.")
+                : null
+            }
+            onUpload={onUploadAttachment}
+            onDownload={onDownloadAttachment}
+          />
+        </Card>
+      )}
 
       {editOpen && (
         <EditIncidentDialog
@@ -503,6 +695,17 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               },
             )
           }
+        />
+      )}
+
+      {resolutionTarget && (
+        <IncidentResolutionDialog
+          target={resolutionTarget}
+          isSubmitting={patchIncident.isPending}
+          onClose={() => {
+            if (!patchIncident.isPending) setResolutionTarget(null);
+          }}
+          onSubmit={onResolutionSubmit}
         />
       )}
     </Box>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -146,9 +146,9 @@ export default function CsmIncidentDetailPage(): JSX.Element {
     recordView({
       kind: "incident",
       id: data.id,
-      title: data.number
-        ? `${data.number} · ${data.subject ?? ""}`.trim()
-        : (data.subject ?? "(no subject)"),
+      title:
+        [data.number, data.subject].filter((s): s is string => !!s?.trim()).join(" · ") ||
+        "(no subject)",
       subtitle: data.assignedTo?.name,
       href: `/operations/incidents/${data.id}`,
     });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -63,7 +63,9 @@ import {
   useGetCsmCaseAttachments,
   usePostCsmCaseAttachment,
   useDownloadCsmCaseAttachment,
+  useGetCsmCaseAttachmentContent,
 } from "@features/csm-cases/api/useCsmCaseAttachments";
+import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
 import type {
   BeEntityRef,
   BeIncidentDetail,
@@ -172,7 +174,12 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   const { data: attachments } = useGetCsmCaseAttachments(id, "incident");
   const postAttachment = usePostCsmCaseAttachment();
   const downloadAttachment = useDownloadCsmCaseAttachment();
+  const getAttachmentPreviewContent = useGetCsmCaseAttachmentContent();
   const [composerOpen, setComposerOpen] = useState(false);
+  // Shared between the Activities feed and the Attachments tab, same as
+  // CsmCaseDetailPage — one attachment previewed at a time regardless of
+  // which surface opened it.
+  const [previewTarget, setPreviewTarget] = useState<CaseAttachment | null>(null);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
   const watchList = useMemo(() => data?.watchList ?? [], [data?.watchList]);
@@ -474,7 +481,13 @@ export default function CsmIncidentDetailPage(): JSX.Element {
           <CaseActivitiesFeed
             comments={comments ?? []}
             audit={[]}
-            attachments={[]}
+            attachments={attachmentList}
+            onDownloadAttachment={onDownloadAttachment}
+            preview={{
+              onGetPreviewContent: getAttachmentPreviewContent,
+              previewTarget,
+              onPreviewTargetChange: setPreviewTarget,
+            }}
           />
         </Card>
       )}
@@ -657,6 +670,11 @@ export default function CsmIncidentDetailPage(): JSX.Element {
             }
             onUpload={onUploadAttachment}
             onDownload={onDownloadAttachment}
+            preview={{
+              onGetPreviewContent: getAttachmentPreviewContent,
+              previewTarget,
+              onPreviewTargetChange: setPreviewTarget,
+            }}
           />
         </Card>
       )}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -16,12 +16,20 @@
 
 import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, MessageSquarePlus, Pencil } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode, useCallback, useMemo, useState } from "react";
+import {
+  type JSX,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
+import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useGetIncident } from "@features/csm-operations/api/useGetIncident";
 import { usePatchIncident } from "@features/csm-operations/api/usePatchIncident";
 import {
@@ -131,6 +139,20 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   const [composerOpen, setComposerOpen] = useState(false);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
+
+  const recordView = useRecordRecentView();
+  useEffect(() => {
+    if (!data?.id) return;
+    recordView({
+      kind: "incident",
+      id: data.id,
+      title: data.number
+        ? `${data.number} · ${data.subject ?? ""}`.trim()
+        : (data.subject ?? "(no subject)"),
+      subtitle: data.assignedTo?.name,
+      href: `/operations/incidents/${data.id}`,
+    });
+  }, [data, recordView]);
 
   const onUploadAttachment = useCallback(
     (file: File) => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -105,9 +105,9 @@ export default function ProblemDetailPage(): JSX.Element {
     recordView({
       kind: "problem",
       id: data.id,
-      title: data.number
-        ? `${data.number} · ${data.subject ?? ""}`.trim()
-        : (data.subject ?? "(no subject)"),
+      title:
+        [data.number, data.subject].filter((s): s is string => !!s?.trim()).join(" · ") ||
+        "(no subject)",
       subtitle: data.assignedTo?.name,
       href: `/operations/problems/${data.id}`,
     });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -16,13 +16,14 @@
 
 import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Link as LinkIcon } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode } from "react";
+import { type JSX, type ReactNode, useEffect } from "react";
 import { useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useGetProblem } from "@features/csm-operations/api/useGetProblem";
 import { problemStateColor, problemStateLabel } from "@features/csm-operations/utils/problems";
 import type { BeEntityRef, BeProblemRef } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 
 const OPERATIONS_PROBLEMS_PATH = "/operations?tab=problems";
 
@@ -97,6 +98,20 @@ export default function ProblemDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
   const { data, isLoading, isError } = useGetProblem(id);
+
+  const recordView = useRecordRecentView();
+  useEffect(() => {
+    if (!data?.id) return;
+    recordView({
+      kind: "problem",
+      id: data.id,
+      title: data.number
+        ? `${data.number} · ${data.subject ?? ""}`.trim()
+        : (data.subject ?? "(no subject)"),
+      subtitle: data.assignedTo?.name,
+      href: `/operations/problems/${data.id}`,
+    });
+  }, [data, recordView]);
 
   const back = (): void => {
     navigate(OPERATIONS_PROBLEMS_PATH);

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.test.tsx
@@ -64,9 +64,9 @@ const { default: QuickNav } = await import("./QuickNav");
 
 const idleResult = { data: undefined, isFetching: false };
 
-function renderQuickNav() {
+function renderQuickNav(initialEntries?: string[]) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <QuickNav />
     </MemoryRouter>,
   );
@@ -146,5 +146,47 @@ describe("QuickNav", () => {
     expect(screen.queryByText("Change Requests")).not.toBeInTheDocument();
     expect(screen.queryByText("Problems")).not.toBeInTheDocument();
     expect(screen.getByText("No matches.")).toBeInTheDocument();
+  });
+
+  it("opens pre-filled and searching from a `?q=` link", async () => {
+    renderQuickNav(["/?q=CS0440883"]);
+
+    const input = await screen.findByLabelText("Quick nav search");
+    expect(input).toHaveValue("CS0440883");
+    await waitFor(() =>
+      expect(quickCaseSearchMock).toHaveBeenLastCalledWith("CS0440883"),
+    );
+  });
+
+  it("auto-navigates to the single record a `?goto=` link resolves to", async () => {
+    quickIncidentSearchMock.mockReturnValue({
+      data: [
+        {
+          id: "inc-1",
+          number: "INC0001234",
+          subject: "Prod cluster down",
+          state: "IN_PROGRESS",
+        },
+      ],
+      isFetching: false,
+    });
+
+    renderQuickNav(["/?goto=INC0001234"]);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/operations/incidents/inc-1"),
+    );
+  });
+
+  it("leaves the palette open when `?goto=` matches nothing", async () => {
+    renderQuickNav(["/?goto=NOPE0000"]);
+
+    const input = await screen.findByLabelText("Quick nav search");
+    await waitFor(() =>
+      expect(quickCaseSearchMock).toHaveBeenLastCalledWith("NOPE0000"),
+    );
+    await waitFor(() => expect(screen.getByText("No matches.")).toBeInTheDocument());
+    expect(input).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.test.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@asgardeo/react", () => ({
+  useAsgardeo: () => ({ isSignedIn: true }),
+}));
+
+vi.mock("@features/csm-recent/hooks/useRecentViews", () => ({
+  useRecentViews: () => [],
+}));
+
+vi.mock("@config/featureFlags", () => ({
+  navigableNavNodes: () => [],
+}));
+
+const quickCaseSearchMock = vi.fn();
+vi.mock("@features/csm-cases/api/useQuickCaseSearch", () => ({
+  QUICK_CASE_MIN_QUERY_LEN: 2,
+  useQuickCaseSearch: (q: string) => quickCaseSearchMock(q),
+}));
+
+const quickIncidentSearchMock = vi.fn();
+vi.mock("@features/csm-operations/api/useQuickIncidentSearch", () => ({
+  QUICK_INCIDENT_MIN_QUERY_LEN: 2,
+  useQuickIncidentSearch: (q: string) => quickIncidentSearchMock(q),
+}));
+
+const quickChangeRequestSearchMock = vi.fn();
+vi.mock("@features/csm-operations/api/useQuickChangeRequestSearch", () => ({
+  QUICK_CHANGE_REQUEST_MIN_QUERY_LEN: 2,
+  useQuickChangeRequestSearch: (q: string) => quickChangeRequestSearchMock(q),
+}));
+
+const quickProblemSearchMock = vi.fn();
+vi.mock("@features/csm-operations/api/useQuickProblemSearch", () => ({
+  QUICK_PROBLEM_MIN_QUERY_LEN: 2,
+  useQuickProblemSearch: (q: string) => quickProblemSearchMock(q),
+}));
+
+const navigateMock = vi.fn();
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+
+const { default: QuickNav } = await import("./QuickNav");
+
+const idleResult = { data: undefined, isFetching: false };
+
+function renderQuickNav() {
+  return render(
+    <MemoryRouter>
+      <QuickNav />
+    </MemoryRouter>,
+  );
+}
+
+async function openAndType(query: string) {
+  renderQuickNav();
+  fireEvent.click(screen.getByLabelText("Search or jump to (open quick nav)"));
+  const input = await screen.findByLabelText("Quick nav search");
+  fireEvent.change(input, { target: { value: query } });
+  // Wait past the 180ms debounce for the search hooks to be called with the
+  // settled query.
+  await waitFor(() =>
+    expect(quickCaseSearchMock).toHaveBeenLastCalledWith(query),
+  );
+}
+
+describe("QuickNav", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    quickCaseSearchMock.mockReturnValue(idleResult);
+    quickIncidentSearchMock.mockReturnValue(idleResult);
+    quickChangeRequestSearchMock.mockReturnValue(idleResult);
+    quickProblemSearchMock.mockReturnValue(idleResult);
+  });
+
+  it("renders an 'Incidents' section for a live incident hit and links to the incident route", async () => {
+    quickIncidentSearchMock.mockReturnValue({
+      data: [
+        {
+          id: "inc-1",
+          number: "INC0001234",
+          subject: "Prod cluster down",
+          state: "IN_PROGRESS",
+          assigneeName: "Jane Doe",
+        },
+      ],
+      isFetching: false,
+    });
+
+    await openAndType("cluster");
+
+    expect(await screen.findByText("Incidents")).toBeInTheDocument();
+    expect(screen.getByText("INC0001234")).toBeInTheDocument();
+    expect(screen.getByText("Prod cluster down")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Prod cluster down"));
+    expect(navigateMock).toHaveBeenCalledWith("/operations/incidents/inc-1");
+  });
+
+  it("renders a 'Change Requests' section for a live CR hit and links to the change-request route", async () => {
+    quickChangeRequestSearchMock.mockReturnValue({
+      data: [
+        {
+          id: "cr-1",
+          number: "CHG0005",
+          subject: "Upgrade the API gateway",
+          state: "assess",
+          assigneeName: "John Smith",
+        },
+      ],
+      isFetching: false,
+    });
+
+    await openAndType("upgrade");
+
+    expect(await screen.findByText("Change Requests")).toBeInTheDocument();
+    expect(screen.getByText("CHG0005")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Upgrade the API gateway"));
+    expect(navigateMock).toHaveBeenCalledWith("/operations/change-requests/cr-1");
+  });
+
+  it("shows no entity sections beyond Pages while nothing has matched", async () => {
+    await openAndType("zz");
+    expect(screen.queryByText("Incidents")).not.toBeInTheDocument();
+    expect(screen.queryByText("Change Requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("Problems")).not.toBeInTheDocument();
+    expect(screen.getByText("No matches.")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -25,6 +25,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Search } from "@wso2/oxygen-ui-icons-react";
 import { useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { useSearchParams } from "react-router";
 import { useAsgardeo } from "@asgardeo/react";
 
 import { navigableNavNodes } from "@config/featureFlags";
@@ -106,6 +107,14 @@ export default function QuickNav(): JSX.Element | null {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
 
+  // Shareable-link support: `?q=` opens the palette pre-filled with a search
+  // (e.g. a link like `/?q=CS0440883` someone pastes to a colleague), and
+  // `?goto=` additionally auto-jumps into the single matching record once
+  // its search settles, instead of leaving the user to click it themselves.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [gotoTarget, setGotoTarget] = useState<string | null>(null);
+  const consumedInitialParams = useRef(false);
+
   // Debounce the text fed to the case-search API so each keystroke doesn't fire
   // a request; the in-memory pinned/recent/page matching still reacts instantly
   // to `query`.
@@ -146,6 +155,24 @@ export default function QuickNav(): JSX.Element | null {
   const problemSearch = useQuickProblemSearch(open ? debouncedQuery : "");
 
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Consume `?q=`/`?goto=` once per page load, not on every render — a
+  // `setSearchParams` below removes them from the URL, and re-reading them
+  // after that (e.g. from a stale closure) would just no-op harmlessly, but
+  // this guard also stops a re-mount from re-opening the palette if the user
+  // has already closed it once this session.
+  useEffect(() => {
+    if (!isSignedIn || consumedInitialParams.current) return;
+    const q = searchParams.get("q");
+    const goto = searchParams.get("goto");
+    if (!q && !goto) return;
+    consumedInitialParams.current = true;
+    /* eslint-disable react-hooks/set-state-in-effect -- syncs palette state to an external one-shot source (the URL's initial q/goto params) */
+    setOpen(true);
+    setQuery(goto || q || "");
+    if (goto) setGotoTarget(goto.trim());
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [isSignedIn, searchParams]);
 
   // ⌘K / Ctrl+K toggles the palette — only while signed in, so we don't hijack
   // the browser shortcut on the sign-in screen (where the palette can't render).
@@ -341,6 +368,83 @@ export default function QuickNav(): JSX.Element | null {
     close();
     navigate(r.href);
   };
+
+  // `?goto=` resolution: once every search this query feeds has settled (not
+  // just the case search — an incident/CR/problem number should auto-jump
+  // too), look for an exact (case-insensitive) match on whichever identifier
+  // a person would actually paste into a link — a display number
+  // (`CS0440883`/`INC0012345`/...), the internal WSO2 case id, or a raw
+  // record id — across all four result sets combined. Exactly one match
+  // navigates straight there; zero or multiple matches leave the palette
+  // open on its normal search results so the user can pick, since a forced
+  // jump would be wrong (or arbitrary) either way.
+  useEffect(() => {
+    if (!gotoTarget) return;
+    const allSettled =
+      caseHitsSettled &&
+      !caseSearch.isFetching &&
+      !incidentSearch.isFetching &&
+      !changeRequestSearch.isFetching &&
+      !problemSearch.isFetching;
+    if (!allSettled) return;
+
+    const target = gotoTarget.toLowerCase();
+    const matchesTarget = (...ids: (string | null | undefined)[]) =>
+      ids.some((id) => id?.toLowerCase() === target);
+
+    const caseHref = (caseSearch.data ?? []).find((c) =>
+      matchesTarget(c.id, c.caseNumber, c.wso2CaseId),
+    );
+    const incidentHref = (incidentSearch.data ?? []).find((i) =>
+      matchesTarget(i.id, i.number),
+    );
+    const crHref = (changeRequestSearch.data ?? []).find((cr) =>
+      matchesTarget(cr.id, cr.number),
+    );
+    const problemHref = (problemSearch.data ?? []).find((p) =>
+      matchesTarget(p.id, p.number),
+    );
+
+    const matches = [
+      caseHref && `/cases/${caseHref.id}`,
+      incidentHref && `/operations/incidents/${incidentHref.id}`,
+      crHref && `/operations/change-requests/${crHref.id}`,
+      problemHref && `/operations/problems/${problemHref.id}`,
+    ].filter((href): href is string => !!href);
+
+    /* eslint-disable react-hooks/set-state-in-effect -- syncs palette state to the external goto/search resolution outcome, a one-shot action once the search settles */
+    setGotoTarget(null);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("q");
+        next.delete("goto");
+        return next;
+      },
+      { replace: true },
+    );
+
+    if (matches.length === 1) {
+      close();
+      navigate(matches[0]);
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+    // matches.length === 0 or > 1: leave the palette open on its normal
+    // search results rather than guessing which one was meant.
+  }, [
+    gotoTarget,
+    caseHitsSettled,
+    caseSearch.isFetching,
+    caseSearch.data,
+    incidentSearch.isFetching,
+    incidentSearch.data,
+    changeRequestSearch.isFetching,
+    changeRequestSearch.data,
+    problemSearch.isFetching,
+    problemSearch.data,
+    navigate,
+    setSearchParams,
+  ]);
 
   const onListKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -35,6 +35,7 @@ import {
 } from "@features/csm-recent/hooks/useRecentViews";
 import { kindIcon } from "@features/csm-recent/kindMeta";
 import QuickNavCaseCard from "@features/csm-recent/components/QuickNavCaseCard";
+import QuickNavEntityCard from "@features/csm-recent/components/QuickNavEntityCard";
 import QuickNavResultSkeleton from "@features/csm-recent/components/QuickNavResultSkeleton";
 import SearchNoResultsIcon from "@components/empty-state/SearchNoResultsIcon";
 import {
@@ -44,8 +45,36 @@ import {
 } from "@features/csm-cases/api/useQuickCaseSearch";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { useNavTransition } from "@hooks/useNavTransition";
+import {
+  QUICK_INCIDENT_MIN_QUERY_LEN,
+  useQuickIncidentSearch,
+} from "@features/csm-operations/api/useQuickIncidentSearch";
+import {
+  QUICK_CHANGE_REQUEST_MIN_QUERY_LEN,
+  useQuickChangeRequestSearch,
+} from "@features/csm-operations/api/useQuickChangeRequestSearch";
+import {
+  QUICK_PROBLEM_MIN_QUERY_LEN,
+  useQuickProblemSearch,
+} from "@features/csm-operations/api/useQuickProblemSearch";
 
-type Section = "Cases" | "Pinned" | "Recents" | "Pages";
+type Section =
+  | "Cases"
+  | "Incidents"
+  | "Change Requests"
+  | "Problems"
+  | "Pinned"
+  | "Recents"
+  | "Pages";
+
+/** Minimal shape `QuickNavEntityCard` needs, shared by incident/CR/problem hits. */
+interface EntityCardHit {
+  icon: JSX.Element;
+  idLabel?: string | null;
+  subject: string;
+  state?: string | null;
+  assigneeName?: string;
+}
 
 interface Result {
   key: string;
@@ -56,6 +85,8 @@ interface Result {
   section: Section;
   /** Present only for "Cases" results — renders as a rich card instead of a plain row. */
   caseHit?: QuickCaseHit;
+  /** Present only for Incident/Change-request/Problem results — see {@link EntityCardHit}. */
+  entityHit?: EntityCardHit;
 }
 
 const RECENT_LIMIT = 8;
@@ -101,6 +132,18 @@ export default function QuickNav(): JSX.Element | null {
   // `caseSearch.data` still holds the previous results. Without this,
   // the skeleton block and the real "Cases" section would render together.
   const showCasesSkeleton = casesLoading && !caseSearch.data;
+
+  // Same debounced query string fans out to the other searchable entity
+  // kinds — one shared debounce (above) rather than each hook debouncing its
+  // own copy, so a keystroke costs at most one query-string change, not four.
+  // Incidents/CRs/problems are ServiceNow-only and comparatively rare hits,
+  // so — unlike Cases — these don't get a dedicated skeleton: their sections
+  // simply appear once data lands, same as Pinned/Recent/Pages.
+  const incidentSearch = useQuickIncidentSearch(open ? debouncedQuery : "");
+  const changeRequestSearch = useQuickChangeRequestSearch(
+    open ? debouncedQuery : "",
+  );
+  const problemSearch = useQuickProblemSearch(open ? debouncedQuery : "");
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -150,6 +193,66 @@ export default function QuickNav(): JSX.Element | null {
               caseHit: c,
             };
           })
+        : [];
+
+    // Same "only once the debounce settled" gating as Cases above, so a
+    // stale incident/CR/problem hit never stays clickable mid-typing either.
+    const incidents: Result[] =
+      caseHitsSettled && trimmedQuery.length >= QUICK_INCIDENT_MIN_QUERY_LEN
+        ? (incidentSearch.data ?? []).map((i) => ({
+            key: `incident-${i.id}`,
+            icon: kindIcon("incident", 16),
+            label: i.number || i.subject,
+            sublabel: i.number ? i.subject : undefined,
+            href: `/operations/incidents/${i.id}`,
+            section: "Incidents" as const,
+            entityHit: {
+              icon: kindIcon("incident", 16),
+              idLabel: i.number,
+              subject: i.subject,
+              state: i.state,
+              assigneeName: i.assigneeName,
+            },
+          }))
+        : [];
+
+    const changeRequests: Result[] =
+      caseHitsSettled &&
+      trimmedQuery.length >= QUICK_CHANGE_REQUEST_MIN_QUERY_LEN
+        ? (changeRequestSearch.data ?? []).map((cr) => ({
+            key: `cr-${cr.id}`,
+            icon: kindIcon("change_request", 16),
+            label: cr.number || cr.subject,
+            sublabel: cr.number ? cr.subject : undefined,
+            href: `/operations/change-requests/${cr.id}`,
+            section: "Change Requests" as const,
+            entityHit: {
+              icon: kindIcon("change_request", 16),
+              idLabel: cr.number,
+              subject: cr.subject,
+              state: cr.state,
+              assigneeName: cr.assigneeName,
+            },
+          }))
+        : [];
+
+    const problems: Result[] =
+      caseHitsSettled && trimmedQuery.length >= QUICK_PROBLEM_MIN_QUERY_LEN
+        ? (problemSearch.data ?? []).map((p) => ({
+            key: `problem-${p.id}`,
+            icon: kindIcon("problem", 16),
+            label: p.number || p.subject,
+            sublabel: p.number ? p.subject : undefined,
+            href: `/operations/problems/${p.id}`,
+            section: "Problems" as const,
+            entityHit: {
+              icon: kindIcon("problem", 16),
+              idLabel: p.number,
+              subject: p.subject,
+              state: p.state,
+              assigneeName: p.assigneeName,
+            },
+          }))
         : [];
 
     // A pinned/recent entry for a case carries a severity/status snapshot
@@ -204,8 +307,24 @@ export default function QuickNav(): JSX.Element | null {
           }))
       : [];
 
-    return [...cases, ...pinned, ...recent, ...pages];
-  }, [recents, trimmedQuery, caseHitsSettled, caseSearch.data]);
+    return [
+      ...cases,
+      ...incidents,
+      ...changeRequests,
+      ...problems,
+      ...pinned,
+      ...recent,
+      ...pages,
+    ];
+  }, [
+    recents,
+    trimmedQuery,
+    caseHitsSettled,
+    caseSearch.data,
+    incidentSearch.data,
+    changeRequestSearch.data,
+    problemSearch.data,
+  ]);
 
   // Clamp at render so a stale index from shrinking results never points past
   // the end (avoids a setState-in-effect cascade).
@@ -340,7 +459,7 @@ export default function QuickNav(): JSX.Element | null {
                 autoFocus
                 inputRef={inputRef}
                 fullWidth
-                placeholder="Search cases by id, or jump to pinned, recent, pages…"
+                placeholder="Search cases, incidents, change requests, problems, or jump to pinned, recent, pages…"
                 value={query}
                 onChange={(e) => {
                   setQuery(e.target.value);
@@ -378,7 +497,7 @@ export default function QuickNav(): JSX.Element | null {
                     />
                     <Typography variant="body2" color="text.secondary">
                       {trimmedQuery.length === 0
-                        ? "Nothing pinned or recent yet. Start typing to search cases."
+                        ? "Nothing pinned or recent yet. Start typing to search."
                         : "No matches."}
                     </Typography>
                   </Box>
@@ -405,6 +524,19 @@ export default function QuickNav(): JSX.Element | null {
                         <Box sx={{ pb: 1 }}>
                           <QuickNavCaseCard
                             hit={r.caseHit}
+                            active={i === safeActive}
+                            onMouseEnter={() => setActive(i)}
+                            onClick={() => choose(r)}
+                          />
+                        </Box>
+                      ) : r.entityHit ? (
+                        <Box sx={{ pb: 1 }}>
+                          <QuickNavEntityCard
+                            icon={r.entityHit.icon}
+                            idLabel={r.entityHit.idLabel}
+                            subject={r.entityHit.subject}
+                            state={r.entityHit.state}
+                            assigneeName={r.entityHit.assigneeName}
                             active={i === safeActive}
                             onMouseEnter={() => setActive(i)}
                             onClick={() => choose(r)}

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNavEntityCard.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNavEntityCard.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Chip, Form, Stack, Typography } from "@wso2/oxygen-ui";
+import { User } from "@wso2/oxygen-ui-icons-react";
+import type { JSX, ReactNode } from "react";
+
+interface QuickNavEntityCardProps {
+  /** Kind icon (incident/change-request/problem) — see `kindMeta.tsx`. */
+  icon: ReactNode;
+  /** Human id, e.g. the incident/CR/problem number. */
+  idLabel?: string | null;
+  subject: string;
+  /** Raw state string — these entity kinds each have their own state model
+   * (upper-snake for incidents/problems, lower-snake for CRs), so this
+   * renders as a plain outlined chip rather than reusing the case-specific
+   * `StateChip`, which assumes case lifecycle-state semantics/colors. */
+  state?: string | null;
+  assigneeName?: string;
+  active: boolean;
+  onMouseEnter: () => void;
+  onClick: () => void;
+}
+
+/** Best-effort "Upper Case" formatting for a raw, differently-cased state string. */
+function formatState(state: string): string {
+  return state
+    .toLowerCase()
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Result card for an incident/change-request/problem hit in the quick-nav
+ * palette. A smaller, kind-agnostic sibling of `QuickNavCaseCard` — these
+ * entities don't share the case severity/work-state model, so this only
+ * renders what's common: an id, a subject, a raw state, and (when known) the
+ * assignee.
+ */
+export default function QuickNavEntityCard({
+  icon,
+  idLabel,
+  subject,
+  state,
+  assigneeName,
+  active,
+  onMouseEnter,
+  onClick,
+}: QuickNavEntityCardProps): JSX.Element {
+  return (
+    <Form.CardButton
+      selected={active}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+        gap: 0.75,
+        p: 1.5,
+        width: "100%",
+        minWidth: 0,
+      }}
+    >
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: "wrap" }}>
+        {icon}
+        {idLabel && (
+          <Typography variant="body2" fontWeight={500} color="text.secondary">
+            {idLabel}
+          </Typography>
+        )}
+        {state && (
+          <Chip
+            size="small"
+            variant="outlined"
+            label={formatState(state)}
+            sx={{ height: 20, fontSize: "0.75rem" }}
+          />
+        )}
+      </Stack>
+
+      <Typography
+        variant="body2"
+        fontWeight={500}
+        color="text.primary"
+        noWrap
+        title={subject}
+      >
+        {subject}
+      </Typography>
+
+      {assigneeName && (
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <User size={13} />
+          <Typography variant="caption" color="text.secondary">
+            Assigned to {assigneeName}
+          </Typography>
+        </Stack>
+      )}
+    </Form.CardButton>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/RecentViewsButton.tsx
@@ -57,6 +57,9 @@ function groupByKind(
     account: [],
     search: [],
     page: [],
+    incident: [],
+    change_request: [],
+    problem: [],
   };
   for (const e of entries) out[e.kind].push(e);
   return out;

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
@@ -204,6 +204,78 @@ describe("useRecentViews + useRecordRecentView", () => {
     });
   });
 
+  describe("the incident/change_request/problem kinds", () => {
+    it("records and reads back a visit for each new entity kind, keyed independently of case entries", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+
+      act(() =>
+        recorder.result.current({
+          kind: "incident",
+          id: "inc-1",
+          title: "INC0001234 · Prod outage",
+          href: "/operations/incidents/inc-1",
+        }),
+      );
+      act(() =>
+        recorder.result.current({
+          kind: "change_request",
+          id: "cr-1",
+          title: "CHG0005 · Upgrade cluster",
+          href: "/operations/change-requests/cr-1",
+        }),
+      );
+      act(() =>
+        recorder.result.current({
+          kind: "problem",
+          id: "prb-1",
+          title: "PRB0009 · Recurring timeout",
+          href: "/operations/problems/prb-1",
+        }),
+      );
+
+      const kinds = reader.result.current.map((v) => v.kind);
+      expect(kinds).toEqual(["problem", "change_request", "incident"]);
+    });
+
+    it("de-dupes by kind+id even when a case and an incident happen to share the same id", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+
+      act(() => recorder.result.current(entry("shared-id")));
+      act(() =>
+        recorder.result.current({
+          kind: "incident",
+          id: "shared-id",
+          title: "Incident with the same id",
+          href: "/operations/incidents/shared-id",
+        }),
+      );
+
+      expect(reader.result.current).toHaveLength(2);
+      expect(reader.result.current.map((v) => v.kind).sort()).toEqual([
+        "case",
+        "incident",
+      ]);
+    });
+
+    it("can be pinned like any other kind", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() =>
+        recorder.result.current({
+          kind: "change_request",
+          id: "cr-1",
+          title: "CHG0005",
+          href: "/operations/change-requests/cr-1",
+        }),
+      );
+
+      act(() => toggleRecentViewPin("change_request", "cr-1"));
+      expect(reader.result.current[0].pinned).toBe(true);
+    });
+  });
+
   describe("record-then-read within a single session (identity-resolution timing)", () => {
     it("a same-session record survives navigating away and shows up to an already-mounted reader as soon as identity settles — no reload, no extra write needed", () => {
       // Mirrors `RecentViewsButton`: mounted once (e.g. in the persistent

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
@@ -24,7 +24,10 @@ export type RecentViewKind =
   | "project"
   | "account"
   | "search"
-  | "page";
+  | "page"
+  | "incident"
+  | "change_request"
+  | "problem";
 
 const RECENT_VIEW_KINDS: readonly RecentViewKind[] = [
   "case",
@@ -32,6 +35,9 @@ const RECENT_VIEW_KINDS: readonly RecentViewKind[] = [
   "account",
   "search",
   "page",
+  "incident",
+  "change_request",
+  "problem",
 ];
 
 function isRecentViewKind(v: unknown): v is RecentViewKind {

--- a/apps/csm-portal/webapp/src/features/csm-recent/kindMeta.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/kindMeta.tsx
@@ -18,8 +18,11 @@ import {
   Building,
   File,
   FolderOpen,
+  GitPullRequest,
   Headset,
   Search,
+  Siren,
+  Wrench,
 } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import type { RecentViewKind } from "@features/csm-recent/hooks/useRecentViews";
@@ -31,6 +34,9 @@ export const KIND_LABEL: Record<RecentViewKind, string> = {
   account: "Accounts",
   search: "Searches",
   page: "Pages",
+  incident: "Incidents",
+  change_request: "Change requests",
+  problem: "Problems",
 };
 
 /** Stable display order for kind groups. */
@@ -39,6 +45,9 @@ export const KIND_ORDER: RecentViewKind[] = [
   "search",
   "project",
   "account",
+  "incident",
+  "change_request",
+  "problem",
   "page",
 ];
 
@@ -54,5 +63,11 @@ export function kindIcon(kind: RecentViewKind, size = 16): JSX.Element {
       return <Search size={size} />;
     case "page":
       return <File size={size} />;
+    case "incident":
+      return <Siren size={size} />;
+    case "change_request":
+      return <GitPullRequest size={size} />;
+    case "problem":
+      return <Wrench size={size} />;
   }
 }

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -118,10 +118,16 @@ function NotAvailableYetSection({
 export default function UserProfilePage(): JSX.Element {
   const { email: emailParam } = useParams<{ email: string }>();
   const navigate = useNavTransition();
-  const email = useMemo(
-    () => (emailParam ? decodeURIComponent(emailParam) : undefined),
-    [emailParam],
-  );
+  const email = useMemo(() => {
+    if (!emailParam) return undefined;
+    try {
+      return decodeURIComponent(emailParam);
+    } catch {
+      // Malformed percent-encoding (e.g. a lone "%") — fall through to the
+      // existing not-found state instead of throwing during render.
+      return undefined;
+    }
+  }, [emailParam]);
 
   const { data, isLoading, isError, error } = useSearchUsers({
     filters: email ? { emails: [email] } : undefined,

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Card, Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, type JSX, type ReactNode } from "react";
+import { useParams } from "react-router";
+import QueryErrorState from "@components/QueryErrorState";
+import { useNavTransition } from "@hooks/useNavTransition";
+import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import {
+  INTERNAL_USER_ROLES,
+  type NormalizedUser,
+} from "@features/csm-users/types/csmUsers";
+
+function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={onClick}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back
+    </Button>
+  );
+}
+
+function MetaCell({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25, minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+/**
+ * True when `user` is internal (WSO2 staff): either the postgres source's
+ * direct `userType === "internal"`, or the ServiceNow source's `roles`
+ * containing one of {@link INTERNAL_USER_ROLES}. Absent both signals, the
+ * user is treated as a customer.
+ */
+function isInternalUser(user: NormalizedUser): boolean {
+  if (user.userType) return user.userType === "internal";
+  return (user.roles ?? []).some((r) =>
+    (INTERNAL_USER_ROLES as string[]).includes(r),
+  );
+}
+
+/**
+ * Placeholder section for data the backend doesn't expose yet, following the
+ * same visual language as `CsmComingSoonPage` and the admin `roles`/`groups`
+ * stub routes: a "Coming soon" chip plus a short description of what's
+ * blocked and why, so it reads as an intentional gap rather than a bug.
+ */
+function NotAvailableYetSection({
+  title,
+  description,
+  blockedOn,
+}: {
+  title: string;
+  description: string;
+  blockedOn: string;
+}): JSX.Element {
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Typography variant="subtitle2">{title}</Typography>
+        <Chip size="small" label="Coming soon" color="warning" variant="outlined" />
+      </Box>
+      <Typography variant="body2" color="text.secondary">
+        {description}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        Blocked on: {blockedOn}
+      </Typography>
+    </Card>
+  );
+}
+
+/**
+ * A person's profile page, reachable by clicking any user reference in the
+ * portal (case creator, assignee, watchers, comment authors, attachment
+ * uploaders). Shows only what `POST /users/search` already returns today —
+ * name, email, timezone, roles/type, active status. There is no backend
+ * endpoint yet for a customer's projects+roles or an internal user's
+ * groups/team, so that section renders the same "not available yet"
+ * placeholder used by the admin roles/groups stub routes rather than
+ * fabricating data.
+ */
+export default function UserProfilePage(): JSX.Element {
+  const { email: emailParam } = useParams<{ email: string }>();
+  const navigate = useNavTransition();
+  const email = useMemo(
+    () => (emailParam ? decodeURIComponent(emailParam) : undefined),
+    [emailParam],
+  );
+
+  const { data, isLoading, isError, error } = useSearchUsers({
+    filters: email ? { emails: [email] } : undefined,
+  });
+
+  const user = data?.users?.[0];
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Skeleton variant="rounded" height={32} width={240} />
+        <Skeleton variant="rounded" height={220} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate(-1)} />
+        <QueryErrorState
+          message={`Failed to load user: ${error instanceof Error ? error.message : "unknown error"}`}
+          error={error}
+        />
+      </Box>
+    );
+  }
+
+  if (!user) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <BackButton onClick={() => navigate(-1)} />
+        <Typography variant="h5">User not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No user with email <code>{email}</code>.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const internal = isInternalUser(user);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <BackButton onClick={() => navigate(-1)} />
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <Typography variant="h5">{user.name || user.userName || "—"}</Typography>
+          <Chip
+            size="small"
+            label={internal ? "Internal" : "Customer"}
+            color={internal ? "primary" : "default"}
+            variant="outlined"
+          />
+          {user.active !== undefined && (
+            <Chip
+              size="small"
+              label={user.active ? "Active" : "Inactive"}
+              color={user.active ? "success" : "default"}
+              variant="outlined"
+            />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          {user.email}
+        </Typography>
+      </Box>
+
+      <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="subtitle2">Overview</Typography>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <MetaCell label="Username">
+            <Typography variant="body2">{user.userName}</Typography>
+          </MetaCell>
+          <MetaCell label="Email">
+            <Typography variant="body2" sx={{ wordBreak: "break-all" }}>
+              {user.email}
+            </Typography>
+          </MetaCell>
+          <MetaCell label="Timezone">
+            <Typography variant="body2">{user.timezone ?? "Not set"}</Typography>
+          </MetaCell>
+          <MetaCell label="Roles">
+            {user.roles && user.roles.length > 0 ? (
+              <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+                {user.roles.map((r) => (
+                  <Chip
+                    key={r}
+                    size="small"
+                    label={r}
+                    color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
+                    variant="outlined"
+                  />
+                ))}
+              </Stack>
+            ) : (
+              <Typography variant="body2">—</Typography>
+            )}
+          </MetaCell>
+        </Box>
+      </Card>
+
+      {internal ? (
+        <NotAvailableYetSection
+          title="Groups, roles, and team"
+          description="This engineer's group memberships, permission roles, and CRE/SRE team assignment aren't available here yet."
+          blockedOn="csm-portal/backend groups and roles endpoints"
+        />
+      ) : (
+        <NotAvailableYetSection
+          title="Projects and roles per project"
+          description="The projects this customer has access to, and their role on each, aren't available here yet."
+          blockedOn="csm-portal/backend per-project role endpoints"
+        />
+      )}
+    </Box>
+  );
+}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -223,11 +223,15 @@ func snCaseTypeToDomain(ct *snCaseEntityRef) *string {
 	return &domainType
 }
 
-// snParentCaseTypeMap maps the raw ServiceNow task-type value carried on a
-// parent/related case reference to the API's public CaseNumberRef.type enum
-// ("case" | "incident" | "change_request" | "problem").
+// snParentCaseTypeMap maps the raw ServiceNow parent/related-case type value --
+// derived by CaseUtils.js's _mapCaseDetails from the parent record's sys_class_name
+// (sn_customerservice_case -> "case", incident -> "incident", change_request ->
+// "change_request", problem -> "problem") -- to the API's public CaseNumberRef.type
+// enum. SN already emits these exact literal strings, so this is effectively an
+// allow-list guarding against an unrecognised or future upstream value, kept as a
+// map (rather than a set) to match this file's other snXTypeMap conventions.
 var snParentCaseTypeMap = map[string]string{
-	"default_case":   "case",
+	"case":           "case",
 	"incident":       "incident",
 	"change_request": "change_request",
 	"problem":        "problem",

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -166,6 +166,99 @@ func TestSNCaseService_GetCaseByID_MapsWatchListAutoclosureAndTeams(t *testing.T
 	}
 }
 
+// TestSnParentCaseTypeToDomain covers digiops-cs#2568's follow-up: a parent/related
+// case reference's raw ServiceNow type maps to the public enum for every known
+// sys_class_name-derived value, and an unmapped or absent raw value stays nil rather
+// than leaking an unrecognised string onto the API surface.
+func TestSnParentCaseTypeToDomain(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  *string
+		want *string
+	}{
+		{name: "case", raw: strPtr("case"), want: strPtr("case")},
+		{name: "incident", raw: strPtr("incident"), want: strPtr("incident")},
+		{name: "change_request", raw: strPtr("change_request"), want: strPtr("change_request")},
+		{name: "problem", raw: strPtr("problem"), want: strPtr("problem")},
+		{name: "unrecognised value stays nil", raw: strPtr("some_future_sn_class"), want: nil},
+		{name: "nil raw stays nil", raw: nil, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := snParentCaseTypeToDomain(tt.raw)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("snParentCaseTypeToDomain(%v) = %v, want %v", tt.raw, got, tt.want)
+			}
+			if got != nil && *got != *tt.want {
+				t.Fatalf("snParentCaseTypeToDomain(%v) = %q, want %q", tt.raw, *got, *tt.want)
+			}
+		})
+	}
+}
+
+// TestSNCaseService_GetCaseByID_MapsParentCaseType verifies digiops-cs#2568's follow-up
+// end to end: a GetCaseByID response carrying parentCase.type resolves to the matching
+// domain.CaseNumberRef.Type for a known value, and stays nil for an unrecognised one --
+// never passing the raw ServiceNow string through unmapped.
+func TestSNCaseService_GetCaseByID_MapsParentCaseType(t *testing.T) {
+	newBody := func(parentType string) string {
+		return `{
+			"id": "` + testWLCaseSysid + `",
+			"internalId": "WSO2-001",
+			"number": "CS0001001",
+			"title": "Case subject",
+			"description": "Case description",
+			"createdOn": "2026-01-01 10:00:00",
+			"updatedOn": "2026-01-02 10:00:00",
+			"createdBy": "reporter@example.com",
+			"project": {"id": "` + testProjectSysid + `", "name": "Project A"},
+			"deployment": {"id": "", "name": ""},
+			"deployedProduct": {"id": "", "name": "", "version": ""},
+			"state": {"id": 1, "label": "Open"},
+			"parentCase": {"id": "` + testParentCaseUUID + `", "number": "INC0012345", "type": "` + parentType + `"}
+		}`
+	}
+
+	t.Run("known type maps through", func(t *testing.T) {
+		client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(newBody("incident")))
+		})
+		svc := NewServiceNowCaseService(client, nil)
+
+		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cv.ParentCase == nil {
+			t.Fatalf("expected parentCase to be populated")
+		}
+		if cv.ParentCase.Type == nil || *cv.ParentCase.Type != "incident" {
+			t.Fatalf("expected parentCase.type=incident, got %+v", cv.ParentCase.Type)
+		}
+	})
+
+	t.Run("unrecognised type stays nil", func(t *testing.T) {
+		client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(newBody("some_future_sn_class")))
+		})
+		svc := NewServiceNowCaseService(client, nil)
+
+		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cv.ParentCase == nil {
+			t.Fatalf("expected parentCase to be populated (id/number still present)")
+		}
+		if cv.ParentCase.Type != nil {
+			t.Fatalf("expected parentCase.type=nil for unrecognised SN value, got %q", *cv.ParentCase.Type)
+		}
+	})
+}
+
 // TestSNCaseService_GetCaseByID_BallerinaBlockedFieldsAbsent documents current reality:
 // against a real (unmodified) digiops-cs response with none of the blocked fields present,
 // AutoclosureStep/AutoclosureStateTime/CreTeam/SreTeam all stay nil rather than zero-valuing.

--- a/entity-service/internal/service/sn_task_service.go
+++ b/entity-service/internal/service/sn_task_service.go
@@ -66,6 +66,7 @@ type snProductRef struct {
 type snTaskParentCase struct {
 	ID     *string `json:"id"`
 	Number *string `json:"number"`
+	Type   *string `json:"type"`
 }
 
 // snTaskDetail mirrors the Choreo GET /tasks/{id} response.
@@ -219,6 +220,7 @@ func snTaskDetailToDomain(t snTaskDetail) domain.TaskDetail {
 		if t.ParentCase.Number != nil {
 			ref.Number = *t.ParentCase.Number
 		}
+		ref.Type = snParentCaseTypeToDomain(t.ParentCase.Type)
 		detail.ParentCase = ref
 	}
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

A growing set of CSM portal fixes/improvements bundled on one branch (kept together deliberately rather than split into many small PRs during active development):

1. `pnpm build` (`tsc -b`) had been failing on `main` since commit `94aad2228` ("decouple SRA attachment upload from case creation"), which is why staging stayed pinned on an old commit despite several later merges.
2. A render crash on `csm-stg` case detail pages (React error 31) left the user stuck on the error boundary's fallback screen forever, with no way out and no way to report it.
3. Every place the portal shows a person's name was plain unclickable text.
4. Comment/activity permalinks weren't discoverable, and image/PDF attachments in the case Activities tab had no inline preview.
5. `digiops-cs#2568`: `parentCase` came back null when a case's parent was an Incident rather than another Case (SN-side already fixed; entity-service/BFF needed the new `type` field threaded through).
6. The quick-nav (⌘K) search palette claimed to be global but only ever searched regular cases — SR/SRA/announcements/engagements were silently excluded by a backend default, and Incidents/Change Requests/Problems weren't wired in at all.
7. Quick-nav had no way to deep-link a search or a specific record (e.g. to share with a colleague).
8. Incident and Change Request detail pages didn't have the same tabbed structure/lifecycle actions as the case detail page — the incident page in particular had no way to change an incident's state from the portal at all.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Restore a green `main` build so Choreo can deploy commits to staging again.
2. Give the crash fallback screen a way out of a persistent crash loop, plus a way to copy enough detail for a bug report.
3. Make user references clickable, linking to a profile page with whatever the backend already exposes today.
4. Make the permalink affordance discoverable; let an image/PDF attachment be previewed inline in the Activities tab.
5. Thread the SN-fixed `parentCase.type` field all the way to the FE so a case's parent (case/incident/change request/problem) is a real, correctly-routed reference.
6. Make quick-nav search every record type it can (all 5 case sub-types, plus incidents/change requests/problems as their own sections).
7. Let a quick-nav search or a specific record be reached via a shareable URL.
8. Bring the incident detail page up to the case page's structural standard, including state-transition buttons; verify the change-request page (revamped in a prior PR) is still in good shape.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

1. **Build fix**: marked `BeSecurityReportCreatePayload.attachments` optional to match the call site that already treats it as optional — no behavior change, verified with a full `pnpm build` (the exact command Choreo's build step runs).
2. **Error boundary**: `AppErrorBoundary.tsx` gained a "Go to home" link and a "Copy error details" button (error, component stack, URL, timestamp, correlation ID when present), guarded against an unavailable/rejected clipboard write.
3. **User-reference links**: new shared `UserRefLink` component + `/people/:email` profile page (`POST /users/search`-backed: name/email/timezone/roles, with a "coming soon" placeholder for per-project roles/groups since no backend endpoint exposes either yet). Wired into case creator/assignee, watchers, comment authors, and attachment uploaders.
4. **Permalink + preview**: `RelativeTime.tsx` gained a link-icon copy button next to its permalink anchor (guarded against clipboard failure, generic wording since it renders for comments/audit entries/attachments alike). The Activities tab's inline attachment entries now use the existing `AttachmentPreviewDialog` mechanism the Attachments tab already had, extended rather than duplicated.
5. **`parentCase.type`**: added `Type` to entity-service's `CaseNumberRef`, mapped from SN's `type` literal (fixed a map-key mismatch found while verifying: the map used `"default_case"` where live SN actually emits `"case"`), threaded through `GetCaseByID` and the task-detail parent reference, added to both `openapi.yaml`s. FE routes a case-typed parent to `/cases/:id`, an incident-typed one to `/operations/incidents/:id`, etc.
6. **Quick-nav coverage**: `useQuickCaseSearch` now explicitly requests all 5 known case sub-types instead of relying on the backend's silent `["case"]`-only default. Added `useQuickIncidentSearch`/`useQuickChangeRequestSearch`/`useQuickProblemSearch` (mirroring the existing hook's shape), fanned out from one shared debounce, each rendering its own labeled section with correct routing. Extended `RecentViewKind` to cover incidents/CRs/problems so visiting one is genuinely trackable/pinnable.
7. **Shareable links**: `?q=<text>` opens quick-nav pre-filled and searching; `?goto=<id>` waits for the searches it feeds to settle, then auto-navigates to the single matching record (by display number, WSO2 case id, or raw id) — leaves the palette open on ambiguous (zero or multiple) matches rather than guessing.
8. **Incident page revamp**: restructured to match the case page's tabs (Activities, Details, Related, Watchers, Attachments — no call-requests/time-tracking/tasks, which don't apply to incidents). Added `IncidentActionBar` (state buttons driven by the existing `getLegalNextIncidentStates` guardrail — confirmed live that ServiceNow itself enforces no incident transition legality beyond blocking updates on an already-Closed incident) and `IncidentResolutionDialog` (collects the resolution code/notes ServiceNow requires before RESOLVED/CLOSED). The change-request page was verified only — its tabs and `legalNextStates`-driven "Request Approval" gating already work correctly, not touched.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer, when the app hits an unexpected error, I want to escape back to a working page and easily report what happened.
- As a CS engineer looking at a case, I want to click on any person's name to see who they are without leaving the case.
- As a CS engineer, I want to preview an image attachment inline and copy a permalink to a specific comment or activity.
- As a CS engineer, I want quick-nav to actually search everything — cases, SRs, SRAs, incidents, change requests, problems — and I want to be able to share a search or a direct link to a record with a colleague.
- As a CS engineer working an incident, I want the same tabbed layout and lifecycle actions I already have on cases, including a way to change its state.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

- Fixed a build regression that was blocking CSM portal deployments to staging.
- The crash screen now offers a way home and a one-click way to copy error details.
- Person names throughout the case view are now clickable, linking to a profile page.
- Comment/activity timestamps have a visible copy-permalink button; image/PDF attachments in the Activities tab can be previewed inline.
- A case's linked incident/change-request/problem parent now resolves and routes correctly instead of showing nothing.
- Quick-nav (⌘K) search now covers every record type — cases, service requests, security report analyses, announcements, engagements, incidents, change requests, and problems — and supports shareable `?q=`/`?goto=` links.
- The incident detail page now has the same tabbed structure as the case detail page, plus buttons to change an incident's state.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal CSM-portal-only UI/build changes, no externally published documentation covers this workflow.

## Training

N/A — no training content exists for this internal tool.

## Certification

N/A — internal tool, not covered by any certification exam.

## Marketing

N/A — internal tool, not customer/market-facing.

## Automation tests
 - Unit tests
   > Code coverage information

Added/updated unit tests across every change in this PR: `AppErrorBoundary`, `UserRefLink`, `RelativeTime`, `CaseDetailWidgets`, `CaseActivitiesFeed` (attachment preview), `useQuickCaseSearch`, `useRecentViews`, `QuickNav` (including the new `?q=`/`?goto=` behavior), `CsmIncidentDetailPage`/`IncidentActionBar` (including a test-isolation bug fixed along the way — a shared mock wasn't reset between tests). Full `pnpm exec vitest run`: 519 passed / 9 failed, all 9 reproduced identically on a clean pre-change checkout (`CaseActivitiesFeed.test.tsx` module-import-time config error, `CsmAnnouncementsPage.test.tsx`, `CaseActionBar.test.tsx`) — confirmed pre-existing and unrelated to this PR.
 - Integration tests
   > Details about the test cases and coverage

No new e2e scenarios; FE unit-test coverage plus manual verification of the build fix (`pnpm build`, matching Choreo's build step) and the `parentCase`/watchlist/call-request fixes against real ServiceNow-backed staging data via a local dev server pointed at the staging backend with real Asgardeo auth.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React and Go, not a Java target; ran `pnpm lint`/`tsc -b`/`pnpm build` and `go build`/`go vet`/`go test` clean instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

None.

## Migrations (if applicable)

N/A — no data migration involved.

## Test environment

Node/pnpm toolchain per `apps/csm-portal/webapp/package.json`; Go toolchain per `entity-service/go.mod`; unit tests via `vitest`/`go test`. Build verified with `pnpm build` locally against the exact command Choreo's build pipeline runs (confirmed via Choreo build logs for the originally-failing build). Several features were manually verified against real ServiceNow-backed staging data via a local dev server pointed at the staging backend with real Asgardeo auth.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

The build failure was root-caused by reading Choreo's own build logs directly rather than assuming a deploy-lag explanation. The quick-nav SRA gap was root-caused to a backend default (`SearchCases` defaulting `types` to `["default_case"]` when unspecified) rather than a frontend bug. The `digiops-cs#2568` fix was verified end-to-end against the live ServiceNow scripted API to confirm the exact `type` literal strings it emits, and a pre-existing map-key mismatch (`"default_case"` vs. the live `"case"`) was caught by a new unit test rather than assumed correct. The incident state-transition model was confirmed live against ServiceNow's own `Update Incidents` scripted API — no transition-legality rule exists there beyond blocking updates on a Closed incident — before deciding the button set client-side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added user profile pages with direct `people/:email` navigation from case details and timelines.
  * Enabled inline preview for supported image/PDF-like attachments, with fullscreen preview.
  * Added permalink copying for timestamps and richer error fallback actions (reload/home/copy error details).
  * Expanded quick navigation and “recently viewed” to include incidents, change requests, and problems.
* **Bug Fixes**
  * Improved author/uploader/creator/assignee display by linking to profiles when email data is available.
* **Changes**
  * Made security-report attachments optional during initial report creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->