### PR TITLE
[Entity Service] fix deployed-products search: category is a reference object, not a string

### DIFF
--- a/entity-service/internal/service/sn_deployed_product_service.go
+++ b/entity-service/internal/service/sn_deployed_product_service.go
@@ -43,7 +43,7 @@ type snDeployedProduct struct {
 	Version    *snDeployedProductVersion `json:"version"`
 	Cores      *int                      `json:"cores"`
 	TPS        *float64                  `json:"tps"` // Ballerina decimal? serialises as 100.0
-	Category   *string                   `json:"category"`
+	Category   *snDeployedProductRef     `json:"category"`
 	CreatedOn  string                    `json:"createdOn"`
 	UpdatedOn  string                    `json:"updatedOn"`
 }
@@ -332,6 +332,11 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 			tps = &s
 		}
 
+		var category *string
+		if dp.Category != nil {
+			category = &dp.Category.Name
+		}
+
 		views = append(views, domain.DeployedProductView{
 			ID:         sysidToUUID(dp.ID),
 			Deployment: domain.EntityRef{ID: sysidToUUID(dp.Deployment.ID), Name: dp.Deployment.Name},
@@ -339,7 +344,7 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 			Version:    versionRef,
 			Cores:      cores,
 			TPS:        tps,
-			Category:   dp.Category,
+			Category:   category,
 			CreatedOn:  createdOn,
 			UpdatedOn:  updatedOn,
 		})

--- a/entity-service/internal/service/sn_deployed_product_service_test.go
+++ b/entity-service/internal/service/sn_deployed_product_service_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+var (
+	testDeployedProductSysid       = sysid32('1')
+	testDeployedProductDeploySysid = sysid32('2')
+	testDeployedProductProdSysid   = sysid32('3')
+	testDeployedProductCatSysid    = sysid32('4')
+)
+
+// TestSNDeployedProductService_SearchDeployedProducts_MapsCategoryFromReferenceObject
+// guards against reintroducing a plain-string decode for the SN response's
+// "category" field. It is a ReferenceTableItem ({id, name, ...}), not a
+// string -- decoding it into *string broke every deployed-products search
+// with "json: cannot unmarshal object into Go struct field ...category of
+// type string".
+func TestSNDeployedProductService_SearchDeployedProducts_MapsCategoryFromReferenceObject(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deployed-products/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployedProducts": []map[string]any{
+				{
+					"id":         testDeployedProductSysid,
+					"deployment": map[string]any{"id": testDeployedProductDeploySysid, "name": "Production"},
+					"product":    map[string]any{"id": testDeployedProductProdSysid, "name": "API Manager"},
+					"category":   map[string]any{"id": testDeployedProductCatSysid, "name": "Middleware"},
+					"createdOn":  "2026-01-01 00:00:00",
+					"updatedOn":  "2026-01-02 00:00:00",
+				},
+			},
+			"totalRecords": 1, "offset": 0, "limit": 20,
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowDeployedProductService(client)
+
+	resp, err := svc.SearchDeployedProducts(contextWithUserIDToken("token"), domain.SearchDeployedProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.DeployedProducts) != 1 {
+		t.Fatalf("expected 1 deployed product, got %d", len(resp.DeployedProducts))
+	}
+	got := resp.DeployedProducts[0]
+	if got.Category == nil || *got.Category != "Middleware" {
+		t.Fatalf("expected category %q, got %v", "Middleware", got.Category)
+	}
+}
+
+func TestSNDeployedProductService_SearchDeployedProducts_NilCategoryStaysNil(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deployed-products/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployedProducts": []map[string]any{
+				{
+					"id":         testDeployedProductSysid,
+					"deployment": map[string]any{"id": testDeployedProductDeploySysid, "name": "Production"},
+					"product":    map[string]any{"id": testDeployedProductProdSysid, "name": "API Manager"},
+					"category":   nil,
+					"createdOn":  "2026-01-01 00:00:00",
+					"updatedOn":  "2026-01-02 00:00:00",
+				},
+			},
+			"totalRecords": 1, "offset": 0, "limit": 20,
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowDeployedProductService(client)
+
+	resp, err := svc.SearchDeployedProducts(contextWithUserIDToken("token"), domain.SearchDeployedProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.DeployedProducts) != 1 {
+		t.Fatalf("expected 1 deployed product, got %d", len(resp.DeployedProducts))
+	}
+	if resp.DeployedProducts[0].Category != nil {
+		t.Fatalf("expected nil category, got %v", *resp.DeployedProducts[0].Category)
+	}
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

`POST /deployed-products/search` fails for every deployed product:
```
Internal error: POST /deployed-products/search: sn deployed products: parse response: json: cannot unmarshal object into Go struct field snDeployedProduct.deployedProducts.category of type string
```

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Restore deployed-products search.

## Approach
> Describe how you are implementing the solutions.

ServiceNow's `category` field on a deployed product is a `ReferenceTableItem`
(`{id, name, ...}`), not a plain string -- confirmed against the
entity-service's own Ballerina type definitions (`DeployedProduct.category:
ReferenceTableItem?`). The Go-side `snDeployedProduct` struct decoded it
straight into `*string`, which worked only as long as the field happened to
be absent/null; once SN started sending the populated reference object, every
search failed at JSON decode time.

Fixed by decoding `category` as `*snDeployedProductRef` (the same `{id,
name}` shape already used for `deployment`/`product` on this struct), then
mapping its `Name` into the domain response's `Category *string` field --
matching this repo's convention of always rendering reference/label fields
as plain nullable strings in API responses, not `{id, name}` objects.

## Automation tests
 - Unit tests
   No test coverage existed for this service at all. Added
   `TestSNDeployedProductService_SearchDeployedProducts_MapsCategoryFromReferenceObject`
   (asserts the reference object's `name` is mapped into the string field)
   and `TestSNDeployedProductService_SearchDeployedProducts_NilCategoryStaysNil`
   (asserts a null category stays nil). Full `go test ./...` and
   `go vet ./...` are clean.

## Test environment
Go 1.x, `go test ./...` locally. Root cause confirmed against the
entity-service's own Ballerina `DeployedProduct`/`ReferenceTableItem` type
definitions.

## Security checks
 - Followed secure coding standards: yes
 - Ran FindSecurityBugs plugin and verified report: N/A (Go, not Java)
 - Confirmed no keys/passwords/tokens/secrets committed: yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployed product search results when categories are provided as reference objects.
  * Category names now display correctly, while missing categories remain blank instead of causing errors.
* **Tests**
  * Added coverage for category mapping and null category handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->