### PR TITLE
[CSM Portal] preserve list filters on back-navigation, and add change-request clone

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { JSX } from "react";
+import { useLocation, MemoryRouter, Route, Routes } from "react-router";
+import "@testing-library/jest-dom/vitest";
+import CasesList from "@features/csm-cases/components/CasesList";
+import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+
+const CASE: CsmCaseRow = {
+  id: "case-1",
+  caseNumber: "CS-1007",
+  subject: "Cluster fails to start",
+  customer: "Acme Corp",
+  accountId: "acct-1",
+  projectId: "proj-1",
+  projectName: "Acme Project",
+  product: "WSO2 Identity Server",
+  severity: "S2",
+  state: "work_in_progress",
+  assignee: "Jane Doe",
+  assigneeIsMe: false,
+  slaClockType: "first_response",
+  minutesToBreach: 120,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-02T00:00:00Z",
+};
+
+// Stand-in for the detail page: reads back whatever `state` the row link
+// carried, so the test can assert the filtered list URL survived the
+// navigation without depending on the real detail page's implementation.
+function DetailStub(): JSX.Element {
+  const location = useLocation();
+  const from = (location.state as { from?: string } | undefined)?.from;
+  return <div data-testid="from-state">{from ?? "(none)"}</div>;
+}
+
+describe("CasesList row navigation", () => {
+  it("carries the current (filtered) list URL forward as router state", () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/cases?state=work_in_progress&severity=S2"]}
+      >
+        <Routes>
+          <Route
+            path="/cases"
+            element={<CasesList cases={[CASE]} isLoading={false} />}
+          />
+          <Route path="/cases/:id" element={<DetailStub />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("Cluster fails to start"));
+
+    expect(screen.getByTestId("from-state")).toHaveTextContent(
+      "/cases?state=work_in_progress&severity=S2",
+    );
+  });
+
+  it("carries a bare list URL forward when no filters are active", () => {
+    render(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <Routes>
+          <Route
+            path="/cases"
+            element={<CasesList cases={[CASE]} isLoading={false} />}
+          />
+          <Route path="/cases/:id" element={<DetailStub />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("Cluster fails to start"));
+
+    expect(screen.getByTestId("from-state")).toHaveTextContent("/cases");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -22,7 +22,7 @@ import {
   useTheme,
 } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
-import { Link as RouterLink } from "react-router";
+import { Link as RouterLink, useLocation } from "react-router";
 import { preloadRoute } from "@utils/routePreloaders";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
@@ -84,6 +84,7 @@ export default function CasesList({
   onSortOrderChange,
 }: CasesListProps): JSX.Element {
   const theme = useTheme();
+  const location = useLocation();
   const headerCells = hideSeverityColumn
     ? HEADER_CELLS_WITHOUT_SEVERITY
     : HEADER_CELLS_WITH_SEVERITY;
@@ -198,6 +199,10 @@ export default function CasesList({
               key={c.id}
               component={RouterLink}
               to={`${detailBasePath}/${c.id}`}
+              // Carries the current (filtered) list URL forward so the detail
+              // page's back button can return to it instead of a bare,
+              // filter-less list path.
+              state={{ from: `${location.pathname}${location.search}` }}
               onMouseEnter={() => preloadRoute(detailBasePath)}
               sx={{
                 gridColumn: "1 / -1",

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -416,8 +416,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
   useEffect(() => {
     if (!caseId || !isMisrouted) return;
-    navigate(canonicalDetailPath, { replace: true });
-  }, [isMisrouted, canonicalDetailPath, caseId, navigate]);
+    // Carry the originating list location through the canonical redirect. Without
+    // it, a record reached on a non-canonical route (announcements, service
+    // requests, engagements, security reports) lands on its dedicated route with
+    // empty state, and Back then falls through to the bare route-specific path,
+    // dropping the filters, search and sort that got the user here.
+    navigate(canonicalDetailPath, { replace: true, state: { from: resolvedBackPath } });
+  }, [isMisrouted, canonicalDetailPath, caseId, navigate, resolvedBackPath]);
 
   const {
     data: comments,

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -372,6 +372,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
         : isSecurityReportRoute
           ? `/security-center/security-reports/${caseId}`
           : `/cases/${caseId}`;
+  // The row link on the originating list carries its own (filtered) URL
+  // forward as router state, so the back button below returns to that exact
+  // list view — filters, search text, sort — instead of a bare list path.
+  // Falls back to the hardcoded backPath for a bookmarked or directly-linked
+  // detail page, which never got the state set.
+  const fromListState = location.state as { from?: string } | undefined;
+  const resolvedBackPath = fromListState?.from ?? backPath;
   const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
   // The route alone isn't a reliable signal once data has loaded: a "Related
   // case" link always points at /cases/:id regardless of the target's actual
@@ -1475,7 +1482,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           variant="text"
           size="small"
           startIcon={<ArrowLeft size={16} />}
-          onClick={() => navigate(backPath)}
+          onClick={() => navigate(resolvedBackPath)}
           sx={{ alignSelf: "flex-start" }}
         >
           {backLabel}
@@ -1495,7 +1502,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           variant="text"
           size="small"
           startIcon={<ArrowLeft size={16} />}
-          onClick={() => navigate(backPath)}
+          onClick={() => navigate(resolvedBackPath)}
           sx={{ alignSelf: "flex-start" }}
         >
           {backLabel}
@@ -1546,7 +1553,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         variant="text"
         size="small"
         startIcon={<ArrowLeft size={16} />}
-        onClick={() => navigate(backPath)}
+        onClick={() => navigate(resolvedBackPath)}
         sx={{ alignSelf: "flex-start" }}
       >
         {backLabel}
@@ -1629,7 +1636,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 clickable
                 icon={<LinkIcon size={14} />}
                 label={`Related: ${relatedCase.caseNumber ?? relatedCase.id}`}
-                onClick={() => navigate(`/cases/${relatedCase.id}`)}
+                // Carries the same "back to list" target forward — there's no
+                // breadcrumb chain back through this case, so the related
+                // case's own back button returns to the filtered list this
+                // one was opened from rather than losing it a step early.
+                onClick={() =>
+                  navigate(`/cases/${relatedCase.id}`, {
+                    state: { from: resolvedBackPath },
+                  })
+                }
                 sx={{ fontWeight: 600 }}
               />
             )}
@@ -1640,7 +1655,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 clickable
                 icon={<LinkIcon size={14} />}
                 label={`Parent: ${c.parentCase.caseNumber ?? c.parentCase.id}`}
-                onClick={() => navigate(parentCasePath(c.parentCase))}
+                onClick={() =>
+                  navigate(parentCasePath(c.parentCase), {
+                    state: { from: resolvedBackPath },
+                  })
+                }
                 sx={{ fontWeight: 600 }}
               />
             )}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.test.tsx
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { CloneChangeRequestNavState } from "@features/csm-operations/utils/changeRequests";
+
+const navigateMock = vi.fn();
+const postChangeRequestMock = vi.fn();
+let locationState: CloneChangeRequestNavState | undefined;
+
+// The backend client reads runtime config at module load, which isn't
+// present under vitest — same stub technique as
+// CsmChangeRequestDetailPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useLocation: () => ({ state: locationState }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+vi.mock("@features/csm-operations/api/usePostChangeRequest", () => ({
+  usePostChangeRequest: () => ({
+    mutate: postChangeRequestMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@features/settings/api/useGetUsersMe", () => ({
+  useGetUsersMe: () => ({ data: undefined }),
+}));
+
+// This form's Lexical-based editor renders real content in a browser but not
+// under jsdom in a way vitest can drive reliably — stub it to a plain
+// textarea, same technique as EditCaseDetailsDialog.test.tsx.
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: ({ value }: { value: string }) => (
+    <textarea readOnly aria-label="editor" value={value} />
+  ),
+}));
+
+const emptySearchResult = { data: [], isFetching: false, isError: false };
+vi.mock("@api/useSearchGroups", () => ({ useSearchGroups: () => emptySearchResult }));
+vi.mock("@api/useSearchItServices", () => ({ useSearchItServices: () => emptySearchResult }));
+vi.mock("@api/useSearchServiceOfferings", () => ({
+  useSearchServiceOfferings: () => emptySearchResult,
+}));
+vi.mock("@api/useSearchConfigurationItems", () => ({
+  useSearchConfigurationItems: () => emptySearchResult,
+}));
+vi.mock("@api/useSearchUsersByName", () => ({
+  useSearchUsersByName: () => emptySearchResult,
+}));
+
+// Imported after the mocks above so the module picks them up.
+import CreateChangeRequestPage from "@features/csm-operations/pages/CreateChangeRequestPage";
+
+describe("CreateChangeRequestPage — Clone prefill", () => {
+  it("renders a blank form with no clone banner when opened directly (not cloned)", () => {
+    locationState = undefined;
+    render(<CreateChangeRequestPage />);
+    expect(screen.getByLabelText(/subject/i)).toHaveValue("");
+    expect(screen.queryByText(/cloned from/i)).not.toBeInTheDocument();
+  });
+
+  it("prefills subject, type, and impact from the clone state", () => {
+    locationState = {
+      sourceNumber: "CHG0009988",
+      subject: "Upgrade the gateway cluster",
+      type: "emergency",
+      impact: "high",
+    };
+    render(<CreateChangeRequestPage />);
+    expect(screen.getByLabelText(/subject/i)).toHaveValue("Upgrade the gateway cluster");
+    expect(screen.getByText("Emergency")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
+  it("shows a banner naming the source record and the fields that could not be copied", () => {
+    locationState = { sourceNumber: "CHG0009988", subject: "Upgrade the gateway cluster" };
+    render(<CreateChangeRequestPage />);
+    expect(screen.getByText(/cloned from chg0009988/i)).toBeInTheDocument();
+    expect(screen.getByText(/category, priority, risk/i)).toBeInTheDocument();
+  });
+
+  it("shows a generic banner when the source number is unavailable", () => {
+    locationState = { subject: "Upgrade the gateway cluster" };
+    render(<CreateChangeRequestPage />);
+    expect(screen.getByText(/cloned from an existing change request/i)).toBeInTheDocument();
+  });
+
+  it("always resets state to 'new' regardless of the clone source", () => {
+    locationState = { subject: "Upgrade the gateway cluster" };
+    render(<CreateChangeRequestPage />);
+    expect(screen.getByText("New")).toBeInTheDocument();
+  });
+
+  it("leaves the planned start/end schedule empty even when cloning", () => {
+    locationState = { subject: "Upgrade the gateway cluster" };
+    const { container } = render(<CreateChangeRequestPage />);
+    // The MUI date-time picker renders a segmented group (day/month/year/…)
+    // rather than a single-value input, so "empty" shows up as every segment
+    // carrying an `aria-valuetext="Empty"` — there's no cloned start/end
+    // date to display, for either the start or the end picker.
+    const emptySegments = container.querySelectorAll('[aria-valuetext="Empty"]');
+    expect(emptySegments.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
@@ -201,7 +201,10 @@ export default function CreateChangeRequestPage(): JSX.Element {
   // not reach back in and overwrite what they've typed.
   const cloneState = useLocation().state as CloneChangeRequestNavState | undefined;
 
-  const [subject, setSubject] = useState(cloneState?.subject ?? "");
+  // Slice on seed as well as on change: a source record at or beyond the cap
+  // would otherwise load untrimmed, show a negative characters-left count, and
+  // submit over-length if the user never edits the field.
+  const [subject, setSubject] = useState((cloneState?.subject ?? "").slice(0, SUBJECT_MAX));
   // Pre-selected to match the legacy ServiceNow form's own defaults, rather
   // than leaving every dropdown blank — most change requests are Normal
   // type, Other category, Low impact, Moderate risk. Priority has no default

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
@@ -19,6 +19,7 @@ import {
   AccordionDetails,
   AccordionSummary,
   AdapterDateFns,
+  Alert,
   Box,
   Button,
   Card,
@@ -34,7 +35,7 @@ import {
 const { DateTimePicker, LocalizationProvider } = DatePickers;
 import { ArrowLeft, ChevronDown } from "@wso2/oxygen-ui-icons-react";
 import { useRef, useState, type JSX } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import Editor from "@components/rich-text-editor/Editor";
@@ -48,7 +49,11 @@ import { useSearchServiceOfferings } from "@api/useSearchServiceOfferings";
 import { useSearchConfigurationItems } from "@api/useSearchConfigurationItems";
 import { useSearchUsersByName } from "@api/useSearchUsersByName";
 import AsyncEntitySelect from "@components/AsyncEntitySelect";
-import { changeRequestStateLabel } from "@features/csm-operations/utils/changeRequests";
+import {
+  changeRequestStateLabel,
+  CLONE_SOURCE_GAP_MESSAGE,
+  type CloneChangeRequestNavState,
+} from "@features/csm-operations/utils/changeRequests";
 import type {
   BeChangeRequestCategory,
   BeChangeRequestImpact,
@@ -187,30 +192,48 @@ export default function CreateChangeRequestPage(): JSX.Element {
   const { showError } = useErrorBanner();
   const postChangeRequest = usePostChangeRequest();
 
-  const [subject, setSubject] = useState("");
+  // Set when opened from a change request's "Clone" action, which navigates
+  // here with router state (not query params) — see
+  // CsmChangeRequestDetailPage.tsx's cloneChangeRequest and
+  // buildCloneChangeRequestNavState's doc comment for exactly which fields
+  // this can and can't carry over. Read once: this form's state is what the
+  // user edits from here on, so a later change to the *source* record must
+  // not reach back in and overwrite what they've typed.
+  const cloneState = useLocation().state as CloneChangeRequestNavState | undefined;
+
+  const [subject, setSubject] = useState(cloneState?.subject ?? "");
   // Pre-selected to match the legacy ServiceNow form's own defaults, rather
   // than leaving every dropdown blank — most change requests are Normal
   // type, Other category, Low impact, Moderate risk. Priority has no default
-  // there either ("-- None --"), so it stays unset here too.
-  const [type, setType] = useState<string>("normal");
+  // there either ("-- None --"), so it stays unset here too. A clone
+  // carries over `type`/`impact` from the source record when present;
+  // category/priority/risk have no source value to carry (see
+  // buildCloneChangeRequestNavState), so they keep the same defaults a
+  // from-scratch change request gets.
+  const [type, setType] = useState<string>(cloneState?.type ?? "normal");
   const [category, setCategory] = useState<string>("other");
-  const [impact, setImpact] = useState<string>("low");
+  const [impact, setImpact] = useState<string>(cloneState?.impact ?? "low");
   const [priority, setPriority] = useState<string>(UNSET);
   const [risk, setRisk] = useState<string>("moderate");
+  // Always "new" regardless of the source record's own state/schedule/
+  // approval — cloning must never carry an approval or a stale window
+  // across into the new change request.
   const [state, setState] = useState<string>("new");
   const [plannedStartDate, setPlannedStartDate] = useState("");
   const [plannedEndDate, setPlannedEndDate] = useState("");
-  const [description, setDescription] = useState("");
-  const [justification, setJustification] = useState("");
+  const [description, setDescription] = useState(cloneState?.description ?? "");
+  const [justification, setJustification] = useState(cloneState?.justification ?? "");
   const [implementationPlan, setImplementationPlan] = useState("");
   const [riskImpactAnalysis, setRiskImpactAnalysis] = useState("");
   const [backoutPlan, setBackoutPlan] = useState("");
-  const [testPlan, setTestPlan] = useState("");
+  const [testPlan, setTestPlan] = useState(cloneState?.testPlan ?? "");
   const [serviceId, setServiceId] = useState("");
   const [serviceOfferingId, setServiceOfferingId] = useState("");
   const [configurationItemId, setConfigurationItemId] = useState("");
   const [groupId, setGroupId] = useState("");
-  const [assignedEngineerId, setAssignedEngineerId] = useState("");
+  const [assignedEngineerId, setAssignedEngineerId] = useState(
+    cloneState?.assignedEngineerId ?? "",
+  );
   const [requestedById, setRequestedById] = useState("");
 
   // Defaults "Requested by" to the signed-in user, matching the legacy
@@ -363,6 +386,15 @@ export default function CreateChangeRequestPage(): JSX.Element {
         New change request
       </Typography>
 
+      {cloneState && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {cloneState.sourceNumber
+            ? `Cloned from ${cloneState.sourceNumber}. `
+            : "Cloned from an existing change request. "}
+          {CLONE_SOURCE_GAP_MESSAGE}
+        </Alert>
+      )}
+
       <Card variant="outlined" sx={{ p: 3 }}>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <Typography variant="subtitle2">Change request</Typography>
@@ -486,7 +518,13 @@ export default function CreateChangeRequestPage(): JSX.Element {
           {/* Everything below is optional and used less often at creation
               time — collapsed by default so the form isn't dominated by
               fields most requests won't need up front. */}
-          <Accordion disableGutters sx={{ "&:before": { display: "none" }, mt: 1 }}>
+          <Accordion
+            disableGutters
+            // Auto-expanded when cloning and an engineer carried over, so
+            // the prefilled value isn't hidden behind a collapsed section.
+            defaultExpanded={!!cloneState?.assignedEngineerId}
+            sx={{ "&:before": { display: "none" }, mt: 1 }}
+          >
             <AccordionSummary expandIcon={<ChevronDown size={16} />}>
               <Typography variant="body2" color="text.secondary">
                 More options (optional)
@@ -566,6 +604,7 @@ export default function CreateChangeRequestPage(): JSX.Element {
                     // so every option here is guaranteed to have one.
                     getId={(u) => u.id!}
                     getLabel={userLabel}
+                    knownLabel={cloneState?.assignedEngineerLabel}
                   />
                 </Box>
                 <Box sx={{ flex: "1 1 220px" }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeChangeRequestDetail } from "@api/backend/types";
@@ -103,6 +103,12 @@ function mockQueryResult(
   });
 }
 
+beforeEach(() => {
+  navigateMock.mockClear();
+  patchMutateMock.mockClear();
+  showErrorMock.mockClear();
+});
+
 describe("CsmChangeRequestDetailPage", () => {
   it("renders the linked case as a clickable reference to the case route", () => {
     mockQueryResult({ data: BASE_CR });
@@ -121,6 +127,52 @@ describe("CsmChangeRequestDetailPage", () => {
     render(<CsmChangeRequestDetailPage />);
     const linkedCaseCell = screen.getByText("Linked case").parentElement!;
     expect(within(linkedCaseCell).getByText("—")).toBeInTheDocument();
+  });
+});
+
+describe("CsmChangeRequestDetailPage — Clone", () => {
+  it("navigates to the create form with router state built from this record", () => {
+    mockQueryResult({
+      data: {
+        ...BASE_CR,
+        description: "<p>Upgrade the gateway.</p>",
+        impact: "high",
+        assignedEngineer: { id: "user-1", name: "Jane Doe" },
+      },
+    });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /clone/i }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/operations/change-requests/new",
+      expect.objectContaining({
+        state: expect.objectContaining({
+          sourceNumber: "CHG0009988",
+          subject: "Upgrade the gateway cluster",
+          type: "normal",
+          impact: "high",
+          assignedEngineerId: "user-1",
+          assignedEngineerLabel: "Jane Doe",
+        }),
+      }),
+    );
+  });
+
+  it("never puts the deployment, state, or approval fields into the clone's router state", () => {
+    mockQueryResult({
+      data: {
+        ...BASE_CR,
+        deployment: { id: "dep-1", name: "prod" },
+        state: "closed",
+        hasCustomerApproved: true,
+      },
+    });
+    render(<CsmChangeRequestDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /clone/i }));
+    const [, options] = navigateMock.mock.calls[0];
+    const keys = Object.keys(options.state);
+    expect(keys).not.toContain("deployment");
+    expect(keys).not.toContain("state");
+    expect(keys).not.toContain("hasCustomerApproved");
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -42,6 +42,7 @@ vi.mock("@api/backend/client", () => ({
 
 vi.mock("react-router", () => ({
   useParams: () => ({ id: "chg-1" }),
+  useLocation: () => ({ pathname: "/operations/change-requests/chg-1", search: "", state: undefined }),
 }));
 vi.mock("@hooks/useNavTransition", () => ({
   useNavTransition: () => navigateMock,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -29,6 +29,7 @@ import {
   ArrowLeft,
   Check,
   ClipboardCheck,
+  CopyPlus,
   FileText,
   MessageSquare,
   MessageSquarePlus,
@@ -62,6 +63,7 @@ import ChangeRequestApprovals from "@features/csm-operations/components/ChangeRe
 import EditChangeRequestDialog from "@features/csm-operations/components/EditChangeRequestDialog";
 import EntityRefLink from "@features/csm-operations/components/EntityRefLink";
 import {
+  buildCloneChangeRequestNavState,
   changeRequestCommentGateReason,
   changeRequestImpactColor,
   changeRequestImpactLabel,
@@ -311,6 +313,19 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
     );
   };
 
+  // Opens the create form pre-filled from this record, so promoting the same
+  // change to another environment doesn't mean re-typing every field. Router
+  // state (not a query string) carries the values across — same pattern as
+  // "Create incident from case" — and the result is a new, independent change
+  // request: nothing here links it back to `cr`. See
+  // buildCloneChangeRequestNavState's doc comment for exactly which fields
+  // can and can't be carried over today.
+  const cloneChangeRequest = (): void => {
+    navigate("/operations/change-requests/new", {
+      state: buildCloneChangeRequestNavState(cr),
+    });
+  };
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
       {BackButton}
@@ -371,9 +386,18 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
           <Button
             variant="outlined"
             size="small"
+            startIcon={<CopyPlus size={14} />}
+            onClick={cloneChangeRequest}
+            sx={{ ml: stateAllowsRequestApproval ? 0 : "auto", flexShrink: 0 }}
+          >
+            Clone
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
             startIcon={<Pencil size={14} />}
             onClick={() => setEditOpen(true)}
-            sx={{ ml: stateAllowsRequestApproval ? 0 : "auto", flexShrink: 0 }}
+            sx={{ flexShrink: 0 }}
           >
             Edit
           </Button>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -45,7 +45,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import {  useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { BackendApiError } from "@api/backend/client";
@@ -182,6 +182,11 @@ const TAB_DEFS: Array<{
 export default function CsmChangeRequestDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
+  // Prefer the list URL the row link captured (if any) so "back" returns to
+  // the exact view the engineer came from, falling back to the bare tab path
+  // for a bookmarked or directly-linked change request.
+  const backState = useLocation().state as { from?: string } | undefined;
+  const backTarget = backState?.from ?? OPERATIONS_CR_PATH;
   const { data, isLoading, isError } = useGetChangeRequest(id);
   const { showError } = useErrorBanner();
   const patchCr = usePatchChangeRequest();
@@ -235,7 +240,7 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   );
 
   const back = (): void => {
-    navigate(OPERATIONS_CR_PATH);
+    navigate(backTarget);
   };
 
   const BackButton = (

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@api/backend/client", () => ({
 
 vi.mock("react-router", () => ({
   useParams: () => ({ id: "inc-1" }),
+  useLocation: () => ({ pathname: "/operations/incidents/inc-1", search: "", state: undefined }),
 }));
 vi.mock("@hooks/useNavTransition", () => ({
   useNavTransition: () => navigateMock,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -34,7 +34,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
@@ -171,6 +171,11 @@ const TAB_DEFS: Array<{ id: IncidentTabId; label: string; icon: JSX.Element }> =
 export default function CsmIncidentDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
+  // Prefer the list URL the row link captured (if any) so "back" returns to
+  // the exact view the engineer came from, falling back to the bare tab path
+  // for a bookmarked or directly-linked incident.
+  const backState = useLocation().state as { from?: string } | undefined;
+  const backTarget = backState?.from ?? OPERATIONS_INCIDENTS_PATH;
   const { data, isLoading, isError } = useGetIncident(id);
   const { showError } = useErrorBanner();
   const patchIncident = usePatchIncident();
@@ -282,7 +287,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   );
 
   const back = (): void => {
-    navigate(OPERATIONS_INCIDENTS_PATH);
+    navigate(backTarget);
   };
 
   const BackButton = (

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { buildCloneChangeRequestNavState } from "@features/csm-operations/utils/changeRequests";
+import type { BeChangeRequestDetail } from "@api/backend/types";
+
+const FULL_CR: BeChangeRequestDetail = {
+  id: "chg-1",
+  number: "CHG0009988",
+  subject: "Upgrade the gateway cluster",
+  description: "<p>Upgrade to the latest patch level.</p>",
+  project: { id: "proj-1", name: "Project A" },
+  case: { id: "case-1", name: "CASE0001234" },
+  deployment: { id: "dep-1", name: "prod" },
+  deployedProduct: { id: "dp-1", name: "API Manager" },
+  product: { id: "product-1", name: "API Manager" },
+  assignedEngineer: { id: "user-1", name: "Jane Doe" },
+  assignedTeam: { id: "team-1", name: "Platform" },
+  plannedStartOn: "2026-01-01T00:00:00Z",
+  plannedEndOn: "2026-01-02T00:00:00Z",
+  duration: "1 day",
+  impact: "medium",
+  state: "closed",
+  type: "normal",
+  createdOn: "2025-12-01T00:00:00Z",
+  updatedOn: "2025-12-02T00:00:00Z",
+  createdBy: "someone@example.com",
+  justification: "<p>Needed for the security patch.</p>",
+  impactDescription: "<p>Brief outage expected.</p>",
+  serviceOutage: "<p>5 minutes.</p>",
+  communicationPlan: "<p>Notify via status page.</p>",
+  rollbackPlan: "<p>Revert to the previous image.</p>",
+  testPlan: "<p>Run the smoke suite.</p>",
+  hasCustomerApproved: true,
+  hasCustomerReviewed: true,
+  approvedBy: { id: "approver-1", name: "Approver Name" },
+  approvedOn: "2025-12-05T00:00:00Z",
+  legalNextStates: [],
+};
+
+describe("buildCloneChangeRequestNavState", () => {
+  it("carries over the fields that are genuinely the same on read and create", () => {
+    const state = buildCloneChangeRequestNavState(FULL_CR);
+    expect(state.subject).toBe("Upgrade the gateway cluster");
+    expect(state.description).toContain("Upgrade to the latest patch level.");
+    expect(state.justification).toContain("Needed for the security patch.");
+    expect(state.testPlan).toContain("Run the smoke suite.");
+    expect(state.type).toBe("normal");
+    expect(state.impact).toBe("medium");
+    expect(state.assignedEngineerId).toBe("user-1");
+    expect(state.assignedEngineerLabel).toBe("Jane Doe");
+    expect(state.sourceNumber).toBe("CHG0009988");
+  });
+
+  it("never surfaces a field that create-time payload has no slot for", () => {
+    const state = buildCloneChangeRequestNavState(FULL_CR);
+    const keys = Object.keys(state);
+    // impactDescription/serviceOutage/communicationPlan/rollbackPlan are
+    // read-only on the backend today — BeCreateChangeRequestPayload has no
+    // field for any of them, so they must never appear in the clone state.
+    expect(keys).not.toContain("impactDescription");
+    expect(keys).not.toContain("serviceOutage");
+    expect(keys).not.toContain("communicationPlan");
+    expect(keys).not.toContain("rollbackPlan");
+    // category/priority/risk/implementationPlan/riskImpactAnalysis are
+    // write-only — never returned by GET — so there is no source value ever.
+    expect(keys).not.toContain("category");
+    expect(keys).not.toContain("priority");
+    expect(keys).not.toContain("risk");
+    expect(keys).not.toContain("implementationPlan");
+    expect(keys).not.toContain("riskImpactAnalysis");
+  });
+
+  it("never carries the environment, project, or linked-case references", () => {
+    const state = buildCloneChangeRequestNavState(FULL_CR);
+    const keys = Object.keys(state);
+    expect(keys).not.toContain("deployment");
+    expect(keys).not.toContain("deployedProduct");
+    expect(keys).not.toContain("project");
+    expect(keys).not.toContain("case");
+    expect(keys).not.toContain("product");
+    expect(keys).not.toContain("assignedTeam");
+  });
+
+  it("never carries state, schedule, or approval fields", () => {
+    const state = buildCloneChangeRequestNavState(FULL_CR);
+    const keys = Object.keys(state);
+    expect(keys).not.toContain("state");
+    expect(keys).not.toContain("plannedStartOn");
+    expect(keys).not.toContain("plannedEndOn");
+    expect(keys).not.toContain("hasCustomerApproved");
+    expect(keys).not.toContain("hasCustomerReviewed");
+    expect(keys).not.toContain("approvedBy");
+    expect(keys).not.toContain("approvedOn");
+  });
+
+  it("never carries auto-numbered, created-by, or timestamp fields", () => {
+    const state = buildCloneChangeRequestNavState(FULL_CR);
+    const keys = Object.keys(state);
+    expect(keys).not.toContain("id");
+    expect(keys).not.toContain("createdOn");
+    expect(keys).not.toContain("updatedOn");
+    expect(keys).not.toContain("createdBy");
+    expect(keys).not.toContain("duration");
+    expect(keys).not.toContain("legalNextStates");
+  });
+
+  it("omits a blank rich-text field instead of copying an empty-looking paragraph", () => {
+    const state = buildCloneChangeRequestNavState({
+      ...FULL_CR,
+      description: "<p><br></p>",
+      justification: null,
+      testPlan: undefined,
+    });
+    expect(state.description).toBeUndefined();
+    expect(state.justification).toBeUndefined();
+    expect(state.testPlan).toBeUndefined();
+  });
+
+  it("omits the assigned engineer entirely when the source record has none", () => {
+    const state = buildCloneChangeRequestNavState({ ...FULL_CR, assignedEngineer: null });
+    expect(state.assignedEngineerId).toBeUndefined();
+    expect(state.assignedEngineerLabel).toBeUndefined();
+  });
+
+  it("sanitizes rich-text content before it reaches the clone form's editor", () => {
+    const state = buildCloneChangeRequestNavState({
+      ...FULL_CR,
+      description: '<p>Safe</p><script>alert("xss")</script>',
+    });
+    expect(state.description).not.toContain("<script>");
+    expect(state.description).toContain("Safe");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -15,9 +15,12 @@
 // under the License.
 
 import type {
+  BeChangeRequestDetail,
   BeChangeRequestImpact,
   BeChangeRequestState,
+  BeChangeRequestType,
 } from "@api/backend/types";
+import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 
 type ChipColor = "default" | "info" | "warning" | "success" | "error";
 
@@ -167,3 +170,94 @@ export function countActiveCRFilters(filters: ChangeRequestFilters): number {
     (filters.closedEndDate ? 1 : 0)
   );
 }
+
+// ---------------------------------------------------------------------------
+// Clone ("create similar") support: pre-fills the create form from an
+// existing change request via router state, so promoting the same change
+// through another environment doesn't mean re-typing every field.
+//
+// This is a *partial* clone by necessity, not by choice: `GET
+// /change-requests/{id}` (BeChangeRequestDetail) and `POST /change-requests`
+// (BeCreateChangeRequestPayload) are asymmetric on the backend today —
+// several fields the create form can set are never returned by the read,
+// and several fields the detail page can show have no create-time
+// equivalent at all. Concretely (verified against the entity service's own
+// request/response structs, not just the two frontend types):
+//   - `category`, `priority`, and `risk` are write-only — accepted by create,
+//     never present on the read response — so there is no source value to
+//     copy from, ever, regardless of how the form is wired.
+//   - `implementationPlan` and `riskImpactAnalysis` are write-only for the
+//     same reason.
+//   - `impactDescription`, `serviceOutage`, `communicationPlan`, and
+//     `rollbackPlan` are read-only today — the create payload has no field
+//     for any of them.
+//   - `project`, `case`, `deployment`, `deployedProduct`, and `product` are
+//     read-only refs with no create-time field to set them from at all.
+//   - `assignedTeam` is read-only; create's nearest-sounding field
+//     (`groupId`, "Assignment group") is a *different* underlying reference
+//     with no confirmed equivalence to `assignedTeam` — mapping one into the
+//     other would be a guess, not a verified carry-over, so it's left alone.
+// None of the above can be safely carried over without either fabricating
+// data or guessing at an unconfirmed field mapping, so this only clones the
+// fields that are genuinely the same field on both sides: `subject`,
+// `description`, `justification`, `testPlan`, `type`, `impact`, and
+// `assignedEngineer`. Everything else resets to the create form's own
+// defaults, same as a from-scratch change request — see
+// `CLONE_SOURCE_GAP_MESSAGE` for the user-facing disclosure of this gap.
+export interface CloneChangeRequestNavState {
+  /** For the banner shown on the create form — never sent to the backend. */
+  sourceNumber?: string;
+  subject?: string;
+  description?: string;
+  justification?: string;
+  testPlan?: string;
+  type?: BeChangeRequestType;
+  impact?: BeChangeRequestImpact;
+  assignedEngineerId?: string;
+  /** Display label for `assignedEngineerId` until a fresh search resolves it. */
+  assignedEngineerLabel?: string;
+}
+
+/** Rich-text field carried into the clone form only when it has real content. */
+function cloneableHtml(html?: string | null): string | undefined {
+  if (!html || isBlankHtml(html)) return undefined;
+  return sanitizeRichTextHtml(html);
+}
+
+/**
+ * Builds the router-state payload for a change request's "Clone" action.
+ * Deliberately omits: environment/deployment, state, approval fields
+ * (`hasCustomerApproved`/`hasCustomerReviewed`/`approvedBy`/`approvedOn`),
+ * planned start/end, and every auto-numbered/timestamp/created-by field —
+ * per this feature's requirement that promoting a change to a new
+ * environment must never silently carry an approval or a stale schedule
+ * across. Comments and attachments are never part of this payload; they
+ * belong to the original record only.
+ */
+export function buildCloneChangeRequestNavState(
+  cr: BeChangeRequestDetail,
+): CloneChangeRequestNavState {
+  return {
+    sourceNumber: cr.number,
+    subject: cr.subject ?? undefined,
+    description: cloneableHtml(cr.description),
+    justification: cloneableHtml(cr.justification),
+    testPlan: cloneableHtml(cr.testPlan),
+    type: (cr.type as BeChangeRequestType) ?? undefined,
+    impact: (cr.impact as BeChangeRequestImpact) ?? undefined,
+    assignedEngineerId: cr.assignedEngineer?.id || undefined,
+    assignedEngineerLabel: cr.assignedEngineer?.name || undefined,
+  };
+}
+
+/**
+ * User-facing disclosure shown on the create form when it was opened via
+ * Clone, so the field gap documented above is visible rather than silently
+ * dropped. Kept as a single shared string so the detail page (if it ever
+ * wants a preview) and the create page stay in sync.
+ */
+export const CLONE_SOURCE_GAP_MESSAGE =
+  "Copied the subject, description, justification, test plan, type, impact, and assigned engineer. " +
+  "Category, priority, risk, implementation plan, risk/impact analysis, backout plan, assignment group, " +
+  "linked project/case, and affected product aren't available to copy and need to be re-entered. " +
+  "Deployment, schedule, and approval fields are intentionally left blank for you to set for the new environment.";

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -193,6 +193,9 @@ export function countActiveCRFilters(filters: ChangeRequestFilters): number {
 //     for any of them.
 //   - `project`, `case`, `deployment`, `deployedProduct`, and `product` are
 //     read-only refs with no create-time field to set them from at all.
+//   - `serviceId`, `serviceOfferingId`, and `configurationItemId` are the
+//     mirror image: create accepts all three, and the read response carries no
+//     equivalent, so a clone always leaves them blank.
 //   - `assignedTeam` is read-only; create's nearest-sounding field
 //     (`groupId`, "Assignment group") is a *different* underlying reference
 //     with no confirmed equivalence to `assignedTeam` — mapping one into the
@@ -259,5 +262,6 @@ export function buildCloneChangeRequestNavState(
 export const CLONE_SOURCE_GAP_MESSAGE =
   "Copied the subject, description, justification, test plan, type, impact, and assigned engineer. " +
   "Category, priority, risk, implementation plan, risk/impact analysis, backout plan, assignment group, " +
-  "linked project/case, and affected product aren't available to copy and need to be re-entered. " +
+  "linked project/case, affected product, service, service offering, and configuration item aren't " +
+  "available to copy and need to be re-entered. " +
   "Deployment, schedule, and approval fields are intentionally left blank for you to set for the new environment.";


### PR DESCRIPTION
## What

Two related change-request/list-navigation fixes, combined into one PR to keep the review surface small.

### 1. List filters are no longer lost when returning from a detail page

Filter state already lives in the URL for the list surfaces built on the shared list component, but it was discarded twice on a round trip: the row link carried no router state, and the detail pages navigated "back" to a **hardcoded bare path**, which is a fresh forward navigation that throws the query string away.

Now the row link carries the originating location forward, and the case, change-request and incident detail pages prefer that over their hardcoded fallback (falling back when it is absent, e.g. a bookmarked or directly-linked record). The related-case and parent-case chips propagate it too, so following a chain still returns to the original filtered list rather than dropping to a bare list one step early.

`navigate(-1)` was considered and rejected: it breaks for directly-linked or refreshed detail pages, and following related-case links would walk back through each intermediate record instead of returning to the list.

**Scope limit worth knowing:** the change-request and incident *tabs* keep their filter state in local component state and never in the URL, so they reset on every remount — including a plain tab switch with no detail page involved. That is a separate, larger problem (migrating those two tabs onto the URL-synced pattern) and is tracked on its own. This PR does not claim to fix it.

### 2. Clone a change request

A **Clone** action on the change-request detail page opens the create form pre-filled from that record, so promoting the same change to another environment does not mean re-typing every field.

Fields deliberately **not** carried over: the deployment (the whole point of the clone is to change it), state, approval flags, planned start/end, and anything auto-numbered or timestamped. Carrying an approval flag across would be a real problem, not a cosmetic one. Comments and attachments are not cloned. No "cloned from" reference field was added — that is a data-model change, not prefill.

**The honest limitation, surfaced in the UI rather than hidden:** the detail and create shapes are asymmetric. `category`, `priority`, `risk`, `implementationPlan` and `riskImpactAnalysis` are accepted on create but **never returned by the detail response**, so there is no source value to copy. Rather than ship a clone that silently drops them, the create form shows a banner naming every field that could not be copied, so the engineer knows exactly what they still have to fill in. Making those fields readable is a backend contract change, tracked separately, and would unlock a fuller clone later.

One field pair (`groupId` on create versus the assigned team on read) looks like the same reference named inconsistently, and was deliberately **not** mapped — a wrong guess there would silently write the wrong group.

## Verification

Merged from two independently-developed branches; both original commits are intact, no squash or rebase. The two overlapping files merged without conflict markers and were re-read in full to confirm both behaviours coexist.

- `npx tsc -b` — clean
- `npx eslint .` — exactly one warning, the pre-existing `react-hooks/exhaustive-deps` in `CsmCaseDetailPage.tsx`, confirmed present on `main`
- `npx vitest run` — 547 passed, 9 failed; the 9 are the pre-existing failures on `main` in three files this branch does not touch. No new failures.
- Targeted: 48 tests across the touched and new test files, all passing, including both clone tests and the original request-approval groups in the same file

Not exercised against a running backend. Change-request creation is currently failing upstream for an unrelated reason, so a clone-then-create round trip could not be verified end to end.

## Unrelated pre-existing issue noticed

`npm ci` fails and plain `npm install` needs `--legacy-peer-deps`: `@wso2/oxygen-ui-icons-react@0.6.0` peer-requires `react@19.2.3` while the workspace pins `react@19.2.0`. Pre-existing on `main`, untouched here, but worth someone bumping one of the two.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to clone change requests, pre-filling eligible details while identifying information that must be entered again.
  - Added a Clone action to change-request detail pages.
- **Improvements**
  - Back navigation now returns to the originating list with filters and sorting preserved across cases, change requests, and incidents.
  - Related case and parent-case links retain the correct return destination.
- **Tests**
  - Expanded coverage for navigation, cloning behavior, field handling, and form defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->