### PR TITLE
feat(customer-portal): scaffold Go backend-v2 with first 5 endpoints

### DIFF
--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -1,0 +1,17 @@
+# Entity service (cs-tools/entity-service)
+ENTITY_SERVICE_BASE_URL=http://localhost:8081
+# Optional — only needed if entity-service sits behind a gateway that requires
+# OAuth2 client-credentials auth. Leave unset for a local direct-to-service run.
+OAUTH2_CLIENT_ID=
+OAUTH2_CLIENT_SECRET=
+OAUTH2_TOKEN_URL=
+ENTITY_SERVICE_SCOPES=
+
+# Auth — set to false for local testing (skips JWT signature verification)
+AUTH_JWKS_ENDPOINT=
+AUTH_ISSUER=
+AUTH_AUDIENCE=                    # comma-separated; token is accepted if any listed audience is present
+AUTH_TOKEN_VALIDATOR_ENABLED=true
+
+# Server
+PORT=8080

--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -7,11 +7,14 @@ OAUTH2_CLIENT_SECRET=
 OAUTH2_TOKEN_URL=
 ENTITY_SERVICE_SCOPES=
 
-# Auth — set to false for local testing (skips JWT signature verification)
-AUTH_JWKS_ENDPOINT=
+# Auth
+# AUTH_TOKEN_VALIDATOR_ENABLED=false (below) skips JWT signature verification —
+# local development only. Production MUST set it to true with a real
+# AUTH_JWKS_ENDPOINT/AUTH_ISSUER/AUTH_AUDIENCE.
+AUTH_AUDIENCE=
 AUTH_ISSUER=
-AUTH_AUDIENCE=                    # comma-separated; token is accepted if any listed audience is present
-AUTH_TOKEN_VALIDATOR_ENABLED=true
+AUTH_JWKS_ENDPOINT=
+AUTH_TOKEN_VALIDATOR_ENABLED=false
 
 # Server
 PORT=8080

--- a/apps/customer-portal/backend-v2/.gitignore
+++ b/apps/customer-portal/backend-v2/.gitignore
@@ -1,0 +1,31 @@
+# Environment
+.env
+
+# Build output
+/server
+/bin/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test output
+*.test
+*.out
+coverage.html
+coverage.out
+
+# Go workspace
+go.work
+go.work.sum
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/apps/customer-portal/backend-v2/.gitignore
+++ b/apps/customer-portal/backend-v2/.gitignore
@@ -1,5 +1,6 @@
 # Environment
 .env
+Config.toml
 
 # Build output
 /server

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -103,7 +103,7 @@ request side.
 
 - **Never commit secrets** — `.env`, `Config.toml`, or any file with real credentials must never be
   staged.
