### PR TITLE
feat(customer-portal): add accounts/updates/scim modules and next 5 endpoints

### DIFF
--- a/apps/customer-portal/backend-v2/.choreo/component.yaml
+++ b/apps/customer-portal/backend-v2/.choreo/component.yaml
@@ -1,0 +1,12 @@
+schemaVersion: 1.2
+
+endpoints:
+  - name: customer-portal-api
+    displayName: Customer Portal API (v2)
+    service:
+      basePath: /
+      port: 8080
+    type: REST
+    networkVisibilities:
+      - Public
+    schemaFilePath: openapi.yaml

--- a/apps/customer-portal/backend-v2/.choreo/component.yaml
+++ b/apps/customer-portal/backend-v2/.choreo/component.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.2
 
 endpoints:
   - name: customer-portal-api
-    displayName: Customer Portal API (v2)
+    displayName: Customer Portal API
     service:
       basePath: /
       port: 8080

--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -1,11 +1,23 @@
-# Entity service (cs-tools/entity-service)
-ENTITY_SERVICE_BASE_URL=http://localhost:8081
-# Optional — only needed if entity-service sits behind a gateway that requires
-# OAuth2 client-credentials auth. Leave unset for a local direct-to-service run.
+# Shared OAuth2 client credentials — entity-service, the updates service, and
+# SCIM all authenticate as this same app; only each service's base URL and
+# scopes differ. Optional — only needed if a service sits behind a gateway
+# that requires OAuth2 client-credentials auth. Leave unset for a local
+# direct-to-service run.
 OAUTH2_CLIENT_ID=
 OAUTH2_CLIENT_SECRET=
 OAUTH2_TOKEN_URL=
+
+# Entity service (cs-tools/entity-service)
+ENTITY_SERVICE_BASE_URL=http://localhost:8081
 ENTITY_SERVICE_SCOPES=
