### PR TITLE
[CSM Portal Microapp] Fix glassy/unreadable filter popups

### DIFF
--- a/apps/csm-portal/microapp/src/theme/index.ts
+++ b/apps/csm-portal/microapp/src/theme/index.ts
@@ -20,6 +20,25 @@ import { typography } from "@theme/typography";
 
 const theme = extendTheme(AcrylicOrangeTheme, {
   typography,
+  components: {
+    // @wso2/oxygen-ui's own MuiDialog override (dist/index.js) sets `opacity: 0.7` plus a
+    // backdrop blur on the dialog surface itself — on top of an already semi-transparent
+    // background.paper token, that's a double-transparency effect that makes the whole
+    // surface, including its text, read as hazy/unreadable. All of this app's filter sheets
+    // (FiltersSheet.tsx and friends) are built on MUI Dialog, so fix it once here rather than
+    // overriding sx per sheet. Solid, not background.paper/acrylic — same reasoning as
+    // TabBar.tsx/TopBar.tsx's own fix for the same underlying tokens.
+    MuiDialog: {
+      styleOverrides: {
+        paper: ({ theme }) => ({
+          WebkitBackdropFilter: "none",
+          backdropFilter: "none",
+          background: theme.palette.mode === "dark" ? "#000000" : "#ffffff",
+          opacity: 1,
+        }),
+      },
+    },
+  },
 }) as OxygenTheme;
 
 export default theme;


### PR DESCRIPTION
## Summary
- `@wso2/oxygen-ui`'s own `MuiDialog` style override sets `opacity: 0.7` plus a backdrop blur on the dialog surface, stacked on top of an already semi-transparent `background.paper` token. Every filter sheet in this app (`FiltersSheet.tsx` and its siblings across support/operations/timecards/announcements/engagements/security-center/settings) is built on MUI `Dialog`, so all of them rendered hazy — including the text inside, which made them hard to read against whatever was behind them.
- Fixed once at the theme level (`theme/index.ts`) by overriding `MuiDialog`'s `paper` style with a solid background (keyed off `theme.palette.mode`, consistent with the earlier `TabBar`/`TopBar` fix) and no backdrop filter, rather than patching every individual sheet component.

## Test plan
- [x] `tsc -b --noEmit` passes
- [x] `eslint` passes
- [x] Verified in the iOS simulator: filter dialog now renders solid/opaque and readable instead of glassy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog appearance by removing unwanted transparency effects.
  * Dialog backgrounds now display as solid black in dark mode and solid white in light mode.
  * Ensured dialogs render at full opacity for clearer, more consistent visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->