### PR TITLE
[Entity Service + Webapp] fix ongoing-work-item pre-check and unblock case closing

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseComposition.ts
@@ -105,6 +105,10 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
               filters: {
                 severities: [priorityFromSeverity(sev)],
                 states: activeStateKeys,
+                // The pies drill into the cases list, which is locked to
+                // plain cases — pin every count to the same type so the
+                // totals reconcile with that destination and the matrix.
+                types: ["case"],
               },
             }).then((n) => ({ key: sev, n })),
           ),
@@ -116,6 +120,7 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
               filters: {
                 states: [beStateFromUi(st)],
                 severities: allPriorityKeys,
+                types: ["case"],
               },
             }).then((n) => ({ key: st, n })),
           ),
@@ -125,6 +130,7 @@ export function useCaseComposition(): UseQueryResult<CaseComposition, Error> {
           filters: {
             states: [beStateFromUi("closed")],
             severities: allPriorityKeys,
+            types: ["case"],
           },
         }),
       ]);

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseCountsMatrix.ts
@@ -96,6 +96,9 @@ export function useCaseCountsMatrix(): UseQueryResult<CaseCountsMatrix, Error> {
               filters: {
                 severities: [priorityFromSeverity(severity)],
                 states: [beStateFromUi(state)],
+                // Cells drill into the cases list, which is locked to plain
+                // cases — pin the count to the same type so it reconciles.
+                types: ["case"],
               },
             })
             .then((res) => ({ severity, state, count: res.total ?? 0 })),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetMyAssignedOpenCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetMyAssignedOpenCases.ts
@@ -114,6 +114,10 @@ export function useGetMyAssignedOpenCases(
           filters: {
             assignedUserIds: [userId as string],
             states: NON_CLOSED_STATES,
+            // The "View all" link deep-links into the cases list, which is
+            // locked to plain cases — pin the widget to the same type so its
+            // count/rows match what that destination shows.
+            types: ["case"],
           },
         },
       );

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCasesForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchCasesForSelect.ts
@@ -34,6 +34,10 @@ const CASE_SEARCH_LIMIT = 20;
  * as soon as the dropdown opens, even with an empty query, so the picker
  * shows a default page instead of looking broken until the caller types
  * something.
+ *
+ * A problem's origin case must be a plain case, not a service request,
+ * engagement, or other case type, so the search is pinned to `types:
+ * ["case"]` rather than relying on the backend's (now cross-type) default.
  */
 export function useSearchCasesForSelect(
   query: string,
@@ -47,7 +51,10 @@ export function useSearchCasesForSelect(
     queryFn: async (): Promise<BeCaseSearchView[]> => {
       const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
         "/cases/search",
-        { filters: { searchQuery: q }, pagination: { offset: 0, limit: CASE_SEARCH_LIMIT } },
+        {
+          filters: { searchQuery: q, types: ["case"] },
+          pagination: { offset: 0, limit: CASE_SEARCH_LIMIT },
+        },
       );
       return res.cases ?? [];
     },

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1349,20 +1349,6 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		payload.PublicTicket = req.PublicTicket
 	}
 
-	// Close-gate: reject closing a case that still has an open, customer-visible task.
-	// This is the authoritative server-side check (item 1's close-gating requirement) --
-	// it only needs the existing read path (task search + task detail), so it is fully
-	// wired even though task writes themselves are still Ballerina-blocked.
-	if payload.StateKey != nil && *payload.StateKey == snStateIDMap[domain.CaseStateClosed] {
-		blocked, err := s.hasOpenVisibleTasks(ctx, uuidToSysid(req.ID), token)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, err
-		}
-		if blocked {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "case cannot be closed while it has an open task visible to the customer"}
-		}
-	}
-
 	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)
 	if err != nil {
 		return domain.UpdateCaseResponse{}, err
@@ -2102,51 +2088,6 @@ func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
 	default:
 		return nil
 	}