+
+# WSO2 Updates service (product update levels / update descriptions)
+UPDATES_BASE_URL=
+UPDATES_SCOPES=
+
+# SCIM operations service (phone number read/update for GET/PATCH /users/me)
+SCIM_BASE_URL=
+SCIM_SCOPES=
 
 # Auth
 # AUTH_TOKEN_VALIDATOR_ENABLED=false (below) skips JWT signature verification —

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,11 +6,13 @@ responses for the frontend. This is a Go rewrite of the Ballerina backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** Only 6 routes are wired up so far (`GET /health`, `GET /users/me`,
-`POST /projects/search`, `GET /projects/{id}`, `POST /cases/search`, `GET /cases/{id}`). The
-Ballerina backend exposes ~100 routes across many more modules (accounts, deployments, deployed
-products, attachments, comments, conversations, change requests, call requests, catalogs, time
-cards, updates, registry tokens, contacts, escalations, product vulnerabilities, AI chat/websocket,
+**Status: in progress.** 11 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
+`POST /accounts/search`, `GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
+`POST /cases/search`, `GET /cases/{id}`, `GET /updates/product-update-levels`,
+`POST /updates/levels/search`) across three upstream services: entity-service, the WSO2 Updates
+service, and SCIM. The Ballerina backend exposes ~100 routes across many more modules (deployments,
+deployed products, attachments, comments, conversations, change requests, call requests, catalogs,
+time cards, registry tokens, contacts, escalations, product vulnerabilities, AI chat/websocket,
 etc.) — none of those are ported yet. Follow the recipe below to add the next one.
 
 ## Which entity-service
@@ -26,6 +28,27 @@ deployment will 404 on those. If the Ballerina backend has an endpoint with no `
 equivalent at all (e.g. `GET /metadata` — entity-service has no metadata endpoint), do not invent
 one; add a code comment at the call site noting the gap and flag it instead of fabricating a
 response.
+
+## Other upstream services
+
+Not everything comes from entity-service. Two more upstream service clients exist, each following
+the same `Config{BaseURL, TokenURL, ClientID, ClientSecret, Scopes}` + `Client` + `NewClient` +
+private `do()` shape as `internal/entity`:
+
+- **`internal/updates`** — the WSO2 Updates service (product update levels, update descriptions
+  between levels). Its own types are already portal-shaped camelCase (`internal/updates/types.go`
+  defines both the upstream snake_case wire structs and the portal camelCase structs, translated by
+  `internal/updates/mapper.go`) — so handlers write its return values directly via `writeJSONValue`
+  with **no** further `internal/dto` mapping layer. This is the one deliberate exception to the
+  "always map through dto" rule below, because the mapping already happened inside the client.
+- **`internal/scim`** — the SCIM operations service, used only for a user's phone number
+  (`SearchUser`, `UpdateUserPhone`). Its `UserInfo` return type is already a small portal-clean
+  struct, so it's merged directly into `dto.UserMeResponse`/`dto.UserUpdateResponse` in
+  `internal/handler/users.go` — again no separate mapping layer needed.
+
+All three service clients (entity, updates, SCIM) authenticate as the same shared OAuth2
+client-credentials app in `cmd/server/main.go` — only each service's `*_BASE_URL`/`*_SCOPES` env
+vars differ.
 
 ## Middleware chain
 
@@ -62,6 +85,20 @@ When you add a new endpoint, add the equivalent trimming — read the field care
 including it; when in doubt whether a field is customer-appropriate, leave it out and note why in
 a comment on the DTO struct (see `internal/dto/case.go` for examples).
 
+**Data-source normalization is a second job of the DTO layer.** Unlike projects and cases,
+entity-service's account endpoints (`GET /accounts/{id}`, `POST /accounts/search`) return a
+genuinely different wire shape depending on whether it's deployed with `DATA_SOURCE=postgres` or
+`DATA_SOURCE=servicenow` — see `internal/entity/types.go`'s `AccountDetail`/`AccountSummary`
+comments for how the two shapes are unioned into one Go struct (their JSON keys never collide) and
+`internal/dto/account.go` for how the DTO mapper picks whichever fields the active data source
+populated (e.g. `Tier` prefers entity-service's `tier`, falling back to `classification`) to
+produce one consistent contract for the frontend regardless of which data source is live. This is
+a genuine advantage of the DTO-mapping convention over raw passthrough — `apps/csm-portal/backend`
+has to model this as an OpenAPI `oneOf` in its spec and pass the ambiguity on to the frontend;
+here, it's resolved once in the mapper. Also deliberately excluded from account DTOs: `ArrToday`
+(annual recurring revenue — WSO2-internal financial data, never expose to the customer) and `Pod`
+(WSO2-internal account routing).
+
 Request bodies are the exception: incoming search/filter payloads are decoded directly into the
 entity package's request structs (e.g. `entity.SearchProjectsRequest`) with no separate DTO layer,
 since those shapes are already what the frontend needs to send — there is nothing to hide on the
@@ -85,7 +122,10 @@ request side.
 6. **Route** (`cmd/server/main.go`) — register using Go 1.22 method-prefixed patterns:
    `"POST /cases/{id}/comments"`.
 7. **README** — add the endpoint under "API Endpoints" in `README.md`.
-8. **gosec** — run `gosec -fmt=text ./...` (must report 0 issues) before opening a PR.
+8. **OpenAPI spec** (`openapi.yaml`) — add the path with `200`/`400`/`401`/`403`/`500` responses
+   (`404` too for get-by-id, `413` too for endpoints with a request body); every endpoint must
+   declare `403` since `mapUpstreamError` can return it.
+9. **gosec** — run `gosec -fmt=text ./...` (must report 0 issues) before opening a PR.
 
 ## Handler conventions
 

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,9 +5,10 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the first 6 routes are implemented so far (see below).
-Everything else the Ballerina backend exposes still needs a Go handler; add them following the
-pattern described in [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
+This is a work in progress — only the 11 routes listed below are implemented so far, across
+entity-service, the WSO2 Updates service, and SCIM. Everything else the Ballerina backend exposes
+still needs a Go handler; add them following the pattern described in
+[CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
 
 ## Quick Start
 
@@ -27,14 +28,17 @@ Backend starts at `http://localhost:8080`.
 - Entry point: `cmd/server/main.go`
 - Authentication:
   - Incoming requests: JWT Bearer token; pass as `x-jwt-assertion` header when testing locally
-  - Outbound calls to entity-service: OAuth2 client credentials grant (optional — entity-service
-    itself does not validate inbound credentials, see [CLAUDE.md](./CLAUDE.md))
+  - Outbound calls to entity-service, the Updates service, and SCIM: OAuth2 client credentials
+    grant, shared across all three (optional — entity-service itself does not validate inbound
+    credentials, see [CLAUDE.md](./CLAUDE.md))
 
 ## Prerequisites
 
 - Go `1.26+` — [install](https://go.dev/doc/install)
 - A running instance of `cs-tools/entity-service` (see its own README for `DATA_SOURCE` setup —
-  `GET /users/me` requires `DATA_SOURCE=servicenow`)
+  `GET`/`PATCH /users/me` require `DATA_SOURCE=servicenow`)
+- A running instance of the WSO2 Updates service and the SCIM operations service (for the
+  `/updates/*` routes and phone-number fields on `/users/me`)
 
 ## Testing
 
@@ -71,13 +75,35 @@ The scan must report **0 issues** before opening a PR touching this backend.
 
 Copy `.env.example` to `.env` and fill in the values.
 
+### Shared OAuth2 client credentials
+
+Every upstream service client (entity-service, updates, SCIM) authenticates as the same OAuth2
+client-credentials app — only each service's base URL and scopes differ.
+
+| Variable | Description |
+|---|---|
+| `OAUTH2_CLIENT_ID` / `OAUTH2_CLIENT_SECRET` / `OAUTH2_TOKEN_URL` | Optional — only needed if a service sits behind a gateway requiring OAuth2 client-credentials auth |
+
 ### Entity service
 
 | Variable | Description |
 |---|---|
 | `ENTITY_SERVICE_BASE_URL` | Base URL of `cs-tools/entity-service` |
-| `OAUTH2_CLIENT_ID` / `OAUTH2_CLIENT_SECRET` / `OAUTH2_TOKEN_URL` | Optional — only needed if entity-service sits behind a gateway requiring OAuth2 client-credentials auth |
 | `ENTITY_SERVICE_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+
+### Updates service
+
+| Variable | Description |
+|---|---|
+| `UPDATES_BASE_URL` | Base URL of the WSO2 Updates service |
+| `UPDATES_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+
+### SCIM operations service
+
+| Variable | Description |
+|---|---|
+| `SCIM_BASE_URL` | Base URL of the SCIM operations service |
+| `SCIM_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 
 ### Auth
 
@@ -102,13 +128,24 @@ backend-v2/
 ├── internal/
 │   ├── apierror/                # Typed upstream error type (4xx/5xx passthrough)
 │   ├── entity/                  # OAuth2 HTTP client for cs-tools/entity-service
-│   │   ├── client.go            # Config/Client/do()/getJSON()/postJSON()
+│   │   ├── client.go            # Config/Client/do()/getJSON()/postJSON()/patchJSON()
 │   │   ├── types.go             # entity-service's wire-format structs (internal to this package)
-│   │   ├── users.go             # GetMe
+│   │   ├── users.go             # GetMe, PatchMe
+│   │   ├── accounts.go          # SearchAccounts, GetAccount
 │   │   ├── projects.go          # SearchProjects, GetProject
 │   │   └── cases.go             # SearchCases, GetCase
+│   ├── updates/                 # OAuth2 HTTP client for the WSO2 Updates service
+│   │   ├── client.go            # Config/Client/do()
+│   │   ├── types.go             # upstream (snake_case) vs portal (camelCase) structs
+│   │   ├── mapper.go            # snake_case <-> camelCase mapping
+│   │   └── updates.go           # GetProductUpdateLevels, SearchUpdatesBetweenUpdateLevels
+│   ├── scim/                    # OAuth2 HTTP client for the SCIM operations service
+│   │   ├── client.go            # Config/Client/do()
+│   │   ├── types.go
+│   │   └── scim.go              # SearchUser, UpdateUserPhone
 │   ├── dto/                     # Portal-facing response shapes + Map* functions from entity types
 │   │   ├── user.go
+│   │   ├── account.go
 │   │   ├── project.go
 │   │   └── case.go
 │   ├── middleware/
@@ -118,9 +155,13 @@ backend-v2/
 │   │   └── security_headers.go  # X-Content-Type-Options, CSP, HSTS on every response
 │   └── handler/
 │       ├── response.go          # writeJSON/writeError/mapUpstreamError shared helpers
-│       ├── users.go             # GET /users/me
+│       ├── users.go             # GET/PATCH /users/me
+│       ├── accounts.go          # POST /accounts/search, GET /accounts/{id}
 │       ├── projects.go          # POST /projects/search, GET /projects/{id}
-│       └── cases.go             # POST /cases/search, GET /cases/{id}
+│       ├── cases.go             # POST /cases/search, GET /cases/{id}
+│       └── updates.go           # GET /updates/product-update-levels, POST /updates/levels/search
+├── .choreo/component.yaml
+├── openapi.yaml
 ├── .env.example
 └── go.mod
 ```
@@ -128,15 +169,24 @@ backend-v2/
 ## API Endpoints
 
 - `GET /health` — liveness check, no auth
-- `GET /users/me` — current user's profile (requires entity-service running with `DATA_SOURCE=servicenow`)
+- `GET /users/me` — current user's profile; name/timezone/roles from entity-service (requires
+  `DATA_SOURCE=servicenow`), phone number from SCIM
+- `PATCH /users/me` — update phone number (SCIM) and/or timezone (entity-service); at least one required
+- `POST /accounts/search` — search accounts (normalizes entity-service's Postgres/ServiceNow shapes into one)
+- `GET /accounts/{id}` — get account by ID (same normalization)
 - `POST /projects/search` — search projects
 - `GET /projects/{id}` — get project by ID
 - `POST /cases/search` — search cases
 - `GET /cases/{id}` — get case by ID
+- `GET /updates/product-update-levels` — list product update levels
+- `POST /updates/levels/search` — search update descriptions between two update levels
 
-All response shapes are portal-owned DTOs (see `internal/dto`) — entity-service's raw response is
+Full request/response schemas are documented in [openapi.yaml](./openapi.yaml). All entity-service
+and SCIM response shapes are portal-owned DTOs (see `internal/dto`) — the raw upstream response is
 never returned verbatim; see [CLAUDE.md](./CLAUDE.md#response-shaping) for what is deliberately
-excluded from each and why.
+excluded from each and why. The `updates` client is the one exception — its own types are already
+portal-shaped camelCase (translated from the upstream snake_case in `internal/updates/mapper.go`),
+so handlers write its return values directly with no further DTO layer.
 
 ## Run Locally
 
@@ -154,6 +204,16 @@ JWT="<your-jwt-token>"
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/users/me
 
+curl -X PATCH http://localhost:8080/users/me \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"timeZone":"Asia/Colombo"}'
+
+curl -X POST http://localhost:8080/accounts/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0},"filters":{"searchQuery":"acme"}}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/accounts/<account-id>
+
 curl -X POST http://localhost:8080/projects/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":10,"offset":0},"searchQuery":"acme"}'
@@ -165,4 +225,10 @@ curl -X POST http://localhost:8080/cases/search \
   -d '{"pagination":{"limit":10,"offset":0},"filters":{"searchQuery":"login error"}}'
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/cases/<case-id>
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/product-update-levels
+
+curl -X POST http://localhost:8080/updates/levels/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"productName":"wso2am","productVersion":"4.2.0","startingUpdateLevel":1,"endingUpdateLevel":10}'
 ```

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -34,24 +34,53 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/handler"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/scim"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/updates"
 )
 
 func main() {
 	loadDotEnv(".env")
 	middleware.ConfigureLogger()
 
+	// entity-service, the updates service, and SCIM all authenticate as the
+	// same OAuth2 client-credentials app; only each service's base URL and
+	// scopes differ.
+	oauth2ClientID := os.Getenv("OAUTH2_CLIENT_ID")
+	oauth2ClientSecret := os.Getenv("OAUTH2_CLIENT_SECRET")
+	oauth2TokenURL := os.Getenv("OAUTH2_TOKEN_URL")
+
 	entityCfg := entity.Config{
 		BaseURL:      mustEnv("ENTITY_SERVICE_BASE_URL"),
-		TokenURL:     os.Getenv("OAUTH2_TOKEN_URL"),
-		ClientID:     os.Getenv("OAUTH2_CLIENT_ID"),
-		ClientSecret: os.Getenv("OAUTH2_CLIENT_SECRET"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
 		Scopes:       splitComma(os.Getenv("ENTITY_SERVICE_SCOPES")),
 	}
 	entityClient := entity.NewClient(entityCfg)
 
-	userHandler := handler.NewUserHandler(entityClient)
+	updatesCfg := updates.Config{
+		BaseURL:      mustEnv("UPDATES_BASE_URL"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
+		Scopes:       splitComma(os.Getenv("UPDATES_SCOPES")),
+	}
+	updatesClient := updates.NewClient(updatesCfg)
+
+	scimCfg := scim.Config{
+		BaseURL:      mustEnv("SCIM_BASE_URL"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
+		Scopes:       splitComma(os.Getenv("SCIM_SCOPES")),
+	}
+	scimClient := scim.NewClient(scimCfg)
+
+	userHandler := handler.NewUserHandler(entityClient, scimClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
 	caseHandler := handler.NewCaseHandler(entityClient)
+	accountHandler := handler.NewAccountHandler(entityClient)
+	updatesHandler := handler.NewUpdatesHandler(updatesClient)
 
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
@@ -66,15 +95,22 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	// GET /users/me is only served by entity-service when it runs with
-	// DATA_SOURCE=servicenow — see internal/entity/users.go.
+	// GET/PATCH /users/me are only served by entity-service when it runs
+	// with DATA_SOURCE=servicenow — see internal/entity/users.go.
 	mux.HandleFunc("GET /users/me", userHandler.GetMe)
+	mux.HandleFunc("PATCH /users/me", userHandler.PatchMe)
 
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("GET /projects/{id}", projectHandler.GetProject)
 
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
+
+	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
+	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)
+
+	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
+	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)
 
 	addr := ":" + mustPort("PORT", "8080")
 

--- a/apps/customer-portal/backend-v2/internal/dto/account.go
+++ b/apps/customer-portal/backend-v2/internal/dto/account.go
@@ -42,6 +42,7 @@ type AccountSummary struct {
 	HasAgent         bool    `json:"hasAgent"`
 	HasKbReferences  bool    `json:"hasKbReferences"`
 	CreatedOn        *string `json:"createdOn,omitempty"`
+	UpdatedOn        *string `json:"updatedOn,omitempty"`
 }
 
 // SearchAccountsResponse is the portal's response for POST /accounts/search.
@@ -63,13 +64,14 @@ func MapSearchAccounts(r entity.SearchAccountsResponse) SearchAccountsResponse {
 			Tier:             firstNonNil(a.Tier, a.Classification),
 			Region:           a.Region,
 			SupportTier:      a.SupportTier,
-			Owner:            mapAccountRef(a.Owner, a.OwnerID),
-			TechnicalOwner:   mapAccountRef(a.TechnicalOwner, a.TechnicalOwnerID),
+			Owner:            mapAccountRef(a.Owner),
+			TechnicalOwner:   mapAccountRef(a.TechnicalOwner),
 			ActivationDate:   a.ActivationDate,
 			DeactivationDate: a.DeactivationDate,
 			HasAgent:         boolValue(firstNonNilBool(a.HasAgent, a.AgentEnabled)),
 			HasKbReferences:  boolValue(firstNonNilBool(a.HasKbReferences, a.KbReferencesEnabled)),
 			CreatedOn:        a.CreatedOn,
+			UpdatedOn:        a.UpdatedOn,
 		})
 	}
 	return SearchAccountsResponse{
@@ -111,8 +113,8 @@ func MapAccountDetails(a entity.AccountDetail) AccountDetails {
 		Tier:             firstNonNil(a.Tier, a.Classification),
 		Region:           a.Region,
 		SupportTier:      supportTier,
-		Owner:            mapAccountRef(a.Owner, a.OwnerID),
-		TechnicalOwner:   mapAccountRef(a.TechnicalOwner, a.TechnicalOwnerID),
+		Owner:            mapAccountRef(a.Owner),
+		TechnicalOwner:   mapAccountRef(a.TechnicalOwner),
 		ActivationDate:   a.ActivationDate,
 		DeactivationDate: a.DeactivationDate,
 		HasAgent:         boolValue(firstNonNilBool(a.HasAgent, a.AgentEnabled)),
@@ -122,17 +124,15 @@ func MapAccountDetails(a entity.AccountDetail) AccountDetails {
 	}
 }
 
-// mapAccountRef prefers the ServiceNow {id,name} reference; if only a bare
-// Postgres ID is available, it's surfaced as a Ref with an empty Name rather
-// than dropped entirely.
-func mapAccountRef(ref *entity.EntityRef, bareID *string) *Ref {
-	if ref != nil {
-		return &Ref{ID: ref.ID, Name: ref.Name}
+// mapAccountRef surfaces the ServiceNow {id,name} reference only. A bare
+// Postgres owner/technicalOwner ID (no name attached) is intentionally
+// dropped rather than exposed as a nameless Ref — see AccountSummary's doc
+// comment.
+func mapAccountRef(ref *entity.EntityRef) *Ref {
+	if ref == nil {
+		return nil
 	}
-	if bareID != nil {
-		return &Ref{ID: *bareID}
-	}
-	return nil
+	return &Ref{ID: ref.ID, Name: ref.Name}
 }
 
 func firstNonNil(a, b *string) *string {

--- a/apps/customer-portal/backend-v2/internal/dto/account.go
+++ b/apps/customer-portal/backend-v2/internal/dto/account.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// AccountSummary is one item of the portal's response for POST /accounts/search.
+//
+// Normalizes entity-service's two data-source-dependent shapes (Postgres
+// Account vs ServiceNow SNAccountView) into one: Tier prefers entity-service's
+// "tier" and falls back to "classification"; SupportTier carries the plain
+// label. Deliberately excludes entity-service's SfID (Salesforce internal
+// ID), OwnerID/TechnicalOwnerID (bare internal IDs with no name — Owner/
+// TechnicalOwner below is used instead when available), Pod (WSO2-internal
+// account routing), CreatedBy (internal user ID), and ArrToday — annual
+// recurring revenue is WSO2-internal financial data and must never reach the
+// customer portal frontend.
+type AccountSummary struct {
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	Tier             *string `json:"tier,omitempty"`
+	Region           *string `json:"region,omitempty"`
+	SupportTier      *string `json:"supportTier,omitempty"`
+	Owner            *Ref    `json:"owner,omitempty"`
+	TechnicalOwner   *Ref    `json:"technicalOwner,omitempty"`
+	ActivationDate   *string `json:"activationDate,omitempty"`
+	DeactivationDate *string `json:"deactivationDate,omitempty"`
+	HasAgent         bool    `json:"hasAgent"`
+	HasKbReferences  bool    `json:"hasKbReferences"`
+	CreatedOn        *string `json:"createdOn,omitempty"`
+}
+
+// SearchAccountsResponse is the portal's response for POST /accounts/search.
+type SearchAccountsResponse struct {
+	Accounts []AccountSummary `json:"accounts"`
+	Total    int              `json:"total"`
+	Limit    int              `json:"limit"`
+	Offset   int              `json:"offset"`
+	HasMore  bool             `json:"hasMore"`
+}
+
+// MapSearchAccounts builds the portal response from entity-service's SearchAccountsResponse.
+func MapSearchAccounts(r entity.SearchAccountsResponse) SearchAccountsResponse {
+	accounts := make([]AccountSummary, 0, len(r.Accounts))
+	for _, a := range r.Accounts {
+		accounts = append(accounts, AccountSummary{
+			ID:               a.ID,
+			Name:             a.Name,
+			Tier:             firstNonNil(a.Tier, a.Classification),
+			Region:           a.Region,
+			SupportTier:      a.SupportTier,
+			Owner:            mapAccountRef(a.Owner, a.OwnerID),
+			TechnicalOwner:   mapAccountRef(a.TechnicalOwner, a.TechnicalOwnerID),
+			ActivationDate:   a.ActivationDate,
+			DeactivationDate: a.DeactivationDate,
+			HasAgent:         boolValue(firstNonNilBool(a.HasAgent, a.AgentEnabled)),
+			HasKbReferences:  boolValue(firstNonNilBool(a.HasKbReferences, a.KbReferencesEnabled)),
+			CreatedOn:        a.CreatedOn,
+		})
+	}
+	return SearchAccountsResponse{
+		Accounts: accounts,
+		Total:    r.Total,
+		Limit:    r.Limit,
+		Offset:   r.Offset,
+		HasMore:  r.HasMore,
+	}
+}
+
+// AccountDetails is the portal's response for GET /accounts/{id}. See
+// AccountSummary's doc comment for the fields deliberately excluded here too.
+type AccountDetails struct {
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	Tier             *string `json:"tier,omitempty"`
+	Region           *string `json:"region,omitempty"`
+	SupportTier      *string `json:"supportTier,omitempty"`
+	Owner            *Ref    `json:"owner,omitempty"`
+	TechnicalOwner   *Ref    `json:"technicalOwner,omitempty"`
+	ActivationDate   *string `json:"activationDate,omitempty"`
+	DeactivationDate *string `json:"deactivationDate,omitempty"`
+	HasAgent         bool    `json:"hasAgent"`
+	HasKbReferences  bool    `json:"hasKbReferences"`
+	CreatedOn        *string `json:"createdOn,omitempty"`
+	UpdatedOn        *string `json:"updatedOn,omitempty"`
+}
+
+// MapAccountDetails builds the portal response from entity-service's AccountDetail.
+func MapAccountDetails(a entity.AccountDetail) AccountDetails {
+	var supportTier *string
+	if a.SupportTier != nil {
+		supportTier = &a.SupportTier.Label
+	}
+	return AccountDetails{
+		ID:               a.ID,
+		Name:             a.Name,
+		Tier:             firstNonNil(a.Tier, a.Classification),
+		Region:           a.Region,
+		SupportTier:      supportTier,
+		Owner:            mapAccountRef(a.Owner, a.OwnerID),
+		TechnicalOwner:   mapAccountRef(a.TechnicalOwner, a.TechnicalOwnerID),
+		ActivationDate:   a.ActivationDate,
+		DeactivationDate: a.DeactivationDate,
+		HasAgent:         boolValue(firstNonNilBool(a.HasAgent, a.AgentEnabled)),
+		HasKbReferences:  boolValue(firstNonNilBool(a.HasKbReferences, a.KbReferencesEnabled)),
+		CreatedOn:        a.CreatedOn,
+		UpdatedOn:        a.UpdatedOn,
+	}
+}
+
+// mapAccountRef prefers the ServiceNow {id,name} reference; if only a bare
+// Postgres ID is available, it's surfaced as a Ref with an empty Name rather
+// than dropped entirely.
+func mapAccountRef(ref *entity.EntityRef, bareID *string) *Ref {
+	if ref != nil {
+		return &Ref{ID: ref.ID, Name: ref.Name}
+	}
+	if bareID != nil {
+		return &Ref{ID: *bareID}
+	}
+	return nil
+}
+
+func firstNonNil(a, b *string) *string {
+	if a != nil {
+		return a
+	}
+	return b
+}
+
+func firstNonNilBool(a, b *bool) *bool {
+	if a != nil {
+		return a
+	}
+	return b
+}
+
+func boolValue(b *bool) bool {
+	return b != nil && *b
+}

--- a/apps/customer-portal/backend-v2/internal/dto/project.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project.go
@@ -44,7 +44,7 @@ type SearchProjectsResponse struct {
 	Total    int              `json:"total"`
 	Limit    int              `json:"limit"`
 	Offset   int              `json:"offset"`
-	HasMore  bool              `json:"hasMore"`
+	HasMore  bool             `json:"hasMore"`
 }
 
 // MapSearchProjects builds the portal response from entity-service's SearchProjectsResponse.

--- a/apps/customer-portal/backend-v2/internal/dto/user.go
+++ b/apps/customer-portal/backend-v2/internal/dto/user.go
@@ -23,14 +23,18 @@ package dto
 
 import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 
-// UserMeResponse is the portal's response for GET /users/me.
+// UserMeResponse is the portal's response for GET /users/me. PhoneNumber is
+// not part of entity-service's response — the handler sets it separately from
+// the SCIM client's result, since phone numbers are sourced from SCIM, not
+// entity-service.
 type UserMeResponse struct {
-	ID        string   `json:"id"`
-	Email     string   `json:"email"`
-	FirstName *string  `json:"firstName,omitempty"`
-	LastName  string   `json:"lastName"`
-	TimeZone  *string  `json:"timeZone,omitempty"`
-	Roles     []string `json:"roles"`
+	ID          string   `json:"id"`
+	Email       string   `json:"email"`
+	FirstName   *string  `json:"firstName,omitempty"`
+	LastName    string   `json:"lastName"`
+	TimeZone    *string  `json:"timeZone,omitempty"`
+	Roles       []string `json:"roles"`
+	PhoneNumber *string  `json:"phoneNumber,omitempty"`
 }
 
 // MapUserMe builds the portal response from entity-service's GetUserMeResponse.
@@ -43,4 +47,12 @@ func MapUserMe(u entity.GetUserMeResponse) UserMeResponse {
 		TimeZone:  u.TimeZone,
 		Roles:     u.Roles,
 	}
+}
+
+// UserUpdateResponse is the portal's response for PATCH /users/me. Only the
+// fields that were actually updated are set — phoneNumber via SCIM,
+// timeZone via entity-service.
+type UserUpdateResponse struct {
+	PhoneNumber *string `json:"phoneNumber,omitempty"`
+	TimeZone    *string `json:"timeZone,omitempty"`
 }

--- a/apps/customer-portal/backend-v2/internal/entity/accounts.go
+++ b/apps/customer-portal/backend-v2/internal/entity/accounts.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// SearchAccounts calls POST /accounts/search.
+func (c *Client) SearchAccounts(ctx context.Context, req SearchAccountsRequest) (SearchAccountsResponse, error) {
+	var out SearchAccountsResponse
+	err := c.postJSON(ctx, "/accounts/search", req, &out)
+	return out, err
+}
+
+// GetAccount calls GET /accounts/{id}.
+func (c *Client) GetAccount(ctx context.Context, id string) (AccountDetail, error) {
+	var out AccountDetail
+	err := c.getJSON(ctx, fmt.Sprintf("/accounts/%s", url.PathEscape(id)), &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/client.go
+++ b/apps/customer-portal/backend-v2/internal/entity/client.go
@@ -214,3 +214,20 @@ func (c *Client) postJSON(ctx context.Context, path string, reqBody, out any) er
 	}
 	return nil
 }
+
+// patchJSON marshals reqBody, issues a PATCH request, and decodes the JSON
+// response into out.
+func (c *Client) patchJSON(ctx context.Context, path string, reqBody, out any) error {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("entity: encode request for PATCH %s: %w", path, err)
+	}
+	body, err := c.do(ctx, http.MethodPatch, path, payload)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("entity: decode response for PATCH %s: %w", path, err)
+	}
+	return nil
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -79,7 +79,7 @@ type SearchProjectsRequest struct {
 // ProjectClosureFields groups the ServiceNow-only closure-tracking fields
 // shared by ProjectDetailsView and ProjectView.
 type ProjectClosureFields struct {
-	ClosureState                   *string         `json:"closureState"`
+	ClosureState                    *string         `json:"closureState"`
 	EndDateClosureState             *string         `json:"endDateClosureState"`
 	InvoiceDueDateClosureState      *string         `json:"invoiceDueDateClosureState"`
 	ComplianceViolationClosureState *string         `json:"complianceViolationClosureState"`
@@ -170,16 +170,16 @@ type SearchAccountsRequest struct {
 // AccountSummary is a single search result item from POST /accounts/search —
 // a superset of entity-service's Postgres Account and ServiceNow SNAccountView.
 type AccountSummary struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
 	Region *string `json:"region,omitempty"`
 	// Postgres-only.
-	SfID             *string `json:"sfId,omitempty"`
-	Tier             *string `json:"tier,omitempty"`
-	OwnerID          *string `json:"ownerId,omitempty"`
-	TechnicalOwnerID *string `json:"technicalOwnerId,omitempty"`
-	AgentEnabled     *bool   `json:"agentEnabled,omitempty"`
-	KbReferencesEnabled *bool `json:"kbReferencesEnabled,omitempty"`
+	SfID                *string `json:"sfId,omitempty"`
+	Tier                *string `json:"tier,omitempty"`
+	OwnerID             *string `json:"ownerId,omitempty"`
+	TechnicalOwnerID    *string `json:"technicalOwnerId,omitempty"`
+	AgentEnabled        *bool   `json:"agentEnabled,omitempty"`
+	KbReferencesEnabled *bool   `json:"kbReferencesEnabled,omitempty"`
 	// ServiceNow-only.
 	Classification  *string    `json:"classification,omitempty"`
 	Pod             *string    `json:"pod,omitempty"`
@@ -213,12 +213,12 @@ type AccountDetail struct {
 	Name   string  `json:"name"`
 	Region *string `json:"region,omitempty"`
 	// Postgres-only.
-	SfID             *string `json:"sfId,omitempty"`
-	Tier             *string `json:"tier,omitempty"`
-	OwnerID          *string `json:"ownerId,omitempty"`
-	TechnicalOwnerID *string `json:"technicalOwnerId,omitempty"`
-	AgentEnabled     *bool   `json:"agentEnabled,omitempty"`
-	KbReferencesEnabled *bool `json:"kbReferencesEnabled,omitempty"`
+	SfID                *string `json:"sfId,omitempty"`
+	Tier                *string `json:"tier,omitempty"`
+	OwnerID             *string `json:"ownerId,omitempty"`
+	TechnicalOwnerID    *string `json:"technicalOwnerId,omitempty"`
+	AgentEnabled        *bool   `json:"agentEnabled,omitempty"`
+	KbReferencesEnabled *bool   `json:"kbReferencesEnabled,omitempty"`
 	// ServiceNow-only.
 	Classification  *string         `json:"classification,omitempty"`
 	Pod             *string         `json:"pod,omitempty"`
@@ -248,21 +248,21 @@ type CaseSort struct {
 // Only the fields the portal currently exposes are included here; extend as
 // needed when more filters are surfaced to the frontend.
 type SearchCasesFilters struct {
-	Types           []string   `json:"types,omitempty"`
-	SearchQuery     string     `json:"searchQuery,omitempty"`
-	ProjectIDs      []string   `json:"projectIds,omitempty"`
-	DeploymentIDs   []string   `json:"deploymentIds,omitempty"`
-	States          []string   `json:"states,omitempty"`
-	Severities      []string   `json:"severities,omitempty"`
-	IssueTypes      []string   `json:"issueTypes,omitempty"`
-	EngagementTypes []string   `json:"engagementTypes,omitempty"`
-	CreatedBy       []string   `json:"createdBy,omitempty"`
-	CreatedByMe     bool       `json:"createdByMe,omitempty"`
-	WorkStates      []string   `json:"workStates,omitempty"`
-	AssignedUserIDs []string   `json:"assignedUserIds,omitempty"`
-	ProductNames    []string   `json:"productNames,omitempty"`
-	Tags            []string   `json:"tags,omitempty"`
-	ParentID        *string    `json:"parentId,omitempty"`
+	Types           []string `json:"types,omitempty"`
+	SearchQuery     string   `json:"searchQuery,omitempty"`
+	ProjectIDs      []string `json:"projectIds,omitempty"`
+	DeploymentIDs   []string `json:"deploymentIds,omitempty"`
+	States          []string `json:"states,omitempty"`
+	Severities      []string `json:"severities,omitempty"`
+	IssueTypes      []string `json:"issueTypes,omitempty"`
+	EngagementTypes []string `json:"engagementTypes,omitempty"`
+	CreatedBy       []string `json:"createdBy,omitempty"`
+	CreatedByMe     bool     `json:"createdByMe,omitempty"`
+	WorkStates      []string `json:"workStates,omitempty"`
+	AssignedUserIDs []string `json:"assignedUserIds,omitempty"`
+	ProductNames    []string `json:"productNames,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	ParentID        *string  `json:"parentId,omitempty"`
 }
 
 // SearchCasesRequest is the input for POST /cases/search.

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -45,6 +45,24 @@ type GetUserMeResponse struct {
 	Roles     []string `json:"roles"`
 }
 
+// PatchUserMeRequest is the request body for PATCH /users/me.
+type PatchUserMeRequest struct {
+	TimeZone string `json:"timeZone"`
+}
+
+// PatchUserMeUpdated contains the key fields returned after a successful user update.
+type PatchUserMeUpdated struct {
+	ID        string `json:"id"`
+	UpdatedBy string `json:"updatedBy"`
+	UpdatedOn string `json:"updatedOn"`
+}
+
+// PatchUserMeResponse is entity-service's response for PATCH /users/me.
+type PatchUserMeResponse struct {
+	Message string             `json:"message"`
+	User    PatchUserMeUpdated `json:"user"`
+}
+
 // --- projects ---
 
 // SearchProjectsRequest is the input for POST /projects/search.
@@ -113,6 +131,109 @@ type ProjectDetailsView struct {
 	CreatedOn        time.Time         `json:"createdOn"`
 	UpdatedOn        time.Time         `json:"updatedOn"`
 	ProjectClosureFields
+}
+
+// --- accounts ---
+//
+// entity-service returns a different wire shape for these two endpoints
+// depending on its DATA_SOURCE (postgres vs servicenow) — unlike projects and
+// cases, account responses have not been unified upstream. The structs below
+// are a superset of both shapes: JSON key names never collide between the two
+// data sources (they use different field names for the same concept, e.g.
+// "tier" vs "classification", "agentEnabled" vs "hasAgent"), and every date/
+// time field is typed as *string here since a Go string field decodes a JSON
+// string value regardless of whether the source type was time.Time or a
+// plain string — so only the fields the active data source actually
+// populates come out non-nil.
+
+// SupportTierRef is a compact reference to a support tier carrying its label
+// (ServiceNow data source, GET /accounts/{id} only).
+type SupportTierRef struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// SearchAccountsFilters holds the optional filter criteria for an account search.
+type SearchAccountsFilters struct {
+	SearchQuery    string `json:"searchQuery,omitempty"`
+	Active         *bool  `json:"active,omitempty"`
+	Pod            string `json:"pod,omitempty"`
+	Classification string `json:"classification,omitempty"`
+}
+
+// SearchAccountsRequest is the input for POST /accounts/search.
+type SearchAccountsRequest struct {
+	Pagination Pagination            `json:"pagination"`
+	Filters    SearchAccountsFilters `json:"filters,omitempty"`
+}
+
+// AccountSummary is a single search result item from POST /accounts/search —
+// a superset of entity-service's Postgres Account and ServiceNow SNAccountView.
+type AccountSummary struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Region *string `json:"region,omitempty"`
+	// Postgres-only.
+	SfID             *string `json:"sfId,omitempty"`
+	Tier             *string `json:"tier,omitempty"`
+	OwnerID          *string `json:"ownerId,omitempty"`
+	TechnicalOwnerID *string `json:"technicalOwnerId,omitempty"`
+	AgentEnabled     *bool   `json:"agentEnabled,omitempty"`
+	KbReferencesEnabled *bool `json:"kbReferencesEnabled,omitempty"`
+	// ServiceNow-only.
+	Classification  *string    `json:"classification,omitempty"`
+	Pod             *string    `json:"pod,omitempty"`
+	SupportTier     *string    `json:"supportTier,omitempty"`
+	ArrToday        *string    `json:"arrToday,omitempty"`
+	Owner           *EntityRef `json:"owner,omitempty"`
+	TechnicalOwner  *EntityRef `json:"technicalOwner,omitempty"`
+	HasAgent        *bool      `json:"hasAgent,omitempty"`
+	HasKbReferences *bool      `json:"hasKbReferences,omitempty"`
+	CreatedBy       *string    `json:"createdBy,omitempty"`
+	// Shared (identical key/type on both data sources).
+	ActivationDate   *string `json:"activationDate,omitempty"`
+	DeactivationDate *string `json:"deactivationDate,omitempty"`
+	CreatedOn        *string `json:"createdOn,omitempty"`
+	UpdatedOn        *string `json:"updatedOn,omitempty"`
+}
+
+// SearchAccountsResponse is entity-service's response for POST /accounts/search.
+type SearchAccountsResponse struct {
+	Accounts []AccountSummary `json:"accounts"`
+	Total    int              `json:"total"`
+	Limit    int              `json:"limit"`
+	Offset   int              `json:"offset"`
+	HasMore  bool             `json:"hasMore"`
+}
+
+// AccountDetail is entity-service's response for GET /accounts/{id} — a
+// superset of entity-service's Postgres Account and ServiceNow SNAccountDetail.
+type AccountDetail struct {
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
+	Region *string `json:"region,omitempty"`
+	// Postgres-only.
+	SfID             *string `json:"sfId,omitempty"`
+	Tier             *string `json:"tier,omitempty"`
+	OwnerID          *string `json:"ownerId,omitempty"`
+	TechnicalOwnerID *string `json:"technicalOwnerId,omitempty"`
+	AgentEnabled     *bool   `json:"agentEnabled,omitempty"`
+	KbReferencesEnabled *bool `json:"kbReferencesEnabled,omitempty"`
+	// ServiceNow-only.
+	Classification  *string         `json:"classification,omitempty"`
+	Pod             *string         `json:"pod,omitempty"`
+	SupportTier     *SupportTierRef `json:"supportTier,omitempty"`
+	ArrToday        *string         `json:"arrToday,omitempty"`
+	Owner           *EntityRef      `json:"owner,omitempty"`
+	TechnicalOwner  *EntityRef      `json:"technicalOwner,omitempty"`
+	HasAgent        *bool           `json:"hasAgent,omitempty"`
+	HasKbReferences *bool           `json:"hasKbReferences,omitempty"`
+	CreatedBy       *string         `json:"createdBy,omitempty"`
+	// Shared (identical key/type on both data sources).
+	ActivationDate   *string `json:"activationDate,omitempty"`
+	DeactivationDate *string `json:"deactivationDate,omitempty"`
+	CreatedOn        *string `json:"createdOn,omitempty"`
+	UpdatedOn        *string `json:"updatedOn,omitempty"`
 }
 
 // --- cases ---

--- a/apps/customer-portal/backend-v2/internal/entity/users.go
+++ b/apps/customer-portal/backend-v2/internal/entity/users.go
@@ -28,3 +28,14 @@ func (c *Client) GetMe(ctx context.Context) (GetUserMeResponse, error) {
 	err := c.getJSON(ctx, "/users/me", &out)
 	return out, err
 }
+
+// PatchMe calls PATCH /users/me to update the caller's timezone.
+//
+// NOTE: this route is only registered by entity-service when it is deployed
+// with DATA_SOURCE=servicenow (see cs-tools/entity-service/internal/server/routes.go).
+// A Postgres-mode deployment will 404 on this call.
+func (c *Client) PatchMe(ctx context.Context, req PatchUserMeRequest) (PatchUserMeResponse, error) {
+	var out PatchUserMeResponse
+	err := c.patchJSON(ctx, "/users/me", req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/handler/accounts.go
+++ b/apps/customer-portal/backend-v2/internal/handler/accounts.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityAccountClient abstracts the entity-service account operations used by AccountHandler.
+type entityAccountClient interface {
+	SearchAccounts(ctx context.Context, req entity.SearchAccountsRequest) (entity.SearchAccountsResponse, error)
+	GetAccount(ctx context.Context, id string) (entity.AccountDetail, error)
+}
+
+// AccountHandler handles HTTP requests for account operations.
+type AccountHandler struct {
+	entity entityAccountClient
+}
+
+// NewAccountHandler creates an AccountHandler backed by the given entity client.
+func NewAccountHandler(entity entityAccountClient) *AccountHandler {
+	return &AccountHandler{entity: entity}
+}
+
+// SearchAccounts handles POST /accounts/search.
+func (h *AccountHandler) SearchAccounts(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchAccountsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchAccounts(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchAccounts failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search accounts.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchAccounts(result))
+}
+
+// GetAccount handles GET /accounts/{id}.
+func (h *AccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetAccount(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetAccount failed", "userID", user.UserID, "accountID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve account.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapAccountDetails(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/updates.go
+++ b/apps/customer-portal/backend-v2/internal/handler/updates.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/updates"
+)
+
+// updatesClient abstracts the updates-service operations used by UpdatesHandler.
+type updatesClient interface {
+	GetProductUpdateLevels(ctx context.Context) ([]updates.ProductUpdateLevel, error)
+	SearchUpdatesBetweenUpdateLevels(ctx context.Context, payload updates.SearchPayload, userEmail string) (map[string]updates.UpdateLevelGroup, error)
+}
+
+// UpdatesHandler handles HTTP requests for update-related operations,
+// delegating to the WSO2 Updates service. Unlike entity-service responses,
+// the updates package's own types are already portal-shaped (camelCase, with
+// the upstream snake_case translation done in internal/updates/mapper.go), so
+// no separate dto layer is needed here.
+type UpdatesHandler struct {
+	updates updatesClient
+}
+
+// NewUpdatesHandler creates an UpdatesHandler backed by the given updates client.
+func NewUpdatesHandler(updates updatesClient) *UpdatesHandler {
+	return &UpdatesHandler{updates: updates}
+}
+
+// GetProductUpdateLevels handles GET /updates/product-update-levels.
+func (h *UpdatesHandler) GetProductUpdateLevels(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	result, err := h.updates.GetProductUpdateLevels(r.Context())
+	if err != nil {
+		slog.ErrorContext(r.Context(), "updates GetProductUpdateLevels failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to get product update levels.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, result)
+}
+
+// SearchUpdatesBetweenUpdateLevels handles POST /updates/levels/search.
+func (h *UpdatesHandler) SearchUpdatesBetweenUpdateLevels(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var payload updates.SearchPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.updates.SearchUpdatesBetweenUpdateLevels(r.Context(), payload, user.Email)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "updates SearchUpdatesBetweenUpdateLevels failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search updates.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, result)
+}

--- a/apps/customer-portal/backend-v2/internal/handler/updates.go
+++ b/apps/customer-portal/backend-v2/internal/handler/updates.go
@@ -82,6 +82,14 @@ func (h *UpdatesHandler) SearchUpdatesBetweenUpdateLevels(w http.ResponseWriter,
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
+	if payload.ProductName == "" || payload.ProductVersion == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if payload.StartingUpdateLevel < 0 || payload.EndingUpdateLevel < payload.StartingUpdateLevel {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
 
 	result, err := h.updates.SearchUpdatesBetweenUpdateLevels(r.Context(), payload, user.Email)
 	if err != nil {

--- a/apps/customer-portal/backend-v2/internal/handler/users.go
+++ b/apps/customer-portal/backend-v2/internal/handler/users.go
@@ -18,27 +18,46 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/scim"
 )
 
 // entityUserClient abstracts the entity-service user operations used by UserHandler.
 type entityUserClient interface {
 	GetMe(ctx context.Context) (entity.GetUserMeResponse, error)
+	PatchMe(ctx context.Context, req entity.PatchUserMeRequest) (entity.PatchUserMeResponse, error)
+}
+
+// scimUserClient abstracts the SCIM operations used by UserHandler.
+type scimUserClient interface {
+	SearchUser(ctx context.Context, email string) (*scim.UserInfo, error)
+	UpdateUserPhone(ctx context.Context, userID, mobile string) (*string, error)
 }
 
 // UserHandler handles HTTP requests for the logged-in user's own profile.
+// Profile fields (name, timezone, roles) are sourced from entity-service;
+// phone number is sourced from SCIM.
 type UserHandler struct {
 	entity entityUserClient
+	scim   scimUserClient
 }
 
-// NewUserHandler creates a UserHandler backed by the given entity client.
-func NewUserHandler(entity entityUserClient) *UserHandler {
-	return &UserHandler{entity: entity}
+// NewUserHandler creates a UserHandler backed by the given entity and SCIM clients.
+func NewUserHandler(entity entityUserClient, scim scimUserClient) *UserHandler {
+	return &UserHandler{entity: entity, scim: scim}
+}
+
+// userUpdateRequest is the PATCH /users/me request shape. At least one field
+// must be set.
+type userUpdateRequest struct {
+	PhoneNumber *string `json:"phoneNumber,omitempty"`
+	TimeZone    *string `json:"timeZone,omitempty"`
 }
 
 // GetMe handles GET /users/me.
@@ -56,5 +75,67 @@ func (h *UserHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSONValue(w, http.StatusOK, dto.MapUserMe(result))
+	resp := dto.MapUserMe(result)
+
+	// Phone number is sourced from SCIM, not entity-service. A SCIM lookup
+	// failure or miss is not fatal to the request — the profile is still
+	// useful without a phone number.
+	scimInfo, scimErr := h.scim.SearchUser(r.Context(), user.Email)
+	if scimErr != nil {
+		slog.ErrorContext(r.Context(), "scim SearchUser failed", "userID", user.UserID, "err", summarizeErr(scimErr))
+	} else if scimInfo == nil {
+		slog.WarnContext(r.Context(), "no SCIM user found", "userID", user.UserID)
+	} else {
+		resp.PhoneNumber = scimInfo.PhoneNumber
+	}
+
+	writeJSONValue(w, http.StatusOK, resp)
+}
+
+// PatchMe handles PATCH /users/me. phoneNumber is updated via SCIM; timeZone
+// is updated via entity-service. At least one field must be provided.
+func (h *UserHandler) PatchMe(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var payload userUpdateRequest
+	if err := json.Unmarshal(body, &payload); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if payload.PhoneNumber == nil && payload.TimeZone == nil {
+		writeError(w, http.StatusBadRequest, "At least one field must be provided for update.")
+		return
+	}
+
+	resp := dto.UserUpdateResponse{}
+
+	if payload.PhoneNumber != nil {
+		updatedPhone, err := h.scim.UpdateUserPhone(r.Context(), user.UserID, *payload.PhoneNumber)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "scim UpdateUserPhone failed", "userID", user.UserID, "err", summarizeErr(err))
+			mapUpstreamError(w, err, "Failed to update phone number.")
+			return
+		}
+		resp.PhoneNumber = updatedPhone
+	}
+
+	if payload.TimeZone != nil {
+		if _, err := h.entity.PatchMe(r.Context(), entity.PatchUserMeRequest{TimeZone: *payload.TimeZone}); err != nil {
+			slog.ErrorContext(r.Context(), "entity PatchMe failed", "userID", user.UserID, "err", summarizeErr(err))
+			mapUpstreamError(w, err, "Failed to update time zone.")
+			return
+		}
+		resp.TimeZone = payload.TimeZone
+	}
+
+	writeJSONValue(w, http.StatusOK, resp)
 }

--- a/apps/customer-portal/backend-v2/internal/middleware/correlation.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/correlation.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/scim"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/updates"
 )
 
 const correlationIDHeader = "X-CSM-Correlation-ID"
@@ -41,8 +43,8 @@ type correlationIDKey struct{}
 // header or generates a UUID v4 if absent, ensuring the value carries the
 // "cp-" (customer portal) prefix before it is used further. The ID is:
 //   - stored in the context for automatic inclusion in slog records
-//   - stored in the entity client context so it is forwarded on every outgoing
-//     entity-service request
+//   - stored in the entity, scim, and updates client contexts so it is
+//     forwarded on every outgoing request to any of those three services
 //   - echoed in the response header so callers can reference it in support
 //     requests
 func CorrelationID(next http.Handler) http.Handler {
@@ -57,6 +59,8 @@ func CorrelationID(next http.Handler) http.Handler {
 		w.Header().Set(correlationIDHeader, id)
 		ctx := context.WithValue(r.Context(), correlationIDKey{}, id)
 		ctx = entity.WithCorrelationID(ctx, id)
+		ctx = scim.WithCorrelationID(ctx, id)
+		ctx = updates.WithCorrelationID(ctx, id)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/apps/customer-portal/backend-v2/internal/scim/client.go
+++ b/apps/customer-portal/backend-v2/internal/scim/client.go
@@ -37,6 +37,21 @@ import (
 // Overridden in tests to keep them fast.
 var tokenFetchTimeout = 10 * time.Second
 
+type ctxKey string
+
+const correlationIDKey ctxKey = "x-csm-correlation-id" // #nosec G101 -- context map key, not a credential
+
+// WithCorrelationID returns a copy of ctx carrying the correlation ID to be
+// forwarded as X-CSM-Correlation-ID on every outgoing SCIM request.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationIDKey, id)
+}
+
+func correlationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey).(string)
+	return v
+}
+
 // maxResponseBodyBytes bounds how much of a SCIM response this client will
 // read into memory, protecting against a huge or malicious upstream response
 // exhausting process memory.
@@ -109,6 +124,9 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 	}
 	if len(body) > 0 {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if id := correlationIDFromContext(ctx); id != "" {
+		req.Header.Set("X-CSM-Correlation-ID", id)
 	}
 
 	resp, err := c.http.Do(req)

--- a/apps/customer-portal/backend-v2/internal/scim/client.go
+++ b/apps/customer-portal/backend-v2/internal/scim/client.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package scim is the HTTP client for the SCIM operations service, used to
+// read/update a user's phone number (the customer portal's user profile is
+// otherwise sourced from entity-service).
+package scim
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var tokenFetchTimeout = 10 * time.Second
+
+// maxResponseBodyBytes bounds how much of a SCIM response this client will
+// read into memory, protecting against a huge or malicious upstream response
+// exhausting process memory.
+const maxResponseBodyBytes = 10 << 20 // 10 MiB
+
+// noRedirect stops an *http.Client from following any redirect, returning the
+// redirect response itself instead.
+func noRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+// Config holds the configuration for the SCIM operations service client.
+type Config struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// Client is an HTTP client for the SCIM operations service, authenticated via
+// the OAuth2 client credentials grant. Tokens are acquired and refreshed
+// automatically; callers need not manage them.
+type Client struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewClient constructs a Client that authenticates against the SCIM
+// operations service using the OAuth2 client credentials grant type.
+func NewClient(cfg Config) *Client {
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout, CheckRedirect: noRedirect})
+
+	// clientcredentials.Config.Client's returned *http.Client and its
+	// Transport must not be mutated (see the package doc comment) — wrap its
+	// Transport in a fresh http.Client we own instead of setting fields
+	// directly on the returned one.
+	oauthClient := cc.Client(tokenCtx)
+	httpClient := &http.Client{
+		Transport:     oauthClient.Transport,
+		Timeout:       25 * time.Second,
+		CheckRedirect: noRedirect,
+	}
+
+	return &Client{
+		http:    httpClient,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+	}
+}
+
+// do executes an authenticated HTTP request against the SCIM service and
+// returns the raw JSON response body. The caller owns the returned slice.
+func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("scim: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scim: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxResponseBodyBytes+1)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("scim: read response body: %w", err)
+	}
+	if len(respBody) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("scim: %s %s: response body exceeds %d bytes", method, path, maxResponseBodyBytes)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	return respBody, nil
+}

--- a/apps/customer-portal/backend-v2/internal/scim/scim.go
+++ b/apps/customer-portal/backend-v2/internal/scim/scim.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package scim
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	// org is fixed to "internal" — matches the org used for WSO2-employee
+	// SCIM lookups in apps/csm-portal/backend's SCIM client.
+	org = "internal"
+
+	domainDefault    = "DEFAULT"
+	attrPhoneNumbers = "phoneNumbers"
+	attrUserName     = "userName"
+	attrSchema       = "urn:scim:wso2:schema"
+
+	mobilePhoneType = "mobile"
+)
+
+// SearchUser fetches SCIM data for the given email and returns the extracted
+// phone number and last password update time. Returns nil, nil if no
+// matching user is found in the SCIM service.
+func (c *Client) SearchUser(ctx context.Context, email string) (*UserInfo, error) {
+	startIndex := 1
+	var found *scimUser
+
+	for {
+		reqBody, err := json.Marshal(scimSearchRequest{
+			Domain:     domainDefault,
+			Attributes: []string{attrPhoneNumbers, attrUserName, attrSchema},
+			Filter:     fmt.Sprintf("userName eq %s", email),
+			StartIndex: startIndex,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scim: encode search request: %w", err)
+		}
+
+		raw, err := c.do(ctx, http.MethodPost, "/organizations/"+org+"/users/search", reqBody)
+		if err != nil {
+			return nil, err
+		}
+
+		var result scimSearchResponse
+		if err := json.Unmarshal(raw, &result); err != nil {
+			return nil, fmt.Errorf("scim: decode search response: %w", err)
+		}
+
+		if len(result.Resources) > 0 && found == nil {
+			u := result.Resources[0]
+			found = &u
+		}
+
+		if result.ItemsPerPage == 0 || (startIndex+result.ItemsPerPage-1) >= result.TotalResults {
+			break
+		}
+		startIndex += result.ItemsPerPage
+	}
+
+	if found == nil {
+		return nil, nil
+	}
+
+	return &UserInfo{
+		PhoneNumber:            extractMobilePhone(*found),
+		LastPasswordUpdateTime: extractLastPasswordUpdateTime(*found),
+	}, nil
+}
+
+// UpdateUserPhone updates the mobile phone number for the given user via a
+// SCIM PATCH and returns the updated phone number extracted from the response.
+func (c *Client) UpdateUserPhone(ctx context.Context, userID, mobile string) (*string, error) {
+	reqBody, err := json.Marshal(scimUpdateRequest{
+		PhoneNumber: &scimPhonePayload{Mobile: mobile},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scim: encode update request: %w", err)
+	}
+
+	path := "/organizations/" + org + "/users/" + url.PathEscape(userID)
+	raw, err := c.do(ctx, http.MethodPatch, path, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedUser scimUser
+	if err := json.Unmarshal(raw, &updatedUser); err != nil {
+		return nil, fmt.Errorf("scim: decode update response: %w", err)
+	}
+
+	return extractMobilePhone(updatedUser), nil
+}
+
+// extractMobilePhone returns the first phone number of type "mobile", or nil.
+func extractMobilePhone(u scimUser) *string {
+	for _, p := range u.PhoneNumbers {
+		if p.Type == mobilePhoneType {
+			v := p.Value
+			return &v
+		}
+	}
+	return nil
+}
+
+// extractLastPasswordUpdateTime returns the lastPasswordUpdateTime from the
+// WSO2 SCIM extension schema, or nil.
+func extractLastPasswordUpdateTime(u scimUser) *string {
+	if u.SchemaScope != nil {
+		return u.SchemaScope.LastPasswordUpdateTime
+	}
+	return nil
+}

--- a/apps/customer-portal/backend-v2/internal/scim/scim.go
+++ b/apps/customer-portal/backend-v2/internal/scim/scim.go
@@ -48,7 +48,9 @@ func (c *Client) SearchUser(ctx context.Context, email string) (*UserInfo, error
 		reqBody, err := json.Marshal(scimSearchRequest{
 			Domain:     domainDefault,
 			Attributes: []string{attrPhoneNumbers, attrUserName, attrSchema},
-			Filter:     fmt.Sprintf("userName eq %s", email),
+			// RFC 7644 requires SCIM filter string literals to be quoted,
+			// with embedded quotes/backslashes escaped — %q does both.
+			Filter:     fmt.Sprintf("userName eq %q", email),
 			StartIndex: startIndex,
 		})
 		if err != nil {

--- a/apps/customer-portal/backend-v2/internal/scim/types.go
+++ b/apps/customer-portal/backend-v2/internal/scim/types.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package scim
+
+// ---- upstream (SCIM wire) types ----
+
+type scimSearchRequest struct {
+	Domain     string   `json:"domain"`
+	Attributes []string `json:"attributes"`
+	Filter     string   `json:"filter"`
+	StartIndex int      `json:"startIndex"`
+}
+
+type scimSearchResponse struct {
+	TotalResults int        `json:"totalResults"`
+	StartIndex   int        `json:"startIndex"`
+	ItemsPerPage int        `json:"itemsPerPage"`
+	Resources    []scimUser `json:"Resources"`
+}
+
+// scimUser mirrors the SCIM User record. The WSO2 schema field uses the
+// literal key "urn:scim:wso2:schema", which Go handles with a JSON struct tag.
+type scimUser struct {
+	ID           string      `json:"id"`
+	PhoneNumbers []scimPhone `json:"phoneNumbers,omitempty"`
+	SchemaScope  *scimSchema `json:"urn:scim:wso2:schema,omitempty"`
+}
+
+type scimPhone struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// scimSchema holds the WSO2-specific SCIM extension fields.
+type scimSchema struct {
+	LastPasswordUpdateTime *string `json:"lastPasswordUpdateTime,omitempty"`
+}
+
+type scimUpdateRequest struct {
+	PhoneNumber *scimPhonePayload `json:"phoneNumber,omitempty"`
+}
+
+type scimPhonePayload struct {
+	Mobile string `json:"mobile"`
+}
+
+// ---- public types ----
+
+// UserInfo holds the SCIM-derived fields for a user, already in
+// portal-appropriate shape — no further mapping layer is needed for these.
+type UserInfo struct {
+	PhoneNumber            *string
+	LastPasswordUpdateTime *string
+}

--- a/apps/customer-portal/backend-v2/internal/updates/client.go
+++ b/apps/customer-portal/backend-v2/internal/updates/client.go
@@ -39,6 +39,21 @@ import (
 // Overridden in tests to keep them fast.
 var tokenFetchTimeout = 10 * time.Second
 
+type ctxKey string
+
+const correlationIDKey ctxKey = "x-csm-correlation-id" // #nosec G101 -- context map key, not a credential
+
+// WithCorrelationID returns a copy of ctx carrying the correlation ID to be
+// forwarded as X-CSM-Correlation-ID on every outgoing updates-service request.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationIDKey, id)
+}
+
+func correlationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey).(string)
+	return v
+}
+
 // maxResponseBodyBytes bounds how much of an updates-service response this
 // client will read into memory, protecting against a huge or malicious
 // upstream response exhausting process memory.
@@ -111,6 +126,9 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 	}
 	if len(body) > 0 {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if id := correlationIDFromContext(ctx); id != "" {
+		req.Header.Set("X-CSM-Correlation-ID", id)
 	}
 
 	resp, err := c.http.Do(req)

--- a/apps/customer-portal/backend-v2/internal/updates/client.go
+++ b/apps/customer-portal/backend-v2/internal/updates/client.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package updates is the HTTP client for the WSO2 Updates service (product
+// update levels and update descriptions between levels). It returns
+// portal-shaped (camelCase) types directly — the upstream snake_case wire
+// format is translated in mapper.go, so no further mapping layer is needed
+// in the handler.
+package updates
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var tokenFetchTimeout = 10 * time.Second
+
+// maxResponseBodyBytes bounds how much of an updates-service response this
+// client will read into memory, protecting against a huge or malicious
+// upstream response exhausting process memory.
+const maxResponseBodyBytes = 10 << 20 // 10 MiB
+
+// noRedirect stops an *http.Client from following any redirect, returning the
+// redirect response itself instead.
+func noRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+// Config holds the configuration for the updates service client.
+type Config struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// Client is an HTTP client for the WSO2 Updates service, authenticated via
+// the OAuth2 client credentials grant. Tokens are acquired and refreshed
+// automatically; callers need not manage them.
+type Client struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewClient constructs a Client that authenticates against the updates
+// service using the OAuth2 client credentials grant type.
+func NewClient(cfg Config) *Client {
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout, CheckRedirect: noRedirect})
+
+	// clientcredentials.Config.Client's returned *http.Client and its
+	// Transport must not be mutated (see the package doc comment) — wrap its
+	// Transport in a fresh http.Client we own instead of setting fields
+	// directly on the returned one.
+	oauthClient := cc.Client(tokenCtx)
+	httpClient := &http.Client{
+		Transport:     oauthClient.Transport,
+		Timeout:       25 * time.Second,
+		CheckRedirect: noRedirect,
+	}
+
+	return &Client{
+		http:    httpClient,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+	}
+}
+
+// do executes an authenticated HTTP request against the updates service and
+// returns the raw JSON response body. The caller owns the returned slice.
+func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("updates: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("updates: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxResponseBodyBytes+1)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("updates: read response body: %w", err)
+	}
+	if len(respBody) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("updates: %s %s: response body exceeds %d bytes", method, path, maxResponseBodyBytes)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	return respBody, nil
+}

--- a/apps/customer-portal/backend-v2/internal/updates/mapper.go
+++ b/apps/customer-portal/backend-v2/internal/updates/mapper.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package updates
+
+import "strconv"
+
+// mapProductUpdateLevels converts the upstream snake-case response to the
+// portal camelCase response shape.
+func mapProductUpdateLevels(src []upstreamProductUpdateLevel) []ProductUpdateLevel {
+	out := make([]ProductUpdateLevel, len(src))
+	for i, s := range src {
+		levels := make([]UpdateLevel, len(s.ProductUpdateLevels))
+		for j, ul := range s.ProductUpdateLevels {
+			levels[j] = UpdateLevel{
+				ProductBaseVersion: ul.ProductBaseVersion,
+				Channel:            ul.Channel,
+				UpdateLevels:       ul.UpdateLevels,
+			}
+		}
+		out[i] = ProductUpdateLevel{
+			ProductName:         s.ProductName,
+			ProductUpdateLevels: levels,
+		}
+	}
+	return out
+}
+
+// buildSearchRequest constructs the upstream snake-case request from the
+// portal camelCase payload and the authenticated user's email.
+func buildSearchRequest(payload SearchPayload, userEmail string) upstreamUpdateDescriptionRequest {
+	return upstreamUpdateDescriptionRequest{
+		ProductName:         payload.ProductName,
+		ProductVersion:      payload.ProductVersion,
+		Channel:             channel,
+		StartingUpdateLevel: payload.StartingUpdateLevel,
+		EndingUpdateLevel:   payload.EndingUpdateLevel,
+		UserEmail:           userEmail,
+	}
+}
+
+// groupByUpdateLevel groups update descriptions by their update level and
+// determines the overall update type for each group.
+func groupByUpdateLevel(src []upstreamUpdateDescription) map[string]UpdateLevelGroup {
+	groups := make(map[string]UpdateLevelGroup)
+
+	for _, d := range src {
+		key := strconv.Itoa(d.UpdateLevel)
+
+		group, exists := groups[key]
+		if !exists {
+			updateType := updateTypeRegular
+			if d.UpdateType == updateTypeSecurity {
+				updateType = updateTypeSecurity
+			}
+			group = UpdateLevelGroup{
+				UpdateType:              updateType,
+				UpdateDescriptionLevels: make([]UpdateDescription, 0),
+			}
+		}
+
+		if d.UpdateType == updateTypeSecurity {
+			group.UpdateType = updateTypeSecurity
+		}
+
+		group.UpdateDescriptionLevels = append(group.UpdateDescriptionLevels, mapUpdateDescription(d))
+		groups[key] = group
+	}
+
+	return groups
+}
+
+func mapUpdateDescription(d upstreamUpdateDescription) UpdateDescription {
+	advisories := make([]SecurityAdvisory, len(d.SecurityAdvisories))
+	for i, a := range d.SecurityAdvisories {
+		advisories[i] = SecurityAdvisory{
+			ID:          a.ID,
+			Overview:    a.Overview,
+			Severity:    a.Severity,
+			Description: a.Description,
+			Impact:      a.Impact,
+			Solution:    a.Solution,
+			Notes:       a.Notes,
+			Credits:     a.Credits,
+		}
+	}
+
+	var releases []DependantRelease
+	if len(d.DependantReleases) > 0 {
+		releases = make([]DependantRelease, len(d.DependantReleases))
+		for i, r := range d.DependantReleases {
+			releases[i] = DependantRelease{
+				Repository:     r.Repository,
+				ReleaseVersion: r.ReleaseVersion,
+			}
+		}
+	}
+
+	return UpdateDescription{
+		UpdateLevel:        d.UpdateLevel,
+		ProductName:        d.ProductName,
+		ProductVersion:     d.ProductVersion,
+		Channel:            d.Channel,
+		UpdateType:         d.UpdateType,
+		UpdateNumber:       d.UpdateNumber,
+		Description:        d.Description,
+		Instructions:       d.Instructions,
+		BugFixes:           d.BugFixes,
+		FilesAdded:         d.FilesAdded,
+		FilesModified:      d.FilesModified,
+		FilesRemoved:       d.FilesRemoved,
+		BundlesInfoChanges: d.BundlesInfoChanges,
+		DependantReleases:  releases,
+		Timestamp:          d.Timestamp,
+		SecurityAdvisories: advisories,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/updates/types.go
+++ b/apps/customer-portal/backend-v2/internal/updates/types.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package updates
+
+// channel is the fixed update channel value forwarded to the upstream service.
+const channel = "full"
+
+const updateTypeSecurity = "security"
+const updateTypeRegular = "regular"
+
+// ---- upstream (snake-case) types ----
+
+type upstreamProductUpdateLevel struct {
+	ProductName         string                `json:"product-name"`
+	ProductUpdateLevels []upstreamUpdateLevel `json:"product-update-levels"`
+}
+
+type upstreamUpdateLevel struct {
+	ProductBaseVersion string `json:"product-base-version"`
+	Channel            string `json:"channel"`
+	UpdateLevels       []int  `json:"update-levels"`
+}
+
+type upstreamUpdateDescriptionRequest struct {
+	ProductName         string `json:"product-name"`
+	ProductVersion      string `json:"product-version"`
+	Channel             string `json:"channel"`
+	StartingUpdateLevel int    `json:"starting-update-level"`
+	EndingUpdateLevel   int    `json:"ending-update-level"`
+	UserEmail           string `json:"user-email"`
+}
+
+type upstreamUpdateDescription struct {
+	ProductName        string                     `json:"product-name"`
+	ProductVersion     string                     `json:"product-version"`
+	Channel            string                     `json:"channel"`
+	UpdateLevel        int                        `json:"update-level"`
+	UpdateNumber       int                        `json:"update-number"`
+	Description        *string                    `json:"description,omitempty"`
+	Instructions       *string                    `json:"instructions,omitempty"`
+	BugFixes           *string                    `json:"bug-fixes,omitempty"`
+	FilesAdded         *string                    `json:"files-added,omitempty"`
+	FilesModified      *string                    `json:"files-modified,omitempty"`
+	FilesRemoved       *string                    `json:"files-removed,omitempty"`
+	BundlesInfoChanges *string                    `json:"bundles-info-changes,omitempty"`
+	DependantReleases  []upstreamDependantRelease `json:"dependant-releases,omitempty"`
+	UpdateType         string                     `json:"update-type"`
+	Timestamp          int64                      `json:"timestamp"`
+	SecurityAdvisories []upstreamSecurityAdvisory `json:"security-advisories"`
+}
+
+type upstreamDependantRelease struct {
+	Repository     string `json:"repository"`
+	ReleaseVersion string `json:"release-version"`
+}
+
+type upstreamSecurityAdvisory struct {
+	ID          string `json:"id"`
+	Overview    string `json:"overview"`
+	Severity    string `json:"severity"`
+	Description string `json:"description"`
+	Impact      string `json:"impact"`
+	Solution    string `json:"solution"`
+	Notes       string `json:"notes"`
+	Credits     string `json:"credits"`
+}
+
+// ---- portal (camelCase) types — returned directly to the customer portal frontend ----
+
+// ProductUpdateLevel is the portal response shape for a product's update levels.
+type ProductUpdateLevel struct {
+	ProductName         string        `json:"productName"`
+	ProductUpdateLevels []UpdateLevel `json:"productUpdateLevels"`
+}
+
+// UpdateLevel is the portal response shape for a single update level entry.
+type UpdateLevel struct {
+	ProductBaseVersion string `json:"productBaseVersion"`
+	Channel            string `json:"channel"`
+	UpdateLevels       []int  `json:"updateLevels"`
+}
+
+// SearchPayload is the portal request shape for searching updates between
+// levels. Received as camelCase JSON from the frontend; mapped to the
+// upstream snake-case format before forwarding.
+type SearchPayload struct {
+	ProductName         string `json:"productName"`
+	ProductVersion      string `json:"productVersion"`
+	StartingUpdateLevel int    `json:"startingUpdateLevel"`
+	EndingUpdateLevel   int    `json:"endingUpdateLevel"`
+}
+
+// UpdateLevelGroup is the portal response shape grouping update descriptions
+// by update level.
+type UpdateLevelGroup struct {
+	UpdateType              string              `json:"updateType"`
+	UpdateDescriptionLevels []UpdateDescription `json:"updateDescriptionLevels"`
+}
+
+// UpdateDescription is the portal response shape for a single update description.
+type UpdateDescription struct {
+	UpdateLevel        int                `json:"updateLevel"`
+	ProductName        string             `json:"productName"`
+	ProductVersion     string             `json:"productVersion"`
+	Channel            string             `json:"channel"`
+	UpdateType         string             `json:"updateType"`
+	UpdateNumber       int                `json:"updateNumber"`
+	Description        *string            `json:"description,omitempty"`
+	Instructions       *string            `json:"instructions,omitempty"`
+	BugFixes           *string            `json:"bugFixes,omitempty"`
+	FilesAdded         *string            `json:"filesAdded,omitempty"`
+	FilesModified      *string            `json:"filesModified,omitempty"`
+	FilesRemoved       *string            `json:"filesRemoved,omitempty"`
+	BundlesInfoChanges *string            `json:"bundlesInfoChanges,omitempty"`
+	DependantReleases  []DependantRelease `json:"dependantReleases,omitempty"`
+	Timestamp          int64              `json:"timestamp"`
+	SecurityAdvisories []SecurityAdvisory `json:"securityAdvisories"`
+}
+
+// SecurityAdvisory is the portal response shape for a security advisory.
+type SecurityAdvisory struct {
+	ID          string `json:"id"`
+	Overview    string `json:"overview"`
+	Severity    string `json:"severity"`
+	Description string `json:"description"`
+	Impact      string `json:"impact"`
+	Solution    string `json:"solution"`
+	Notes       string `json:"notes"`
+	Credits     string `json:"credits"`
+}
+
+// DependantRelease is the portal response shape for a dependant release.
+type DependantRelease struct {
+	Repository     string `json:"repository"`
+	ReleaseVersion string `json:"releaseVersion"`
+}

--- a/apps/customer-portal/backend-v2/internal/updates/updates.go
+++ b/apps/customer-portal/backend-v2/internal/updates/updates.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package updates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// GetProductUpdateLevels fetches all product update levels and returns them
+// mapped to the portal camelCase response shape.
+func (c *Client) GetProductUpdateLevels(ctx context.Context) ([]ProductUpdateLevel, error) {
+	raw, err := c.do(ctx, http.MethodGet, "/updates/product-update-levels", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var upstream []upstreamProductUpdateLevel
+	if err := json.Unmarshal(raw, &upstream); err != nil {
+		return nil, fmt.Errorf("updates: decode product update levels: %w", err)
+	}
+
+	return mapProductUpdateLevels(upstream), nil
+}
+
+// SearchUpdatesBetweenUpdateLevels searches for update descriptions between
+// the given update levels for the given user and returns them grouped by
+// update level.
+func (c *Client) SearchUpdatesBetweenUpdateLevels(ctx context.Context, payload SearchPayload, userEmail string) (map[string]UpdateLevelGroup, error) {
+	reqBody, err := json.Marshal(buildSearchRequest(payload, userEmail))
+	if err != nil {
+		return nil, fmt.Errorf("updates: encode search request: %w", err)
+	}
+
+	raw, err := c.do(ctx, http.MethodPost, "/updates/descriptions", reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var upstream []upstreamUpdateDescription
+	if err := json.Unmarshal(raw, &upstream); err != nil {
+		return nil, fmt.Errorf("updates: decode update descriptions: %w", err)
+	}
+
+	return groupByUpdateLevel(upstream), nil
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -43,6 +43,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserMeResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
           content:
@@ -423,6 +429,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProductUpdateLevel'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
           content:

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -1,0 +1,1083 @@
+openapi: 3.0.1
+info:
+  title: Customer Portal API (v2)
+  version: 0.1.0
+  description: >
+    Backend-for-frontend for the customer portal. Forwards requests to
+    cs-tools/entity-service, the WSO2 Updates service, and the SCIM
+    operations service, shaping every response into a portal-owned contract
+    before it reaches the frontend. Work in progress — only the endpoints
+    listed below are implemented so far.
+security:
+  - bearerAuth: []
+servers:
+  - url: "{server}:{port}/"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "8080"
+paths:
+  /health:
+    get:
+      summary: Health check endpoint.
+      operationId: getHealth
+      security: []
+      responses:
+        "200":
+          description: Ok
+
+  /users/me:
+    get:
+      summary: Get the logged-in user's profile.
+      description: >
+        Profile fields (id, email, firstName, lastName, timeZone, roles) are
+        sourced from entity-service; phoneNumber is sourced from SCIM.
+        entity-service only serves this route when deployed with
+        DATA_SOURCE=servicenow.
+      operationId: getUsersMe
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserMeResponse'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+    patch:
+      summary: Update the logged-in user's phone number and/or time zone.
+      description: >
+        phoneNumber is updated via SCIM; timeZone is updated via
+        entity-service (DATA_SOURCE=servicenow only). At least one field is
+        required.
+      operationId: patchUsersMe
+      requestBody:
+        description: User update payload — at least one field required.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdateRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserUpdateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /accounts/{id}:
+    get:
+      summary: Get an account by ID.
+      description: >
+        Normalizes entity-service's two data-source-dependent response shapes
+        (Postgres vs ServiceNow) into one consistent contract — see
+        AccountDetails.
+      operationId: getAccountsId
+      parameters:
+        - name: id
+          in: path
+          description: ID of the account
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountDetails'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /accounts/search:
+    post:
+      summary: Search accounts.
+      operationId: postAccountsSearch
+      requestBody:
+        description: Account search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchAccountsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchAccountsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}:
+    get:
+      summary: Get a project by ID.
+      operationId: getProjectsId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectDetails'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/search:
+    post:
+      summary: Search projects.
+      operationId: postProjectsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchProjectsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchProjectsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases/{id}:
+    get:
+      summary: Get a case by ID.
+      operationId: getCasesId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseDetails'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases/search:
+    post:
+      summary: Search cases.
+      operationId: postCasesSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCasesRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCasesResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /updates/product-update-levels:
+    get:
+      summary: Get product update levels.
+      operationId: getUpdatesProductUpdateLevels
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductUpdateLevel'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /updates/levels/search:
+    post:
+      summary: Search update descriptions between two update levels.
+      operationId: postUpdatesLevelsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatesSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/UpdateLevelGroup'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: apiKey
+      in: header
+      name: x-jwt-assertion
+
+  schemas:
+    ErrorPayload:
+      type: object
+      properties:
+        message:
+          type: string
+
+    Pagination:
+      type: object
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+        offset:
+          type: integer
+          minimum: 0
+
+    Ref:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+
+    NumberRef:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+
+    PersonRef:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+
+    # ---- users ----
+
+    UserMeResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        timeZone:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        phoneNumber:
+          type: string
+
+    UserUpdateRequest:
+      type: object
+      properties:
+        phoneNumber:
+          type: string
+        timeZone:
+          type: string
+
+    UserUpdateResponse:
+      type: object
+      properties:
+        phoneNumber:
+          type: string
+        timeZone:
+          type: string
+
+    # ---- accounts ----
+
+    SearchAccountsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        filters:
+          type: object
+          properties:
+            searchQuery:
+              type: string
+            active:
+              type: boolean
+            pod:
+              type: string
+            classification:
+              type: string
+
+    AccountSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        tier:
+          type: string
+        region:
+          type: string
+        supportTier:
+          type: string
+        owner:
+          $ref: '#/components/schemas/Ref'
+        technicalOwner:
+          $ref: '#/components/schemas/Ref'
+        activationDate:
+          type: string
+        deactivationDate:
+          type: string
+        hasAgent:
+          type: boolean
+        hasKbReferences:
+          type: boolean
+        createdOn:
+          type: string
+
+    SearchAccountsResponse:
+      type: object
+      properties:
+        accounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    AccountDetails:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        tier:
+          type: string
+        region:
+          type: string
+        supportTier:
+          type: string
+        owner:
+          $ref: '#/components/schemas/Ref'
+        technicalOwner:
+          $ref: '#/components/schemas/Ref'
+        activationDate:
+          type: string
+        deactivationDate:
+          type: string
+        hasAgent:
+          type: boolean
+        hasKbReferences:
+          type: boolean
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    # ---- projects ----
+
+    SearchProjectsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        searchQuery:
+          type: string
+        closureStatus:
+          type: string
+        endDateFrom:
+          type: string
+        endDateTo:
+          type: string
+        sortBy:
+          type: string
+        sortOrder:
+          type: string
+
+    ProjectSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        key:
+          type: string
+        subscriptionType:
+          type: string
+        endDate:
+          type: string
+        createdOn:
+          type: string
+        closureState:
+          type: string
+
+    SearchProjectsResponse:
+      type: object
+      properties:
+        projects:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    ProjectAccount:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        tier:
+          type: string
+        region:
+          type: string
+
+    ProjectDetails:
+      type: object
+      properties:
+        id:
+          type: string
+        account:
+          $ref: '#/components/schemas/ProjectAccount'
+        name:
+          type: string
+        key:
+          type: string
+        subscriptionType:
+          type: string
+        startDate:
+          type: string
+        endDate:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        closureState:
+          type: string
+
+    # ---- cases ----
+
+    SearchCasesRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+            order:
+              type: string
+        filters:
+          type: object
+          properties:
+            types:
+              type: array
+              items:
+                type: string
+            searchQuery:
+              type: string
+            projectIds:
+              type: array
+              items:
+                type: string
+            deploymentIds:
+              type: array
+              items:
+                type: string
+            states:
+              type: array
+              items:
+                type: string
+            severities:
+              type: array
+              items:
+                type: string
+            issueTypes:
+              type: array
+              items:
+                type: string
+            engagementTypes:
+              type: array
+              items:
+                type: string
+            createdBy:
+              type: array
+              items:
+                type: string
+            createdByMe:
+              type: boolean
+            workStates:
+              type: array
+              items:
+                type: string
+            assignedUserIds:
+              type: array
+              items:
+                type: string
+            productNames:
+              type: array
+              items:
+                type: string
+            tags:
+              type: array
+              items:
+                type: string
+            parentId:
+              type: string
+
+    CaseSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        subject:
+          type: string
+        description:
+          type: string
+        state:
+          type: string
+        severity:
+          type: string
+        issueType:
+          type: string
+        engagementType:
+          type: string
+        workState:
+          type: string
+        type:
+          type: string
+        createdOn:
+          type: string
+        project:
+          $ref: '#/components/schemas/Ref'
+        deployment:
+          $ref: '#/components/schemas/Ref'
+        product:
+          $ref: '#/components/schemas/Ref'
+        assignedTeam:
+          $ref: '#/components/schemas/Ref'
+
+    SearchCasesResponse:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    CaseTag:
+      type: object
+      properties:
+        label:
+          type: string
+        color:
+          type: string
+
+    LinkedServiceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        name:
+          type: string
+
+    CaseDetails:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        subject:
+          type: string
+        description:
+          type: string
+        severity:
+          type: string
+        issueType:
+          type: string
+        state:
+          type: string
+        workState:
+          type: string
+        type:
+          type: string
+        engagementType:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        closedOn:
+          type: string
+        createdBy:
+          $ref: '#/components/schemas/PersonRef'
+        project:
+          $ref: '#/components/schemas/Ref'
+        deployment:
+          $ref: '#/components/schemas/Ref'
+        deployedProduct:
+          $ref: '#/components/schemas/Ref'
+        product:
+          $ref: '#/components/schemas/Ref'
+        assignedTeam:
+          $ref: '#/components/schemas/Ref'
+        conversation:
+          $ref: '#/components/schemas/Ref'
+        assignedEngineer:
+          $ref: '#/components/schemas/PersonRef'
+        parentCase:
+          $ref: '#/components/schemas/NumberRef'
+        relatedCase:
+          $ref: '#/components/schemas/NumberRef'
+        linkedServiceRequests:
+          type: array
+          items:
+            $ref: '#/components/schemas/LinkedServiceRequest'
+        resolvedOn:
+          type: string
+        resolutionCode:
+          type: string
+        cause:
+          type: string
+        resolutionNotes:
+          type: string
+        fixEta:
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseTag'
+
+    # ---- updates ----
+
+    UpdateLevel:
+      type: object
+      properties:
+        productBaseVersion:
+          type: string
+        channel:
+          type: string
+        updateLevels:
+          type: array
+          items:
+            type: integer
+
+    ProductUpdateLevel:
+      type: object
+      properties:
+        productName:
+          type: string
+        productUpdateLevels:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdateLevel'
+
+    UpdatesSearchPayload:
+      type: object
+      properties:
+        productName:
+          type: string
+        productVersion:
+          type: string
+        startingUpdateLevel:
+          type: integer
+        endingUpdateLevel:
+          type: integer
+
+    SecurityAdvisory:
+      type: object
+      properties:
+        id:
+          type: string
+        overview:
+          type: string
+        severity:
+          type: string
+        description:
+          type: string
+        impact:
+          type: string
+        solution:
+          type: string
+        notes:
+          type: string
+        credits:
+          type: string
+
+    DependantRelease:
+      type: object
+      properties:
+        repository:
+          type: string
+        releaseVersion:
+          type: string
+
+    UpdateDescription:
+      type: object
+      properties:
+        updateLevel:
+          type: integer
+        productName:
+          type: string
+        productVersion:
+          type: string
+        channel:
+          type: string
+        updateType:
+          type: string
+        updateNumber:
+          type: integer
+        description:
+          type: string
+        instructions:
+          type: string
+        bugFixes:
+          type: string
+        filesAdded:
+          type: string
+        filesModified:
+          type: string
+        filesRemoved:
+          type: string
+        bundlesInfoChanges:
+          type: string
+        dependantReleases:
+          type: array
+          items:
+            $ref: '#/components/schemas/DependantRelease'
+        timestamp:
+          type: integer
+          format: int64
+        securityAdvisories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecurityAdvisory'
+
+    UpdateLevelGroup:
+      type: object
+      properties:
+        updateType:
+          type: string
+        updateDescriptionLevels:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdateDescription'


### PR DESCRIPTION
## Summary
- Adds 5 more endpoints to `apps/customer-portal/backend-v2`: `PATCH /users/me`, `POST /accounts/search`, `GET /accounts/{id}`, `GET /updates/product-update-levels`, `POST /updates/levels/search` (11 total now).
- Adds two new upstream service client packages, modeled on `apps/csm-portal/backend`'s conventions:
  - `internal/updates` — WSO2 Updates service client. Its own types are already portal-shaped camelCase (`mapper.go` translates the upstream snake_case), so handlers write its results directly — the one deliberate exception to this backend's "always map through dto" rule.
  - `internal/scim` — SCIM operations client, used for phone number read/update on `GET`/`PATCH /users/me` (name/timezone/roles still come from entity-service).
- Account endpoints normalize entity-service's two data-source-dependent response shapes (Postgres vs ServiceNow) into one consistent portal DTO (`internal/dto/account.go`), instead of exposing an OpenAPI `oneOf` for the same ambiguity like `apps/csm-portal/backend` does.
- Adds `.choreo/component.yaml` and `openapi.yaml` (covering all 11 routes implemented so far), matching `apps/csm-portal/backend`'s Choreo/OpenAPI conventions — these were missing from the previous PR.
- Updates `README.md`/`CLAUDE.md` to document the new modules, the account-normalization pattern, and the OpenAPI-spec maintenance step in the "Adding a new endpoint" recipe.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml`/`.choreo/component.yaml` validated as well-formed YAML
- [x] Manually ran the server and verified: `PATCH /users/me` with empty body → 400; `GET /accounts/{id}` with invalid UUID → 400; all new endpoints map an unreachable upstream to a clean 500 (no leakage); correlation IDs carry the `cp-` prefix
- [ ] Wire up against real running entity-service (`DATA_SOURCE=servicenow`), Updates service, and SCIM instances

## Linked issues
Closes wso2-enterprise/wso2-digital-team-project-management#842
Closes wso2-enterprise/wso2-digital-team-project-management#843
Closes wso2-enterprise/wso2-digital-team-project-management#844
Closes wso2-enterprise/wso2-digital-team-project-management#845
Closes wso2-enterprise/wso2-digital-team-project-management#846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Customer Portal API v2 support for account search and account details.
  * Added product update-level retrieval and update searches.
  * Added user profile updates for phone number and time zone.
  * Enhanced user profiles with phone number information.
  * Added authenticated integrations for account, updates, and directory services.
  * Added a public API specification with standardized requests, responses, pagination, and errors.

* **Documentation**
  * Updated setup instructions, configuration guidance, endpoint coverage, examples, and local usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
