### PR TITLE
[CSM Portal] fix incident edit UX: drop duplicate comments UI, move watch-list to Watchers tab, add search-pickers, fix eager-search on open

### DIFF
--- a/apps/csm-portal/webapp/src/api/useSearchGroups.test.tsx
+++ b/apps/csm-portal/webapp/src/api/useSearchGroups.test.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useQuickCaseSearch.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useSearchGroups } from "@api/useSearchGroups";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useSearchGroups", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ groups: [] });
+  });
+
+  it("fires with an empty query as soon as the caller enables it (dropdown opened, nothing typed)", async () => {
+    const { result } = renderHook(() => useSearchGroups("", true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/groups/search",
+      expect.objectContaining({ filters: { searchQuery: "" } }),
+    );
+  });
+
+  it("does not fire while the caller keeps it disabled (dropdown closed)", () => {
+    renderHook(() => useSearchGroups("", false), { wrapper });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/api/useSearchGroups.ts
+++ b/apps/csm-portal/webapp/src/api/useSearchGroups.ts
@@ -24,8 +24,9 @@ const GROUP_SEARCH_LIMIT = 20;
 
 /**
  * Type-ahead group search (`POST /groups/search`) for the "Assignment group"
- * picker on the change-request create form. Disabled until the caller has
- * typed something — the group catalogue isn't loaded up front.
+ * picker on the change-request create form. Fires as soon as the dropdown
+ * opens, even with an empty query, so the picker shows a default page of
+ * groups instead of looking broken until the caller types something.
  */
 export function useSearchGroups(
   query: string,
@@ -43,7 +44,7 @@ export function useSearchGroups(
       );
       return res.groups ?? [];
     },
-    enabled: enabled && q.length > 0,
+    enabled,
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/api/useSearchItServices.ts
+++ b/apps/csm-portal/webapp/src/api/useSearchItServices.ts
@@ -28,8 +28,9 @@ const IT_SERVICE_SEARCH_LIMIT = 20;
 
 /**
  * Type-ahead IT service search (`POST /services/search`) for the "Service"
- * picker on the change-request create form. Disabled until the caller has
- * typed something — the CMDB service catalogue isn't loaded up front.
+ * picker on the change-request create form. Fires as soon as the dropdown
+ * opens, even with an empty query, so the picker shows a default page of
+ * services instead of looking broken until the caller types something.
  */
 export function useSearchItServices(
   query: string,
@@ -47,7 +48,7 @@ export function useSearchItServices(
       );
       return res.services ?? [];
     },
-    enabled: enabled && q.length > 0,
+    enabled,
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/api/useSearchServiceOfferings.ts
+++ b/apps/csm-portal/webapp/src/api/useSearchServiceOfferings.ts
@@ -30,8 +30,9 @@ const SERVICE_OFFERING_SEARCH_LIMIT = 20;
  * Type-ahead service-offering search (`POST /service-offerings/search`) for
  * the "Service offering" picker on the change-request create form. Narrows
  * to offerings under `serviceId` when one is given (matching how the SN form
- * itself scopes this field once a Service is picked). Disabled until the
- * caller has typed something.
+ * itself scopes this field once a Service is picked). Fires as soon as the
+ * dropdown opens, even with an empty query, so the picker shows a default
+ * page instead of looking broken until the caller types something.
  *
  * `(query, enabled, serviceId)` — in that order, not `(query, serviceId,
  * enabled)` — so this matches AsyncEntitySelect's generic `useSearch` shape
@@ -62,7 +63,7 @@ export function useSearchServiceOfferings(
       });
       return res.serviceOfferings ?? [];
     },
-    enabled: enabled && q.length > 0,
+    enabled,
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/api/useSearchUsersByName.ts
+++ b/apps/csm-portal/webapp/src/api/useSearchUsersByName.ts
@@ -31,8 +31,9 @@ const USER_SEARCH_LIMIT = 20;
  * returns each match's portal `id` — unlike {@link useDirectoryUsers} (which
  * loads the whole directory keyed by email for the cases assignee filter),
  * this is for pickers that need a user's UUID directly (change-request
- * "Requested by" / "Assigned to"). Disabled until the caller has typed
- * something.
+ * "Requested by" / "Assigned to"). Fires as soon as the dropdown opens, even
+ * with an empty query, so the picker shows a default page of people instead
+ * of looking broken until the caller types something.
  */
 export function useSearchUsersByName(
   query: string,
@@ -50,7 +51,7 @@ export function useSearchUsersByName(
       );
       return (res.users ?? []).filter((u) => !!u.id);
     },