-}
-
-// hasOpenVisibleTasks reports whether the case identified by caseSysid has any
-// open task that is visible to the customer. Used by the close-gate in
-// UpdateCase (item 1's authoritative "can this case close?" check).
-//
-// SN's case-scoped task listing (snTask/snCaseTasksResponse, see
-// sn_task_service.go) does not carry visibleToCustomer -- only the single-task
-// detail response (snTaskDetail) does. So this walks the non-closed tasks
-// returned by the search and fetches each one's detail to check visibility.
-// Case task counts are small in practice, so a single page (limit 100) is
-// fetched rather than paginating fully; if that assumption stops holding, this
-// should switch to paging until exhausted.
-func (s *snCaseService) hasOpenVisibleTasks(ctx context.Context, caseSysid, token string) (bool, error) {
-	payload := snCaseTasksSearchPayload{Pagination: snProjectPagination{Limit: 100, Offset: 0}}
-
-	raw, err := s.client.Post(ctx, "/cases/"+caseSysid+"/tasks/search", token, payload)
-	if err != nil {
-		return false, err
-	}
-
-	var tasksResp snCaseTasksResponse
-	if err := json.Unmarshal(raw, &tasksResp); err != nil {
-		return false, fmt.Errorf("sn update case: parse case tasks response: %w", err)
-	}
-
-	for _, t := range tasksResp.Tasks {
-		if t.State != nil && *t.State == "CLOSED" {
-			continue
-		}
-
-		detailRaw, err := s.client.Get(ctx, "/tasks/"+t.ID, token)
-		if err != nil {
-			return false, err
-		}
-		var detail snTaskDetail
-		if err := json.Unmarshal(detailRaw, &detail); err != nil {
-			return false, fmt.Errorf("sn update case: parse task detail response: %w", err)
-		}
-		if detail.VisibleToCustomer {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 // snAddTagPayload is the Choreo POST /cases/{id}/tags request body.

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1865,10 +1865,14 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "types contains invalid value: " + t}
 		}
 	}
+	// An empty/omitted Types filter means "no type restriction" -- SN's own case
+	// search (CaseUtils._resolveCaseTypeIds + applyFilters) already treats an
+	// empty caseTypes list this way, skipping the type query entirely. Defaulting
+	// it to ["default_case"] here silently excluded every non-"case" type (most
+	// importantly service_request) from callers that search across all types,
+	// e.g. the "does this engineer already have another ongoing work item"
+	// pre-check before starting a new case.
 	snCaseTypes := domainTypeKeysToSN(req.Filters.Types)
-	if len(snCaseTypes) == 0 {
-		snCaseTypes = []string{"default_case"}
-	}
 
 	payload := snCaseSearchPayload{
 		Filters: snCaseFilters{

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -933,6 +933,37 @@ func TestSNCaseService_UpdateCase_EchoesInternalFixEtaFieldsBack(t *testing.T) {
 
 // --- SearchTags ---
 
+func TestSNCaseService_SearchCases_EmptyTypesFilterSendsNoTypeRestriction(t *testing.T) {
+	// An empty/omitted Types filter must mean "search every case type" -- SN's
+	// own case search already treats an empty caseTypes list this way. Guards
+	// against reintroducing a default like ["default_case"], which silently
+	// excluded service_request (and every other non-"case" type) from any
+	// caller searching across all types, e.g. the "does this engineer already
+	// have another ongoing work item" pre-check.
+	var gotBody struct {
+		Filters struct {
+			CaseTypes []string `json:"caseTypes"`
+		} `json:"filters"`
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	if _, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gotBody.Filters.CaseTypes) != 0 {
+		t.Fatalf("expected no caseTypes restriction sent when Types filter is empty, got %v", gotBody.Filters.CaseTypes)
+	}
+}
+
 func TestSNCaseService_SearchTags_Success(t *testing.T) {
 	var gotQuery string
 	mux := http.NewServeMux()

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -557,7 +557,9 @@ func TestSNCaseService_UpdateCase_Close_NoLongerCallsTaskSearch(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"tasks": []map[string]any{}, "total": 0, "offset": 0, "limit": 100})
 	})
 	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
-		patchCalled = true
+		if r.Method == http.MethodPatch {
+			patchCalled = true
+		}
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
 	})

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -536,23 +536,25 @@ func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
 	}
 }
 
-// --- UpdateCase: close-gate ---
+// --- UpdateCase: close no longer gated on open visible tasks ---
+//
+// The open-visible-task close-gate previously enforced here has been removed:
+// it required two extra round trips (task search + per-task detail) to a
+// dependency whose own pagination limit violated the entity-service's
+// Pagination.limit constraint (max 50 vs the hardcoded 100 this gate sent),
+// which broke every case close in production. That business rule belongs at
+// the ServiceNow layer instead (see CaseUtils.patchCaseState's existing,
+// zero-round-trip child-case-block-close pattern) -- tracked in
+// tasks/active/2026-07-30-sn-close-gate-migration.md. This test guards
+// against silently reintroducing the Go-side gate.
 
