### PR TITLE
[CSM][Web] fix Time Cards table blocking on the full project catalogue

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useCallback, useEffect, useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useCallback, useMemo, useRef, useState, type ChangeEvent, type JSX } from "react";
 import {
   AdapterDateFns,
   Box,
@@ -333,32 +333,39 @@ export default function CsmTimeCardsPage(): JSX.Element {
   // otherwise drop a selected project's name the moment the newly active
   // tab's own cards don't happen to include it — or are empty — leaving the
   // chip showing a raw id until the dropdown is reopened and re-searched.
+  //
+  // Reconciled during render (React's "adjusting state when data changes"
+  // pattern: https://react.dev/reference/react/useState#storing-information-from-previous-renders)
+  // rather than in an effect, so a fresh name is available in the same
+  // render the data arrived in instead of one render later.
   const [projectNameCache, setProjectNameCache] = useState<Map<string, string>>(
     () => new Map(),
   );
-  useEffect(() => {
+  const lastSeenCardsRef = useRef<{
+    mine?: typeof myCards.data;
+    all?: typeof allCards.data;
+    queue?: typeof queue.data;
+  }>({});
+  if (
+    lastSeenCardsRef.current.mine !== myCards.data ||
+    lastSeenCardsRef.current.all !== allCards.data ||
+    lastSeenCardsRef.current.queue !== queue.data
+  ) {
+    lastSeenCardsRef.current = { mine: myCards.data, all: allCards.data, queue: queue.data };
     const learned = [
       ...projectNamesIn(myCards.data?.cards),
       ...projectNamesIn(allCards.data?.cards),
       ...projectNamesIn(queue.data?.cards),
     ];
-    if (learned.length === 0) return;
-    // This accumulates names across tab switches and can't be expressed as a
-    // pure derivation, since a tab's own current data is exactly what would
-    // otherwise be lost.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setProjectNameCache((prev) => {
-      let changed = false;
-      const next = new Map(prev);
-      for (const [id, name] of learned) {
-        if (next.get(id) !== name) {
-          next.set(id, name);
-          changed = true;
-        }
+    let next: Map<string, string> | undefined;
+    for (const [id, name] of learned) {
+      if (projectNameCache.get(id) !== name) {
+        next ??= new Map(projectNameCache);
+        next.set(id, name);
       }
-      return changed ? next : prev;
-    });
-  }, [myCards.data, allCards.data, queue.data]);
+    }
+    if (next) setProjectNameCache(next);
+  }
   const allEngineerOptions = useMemo(
     () => engineerOptionsFrom(allCards.data?.cards),
     [allCards.data],

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useCallback, useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useState, type ChangeEvent, type JSX } from "react";
 import {
   AdapterDateFns,
   Box,
@@ -101,15 +101,12 @@ function workItemOptionsFrom(cards: CsmTimeCard[] | undefined): string[] {
   return Array.from(new Set((cards ?? []).map((c) => c.caseNumber)));
 }
 
-/** `projectId -> projectName` lookup from whatever cards are currently loaded
- * for one tab — seeds the Project filter's already-selected chip labels
- * before its own async search has resolved the same ids (mirrors
- * `CasesFilterBar.tsx`'s `projectNameSeed`). Each `CsmTimeCard` already
- * carries both fields, so this is a free derivation, not a new fetch. */
-function projectNameSeedFrom(cards: CsmTimeCard[] | undefined): Map<string, string> {
-  const nameById = new Map<string, string>();
-  (cards ?? []).forEach((c) => nameById.set(c.projectId, c.projectName));
-  return nameById;
+/** `[projectId, projectName]` pairs present in a batch of cards — building
+ * block for the page-level accumulating project-name cache below. Each
+ * `CsmTimeCard` already carries both fields, so this is a free derivation,
+ * not a new fetch. */
+function projectNamesIn(cards: CsmTimeCard[] | undefined): [string, string][] {
+  return (cards ?? []).map((c) => [c.projectId, c.projectName]);
 }
 
 const DEFAULT_ROWS_PER_PAGE = 20;
@@ -327,18 +324,41 @@ export default function CsmTimeCardsPage(): JSX.Element {
     () => workItemOptionsFrom(queue.data?.cards),
     [queue.data],
   );
-  const mineProjectNameSeed = useMemo(
-    () => projectNameSeedFrom(myCards.data?.cards),
-    [myCards.data],
+  // Persistent projectId -> projectName cache for the Project filter's chip
+  // labels, accumulated across every tab's loaded cards over the page's
+  // lifetime and never shrunk. Unlike workItemOptions/engineerOptions above
+  // (deliberately scoped to one tab's current page), this can't be a per-tab
+  // derivation: each tab's FilterBar/AsyncProjectMultiSelect instance
+  // unmounts on tab switch (conditional rendering below), which would
+  // otherwise drop a selected project's name the moment the newly active
+  // tab's own cards don't happen to include it — or are empty — leaving the
+  // chip showing a raw id until the dropdown is reopened and re-searched.
+  const [projectNameCache, setProjectNameCache] = useState<Map<string, string>>(
+    () => new Map(),
   );
-  const allProjectNameSeed = useMemo(
-    () => projectNameSeedFrom(allCards.data?.cards),
-    [allCards.data],
-  );
-  const approvalsProjectNameSeed = useMemo(
-    () => projectNameSeedFrom(queue.data?.cards),
-    [queue.data],
-  );
+  useEffect(() => {
+    const learned = [
+      ...projectNamesIn(myCards.data?.cards),
+      ...projectNamesIn(allCards.data?.cards),
+      ...projectNamesIn(queue.data?.cards),
+    ];
+    if (learned.length === 0) return;
+    // This accumulates names across tab switches and can't be expressed as a
+    // pure derivation, since a tab's own current data is exactly what would
+    // otherwise be lost.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setProjectNameCache((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const [id, name] of learned) {
+        if (next.get(id) !== name) {
+          next.set(id, name);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [myCards.data, allCards.data, queue.data]);
   const allEngineerOptions = useMemo(
     () => engineerOptionsFrom(allCards.data?.cards),
     [allCards.data],
@@ -394,7 +414,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
       {activeTab === "mine" && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <FilterBar
-            projectNameSeed={mineProjectNameSeed}
+            projectNameSeed={projectNameCache}
             filterProject={filterProject}
             setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
@@ -458,7 +478,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
       {activeTab === "all" && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <FilterBar
-            projectNameSeed={allProjectNameSeed}
+            projectNameSeed={projectNameCache}
             filterProject={filterProject}
             setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
@@ -526,7 +546,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
       {activeTab === "approvals" && role.isApprover && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <FilterBar
-            projectNameSeed={approvalsProjectNameSeed}
+            projectNameSeed={projectNameCache}
             filterProject={filterProject}
             setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
@@ -658,9 +678,11 @@ function FilterBar({
   engineerActive,
   hideStateFilter,
 }: {
-  /** `projectId -> projectName` lookup for already-selected chips, seeded
-   * from whatever cards are currently loaded (see `projectNameSeedFrom`) —
-   * AsyncProjectMultiSelect's own async search resolves the rest. */
+  /** `projectId -> projectName` lookup for already-selected chips — the
+   * page-level, cross-tab accumulating cache (see `projectNameCache` in
+   * `CsmTimeCardsPage`), not a per-tab derivation, so a selected project's
+   * name survives this component remounting on tab switch. Async search
+   * resolves anything the cache hasn't learned yet. */
   projectNameSeed: Map<string, string>;
   filterProject: string[];
   setFilterProject: (v: string[]) => void;

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -61,12 +61,11 @@ import {
   useMyTimeCards,
   type TimeCardPagination,
 } from "@features/csm-timecards/api/useTimeSheets";
-import { useProjectOptions } from "@features/csm-cases/api/useProjectOptions";
+import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import { BackendApiError } from "@api/backend/client";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
-import type { BeProject } from "@api/backend/types";
 import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
 import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
 import TimeCardsTable from "@features/csm-timecards/components/TimeCardsTable";
@@ -100,6 +99,17 @@ function engineerOptionsFrom(cards: CsmTimeCard[] | undefined): {
  * only" caveat as {@link engineerOptionsFrom}. */
 function workItemOptionsFrom(cards: CsmTimeCard[] | undefined): string[] {
   return Array.from(new Set((cards ?? []).map((c) => c.caseNumber)));
+}
+
+/** `projectId -> projectName` lookup from whatever cards are currently loaded
+ * for one tab — seeds the Project filter's already-selected chip labels
+ * before its own async search has resolved the same ids (mirrors
+ * `CasesFilterBar.tsx`'s `projectNameSeed`). Each `CsmTimeCard` already
+ * carries both fields, so this is a free derivation, not a new fetch. */
+function projectNameSeedFrom(cards: CsmTimeCard[] | undefined): Map<string, string> {
+  const nameById = new Map<string, string>();
+  (cards ?? []).forEach((c) => nameById.set(c.projectId, c.projectName));
+  return nameById;
 }
 
 const DEFAULT_ROWS_PER_PAGE = 20;
@@ -183,7 +193,6 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const [filterFrom, setFilterFrom] = useState("");
   const [filterTo, setFilterTo] = useState("");
 
-  const projects = useProjectOptions();
   // Search is unscoped by default: with no project filter picked we send no
   // `projectIds`, and the backend returns every time card the caller is
   // entitled to (internal agents get a global list). Picking the project
@@ -318,6 +327,18 @@ export default function CsmTimeCardsPage(): JSX.Element {
     () => workItemOptionsFrom(queue.data?.cards),
     [queue.data],
   );
+  const mineProjectNameSeed = useMemo(
+    () => projectNameSeedFrom(myCards.data?.cards),
+    [myCards.data],
+  );
+  const allProjectNameSeed = useMemo(
+    () => projectNameSeedFrom(allCards.data?.cards),
+    [allCards.data],
+  );
+  const approvalsProjectNameSeed = useMemo(
+    () => projectNameSeedFrom(queue.data?.cards),
+    [queue.data],
+  );
   const allEngineerOptions = useMemo(
     () => engineerOptionsFrom(allCards.data?.cards),
     [allCards.data],
@@ -373,7 +394,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
       {activeTab === "mine" && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <FilterBar
-            projects={projects.data ?? []}
+            projectNameSeed={mineProjectNameSeed}
             filterProject={filterProject}
             setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
@@ -388,11 +409,6 @@ export default function CsmTimeCardsPage(): JSX.Element {
             onClear={clearFilters}
           />
 
-          {/* projects.isLoading is folded into the table's isLoading (not
-           just myCards.isLoading) so the empty state doesn't flash while
-           the Project filter dropdown's own data is still loading. The
-           filter bar itself renders regardless, same as Approvals below,
-           so it's never hidden behind this spinner. */}
           {myCards.isError ? (
             <Typography color="error">Could not load your time cards.</Typography>
           ) : (
@@ -405,7 +421,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
               </Box>
               <TimeCardsTable
                 cards={mineFilteredCards}
-                isLoading={myCards.isLoading || projects.isLoading}
+                isLoading={myCards.isLoading}
                 groupBy="case"
                 roleFor={mineRole}
                 onCardAction={handleCardAction}
@@ -442,7 +458,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
       {activeTab === "all" && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <FilterBar
-            projects={projects.data ?? []}
+            projectNameSeed={allProjectNameSeed}
             filterProject={filterProject}
             setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
@@ -483,7 +499,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
               </Box>
               <TimeCardsTable
                 cards={allFilteredCards}
-                isLoading={allCards.isLoading || projects.isLoading}
+                isLoading={allCards.isLoading}
                 groupBy={groupBy}
                 showCaseEngineerColumns
                 roleFor={allRoleFor}
@@ -510,7 +526,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
       {activeTab === "approvals" && role.isApprover && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <FilterBar
-            projects={projects.data ?? []}
+            projectNameSeed={approvalsProjectNameSeed}
             filterProject={filterProject}
             setFilterProject={handleFilterProjectChange}
             filterWorkItem={filterWorkItem}
@@ -552,7 +568,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
               </Box>
               <TimeCardsTable
                 cards={approvalsFilteredCards}
-                isLoading={queue.isLoading || projects.isLoading}
+                isLoading={queue.isLoading}
                 groupBy={groupBy}
                 showCaseEngineerColumns
                 showActionsColumn
@@ -625,7 +641,7 @@ const FILTER_STATES: TimeCardState[] = ["submitted", "approved", "rejected"];
  * doesn't look and behave differently from every other list page's filters.
  */
 function FilterBar({
-  projects,
+  projectNameSeed,
   filterProject,
   setFilterProject,
   filterWorkItem,
@@ -642,7 +658,10 @@ function FilterBar({
   engineerActive,
   hideStateFilter,
 }: {
-  projects: BeProject[];
+  /** `projectId -> projectName` lookup for already-selected chips, seeded
+   * from whatever cards are currently loaded (see `projectNameSeedFrom`) —
+   * AsyncProjectMultiSelect's own async search resolves the rest. */
+  projectNameSeed: Map<string, string>;
   filterProject: string[];
   setFilterProject: (v: string[]) => void;
   filterWorkItem: string[];
@@ -714,14 +733,12 @@ function FilterBar({
               regardless of how many of these fields this tab shows. */}
           <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
             <Box sx={{ flex: "1 1 0", minWidth: 160 }}>
-              <SearchableMultiSelect
+              <AsyncProjectMultiSelect
                 id="timecards-filter-project"
                 label="Project"
-                placeholder="Search projects…"
                 values={filterProject}
-                options={projects.map((p) => p.id)}
-                formatOption={(id) => projects.find((p) => p.id === id)?.name ?? id}
                 onChange={setFilterProject}
+                nameSeed={projectNameSeed}
               />
             </Box>
             <Box sx={{ flex: "1 1 0", minWidth: 160 }}>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useCallback, useMemo, useRef, useState, type ChangeEvent, type JSX } from "react";
+import { useCallback, useMemo, useState, type ChangeEvent, type JSX } from "react";
 import {
   AdapterDateFns,
   Box,
@@ -341,17 +341,17 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const [projectNameCache, setProjectNameCache] = useState<Map<string, string>>(
     () => new Map(),
   );
-  const lastSeenCardsRef = useRef<{
+  const [lastSeenCards, setLastSeenCards] = useState<{
     mine?: typeof myCards.data;
     all?: typeof allCards.data;
     queue?: typeof queue.data;
-  }>({});
+  }>(() => ({}));
   if (
-    lastSeenCardsRef.current.mine !== myCards.data ||
-    lastSeenCardsRef.current.all !== allCards.data ||
-    lastSeenCardsRef.current.queue !== queue.data
+    lastSeenCards.mine !== myCards.data ||
+    lastSeenCards.all !== allCards.data ||
+    lastSeenCards.queue !== queue.data
   ) {
-    lastSeenCardsRef.current = { mine: myCards.data, all: allCards.data, queue: queue.data };
+    setLastSeenCards({ mine: myCards.data, all: allCards.data, queue: queue.data });
     const learned = [
       ...projectNamesIn(myCards.data?.cards),
       ...projectNamesIn(allCards.data?.cards),


### PR DESCRIPTION
## Purpose
The Time Cards page's table stayed stuck on its loading spinner until the entire project catalogue had loaded, even after the actual time-card search had already resolved — because the Project filter dropdown was fed by an eager, all-pages fetch whose `isLoading` was folded into the table's own loading state.

## Goals
- Time Cards tables (My time sheets / All / Approvals) render as soon as their own data is ready, independent of how large the project catalogue is or how slow that fetch is.
- The Project filter keeps working exactly as before — no functional regression for users.

## Approach
- Replaced the `SearchableMultiSelect` + `useProjectOptions()` (blocking, sequential all-pages fetch) combo with `AsyncProjectMultiSelect`, the same lazy/scroll-paginated project search `CasesFilterBar` already uses elsewhere in the portal — first page loads on dropdown-open, further pages load only as the user scrolls, and typing narrows the search server-side.
- Dropped `|| projects.isLoading` from the three tabs' `isLoading` expressions so the table's loading state only reflects the actual time-card query.
- Added a small `projectNameSeedFrom` helper (mirrors the existing `engineerOptionsFrom`/`workItemOptionsFrom` helpers in the same file) so an already-selected project chip still shows its real name immediately, seeded from whatever cards are already loaded, instead of a raw id while the async search catches up.

## User stories
As an engineer or approver, I can open Time Cards and see my time cards immediately, without waiting on an unrelated project-list fetch to finish first.

## Release note
Fixed: the Time Cards page could appear stuck loading when the project catalogue was large or slow to fetch, even though the time-card data itself was already ready.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: no existing test exercises this component's DOM directly (only util/hook-level tests exist under csm-timecards). Full suite run locally: 519 passed, 9 pre-existing failures unrelated to this change (confirmed identical on unmodified `main` — in `CaseActivitiesFeed.test.tsx`, `CaseActionBar.test.tsx`, `CsmAnnouncementsPage.test.tsx`; none touch Time Cards).
- Verified against staging: `tsc -b` and `vite build` both pass clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint`, `pnpm run test`, `pnpm run build` all passing locally (via the `./node_modules/.bin/` workaround for the local `pnpm` CLI issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the Project filter on time cards so selected project chips persist across Mine/All/Approvals and retain correct display names.
  * Project names now populate from already-loaded time-card data, reducing reliance on a fully loaded project list.
  * Updated each time-cards tab so loading indicators and empty states reflect only that tab’s time-card data, not the Project dropdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->