### PR TITLE
[Customer portal webapp] Add Playwright initial setup

### DIFF
--- a/apps/customer-portal/webapp/.gitignore
+++ b/apps/customer-portal/webapp/.gitignore
@@ -31,3 +31,11 @@ dist-ssr
 # OS files
 .DS_Store
 config.js
+
+# Playwright E2E
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+# Captured auth sessions hold real tokens — never commit them.
+tests/e2e/storageState/*.json

--- a/apps/customer-portal/webapp/eslint.config.js
+++ b/apps/customer-portal/webapp/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'test-results', 'playwright-report', 'blob-report']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/apps/customer-portal/webapp/package.json
+++ b/apps/customer-portal/webapp/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@asgardeo/react": "0.25.6",
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.1",
+    "@playwright/test": "1.62.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/apps/customer-portal/webapp/playwright.config.ts
+++ b/apps/customer-portal/webapp/playwright.config.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { defineConfig, devices } from "@playwright/test";
+
+// Base URL of the locally-served app (vite dev server, see vite.config.ts).
+// Override with E2E_BASE_URL to point at a deployed environment, and set
+// E2E_NO_WEBSERVER=1 so the `webServer` block below is skipped in that case.
+const BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  // Specs are expected to run against a real (staging) backend under a single
+  // captured account, where concurrent workers cause real network contention
+  // and flaky timeouts. Serial by default; revisit if specs ever get isolated
+  // per-account fixtures.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  outputDir: "test-results",
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  // Boot the local dev server for the run (reused if already running). Skipped
+  // when targeting a remote E2E_BASE_URL.
+  webServer: process.env.E2E_NO_WEBSERVER
+    ? undefined
+    : {
+        command: "pnpm run dev",
+        url: BASE_URL,
+        // Locally, reuse an already-running dev server. In CI, always boot a
+        // fresh one — reusing a stray/stale process there could mask a real
+        // failure to start, or run against unexpected leftover state.
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/apps/customer-portal/webapp/pnpm-lock.yaml
+++ b/apps/customer-portal/webapp/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@eslint/js':
         specifier: 9.39.1
         version: 9.39.1
+      '@playwright/test':
+        specifier: 1.62.0
+        version: 1.62.0
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -978,6 +981,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -1983,6 +1991,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2580,6 +2593,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4110,6 +4133,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
+
   '@popperjs/core@2.11.8': {}
 
   '@preact/signals-core@1.13.0': {}
@@ -5193,6 +5220,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6012,6 +6042,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/apps/customer-portal/webapp/tests/e2e/README.md
+++ b/apps/customer-portal/webapp/tests/e2e/README.md
@@ -1,0 +1,75 @@
+<!--
+Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+
+WSO2 LLC. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Customer Portal E2E (Playwright, local)
+
+Scaffolding only — **no specs yet**. Runs locally against `pnpm run dev`
+(:3000), authenticated by a **captured browser session** so no login page or
+2FA is driven. See [`auth/README.md`](./auth/README.md) to capture one.
+
+There is no mock backend here: specs will hit the same backend the dev server
+is configured against (`public/config.js`), so anything a spec creates is a
+**real record** in that environment. Tag created data so it stays identifiable.
+
+## Run
+
+```bash
+pnpm run test:e2e                          # all specs (boots dev server)
+node_modules/.bin/playwright test --ui     # author/debug interactively
+node_modules/.bin/playwright show-report   # open the last HTML report
+```
+
+> Note: `pnpm exec playwright …` fails in this repo ("packages field missing");
+> call the binary directly via `node_modules/.bin/playwright …`.
+
+Environment switches (see `playwright.config.ts`):
+
+| Var | Effect |
+|---|---|
+| `E2E_BASE_URL` | Target a deployed environment instead of `http://localhost:3000` |
+| `E2E_NO_WEBSERVER=1` | Don't boot the dev server (use with `E2E_BASE_URL`) |
+| `CI` | `forbidOnly`, and never reuse an already-running dev server |
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `auth/README.md` | How to capture a session bundle (localStorage + sessionStorage) |
+| `fixtures/test.ts` | `withRole(test, role)` replays a session and skips the file if absent; `openContextAs(browser, role)` opens a second authenticated context |
+| `pages/` | Page objects — one per screen, no assertions inside |
+| `specs/` | The specs, grouped in subfolders by feature area |
+| `utils/` | Shared selectors / data-tagging helpers |
+| `storageState/` | Captured session bundles — **git-ignored, real tokens** |
+
+## Roles
+
+`PortalRole` in `fixtures/test.ts` is `"admin" | "lead" | "portal" | "security"`,
+matching the portal's user types. Capabilities are split across two sources, so
+a test account needs both set correctly:
+
+- **admin** — the ServiceNow user role `sn_customerservice.customer_admin`
+  (read from `GET /users/me`), which gates Settings user management and
+  registry service tokens.
+- **lead / portal / security** — project **membership** flags (`isLead`,
+  `isPortalUser`, `isSecurityContact`) on the project under test, read from the
+  project contacts list.
+
+Project-level feature visibility (Operations, Security Center, Updates,
+Engagements, Usage & Metrics …) is independent of all of these — it comes from
+`GET /projects/{id}/features`. Pick the project a spec runs against
+accordingly.

--- a/apps/customer-portal/webapp/tests/e2e/README.md
+++ b/apps/customer-portal/webapp/tests/e2e/README.md
@@ -50,7 +50,7 @@ Environment switches (see `playwright.config.ts`):
 | Path | Purpose |
 |---|---|
 | `auth/README.md` | How to capture a session bundle (localStorage + sessionStorage) |
-| `fixtures/test.ts` | `withRole(test, role)` replays a session and skips the file if absent; `openContextAs(browser, role)` opens a second authenticated context |
+| `fixtures/test.ts` | `withRole(test, role)` replays a session, skipping each test that uses it when the bundle is absent (it skips from `beforeEach`, so tests are reported individually as skipped rather than the file being skipped as a unit); `openContextAs(browser, role)` opens a second authenticated context |
 | `pages/` | Page objects — one per screen, no assertions inside |
 | `specs/` | The specs, grouped in subfolders by feature area |
 | `utils/` | Shared selectors / data-tagging helpers |
@@ -62,9 +62,10 @@ Environment switches (see `playwright.config.ts`):
 matching the portal's user types. Capabilities are split across two sources, so
 a test account needs both set correctly:
 
-- **admin** — the ServiceNow user role `sn_customerservice.customer_admin`
+- **admin** — both the ServiceNow user role `sn_customerservice.customer_admin`
   (read from `GET /users/me`), which gates Settings user management and
-  registry service tokens.
+  registry service tokens, **and** an Admin membership on the project under
+  test.
 - **lead / portal / security** — project **membership** flags (`isLead`,
   `isPortalUser`, `isSecurityContact`) on the project under test, read from the
   project contacts list.

--- a/apps/customer-portal/webapp/tests/e2e/auth/README.md
+++ b/apps/customer-portal/webapp/tests/e2e/auth/README.md
@@ -1,0 +1,72 @@
+<!--
+Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+
+WSO2 LLC. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# E2E auth — captured sessions (local)
+
+Specs run **authenticated** by replaying a captured browser session, so no
+login page or 2FA is driven locally. Capture a session once per role into
+`tests/e2e/storageState/<role>.json` (git-ignored — it holds real tokens).
+
+> **Why a full bundle, not just localStorage:** the Asgardeo React SDK keeps its
+> tokens in **`sessionStorage`** (`session_data-instance_…`), with only an
+> `asgardeo-session-active` flag in localStorage. Playwright's `storageState`
+> restores localStorage/cookies but **not** sessionStorage, so we capture both
+> stores and replay them via an init script (see `../fixtures/test.ts`).
+
+## Capture a session (browser console)
+
+1. Sign in to the app (`http://localhost:3000`) as the account you want.
+2. Open DevTools → **Console**. If Chrome shows the self-XSS warning, type
+   `allow pasting` and press Enter.
+3. Run — this copies a session bundle (both stores) to your clipboard:
+
+   ```js
+   copy(JSON.stringify({
+     origin: location.origin,
+     localStorage: Object.fromEntries(Object.entries(localStorage)),
+     sessionStorage: Object.fromEntries(Object.entries(sessionStorage)),
+   }, null, 2))
+   ```
+
+4. Save it to the role's file (from `apps/customer-portal/webapp`):
+
+   ```bash
+   pbpaste > tests/e2e/storageState/admin.json
+   ```
+
+Repeat per account for `lead.json`, `portal.json`, `security.json`.
+
+## What each account needs
+
+| Bundle | Account setup |
+|---|---|
+| `admin.json` | `sn_customerservice.customer_admin` in `GET /users/me` roles, and an Admin membership on the project under test |
+| `lead.json` | Project membership with `isLead: true` (implies `isPortalUser`), **no** customer-admin role — isolates escalation past EL3 from admin powers |
+| `portal.json` | Plain `isPortalUser: true` membership only — the baseline/negative case |
+| `security.json` | `isSecurityContact: true` only — verifies exclusion from watchlist and contact pickers |
+
+## Notes
+
+- **Staleness:** the captured access token expires (~1h). If a run fails on
+  auth, re-capture. (The bundle also carries the refresh token, so the SDK may
+  refresh silently within a run.)
+- **Secrecy:** `storageState/*.json` is git-ignored. Never commit it.
+- **Config:** the app must have a working `public/config.js` for the same
+  tenant/backend the session was issued against — the client-instance hash in
+  the sessionStorage keys must match, which it does when the config is
+  unchanged.

--- a/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
+++ b/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
@@ -41,6 +41,9 @@ export type PortalRole = "admin" | "lead" | "portal" | "security";
  * token refresh can succeed mid-run when the short-lived access token expires;
  * bundles without it still replay fine for the access token's TTL. */
 interface SessionBundle {
+  /** Origin the bundle was captured from. Required in practice — it scopes the
+   * storage replay so tokens are never restored into a cross-origin frame.
+   * Optional here only because the on-disk JSON is untrusted input. */
   origin?: string;
   localStorage?: Record<string, string>;
   sessionStorage?: Record<string, string>;
@@ -65,6 +68,16 @@ async function applySession(
   role: PortalRole,
 ): Promise<void> {
   const bundle = readBundle(role);
+  if (!bundle.origin) {
+    // Without an origin we cannot tell the portal's documents apart from the
+    // IdP's, and the init script below would have to either skip everything or
+    // write tokens into whatever frame loads first. Fail loudly here instead of
+    // silently booting signed-out. The capture snippet in auth/README.md always
+    // records `origin`; a bundle missing it predates that and must be recaptured.
+    throw new Error(
+      `Session bundle for '${role}' has no "origin". Recapture it — see tests/e2e/auth/README.md.`,
+    );
+  }
   if (bundle.cookies?.length) {
     // Best-effort: lets the SDK's hidden-iframe silent refresh reach the IdP
     // with an existing session when the access token expires during a long run.
@@ -78,6 +91,14 @@ async function applySession(
     }
   }
   await context.addInitScript((b: SessionBundle) => {
+    // This runs in *every* document in the context, including cross-origin
+    // frames — notably the SDK's hidden IdP iframe used for silent token
+    // refresh. Restore only into the origin the bundle was captured from, so
+    // the portal's tokens are never written into another origin's storage.
+    // (A stale bundle captured against a different origin than the one under
+    // test therefore restores nothing and the app boots signed-out; recapture
+    // against the target environment — see auth/README.md.)
+    if (!b.origin || window.location.origin !== b.origin) return;
     try {
       for (const [k, v] of Object.entries(b.localStorage ?? {})) {
         window.localStorage.setItem(k, v);

--- a/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
+++ b/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Shared Playwright test helpers. Auth is by replaying a captured browser
+// session — no login page is driven. The Asgardeo React SDK keeps its tokens in
+// **sessionStorage** (session_data-instance_… etc.), which Playwright's
+// storageState does not restore, so we replay both localStorage and
+// sessionStorage via an init script that runs before the app boots. A file is
+// skipped (not failed) when its role's session bundle hasn't been captured.
+//
+
+import {
+  test as base,
+  expect,
+  type Browser,
+  type BrowserContext,
+} from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+/** Portal user types, each backed by its own captured session bundle.
+ * See tests/e2e/auth/README.md for what each account must be granted. */
+export type PortalRole = "admin" | "lead" | "portal" | "security";
+
+/** A captured session: the origin's localStorage + sessionStorage snapshots.
+ * `cookies` (optional) carries the IdP-domain cookies so the SDK's silent
+ * token refresh can succeed mid-run when the short-lived access token expires;
+ * bundles without it still replay fine for the access token's TTL. */
+interface SessionBundle {
+  origin?: string;
+  localStorage?: Record<string, string>;
+  sessionStorage?: Record<string, string>;
+  cookies?: Parameters<BrowserContext["addCookies"]>[0];
+}
+
+/** Absolute path to a role's captured session bundle. */
+export function sessionPath(role: PortalRole): string {
+  return path.join(process.cwd(), "tests", "e2e", "storageState", `${role}.json`);
+}
+
+export function hasSession(role: PortalRole): boolean {
+  return fs.existsSync(sessionPath(role));
+}
+
+function readBundle(role: PortalRole): SessionBundle {
+  return JSON.parse(fs.readFileSync(sessionPath(role), "utf8")) as SessionBundle;
+}
+
+async function applySession(
+  context: BrowserContext,
+  role: PortalRole,
+): Promise<void> {
+  const bundle = readBundle(role);
+  if (bundle.cookies?.length) {
+    // Best-effort: lets the SDK's hidden-iframe silent refresh reach the IdP
+    // with an existing session when the access token expires during a long run.
+    // A malformed cookies array must not abort the role's beforeEach — degrade
+    // gracefully, same as the storage replay below.
+    try {
+      await context.addCookies(bundle.cookies);
+    } catch {
+      // Cookies not applicable to this context; the silent refresh path just
+      // won't have an IdP session to lean on, which is safe to ignore here.
+    }
+  }
+  await context.addInitScript((b: SessionBundle) => {
+    try {
+      for (const [k, v] of Object.entries(b.localStorage ?? {})) {
+        window.localStorage.setItem(k, v);
+      }
+      for (const [k, v] of Object.entries(b.sessionStorage ?? {})) {
+        window.sessionStorage.setItem(k, v);
+      }
+    } catch {
+      // Storage not accessible on this document yet; the next navigation
+      // re-runs this init script, so it's safe to ignore.
+    }
+  }, bundle);
+}
+
+/**
+ * Opens a second, independent browser context authenticated as `role` — for
+ * specs that need two identities in the same test (e.g. an admin edits another
+ * user's roles). Caller must close the returned context. Requires that role's
+ * session to have been captured.
+ */
+export async function openContextAs(
+  browser: Browser,
+  role: PortalRole,
+): Promise<BrowserContext> {
+  const context = await browser.newContext();
+  await applySession(context, role);
+  return context;
+}
+
+/**
+ * Configure a test file to run authenticated as `role`. Replays the captured
+ * localStorage + sessionStorage before each page loads (so the Asgardeo SDK
+ * finds its session and boots signed-in). Skips the whole file when the bundle
+ * is absent, with a message pointing at the capture steps.
+ *
+ * Usage at the top of a spec:
+ *   withRole(test, "admin");
+ */
+export function withRole(t: typeof base, role: PortalRole): void {
+  t.beforeEach(async ({ context }) => {
+    t.skip(
+      !hasSession(role),
+      `No captured session for '${role}'. See tests/e2e/auth/README.md to create ` +
+        `tests/e2e/storageState/${role}.json.`,
+    );
+    await applySession(context, role);
+  });
+}
+
+export const test = base;
+export { expect };

--- a/apps/customer-portal/webapp/tests/e2e/tsconfig.json
+++ b/apps/customer-portal/webapp/tests/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/apps/customer-portal/webapp/vite.config.ts
+++ b/apps/customer-portal/webapp/vite.config.ts
@@ -16,7 +16,10 @@
 
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig, mergeConfig } from "vite";
-import { defineConfig as defineVitestConfig } from "vitest/config";
+import {
+  configDefaults,
+  defineConfig as defineVitestConfig,
+} from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 const viteConfig = defineConfig({
@@ -107,6 +110,11 @@ const vitestConfig = defineVitestConfig({
     environment: "jsdom",
     setupFiles: ["./src/vitest.setup.ts"],
     css: true,
+    // Vitest's default glob (**/*.spec.ts) collides with the Playwright specs
+    // under tests/e2e/ (own runner, own tsconfig) -- exclude that tree plus
+    // Vitest's own defaults (which get overridden, not merged, once `exclude`
+    // is set explicitly).
+    exclude: [...configDefaults.exclude, "tests/e2e/**"],
     server: {
       deps: {
         inline: [


### PR DESCRIPTION
Description

### What

Sets up Playwright for `apps/customer-portal/webapp`.

### Added

| Path | Purpose |
|---|---|
| `playwright.config.ts` | `testDir: ./tests/e2e`, baseURL `:3000`, chromium, serial (1 worker), HTML + list reporters, auto-boots the dev server |
| `tests/e2e/tsconfig.json` | Separate from `tsconfig.app/node` — node types, no path aliases |
| `tests/e2e/fixtures/test.ts` | `withRole()` / `openContextAs()` / `hasSession()` — session-replay auth helpers |
| `tests/e2e/README.md` | How to run, env switches, layout, role notes |
| `tests/e2e/auth/README.md` | How to capture a session bundle per role |
| `tests/e2e/{specs,pages,utils,storageState}/` | Empty dirs for specs, page objects, shared selectors, captured sessions |

### Changed

- `package.json` — `@playwright/test` 1.62.0 (matching csm-portal) + `test:e2e` script
- `vite.config.ts` — `exclude: [...configDefaults.exclude, "tests/e2e/**"]` on the
  vitest block. **Required:** vitest's default glob is `**/*.{test,spec}.*` with no
  `include` override here, so Playwright specs named `*.spec.ts` would otherwise be
  collected by vitest and fail.
- `.gitignore` — Playwright output dirs, plus `tests/e2e/storageState/*.json`
  (those bundles hold real tokens and must never be committed)
- `eslint.config.js` — Playwright output dirs added to `globalIgnores`

### Auth approach

Specs authenticate by replaying a **captured browser session** rather than driving
the login page — no 2FA automation needed. The Asgardeo React SDK keeps its tokens
in `sessionStorage`, which Playwright's `storageState` does not restore, so the
fixture replays both `localStorage` and `sessionStorage` through an init script that
runs before the app boots. Files skip (not fail) when their role's bundle is absent.

`PortalRole` is `"admin" | "lead" | "portal" | "security"`, matching the portal's
user types. `auth/README.md` documents what each test account needs — including that
**admin** comes from the ServiceNow user role `sn_customerservice.customer_admin`
while **lead/portal/security** come from project membership flags, so an account
with only the membership flag set will see no admin UI.

### Testing

- `pnpm install` — `@playwright/test` 1.62.0 installed, browsers already in the shared cache
- `playwright test --list` — config parses cleanly (reports 0 tests, as expected)
- `tsc --noEmit -p tests/e2e/tsconfig.json` — clean
- `vitest list --filesOnly` — still collects all 404 existing test files, zero from `tests/e2e/`
- `eslint playwright.config.ts tests/e2e` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Playwright end-to-end testing support for the Customer Portal.
  * Added configurable browser testing with local development server support.
  * Added authenticated test-session replay for supported portal roles.

* **Documentation**
  * Added setup and usage guides for running E2E tests, viewing reports, and managing authenticated sessions.

* **Chores**
  * Added configuration to keep E2E artifacts, caches, and captured session files out of source control.
  * Prevented E2E tests from being included in standard Vitest runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->