-func TestSNCaseService_UpdateCase_CloseGate_BlocksOnOpenVisibleTask(t *testing.T) {
+func TestSNCaseService_UpdateCase_Close_NoLongerCallsTaskSearch(t *testing.T) {
+	taskSearchCalled := false
 	patchCalled := false
 	mux := http.NewServeMux()
 	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks/search", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"tasks": []map[string]any{
-				{"id": testTaskSysid, "subject": "follow up", "state": "OPEN"},
-			},
-			"total": 1, "offset": 0, "limit": 100,
-		})
-	})
-	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id": testTaskSysid, "subject": "follow up", "visibleToCustomer": true,
-		})
+		taskSearchCalled = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"tasks": []map[string]any{}, "total": 0, "offset": 0, "limit": 100})
 	})
 	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
 		patchCalled = true
@@ -564,47 +566,14 @@ func TestSNCaseService_UpdateCase_CloseGate_BlocksOnOpenVisibleTask(t *testing.T
 	svc := NewServiceNowCaseService(client, nil)
 
 	closed := domain.CaseStateClosed
-	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed})
-	if _, ok := err.(*apierror.ValidationError); !ok {
-		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
-	}
-	if patchCalled {
-		t.Fatalf("expected PATCH /cases/{id} not to be called when an open visible task blocks the close")
-	}
-}
-
-func TestSNCaseService_UpdateCase_CloseGate_AllowsWhenNoVisibleOpenTask(t *testing.T) {
-	patchCalled := false
-	mux := http.NewServeMux()
-	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks/search", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"tasks": []map[string]any{
-				{"id": testTaskSysid, "subject": "internal note", "state": "OPEN"},
-			},
-			"total": 1, "offset": 0, "limit": 100,
-		})
-	})
-	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id": testTaskSysid, "subject": "internal note", "visibleToCustomer": false,
-		})
-	})
-	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
-		patchCalled = true
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
-	})
-
-	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil)
-
-	closed := domain.CaseStateClosed
-	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed})
-	if err != nil {
+	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed}); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
+	if taskSearchCalled {
+		t.Fatalf("expected closing a case not to call /cases/{id}/tasks/search (close-gate removed from Go)")
+	}
 	if !patchCalled {
-		t.Fatalf("expected PATCH /cases/{id} to be called when no visible open task blocks the close")
+		t.Fatalf("expected PATCH /cases/{id} to be called")
 	}
 }
 

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -911,7 +911,7 @@ func TestSNCaseService_SearchCases_EmptyTypesFilterSendsNoTypeRestriction(t *tes
 	// have another ongoing work item" pre-check.
 	var gotBody struct {
 		Filters struct {
-			CaseTypes []string `json:"caseTypes"`
+			CaseTypes *[]string `json:"caseTypes"`
 		} `json:"filters"`
 	}
 	mux := http.NewServeMux()
@@ -928,8 +928,14 @@ func TestSNCaseService_SearchCases_EmptyTypesFilterSendsNoTypeRestriction(t *tes
 	if _, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(gotBody.Filters.CaseTypes) != 0 {
-		t.Fatalf("expected no caseTypes restriction sent when Types filter is empty, got %v", gotBody.Filters.CaseTypes)
+	// Decode caseTypes as *[]string (not []string) so this distinguishes the
+	// actual wire contract -- Go always sends an explicit empty array, never
+	// omits the field or sends null -- from a regression that would omit it.
+	if gotBody.Filters.CaseTypes == nil {
+		t.Fatalf("expected caseTypes to be sent as an explicit empty array, got the field omitted/null")
+	}
+	if len(*gotBody.Filters.CaseTypes) != 0 {
+		t.Fatalf("expected no caseTypes restriction sent when Types filter is empty, got %v", *gotBody.Filters.CaseTypes)
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Two case-close/case-search bugs, both stemming from the same investigation:

1. An engineer with an ongoing service request (SR) couldn't start work on a
   new case: the FE's "does this engineer already have an ongoing work item"
   pre-check doesn't see the SR, so the UI proceeds and ServiceNow's own
   one-ongoing-item-per-engineer validation rejects the follow-up PATCH.
2. Closing any case is currently broken in production: `PATCH /cases/{id}
   {"state":"closed"}` fails with `400 {"message":"Failed to bind request
   payload to the expected schema."}` for every case, regardless of state or
   task content.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Make the "ongoing work item" pre-check search across every case type as
intended, without changing behavior for other case-search callers; and
unblock case closing now rather than patch a fragile mechanism again.

## Approach
> Describe how you are implementing the solutions.

**Ongoing-work-item pre-check (backend):** the FE's `useFindMyOngoingCases`
deliberately omits a `types` filter, to search across every case type owned
by the engineer. `snCaseService.SearchCases` (ServiceNow-backed) was
defaulting that empty filter to `["default_case"]`, silently excluding
`service_request` (and every other non-"case" type). Verified against
ServiceNow's own `CaseUtils` script that this default was unnecessary --
`_resolveCaseTypeIds` already returns no ids for an empty/omitted
`caseTypes` filter, and `applyFilters` only adds the type query when
`caseTypeIds.length > 0`, so an empty filter already means "no restriction"
at the SN layer. Removed the Go-side default; an empty `Types` filter now
passes through unrestricted, matching the Postgres-backed
`case_service.go`'s existing behavior.

**Frontend fallout (audited every `/cases/search` call site):** most callers
either already pass an explicit `types` filter (unaffected) or genuinely want
cross-type results by design (correctly fixed by this change: the project
"Issues" tab, quick-nav search, case linking). Four surfaces omitted `types`
while their copy or linked destination implicitly assumed case-only, and
would have started silently mixing in service requests/engagements/etc. as a
regression:
- `useSearchCasesForSelect` (`CreateProblemPage`'s "Origin case" picker) -- a
  Problem's origin case must be a plain case.
- `useGetMyAssignedOpenCases` (dashboard "Assigned to me" widget) -- its
  "View all" link deep-links into the cases list, which is locked to plain
  cases.
- `useCaseCountsMatrix` (dashboard severity/state matrix) -- cells drill into
  the same cases-list destination.
- `useCaseComposition` (dashboard composition pies) -- same drill-down
  destination as the matrix.

Pinned each to `types: ["case"]` so their counts/rows/results match what
their own labels and linked destinations already promise.

**Case-close (backend):** root cause of the close failure is `UpdateCase`'s
close-gate, which calls `hasOpenVisibleTasks` -- POSTing
`/cases/{id}/tasks/search` with a hardcoded pagination limit of 100. The
entity-service's shared `Pagination` record constrains `limit` to a
`maxValue` of 50, so a limit of 100 fails ServiceNow's own request
validation at bind time, for every case, independent of that case's actual
task count. That bind failure was propagating up as if the close itself had
failed.

Rather than patch the limit value again, this removes the Go-side
close-gate entirely. The underlying rule -- "don't close a case that still
has an open, customer-visible task" -- is a server-side authority concern.
ServiceNow's own `CaseUtils.patchCaseState` already has a directly analogous,
zero-round-trip pattern for the same class of rule (blocks closing while
open *child cases* exist, via a single in-transaction GlideRecord query).
The Go-side version required two extra network calls per close (task search
+ per-task detail fetch) purely to reconstruct visibility info SN already
has locally -- that fragility is exactly what broke production here.

This unblocks case closing immediately. The equivalent check moving into
ServiceNow (mirroring the child-case-block pattern) is scoped separately:
`tasks/active/2026-07-30-sn-close-gate-migration.md` in the planning repo --
still has open blockers (exact SN task-visibility field/table, the target
update set, and a customer-portal impact check, since `patchCaseState` is
confirmed to be on the customer portal's live path). Until that lands, there
is no server-side enforcement of the open-task rule -- an accepted, explicit
tradeoff to unblock closing now rather than leave every case close broken
while that follow-up is scoped and reviewed.

## Automation tests
 - Unit tests
   - `TestSNCaseService_SearchCases_EmptyTypesFilterSendsNoTypeRestriction` --
     asserts no `caseTypes` restriction is sent to ServiceNow when the
     `Types` filter is empty.
   - `TestSNCaseService_UpdateCase_Close_NoLongerCallsTaskSearch` (replaces
     the two former close-gate tests) -- asserts closing a case succeeds and
     no longer calls `/cases/{id}/tasks/search` at all.
   - Full `go test ./...` and `go vet ./...` are clean.
   - `npx tsc -b` clean on the webapp; ran the affected FE test file
     (`CreateProblemPage.test.tsx`, 8 tests) -- the three dashboard hooks have
     no dedicated test files today.

## Test environment
Go 1.x, `go test ./...` locally. Node/vitest for the webapp. Root-cause
behavior for both fixes confirmed against the live ServiceNow `CaseUtils`
script include's actual handling, not just the wire shape.

## Security checks
 - Followed secure coding standards: yes
 - Ran FindSecurityBugs plugin and verified report: N/A (Go, not Java)
 - Confirmed no keys/passwords/tokens/secrets committed: yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case searches now keep “no type restriction” when no type filter is provided, instead of applying a default case type.

* **Bug Fixes**
  * Cases can now be closed even when open customer-visible tasks exist.
  * Dashboard counts, assigned-case widgets, and case selectors are now consistently restricted to standard cases so totals match the cases shown in lists and drill-downs.

* **Documentation**
  * Clarified that dashboard/counts queries are pinned to standard case types.

* **Tests**
  * Updated close-handling and request-shape tests to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->