### PR TITLE
[CSM Portal] add CSV export of the filtered result set to the listing pages

### DIFF
--- a/apps/csm-portal/webapp/src/components/FilteredCsvExportButton.test.tsx
+++ b/apps/csm-portal/webapp/src/components/FilteredCsvExportButton.test.tsx
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import FilteredCsvExportButton from "@components/FilteredCsvExportButton";
+
+const showErrorMock = vi.fn();
+const showSuccessMock = vi.fn();
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: showErrorMock }),
+}));
+vi.mock("@context/success-banner/SuccessBannerContext", () => ({
+  useSuccessBanner: () => ({ showSuccess: showSuccessMock }),
+}));
+vi.mock("@utils/saveBlob", () => ({ saveBlob: vi.fn() }));
+
+interface Row {
+  id: number;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("FilteredCsvExportButton", () => {
+  beforeEach(() => {
+    showErrorMock.mockClear();
+    showSuccessMock.mockClear();
+  });
+
+  it("is disabled when the caller says there's nothing to export", () => {
+    render(
+      <FilteredCsvExportButton<Row>
+        entityName="widgets"
+        header={["ID"]}
+        toRow={(r) => [String(r.id)]}
+        fetchPage={async () => ({ items: [], total: 0 })}
+        disabled
+      />,
+    );
+    expect(screen.getByRole("button", { name: /export csv/i })).toBeDisabled();
+  });
+
+  it("shows a success banner with the row count after a clean export", async () => {
+    const fetchPage = vi.fn(async () => ({ items: [{ id: 1 }, { id: 2 }], total: 2 }));
+    render(
+      <FilteredCsvExportButton<Row>
+        entityName="widgets"
+        entityNounPlural="widgets"
+        header={["ID"]}
+        toRow={(r) => [String(r.id)]}
+        fetchPage={fetchPage}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+    await waitFor(() => expect(showSuccessMock).toHaveBeenCalledWith("Exported 2 widgets to CSV."));
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a busy state with a live count while paging, then re-enables", async () => {
+    const first = deferred<{ items: Row[]; total: number }>();
+    const fetchPage = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce({ items: [{ id: 2 }], total: 2 });
+
+    render(
+      <FilteredCsvExportButton<Row>
+        entityName="widgets"
+        header={["ID"]}
+        toRow={(r) => [String(r.id)]}
+        fetchPage={fetchPage}
+        pageSize={1}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    // The busy variant is wrapped in a Tooltip (different subtree), so
+    // re-query rather than holding onto the pre-click button node.
+    await waitFor(() =>
+      expect(screen.getByRole("button")).toHaveAttribute("aria-busy", "true"),
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+
+    first.resolve({ items: [{ id: 1 }], total: 2 });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /export csv/i })).not.toBeDisabled(),
+    );
+  });
+
+  it("surfaces a clear truncation notice (not a generic error) when the row cap is hit", async () => {
+    const fetchPage = vi.fn(async () => ({
+      items: [{ id: 1 }],
+      total: 500,
+    }));
+    render(
+      <FilteredCsvExportButton<Row>
+        entityName="widgets"
+        entityNounPlural="widgets"
+        header={["ID"]}
+        toRow={(r) => [String(r.id)]}
+        fetchPage={fetchPage}
+        pageSize={1}
+        maxRows={1}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+    await waitFor(() =>
+      expect(showErrorMock).toHaveBeenCalledWith(
+        expect.stringMatching(/stopped at 1 of 500 widgets.*narrow your filters/i),
+      ),
+    );
+  });
+
+  it("reports a failure without claiming an export happened", async () => {
+    const fetchPage = vi.fn().mockRejectedValue(new Error("network down"));
+    render(
+      <FilteredCsvExportButton<Row>
+        entityName="widgets"
+        header={["ID"]}
+        toRow={(r) => [String(r.id)]}
+        fetchPage={fetchPage}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+    await waitFor(() =>
+      expect(showErrorMock).toHaveBeenCalledWith(
+        expect.stringMatching(/could not complete the export.*no file was downloaded/i),
+        expect.any(Error),
+      ),
+    );
+    expect(showSuccessMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/FilteredCsvExportButton.tsx
+++ b/apps/csm-portal/webapp/src/components/FilteredCsvExportButton.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Button, CircularProgress, Tooltip } from "@wso2/oxygen-ui";
+import { Download } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
+import {
+  useFilteredCsvExport,
+  type UseFilteredCsvExportConfig,
+} from "@hooks/useFilteredCsvExport";
+
+export interface FilteredCsvExportButtonProps<T> extends UseFilteredCsvExportConfig<T> {
+  /** Disable the action entirely (e.g. the underlying list query errored, or
+   * the caller already knows there's nothing to export). The button also
+   * disables itself while an export is in flight regardless of this prop. */
+  disabled?: boolean;
+  /** Noun used in banner copy, e.g. "incidents", "cases". Defaults to
+   * `entityName` with hyphens turned into spaces. */
+  entityNounPlural?: string;
+}
+
+/**
+ * "Export CSV" action for a filtered listing page. Pages the *entire*
+ * currently filtered (and sorted) result set via `useFilteredCsvExport` — not
+ * just the page currently rendered in the table — and downloads it as one
+ * CSV file. Shows a busy state with live progress while paging (this can take
+ * a while for a wide filter), and never hands the user a truncated file
+ * without saying so plainly.
+ */
+export default function FilteredCsvExportButton<T>({
+  disabled,
+  entityNounPlural,
+  ...config
+}: FilteredCsvExportButtonProps<T>): JSX.Element {
+  const { isExporting, progress, runExport } = useFilteredCsvExport(config);
+  const { showError } = useErrorBanner();
+  const { showSuccess } = useSuccessBanner();
+  const noun = entityNounPlural ?? config.entityName.replace(/-/g, " ");
+
+  const handleClick = async (): Promise<void> => {
+    try {
+      const { truncated, rowCount, total } = await runExport();
+      if (truncated) {
+        showError(
+          `Export stopped at ${rowCount.toLocaleString()} of ${total.toLocaleString()} ${noun} — the file only contains the first ${rowCount.toLocaleString()}. Narrow your filters (e.g. a shorter date range or a specific product) and export again to get the rest.`,
+        );
+      } else {
+        showSuccess(`Exported ${rowCount.toLocaleString()} ${noun} to CSV.`);
+      }
+    } catch (err) {
+      showError(
+        "Could not complete the export. No file was downloaded — please try again, or narrow your filters first.",
+        err,
+      );
+    }
+  };
+
+  const label =
+    isExporting && progress
+      ? progress.total > 0
+        ? `Exporting ${progress.loaded.toLocaleString()} of ${progress.total.toLocaleString()}…`
+        : "Exporting…"
+      : "Export CSV";
+
+  const button = (
+    <Button
+      size="small"
+      variant="text"
+      startIcon={isExporting ? <CircularProgress size={14} /> : <Download size={14} />}
+      disabled={disabled || isExporting}
+      onClick={handleClick}
+      aria-busy={isExporting}
+    >
+      {label}
+    </Button>
+  );
+
+  // Only worth a tooltip while actively paging (the button's own label
+  // already shows the count) — explains *why* it's taking a while for
+  // anyone who wasn't watching the label tick up. The button is disabled in
+  // this state, and a disabled element fires no pointer events for the
+  // Tooltip to listen to — MUI's documented fix is a non-disabled wrapper.
+  return isExporting ? (
+    <Tooltip title="Fetching every page of the current filter before downloading — this can take a while for a wide filter.">
+      <span>{button}</span>
+    </Tooltip>
+  ) : (
+    button
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -17,21 +17,16 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useLogger } from "@hooks/useLogger";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
-import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import {
-  beStateFromUi,
-  priorityFromSeverity,
-  severityFromPriority,
-  uiStateFromBe,
-} from "@api/backend/mappers";
-import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
+  ASSIGNEE_FILTER_RESOLVED_EMPTY,
+  buildCaseSearchFilters,
+  mapCaseSearchViewToRow,
+  resolveAssignedUserIds,
+} from "@features/csm-cases/utils/caseSearchPayload";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
-import type {
-  BeCaseSearchPayload,
-  BeCaseSearchResponse,
-  BeUserSearchResponse,
-} from "@api/backend/types";
+import type { BeCaseSearchPayload, BeCaseSearchResponse } from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import type {
   CsmCaseRow,
@@ -60,7 +55,7 @@ import {
  * `limit` / `offset` / `hasMore`).
  *
  * `page` is zero-based (matching MUI `TablePagination`); `pageSize` is the row
- * limit (≤ {@link BE_MAX_PAGE_LIMIT}). Cases are always sorted by `updatedOn`;
+ * limit (≤ the backend's page-size cap, `BE_MAX_PAGE_LIMIT`). Cases are always sorted by `updatedOn`;
  * `sortOrder` (default `"desc"`) controls direction, so the cases page loads
  * the most recently updated cases on arrival by default but can be flipped
  * to oldest-updated-first. `enabled` is an optional escape hatch to suspend
@@ -111,52 +106,28 @@ export function useGetCsmCases(
     ],
     queryFn: async (): Promise<CsmCasesListResponse> => {
       // Resolve the assignee filter (engineer emails + the `@me` sentinel) to
-      // the UUIDs `/cases/search` expects. Named engineers → ids from a
-      // targeted `/users/search` by email (selectable emails always come from
-      // the directory, so this resolves them all); `@me` → the caller's id,
-      // taken from the app-wide CurrentUserProvider (no per-query `/users/me`).
-      // Runs only when the assignee filter is active. A user whose id can't be
-      // resolved (e.g. `@me` when `/users/me` omits `id` — entity service down
-      // — or an email with no match) is dropped. If an active assignee filter
-      // resolves to NO ids, the result is definitionally empty (cases assigned
-      // to engineers we couldn't identify), so we return an empty list rather
-      // than omitting the filter — omitting it would broaden the search to ALL
-      // cases, the opposite of what the user asked for. A transport failure of
-      // the lookup is NOT swallowed — it throws so the query errors (the list
-      // shows an error) instead of silently broadening to all cases.
+      // the UUIDs `/cases/search` expects — shared with the export action via
+      // `resolveAssignedUserIds` so both apply the identical assignee filter.
+      // A transport failure of the lookup is NOT swallowed — it throws so the
+      // query errors (the list shows an error) instead of silently
+      // broadening to all cases.
       let assignedUserIds: string[] | undefined;
       if (filters.assignees.length > 0) {
-        const wantsMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
-        const emails = filters.assignees.filter((a) => a !== ASSIGNEE_ME_TOKEN);
-        let byEmail: BeUserSearchResponse | null = null;
-        if (emails.length > 0) {
-          try {
-            byEmail = await api.post<
-              { filters: { emails: string[] }; pagination: { limit: number } },
-              BeUserSearchResponse
-            >("/users/search", {
-              filters: { emails },
-              pagination: { limit: BE_MAX_PAGE_LIMIT },
-            });
-          } catch (err) {
-            logger.warn(
-              `[useGetCsmCases] assignee lookup failed: ${(err as Error).message}`,
-            );
-            throw new Error("Failed to resolve the assignee filter");
-          }
+        let resolved: Awaited<ReturnType<typeof resolveAssignedUserIds>>;
+        try {
+          resolved = await resolveAssignedUserIds(api, filters.assignees, currentUserId);
+        } catch (err) {
+          logger.warn(
+            `[useGetCsmCases] assignee lookup failed: ${(err as Error).message}`,
+          );
+          throw new Error("Failed to resolve the assignee filter");
         }
-        const ids = new Set<string>();
-        (byEmail?.users ?? []).forEach((u) => {
-          if (u.id) ids.add(u.id);
-        });
-        if (wantsMe && currentUserId) ids.add(currentUserId);
-        if (ids.size > 0) assignedUserIds = [...ids];
-      }
-
-      // Active assignee filter that resolved to nothing → empty result, not a
-      // broadened (filter-less) search. See the resolution note above.
-      if (filters.assignees.length > 0 && !assignedUserIds) {
-        return { cases: [], total: 0, limit: pageSize, offset, hasMore: false };
+        // Active assignee filter that resolved to nothing → empty result, not
+        // a broadened (filter-less) search. See `resolveAssignedUserIds`.
+        if (resolved === ASSIGNEE_FILTER_RESOLVED_EMPTY) {
+          return { cases: [], total: 0, limit: pageSize, offset, hasMore: false };
+        }
+        assignedUserIds = resolved;
       }
 
       // One cross-project case search. No account/project directory scan: the
@@ -168,82 +139,12 @@ export function useGetCsmCases(
       >("/cases/search", {
           pagination: { offset, limit: pageSize },
           sortBy: { field: "updatedOn", order: sortOrder },
-          // Filter fields are nested under `filters` (BE payload restructure).
-          filters: {
-            ...(search.length > 0 && { searchQuery: search }),
-            ...(filters.severities.length > 0 && {
-              severities: filters.severities.map(priorityFromSeverity),
-            }),
-            ...(filters.states.length > 0 && {
-              states: filters.states.map(beStateFromUi),
-            }),
-            ...(filters.caseTypes.length > 0 && {
-              types: filters.caseTypes,
-            }),
-            // Work sub-state filter (ongoing/paused); only meaningful when
-            // `states` includes `work_in_progress`, but the BE accepts it
-            // independently so we forward it as-is.
-            ...(filters.workStates.length > 0 && {
-              workStates: filters.workStates,
-            }),
-            ...(filters.engagementTypes.length > 0 && {
-              engagementTypes: filters.engagementTypes,
-            }),
-            // `filters.projects` holds project IDs (the filter is id-based).
-            ...(filters.projects.length > 0 && {
-              projectIds: filters.projects,
-            }),
-            // Assignee filter, resolved to engineer UUIDs above.
-            ...(assignedUserIds && assignedUserIds.length > 0 && {
-              assignedUserIds,
-            }),
-            // Product family names; SN matches `product.name` (all versions).
-            ...(filters.productNames.length > 0 && {
-              productNames: filters.productNames,
-            }),
-            // Tag filter deliberately not wired in here for now — see the
-            // removal note on `CasesFilters` in casesFiltersUrl.ts.
-          },
+          filters: buildCaseSearchFilters(filters, search, assignedUserIds),
       });
 
-      const myEmail = currentUserEmail?.toLowerCase();
-      const cases: CsmCaseRow[] = (casesResponse.cases ?? []).map((c) => {
-        const projectId = c.project?.id ?? "";
-        const assigneeEmail = c.assignedEngineer?.email;
-        const assignee =
-          c.assignedEngineer?.name?.trim() || assigneeEmail || "Unassigned";
-        const assigneeIsMe =
-          !!assigneeEmail && !!myEmail && assigneeEmail.toLowerCase() === myEmail;
-        return {
-          id: c.id,
-          caseNumber: c.number,
-          wso2CaseId: c.internalId,
-          subject: c.subject ?? "(no subject)",
-          // Not shown in the list; kept on the row shape but no longer resolved
-          // (see the account-scan removal note above).
-          customer: "",
-          accountId: "",
-          projectId,
-          projectName: c.project?.name ?? "-",
-          // Search embeds deployedProduct as { id, name } (name includes the
-          // version); the GET view uses a displayName-shaped ref instead.
-          product: c.deployedProduct?.name ?? c.product?.name ?? "-",
-          severity: severityFromPriority(c.severity),
-          state: uiStateFromBe(c.state),
-          caseType: c.type,
-          workState: c.workState ?? null,
-          assignee,
-          assigneeIsMe,
-          slaClockType: "ack",
-          minutesToBreach: 0,
-          // No SLA data from the backend yet — keep the SLA column neutral
-          // rather than painting every open row orange with a bogus "0m left".
-          hasSla: false,
-          createdAt: c.createdOn ?? "",
-          updatedAt: c.updatedOn ?? c.createdOn ?? "",
-          updatedAtIsCreatedFallback: !c.updatedOn && !!c.createdOn,
-        };
-      });
+      const cases: CsmCaseRow[] = (casesResponse.cases ?? []).map((c) =>
+        mapCaseSearchViewToRow(c, currentUserEmail),
+      );
 
       return {
         cases,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -27,12 +27,23 @@ import {
 } from "react";
 import { useSearchParams } from "react-router";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { useBackendApi } from "@api/backend/client";
+import FilteredCsvExportButton from "@components/FilteredCsvExportButton";
 import CasesFilterBar, {
   type CasesFilters,
 } from "@features/csm-cases/components/CasesFilterBar";
 import CasesList from "@features/csm-cases/components/CasesList";
 import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
+import {
+  ASSIGNEE_FILTER_RESOLVED_EMPTY,
+  buildCaseSearchFilters,
+  mapCaseSearchViewToRow,
+  resolveAssignedUserIds,
+} from "@features/csm-cases/utils/caseSearchPayload";
 import { useDirectoryUsers } from "@api/useDirectoryUsers";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
@@ -45,6 +56,10 @@ import {
   DEFAULT_CASES_SORT,
   type CasesSortOrder,
 } from "@features/csm-cases/utils/casesSort";
+import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
+import { WORK_STATE_LABEL } from "@features/csm-cases/utils/caseWorkState";
+import type { BeCaseSearchPayload, BeCaseSearchResponse } from "@api/backend/types";
+import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, DEFAULT_ROWS_PER_PAGE, BE_MAX_PAGE_LIMIT];
@@ -190,6 +205,89 @@ export default function CsmIssuesView({
   const { showError } = useErrorBanner();
   const hasShownErrorRef = useRef(false);
 
+  // Export CSV: pages `/cases/search` with the exact same filters/sort as the
+  // listing above (`buildCaseSearchFilters`/`resolveAssignedUserIds` are the
+  // same helpers `useGetCsmCases` uses), independent of the table's own
+  // page/rowsPerPage — the export always fetches the *whole* filtered result
+  // set, not whatever page happens to be on screen. See
+  // `useFilteredCsvExport`/`fetchAllPages` for the paging + truncation logic.
+  const api = useBackendApi();
+  const currentUserEmail = useIdTokenClaims()?.email;
+  const currentUserId = useCurrentUser().user?.id;
+  const exportSearch = queryFilters.search.trim();
+  const fetchCasesExportPage = useCallback(
+    async (offset: number, limit: number) => {
+      // Re-resolved per page when an assignee filter is active — a small,
+      // deterministic, targeted `/users/search` by email, not a directory
+      // scan — rather than caching it across pages, so the export can never
+      // serve a stale resolution if this closure is reused across a filter
+      // change mid-export (it isn't today, but this keeps that safe by
+      // construction rather than by care).
+      let assignedUserIds: string[] | undefined;
+      if (queryFilters.assignees.length > 0) {
+        const resolved = await resolveAssignedUserIds(
+          api,
+          queryFilters.assignees,
+          currentUserId,
+        );
+        if (resolved === ASSIGNEE_FILTER_RESOLVED_EMPTY) {
+          return { items: [] as CsmCaseRow[], total: 0 };
+        }
+        assignedUserIds = resolved;
+      }
+      const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+        "/cases/search",
+        {
+          pagination: { offset, limit },
+          sortBy: { field: "updatedOn", order: sortOrder },
+          filters: buildCaseSearchFilters(queryFilters, exportSearch, assignedUserIds),
+        },
+      );
+      const items = (res.cases ?? []).map((c) => mapCaseSearchViewToRow(c, currentUserEmail));
+      return { items, total: res.total };
+    },
+    [api, queryFilters, exportSearch, sortOrder, currentUserId, currentUserEmail],
+  );
+
+  // Same gate `CasesList` is given (`hideSeverityColumn={isServiceRequestOnly
+  // || hideSeverityColumn}`) so the export's column set can never drift from
+  // what's actually rendered.
+  const showExportSeverityColumn = !(isServiceRequestOnly || hideSeverityColumn);
+  const caseToCsvRow = useCallback(
+    (c: CsmCaseRow): string[] => {
+      const caseId =
+        c.wso2CaseId && c.caseNumber
+          ? `${c.wso2CaseId}/${c.caseNumber}`
+          : c.wso2CaseId || c.caseNumber || "";
+      const updated = formatBackendTimestampForDisplay(c.updatedAt, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      const stateText =
+        stateLabel(c.state) +
+        (c.state === "work_in_progress" && c.workState
+          ? ` (${WORK_STATE_LABEL[c.workState]})`
+          : "");
+      const row = [caseId, c.subject, c.projectName, c.product];
+      if (showExportSeverityColumn) row.push(c.severity);
+      row.push(stateText, updated ?? "");
+      return row;
+    },
+    [showExportSeverityColumn],
+  );
+  const exportHeader = [
+    "Case ID",
+    "Subject",
+    "Project",
+    "Product",
+    ...(showExportSeverityColumn ? ["Severity"] : []),
+    "State",
+    "Updated",
+  ];
+
   useEffect(() => {
     if (isError && !hasShownErrorRef.current) {
       hasShownErrorRef.current = true;
@@ -269,6 +367,14 @@ export default function CsmIssuesView({
           {breachedCount > 0 && (
             <Chip size="small" color="error" label={`${breachedCount} breached`} />
           )}
+          <FilteredCsvExportButton<CsmCaseRow>
+            entityName={entityNoun.replace(/\s+/g, "-")}
+            entityNounPlural={entityNoun}
+            header={exportHeader}
+            toRow={caseToCsvRow}
+            fetchPage={fetchCasesExportPage}
+            disabled={isError || total === 0}
+          />
           {actions}
         </Box>
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BackendApi } from "@api/backend/client";
+import {
+  beStateFromUi,
+  priorityFromSeverity,
+  severityFromPriority,
+  uiStateFromBe,
+} from "@api/backend/mappers";
+import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import type {
+  BeCaseSearchFilters,
+  BeCaseSearchView,
+  BeUserSearchResponse,
+} from "@api/backend/types";
+import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+
+/**
+ * Builds the `/cases/search` `filters` object for the given UI filter state
+ * — shared by `useGetCsmCases` (the listing) and the cases/service-requests
+ * "Export CSV" action, so the export is provably searching with the exact
+ * same filter payload the listing itself sent, not a hand-rolled
+ * approximation that can silently drift from it.
+ *
+ * `assignedUserIds` must already be resolved (see
+ * {@link resolveAssignedUserIds}) — this function does no async work.
+ */
+export function buildCaseSearchFilters(
+  filters: CasesFilters,
+  search: string,
+  assignedUserIds: string[] | undefined,
+): BeCaseSearchFilters {
+  return {
+    ...(search.length > 0 && { searchQuery: search }),
+    ...(filters.severities.length > 0 && {
+      severities: filters.severities.map(priorityFromSeverity),
+    }),
+    ...(filters.states.length > 0 && {
+      states: filters.states.map(beStateFromUi),
+    }),
+    ...(filters.caseTypes.length > 0 && {
+      types: filters.caseTypes,
+    }),
+    ...(filters.workStates.length > 0 && {
+      workStates: filters.workStates,
+    }),
+    ...(filters.engagementTypes.length > 0 && {
+      engagementTypes: filters.engagementTypes,
+    }),
+    ...(filters.projects.length > 0 && {
+      projectIds: filters.projects,
+    }),
+    ...(assignedUserIds && assignedUserIds.length > 0 && {
+      assignedUserIds,
+    }),
+    ...(filters.productNames.length > 0 && {
+      productNames: filters.productNames,
+    }),
+  };
+}
+
+/** Sentinel: the assignee filter is active (one or more engineers/`@me`
+ * selected) but resolved to no ids at all — the caller must treat this as a
+ * definitionally-empty result, never as "no assignee filter" (which would
+ * silently broaden the search back to every case). See the resolution note
+ * in `useGetCsmCases` for why. */
+export const ASSIGNEE_FILTER_RESOLVED_EMPTY = Symbol("assignee-filter-resolved-empty");
+
+/**
+ * Resolves the assignee filter (engineer emails + the `@me` sentinel) to the
+ * user UUIDs `/cases/search` expects. Shared between `useGetCsmCases` and the
+ * export action so both apply the exact same assignee filter to the exact
+ * same set of cases.
+ */
+export async function resolveAssignedUserIds(
+  api: BackendApi,
+  assignees: string[],
+  currentUserId: string | undefined,
+): Promise<string[] | undefined | typeof ASSIGNEE_FILTER_RESOLVED_EMPTY> {
+  if (assignees.length === 0) return undefined;
+
+  const wantsMe = assignees.includes(ASSIGNEE_ME_TOKEN);
+  const emails = assignees.filter((a) => a !== ASSIGNEE_ME_TOKEN);
+  let byEmail: BeUserSearchResponse | null = null;
+  if (emails.length > 0) {
+    byEmail = await api.post<
+      { filters: { emails: string[] }; pagination: { limit: number } },
+      BeUserSearchResponse
+    >("/users/search", {
+      filters: { emails },
+      pagination: { limit: BE_MAX_PAGE_LIMIT },
+    });
+  }
+  const ids = new Set<string>();
+  (byEmail?.users ?? []).forEach((u) => {
+    if (u.id) ids.add(u.id);
+  });
+  if (wantsMe && currentUserId) ids.add(currentUserId);
+
+  if (ids.size === 0) return ASSIGNEE_FILTER_RESOLVED_EMPTY;
+  return [...ids];
+}
+
+/**
+ * Maps one `/cases/search` result item to the UI's `CsmCaseRow` shape —
+ * shared by `useGetCsmCases` (the listing) and the export action's own
+ * paging, so an exported row is provably the same transform the table itself
+ * applies, not a second, driftable copy of it.
+ */
+export function mapCaseSearchViewToRow(
+  c: BeCaseSearchView,
+  currentUserEmail: string | undefined,
+): CsmCaseRow {
+  const projectId = c.project?.id ?? "";
+  const assigneeEmail = c.assignedEngineer?.email;
+  const assignee = c.assignedEngineer?.name?.trim() || assigneeEmail || "Unassigned";
+  const myEmail = currentUserEmail?.toLowerCase();
+  const assigneeIsMe =
+    !!assigneeEmail && !!myEmail && assigneeEmail.toLowerCase() === myEmail;
+  return {
+    id: c.id,
+    caseNumber: c.number,
+    wso2CaseId: c.internalId,
+    subject: c.subject ?? "(no subject)",
+    customer: "",
+    accountId: "",
+    projectId,
+    projectName: c.project?.name ?? "-",
+    product: c.deployedProduct?.name ?? c.product?.name ?? "-",
+    severity: severityFromPriority(c.severity),
+    state: uiStateFromBe(c.state),
+    caseType: c.type,
+    workState: c.workState ?? null,
+    assignee,
+    assigneeIsMe,
+    slaClockType: "ack",
+    minutesToBreach: 0,
+    hasSla: false,
+    createdAt: c.createdOn ?? "",
+    updatedAt: c.updatedOn ?? c.createdOn ?? "",
+    updatedAtIsCreatedFallback: !c.updatedOn && !!c.createdOn,
+  };
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -142,7 +142,7 @@ export default function ChangeRequestsTab(): JSX.Element {
           pagination: { offset, limit },
         },
       );
-      return { items: res.changeRequests, total: res.total };
+      return { items: res.changeRequests ?? [], total: res.total ?? 0 };
     },
     [api, payload.filters],
   );

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -29,10 +29,12 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useCallback, useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
+import FilteredCsvExportButton from "@components/FilteredCsvExportButton";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useBackendApi } from "@api/backend/client";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useSearchChangeRequests } from "@features/csm-operations/api/useSearchChangeRequests";
 import {
@@ -44,6 +46,11 @@ import {
   type ChangeRequestFilters,
 } from "@features/csm-operations/utils/changeRequests";
 import ChangeRequestsFilterBar from "@features/csm-operations/components/ChangeRequestsFilterBar";
+import type {
+  BeChangeRequestSearchPayload,
+  BeChangeRequestSearchResponse,
+  BeChangeRequestSearchView,
+} from "@api/backend/types";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -75,6 +82,7 @@ function toISOEnd(date: string): string {
  */
 export default function ChangeRequestsTab(): JSX.Element {
   const navigate = useNavTransition();
+  const api = useBackendApi();
   const [filters, setFilters] = useState<ChangeRequestFilters>(DEFAULT_CR_FILTERS);
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [page, setPage] = useState(0);
@@ -120,9 +128,48 @@ export default function ChangeRequestsTab(): JSX.Element {
     setPage(0);
   };
 
+  // Pages `/change-requests/search` with the currently applied filters
+  // (same `filters` as `payload` above) until the full filtered result set
+  // has been fetched — see `useFilteredCsvExport`/`fetchAllPages`. The CR
+  // search response carries no `hasMore` (unlike incidents/cases), but
+  // `fetchAllPages` only ever needs `total`, so that's not a problem here.
+  const fetchChangeRequestsPage = useCallback(
+    async (offset: number, limit: number) => {
+      const res = await api.post<BeChangeRequestSearchPayload, BeChangeRequestSearchResponse>(
+        "/change-requests/search",
+        {
+          filters: payload.filters,
+          pagination: { offset, limit },
+        },
+      );
+      return { items: res.changeRequests, total: res.total };
+    },
+    [api, payload.filters],
+  );
+
+  const changeRequestToCsvRow = useCallback(
+    (cr: BeChangeRequestSearchView): string[] => [
+      cr.number ?? "",
+      cr.subject ?? "",
+      cr.project?.name ?? "",
+      changeRequestStateLabel(cr.state),
+      changeRequestImpactLabel(cr.impact),
+      formatDate(cr.plannedStartOn),
+      formatDate(cr.updatedOn),
+    ],
+    [],
+  );
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+        <FilteredCsvExportButton<BeChangeRequestSearchView>
+          entityName="change-requests"
+          header={["Number", "Subject", "Project", "State", "Impact", "Planned start", "Updated"]}
+          toRow={changeRequestToCsvRow}
+          fetchPage={fetchChangeRequestsPage}
+          disabled={isError}
+        />
         <Button
           variant="contained"
           color="primary"

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
@@ -125,7 +125,7 @@ export default function IncidentsTab(): JSX.Element {
           pagination: { offset, limit },
         },
       );
-      return { items: res.incidents, total: res.total };
+      return { items: res.incidents ?? [], total: res.total ?? 0 };
     },
     [api, payload.filters, payload.sortBy],
   );

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
@@ -29,10 +29,12 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useCallback, useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
+import FilteredCsvExportButton from "@components/FilteredCsvExportButton";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useBackendApi } from "@api/backend/client";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useSearchIncidents } from "@features/csm-operations/api/useSearchIncidents";
 import {
@@ -44,6 +46,7 @@ import {
   type IncidentFilters,
 } from "@features/csm-operations/utils/incidents";
 import IncidentsFilterBar from "@features/csm-operations/components/IncidentsFilterBar";
+import type { BeIncident, BeIncidentSearchPayload, BeIncidentSearchResponse } from "@api/backend/types";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -66,6 +69,7 @@ function formatDate(value?: string | null): string {
  */
 export default function IncidentsTab(): JSX.Element {
   const navigate = useNavTransition();
+  const api = useBackendApi();
   const [filters, setFilters] = useState<IncidentFilters>(DEFAULT_INCIDENT_FILTERS);
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [page, setPage] = useState(0);
@@ -104,9 +108,51 @@ export default function IncidentsTab(): JSX.Element {
     setPage(0);
   };
 
+  // Pages `/incidents/search` with the *currently applied* filters/sort
+  // (same `filters`/`sortBy` as `payload` above, just re-built per page with
+  // its own offset/limit instead of the table's) until the full filtered
+  // result set has been fetched — see `useFilteredCsvExport`/`fetchAllPages`.
+  // Bound fresh on every render via the hook's ref pattern, so a filter
+  // change is picked up even mid-typing without this identity needing to be
+  // stable.
+  const fetchIncidentsPage = useCallback(
+    async (offset: number, limit: number) => {
+      const res = await api.post<BeIncidentSearchPayload, BeIncidentSearchResponse>(
+        "/incidents/search",
+        {
+          filters: payload.filters,
+          sortBy: payload.sortBy,
+          pagination: { offset, limit },
+        },
+      );
+      return { items: res.incidents, total: res.total };
+    },
+    [api, payload.filters, payload.sortBy],
+  );
+
+  const incidentToCsvRow = useCallback(
+    (incident: BeIncident): string[] => [
+      incident.number ?? "",
+      incident.subject ?? "",
+      incident.caller?.name ?? "",
+      incidentStateLabel(incident.state),
+      incidentPriorityLabel(incident.priority),
+      formatDate(incident.openedOn),
+      formatDate(incident.updatedOn),
+    ],
+    [],
+  );
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+        <FilteredCsvExportButton<BeIncident>
+          entityName="incidents"
+          header={["Number", "Subject", "Caller", "State", "Priority", "Opened", "Updated"]}
+          toRow={incidentToCsvRow}
+          fetchPage={fetchIncidentsPage}
+          disabled={isError}
+        />
         <Button
           variant="contained"
           color="primary"

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardCsvExport.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { saveBlob } from "@utils/saveBlob";
+import { downloadCsv, rowsToCsvText } from "@utils/csvExport";
 import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 
@@ -34,43 +34,35 @@ const CSV_HEADER = [
   "Rejection reason",
 ];
 
-/** Quotes a CSV field only when it needs it (contains a comma, quote, or
- * carriage return/newline), doubling any internal quotes — the minimal
- * escaping RFC 4180 requires. */
-function csvField(value: string): string {
-  if (!/["\r\n,]/.test(value)) return value;
-  return `"${value.replace(/"/g, '""')}"`;
+function timeCardRows(cards: CsmTimeCard[]): string[][] {
+  return cards.map((c) => [
+    c.workDate,
+    c.caseNumber,
+    c.projectName,
+    c.userName,
+    TIME_CARD_STATE_META[c.state].label,
+    c.billable ? "Yes" : "No",
+    String(c.totalMinutes),
+    c.approvedByName ?? "",
+    c.rejectionReason ?? "",
+  ]);
 }
 
 /** Builds the CSV text for a list of cards — split out from
  * {@link exportTimeCardsCsv} so it's testable without mocking the browser
  * download APIs. */
 export function timeCardsToCsv(cards: CsmTimeCard[]): string {
-  const rows = cards.map((c) =>
-    [
-      c.workDate,
-      c.caseNumber,
-      c.projectName,
-      c.userName,
-      TIME_CARD_STATE_META[c.state].label,
-      c.billable ? "Yes" : "No",
-      String(c.totalMinutes),
-      c.approvedByName ?? "",
-      c.rejectionReason ?? "",
-    ]
-      .map(csvField)
-      .join(","),
-  );
-  return [CSV_HEADER.join(","), ...rows].join("\r\n");
+  return rowsToCsvText(CSV_HEADER, timeCardRows(cards));
 }
 
 /**
  * Downloads the given cards as a CSV file. Exports only the cards passed in
  * — callers currently only have one page loaded at a time (see the
  * pagination notes in `useTimeSheets.ts`), so this is a "current page"
- * export, not a full report across the whole scope.
+ * export, not a full report across the whole scope. Contrast with
+ * `useFilteredCsvExport`, used by the cases/incidents/change-requests
+ * listings, which pages the whole filtered result set.
  */
 export function exportTimeCardsCsv(cards: CsmTimeCard[], filename: string): void {
-  const csv = timeCardsToCsv(cards);
-  saveBlob(new Blob([csv], { type: "text/csv;charset=utf-8;" }), filename);
+  downloadCsv(CSV_HEADER, timeCardRows(cards), filename);
 }

--- a/apps/csm-portal/webapp/src/hooks/__tests__/useFilteredCsvExport.test.ts
+++ b/apps/csm-portal/webapp/src/hooks/__tests__/useFilteredCsvExport.test.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { downloadCsv } from "@utils/csvExport";
+import { useFilteredCsvExport } from "@hooks/useFilteredCsvExport";
+
+// Mock only `downloadCsv` (the browser-facing side effect) so the row-building
+// / paging logic in `useFilteredCsvExport` still runs for real — this avoids
+// needing to reconstruct CSV text out of a jsdom `Blob` (which lacks `.text()`
+// and doesn't interop with the platform `Blob`/`Response` used elsewhere).
+vi.mock("@utils/csvExport", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@utils/csvExport")>();
+  return { ...actual, downloadCsv: vi.fn() };
+});
+
+interface Row {
+  id: number;
+  name: string;
+}
+
+function makeFetchPage(rows: Row[], failAtOffset?: number) {
+  return vi.fn(async (offset: number, limit: number) => {
+    if (failAtOffset !== undefined && offset === failAtOffset) {
+      throw new Error("boom");
+    }
+    return { items: rows.slice(offset, offset + limit), total: rows.length };
+  });
+}
+
+describe("useFilteredCsvExport", () => {
+  beforeEach(() => {
+    vi.mocked(downloadCsv).mockClear();
+  });
+
+  it("pages the full result set and downloads one CSV containing every row", async () => {
+    const rows = Array.from({ length: 120 }, (_, i) => ({ id: i, name: `Row ${i}` }));
+    const fetchPage = makeFetchPage(rows);
+    const { result } = renderHook(() =>
+      useFilteredCsvExport<Row>({
+        header: ["ID", "Name"],
+        toRow: (r) => [String(r.id), r.name],
+        entityName: "widgets",
+        fetchPage,
+        pageSize: 50,
+      }),
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.runExport>> | undefined;
+    await act(async () => {
+      outcome = await result.current.runExport();
+    });
+
+    expect(outcome).toEqual({ truncated: false, rowCount: 120, total: 120 });
+    expect(fetchPage).toHaveBeenCalledTimes(3); // 50 + 50 + 20
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+
+    const [header, csvRows, filename] = vi.mocked(downloadCsv).mock.calls[0];
+    expect(filename).toMatch(/^widgets-export-.*\.csv$/);
+    expect(filename).not.toContain("partial");
+    expect(header).toEqual(["ID", "Name"]);
+    expect(csvRows).toHaveLength(120);
+    expect(csvRows[0]).toEqual(["0", "Row 0"]);
+    expect(csvRows[119]).toEqual(["119", "Row 119"]);
+  });
+
+  it("tags the filename and reports truncation when the row cap is hit", async () => {
+    const rows = Array.from({ length: 500 }, (_, i) => ({ id: i, name: `Row ${i}` }));
+    const fetchPage = makeFetchPage(rows);
+    const { result } = renderHook(() =>
+      useFilteredCsvExport<Row>({
+        header: ["ID", "Name"],
+        toRow: (r) => [String(r.id), r.name],
+        entityName: "widgets",
+        fetchPage,
+        pageSize: 50,
+        maxRows: 100,
+      }),
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.runExport>> | undefined;
+    await act(async () => {
+      outcome = await result.current.runExport();
+    });
+
+    expect(outcome?.truncated).toBe(true);
+    expect(outcome?.total).toBe(500);
+    expect(outcome?.rowCount).toBeLessThan(500);
+    const [, , filename] = vi.mocked(downloadCsv).mock.calls[0];
+    expect(filename).toContain("-partial.csv");
+  });
+
+  it("reports live progress while paging, and clears it when done", async () => {
+    const rows = Array.from({ length: 30 }, (_, i) => ({ id: i, name: `Row ${i}` }));
+    const fetchPage = makeFetchPage(rows);
+    const { result } = renderHook(() =>
+      useFilteredCsvExport<Row>({
+        header: ["ID", "Name"],
+        toRow: (r) => [String(r.id), r.name],
+        entityName: "widgets",
+        fetchPage,
+        pageSize: 10,
+      }),
+    );
+
+    expect(result.current.progress).toBeNull();
+    let runPromise!: Promise<unknown>;
+    act(() => {
+      runPromise = result.current.runExport();
+    });
+    await waitFor(() => expect(result.current.isExporting).toBe(true));
+    await act(async () => {
+      await runPromise;
+    });
+
+    expect(result.current.isExporting).toBe(false);
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("never downloads a file when a page fetch fails partway through", async () => {
+    const rows = Array.from({ length: 200 }, (_, i) => ({ id: i, name: `Row ${i}` }));
+    const fetchPage = makeFetchPage(rows, 50); // fails on the 2nd page
+    const { result } = renderHook(() =>
+      useFilteredCsvExport<Row>({
+        header: ["ID", "Name"],
+        toRow: (r) => [String(r.id), r.name],
+        entityName: "widgets",
+        fetchPage,
+        pageSize: 50,
+      }),
+    );
+
+    await expect(
+      act(async () => {
+        await result.current.runExport();
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(downloadCsv).not.toHaveBeenCalled();
+    expect(result.current.isExporting).toBe(false);
+  });
+
+  it("always fetches against the latest config, even if it changed since mount", async () => {
+    const initialFetch = makeFetchPage([{ id: 1, name: "stale" }]);
+    const latestFetch = makeFetchPage([{ id: 2, name: "fresh" }]);
+
+    const { result, rerender } = renderHook(
+      (fetchPage: typeof initialFetch) =>
+        useFilteredCsvExport<Row>({
+          header: ["ID", "Name"],
+          toRow: (r) => [String(r.id), r.name],
+          entityName: "widgets",
+          fetchPage,
+        }),
+      { initialProps: initialFetch },
+    );
+
+    rerender(latestFetch);
+
+    await act(async () => {
+      await result.current.runExport();
+    });
+
+    expect(initialFetch).not.toHaveBeenCalled();
+    expect(latestFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/csm-portal/webapp/src/hooks/useFilteredCsvExport.ts
+++ b/apps/csm-portal/webapp/src/hooks/useFilteredCsvExport.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback, useRef, useState } from "react";
+import { downloadCsv, fetchAllPages, type CsvExportPageFetcher } from "@utils/csvExport";
+
+export interface UseFilteredCsvExportConfig<T> {
+  /** Column headers, in display order — must match the listing's own column
+   * order/labels so the export is recognizably "the same table as a file". */
+  header: string[];
+  /** Maps one fetched item to a CSV row, in the same order as `header`. */
+  toRow: (item: T) => string[];
+  /** Noun used to build the downloaded filename, e.g. "incidents",
+   * "change-requests". Lower-case, hyphenated; no spaces. */
+  entityName: string;
+  /**
+   * Fetches one page, `[offset, offset+limit)`, of the *current* filtered
+   * search — bind whatever filters/sort are currently applied into this
+   * closure. Re-supplied on every render (see the ref pattern below) so
+   * `runExport` always fetches against whatever is selected at the moment the
+   * user clicks Export, not whatever was selected when the hook first
+   * mounted.
+   */
+  fetchPage: CsvExportPageFetcher<T>;
+  /** Page size per request. Defaults to 50 (see `fetchAllPages`). */
+  pageSize?: number;
+  /** Row cap override. Defaults to `CSV_EXPORT_ROW_CAP`. */
+  maxRows?: number;
+}
+
+export interface CsvExportProgress {
+  loaded: number;
+  total: number;
+}
+
+export interface UseFilteredCsvExportResult {
+  isExporting: boolean;
+  /** `null` when not currently exporting; otherwise rows fetched so far vs.
+   * the server-reported total for the current filter. */
+  progress: CsvExportProgress | null;
+  /**
+   * Kicks off the export: pages the current filtered search to exhaustion (or
+   * the safety cap), then downloads one CSV file. Resolves with whether the
+   * export was truncated by the row cap, or throws if a page fetch failed
+   * partway through (in which case nothing is downloaded — no partial file is
+   * ever handed to the user as if it were complete).
+   */
+  runExport: () => Promise<{ truncated: boolean; rowCount: number; total: number }>;
+}
+
+/**
+ * Backs every "Export CSV" action on the CSM portal's filtered listing pages
+ * (cases, service requests, incidents, change requests, and any other view
+ * built on the shared cases search).
+ *
+ * There is no server-side export endpoint — a project decision, not an
+ * oversight: exporting is client-side, paging the same list-search endpoint
+ * the listing itself already uses, filters and sort included, until the full
+ * filtered result set has been fetched (see `fetchAllPages`). This is
+ * necessarily chattier and slower than a dedicated backend export for a large
+ * result set (a month of incidents across a busy account can be hundreds of
+ * rows, i.e. several roundtrips at the backend's 50-row page cap) — that
+ * tradeoff is the accepted cost of not adding a backend endpoint, not a bug
+ * in this hook.
+ */
+export function useFilteredCsvExport<T>(
+  config: UseFilteredCsvExportConfig<T>,
+): UseFilteredCsvExportResult {
+  const [isExporting, setIsExporting] = useState(false);
+  const [progress, setProgress] = useState<CsvExportProgress | null>(null);
+
+  // Always read the latest config at call time (current filters/sort), not
+  // whatever closure captured `runExport` on first render — `runExport`
+  // itself is stable (empty deps) so callers don't need to worry about it
+  // changing identity every keystroke of a filter field.
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  const runExport = useCallback(async () => {
+    const { header, toRow, entityName, fetchPage, pageSize, maxRows } = configRef.current;
+    setIsExporting(true);
+    setProgress({ loaded: 0, total: 0 });
+    try {
+      const { items, truncated, total } = await fetchAllPages(fetchPage, {
+        pageSize,
+        maxRows,
+        onProgress: (loaded, pageTotal) => setProgress({ loaded, total: pageTotal }),
+      });
+
+      const rows = items.map(toRow);
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      // A truncated export is tagged in the filename itself, not just an
+      // on-screen notice — the notice can be missed or the file can be
+      // shared/opened later, outside the app, with no way to tell it isn't
+      // the complete set otherwise.
+      const filename = `${entityName}-export-${timestamp}${truncated ? "-partial" : ""}.csv`;
+      downloadCsv(header, rows, filename);
+
+      return { truncated, rowCount: rows.length, total };
+    } finally {
+      setIsExporting(false);
+      setProgress(null);
+    }
+  }, []);
+
+  return { isExporting, progress, runExport };
+}

--- a/apps/csm-portal/webapp/src/utils/__tests__/csvExport.test.ts
+++ b/apps/csm-portal/webapp/src/utils/__tests__/csvExport.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it, vi } from "vitest";
+import { csvField, fetchAllPages, rowsToCsvText } from "@utils/csvExport";
+
+describe("csvField", () => {
+  it("leaves a plain value untouched", () => {
+    expect(csvField("hello")).toBe("hello");
+  });
+
+  it("quotes a value containing a comma", () => {
+    expect(csvField("a, b")).toBe('"a, b"');
+  });
+
+  it("doubles internal quotes", () => {
+    expect(csvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("quotes a value with a bare carriage return", () => {
+    expect(csvField("a\rb")).toBe('"a\rb"');
+  });
+});
+
+describe("rowsToCsvText", () => {
+  it("joins header and rows with CRLF", () => {
+    const text = rowsToCsvText(["A", "B"], [["1", "2"], ["3", "4"]]);
+    expect(text).toBe("A,B\r\n1,2\r\n3,4");
+  });
+});
+
+describe("fetchAllPages", () => {
+  function makeFetcher(items: number[], pageErrorAt?: number) {
+    return vi.fn(async (offset: number, limit: number) => {
+      if (pageErrorAt !== undefined && offset === pageErrorAt) {
+        throw new Error("network blip");
+      }
+      return {
+        items: items.slice(offset, offset + limit),
+        total: items.length,
+      };
+    });
+  }
+
+  it("pages until the result set is exhausted", async () => {
+    const items = Array.from({ length: 125 }, (_, i) => i);
+    const fetchPage = makeFetcher(items);
+    const result = await fetchAllPages(fetchPage, { pageSize: 50 });
+
+    expect(result.items).toEqual(items);
+    expect(result.truncated).toBe(false);
+    expect(result.total).toBe(125);
+    // 125 rows at 50/page -> 3 requests (50 + 50 + 25).
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops after a single page when total fits in it", async () => {
+    const items = [1, 2, 3];
+    const fetchPage = makeFetcher(items);
+    const result = await fetchAllPages(fetchPage, { pageSize: 50 });
+    expect(result.items).toEqual(items);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty result without looping when there's nothing to fetch", async () => {
+    const fetchPage = makeFetcher([]);
+    const result = await fetchAllPages(fetchPage, { pageSize: 50 });
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("truncates at the row cap instead of looping forever, and says so", async () => {
+    const items = Array.from({ length: 500 }, (_, i) => i);
+    const fetchPage = makeFetcher(items);
+    const result = await fetchAllPages(fetchPage, { pageSize: 50, maxRows: 120 });
+
+    // Cap of 120 rows at 50/page -> stops after the 3rd page (150 fetched,
+    // still >= cap), never fetching all 500.
+    expect(result.truncated).toBe(true);
+    expect(result.items.length).toBeLessThan(500);
+    expect(result.items.length).toBeGreaterThanOrEqual(120);
+    expect(result.total).toBe(500);
+  });
+
+  it("reports progress after every page via onProgress", async () => {
+    const items = Array.from({ length: 30 }, (_, i) => i);
+    const fetchPage = makeFetcher(items);
+    const onProgress = vi.fn();
+    await fetchAllPages(fetchPage, { pageSize: 10, onProgress });
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, 10, 30);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 20, 30);
+    expect(onProgress).toHaveBeenNthCalledWith(3, 30, 30);
+  });
+
+  it("propagates a mid-export page failure instead of returning a partial result", async () => {
+    const items = Array.from({ length: 100 }, (_, i) => i);
+    const fetchPage = makeFetcher(items, 50);
+    await expect(fetchAllPages(fetchPage, { pageSize: 50 })).rejects.toThrow(
+      "network blip",
+    );
+  });
+
+  it("never loops forever if a page comes back empty despite a nonzero total", async () => {
+    const fetchPage = vi.fn(async () => ({ items: [] as number[], total: 999 }));
+    const result = await fetchAllPages(fetchPage, { pageSize: 50 });
+    expect(result.items).toEqual([]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/csm-portal/webapp/src/utils/csvExport.ts
+++ b/apps/csm-portal/webapp/src/utils/csvExport.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { saveBlob } from "@utils/saveBlob";
+
+/**
+ * Quotes a CSV field only when it needs it (contains a comma, quote, or
+ * carriage return/newline), doubling any internal quotes — the minimal
+ * escaping RFC 4180 requires. Shared by every CSV export on the portal so the
+ * escaping rules can't drift between them (originally lived only in the time
+ * cards export).
+ */
+export function csvField(value: string): string {
+  if (!/["\r\n,]/.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/** Builds RFC 4180-ish CSV text (CRLF line endings) from a header row and a
+ * list of already-stringified data rows. */
+export function rowsToCsvText(header: string[], rows: string[][]): string {
+  const lines = [header, ...rows].map((row) => row.map(csvField).join(","));
+  return lines.join("\r\n");
+}
+
+/** Builds the CSV text and triggers a browser download for it. */
+export function downloadCsv(header: string[], rows: string[][], filename: string): void {
+  const csv = rowsToCsvText(header, rows);
+  saveBlob(new Blob([csv], { type: "text/csv;charset=utf-8;" }), filename);
+}
+
+/**
+ * Safety cap on the number of rows a single filtered export will fetch.
+ *
+ * There is no server-side export endpoint (see the design note on
+ * `useFilteredCsvExport`), so exporting "the whole filtered result set" means
+ * paging the existing list-search endpoint client-side until it's exhausted.
+ * An unbounded loop is a real risk for a wide-open filter (or none at all), so
+ * this caps it — but per the product decision that shaped this feature, a cap
+ * must never produce a CSV that silently looks complete. When it's hit, the
+ * export still downloads what it fetched, but the filename and the on-screen
+ * notice both say so explicitly (see `useFilteredCsvExport`).
+ */
+export const CSV_EXPORT_ROW_CAP = 5000;
+
+/** One page of results from a list-search endpoint, as far as the exporter
+ * cares — just the items and the server-reported total. */
+export interface CsvExportPage<T> {
+  items: T[];
+  total: number;
+}
+
+/** A single fetch of one page, `[offset, limit)`, of the current filtered
+ * search — bind the caller's current filters/sort into this closure. */
+export type CsvExportPageFetcher<T> = (
+  offset: number,
+  limit: number,
+) => Promise<CsvExportPage<T>>;
+
+export interface FetchAllPagesOptions {
+  /** Rows requested per page. Defaults to 50 (the backend's page-size cap on
+   * every search endpoint today); override only if a specific endpoint's cap
+   * differs. */
+  pageSize?: number;
+  /** See {@link CSV_EXPORT_ROW_CAP}. */
+  maxRows?: number;
+  /** Invoked after each page lands, with rows fetched so far and the
+   * server-reported total (best-effort — a filter that changes counts
+   * mid-export can move the total; the loop always trusts the *first*
+   * observed total to size the progress bar and to decide when it's done, so
+   * a shrinking total from concurrent data changes can't wedge it early or
+   * make the reported progress un-monotonic). */
+  onProgress?: (loaded: number, total: number) => void;
+}
+
+export interface FetchAllPagesResult<T> {
+  items: T[];
+  /** True when {@link CSV_EXPORT_ROW_CAP} (or a caller override) was hit
+   * before every matching row had been fetched — the result is a prefix of
+   * the full filtered set, not the whole thing. */
+  truncated: boolean;
+  /** The server-reported total for the filter, at the time of the first page. */
+  total: number;
+}
+
+/**
+ * Pages a list-search endpoint via `fetchPage` until the full filtered result
+ * set has been retrieved (or the safety cap is hit) and returns every item
+ * fetched. Never returns a "silently short" result: hitting the cap is
+ * reported via `truncated`, and it is the caller's job to communicate that to
+ * the user, not swallow it.
+ */
+export async function fetchAllPages<T>(
+  fetchPage: CsvExportPageFetcher<T>,
+  options: FetchAllPagesOptions = {},
+): Promise<FetchAllPagesResult<T>> {
+  const { pageSize = 50, maxRows = CSV_EXPORT_ROW_CAP, onProgress } = options;
+  const items: T[] = [];
+  let offset = 0;
+  let total = 0;
+  let firstPage = true;
+  let truncated = false;
+
+  for (;;) {
+    const page = await fetchPage(offset, pageSize);
+    if (firstPage) {
+      total = page.total;
+      firstPage = false;
+    }
+    items.push(...page.items);
+    onProgress?.(items.length, total);
+
+    // Defensive: an empty page (regardless of what `total` claims) always
+    // ends the loop rather than looping forever on a backend inconsistency.
+    if (page.items.length === 0) break;
+    offset += page.items.length;
+    if (offset >= total) break;
+
+    if (items.length >= maxRows) {
+      truncated = true;
+      break;
+    }
+  }
+
+  return { items, truncated, total };
+}


### PR DESCRIPTION
## What

Adds an **Export CSV** action to the CSM portal's listing pages: cases and service requests (plus engagements, security reports and the project-scoped issues tab, which share the same list component), incidents, and change requests.

The export covers the **entire currently-filtered, currently-sorted result set** — not just the page on screen — by paging the existing search endpoints client side. No new backend endpoint.

## Why

CS engineers need the filtered list out of the portal for periodic reporting (for example, every incident created in a given month for one product). Today the only options are paging through the UI and copying by hand, or asking someone to pull the data from the backing data source.

## How, and the part worth reviewing closely

The risk with a client-side export is a file that looks complete and is not. Guards against that:

- The pager loops until the server's reported total is exhausted.
- There is a safety cap (default 5,000 rows, overridable per call site). Past it the file still downloads, but it is named `*-partial.csv` **and** a banner tells the user the export was truncated and to narrow the filter. It never silently stops short.
- A mid-export failure is surfaced, not handed over as a partial file pretending to be whole.
- Progress shows as a live "N of Total" count, because paging a month of records is not instant and a button that appears to do nothing reads as a bug.

To stop the export drifting from what the screen shows, the filter-payload builder and row mapper were **extracted** out of the list hook into a shared module and used by both, rather than duplicated. `timeCardCsvExport` was also refactored onto the shared CSV helpers instead of its own private copy (behaviour and tests unchanged).

## Known limitation, deliberately not worked around

The incident listing currently supports only free-text search, priority and parent as filters — there is no created-date range and no product filter yet. So the export faithfully exports what the filter bar can express today, which is less than the reporting use case needs. Adding those filters is tracked separately; this change does not paper over the gap.

Client-side paging is also inherently chatty: page size below is capped at 50, so a few hundred rows means several sequential round trips before the download begins. That trade was chosen deliberately over adding a server-side export endpoint.

## Verification

- `npx tsc -b` — clean
- `npx eslint .` — 0 errors; 1 pre-existing warning in `CsmCaseDetailPage.tsx`, confirmed present on `main`
- `npx vitest run` — 551 passed, 9 failed; the 9 are pre-existing failures on `main` in three files this branch does not touch
- 22 new tests: pager exhaustion, truncation, mid-export failure, hook progress and filename tagging, button busy state and banners

Not exercised against a running backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV export for filtered cases, incidents, and change requests across all result pages.
  * Added export progress indicators, busy states, success confirmations, and clear failure or truncation notices.
  * Added a 5,000-row safety limit for exports.
* **Bug Fixes**
  * Improved case filtering and result mapping, including assignee resolution and empty-result handling.
  * Standardized CSV formatting and downloading for timecard exports.
* **Tests**
  * Added coverage for pagination, progress, failures, truncation, and CSV formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->