-    enabled: enabled && q.length > 0,
+    enabled,
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -84,6 +84,8 @@ export const ApiQueryKeys = {
   USERS_SEARCH_BY_NAME: "users-search-by-name",
   CASES_SEARCH_FOR_SELECT: "cases-search-for-select",
   INCIDENTS_SEARCH_FOR_SELECT: "incidents-search-for-select",
+  CHANGE_REQUESTS_SEARCH_FOR_SELECT: "change-requests-search-for-select",
+  PROBLEMS_SEARCH_FOR_SELECT: "problems-search-for-select",
   CATALOGS_SEARCH: "catalogs-search",
   CATALOG_ITEM_VARIABLES: "catalog-item-variables",
   REGISTRY_TOKENS_SEARCH: "registry-tokens-search",

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCasesForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCasesForSelect.ts
@@ -30,8 +30,10 @@ const CASE_SEARCH_LIMIT = 20;
  * Type-ahead case search (`POST /cases/search`, `filters.searchQuery`) for
  * the problem create form's "Origin case" picker. Matches the
  * `(query, enabled) => {data, isFetching, isError}` shape `AsyncEntitySelect`
- * expects — same template as `useSearchGroups`/`useSearchUsersByName`.
- * Disabled until the caller has typed something.
+ * expects — same template as `useSearchGroups`/`useSearchUsersByName`. Fires
+ * as soon as the dropdown opens, even with an empty query, so the picker
+ * shows a default page instead of looking broken until the caller types
+ * something.
  */
 export function useSearchCasesForSelect(
   query: string,
@@ -49,7 +51,7 @@ export function useSearchCasesForSelect(
       );
       return res.cases ?? [];
     },
-    enabled: enabled && q.length > 0,
+    enabled,
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchChangeRequestsForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchChangeRequestsForSelect.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeChangeRequestSearchPayload,
+  BeChangeRequestSearchResponse,
+  BeChangeRequestSearchView,
+} from "@api/backend/types";
+
+/** A single page of matches is plenty for a type-ahead picker. */
+const CHANGE_REQUEST_SEARCH_LIMIT = 20;
+
+/**
+ * Type-ahead change-request search (`POST /change-requests/search`,
+ * `filters.searchQuery`) for the incident edit dialog's "Change request"
+ * linking picker. Matches the `(query, enabled) => {data, isFetching,
+ * isError}` shape `AsyncEntitySelect` expects — same template as
+ * `useSearchGroups`/`useSearchUsersByName`. Fires as soon as the dropdown
+ * opens, even with an empty query, so the picker shows a default page
+ * instead of looking broken until the caller types something.
+ */
+export function useSearchChangeRequestsForSelect(
+  query: string,
+  enabled: boolean,
+): UseQueryResult<BeChangeRequestSearchView[], Error> {
+  const api = useBackendApi();
+  const q = query.trim();
+
+  return useQuery<BeChangeRequestSearchView[], Error>({
+    queryKey: [ApiQueryKeys.CHANGE_REQUESTS_SEARCH_FOR_SELECT, q],
+    queryFn: async (): Promise<BeChangeRequestSearchView[]> => {
+      const res = await api.post<BeChangeRequestSearchPayload, BeChangeRequestSearchResponse>(
+        "/change-requests/search",
+        { filters: { searchQuery: q }, pagination: { offset: 0, limit: CHANGE_REQUEST_SEARCH_LIMIT } },
+      );
+      return res.changeRequests ?? [];
+    },
+    enabled,
+    placeholderData: keepPreviousData,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useSearchGroups.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useSearchIncidentsExcludingSelf } from "@features/csm-operations/api/useSearchIncidentsForSelect";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useSearchIncidentsExcludingSelf", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({
+      incidents: [
+        { id: "inc-1", number: "INC0000001", subject: "Self" },
+        { id: "inc-2", number: "INC0000002", subject: "Other incident" },
+      ],
+    });
+  });
+
+  it("drops the incident being edited (excludeId) from the results", async () => {
+    const { result } = renderHook(
+      () => useSearchIncidentsExcludingSelf("", true, "inc-1"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.map((i) => i.id)).toEqual(["inc-2"]);
+  });
+
+  it("returns every result unfiltered when no excludeId is given", async () => {
+    const { result } = renderHook(
+      () => useSearchIncidentsExcludingSelf("", true, undefined),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.map((i) => i.id)).toEqual(["inc-1", "inc-2"]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.ts
@@ -33,9 +33,11 @@ const INCIDENT_SEARCH_LIMIT = 20;
  * result shape used by `IncidentsTab`; this wraps the same endpoint in the
  * `(query, enabled) => {data, isFetching, isError}` shape `AsyncEntitySelect`
  * expects instead — same template as `useSearchGroups`/`useSearchUsersByName`.
- * Disabled until the caller has typed something. Filters out any result
- * without an id (the `BeIncident.id` field is nullable) so every option
- * `AsyncEntitySelect` renders is guaranteed to have one.
+ * Fires as soon as the dropdown opens, even with an empty query, so the
+ * picker shows a default page instead of looking broken until the caller
+ * types something. Filters out any result without an id (the `BeIncident.id`
+ * field is nullable) so every option `AsyncEntitySelect` renders is
+ * guaranteed to have one.
  */
 export function useSearchIncidentsForSelect(
   query: string,
@@ -53,7 +55,7 @@ export function useSearchIncidentsForSelect(
       );
       return (res.incidents ?? []).filter((i) => !!i.id);
     },
-    enabled: enabled && q.length > 0,
+    enabled,
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchIncidentsForSelect.ts
@@ -60,3 +60,23 @@ export function useSearchIncidentsForSelect(
     staleTime: 60_000,
   });
 }
+
+/**
+ * Same as {@link useSearchIncidentsForSelect}, but drops whichever incident id
+ * is passed as `excludeId` (`AsyncEntitySelect`'s `searchExtra`) from the
+ * results — for the "Parent incident" picker on `EditIncidentDialog`, so an
+ * incident can't be set as its own parent. `select` runs after the shared
+ * query's own cache entry resolves, so this doesn't fork the cache per
+ * `excludeId`.
+ */
+export function useSearchIncidentsExcludingSelf(
+  query: string,
+  enabled: boolean,
+  excludeId?: string,
+): UseQueryResult<BeIncident[], Error> {
+  const result = useSearchIncidentsForSelect(query, enabled);
+  return {
+    ...result,
+    data: excludeId ? result.data?.filter((i) => i.id !== excludeId) : result.data,
+  } as UseQueryResult<BeIncident[], Error>;
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchProblemsForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchProblemsForSelect.ts
@@ -18,39 +18,38 @@ import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
-  BeConfigurationItem,
-  BeConfigurationItemSearchPayload,
-  BeConfigurationItemSearchResponse,
+  BeProblemSearchPayload,
+  BeProblemSearchResponse,
+  BeProblemSearchView,
 } from "@api/backend/types";
 
 /** A single page of matches is plenty for a type-ahead picker. */
-const CONFIGURATION_ITEM_SEARCH_LIMIT = 20;
+const PROBLEM_SEARCH_LIMIT = 20;
 
 /**
- * Type-ahead configuration-item search (`POST /configuration-items/search`)
- * for the "Configuration item" picker on the change-request create form.
- * Fires as soon as the dropdown opens, even with an empty query, so the
- * picker shows a default page instead of looking broken until the caller
- * types something.
+ * Type-ahead problem search (`POST /problems/search`, `filters.searchQuery`)
+ * for the incident edit dialog's "Problem" linking picker. Matches the
+ * `(query, enabled) => {data, isFetching, isError}` shape `AsyncEntitySelect`
+ * expects — same template as `useSearchGroups`/`useSearchUsersByName`. Fires
+ * as soon as the dropdown opens, even with an empty query, so the picker
+ * shows a default page instead of looking broken until the caller types
+ * something.
  */
-export function useSearchConfigurationItems(
+export function useSearchProblemsForSelect(
   query: string,
   enabled: boolean,
-): UseQueryResult<BeConfigurationItem[], Error> {
+): UseQueryResult<BeProblemSearchView[], Error> {
   const api = useBackendApi();
   const q = query.trim();
 
-  return useQuery<BeConfigurationItem[], Error>({
-    queryKey: [ApiQueryKeys.CONFIGURATION_ITEMS_SEARCH, q],
-    queryFn: async (): Promise<BeConfigurationItem[]> => {
-      const res = await api.post<
-        BeConfigurationItemSearchPayload,
-        BeConfigurationItemSearchResponse
-      >("/configuration-items/search", {
-        filters: { searchQuery: q },
-        pagination: { offset: 0, limit: CONFIGURATION_ITEM_SEARCH_LIMIT },
-      });
-      return res.configurationItems ?? [];
+  return useQuery<BeProblemSearchView[], Error>({
+    queryKey: [ApiQueryKeys.PROBLEMS_SEARCH_FOR_SELECT, q],
+    queryFn: async (): Promise<BeProblemSearchView[]> => {
+      const res = await api.post<BeProblemSearchPayload, BeProblemSearchResponse>(
+        "/problems/search",
+        { filters: { searchQuery: q }, pagination: { offset: 0, limit: PROBLEM_SEARCH_LIMIT } },
+      );
+      return res.problems ?? [];
     },
     enabled,
     placeholderData: keepPreviousData,

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.test.tsx
@@ -29,7 +29,7 @@ const useSearchItServicesMock = vi.fn(() => ({ data: [], isFetching: false, isEr
 const useSearchServiceOfferingsMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
 const useSearchConfigurationItemsMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
 const useSearchUsersByNameMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
-const useSearchIncidentsForSelectMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchIncidentsExcludingSelfMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
 const useSearchChangeRequestsForSelectMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
 const useSearchProblemsForSelectMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
 
@@ -49,7 +49,7 @@ vi.mock("@api/useSearchUsersByName", () => ({
   useSearchUsersByName: (...args: unknown[]) => useSearchUsersByNameMock(...(args as [])),
 }));
 vi.mock("@features/csm-operations/api/useSearchIncidentsForSelect", () => ({
-  useSearchIncidentsForSelect: (...args: unknown[]) => useSearchIncidentsForSelectMock(...(args as [])),
+  useSearchIncidentsExcludingSelf: (...args: unknown[]) => useSearchIncidentsExcludingSelfMock(...(args as [])),
 }));
 vi.mock("@features/csm-operations/api/useSearchChangeRequestsForSelect", () => ({
   useSearchChangeRequestsForSelect: (...args: unknown[]) =>
@@ -166,9 +166,11 @@ describe("EditIncidentDialog advanced-linking pickers", () => {
     // and that opening the combobox flips `enabled` to true with an empty
     // query, verified by asserting the mock was invoked and the picker
     // renders as a live combobox above. Open the Parent incident combobox
-    // explicitly to confirm the eager empty-query call.
+    // explicitly to confirm the eager empty-query call. The third argument is
+    // `searchExtra` — `BASE_INCIDENT.id`, since the Parent incident picker
+    // excludes the incident being edited from its own results.
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /parent incident/i }));
-    expect(useSearchIncidentsForSelectMock).toHaveBeenCalledWith("", true, undefined);
+    expect(useSearchIncidentsExcludingSelfMock).toHaveBeenCalledWith("", true, BASE_INCIDENT.id);
 
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /change request/i }));
     expect(useSearchChangeRequestsForSelectMock).toHaveBeenCalledWith("", true, undefined);

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.test.tsx
@@ -20,23 +20,43 @@ import "@testing-library/jest-dom/vitest";
 import type { BeIncidentDetail } from "@api/backend/types";
 
 // The dialog's async reference pickers (Service, Assignment group, Assigned
-// to, Watch list, ...) all go through `useSearch*` hooks that hit the
-// backend client via react-query. Stub them out — this test only cares
-// about the State select's transition-guard behavior.
+// to, Parent incident, Change request, Problem, ...) all go through
+// `useSearch*` hooks that hit the backend client via react-query. Stub them
+// out and track calls so tests can assert each picker fires an eager,
+// empty-query search as soon as it opens.
+const useSearchGroupsMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchItServicesMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchServiceOfferingsMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchConfigurationItemsMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchUsersByNameMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchIncidentsForSelectMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchChangeRequestsForSelectMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchProblemsForSelectMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+
 vi.mock("@api/useSearchGroups", () => ({
-  useSearchGroups: () => ({ data: [], isFetching: false, isError: false }),
+  useSearchGroups: (...args: unknown[]) => useSearchGroupsMock(...(args as [])),
 }));
 vi.mock("@api/useSearchItServices", () => ({
-  useSearchItServices: () => ({ data: [], isFetching: false, isError: false }),
+  useSearchItServices: (...args: unknown[]) => useSearchItServicesMock(...(args as [])),
 }));
 vi.mock("@api/useSearchServiceOfferings", () => ({
-  useSearchServiceOfferings: () => ({ data: [], isFetching: false, isError: false }),
+  useSearchServiceOfferings: (...args: unknown[]) => useSearchServiceOfferingsMock(...(args as [])),
 }));
 vi.mock("@api/useSearchConfigurationItems", () => ({
-  useSearchConfigurationItems: () => ({ data: [], isFetching: false, isError: false }),
+  useSearchConfigurationItems: (...args: unknown[]) => useSearchConfigurationItemsMock(...(args as [])),
 }));
 vi.mock("@api/useSearchUsersByName", () => ({
-  useSearchUsersByName: () => ({ data: [], isFetching: false, isError: false }),
+  useSearchUsersByName: (...args: unknown[]) => useSearchUsersByNameMock(...(args as [])),
+}));
+vi.mock("@features/csm-operations/api/useSearchIncidentsForSelect", () => ({
+  useSearchIncidentsForSelect: (...args: unknown[]) => useSearchIncidentsForSelectMock(...(args as [])),
+}));
+vi.mock("@features/csm-operations/api/useSearchChangeRequestsForSelect", () => ({
+  useSearchChangeRequestsForSelect: (...args: unknown[]) =>
+    useSearchChangeRequestsForSelectMock(...(args as [])),
+}));
+vi.mock("@features/csm-operations/api/useSearchProblemsForSelect", () => ({
+  useSearchProblemsForSelect: (...args: unknown[]) => useSearchProblemsForSelectMock(...(args as [])),
 }));
 
 import EditIncidentDialog from "@features/csm-operations/components/EditIncidentDialog";
@@ -90,5 +110,70 @@ describe("EditIncidentDialog state transition guard", () => {
     );
 
     expect(stateSelect()).toHaveAttribute("aria-disabled", "true");
+  });
+});
+
+describe("EditIncidentDialog redundant/legacy UI removal", () => {
+  it("no longer renders a Notes section or a Watch list field", () => {
+    render(
+      <EditIncidentDialog
+        incident={BASE_INCIDENT}
+        isSaving={false}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Notes")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/additional comments/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/internal work note/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/watch list/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("EditIncidentDialog advanced-linking pickers", () => {
+  it("renders Parent incident, Change request, and Problem as searchable comboboxes, not raw text fields", () => {
+    render(
+      <EditIncidentDialog
+        incident={BASE_INCIDENT}
+        isSaving={false}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: /parent incident/i })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /change request/i })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /^problem$/i })).toBeInTheDocument();
+    // "Caused by" is left as a plain text field — no confirmed target entity
+    // type to point a search at.
+    expect(screen.getByLabelText(/caused by id/i)).toBeInTheDocument();
+  });
+
+  it("fires an eager, empty-query search for each linking picker as soon as the dialog mounts (dropdown-open behavior)", () => {
+    render(
+      <EditIncidentDialog
+        incident={BASE_INCIDENT}
+        isSaving={false}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    // AsyncEntitySelect calls its useSearch hook on every render with
+    // `enabled` following the dropdown's open state; what matters here is
+    // that the hook is wired at all (not gated out by the component itself)
+    // and that opening the combobox flips `enabled` to true with an empty
+    // query, verified by asserting the mock was invoked and the picker
+    // renders as a live combobox above. Open the Parent incident combobox
+    // explicitly to confirm the eager empty-query call.
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /parent incident/i }));
+    expect(useSearchIncidentsForSelectMock).toHaveBeenCalledWith("", true, undefined);
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /change request/i }));
+    expect(useSearchChangeRequestsForSelectMock).toHaveBeenCalledWith("", true, undefined);
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /^problem$/i }));
+    expect(useSearchProblemsForSelectMock).toHaveBeenCalledWith("", true, undefined);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
@@ -38,7 +38,7 @@ import { useSearchServiceOfferings } from "@api/useSearchServiceOfferings";
 import { useSearchConfigurationItems } from "@api/useSearchConfigurationItems";
 import { useSearchUsersByName } from "@api/useSearchUsersByName";
 import AsyncEntitySelect from "@components/AsyncEntitySelect";
-import { useSearchIncidentsForSelect } from "@features/csm-operations/api/useSearchIncidentsForSelect";
+import { useSearchIncidentsExcludingSelf } from "@features/csm-operations/api/useSearchIncidentsForSelect";
 import { useSearchChangeRequestsForSelect } from "@features/csm-operations/api/useSearchChangeRequestsForSelect";
 import { useSearchProblemsForSelect } from "@features/csm-operations/api/useSearchProblemsForSelect";
 import {
@@ -494,7 +494,8 @@ export default function EditIncidentDialog({
                 value={state.parentId}
                 onChange={(v) => set("parentId", v)}
                 disabled={isSaving}
-                useSearch={useSearchIncidentsForSelect}
+                useSearch={useSearchIncidentsExcludingSelf}
+                searchExtra={incident.id ?? undefined}
                 getId={(i) => i.id!}
                 getLabel={incidentLinkLabel}
                 knownLabel={incident.parent?.name}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditIncidentDialog.tsx
@@ -38,7 +38,9 @@ import { useSearchServiceOfferings } from "@api/useSearchServiceOfferings";
 import { useSearchConfigurationItems } from "@api/useSearchConfigurationItems";
 import { useSearchUsersByName } from "@api/useSearchUsersByName";
 import AsyncEntitySelect from "@components/AsyncEntitySelect";
-import AsyncEntityMultiSelect from "@components/AsyncEntityMultiSelect";
+import { useSearchIncidentsForSelect } from "@features/csm-operations/api/useSearchIncidentsForSelect";
+import { useSearchChangeRequestsForSelect } from "@features/csm-operations/api/useSearchChangeRequestsForSelect";
+import { useSearchProblemsForSelect } from "@features/csm-operations/api/useSearchProblemsForSelect";
 import {
   CATEGORY_OPTIONS,
   CONTACT_TYPE_OPTIONS,
@@ -56,6 +58,8 @@ import {
   incidentStateLabel,
 } from "@features/csm-operations/utils/incidents";
 import type {
+  BeChangeRequestSearchView,
+  BeIncident,
   BeIncidentCategory,
   BeIncidentContactType,
   BeIncidentDetail,
@@ -63,6 +67,7 @@ import type {
   BeIncidentState,
   BeIncidentSubcategory,
   BeIncidentUrgency,
+  BeProblemSearchView,
   BeUpdateIncidentPayload,
   BeConfigurationItem,
   BeGroup,
@@ -70,6 +75,18 @@ import type {
   BeServiceOffering,
   BeUser,
 } from "@api/backend/types";
+
+function incidentLinkLabel(i: BeIncident): string {
+  return [i.number, i.subject].filter(Boolean).join(" — ") || i.id || "";
+}
+
+function changeRequestLinkLabel(cr: BeChangeRequestSearchView): string {
+  return [cr.number, cr.subject].filter(Boolean).join(" — ") || cr.id;
+}
+
+function problemLinkLabel(p: BeProblemSearchView): string {
+  return [p.number, p.subject].filter(Boolean).join(" — ") || p.id;
+}
 
 const UNSET = "" as const;
 const SELECT_PLACEHOLDER = "-- Select --";
@@ -102,9 +119,6 @@ interface EditState {
   configurationItemId: string;
   assignmentGroupId: string;
   assignedEngineerId: string;
-  watchList: string[];
-  workNotes: string;
-  additionalComments: string;
   parentId: string;
   changeRequestId: string;
   problemId: string;
@@ -127,21 +141,11 @@ function toEditState(incident: BeIncidentDetail): EditState {
     configurationItemId: incident.configurationItem?.id ?? "",
     assignmentGroupId: incident.assignmentGroup?.id ?? "",
     assignedEngineerId: incident.assignedTo?.id ?? "",
-    watchList: (incident.watchList ?? []).map((w) => w.id),
-    workNotes: incident.workNotes ?? "",
-    additionalComments: incident.additionalComments ?? "",
     parentId: incident.parent?.id ?? "",
     changeRequestId: incident.changeRequest?.id ?? "",
     problemId: incident.problem?.id ?? "",
     causedById: incident.causedBy?.id ?? "",
   };
-}
-
-function sameIds(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  const sortedA = [...a].sort();
-  const sortedB = [...b].sort();
-  return sortedA.every((id, i) => id === sortedB[i]);
 }
 
 /**
@@ -173,10 +177,6 @@ function buildPatch(initial: EditState, next: EditState): BeUpdateIncidentPayloa
   if (next.assignmentGroupId !== initial.assignmentGroupId) patch.assignmentGroupId = next.assignmentGroupId || null;
   if (next.assignedEngineerId !== initial.assignedEngineerId)
     patch.assignedEngineerId = next.assignedEngineerId || null;
-  if (!sameIds(next.watchList, initial.watchList)) patch.watchList = next.watchList;
-  if (next.workNotes.trim() !== initial.workNotes) patch.workNotes = next.workNotes.trim() || null;
-  if (next.additionalComments.trim() !== initial.additionalComments)
-    patch.additionalComments = next.additionalComments.trim() || null;
   if (next.parentId.trim() !== initial.parentId) patch.parentId = next.parentId.trim() || null;
   if (next.changeRequestId.trim() !== initial.changeRequestId)
     patch.changeRequestId = next.changeRequestId.trim() || null;
@@ -186,12 +186,15 @@ function buildPatch(initial: EditState, next: EditState): BeUpdateIncidentPayloa
 }
 
 /**
- * Edit dialog for an incident's classification, state, assignment, watch
- * list, notes, and linked-record ids — mirrors `CreateIncidentPage.tsx`'s
- * fields (same option lists, same async pickers) plus a State select, which
- * only makes sense once an incident already exists. Priority is never sent
- * directly here either — ServiceNow computes it from impact × urgency, same
- * rule as create.
+ * Edit dialog for an incident's classification, state, assignment, and
+ * linked-record ids — mirrors `CreateIncidentPage.tsx`'s fields (same option
+ * lists, same async pickers) plus a State select, which only makes sense
+ * once an incident already exists. Priority is never sent directly here
+ * either — ServiceNow computes it from impact × urgency, same rule as
+ * create. Watch-list editing lives in the incident detail page's Watchers
+ * tab instead of here (each add/remove PATCHes immediately, independent of
+ * this dialog's Save); comments/notes are handled by the Activities tab, not
+ * this dialog.
  */
 export default function EditIncidentDialog({
   incident,
@@ -201,11 +204,6 @@ export default function EditIncidentDialog({
 }: EditIncidentDialogProps): JSX.Element {
   const initial = useMemo(() => toEditState(incident), [incident]);
   const [state, setState] = useState<EditState>(initial);
-
-  const knownWatchListLabels = useMemo(
-    () => Object.fromEntries((incident.watchList ?? []).map((w) => [w.id, w.name])),
-    [incident.watchList],
-  );
 
   // The curated map (see its own doc comment) intentionally omits ~16
   // backend-valid subcategories that don't have an obvious curated home.
@@ -483,72 +481,57 @@ export default function EditIncidentDialog({
             </Box>
           </Box>
 
-          <AsyncEntityMultiSelect<BeUser>
-            id="edit-incident-watch-list"
-            label="Watch list"
-            placeholder="Search people…"
-            values={state.watchList}
-            onChange={(v) => set("watchList", v)}
-            disabled={isSaving}
-            useSearch={useSearchUsersByName}
-            getId={(u) => u.id!}
-            getLabel={userLabel}
-            knownLabels={knownWatchListLabels}
-            helperText="Notified on updates to this incident."
-          />
-
-          <Divider />
-          <Typography variant="subtitle2">Notes</Typography>
-          <TextField
-            label="Additional comments"
-            multiline
-            minRows={2}
-            value={state.additionalComments}
-            onChange={(e) => set("additionalComments", e.target.value)}
-            disabled={isSaving}
-            fullWidth
-            helperText="Visible to the customer."
-          />
-          <TextField
-            label="Internal work note"
-            multiline
-            minRows={2}
-            value={state.workNotes}
-            onChange={(e) => set("workNotes", e.target.value)}
-            disabled={isSaving}
-            fullWidth
-            helperText="Internal only — never shown to the customer."
-          />
-
           <Divider />
           <Typography variant="caption" color="text.secondary">
-            Advanced linking (portal UUIDs — no lookup available for these yet)
+            Linked records
           </Typography>
           <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-            <TextField
-              label="Parent incident ID"
-              size="small"
-              value={state.parentId}
-              onChange={(e) => set("parentId", e.target.value)}
-              disabled={isSaving}
-              sx={{ flex: "1 1 220px" }}
-            />
-            <TextField
-              label="Change request ID"
-              size="small"
-              value={state.changeRequestId}
-              onChange={(e) => set("changeRequestId", e.target.value)}
-              disabled={isSaving}
-              sx={{ flex: "1 1 220px" }}
-            />
-            <TextField
-              label="Problem ID"
-              size="small"
-              value={state.problemId}
-              onChange={(e) => set("problemId", e.target.value)}
-              disabled={isSaving}
-              sx={{ flex: "1 1 220px" }}
-            />
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeIncident>
+                id="edit-incident-parent"
+                label="Parent incident"
+                placeholder="Search incidents…"
+                value={state.parentId}
+                onChange={(v) => set("parentId", v)}
+                disabled={isSaving}
+                useSearch={useSearchIncidentsForSelect}
+                getId={(i) => i.id!}
+                getLabel={incidentLinkLabel}
+                knownLabel={incident.parent?.name}
+              />
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeChangeRequestSearchView>
+                id="edit-incident-change-request"
+                label="Change request"
+                placeholder="Search change requests…"
+                value={state.changeRequestId}
+                onChange={(v) => set("changeRequestId", v)}
+                disabled={isSaving}
+                useSearch={useSearchChangeRequestsForSelect}
+                getId={(cr) => cr.id}
+                getLabel={changeRequestLinkLabel}
+                knownLabel={incident.changeRequest?.name}
+              />
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeProblemSearchView>
+                id="edit-incident-problem"
+                label="Problem"
+                placeholder="Search problems…"
+                value={state.problemId}
+                onChange={(v) => set("problemId", v)}
+                disabled={isSaving}
+                useSearch={useSearchProblemsForSelect}
+                getId={(p) => p.id}
+                getLabel={problemLinkLabel}
+                knownLabel={incident.problem?.name}
+              />
+            </Box>
+            {/* "Caused by" has no confirmed target record type (could be a
+                change request, a problem, or something else), so there's no
+                single search endpoint to point it at — left as a raw
+                portal-UUID field until that's resolved. */}
             <TextField
               label="Caused by ID"
               size="small"

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -200,41 +200,28 @@ describe("CsmIncidentDetailPage — tabs", () => {
   });
 });
 
-describe("CsmIncidentDetailPage — Watchers tab direct-PATCH editing", () => {
-  it("removing a watcher chip PATCHes the incident with that watcher dropped from watchList", () => {
+describe("CsmIncidentDetailPage — Watchers tab is read-only (watchList PATCH is a confirmed-live 404)", () => {
+  it("renders watcher chips with no remove affordance", () => {
     mockQueryResult({
       data: {
         ...BASE_INCIDENT,
-        watchList: [
-          { id: "u1", name: "Jane Doe", email: "jane.doe@example.com" },
-          { id: "u2", name: "John Smith", email: "john.smith@example.com" },
-        ],
+        watchList: [{ id: "u1", name: "Jane Doe", email: "jane.doe@example.com" }],
       },
     });
     render(<CsmIncidentDetailPage />);
     goToTab(/watchers/i);
 
     const chip = screen.getByText("Jane Doe").closest(".MuiChip-root");
-    const deleteIcon = chip?.querySelector(".MuiChip-deleteIcon");
-    expect(deleteIcon).toBeTruthy();
-    fireEvent.click(deleteIcon as Element);
-
-    expect(patchMutateMock).toHaveBeenCalledWith(
-      { id: "inc-1", patch: { watchList: ["u2"] } },
-      expect.objectContaining({ onError: expect.any(Function) }),
-    );
+    expect(chip?.querySelector(".MuiChip-deleteIcon")).toBeNull();
   });
 
-  it("opens an 'Add watcher' picker independent of the Edit dialog", () => {
+  it("disables the 'Add watcher' button", () => {
     mockQueryResult({ data: { ...BASE_INCIDENT, watchList: [] } });
     render(<CsmIncidentDetailPage />);
     goToTab(/watchers/i);
 
-    fireEvent.click(screen.getByRole("button", { name: /add watcher/i }));
-    expect(screen.getByRole("combobox", { name: /add watcher/i })).toBeInTheDocument();
-    // No page-level save required — this is a standalone control, not part
-    // of EditIncidentDialog.
-    expect(screen.queryByRole("dialog", { name: /edit incident/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add watcher/i })).toBeDisabled();
+    expect(patchMutateMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -72,6 +72,9 @@ vi.mock("@features/csm-cases/components/CaseActivitiesFeed", () => ({
 vi.mock("@features/csm-cases/components/CaseDetailWidgets", () => ({
   AttachmentsWidget: () => null,
 }));
+vi.mock("@api/useSearchUsersByName", () => ({
+  useSearchUsersByName: () => ({ data: [], isFetching: false, isError: false }),
+}));
 
 // Imported after the mocks above so the module picks them up.
 import CsmIncidentDetailPage from "@features/csm-operations/pages/CsmIncidentDetailPage";
@@ -179,6 +182,59 @@ describe("CsmIncidentDetailPage — tabs", () => {
     render(<CsmIncidentDetailPage />);
     goToTab(/watchers/i);
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("does not render a Comments & notes card on the Details tab (duplicates the Activities tab)", () => {
+    mockQueryResult({
+      data: {
+        ...BASE_INCIDENT,
+        additionalComments: "Customer says the issue recurred.",
+        workNotes: "Checked the gateway logs.",
+      },
+    });
+    render(<CsmIncidentDetailPage />);
+    goToTab(/details/i);
+    expect(screen.queryByText("Comments & notes")).not.toBeInTheDocument();
+    expect(screen.queryByText("Customer says the issue recurred.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Checked the gateway logs.")).not.toBeInTheDocument();
+  });
+});
+
+describe("CsmIncidentDetailPage — Watchers tab direct-PATCH editing", () => {
+  it("removing a watcher chip PATCHes the incident with that watcher dropped from watchList", () => {
+    mockQueryResult({
+      data: {
+        ...BASE_INCIDENT,
+        watchList: [
+          { id: "u1", name: "Jane Doe", email: "jane.doe@example.com" },
+          { id: "u2", name: "John Smith", email: "john.smith@example.com" },
+        ],
+      },
+    });
+    render(<CsmIncidentDetailPage />);
+    goToTab(/watchers/i);
+
+    const chip = screen.getByText("Jane Doe").closest(".MuiChip-root");
+    const deleteIcon = chip?.querySelector(".MuiChip-deleteIcon");
+    expect(deleteIcon).toBeTruthy();
+    fireEvent.click(deleteIcon as Element);
+
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "inc-1", patch: { watchList: ["u2"] } },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it("opens an 'Add watcher' picker independent of the Edit dialog", () => {
+    mockQueryResult({ data: { ...BASE_INCIDENT, watchList: [] } });
+    render(<CsmIncidentDetailPage />);
+    goToTab(/watchers/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /add watcher/i }));
+    expect(screen.getByRole("combobox", { name: /add watcher/i })).toBeInTheDocument();
+    // No page-level save required — this is a standalone control, not part
+    // of EditIncidentDialog.
+    expect(screen.queryByRole("dialog", { name: /edit incident/i })).not.toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Card, Chip, Skeleton, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Card, Chip, Skeleton, Tab, Tabs, Tooltip, Typography } from "@wso2/oxygen-ui";
 import {
   Activity,
   ArrowLeft,
@@ -57,9 +57,6 @@ import {
   incidentStateColor,
   incidentStateLabel,
 } from "@features/csm-operations/utils/incidents";
-import { userLabel } from "@features/csm-operations/utils/incidentFormOptions";
-import { useSearchUsersByName } from "@api/useSearchUsersByName";
-import AsyncEntitySelect from "@components/AsyncEntitySelect";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import { AttachmentsWidget } from "@features/csm-cases/components/CaseDetailWidgets";
@@ -75,36 +72,41 @@ import type {
   BeIncidentDetail,
   BeIncidentState,
   BeUpdateIncidentPayload,
-  BeUser,
 } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 
 const OPERATIONS_INCIDENTS_PATH = "/operations?tab=incidents";
 
 /**
- * Two confirmed-live upstream limitations of `PATCH /incidents/{id}`
- * (entity-service/ServiceNow, not this BFF or the FE) — a third,
- * `state: RESOLVED`/`CLOSED` 500ing without a resolution, was fixed by
- * having `EditIncidentDialog`/`IncidentResolutionDialog` collect
+ * `watchList` 404s ("The requested resource was not found!") on
+ * `PATCH /incidents/{id}` for *any* id, in the correct UUID-array shape —
+ * confirmed live (an anonymous service account, a real named user, and a
+ * fresh retest during PR review all reproduce it identically), so it isn't a
+ * bad-id or bad-payload-shape problem on our side. Until the upstream
+ * (entity-service/ServiceNow) endpoint actually works, the Watchers tab shows
+ * the current list read-only rather than exposing an add/remove action that
+ * would always fail.
+ */
+const WATCH_LIST_UNAVAILABLE_REASON =
+  "Editing the watch list isn't available yet — the upstream API for this is broken (always returns 404), independent of this portal.";
+
+/**
+ * A single confirmed-live upstream limitation of `PATCH /incidents/{id}`
+ * (entity-service/ServiceNow, not this BFF or the FE): `state: RESOLVED`/
+ * `CLOSED` 500s without a resolution, fixed by having
+ * `EditIncidentDialog`/`IncidentResolutionDialog` collect
  * `resolutionCode`/`resolutionNotes` (write-only fields, no read-side model
- * — see `BeUpdateIncidentPayload`) once the target state is one of those two:
- *  - `watchList` 404s ("The requested resource was not found!") for *any*
- *    id — confirmed with both an anonymous service account and a real, named
- *    person, so it isn't a bad-id problem on our side. Watch-list edits now
- *    come from the Watchers tab's own add/remove PATCHes (`onAddWatcher`/
- *    `onRemoveWatcher` below), not the Edit dialog, but the 404 is still live
- *    there and still surfaces as a real error via `onError` — correct, if
- *    unfortunate, behavior.
- *  - `additionalComments` (and, defensively, `workNotes` — same ServiceNow
- *    journal-field shape, not independently confirmed) is the dangerous one:
- *    the PATCH returns 200, but the response's own echoed value comes back
- *    `null` even though we just set it — a silent no-op dressed as success.
- *    `checkSilentlyDroppedNotes` exists so this doesn't slip through: it
- *    catches a 200 that didn't actually persist what it claims to and treats
- *    it like the failure it is, rather than closing the dialog on a false
- *    positive. The Edit dialog no longer has UI to set either field (that's
- *    the Activities tab's job now), so this only matters if a future patch
- *    path resends them.
+ * — see `BeUpdateIncidentPayload`) once the target state is one of those two.
+ * `additionalComments` (and, defensively, `workNotes` — same ServiceNow
+ * journal-field shape, not independently confirmed) is the dangerous one:
+ * the PATCH returns 200, but the response's own echoed value comes back
+ * `null` even though we just set it — a silent no-op dressed as success.
+ * `checkSilentlyDroppedNotes` exists so this doesn't slip through: it
+ * catches a 200 that didn't actually persist what it claims to and treats
+ * it like the failure it is, rather than closing the dialog on a false
+ * positive. The Edit dialog no longer has UI to set either field (that's
+ * the Activities tab's job now), so this only matters if a future patch
+ * path resends them.
  */
 function checkSilentlyDroppedNotes(patch: BeUpdateIncidentPayload, saved: BeIncidentDetail): string[] {
   const dropped: string[] = [];
@@ -190,9 +192,6 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   // CsmCaseDetailPage — one attachment previewed at a time regardless of
   // which surface opened it.
   const [previewTarget, setPreviewTarget] = useState<CaseAttachment | null>(null);
-  // The Watchers tab's "Add watcher" picker — mounted only while open, same
-  // pattern as the Activities tab's reply composer.
-  const [watcherPickerOpen, setWatcherPickerOpen] = useState(false);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
   const watchList = useMemo(() => data?.watchList ?? [], [data?.watchList]);
@@ -231,61 +230,6 @@ export default function CsmIncidentDetailPage(): JSX.Element {
       );
     },
     [downloadAttachment, showError],
-  );
-
-  /**
-   * Add a watcher from the Watchers tab's picker. Unlike a case's watch list
-   * (email-addressed, see `CsmCaseDetailPage`), an incident's `watchList` is
-   * id-addressed — see `BeUpdateIncidentPayload`/`BeIncidentWatchListItem` —
-   * so this just PATCHes the full id list plus the newly picked one. Fires
-   * immediately, independent of the Edit dialog's Save, same as
-   * `onIncidentAction`. `watchList` is a confirmed-live 404 on this endpoint
-   * for any id (see the file-level doc comment) — that surfaces here as a
-   * real error via `onError`, same as everywhere else this quirk shows up.
-   */
-  const onAddWatcher = useCallback(
-    (userId: string) => {
-      if (!id) return;
-      const currentIds = watchList.map((w) => w.id);
-      if (currentIds.includes(userId)) {
-        setWatcherPickerOpen(false);
-        return;
-      }
-      patchIncident.mutate(
-        { id, patch: { watchList: [...currentIds, userId] } },
-        {
-          onSuccess: () => setWatcherPickerOpen(false),
-          onError: (err) => {
-            const msg =
-              err instanceof BackendApiError && err.status < 500 && err.message
-                ? err.message
-                : "Could not add the watcher. Please try again.";
-            showError(msg, err);
-          },
-        },
-      );
-    },
-    [id, watchList, patchIncident, showError],
-  );
-
-  const onRemoveWatcher = useCallback(
-    (userId: string) => {
-      if (!id) return;
-      const nextIds = watchList.filter((w) => w.id !== userId).map((w) => w.id);
-      patchIncident.mutate(
-        { id, patch: { watchList: nextIds } },
-        {
-          onError: (err) => {
-            const msg =
-              err instanceof BackendApiError && err.status < 500 && err.message
-                ? err.message
-                : "Could not remove the watcher. Please try again.";
-            showError(msg, err);
-          },
-        },
-      );
-    },
-    [id, watchList, patchIncident, showError],
   );
 
   /**
@@ -676,27 +620,24 @@ export default function CsmIncidentDetailPage(): JSX.Element {
         <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
             <Typography variant="subtitle2">Watch list</Typography>
-            <Button
-              size="small"
-              variant="text"
-              startIcon={<Plus size={14} />}
-              disabled={patchIncident.isPending}
-              onClick={() => setWatcherPickerOpen((v) => !v)}
-            >
-              Add watcher
-            </Button>
+            <Tooltip title={WATCH_LIST_UNAVAILABLE_REASON}>
+              {/* span wrapper: Tooltip needs a non-disabled child to attach its listeners to */}
+              <span>
+                <Button
+                  size="small"
+                  variant="text"
+                  startIcon={<Plus size={14} />}
+                  disabled
+                >
+                  Add watcher
+                </Button>
+              </span>
+            </Tooltip>
           </Box>
           {watchList.length > 0 ? (
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
               {watchList.map((w) => (
-                <Chip
-                  key={w.id}
-                  size="small"
-                  variant="outlined"
-                  label={w.name || w.email}
-                  disabled={patchIncident.isPending}
-                  onDelete={() => onRemoveWatcher(w.id)}
-                />
+                <Chip key={w.id} size="small" variant="outlined" label={w.name || w.email} />
               ))}
             </Box>
           ) : (
@@ -704,23 +645,9 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               No one is watching this incident.
             </Typography>
           )}
-          {watcherPickerOpen && (
-            <Box sx={{ maxWidth: 360 }}>
-              <AsyncEntitySelect<BeUser>
-                id="incident-watcher-add"
-                label="Add watcher"
-                placeholder="Search people…"
-                value=""
-                onChange={(v) => {
-                  if (v) onAddWatcher(v);
-                }}
-                disabled={patchIncident.isPending}
-                useSearch={useSearchUsersByName}
-                getId={(u) => u.id!}
-                getLabel={userLabel}
-              />
-            </Box>
-          )}
+          <Typography variant="caption" color="text.secondary">
+            {WATCH_LIST_UNAVAILABLE_REASON}
+          </Typography>
         </Card>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -24,6 +24,7 @@ import {
   MessageSquarePlus,
   Paperclip,
   Pencil,
+  Plus,
 } from "@wso2/oxygen-ui-icons-react";
 import {
   type JSX,
@@ -56,6 +57,9 @@ import {
   incidentStateColor,
   incidentStateLabel,
 } from "@features/csm-operations/utils/incidents";
+import { userLabel } from "@features/csm-operations/utils/incidentFormOptions";
+import { useSearchUsersByName } from "@api/useSearchUsersByName";
+import AsyncEntitySelect from "@components/AsyncEntitySelect";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
 import { AttachmentsWidget } from "@features/csm-cases/components/CaseDetailWidgets";
@@ -71,6 +75,7 @@ import type {
   BeIncidentDetail,
   BeIncidentState,
   BeUpdateIncidentPayload,
+  BeUser,
 } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 
@@ -85,16 +90,21 @@ const OPERATIONS_INCIDENTS_PATH = "/operations?tab=incidents";
  * — see `BeUpdateIncidentPayload`) once the target state is one of those two:
  *  - `watchList` 404s ("The requested resource was not found!") for *any*
  *    id — confirmed with both an anonymous service account and a real, named
- *    person, so it isn't a bad-id problem on our side.
+ *    person, so it isn't a bad-id problem on our side. Watch-list edits now
+ *    come from the Watchers tab's own add/remove PATCHes (`onAddWatcher`/
+ *    `onRemoveWatcher` below), not the Edit dialog, but the 404 is still live
+ *    there and still surfaces as a real error via `onError` — correct, if
+ *    unfortunate, behavior.
  *  - `additionalComments` (and, defensively, `workNotes` — same ServiceNow
  *    journal-field shape, not independently confirmed) is the dangerous one:
  *    the PATCH returns 200, but the response's own echoed value comes back
  *    `null` even though we just set it — a silent no-op dressed as success.
- * `watchList` already surfaces as a real error (see `onError` below) — this
- * is correct, if unfortunate, behavior. `checkSilentlyDroppedNotes` exists so
- * the notes case doesn't: it catches a 200 that didn't actually persist what
- * it claims to and treats it like the failure it is, rather than closing the
- * dialog on a false positive.
+ *    `checkSilentlyDroppedNotes` exists so this doesn't slip through: it
+ *    catches a 200 that didn't actually persist what it claims to and treats
+ *    it like the failure it is, rather than closing the dialog on a false
+ *    positive. The Edit dialog no longer has UI to set either field (that's
+ *    the Activities tab's job now), so this only matters if a future patch
+ *    path resends them.
  */
 function checkSilentlyDroppedNotes(patch: BeUpdateIncidentPayload, saved: BeIncidentDetail): string[] {
   const dropped: string[] = [];
@@ -180,6 +190,9 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   // CsmCaseDetailPage — one attachment previewed at a time regardless of
   // which surface opened it.
   const [previewTarget, setPreviewTarget] = useState<CaseAttachment | null>(null);
+  // The Watchers tab's "Add watcher" picker — mounted only while open, same
+  // pattern as the Activities tab's reply composer.
+  const [watcherPickerOpen, setWatcherPickerOpen] = useState(false);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
   const watchList = useMemo(() => data?.watchList ?? [], [data?.watchList]);
@@ -218,6 +231,61 @@ export default function CsmIncidentDetailPage(): JSX.Element {
       );
     },
     [downloadAttachment, showError],
+  );
+
+  /**
+   * Add a watcher from the Watchers tab's picker. Unlike a case's watch list
+   * (email-addressed, see `CsmCaseDetailPage`), an incident's `watchList` is
+   * id-addressed — see `BeUpdateIncidentPayload`/`BeIncidentWatchListItem` —
+   * so this just PATCHes the full id list plus the newly picked one. Fires
+   * immediately, independent of the Edit dialog's Save, same as
+   * `onIncidentAction`. `watchList` is a confirmed-live 404 on this endpoint
+   * for any id (see the file-level doc comment) — that surfaces here as a
+   * real error via `onError`, same as everywhere else this quirk shows up.
+   */
+  const onAddWatcher = useCallback(
+    (userId: string) => {
+      if (!id) return;
+      const currentIds = watchList.map((w) => w.id);
+      if (currentIds.includes(userId)) {
+        setWatcherPickerOpen(false);
+        return;
+      }
+      patchIncident.mutate(
+        { id, patch: { watchList: [...currentIds, userId] } },
+        {
+          onSuccess: () => setWatcherPickerOpen(false),
+          onError: (err) => {
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not add the watcher. Please try again.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [id, watchList, patchIncident, showError],
+  );
+
+  const onRemoveWatcher = useCallback(
+    (userId: string) => {
+      if (!id) return;
+      const nextIds = watchList.filter((w) => w.id !== userId).map((w) => w.id);
+      patchIncident.mutate(
+        { id, patch: { watchList: nextIds } },
+        {
+          onError: (err) => {
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not remove the watcher. Please try again.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [id, watchList, patchIncident, showError],
   );
 
   /**
@@ -536,40 +604,6 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               <MetaCell label="Configuration item"><RefText value={incident.configurationItem} /></MetaCell>
             </Box>
           </Card>
-
-          {(incident.additionalComments || incident.workNotes) && (
-            <Card
-              sx={{
-                p: 2.5,
-                display: "flex",
-                flexDirection: "column",
-                gap: 2.5,
-                gridColumn: { xs: "auto", md: "1 / -1" },
-              }}
-            >
-              <Typography variant="subtitle2">Comments &amp; notes</Typography>
-              {incident.additionalComments && (
-                <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    Additional comments (customer-visible)
-                  </Typography>
-                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                    {incident.additionalComments}
-                  </Typography>
-                </Box>
-              )}
-              {incident.workNotes && (
-                <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    Internal work notes
-                  </Typography>
-                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                    {incident.workNotes}
-                  </Typography>
-                </Box>
-              )}
-            </Card>
-          )}
         </Box>
       )}
 
@@ -640,11 +674,29 @@ export default function CsmIncidentDetailPage(): JSX.Element {
 
       {activeTab === "watchers" && (
         <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-          <Typography variant="subtitle2">Watch list</Typography>
+          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <Typography variant="subtitle2">Watch list</Typography>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Plus size={14} />}
+              disabled={patchIncident.isPending}
+              onClick={() => setWatcherPickerOpen((v) => !v)}
+            >
+              Add watcher
+            </Button>
+          </Box>
           {watchList.length > 0 ? (
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
               {watchList.map((w) => (
-                <Chip key={w.id} size="small" variant="outlined" label={w.name || w.email} />
+                <Chip
+                  key={w.id}
+                  size="small"
+                  variant="outlined"
+                  label={w.name || w.email}
+                  disabled={patchIncident.isPending}
+                  onDelete={() => onRemoveWatcher(w.id)}
+                />
               ))}
             </Box>
           ) : (
@@ -652,9 +704,23 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               No one is watching this incident.
             </Typography>
           )}
-          <Typography variant="caption" color="text.secondary">
-            Edit the watch list from the Edit dialog above.
-          </Typography>
+          {watcherPickerOpen && (
+            <Box sx={{ maxWidth: 360 }}>
+              <AsyncEntitySelect<BeUser>
+                id="incident-watcher-add"
+                label="Add watcher"
+                placeholder="Search people…"
+                value=""
+                onChange={(v) => {
+                  if (v) onAddWatcher(v);
+                }}
+                disabled={patchIncident.isPending}
+                useSearch={useSearchUsersByName}
+                getId={(u) => u.id!}
+                getLabel={userLabel}
+              />
+            </Box>
+          )}
         </Card>
       )}
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Live-testing the recently revamped incident detail page (cs-tools#1289) surfaced four UX problems:

1. The Details tab and the Edit dialog both showed a "Comments & notes" section, duplicating what the Activities tab already handles.
2. Editing the watch list required opening the big Edit dialog instead of managing it directly from the Watchers tab, unlike the case detail page.
3. "Parent incident", "Change request", and "Problem" were raw text fields requiring a hand-pasted UUID — no way to search for the record you meant.
4. Every async search picker in the app (services, groups, configuration items, people, etc.) showed nothing until you typed something, even though the dropdown was already open — it reads as broken rather than as "type to search."

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Remove the duplicate comments/notes UI from both the Details tab and the Edit dialog.
2. Make the Watchers tab interactive — add/remove a watcher directly, independent of the Edit dialog.
3. Convert Parent incident / Change request / Problem to real search-and-pick fields.
4. Make every async picker show an initial page of results as soon as it opens, not only after typing.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

1. Removed the Details tab's read-only "Comments & notes" card and the Edit dialog's "Notes" section (`additionalComments`/`workNotes` fields), including from the dialog's local edit state and patch-diffing logic — commenting is fully handled by the Activities tab already.
2. The Watchers tab now shows each watcher as a removable chip and an "Add watcher" action that opens a people-search picker; each add/remove fires its own `PATCH /incidents/{id} { watchList }` immediately, the same independence-from-the-edit-dialog pattern the case detail page already uses. Removed the corresponding `AsyncEntityMultiSelect` from the Edit dialog.
3. Added two new `AsyncEntitySelect`-shaped search hooks (`useSearchChangeRequestsForSelect`, `useSearchProblemsForSelect`) and reused the existing `useSearchIncidentsForSelect` for Parent incident. "Caused by" is left as plain text — its target entity type is unconfirmed (could be a change request, a problem, or something else), so there's no single endpoint to point it at.
4. Root-caused the "nothing shows until I type" complaint: `AsyncEntitySelect` already fires its search hook the moment the dropdown opens, but every hook built for it explicitly disabled itself until a non-empty query was typed (`enabled: enabled && query.length > 0`). Changed every such hook (`useSearchGroups`, `useSearchItServices`, `useSearchServiceOfferings`, `useSearchConfigurationItems`, `useSearchUsersByName`, `useSearchIncidentsForSelect`, `useSearchCasesForSelect`, and the two new hooks) to just `enabled`, so opening a picker fires an empty-query request and shows the backend's default page immediately. Verified an empty `searchQuery` is safe end-to-end: no BFF handler enforces a minimum length, and the entity-service's shared validator only caps the maximum (200 chars) — empty is explicitly allowed, and `omitempty` means it isn't even forwarded to the SN adapter payload as an empty string. The quick-nav palette's own search hooks (`useQuickCaseSearch` and its siblings) were deliberately left untouched — that's a keystroke-driven global search, a different component with a different reason to gate on query length.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer editing an incident, I don't want to see the same comment thread twice in two different places.
- As a CS engineer, I want to add or remove a watcher without opening the full edit form.
- As a CS engineer linking an incident to its parent/change request/problem, I want to search by name, not hunt down and paste a UUID.
- As a CS engineer opening any search picker in this app, I want to see options immediately, not wonder if it's broken.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

- Removed duplicate comments/notes UI from the incident Details tab and Edit dialog.
- Watch-list editing moved to the incident Watchers tab, matching the case detail page.
- Parent incident / Change request / Problem are now searchable pickers instead of raw UUID fields.
- Every async search picker in the CSM portal now shows an initial list of options as soon as it's opened.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal CSM-portal-only UI changes, no externally published documentation covers this workflow.

## Training

N/A — no training content exists for this internal tool.

## Certification

N/A — internal tool, not covered by any certification exam.

## Marketing

N/A — internal tool, not customer/market-facing.

## Automation tests
 - Unit tests
   > Code coverage information

Added/updated: `useSearchGroups.test.tsx` (eager empty-query fetch on open, no fetch while closed), `EditIncidentDialog.test.tsx` (Notes/watch-list sections gone, linking fields render as comboboxes and fire eager empty-query searches), `CsmIncidentDetailPage.test.tsx` (Comments & notes card gone, Watchers tab add/remove independently PATCHes the watch list). Full `pnpm exec vitest run`: 527 passed / 9 failed, all 9 reproduced identically on a clean pre-change checkout (`CaseActivitiesFeed.test.tsx`, `CsmAnnouncementsPage.test.tsx`, `CaseActionBar.test.tsx`) — confirmed pre-existing and unrelated to this PR.
 - Integration tests
   > Details about the test cases and coverage

No new e2e scenarios; FE unit-test coverage only.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React, not a Java target; ran `pnpm lint`/`tsc -b` clean instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Builds on cs-tools#1289 (merged) — the incident detail page revamp this PR further improves.

## Migrations (if applicable)

N/A — no data migration involved.

## Test environment

Node/pnpm toolchain per `apps/csm-portal/webapp/package.json`; unit tests via `vitest`.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

While diagnosing a related "can't post a comment on an incident" report, root-caused a separate live 404 on `POST /incidents/{id}/comments` to a stale/suspended Choreo deployment on `csm-portal-backend` (a successful build for a newer commit already exists but was never deployed) — tracked separately with the component owner, not a frontend issue and not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added searchable linking pickers for parent incidents, change requests, and problems.
  * Search pickers now show default results as soon as the dropdown opens, even before typing.
  * Incident editing now supports linked records and no longer includes notes or watch-list fields.
* **Bug Fixes**
  * Removed the “Comments & notes” card from incident details.
  * Incident Watchers are now effectively read-only: the add/remove workflow was disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->