### PR TITLE
[Entity Service] remove Go close-gate blocking every case close

### DIFF
--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1349,20 +1349,6 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		payload.PublicTicket = req.PublicTicket
 	}
 
-	// Close-gate: reject closing a case that still has an open, customer-visible task.
-	// This is the authoritative server-side check (item 1's close-gating requirement) --
-	// it only needs the existing read path (task search + task detail), so it is fully
-	// wired even though task writes themselves are still Ballerina-blocked.
-	if payload.StateKey != nil && *payload.StateKey == snStateIDMap[domain.CaseStateClosed] {
-		blocked, err := s.hasOpenVisibleTasks(ctx, uuidToSysid(req.ID), token)
-		if err != nil {
-			return domain.UpdateCaseResponse{}, err
-		}
-		if blocked {
-			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "case cannot be closed while it has an open task visible to the customer"}
-		}
-	}
-
 	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)
 	if err != nil {
 		return domain.UpdateCaseResponse{}, err
@@ -2098,51 +2084,6 @@ func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
 	default:
 		return nil
 	}
-}
-
-// hasOpenVisibleTasks reports whether the case identified by caseSysid has any
-// open task that is visible to the customer. Used by the close-gate in
-// UpdateCase (item 1's authoritative "can this case close?" check).
-//
-// SN's case-scoped task listing (snTask/snCaseTasksResponse, see
-// sn_task_service.go) does not carry visibleToCustomer -- only the single-task
-// detail response (snTaskDetail) does. So this walks the non-closed tasks
-// returned by the search and fetches each one's detail to check visibility.
-// Case task counts are small in practice, so a single page (limit 100) is
-// fetched rather than paginating fully; if that assumption stops holding, this
-// should switch to paging until exhausted.
-func (s *snCaseService) hasOpenVisibleTasks(ctx context.Context, caseSysid, token string) (bool, error) {
-	payload := snCaseTasksSearchPayload{Pagination: snProjectPagination{Limit: 100, Offset: 0}}
-
-	raw, err := s.client.Post(ctx, "/cases/"+caseSysid+"/tasks/search", token, payload)
-	if err != nil {
-		return false, err
-	}
-
-	var tasksResp snCaseTasksResponse
-	if err := json.Unmarshal(raw, &tasksResp); err != nil {
-		return false, fmt.Errorf("sn update case: parse case tasks response: %w", err)
-	}
-
-	for _, t := range tasksResp.Tasks {
-		if t.State != nil && *t.State == "CLOSED" {
-			continue
-		}
-
-		detailRaw, err := s.client.Get(ctx, "/tasks/"+t.ID, token)
-		if err != nil {
-			return false, err
-		}
-		var detail snTaskDetail
-		if err := json.Unmarshal(detailRaw, &detail); err != nil {
-			return false, fmt.Errorf("sn update case: parse task detail response: %w", err)
-		}
-		if detail.VisibleToCustomer {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 // snAddTagPayload is the Choreo POST /cases/{id}/tags request body.

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -536,23 +536,25 @@ func TestSNCaseService_UpdateCase_FieldCountValidation(t *testing.T) {
 	}
 }
 
-// --- UpdateCase: close-gate ---
+// --- UpdateCase: close no longer gated on open visible tasks ---
+//
+// The open-visible-task close-gate previously enforced here has been removed:
+// it required two extra round trips (task search + per-task detail) to a
+// dependency whose own pagination limit violated the entity-service's
+// Pagination.limit constraint (max 50 vs the hardcoded 100 this gate sent),
+// which broke every case close in production. That business rule belongs at
+// the ServiceNow layer instead (see CaseUtils.patchCaseState's existing,
+// zero-round-trip child-case-block-close pattern) -- tracked in
+// tasks/active/2026-07-30-sn-close-gate-migration.md. This test guards
+// against silently reintroducing the Go-side gate.
 
-func TestSNCaseService_UpdateCase_CloseGate_BlocksOnOpenVisibleTask(t *testing.T) {
+func TestSNCaseService_UpdateCase_Close_NoLongerCallsTaskSearch(t *testing.T) {
+	taskSearchCalled := false
 	patchCalled := false
 	mux := http.NewServeMux()
 	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks/search", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"tasks": []map[string]any{
-				{"id": testTaskSysid, "subject": "follow up", "state": "OPEN"},
-			},
-			"total": 1, "offset": 0, "limit": 100,
-		})
-	})
-	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id": testTaskSysid, "subject": "follow up", "visibleToCustomer": true,
-		})
+		taskSearchCalled = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"tasks": []map[string]any{}, "total": 0, "offset": 0, "limit": 100})
 	})
 	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
 		patchCalled = true