-- **No sensitive data in logs** — do not log request bodies, JWT payloads, or user PII.
+- **No sensitive data in logs** — do not log request bodies, JWT payloads, or PII such as email/name. The opaque `userID` claim (`UserInfo.UserID`) is not PII and may be logged for correlation/support purposes, as every handler does today.
 - **JWT is the only inbound auth mechanism** — every non-health endpoint must go through
   `middleware.Auth`.
 - **Run gosec on every change** — `gosec -fmt=text ./...` must report 0 issues before opening a PR.

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -1,0 +1,109 @@
+# Customer Portal Backend (v2)
+
+Go HTTP server (`net/http`, Go 1.26+) that acts as a backend-for-frontend (BFF) for the customer
+portal. It authenticates callers, forwards requests to `cs-tools/entity-service`, and shapes
+responses for the frontend. This is a Go rewrite of the Ballerina backend at
+`apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
+backend's own CLAUDE.md too if something here is underspecified.
+
+**Status: in progress.** Only 6 routes are wired up so far (`GET /health`, `GET /users/me`,
+`POST /projects/search`, `GET /projects/{id}`, `POST /cases/search`, `GET /cases/{id}`). The
+Ballerina backend exposes ~100 routes across many more modules (accounts, deployments, deployed
+products, attachments, comments, conversations, change requests, call requests, catalogs, time
+cards, updates, registry tokens, contacts, escalations, product vulnerabilities, AI chat/websocket,
+etc.) — none of those are ported yet. Follow the recipe below to add the next one.
+
+## Which entity-service
+
+This backend targets **`cs-tools/entity-service`** (this repo, `../../../entity-service`), *not*
+the `digiops-cs/entity-service` that `apps/customer-portal/backend` (the Ballerina original) calls.
+The two are different services with overlapping but not identical APIs — before porting an
+endpoint, verify it actually exists on `cs-tools/entity-service` (check
+`entity-service/internal/server/routes.go` and `entity-service/openapi.yaml`), and note that many
+of its routes are **ServiceNow-only** (registered only when the service runs with
+`DATA_SOURCE=servicenow`; see `entity-service/internal/config/config.go`) — a Postgres-mode
+deployment will 404 on those. If the Ballerina backend has an endpoint with no `cs-tools/entity-service`
+equivalent at all (e.g. `GET /metadata` — entity-service has no metadata endpoint), do not invent
+one; add a code comment at the call site noting the gap and flag it instead of fabricating a
+response.
+
+## Middleware chain
+
+`SecurityHeaders → CorrelationID → Auth → Logger → Mux`
+
+Identical to `apps/csm-portal/backend`'s chain — see that backend's CLAUDE.md for the rationale of
+each layer. `middleware.ConfigureLogger()` must be called at startup.
+
+## Response shaping — the "wrapper" pattern
+
+**Never return an entity-service response struct directly to the frontend.** This is the one
+deliberate difference from `apps/csm-portal/backend` (which does raw `[]byte` passthrough for most
+entity responses) — it mirrors what the Ballerina backend does with its `types` module +
+`utils.bal` mapper functions (`mapCaseResponse`, `mapProjectsResponse`, etc.), which reshape every
+`entity:*Response` into a portal-owned DTO before it reaches the frontend.
+
+Concretely:
+
+- `internal/entity` decodes entity-service's raw JSON into typed Go structs that mirror its wire
+  format 1:1 (see `internal/entity/types.go`) — these types are internal to that package.
+- `internal/dto` defines the portal's own response structs and one `Map*` function per entity type
+  that translates entity → portal, dropping fields the customer portal has no business showing:
+  - Salesforce/internal IDs (e.g. `ProjectDetailsView.SfID`)
+  - Internal feature-flags (e.g. `ProjectAccountRef.AgentEnabled`/`KbReferencesEnabled`)
+  - CSM/WSO2-internal-only fields that entity-service itself documents as such (e.g.
+    `CaseView`'s `BestCaseFixEta`/`MostLikelyFixEta`/`WorstCaseFixEta`, `WatchList` — see the
+    comments in `entity-service/internal/domain/entity.go` on `CaseView`)
+  - WSO2-internal team routing (e.g. `AccountRef.CreTeam`/`SreTeam`)
+  - Internal opaque identifiers not meaningful to a customer (e.g. `SearchCaseView.InternalID`)
+- `internal/handler` calls the entity client, passes the result through the matching `dto.Map*`
+  function, and writes the DTO with `writeJSONValue`.
+
+When you add a new endpoint, add the equivalent trimming — read the field carefully before
+including it; when in doubt whether a field is customer-appropriate, leave it out and note why in
+a comment on the DTO struct (see `internal/dto/case.go` for examples).
+
+Request bodies are the exception: incoming search/filter payloads are decoded directly into the
+entity package's request structs (e.g. `entity.SearchProjectsRequest`) with no separate DTO layer,
+since those shapes are already what the frontend needs to send — there is nothing to hide on the
+request side.
+
+## Adding a new endpoint
+
+1. **Confirm the route exists on `cs-tools/entity-service`** — check `routes.go` and note whether
+   it's Postgres-only, ServiceNow-only, or both (see "Which entity-service" above). If it doesn't
+   exist, stop and add a comment instead of faking it.
+2. **Entity types** (`internal/entity/types.go`) — add the request/response structs, copied field-
+   for-field (name, type, `json` tag) from `entity-service/internal/domain/entity.go`. Don't guess
+   — read the actual struct.
+3. **Entity client method** (`internal/entity/<feature>.go`) — add a method on `Client` using
+   `c.getJSON`/`c.postJSON`; `url.PathEscape()` every path parameter.
+4. **Portal DTO** (`internal/dto/<feature>.go`) — add the trimmed response struct and a `Map*`
+   function. See "Response shaping" above for what to exclude.
+5. **Handler** (`internal/handler/<feature>.go`) — extend or add a local interface naming only the
+   entity-client methods this handler needs; handler method sequence: auth check → path/body
+   guards → call entity client → `mapUpstreamError` on failure → map to DTO → `writeJSONValue`.
+6. **Route** (`cmd/server/main.go`) — register using Go 1.22 method-prefixed patterns:
+   `"POST /cases/{id}/comments"`.
+7. **README** — add the endpoint under "API Endpoints" in `README.md`.
+8. **gosec** — run `gosec -fmt=text ./...` (must report 0 issues) before opening a PR.
+
+## Handler conventions
+
+- **Auth**: always check `middleware.UserInfoFromContext(r.Context()) == nil` first → 401.
+- **Body size**: use the shared `readJSONBody(w, r)` helper (`internal/handler/response.go`) — caps
+  at `maxRequestBodyBytes` (1 MiB) and validates the body is well-formed JSON.
+- **Path params**: guard against empty string after `r.PathValue("id")`; validate UUID-shaped IDs
+  with the package-level `uuidRe` and return 400 on mismatch before calling entity-service.
+- **Upstream errors**: always use `mapUpstreamError(w, err, "<fallback message>")` — never write
+  custom status mappings inline.
+- **Logging**: use `slog.ErrorContext` with `summarizeErr(err)`, never the raw error — an
+  unrecognized error can stringify with the full request URL including query params.
+
+## Security
+
+- **Never commit secrets** — `.env`, `Config.toml`, or any file with real credentials must never be
+  staged.
+- **No sensitive data in logs** — do not log request bodies, JWT payloads, or user PII.
+- **JWT is the only inbound auth mechanism** — every non-health endpoint must go through
+  `middleware.Auth`.
+- **Run gosec on every change** — `gosec -fmt=text ./...` must report 0 issues before opening a PR.

--- a/apps/customer-portal/backend-v2/Makefile
+++ b/apps/customer-portal/backend-v2/Makefile
@@ -1,0 +1,21 @@
+BINARY := server
+
+.PHONY: all setup vet test build clean
+
+all: build
+
+# Install the shared git hooks (run once after cloning).
+setup:
+	git -C "$(shell git rev-parse --show-toplevel)" config core.hooksPath .githooks
+
+vet:
+	go vet ./...
+
+test: vet
+	go test -race ./...
+
+build: test
+	go build -o $(BINARY) ./cmd/server
+
+clean:
+	rm -f $(BINARY)

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -1,0 +1,168 @@
+# Customer Portal Backend (v2)
+
+Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a backend-for-frontend
+(BFF) for the customer portal: it authenticates callers, forwards requests to
+[`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
+`digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
+
+This is a work in progress — only the first 5 endpoints are implemented so far (see below).
+Everything else the Ballerina backend exposes still needs a Go handler; add them following the
+pattern described in [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
+
+## Quick Start
+
+```bash
+# from apps/customer-portal/backend-v2
+go run ./cmd/server/main.go
+```
+
+The server automatically loads `.env` from the working directory on startup (silently ignored if absent).
+
+Backend starts at `http://localhost:8080`.
+
+## Overview
+
+- Default port: `8080`
+- Runtime: Go `1.26+`
+- Entry point: `cmd/server/main.go`
+- Authentication:
+  - Incoming requests: JWT Bearer token; pass as `x-jwt-assertion` header when testing locally
+  - Outbound calls to entity-service: OAuth2 client credentials grant (optional — entity-service
+    itself does not validate inbound credentials, see [CLAUDE.md](./CLAUDE.md))
+
+## Prerequisites
+
+- Go `1.26+` — [install](https://go.dev/doc/install)
+- A running instance of `cs-tools/entity-service` (see its own README for `DATA_SOURCE` setup —
+  `GET /users/me` requires `DATA_SOURCE=servicenow`)
+
+## Testing
+
+```bash
+go test ./...
+go test -race ./...
+go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out
+```
+
+Or use `make`:
+
+```bash
+make test    # vet + test
+make build   # vet + test + compile
+```
+
+### Run tests before every push (recommended)
+
+```bash
+git config core.hooksPath .githooks   # from the repo root, once
+# or: make setup   # from this directory
+```
+
+## Security Scanning
+
+```bash
+go install github.com/securego/gosec/v2/cmd/gosec@latest
+gosec -fmt=text ./...
+```
+
+The scan must report **0 issues** before opening a PR touching this backend.
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill in the values.
+
+### Entity service
+
+| Variable | Description |
+|---|---|
+| `ENTITY_SERVICE_BASE_URL` | Base URL of `cs-tools/entity-service` |
+| `OAUTH2_CLIENT_ID` / `OAUTH2_CLIENT_SECRET` / `OAUTH2_TOKEN_URL` | Optional — only needed if entity-service sits behind a gateway requiring OAuth2 client-credentials auth |
+| `ENTITY_SERVICE_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+
+### Auth
+
+| Variable | Description |
+|---|---|
+| `AUTH_JWKS_ENDPOINT` | JWKS endpoint used to verify JWT signatures |
+| `AUTH_ISSUER` | Expected `iss` claim value |
+| `AUTH_AUDIENCE` | Comma-separated accepted `aud` values |
+| `AUTH_TOKEN_VALIDATOR_ENABLED` | Set to `false` for local development to skip signature verification (default `true`) |
+
+### Server
+
+| Variable | Description |
+|---|---|
+| `PORT` | Server listen port — a plain number, not an address (default `8080`) |
+
+## Project Structure
+
+```text
+backend-v2/
+├── cmd/server/main.go           # Entry point — routes + server startup
+├── internal/
+│   ├── apierror/                # Typed upstream error type (4xx/5xx passthrough)
+│   ├── entity/                  # OAuth2 HTTP client for cs-tools/entity-service
+│   │   ├── client.go            # Config/Client/do()/getJSON()/postJSON()
+│   │   ├── types.go             # entity-service's wire-format structs (internal to this package)
+│   │   ├── users.go             # GetMe
+│   │   ├── projects.go          # SearchProjects, GetProject
+│   │   └── cases.go             # SearchCases, GetCase
+│   ├── dto/                     # Portal-facing response shapes + Map* functions from entity types
+│   │   ├── user.go
+│   │   ├── project.go
+│   │   └── case.go
+│   ├── middleware/
+│   │   ├── auth.go              # JWT validation; injects UserInfo into context
+│   │   ├── correlation.go       # X-CSM-Correlation-ID propagation + slog enrichment
+│   │   ├── logger.go            # Per-request access log
+│   │   └── security_headers.go  # X-Content-Type-Options, CSP, HSTS on every response
+│   └── handler/
+│       ├── response.go          # writeJSON/writeError/mapUpstreamError shared helpers
+│       ├── users.go             # GET /users/me
+│       ├── projects.go          # POST /projects/search, GET /projects/{id}
+│       └── cases.go             # POST /cases/search, GET /cases/{id}
+├── .env.example
+└── go.mod
+```
+
+## API Endpoints
+
+- `GET /health` — liveness check, no auth
+- `GET /users/me` — current user's profile (requires entity-service running with `DATA_SOURCE=servicenow`)
+- `POST /projects/search` — search projects
+- `GET /projects/{id}` — get project by ID
+- `POST /cases/search` — search cases
+- `GET /cases/{id}` — get case by ID
+
+All response shapes are portal-owned DTOs (see `internal/dto`) — entity-service's raw response is
+never returned verbatim; see [CLAUDE.md](./CLAUDE.md#response-shaping) for what is deliberately
+excluded from each and why.
+
+## Run Locally
+
+```bash
+go run ./cmd/server/main.go
+```
+
+When `AUTH_TOKEN_VALIDATOR_ENABLED=false` (default for local), pass any valid JWT as the
+`x-jwt-assertion` header.
+
+### Examples
+
+```bash
+JWT="<your-jwt-token>"
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/users/me
+
+curl -X POST http://localhost:8080/projects/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0},"searchQuery":"acme"}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>
+
+curl -X POST http://localhost:8080/cases/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0},"filters":{"searchQuery":"login error"}}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/cases/<case-id>
+```

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,7 +5,7 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the first 5 endpoints are implemented so far (see below).
+This is a work in progress — only the first 6 routes are implemented so far (see below).
 Everything else the Ballerina backend exposes still needs a Go handler; add them following the
 pattern described in [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
 
@@ -86,7 +86,7 @@ Copy `.env.example` to `.env` and fill in the values.
 | `AUTH_JWKS_ENDPOINT` | JWKS endpoint used to verify JWT signatures |
 | `AUTH_ISSUER` | Expected `iss` claim value |
 | `AUTH_AUDIENCE` | Comma-separated accepted `aud` values |
-| `AUTH_TOKEN_VALIDATOR_ENABLED` | Set to `false` for local development to skip signature verification (default `true`) |
+| `AUTH_TOKEN_VALIDATOR_ENABLED` | `false` skips JWT signature verification — **local development only**; `.env.example` ships `false` for local convenience. Production **must** set this to `true` with a real `AUTH_JWKS_ENDPOINT`/`AUTH_ISSUER`/`AUTH_AUDIENCE` |
 
 ### Server
 
@@ -144,8 +144,8 @@ excluded from each and why.
 go run ./cmd/server/main.go
 ```
 
-When `AUTH_TOKEN_VALIDATOR_ENABLED=false` (default for local), pass any valid JWT as the
-`x-jwt-assertion` header.
+With `AUTH_TOKEN_VALIDATOR_ENABLED=false` (the `.env.example` local default), pass any valid JWT as
+the `x-jwt-assertion` header — its signature is not verified.
 
 ### Examples
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Command server runs the customer-portal backend-v2 HTTP server.
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/handler"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+func main() {
+	loadDotEnv(".env")
+	middleware.ConfigureLogger()
+
+	entityCfg := entity.Config{
+		BaseURL:      mustEnv("ENTITY_SERVICE_BASE_URL"),
+		TokenURL:     os.Getenv("OAUTH2_TOKEN_URL"),
+		ClientID:     os.Getenv("OAUTH2_CLIENT_ID"),
+		ClientSecret: os.Getenv("OAUTH2_CLIENT_SECRET"),
+		Scopes:       splitComma(os.Getenv("ENTITY_SERVICE_SCOPES")),
+	}
+	entityClient := entity.NewClient(entityCfg)
+
+	userHandler := handler.NewUserHandler(entityClient)
+	projectHandler := handler.NewProjectHandler(entityClient)
+	caseHandler := handler.NewCaseHandler(entityClient)
+
+	authCfg := middleware.Config{
+		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
+		Issuer:                mustEnv("AUTH_ISSUER"),
+		Audiences:             splitComma(mustEnv("AUTH_AUDIENCE")),
+		ClockSkew:             5 * time.Second,
+		TokenValidatorEnabled: os.Getenv("AUTH_TOKEN_VALIDATOR_ENABLED") != "false",
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// GET /users/me is only served by entity-service when it runs with
+	// DATA_SOURCE=servicenow — see internal/entity/users.go.
+	mux.HandleFunc("GET /users/me", userHandler.GetMe)
+
+	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
+	mux.HandleFunc("GET /projects/{id}", projectHandler.GetProject)
+
+	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
+	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
+
+	addr := ":" + mustPort("PORT", "8080")
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Error("failed to bind", "addr", addr, "err", err)
+		os.Exit(1)
+	}
+	slog.Info("Customer Portal Backend (v2) started", "addr", addr)
+
+	srv := &http.Server{
+		Handler: middleware.SecurityHeaders(
+			middleware.CorrelationID(
+				middleware.Auth(authCfg)(
+					middleware.Logger(mux),
+				),
+			),
+		),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			slog.Error("server exited", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	stop()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("graceful shutdown failed", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("Customer Portal Backend (v2) stopped")
+}
+
+func mustEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		slog.Error("required environment variable is not set", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// mustPort returns the value of the given environment variable (or def if
+// unset) as a bare port number, e.g. "8080" — not an address like ":8080" or
+// "localhost:8080". Exits the process if the value isn't a valid TCP port.
+func mustPort(key, def string) string {
+	v := envOrDefault(key, def)
+	port, err := strconv.Atoi(v)
+	if err != nil || port < 1 || port > 65535 {
+		slog.Error("environment variable must be a plain port number (e.g. \"8080\"), not an address", "key", key, "value", v)
+		os.Exit(1)
+	}
+	return v
+}
+
+// loadDotEnv reads a .env file and sets any unset environment variables from it.
+// Silently ignored if the file does not exist; logs a warning for any other error.
+func loadDotEnv(path string) {
+	f, err := os.Open(path) // #nosec G304 -- path is always the hardcoded literal ".env" at the only call site
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("loadDotEnv: failed to open .env file", "err", err)
+		}
+		return
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		// Strip surrounding quotes from value.
+		if len(v) >= 2 && ((v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'')) {
+			v = v[1 : len(v)-1]
+		}
+		if os.Getenv(k) == "" {
+			_ = os.Setenv(k, v)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		slog.Warn("loadDotEnv: error reading .env file", "err", err)
+	}
+}
+
+func splitComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
+}

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -177,8 +177,10 @@ func loadDotEnv(path string) {
 		if len(v) >= 2 && ((v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'')) {
 			v = v[1 : len(v)-1]
 		}
-		if os.Getenv(k) == "" {
-			_ = os.Setenv(k, v)
+		if _, exists := os.LookupEnv(k); !exists {
+			if err := os.Setenv(k, v); err != nil {
+				slog.Warn("loadDotEnv: failed to set environment variable", "key", k, "err", err)
+			}
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/apps/customer-portal/backend-v2/go.mod
+++ b/apps/customer-portal/backend-v2/go.mod
@@ -1,0 +1,14 @@
+module github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2
+
+go 1.26.0
+
+require (
+	github.com/MicahParks/keyfunc/v3 v3.8.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	golang.org/x/oauth2 v0.27.0
+)
+
+require (
+	github.com/MicahParks/jwkset v0.11.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
+)

--- a/apps/customer-portal/backend-v2/go.sum
+++ b/apps/customer-portal/backend-v2/go.sum
@@ -1,0 +1,12 @@
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/apps/customer-portal/backend-v2/internal/apierror/apierror.go
+++ b/apps/customer-portal/backend-v2/internal/apierror/apierror.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package apierror defines the error type used to carry upstream (entity-service)
+// HTTP failures back through the client layer to the handler layer.
+package apierror
+
+import "fmt"
+
+// Error wraps a non-2xx response from an upstream service call.
+type Error struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("upstream returned %d: %s", e.StatusCode, e.Body)
+}

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// Ref is a compact {id, name} reference to another entity (project,
+// deployment, product, assigned team, etc.).
+type Ref struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func mapRef(r *entity.EntityRef) *Ref {
+	if r == nil {
+		return nil
+	}
+	return &Ref{ID: r.ID, Name: r.Name}
+}
+
+// NumberRef is a compact reference to a case carrying its human-readable number.
+type NumberRef struct {
+	ID     string `json:"id"`
+	Number string `json:"number"`
+}
+
+func mapNumberRef(r *entity.CaseNumberRef) *NumberRef {
+	if r == nil {
+		return nil
+	}
+	return &NumberRef{ID: r.ID, Number: r.Number}
+}
+
+// CaseSummary is one item of the portal's response for POST /cases/search.
+//
+// Deliberately excludes entity-service's InternalID (internal-only
+// identifier), Catalog/CatalogItem (CMDB implementation detail), Conversation,
+// DeployedProduct, AssignedEngineer, ParentCase/RelatedCase — kept minimal for
+// the list view; the full picture is available via GET /cases/{id}.
+type CaseSummary struct {
+	ID             string  `json:"id"`
+	Number         string  `json:"number"`
+	Subject        *string `json:"subject,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	State          string  `json:"state"`
+	Severity       *string `json:"severity,omitempty"`
+	IssueType      *string `json:"issueType,omitempty"`
+	EngagementType *string `json:"engagementType,omitempty"`
+	WorkState      *string `json:"workState,omitempty"`
+	Type           string  `json:"type"`
+	CreatedOn      string  `json:"createdOn"`
+	Project        Ref     `json:"project"`
+	Deployment     *Ref    `json:"deployment,omitempty"`
+	Product        *Ref    `json:"product,omitempty"`
+	AssignedTeam   *Ref    `json:"assignedTeam,omitempty"`
+}
+
+// SearchCasesResponse is the portal's response for POST /cases/search.
+type SearchCasesResponse struct {
+	Cases  []CaseSummary `json:"cases"`
+	Total  int           `json:"total"`
+	Limit  int           `json:"limit"`
+	Offset int           `json:"offset"`
+}
+
+// MapSearchCases builds the portal response from entity-service's SearchCasesResponse.
+func MapSearchCases(r entity.SearchCasesResponse) SearchCasesResponse {
+	cases := make([]CaseSummary, 0, len(r.Cases))
+	for _, c := range r.Cases {
+		cases = append(cases, CaseSummary{
+			ID:             c.ID,
+			Number:         c.Number,
+			Subject:        c.Subject,
+			Description:    c.Description,
+			State:          c.State,
+			Severity:       c.Severity,
+			IssueType:      c.IssueType,
+			EngagementType: c.EngagementType,
+			WorkState:      c.WorkState,
+			Type:           c.Type,
+			CreatedOn:      c.CreatedOn,
+			Project:        Ref{ID: c.Project.ID, Name: c.Project.Name},
+			Deployment:     mapRef(c.Deployment),
+			Product:        mapRef(c.Product),
+			AssignedTeam:   mapRef(c.AssignedTeam),
+		})
+	}
+	return SearchCasesResponse{
+		Cases:  cases,
+		Total:  r.Total,
+		Limit:  r.Limit,
+		Offset: r.Offset,
+	}
+}
+
+// PersonRef is a compact reference to a person (name + email), used for
+// case creators and assigned engineers. Internal identifiers (entity-service's
+// UserRef.ID/UserID, AssignedEngineerRef.ID) are intentionally dropped.
+type PersonRef struct {
+	Name  string  `json:"name"`
+	Email *string `json:"email,omitempty"`
+}
+
+// LinkedServiceRequest is a compact reference to a service-request case
+// linked to another case as its parent.
+type LinkedServiceRequest struct {
+	ID     string `json:"id"`
+	Number string `json:"number"`
+	Name   string `json:"name"`
+}
+
+// CaseTag is a free-text label attached to a case.
+type CaseTag struct {
+	Label string  `json:"label"`
+	Color *string `json:"color,omitempty"`
+}
+
+// CaseDetails is the portal's response for GET /cases/{id}.
+//
+// Deliberately excludes entity-service's InternalID, Catalog/CatalogItem
+// (CMDB detail), WatchList, AutoclosureStep/AutoclosureStateTime, and
+// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta — entity-service documents
+// the Fix-ETA trio and WatchList as CSM-engineer-facing only, and autoclosure
+// state is internal ServiceNow workflow detail not surfaced to entity-service's
+// decoded CaseView in the first place (see internal/entity/types.go).
+type CaseDetails struct {
+	ID                    string                 `json:"id"`
+	Number                string                 `json:"number"`
+	Subject               string                 `json:"subject"`
+	Description           string                 `json:"description"`
+	Severity              string                 `json:"severity"`
+	IssueType             string                 `json:"issueType"`
+	State                 string                 `json:"state"`
+	WorkState             *string                `json:"workState,omitempty"`
+	Type                  *string                `json:"type,omitempty"`
+	EngagementType        *string                `json:"engagementType,omitempty"`
+	CreatedOn             time.Time              `json:"createdOn"`
+	UpdatedOn             time.Time              `json:"updatedOn"`
+	ClosedOn              *time.Time             `json:"closedOn,omitempty"`
+	CreatedBy             PersonRef              `json:"createdBy"`
+	Project               Ref                    `json:"project"`
+	Deployment            *Ref                   `json:"deployment,omitempty"`
+	DeployedProduct       *Ref                   `json:"deployedProduct,omitempty"`
+	Product               *Ref                   `json:"product,omitempty"`
+	AssignedTeam          *Ref                   `json:"assignedTeam,omitempty"`
+	Conversation          *Ref                   `json:"conversation,omitempty"`
+	AssignedEngineer      *PersonRef             `json:"assignedEngineer,omitempty"`
+	ParentCase            *NumberRef             `json:"parentCase,omitempty"`
+	RelatedCase           *NumberRef             `json:"relatedCase,omitempty"`
+	LinkedServiceRequests []LinkedServiceRequest `json:"linkedServiceRequests,omitempty"`
+	ResolvedOn            *time.Time             `json:"resolvedOn,omitempty"`
+	ResolutionCode        *string                `json:"resolutionCode,omitempty"`
+	Cause                 *string                `json:"cause,omitempty"`
+	ResolutionNotes       *string                `json:"resolutionNotes,omitempty"`
+	FixEta                *time.Time             `json:"fixEta,omitempty"`
+	Tags                  []CaseTag              `json:"tags,omitempty"`
+}
+
+// MapCaseDetails builds the portal response from entity-service's CaseView.
+func MapCaseDetails(c entity.CaseView) CaseDetails {
+	var deployedProduct *Ref
+	if c.DeployedProductDetails != nil {
+		deployedProduct = &Ref{ID: c.DeployedProductDetails.ID, Name: c.DeployedProductDetails.DisplayName}
+	}
+
+	var assignedEngineer *PersonRef
+	if c.AssignedEngineer != nil {
+		assignedEngineer = &PersonRef{Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
+	}
+
+	linked := make([]LinkedServiceRequest, 0, len(c.LinkedServiceRequests))
+	for _, lsr := range c.LinkedServiceRequests {
+		linked = append(linked, LinkedServiceRequest{ID: lsr.ID, Number: lsr.Number, Name: lsr.Name})
+	}
+
+	var tags []CaseTag
+	if len(c.Tags) > 0 {
+		tags = make([]CaseTag, 0, len(c.Tags))
+		for _, t := range c.Tags {
+			tags = append(tags, CaseTag{Label: t.Label, Color: t.Color})
+		}
+	}
+
+	email := c.CreatedByDetails.Email
+	return CaseDetails{
+		ID:              c.ID,
+		Number:          c.Number,
+		Subject:         c.Subject,
+		Description:     c.Description,
+		Severity:        c.Severity,
+		IssueType:       c.IssueType,
+		State:           c.State,
+		WorkState:       c.WorkState,
+		Type:            c.Type,
+		EngagementType:  c.EngagementType,
+		CreatedOn:       c.CreatedOn,
+		UpdatedOn:       c.UpdatedOn,
+		ClosedOn:        c.ClosedOn,
+		CreatedBy:       PersonRef{Name: c.CreatedByDetails.Name, Email: &email},
+		Project:         Ref{ID: c.ProjectDetails.ID, Name: c.ProjectDetails.Name},
+		Deployment:      mapRef(c.DeploymentDetails),
+		DeployedProduct: deployedProduct,
+		Product:         mapRef(c.ProductDetails),
+		AssignedTeam:    mapRef(c.AssignedTeam),
+		Conversation:    mapRef(c.Conversation),
+
+		AssignedEngineer:      assignedEngineer,
+		ParentCase:            mapNumberRef(c.ParentCase),
+		RelatedCase:           mapNumberRef(c.RelatedCase),
+		LinkedServiceRequests: linked,
+		ResolvedOn:            c.ResolvedOn,
+		ResolutionCode:        c.ResolutionCode,
+		Cause:                 c.Cause,
+		ResolutionNotes:       c.ResolutionNotes,
+		FixEta:                c.FixEta,
+		Tags:                  tags,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/project.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// ProjectSummary is one item of the portal's response for POST /projects/search.
+//
+// Deliberately excludes entity-service's endDateClosureState,
+// invoiceDueDateClosureState, complianceViolationClosureState,
+// complianceViolationDate and suspensionProcessState — these are WSO2-internal
+// closure/compliance workflow fields not meant for customer display.
+type ProjectSummary struct {
+	ID               string     `json:"id"`
+	Name             string     `json:"name"`
+	Key              string     `json:"key"`
+	SubscriptionType string     `json:"subscriptionType"`
+	EndDate          *time.Time `json:"endDate,omitempty"`
+	CreatedOn        time.Time  `json:"createdOn"`
+	ClosureState     *string    `json:"closureState,omitempty"`
+}
+
+// SearchProjectsResponse is the portal's response for POST /projects/search.
+type SearchProjectsResponse struct {
+	Projects []ProjectSummary `json:"projects"`
+	Total    int              `json:"total"`
+	Limit    int              `json:"limit"`
+	Offset   int              `json:"offset"`
+	HasMore  bool              `json:"hasMore"`
+}
+
+// MapSearchProjects builds the portal response from entity-service's SearchProjectsResponse.
+func MapSearchProjects(r entity.SearchProjectsResponse) SearchProjectsResponse {
+	projects := make([]ProjectSummary, 0, len(r.Projects))
+	for _, p := range r.Projects {
+		projects = append(projects, ProjectSummary{
+			ID:               p.ID,
+			Name:             p.Name,
+			Key:              p.Key,
+			SubscriptionType: p.SubscriptionType,
+			EndDate:          p.EndDate,
+			CreatedOn:        p.CreatedOn,
+			ClosureState:     p.ClosureState,
+		})
+	}
+	return SearchProjectsResponse{
+		Projects: projects,
+		Total:    r.Total,
+		Limit:    r.Limit,
+		Offset:   r.Offset,
+		HasMore:  r.HasMore,
+	}
+}
+
+// ProjectAccount is the account summary embedded in ProjectDetails.
+//
+// Deliberately excludes entity-service's AgentEnabled/KbReferencesEnabled
+// (internal feature-flags gating WSO2 agent behavior, not customer-facing)
+// and ActivationDate (redundant with the project's own dates for this view).
+type ProjectAccount struct {
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
+	Tier   string  `json:"tier"`
+	Region *string `json:"region,omitempty"`
+}
+
+// ProjectDetails is the portal's response for GET /projects/{id}.
+//
+// Deliberately excludes entity-service's SfID (Salesforce internal ID —
+// must never reach the frontend) and the same closure/compliance fields
+// dropped from ProjectSummary above.
+type ProjectDetails struct {
+	ID               string         `json:"id"`
+	Account          ProjectAccount `json:"account"`
+	Name             string         `json:"name"`
+	Key              string         `json:"key"`
+	SubscriptionType string         `json:"subscriptionType"`
+	StartDate        time.Time      `json:"startDate"`
+	EndDate          time.Time      `json:"endDate"`
+	CreatedOn        time.Time      `json:"createdOn"`
+	UpdatedOn        time.Time      `json:"updatedOn"`
+	ClosureState     *string        `json:"closureState,omitempty"`
+}
+
+// MapProjectDetails builds the portal response from entity-service's ProjectDetailsView.
+func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
+	return ProjectDetails{
+		ID: p.ID,
+		Account: ProjectAccount{
+			ID:     p.Account.ID,
+			Name:   p.Account.Name,
+			Tier:   p.Account.Tier,
+			Region: p.Account.Region,
+		},
+		Name:             p.Name,
+		Key:              p.Key,
+		SubscriptionType: p.SubscriptionType,
+		StartDate:        p.StartDate,
+		EndDate:          p.EndDate,
+		CreatedOn:        p.CreatedOn,
+		UpdatedOn:        p.UpdatedOn,
+		ClosureState:     p.ClosureState,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/user.go
+++ b/apps/customer-portal/backend-v2/internal/dto/user.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package dto defines the portal-facing response shapes returned to the
+// customer-portal frontend, together with Map* functions that translate
+// entity-service's raw response structs into them. This is the Go analogue
+// of the Ballerina backend's "types" module + utils.bal mapper functions:
+// the frontend never sees an entity-service struct directly, only these.
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// UserMeResponse is the portal's response for GET /users/me.
+type UserMeResponse struct {
+	ID        string   `json:"id"`
+	Email     string   `json:"email"`
+	FirstName *string  `json:"firstName,omitempty"`
+	LastName  string   `json:"lastName"`
+	TimeZone  *string  `json:"timeZone,omitempty"`
+	Roles     []string `json:"roles"`
+}
+
+// MapUserMe builds the portal response from entity-service's GetUserMeResponse.
+func MapUserMe(u entity.GetUserMeResponse) UserMeResponse {
+	return UserMeResponse{
+		ID:        u.ID,
+		Email:     u.Email,
+		FirstName: u.FirstName,
+		LastName:  u.LastName,
+		TimeZone:  u.TimeZone,
+		Roles:     u.Roles,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/cases.go
+++ b/apps/customer-portal/backend-v2/internal/entity/cases.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// SearchCases calls POST /cases/search.
+func (c *Client) SearchCases(ctx context.Context, req SearchCasesRequest) (SearchCasesResponse, error) {
+	var out SearchCasesResponse
+	err := c.postJSON(ctx, "/cases/search", req, &out)
+	return out, err
+}
+
+// GetCase calls GET /cases/{id}.
+func (c *Client) GetCase(ctx context.Context, id string) (CaseView, error) {
+	var out CaseView
+	err := c.getJSON(ctx, fmt.Sprintf("/cases/%s", url.PathEscape(id)), &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/client.go
+++ b/apps/customer-portal/backend-v2/internal/entity/client.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package entity is the HTTP client for this repo's entity-service
+// (cs-tools/entity-service), which fronts projects, cases, accounts, deployed
+// products, and related resources.
+package entity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var tokenFetchTimeout = 10 * time.Second
+
+type ctxKey string
+
+const userIDTokenKey ctxKey = "x-user-id-token"        // #nosec G101 -- context map key, not a credential
+const correlationIDKey ctxKey = "x-csm-correlation-id" // #nosec G101 -- context map key, not a credential
+
+// WithUserIDToken returns a copy of ctx carrying the x-user-id-token value to
+// be forwarded on every outgoing entity-service request.
+func WithUserIDToken(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, userIDTokenKey, token)
+}
+
+func userIDTokenFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(userIDTokenKey).(string)
+	return v
+}
+
+// WithCorrelationID returns a copy of ctx carrying the correlation ID to be
+// forwarded as X-CSM-Correlation-ID on every outgoing entity-service request.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationIDKey, id)
+}
+
+func correlationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey).(string)
+	return v
+}
+
+// Config holds the configuration for the entity-service client.
+type Config struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// Client is an HTTP client for cs-tools/entity-service, authenticated via the
+// OAuth2 client credentials grant. Tokens are acquired and refreshed
+// automatically; callers need not manage them.
+//
+// Note: entity-service itself does not validate inbound credentials (see its
+// own internal/middleware/usertoken.go) — it forwards x-user-id-token
+// downstream to ServiceNow as-is. The OAuth2 layer here exists for the
+// gateway/deployment fronting entity-service, mirroring the pattern used by
+// apps/csm-portal/backend's entity client.
+type Client struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewClient constructs a Client that authenticates against entity-service
+// using the OAuth2 client credentials grant type.
+func NewClient(cfg Config) *Client {
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout})
+	httpClient := cc.Client(tokenCtx)
+	httpClient.Timeout = 25 * time.Second
+
+	return &Client{
+		http:    httpClient,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+	}
+}
+
+// do executes an authenticated HTTP request against entity-service and
+// returns the raw JSON response body. The caller owns the returned slice.
+func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("entity: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := userIDTokenFromContext(ctx); token != "" {
+		req.Header.Set("x-user-id-token", token)
+	}
+	if id := correlationIDFromContext(ctx); id != "" {
+		req.Header.Set("X-CSM-Correlation-ID", id)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("entity: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("entity: read response body: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	return respBody, nil
+}
+
+// getJSON issues a GET request and decodes the JSON response into out.
+func (c *Client) getJSON(ctx context.Context, path string, out any) error {
+	body, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("entity: decode response for GET %s: %w", path, err)
+	}
+	return nil
+}
+
+// postJSON marshals reqBody, issues a POST request, and decodes the JSON
+// response into out.
+func (c *Client) postJSON(ctx context.Context, path string, reqBody, out any) error {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("entity: encode request for POST %s: %w", path, err)
+	}
+	body, err := c.do(ctx, http.MethodPost, path, payload)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("entity: decode response for POST %s: %w", path, err)
+	}
+	return nil
+}

--- a/apps/customer-portal/backend-v2/internal/entity/client.go
+++ b/apps/customer-portal/backend-v2/internal/entity/client.go
@@ -38,6 +38,11 @@ import (
 // Overridden in tests to keep them fast.
 var tokenFetchTimeout = 10 * time.Second
 
+// maxResponseBodyBytes bounds how much of an entity-service response this
+// client will read into memory, protecting against a huge or malicious
+// upstream response exhausting process memory.
+const maxResponseBodyBytes = 10 << 20 // 10 MiB
+
 type ctxKey string
 
 const userIDTokenKey ctxKey = "x-user-id-token"        // #nosec G101 -- context map key, not a credential
@@ -102,6 +107,14 @@ func NewClient(cfg Config) *Client {
 		&http.Client{Timeout: tokenFetchTimeout})
 	httpClient := cc.Client(tokenCtx)
 	httpClient.Timeout = 25 * time.Second
+	// x-user-id-token carries the caller's JWT to entity-service. Go's client
+	// only strips sensitive headers on cross-origin redirects for a fixed
+	// allowlist (Authorization, Cookie, etc.) that does not include this
+	// custom header, so a redirecting upstream could otherwise receive it at
+	// a different origin. Disable redirect-following entirely instead.
+	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 
 	return &Client{
 		http:    httpClient,
@@ -137,9 +150,13 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	limited := io.LimitReader(resp.Body, maxResponseBodyBytes+1)
+	respBody, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("entity: read response body: %w", err)
+	}
+	if len(respBody) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("entity: %s %s: response body exceeds %d bytes", method, path, maxResponseBodyBytes)
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {

--- a/apps/customer-portal/backend-v2/internal/entity/client.go
+++ b/apps/customer-portal/backend-v2/internal/entity/client.go
@@ -43,6 +43,13 @@ var tokenFetchTimeout = 10 * time.Second
 // upstream response exhausting process memory.
 const maxResponseBodyBytes = 10 << 20 // 10 MiB
 
+// noRedirect stops an *http.Client from following any redirect, returning the
+// redirect response itself instead. Used on both the token-fetch client and
+// the entity-service request client — see the comment in NewClient.
+func noRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
 type ctxKey string
 
 const userIDTokenKey ctxKey = "x-user-id-token"        // #nosec G101 -- context map key, not a credential
@@ -103,17 +110,25 @@ func NewClient(cfg Config) *Client {
 		Scopes:       cfg.Scopes,
 	}
 
+	// x-user-id-token carries the caller's JWT to entity-service, and the
+	// client-credentials exchange carries cfg.ClientSecret to TokenURL. Go's
+	// client only strips sensitive headers on cross-origin redirects for a
+	// fixed allowlist (Authorization, Cookie, etc.) that covers neither, so a
+	// redirecting TokenURL or BaseURL could otherwise receive one of them at a
+	// different origin. Disable redirect-following entirely on both instead.
 	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
-		&http.Client{Timeout: tokenFetchTimeout})
-	httpClient := cc.Client(tokenCtx)
-	httpClient.Timeout = 25 * time.Second
-	// x-user-id-token carries the caller's JWT to entity-service. Go's client
-	// only strips sensitive headers on cross-origin redirects for a fixed
-	// allowlist (Authorization, Cookie, etc.) that does not include this
-	// custom header, so a redirecting upstream could otherwise receive it at
-	// a different origin. Disable redirect-following entirely instead.
-	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
+		&http.Client{Timeout: tokenFetchTimeout, CheckRedirect: noRedirect})
+
+	// clientcredentials.Config.Client's returned *http.Client and its
+	// Transport must not be mutated (see the package doc comment) — its
+	// Transport is the only part we need (it injects the bearer token), so
+	// wrap it in a fresh http.Client we own instead of setting fields
+	// directly on the returned one.
+	oauthClient := cc.Client(tokenCtx)
+	httpClient := &http.Client{
+		Transport:     oauthClient.Transport,
+		Timeout:       25 * time.Second,
+		CheckRedirect: noRedirect,
 	}
 
 	return &Client{

--- a/apps/customer-portal/backend-v2/internal/entity/projects.go
+++ b/apps/customer-portal/backend-v2/internal/entity/projects.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// SearchProjects calls POST /projects/search.
+func (c *Client) SearchProjects(ctx context.Context, req SearchProjectsRequest) (SearchProjectsResponse, error) {
+	var out SearchProjectsResponse
+	err := c.postJSON(ctx, "/projects/search", req, &out)
+	return out, err
+}
+
+// GetProject calls GET /projects/{id}.
+func (c *Client) GetProject(ctx context.Context, id string) (ProjectDetailsView, error) {
+	var out ProjectDetailsView
+	err := c.getJSON(ctx, fmt.Sprintf("/projects/%s", url.PathEscape(id)), &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// These types mirror entity-service's wire format 1:1 (see
+// cs-tools/entity-service/internal/domain/entity.go) so json.Unmarshal can
+// decode its responses directly. They are internal to this package — the
+// dto package maps them into the portal's own response contracts before
+// anything reaches the frontend.
+
+// Pagination controls which page of results is requested/returned.
+type Pagination struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+// --- users/me ---
+
+// GetUserMeResponse is entity-service's response for GET /users/me.
+type GetUserMeResponse struct {
+	ID        string   `json:"id"`
+	Email     string   `json:"email"`
+	FirstName *string  `json:"firstName,omitempty"`
+	LastName  string   `json:"lastName"`
+	TimeZone  *string  `json:"timeZone,omitempty"`
+	Roles     []string `json:"roles"`
+}
+
+// --- projects ---
+
+// SearchProjectsRequest is the input for POST /projects/search.
+type SearchProjectsRequest struct {
+	Pagination    Pagination `json:"pagination"`
+	SearchQuery   string     `json:"searchQuery,omitempty"`
+	ClosureStatus string     `json:"closureStatus,omitempty"`
+	EndDateFrom   string     `json:"endDateFrom,omitempty"`
+	EndDateTo     string     `json:"endDateTo,omitempty"`
+	SortBy        string     `json:"sortBy,omitempty"`
+	SortOrder     string     `json:"sortOrder,omitempty"`
+}
+
+// ProjectClosureFields groups the ServiceNow-only closure-tracking fields
+// shared by ProjectDetailsView and ProjectView.
+type ProjectClosureFields struct {
+	ClosureState                   *string         `json:"closureState"`
+	EndDateClosureState             *string         `json:"endDateClosureState"`
+	InvoiceDueDateClosureState      *string         `json:"invoiceDueDateClosureState"`
+	ComplianceViolationClosureState *string         `json:"complianceViolationClosureState"`
+	ComplianceViolationDate         *string         `json:"complianceViolationDate"`
+	SuspensionProcessState          json.RawMessage `json:"suspensionProcessState"`
+}
+
+// ProjectView is a single search result item from POST /projects/search.
+type ProjectView struct {
+	ID               string     `json:"id"`
+	Name             string     `json:"name"`
+	Key              string     `json:"key"`
+	SubscriptionType string     `json:"subscriptionType"`
+	EndDate          *time.Time `json:"endDate"`
+	CreatedOn        time.Time  `json:"createdOn"`
+	ProjectClosureFields
+}
+
+// SearchProjectsResponse is entity-service's response for POST /projects/search.
+type SearchProjectsResponse struct {
+	Projects []ProjectView `json:"projects"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+	HasMore  bool          `json:"hasMore"`
+}
+
+// ProjectAccountRef is the account summary embedded in ProjectDetailsView.
+type ProjectAccountRef struct {
+	ID                  string     `json:"id"`
+	Name                string     `json:"name"`
+	ActivationDate      *time.Time `json:"activationDate"`
+	Tier                string     `json:"tier"`
+	Region              *string    `json:"region"`
+	AgentEnabled        bool       `json:"agentEnabled"`
+	KbReferencesEnabled bool       `json:"kbReferencesEnabled"`
+}
+
+// ProjectDetailsView is entity-service's response for GET /projects/{id}.
+type ProjectDetailsView struct {
+	ID               string            `json:"id"`
+	Account          ProjectAccountRef `json:"account"`
+	SfID             string            `json:"sfId"`
+	Name             string            `json:"name"`
+	Key              string            `json:"key"`
+	SubscriptionType string            `json:"subscriptionType"`
+	StartDate        time.Time         `json:"startDate"`
+	EndDate          time.Time         `json:"endDate"`
+	CreatedOn        time.Time         `json:"createdOn"`
+	UpdatedOn        time.Time         `json:"updatedOn"`
+	ProjectClosureFields
+}
+
+// --- cases ---
+
+// CaseSort specifies the sort field and direction for case search results.
+type CaseSort struct {
+	Field string `json:"field,omitempty"`
+	Order string `json:"order,omitempty"`
+}
+
+// SearchCasesFilters holds the optional filter criteria for a case search.
+// Only the fields the portal currently exposes are included here; extend as
+// needed when more filters are surfaced to the frontend.
+type SearchCasesFilters struct {
+	Types           []string   `json:"types,omitempty"`
+	SearchQuery     string     `json:"searchQuery,omitempty"`
+	ProjectIDs      []string   `json:"projectIds,omitempty"`
+	DeploymentIDs   []string   `json:"deploymentIds,omitempty"`
+	States          []string   `json:"states,omitempty"`
+	Severities      []string   `json:"severities,omitempty"`
+	IssueTypes      []string   `json:"issueTypes,omitempty"`
+	EngagementTypes []string   `json:"engagementTypes,omitempty"`
+	CreatedBy       []string   `json:"createdBy,omitempty"`
+	CreatedByMe     bool       `json:"createdByMe,omitempty"`
+	WorkStates      []string   `json:"workStates,omitempty"`
+	AssignedUserIDs []string   `json:"assignedUserIds,omitempty"`
+	ProductNames    []string   `json:"productNames,omitempty"`
+	Tags            []string   `json:"tags,omitempty"`
+	ParentID        *string    `json:"parentId,omitempty"`
+}
+
+// SearchCasesRequest is the input for POST /cases/search.
+type SearchCasesRequest struct {
+	Filters    SearchCasesFilters `json:"filters"`
+	SortBy     CaseSort           `json:"sortBy"`
+	Pagination Pagination         `json:"pagination"`
+}
+
+// EntityRef is a compact reference to a named entity (project, deployment, product, etc.).
+type EntityRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// AssignedEngineerRef is a compact reference to an assigned support engineer.
+type AssignedEngineerRef struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Email *string `json:"email"`
+}
+
+// CaseNumberRef is a compact reference to a case carrying its human-readable number.
+type CaseNumberRef struct {
+	ID     string `json:"id"`
+	Number string `json:"number"`
+}
+
+// LinkedServiceRequestRef is a compact reference to a service-request case
+// linked to another case as its parent.
+type LinkedServiceRequestRef struct {
+	ID     string `json:"id"`
+	Number string `json:"number"`
+	Name   string `json:"name"`
+}
+
+// AccountRef is a compact reference to an account.
+type AccountRef struct {
+	ID      string     `json:"id"`
+	Name    string     `json:"name"`
+	Type    string     `json:"type"`
+	CreTeam *EntityRef `json:"creTeam,omitempty"`
+	SreTeam *EntityRef `json:"sreTeam,omitempty"`
+}
+
+// DeployedProductRef is a compact reference to a deployed product.
+type DeployedProductRef struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
+// UserRef is a reference to a user with key display fields.
+type UserRef struct {
+	ID     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	UserID string `json:"userId,omitempty"`
+	Email  string `json:"email"`
+}
+
+// Tag is a free-text label attached to a case.
+type Tag struct {
+	ID    string  `json:"id"`
+	Label string  `json:"label"`
+	Color *string `json:"color"`
+}
+
+// SearchCaseView is a single search result item from POST /cases/search.
+type SearchCaseView struct {
+	ID               string               `json:"id"`
+	InternalID       string               `json:"internalId"`
+	Number           string               `json:"number"`
+	CreatedOn        string               `json:"createdOn"`
+	CreatedBy        string               `json:"createdBy"`
+	Subject          *string              `json:"subject"`
+	Description      *string              `json:"description"`
+	IssueType        *string              `json:"issueType"`
+	State            string               `json:"state"`
+	Severity         *string              `json:"severity"`
+	Catalog          *EntityRef           `json:"catalog"`
+	CatalogItem      *EntityRef           `json:"catalogItem"`
+	AssignedTeam     *EntityRef           `json:"assignedTeam"`
+	Product          *EntityRef           `json:"product"`
+	EngagementType   *string              `json:"engagementType"`
+	WorkState        *string              `json:"workState"`
+	Type             string               `json:"type"`
+	Project          EntityRef            `json:"project"`
+	Deployment       *EntityRef           `json:"deployment"`
+	DeployedProduct  *EntityRef           `json:"deployedProduct"`
+	AssignedEngineer *AssignedEngineerRef `json:"assignedEngineer"`
+	ParentCase       *EntityRef           `json:"parentCase"`
+	RelatedCase      *EntityRef           `json:"relatedCase"`
+	Conversation     *EntityRef           `json:"conversation"`
+}
+
+// SearchCasesResponse is entity-service's response for POST /cases/search.
+type SearchCasesResponse struct {
+	Cases  []SearchCaseView `json:"cases"`
+	Total  int              `json:"total"`
+	Offset int              `json:"offset"`
+	Limit  int              `json:"limit"`
+}
+
+// CaseView is entity-service's response for GET /cases/{id}.
+type CaseView struct {
+	ID                     string                    `json:"id"`
+	Number                 string                    `json:"number"`
+	InternalID             string                    `json:"internalId"`
+	Subject                string                    `json:"subject"`
+	Description            string                    `json:"description"`
+	Severity               string                    `json:"severity"`
+	IssueType              string                    `json:"issueType"`
+	State                  string                    `json:"state"`
+	WorkState              *string                   `json:"workState"`
+	Type                   *string                   `json:"type"`
+	EngagementType         *string                   `json:"engagementType"`
+	CreatedOn              time.Time                 `json:"createdOn"`
+	UpdatedOn              time.Time                 `json:"updatedOn"`
+	ClosedOn               *time.Time                `json:"closedOn"`
+	CreatedByDetails       UserRef                   `json:"createdBy"`
+	ProjectDetails         EntityRef                 `json:"project"`
+	DeploymentDetails      *EntityRef                `json:"deployment"`
+	DeployedProductDetails *DeployedProductRef       `json:"deployedProduct"`
+	ProductDetails         *EntityRef                `json:"product"`
+	Catalog                *EntityRef                `json:"catalog"`
+	CatalogItem            *EntityRef                `json:"catalogItem"`
+	AssignedTeam           *EntityRef                `json:"assignedTeam"`
+	Conversation           *EntityRef                `json:"conversation"`
+	AssignedEngineer       *AssignedEngineerRef      `json:"assignedEngineer"`
+	ParentCase             *CaseNumberRef            `json:"parentCase"`
+	RelatedCase            *CaseNumberRef            `json:"relatedCase"`
+	AccountDetails         *AccountRef               `json:"account"`
+	LinkedServiceRequests  []LinkedServiceRequestRef `json:"linkedServiceRequests"`
+	ResolvedOn             *time.Time                `json:"resolvedOn"`
+	ResolutionCode         *string                   `json:"resolutionCode"`
+	Cause                  *string                   `json:"cause"`
+	ResolutionNotes        *string                   `json:"resolutionNotes"`
+	// WatchList, AutoclosureStep/AutoclosureStateTime and the Best/MostLikely/
+	// WorstCaseFixEta fields are intentionally NOT decoded here — entity-service
+	// documents them as CSM-engineer-facing only (see entity.go comments on
+	// CaseView), and the customer portal must not surface internal WSO2 support
+	// workflow state to end customers.
+	FixEta *time.Time `json:"fixEta"`
+	Tags   []Tag      `json:"tags"`
+}

--- a/apps/customer-portal/backend-v2/internal/entity/users.go
+++ b/apps/customer-portal/backend-v2/internal/entity/users.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import "context"
+
+// GetMe calls GET /users/me.
+//
+// NOTE: this route is only registered by entity-service when it is deployed
+// with DATA_SOURCE=servicenow (see cs-tools/entity-service/internal/server/routes.go).
+// A Postgres-mode deployment will 404 on this call.
+func (c *Client) GetMe(ctx context.Context) (GetUserMeResponse, error) {
+	var out GetUserMeResponse
+	err := c.getJSON(ctx, "/users/me", &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityCaseClient abstracts the entity-service case operations used by CaseHandler.
+type entityCaseClient interface {
+	SearchCases(ctx context.Context, req entity.SearchCasesRequest) (entity.SearchCasesResponse, error)
+	GetCase(ctx context.Context, id string) (entity.CaseView, error)
+}
+
+// CaseHandler handles HTTP requests for case operations.
+type CaseHandler struct {
+	entity entityCaseClient
+}
+
+// NewCaseHandler creates a CaseHandler backed by the given entity client.
+func NewCaseHandler(entity entityCaseClient) *CaseHandler {
+	return &CaseHandler{entity: entity}
+}
+
+// SearchCases handles POST /cases/search.
+func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchCasesRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchCases(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchCases failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search cases.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchCases(result))
+}
+
+// GetCase handles GET /cases/{id}.
+func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetCase(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetCase failed", "userID", user.UserID, "caseID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve case.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapCaseDetails(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/projects.go
+++ b/apps/customer-portal/backend-v2/internal/handler/projects.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityProjectClient abstracts the entity-service project operations used by ProjectHandler.
+type entityProjectClient interface {
+	SearchProjects(ctx context.Context, req entity.SearchProjectsRequest) (entity.SearchProjectsResponse, error)
+	GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error)
+}
+
+// ProjectHandler handles HTTP requests for project operations.
+type ProjectHandler struct {
+	entity entityProjectClient
+}
+
+// NewProjectHandler creates a ProjectHandler backed by the given entity client.
+func NewProjectHandler(entity entityProjectClient) *ProjectHandler {
+	return &ProjectHandler{entity: entity}
+}
+
+// SearchProjects handles POST /projects/search.
+func (h *ProjectHandler) SearchProjects(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchProjectsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchProjects(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProjects failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search projects.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchProjects(result))
+}
+
+// GetProject handles GET /projects/{id}.
+func (h *ProjectHandler) GetProject(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProject(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProject failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve project.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapProjectDetails(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package handler implements the HTTP layer: decoding requests, calling the
+// entity-service client, mapping responses via the dto package, and writing
+// JSON back to the customer-portal frontend.
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+)
+
+// maxRequestBodyBytes caps request bodies accepted by search/create/update endpoints.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+// uuidRe validates path parameters that are expected to be UUIDs.
+var uuidRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// Error message constants matching the customer-portal error vocabulary.
+const (
+	ErrMsgUnauthorized = "You are not authorized to perform this action. Please try again."
+	ErrMsgForbidden    = "Access to the requested resource is forbidden!"
+	ErrMsgNotFound     = "The requested resource was not found!"
+	ErrMsgBadRequest   = "Invalid request payload."
+	ErrMsgTooLarge     = "Request body too large."
+	ErrMsgInternal     = "An internal server error occurred. Please try again later."
+	ErrMsgInvalidUUID  = "Invalid UUID format."
+	errMsgReadBody     = "Failed to read request body."
+)
+
+// errorBody is the JSON error payload format matching the customer-portal pattern.
+type errorBody struct {
+	Message string `json:"message"`
+}
+
+// writeError writes a JSON error response: {"message": "..."}.
+func writeError(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(errorBody{Message: message})
+}
+
+// writeJSONValue marshals v and writes the result as a JSON response.
+func writeJSONValue(w http.ResponseWriter, statusCode int, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(data) // #nosec G705 -- Content-Type: application/json already set; SecurityHeaders middleware adds X-Content-Type-Options: nosniff
+}
+
+// mapUpstreamError translates an entity-service error to an HTTP response,
+// mirroring the Ballerina getStatusCode pattern in the customer-portal.
+func mapUpstreamError(w http.ResponseWriter, err error, fallbackMsg string) {
+	var apiErr *apierror.Error
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case http.StatusUnauthorized:
+			writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		case http.StatusForbidden:
+			writeError(w, http.StatusForbidden, ErrMsgForbidden)
+		case http.StatusNotFound:
+			writeError(w, http.StatusNotFound, ErrMsgNotFound)
+		case http.StatusBadRequest:
+			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		case http.StatusConflict, http.StatusUnprocessableEntity:
+			writeError(w, apiErr.StatusCode, apiErr.Body)
+		case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			writeError(w, http.StatusServiceUnavailable, fallbackMsg)
+		default:
+			writeError(w, http.StatusInternalServerError, fallbackMsg)
+		}
+		return
+	}
+	writeError(w, http.StatusInternalServerError, fallbackMsg)
+}
+
+// summarizeErr returns a short, log-safe description of err: the upstream status
+// code for a typed *apierror.Error (never its Body, which may carry upstream
+// response data not meant for logs), or a fixed generic message otherwise — an
+// unrecognized error can come from the underlying HTTP client (e.g. a
+// net/url.Error), which stringifies with the full request URL including query
+// parameters, so its raw text is not safe to log verbatim.
+func summarizeErr(err error) string {
+	var apiErr *apierror.Error
+	if errors.As(err, &apiErr) {
+		return fmt.Sprintf("upstream status %d", apiErr.StatusCode)
+	}
+	return "upstream request failed"
+}
+
+// readJSONBody caps r.Body at maxRequestBodyBytes, reads it fully, and
+// validates it is well-formed JSON. Writes the appropriate error response and
+// returns ok=false if the body is too large, unreadable, or invalid JSON.
+func readJSONBody(w http.ResponseWriter, r *http.Request) (body []byte, ok bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, isTooLarge := err.(*http.MaxBytesError); isTooLarge {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return nil, false
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return nil, false
+	}
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return nil, false
+	}
+	return body, true
+}

--- a/apps/customer-portal/backend-v2/internal/handler/users.go
+++ b/apps/customer-portal/backend-v2/internal/handler/users.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityUserClient abstracts the entity-service user operations used by UserHandler.
+type entityUserClient interface {
+	GetMe(ctx context.Context) (entity.GetUserMeResponse, error)
+}
+
+// UserHandler handles HTTP requests for the logged-in user's own profile.
+type UserHandler struct {
+	entity entityUserClient
+}
+
+// NewUserHandler creates a UserHandler backed by the given entity client.
+func NewUserHandler(entity entityUserClient) *UserHandler {
+	return &UserHandler{entity: entity}
+}
+
+// GetMe handles GET /users/me.
+func (h *UserHandler) GetMe(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	result, err := h.entity.GetMe(r.Context())
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetMe failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve user profile.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapUserMe(result))
+}

--- a/apps/customer-portal/backend-v2/internal/middleware/auth.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/auth.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// authErrorBody is the JSON error payload for auth failures.
+type authErrorBody struct {
+	Message string `json:"message"`
+}
+
+func writeAuthError(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(authErrorBody{Message: message})
+}
+
+const jwtAssertionHeader = "x-jwt-assertion"
+
+type contextKey string
+
+const userInfoKey contextKey = "user-info"
+
+// UserInfo holds the authenticated user's identity extracted from the JWT.
+type UserInfo struct {
+	Email  string
+	UserID string
+	Groups []string
+}
+
+// Config holds JWT validation configuration.
+type Config struct {
+	JWKSEndpoint          string
+	Issuer                string
+	Audiences             []string
+	ClockSkew             time.Duration
+	TokenValidatorEnabled bool
+}
+
+// jwtClaims defines the expected JWT payload fields, mirroring the Ballerina
+// CustomJwtPayload in the customer-portal's authorization module.
+type jwtClaims struct {
+	Email  string   `json:"email"`
+	UserID string   `json:"userid"`
+	Groups []string `json:"groups"`
+	jwt.RegisteredClaims
+}
+
+// Auth returns an HTTP middleware that validates the x-jwt-assertion header on
+// every request and stores the resulting UserInfo in the request context.
+// When Config.TokenValidatorEnabled is false the token is only decoded without
+// signature verification — safe for local development only.
+func Auth(cfg Config) func(http.Handler) http.Handler {
+	var keyFunc jwt.Keyfunc
+	if cfg.TokenValidatorEnabled {
+		jwks, err := keyfunc.NewDefault([]string{cfg.JWKSEndpoint})
+		if err != nil {
+			// Misconfigured auth must not silently pass — fail at startup.
+			panic("auth: failed to initialise JWKS from " + cfg.JWKSEndpoint + ": " + err.Error())
+		}
+		keyFunc = jwks.Keyfunc
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addSecurityHeaders(w)
+
+			// Skip auth for the health check endpoint.
+			if r.Method == http.MethodGet && r.URL.Path == "/health" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			tokenStr := r.Header.Get(jwtAssertionHeader)
+			if tokenStr == "" {
+				writeAuthError(w, "You are not authorized to perform this action. Please try again.")
+				return
+			}
+
+			info, err := extractUserInfo(tokenStr, cfg, keyFunc)
+			if err != nil {
+				slog.ErrorContext(r.Context(), "auth: token validation failed", "err", err)
+				writeAuthError(w, "You are not authorized to perform this action. Please try again.")
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), userInfoKey, info)
+			userIDToken := r.Header.Get("x-user-id-token")
+			if userIDToken == "" {
+				userIDToken = tokenStr
+			}
+			ctx = entity.WithUserIDToken(ctx, userIDToken)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// UserInfoFromContext retrieves the authenticated user's info from the context.
+// Returns nil if the auth middleware was not applied.
+func UserInfoFromContext(ctx context.Context) *UserInfo {
+	v, _ := ctx.Value(userInfoKey).(*UserInfo)
+	return v
+}
+
+// WithUserInfo returns a copy of ctx carrying the given UserInfo.
+// Call this in tests to bypass JWT parsing and inject a fake authenticated user.
+func WithUserInfo(ctx context.Context, user *UserInfo) context.Context {
+	return context.WithValue(ctx, userInfoKey, user)
+}
+
+func extractUserInfo(tokenStr string, cfg Config, keyFunc jwt.Keyfunc) (*UserInfo, error) {
+	var c jwtClaims
+
+	if !cfg.TokenValidatorEnabled {
+		// Local mode: decode without signature verification.
+		_, _, err := new(jwt.Parser).ParseUnverified(tokenStr, &c)
+		if err != nil {
+			return nil, fmt.Errorf("decode token: %w", err)
+		}
+	} else {
+		token, err := jwt.ParseWithClaims(tokenStr, &c, keyFunc,
+			jwt.WithIssuer(cfg.Issuer),
+			jwt.WithLeeway(cfg.ClockSkew),
+			jwt.WithExpirationRequired(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("validate token: %w", err)
+		}
+		if !token.Valid {
+			return nil, fmt.Errorf("invalid token")
+		}
+		if len(cfg.Audiences) > 0 {
+			tokenAuds, _ := token.Claims.GetAudience()
+			if !hasAnyAudience(tokenAuds, cfg.Audiences) {
+				return nil, fmt.Errorf("token audience not accepted")
+			}
+		}
+	}
+
+	if c.Email == "" {
+		return nil, fmt.Errorf("token missing email claim")
+	}
+	if c.UserID == "" {
+		return nil, fmt.Errorf("token missing userid claim")
+	}
+
+	return &UserInfo{
+		Email:  c.Email,
+		UserID: c.UserID,
+		Groups: c.Groups,
+	}, nil
+}
+
+func hasAnyAudience(tokenAuds jwt.ClaimStrings, expected []string) bool {
+	for _, want := range expected {
+		for _, got := range tokenAuds {
+			if got == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// addSecurityHeaders mirrors the Ballerina ResponseInterceptor security headers.
+func addSecurityHeaders(w http.ResponseWriter) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Security-Policy", "upgrade-insecure-requests")
+	w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+}

--- a/apps/customer-portal/backend-v2/internal/middleware/auth.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/auth.go
@@ -19,6 +19,7 @@ package middleware
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -104,7 +105,7 @@ func Auth(cfg Config) func(http.Handler) http.Handler {
 
 			info, err := extractUserInfo(tokenStr, cfg, keyFunc)
 			if err != nil {
-				slog.ErrorContext(r.Context(), "auth: token validation failed", "err", err)
+				slog.ErrorContext(r.Context(), "auth: token validation failed", "err", summarizeAuthErr(err))
 				writeAuthError(w, "You are not authorized to perform this action. Please try again.")
 				return
 			}
@@ -174,6 +175,32 @@ func extractUserInfo(tokenStr string, cfg Config, keyFunc jwt.Keyfunc) (*UserInf
 		UserID: c.UserID,
 		Groups: c.Groups,
 	}, nil
+}
+
+// summarizeAuthErr returns a short, log-safe category for a token validation
+// failure — never the raw error, which for some jwt/v5 error paths can embed
+// parts of the offending token or claim values.
+func summarizeAuthErr(err error) string {
+	switch {
+	case errors.Is(err, jwt.ErrTokenExpired):
+		return "token expired"
+	case errors.Is(err, jwt.ErrTokenNotValidYet):
+		return "token not valid yet"
+	case errors.Is(err, jwt.ErrTokenUsedBeforeIssued):
+		return "token used before issued"
+	case errors.Is(err, jwt.ErrTokenSignatureInvalid):
+		return "signature invalid"
+	case errors.Is(err, jwt.ErrTokenMalformed):
+		return "malformed token"
+	case errors.Is(err, jwt.ErrTokenInvalidAudience):
+		return "invalid audience"
+	case errors.Is(err, jwt.ErrTokenInvalidIssuer):
+		return "invalid issuer"
+	case errors.Is(err, jwt.ErrTokenRequiredClaimMissing):
+		return "required claim missing"
+	default:
+		return "token validation failed"
+	}
 }
 
 func hasAnyAudience(tokenAuds jwt.ClaimStrings, expected []string) bool {

--- a/apps/customer-portal/backend-v2/internal/middleware/correlation.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/correlation.go
@@ -23,16 +23,23 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 )
 
 const correlationIDHeader = "X-CSM-Correlation-ID"
 
+// correlationIDPrefix marks a correlation ID as having passed through the
+// customer portal, so it can be told apart from IDs originating in other
+// portals/services sharing the same downstream entity-service.
+const correlationIDPrefix = "cp-"
+
 type correlationIDKey struct{}
 
 // CorrelationID is an HTTP middleware that reads the X-CSM-Correlation-ID request
-// header or generates a UUID v4 if absent. The ID is:
+// header or generates a UUID v4 if absent, ensuring the value carries the
+// "cp-" (customer portal) prefix before it is used further. The ID is:
 //   - stored in the context for automatic inclusion in slog records
 //   - stored in the entity client context so it is forwarded on every outgoing
 //     entity-service request
@@ -43,6 +50,9 @@ func CorrelationID(next http.Handler) http.Handler {
 		id := r.Header.Get(correlationIDHeader)
 		if id == "" {
 			id = newCorrelationID()
+		}
+		if !strings.HasPrefix(id, correlationIDPrefix) {
+			id = correlationIDPrefix + id
 		}
 		w.Header().Set(correlationIDHeader, id)
 		ctx := context.WithValue(r.Context(), correlationIDKey{}, id)

--- a/apps/customer-portal/backend-v2/internal/middleware/correlation.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/correlation.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+const correlationIDHeader = "X-CSM-Correlation-ID"
+
+type correlationIDKey struct{}
+
+// CorrelationID is an HTTP middleware that reads the X-CSM-Correlation-ID request
+// header or generates a UUID v4 if absent. The ID is:
+//   - stored in the context for automatic inclusion in slog records
+//   - stored in the entity client context so it is forwarded on every outgoing
+//     entity-service request
+//   - echoed in the response header so callers can reference it in support
+//     requests
+func CorrelationID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get(correlationIDHeader)
+		if id == "" {
+			id = newCorrelationID()
+		}
+		w.Header().Set(correlationIDHeader, id)
+		ctx := context.WithValue(r.Context(), correlationIDKey{}, id)
+		ctx = entity.WithCorrelationID(ctx, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// CorrelationIDFromContext returns the correlation ID stored in ctx, or ""
+// if the CorrelationID middleware was not applied.
+func CorrelationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey{}).(string)
+	return v
+}
+
+func newCorrelationID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("correlationid: failed to read random bytes: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+// ctxHandler wraps a slog.Handler to automatically inject the correlation ID
+// and authenticated user ID from the request context into every log record
+// produced via *Context methods.
+type ctxHandler struct {
+	inner slog.Handler
+}
+
+func (h ctxHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h ctxHandler) Handle(ctx context.Context, r slog.Record) error {
+	if id := CorrelationIDFromContext(ctx); id != "" {
+		r.AddAttrs(slog.String("correlationID", id))
+	}
+	if user := UserInfoFromContext(ctx); user != nil {
+		r.AddAttrs(slog.String("userID", user.UserID))
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h ctxHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return ctxHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h ctxHandler) WithGroup(name string) slog.Handler {
+	return ctxHandler{inner: h.inner.WithGroup(name)}
+}
+
+// ConfigureLogger sets up the default slog logger with a handler that
+// automatically adds the correlation ID from the request context to every log
+// record. It writes directly to os.Stderr to avoid a deadlock: slog.SetDefault
+// also redirects log.std's output through the new handler, and if the inner
+// handler were the old defaultHandler (which itself writes to log.std) a cycle
+// would form. Call once at startup before any log statements.
+func ConfigureLogger() {
+	inner := slog.NewTextHandler(os.Stderr, nil)
+	slog.SetDefault(slog.New(ctxHandler{inner: inner}))
+}

--- a/apps/customer-portal/backend-v2/internal/middleware/logger.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/logger.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// responseWriter wraps http.ResponseWriter to capture the status code written
+// by the downstream handler so it can be included in the access log.
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Logger is an HTTP middleware that logs each completed request via slog. The
+// correlation ID is included automatically in every record when ConfigureLogger
+// has been called (it is attached by the ctxHandler from the context).
+func Logger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rw, r)
+		slog.InfoContext(r.Context(), "request completed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rw.status,
+			"elapsed", time.Since(start).String(),
+		)
+	})
+}

--- a/apps/customer-portal/backend-v2/internal/middleware/security_headers.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/security_headers.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middleware
+
+import "net/http"
+
+// SecurityHeaders sets security-related response headers on every response,
+// mirroring the ResponseInterceptor in the customer portal's authorization module.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Content-Security-Policy", "upgrade-insecure-requests")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## Summary
- Scaffolds `apps/customer-portal/backend-v2`, a Go rewrite of the Ballerina `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions (net/http, JWT auth middleware, OAuth2 client-credentials outbound client, slog structured logging).
- Targets **`cs-tools/entity-service`** (this repo's own entity-service) rather than the `digiops-cs/entity-service` the Ballerina backend calls — noted explicitly in the new backend's CLAUDE.md so future ports don't assume a 1:1 endpoint match.
- Implements the first 6 routes: `GET /health`, `GET /users/me`, `POST /projects/search`, `GET /projects/{id}`, `POST /cases/search`, `GET /cases/{id}`.
- Preserves the original Ballerina backend's response-wrapping behavior: entity-service responses are never returned verbatim — an `internal/dto` layer maps every response into a portal-owned DTO, stripping internal-only fields (Salesforce IDs, WSO2 team routing, CSM-engineer-only Fix-ETA/WatchList fields), each with a comment explaining the exclusion.
- This is a work in progress — ~94 more Ballerina-backend routes remain to be ported; `CLAUDE.md` documents the "Adding a new endpoint" recipe for follow-up PRs.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] Manually ran the server and verified: `GET /health` → 200; unauthenticated request → 401; invalid UUID path param → 400; malformed JSON body → 400; unreachable upstream → mapped error response (no panic/leak)
- [ ] Wire up against a real running `cs-tools/entity-service` instance (DATA_SOURCE=servicenow for `/users/me`)

## Linked issues
Closes wso2-enterprise/wso2-digital-team-project-management#828
Closes wso2-enterprise/wso2-digital-team-project-management#829
Closes wso2-enterprise/wso2-digital-team-project-management#830
Closes wso2-enterprise/wso2-digital-team-project-management#831
Closes wso2-enterprise/wso2-digital-team-project-management#832
Closes wso2-enterprise/wso2-digital-team-project-management#833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new customer portal backend for authenticated access to user, project, and case information.
  * Added project and case search and detail endpoints, along with the logged-in user profile endpoint.
  * Added consistent JSON responses, input validation, error handling, security headers, request logging, and correlation IDs.
  * Added configurable JWT and service authentication, with graceful startup and shutdown.

* **Documentation**
  * Added setup instructions, configuration guidance, API endpoint details, example requests, and backend development standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