@@ -564,47 +566,14 @@ func TestSNCaseService_UpdateCase_CloseGate_BlocksOnOpenVisibleTask(t *testing.T
 	svc := NewServiceNowCaseService(client, nil)
 
 	closed := domain.CaseStateClosed
-	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed})
-	if _, ok := err.(*apierror.ValidationError); !ok {
-		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
-	}
-	if patchCalled {
-		t.Fatalf("expected PATCH /cases/{id} not to be called when an open visible task blocks the close")
-	}
-}
-
-func TestSNCaseService_UpdateCase_CloseGate_AllowsWhenNoVisibleOpenTask(t *testing.T) {
-	patchCalled := false
-	mux := http.NewServeMux()
-	mux.HandleFunc("/cases/"+testCaseSysid+"/tasks/search", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"tasks": []map[string]any{
-				{"id": testTaskSysid, "subject": "internal note", "state": "OPEN"},
-			},
-			"total": 1, "offset": 0, "limit": 100,
-		})
-	})
-	mux.HandleFunc("/tasks/"+testTaskSysid, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id": testTaskSysid, "subject": "internal note", "visibleToCustomer": false,
-		})
-	})
-	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
-		patchCalled = true
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok", "case": map[string]any{"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00"}})
-	})
-
-	client := newTestSNClient(t, mux)
-	svc := NewServiceNowCaseService(client, nil)
-
-	closed := domain.CaseStateClosed
-	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed})
-	if err != nil {
+	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, State: &closed}); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
+	if taskSearchCalled {
+		t.Fatalf("expected closing a case not to call /cases/{id}/tasks/search (close-gate removed from Go)")
+	}
 	if !patchCalled {
-		t.Fatalf("expected PATCH /cases/{id} to be called when no visible open task blocks the close")
+		t.Fatalf("expected PATCH /cases/{id} to be called")
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Closing any case is currently broken in production: `PATCH /cases/{id}
{"state":"closed"}` fails with `400 {"message":"Failed to bind request
payload to the expected schema."}` for every case, regardless of state or
task content.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Unblock case closing now, and stop reimplementing this business rule in Go
via a fragile multi-round-trip dependency.

## Approach
> Describe how you are implementing the solutions.

Root cause: before allowing a close, `UpdateCase`'s close-gate calls
`hasOpenVisibleTasks`, which POSTs `/cases/{id}/tasks/search` with a
hardcoded pagination limit of 100. The entity-service's shared `Pagination`
record constrains `limit` to a `maxValue` of 50, so a limit of 100 fails
ServiceNow's own request validation at bind time -- for every case,
independent of that case's actual task count. That bind failure was
propagating up as if the close itself had failed.

Rather than patch the limit value again, this removes the Go-side
close-gate entirely. The underlying rule -- "don't close a case that still
has an open, customer-visible task" -- is a server-side authority concern.
ServiceNow's own `CaseUtils.patchCaseState` already has a directly analogous,
zero-round-trip pattern for the same class of rule (blocks closing while
open *child cases* exist, via a single in-transaction GlideRecord query).
The Go-side version required two extra network calls per close (task search
+ per-task detail fetch) purely to reconstruct visibility info SN already
has locally -- that fragility is exactly what broke production here.

This PR removes the Go-side check so case closing works again immediately.
The equivalent check moving into ServiceNow (mirroring the child-case-block
pattern) is scoped separately:
`tasks/active/2026-07-30-sn-close-gate-migration.md` in the planning repo --
that work still has open blockers (exact SN task-visibility field/table, the
target update set, and a customer-portal impact check, since
`patchCaseState` is confirmed to be on the customer portal's live path).
Until that lands, there is no server-side enforcement of the open-task rule
-- an accepted, explicit tradeoff to unblock closing now rather than leave
every case close broken while that follow-up is scoped and reviewed.

## Automation tests
 - Unit tests
   Replaced `TestSNCaseService_UpdateCase_CloseGate_BlocksOnOpenVisibleTask`
   and `TestSNCaseService_UpdateCase_CloseGate_AllowsWhenNoVisibleOpenTask`
   with `TestSNCaseService_UpdateCase_Close_NoLongerCallsTaskSearch`, which
   asserts closing a case succeeds and no longer calls
   `/cases/{id}/tasks/search` at all. Full `go test ./...` and
   `go vet ./...` are clean.

## Test environment
Go 1.x, `go test ./...` locally.

## Security checks
 - Followed secure coding standards: yes
 - Ran FindSecurityBugs plugin and verified report: N/A (Go, not Java)
 - Confirmed no keys/passwords/tokens/secrets committed: yes
