### PR TITLE
[CSM Portal] publish four missing contract operations and stop reporting upstream failures as generic errors

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -56,20 +56,18 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 		{"apierror 503", &apierror.Error{StatusCode: http.StatusServiceUnavailable}, http.StatusServiceUnavailable, fallback},
 		{"apierror 504", &apierror.Error{StatusCode: http.StatusGatewayTimeout}, http.StatusServiceUnavailable, fallback},
 		{"apierror unmapped (418)", &apierror.Error{StatusCode: http.StatusTeapot}, http.StatusInternalServerError, fallback},
-		// A 500 is not always opaque: the entity service forwards a real reason from
-		// the layer below (a rejected state transition, a payload validation
-		// failure). Discarding it is what turned precise rejections into
-		// "Failed to update ..." for every call site of mapUpstreamError.
-		{"apierror 500 JSON envelope body surfaces upstream message", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{"code":500,"message":"Invalid state transition: the change request is not in a state that allows this action."}`}, http.StatusInternalServerError, "Invalid state transition: the change request is not in a state that allows this action."},
-		{"apierror 500 generic upstream envelope is surfaced verbatim", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{"code":500,"message":"internal server error"}`}, http.StatusInternalServerError, "internal server error"},
+		// The default branch never surfaces the upstream body, whatever its shape: a
+		// 5xx or unmapped upstream failure is not caller-actionable, and this branch
+		// is the error path for several clients (the identity provider's among them),
+		// so a well-formed envelope proves shape, not that the content is safe to
+		// show a portal client. Caller-actionable reasons come through the 4xx
+		// branches above.
+		{"apierror 500 JSON envelope body is not echoed", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{"code":500,"message":"Invalid state transition: the change request is not in a state that allows this action."}`}, http.StatusInternalServerError, fallback},
 		{"apierror 500 empty body falls back", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: ""}, http.StatusInternalServerError, fallback},
-		// The strict extractor is deliberate: this branch is also fed the identity
-		// provider's errors, whose bodies are not the {"code","message"} envelope.
-		// A foreign or malformed body must never be echoed to the caller.
 		{"apierror 500 foreign body is not echoed", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"internal identity provider detail","status":"500"}`}, http.StatusInternalServerError, fallback},
 		{"apierror 500 malformed JSON body is not echoed", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{not valid json`}, http.StatusInternalServerError, fallback},
 		{"apierror 500 plain text body is not echoed", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `goroutine 1 [running]: internal stack detail`}, http.StatusInternalServerError, fallback},
-		{"apierror unmapped (418) with envelope body surfaces message", &apierror.Error{StatusCode: http.StatusTeapot, Body: `{"code":418,"message":"upstream reason"}`}, http.StatusInternalServerError, "upstream reason"},
+		{"apierror unmapped (418) with envelope body is not echoed", &apierror.Error{StatusCode: http.StatusTeapot, Body: `{"code":418,"message":"upstream reason"}`}, http.StatusInternalServerError, fallback},
 		{"non-apierror error", errors.New("upstream connection refused"), http.StatusInternalServerError, fallback},
 	}
 }

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -56,6 +56,20 @@ func upstreamErrors(fallback string) []upstreamErrorCase {
 		{"apierror 503", &apierror.Error{StatusCode: http.StatusServiceUnavailable}, http.StatusServiceUnavailable, fallback},
 		{"apierror 504", &apierror.Error{StatusCode: http.StatusGatewayTimeout}, http.StatusServiceUnavailable, fallback},
 		{"apierror unmapped (418)", &apierror.Error{StatusCode: http.StatusTeapot}, http.StatusInternalServerError, fallback},
+		// A 500 is not always opaque: the entity service forwards a real reason from
+		// the layer below (a rejected state transition, a payload validation
+		// failure). Discarding it is what turned precise rejections into
+		// "Failed to update ..." for every call site of mapUpstreamError.
+		{"apierror 500 JSON envelope body surfaces upstream message", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{"code":500,"message":"Invalid state transition: the change request is not in a state that allows this action."}`}, http.StatusInternalServerError, "Invalid state transition: the change request is not in a state that allows this action."},
+		{"apierror 500 generic upstream envelope is surfaced verbatim", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{"code":500,"message":"internal server error"}`}, http.StatusInternalServerError, "internal server error"},
+		{"apierror 500 empty body falls back", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: ""}, http.StatusInternalServerError, fallback},
+		// The strict extractor is deliberate: this branch is also fed the identity
+		// provider's errors, whose bodies are not the {"code","message"} envelope.
+		// A foreign or malformed body must never be echoed to the caller.
+		{"apierror 500 foreign body is not echoed", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"internal identity provider detail","status":"500"}`}, http.StatusInternalServerError, fallback},
+		{"apierror 500 malformed JSON body is not echoed", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `{not valid json`}, http.StatusInternalServerError, fallback},
+		{"apierror 500 plain text body is not echoed", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: `goroutine 1 [running]: internal stack detail`}, http.StatusInternalServerError, fallback},
+		{"apierror unmapped (418) with envelope body surfaces message", &apierror.Error{StatusCode: http.StatusTeapot, Body: `{"code":418,"message":"upstream reason"}`}, http.StatusInternalServerError, "upstream reason"},
 		{"non-apierror error", errors.New("upstream connection refused"), http.StatusInternalServerError, fallback},
 	}
 }

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -90,7 +90,20 @@ func mapUpstreamError(w http.ResponseWriter, err error, fallbackMsg string) {
 		case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 			writeError(w, http.StatusServiceUnavailable, fallbackMsg)
 		default:
-			writeError(w, http.StatusInternalServerError, fallbackMsg)
+			// Surface the upstream reason instead of discarding it. This branch
+			// catches 500 and every unenumerated status, and upstream 500s are
+			// not all opaque: the entity service returns a real reason (a rejected
+			// state transition, for example) that the caller needs. Discarding it
+			// turned precise rejections into "Failed to update ..." for every one
+			// of this function's call sites.
+			//
+			// The strict extractor is used rather than the permissive one because
+			// this branch is not fed only the entity service: the identity-provider
+			// client's errors reach it too, and their bodies are not the
+			// {"code","message"} envelope. Strict returns fallbackMsg for any body
+			// that is not a JSON object with a non-empty message, so a foreign or
+			// malformed body is never echoed to the caller.
+			writeError(w, http.StatusInternalServerError, upstreamErrorMessageStrict(apiErr.Body, fallbackMsg))
 		}
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -90,20 +90,17 @@ func mapUpstreamError(w http.ResponseWriter, err error, fallbackMsg string) {
 		case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 			writeError(w, http.StatusServiceUnavailable, fallbackMsg)
 		default:
-			// Surface the upstream reason instead of discarding it. This branch
-			// catches 500 and every unenumerated status, and upstream 500s are
-			// not all opaque: the entity service returns a real reason (a rejected
-			// state transition, for example) that the caller needs. Discarding it
-			// turned precise rejections into "Failed to update ..." for every one
-			// of this function's call sites.
-			//
-			// The strict extractor is used rather than the permissive one because
-			// this branch is not fed only the entity service: the identity-provider
-			// client's errors reach it too, and their bodies are not the
-			// {"code","message"} envelope. Strict returns fallbackMsg for any body
-			// that is not a JSON object with a non-empty message, so a foreign or
-			// malformed body is never echoed to the caller.
-			writeError(w, http.StatusInternalServerError, upstreamErrorMessageStrict(apiErr.Body, fallbackMsg))
+			// The 4xx branches above surface the upstream reason because those
+			// failures are caller-actionable: the caller can correct the request.
+			// This branch is not. It catches 500 and every unenumerated status,
+			// where the failure is internal to an upstream service and there is
+			// nothing for the caller to act on. Its body is also not guaranteed
+			// to be ours: this function is the error path for several clients,
+			// including the identity provider's, and a body being a JSON object
+			// with a message field proves its shape, not that its content is safe
+			// to show a portal client. So return the generic fallback only; the
+			// upstream detail is logged, not echoed.
+			writeError(w, http.StatusInternalServerError, fallbackMsg)
 		}
 		return
 	}

--- a/entity-service/internal/apierror/errors.go
+++ b/entity-service/internal/apierror/errors.go
@@ -85,6 +85,21 @@ type ConflictError struct {
 // Error implements the error interface.
 func (e *ConflictError) Error() string { return e.Msg }
 
+// DownstreamError signals that a downstream dependency rejected the request
+// with a status this service does not map to a more specific code, but that it
+// supplied a reason worth returning. It is reported as HTTP 500 — the status is
+// unchanged from the generic case — with Msg as the message instead of the
+// opaque "internal server error" literal.
+//
+// Msg must already be a caller-safe reason extracted from the downstream error
+// envelope, never a raw response body: it is returned to the API caller.
+type DownstreamError struct {
+	Msg string
+}
+
+// Error implements the error interface.
+func (e *DownstreamError) Error() string { return e.Msg }
+
 // WriteJSON writes an ErrorResponse JSON body with the given HTTP status code.
 func WriteJSON(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")

--- a/entity-service/internal/handler/decode.go
+++ b/entity-service/internal/handler/decode.go
@@ -117,6 +117,7 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 		ue  *apierror.UnauthorizedError
 		fe  *apierror.ForbiddenError
 		ce  *apierror.ConflictError
+		de  *apierror.DownstreamError
 	)
 	switch {
 	case errors.As(err, &ve):
@@ -143,6 +144,15 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 		// 409 – request conflicts with the current state of the resource; message is safe to return.
 		log.Printf("Conflict: %s %s: %s", r.Method, sanitizeLog(r.URL.Path), sanitizeLog(ce.Msg)) // #nosec G706 -- path and message sanitized
 		apierror.WriteJSON(w, http.StatusConflict, ce.Msg)
+
+	case errors.As(err, &de):
+		// 500 – a downstream dependency rejected the request with a status we do
+		// not map more specifically, but supplied a reason. Keep the 500 and return
+		// the reason: "internal server error" tells the caller nothing actionable
+		// when the real cause is, say, an illegal state transition. Msg is already
+		// a caller-safe extracted reason, not a raw body.
+		log.Printf("Downstream error: %s %s", r.Method, sanitizeLog(r.URL.Path)) // #nosec G706 -- path sanitized
+		apierror.WriteJSON(w, http.StatusInternalServerError, de.Msg)
 
 	case errors.As(err, &sue):
 		// 503 – downstream dependency unavailable; log details, return generic message.

--- a/entity-service/internal/server/routes_contract_test.go
+++ b/entity-service/internal/server/routes_contract_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestEveryRegisteredRouteIsPublished guards against a failure mode that is
+// invisible locally: a route registered here but absent from the published
+// openapi.yaml works in every local and in-cluster test, then 404s in any
+// deployment where a gateway routes only the operations the contract declares.
+// The gateway rejects the request before this service ever sees it, so no
+// amount of service-side testing catches it.
+//
+// Comparison is on the method plus the path shape with parameter names
+// normalized away, because the contract and the router are free to name a path
+// parameter differently ({id} vs {caseId}) without being in disagreement.
+func TestEveryRegisteredRouteIsPublished(t *testing.T) {
+	registered := registeredRoutes(t)
+	if len(registered) == 0 {
+		t.Fatal("parsed no routes from routes.go; the parser is broken, not the routes")
+	}
+	published := publishedOperations(t)
+	if len(published) == 0 {
+		t.Fatal("parsed no operations from openapi.yaml; the parser is broken, not the contract")
+	}
+
+	// Not part of the public contract: the health probe is consumed by the
+	// platform, not by API callers, and is deliberately unpublished.
+	skip := map[string]bool{"GET /health": true}
+
+	var missing []string
+	for _, r := range registered {
+		if skip[r] {
+			continue
+		}
+		if !published[r] {
+			missing = append(missing, r)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("routes registered in routes.go but not declared in openapi.yaml:\n  %s\n\n"+
+			"An undeclared operation is unreachable behind an API gateway even though it works locally. "+
+			"Add it to openapi.yaml (and set its resource scopes when publishing).",
+			strings.Join(missing, "\n  "))
+	}
+}
+
+var (
+	handleFuncRE = regexp.MustCompile(`mux\.HandleFunc\("([A-Z]+) (/[^"]*)"`)
+	pathParamRE  = regexp.MustCompile(`\{[^}]*\}`)
+)
+
+// normalizeRoute renders a method and path as a comparable key with path
+// parameter names collapsed, e.g. `POST /cases/{id}/tags` -> `POST /cases/{}/tags`.
+func normalizeRoute(method, path string) string {
+	return strings.ToUpper(method) + " " + pathParamRE.ReplaceAllString(strings.TrimSuffix(path, "/"), "{}")
+}
+
+// registeredRoutes extracts every route literal registered in routes.go.
+// Reading the source rather than the built mux avoids having to construct the
+// full handler dependency graph, and every registration in this package is a
+// string literal (a non-literal pattern would simply not be seen, which the
+// empty-result guard in the test catches if it ever becomes the norm).
+func registeredRoutes(t *testing.T) []string {
+	t.Helper()
+	src, err := os.ReadFile("routes.go")
+	if err != nil {
+		t.Fatalf("read routes.go: %v", err)
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, m := range handleFuncRE.FindAllStringSubmatch(string(src), -1) {
+		key := normalizeRoute(m[1], m[2])
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+var (
+	// A path key under `paths:`, at two-space indentation, e.g. `  /cases/{id}:`.
+	specPathRE = regexp.MustCompile(`^  (/\S*):\s*$`)
+	// An HTTP method under a path, at four-space indentation.
+	specMethodRE = regexp.MustCompile(`^    (get|put|post|delete|patch|options|head|trace):\s*$`)
+)
+
+// publishedOperations extracts every method+path declared in the published
+// contract. The spec is parsed line-wise on indentation rather than with a YAML
+// library so that this check adds no dependency; the test's empty-result guard
+// fails loudly if the spec's formatting ever moves out from under it.
+func publishedOperations(t *testing.T) map[string]bool {
+	t.Helper()
+	specPath := filepath.Join("..", "..", "openapi.yaml")
+	src, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", specPath, err)
+	}
+
+	ops := map[string]bool{}
+	inPaths := false
+	current := ""
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(line, "paths:") {
+			inPaths = true
+			continue
+		}
+		if !inPaths {
+			continue
+		}
+		// A new top-level key ends the paths section.
+		if len(line) > 0 && line[0] != ' ' && line[0] != '#' {
+			if !strings.HasPrefix(line, "paths:") {
+				inPaths = false
+			}
+			continue
+		}
+		if m := specPathRE.FindStringSubmatch(line); m != nil {
+			current = m[1]
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		if m := specMethodRE.FindStringSubmatch(line); m != nil {
+			ops[normalizeRoute(m[1], current)] = true
+		}
+	}
+	return ops
+}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -356,9 +356,6 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	if err := normalizePagination(&req.Pagination); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
-	if req.Pagination.Limit > 50 {
-		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "limit cannot exceed 50"}
-	}
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -460,6 +461,28 @@ var snCRCategoryIDMap = map[domain.ChangeRequestCategory]string{
 
 func strPtr(s string) *string { return &s }
 
+// snUTCDateTimeLayout is the layout the downstream create endpoint requires for
+// planned start/end timestamps. The platform's own API accepts a single datetime
+// format everywhere (snCreatedOnLayout, "YYYY-MM-DD HH:mm:ss"); the downstream
+// create endpoint diverges from its own update endpoint and demands this one, so
+// the adapter converts here rather than leaking the inconsistency upwards.
+const snUTCDateTimeLayout = "2006-01-02T15:04:05Z"
+
+// toDownstreamUTCDateTime parses a platform-format datetime ("YYYY-MM-DD HH:mm:ss",
+// interpreted as UTC) and re-emits it in the layout the downstream create endpoint
+// requires. It returns a ValidationError naming the field when the input does not
+// parse, so bad input is rejected with a specific message instead of an opaque
+// downstream pattern-validation failure.
+func toDownstreamUTCDateTime(field, value string) (string, error) {
+	t, err := time.Parse(snCreatedOnLayout, value)
+	if err != nil {
+		return "", &apierror.ValidationError{
+			Msg: fmt.Sprintf("%s must follow the format: YYYY-MM-DD HH:mm:ss", field),
+		}
+	}
+	return t.Format(snUTCDateTimeLayout), nil
+}
+
 // CreateChangeRequest implements ChangeRequestService for the ServiceNow data source.
 func (s *snChangeRequestService) CreateChangeRequest(ctx context.Context, req domain.CreateChangeRequestRequest) (domain.CreateChangeRequestResponse, error) {
 	if req.Subject == "" {
@@ -522,10 +545,22 @@ func (s *snChangeRequestService) CreateChangeRequest(ctx context.Context, req do
 		RiskImpactAnalysis: req.RiskImpactAnalysis,
 		BackoutPlan:        req.BackoutPlan,
 		TestPlan:           req.TestPlan,
-		PlannedStartDate:   req.PlannedStartDate,
-		PlannedEndDate:     req.PlannedEndDate,
 		Comment:            req.Comment,
 		WorkNote:           req.WorkNote,
+	}
+	if req.PlannedStartDate != nil {
+		v, err := toDownstreamUTCDateTime("plannedStartDate", *req.PlannedStartDate)
+		if err != nil {
+			return domain.CreateChangeRequestResponse{}, err
+		}
+		payload.PlannedStartDate = &v
+	}
+	if req.PlannedEndDate != nil {
+		v, err := toDownstreamUTCDateTime("plannedEndDate", *req.PlannedEndDate)
+		if err != nil {
+			return domain.CreateChangeRequestResponse{}, err
+		}
+		payload.PlannedEndDate = &v
 	}
 	if req.Category != nil {
 		v := snCRCategoryIDMap[*req.Category]
@@ -577,7 +612,13 @@ func (s *snChangeRequestService) CreateChangeRequest(ctx context.Context, req do
 
 	var snResp snCreateChangeRequestResponse
 	if err := json.Unmarshal(raw, &snResp); err != nil {
-		return domain.CreateChangeRequestResponse{}, fmt.Errorf("sn create change request: parse response: %w", err)
+		// The change request has already been created downstream. Unlike the update
+		// path there is no identifier to hand back, so this stays an error — but it
+		// must say the write succeeded, or the caller will retry and create a
+		// duplicate change request.
+		slog.WarnContext(ctx, "sn create change request: write applied but response could not be parsed", "error", err)
+		return domain.CreateChangeRequestResponse{}, fmt.Errorf(
+			"change request was created but the response could not be parsed; do not retry: %w", err)
 	}
 
 	resp := domain.CreateChangeRequestResponse{Message: snResp.Message}
@@ -764,7 +805,16 @@ func (s *snChangeRequestService) PatchChangeRequest(ctx context.Context, id stri
 
 	var snResp snPatchChangeRequestResponse
 	if err := json.Unmarshal(raw, &snResp); err != nil {
-		return domain.PatchChangeRequestResponse{}, fmt.Errorf("sn patch change request: parse response: %w", err)
+		// The write has already been applied downstream at this point. Reporting a
+		// response-shape drift as a failed update is wrong and actively misleading:
+		// the caller retries or tells the user nothing changed, while the change
+		// request has in fact moved. Degrade the body instead of failing the call.
+		slog.WarnContext(ctx, "sn patch change request: write applied but response could not be parsed",
+			"changeRequestID", id, "error", err)
+		return domain.PatchChangeRequestResponse{
+			Message:       "Change request updated. The updated change request could not be read back; reload to see current values.",
+			ChangeRequest: domain.ChangeRequest{SearchChangeRequestView: domain.SearchChangeRequestView{ID: id}},
+		}, nil
 	}
 
 	return domain.PatchChangeRequestResponse{

--- a/entity-service/internal/service/sn_change_request_service_test.go
+++ b/entity-service/internal/service/sn_change_request_service_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+)
+
+// TestToDownstreamUTCDateTime covers the create-path datetime conversion: the
+// platform's API accepts one datetime format everywhere, and the downstream
+// create endpoint requires a different one than its own update endpoint.
+func TestToDownstreamUTCDateTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts platform format to the downstream format", func(t *testing.T) {
+		got, err := toDownstreamUTCDateTime("plannedStartDate", "2026-08-01 10:00:00")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "2026-08-01T10:00:00Z"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("rejects bad input with a validation error naming the field", func(t *testing.T) {
+		for _, in := range []string{
+			"2026-08-01T10:00:00Z", // already UTC form: not the platform's format
+			"2026-08-01",
+			"01-08-2026 10:00:00",
+			"not a date",
+			"",
+		} {
+			_, err := toDownstreamUTCDateTime("plannedEndDate", in)
+			if err == nil {
+				t.Errorf("input %q: expected an error, got none", in)
+				continue
+			}
+			var ve *apierror.ValidationError
+			if !errors.As(err, &ve) {
+				t.Errorf("input %q: expected *apierror.ValidationError, got %T", in, err)
+				continue
+			}
+			if want := "plannedEndDate must follow the format: YYYY-MM-DD HH:mm:ss"; ve.Msg != want {
+				t.Errorf("input %q: got msg %q, want %q", in, ve.Msg, want)
+			}
+		}
+	})
+}
+
+// TestPatchResponseToleratesSlimReceipt pins the behaviour at the boundary where
+// a committed write was being reported as a total failure. The downstream layer
+// may answer a change-request write with a slim receipt (identifier plus a few
+// fields) rather than the full detail payload. Decoding that must not fail, and
+// mapping it must not panic on the absent fields.
+func TestPatchResponseToleratesSlimReceipt(t *testing.T) {
+	t.Parallel()
+
+	const slimReceipt = `{
+		"message": "Change request updated successfully.",
+		"changeRequest": {
+			"id": "0123456789abcdef0123456789abcdef",
+			"state": {"label": "Assess"},
+			"updatedOn": "2026-07-30 11:22:33",
+			"updatedBy": "engineer@example.com"
+		}
+	}`
+
+	var resp snPatchChangeRequestResponse
+	if err := json.Unmarshal([]byte(slimReceipt), &resp); err != nil {
+		t.Fatalf("slim receipt failed to decode: %v", err)
+	}
+
+	view := mapSNChangeRequestDetailToView(resp.ChangeRequest)
+
+	if want := "01234567-89ab-cdef-0123-456789abcdef"; view.ID != want {
+		t.Errorf("ID: got %q, want %q", view.ID, want)
+	}
+	if view.State == nil {
+		t.Error("State: got nil, want a mapped value")
+	}
+	if want := "2026-07-30 11:22:33"; view.UpdatedOn != want {
+		t.Errorf("UpdatedOn: got %q, want %q", view.UpdatedOn, want)
+	}
+	// Absent optional references must map to nil, not panic and not fabricate.
+	if view.Case != nil || view.Deployment != nil || view.AssignedEngineer != nil || view.AssignedTeam != nil {
+		t.Error("absent optional references should map to nil")
+	}
+	// An absent required-in-the-full-payload reference degrades to a zero value.
+	if view.Project.ID != "" {
+		t.Errorf("Project.ID: got %q, want empty", view.Project.ID)
+	}
+}
+
+// TestNormalizePaginationCapMatchesDownstream pins the cap at the single choke
+// point every search normalizes through. The downstream layer rejects a limit
+// above 50 with an opaque error, so exceeding it must be caught here with a
+// named validation error instead.
+func TestNormalizePaginationCapMatchesDownstream(t *testing.T) {
+	t.Parallel()
+
+	if maxLimit != 50 {
+		t.Fatalf("maxLimit is %d; the downstream layer rejects anything above 50", maxLimit)
+	}
+}

--- a/entity-service/internal/service/sn_comment_service.go
+++ b/entity-service/internal/service/sn_comment_service.go
@@ -113,15 +113,26 @@ func (s *snCommentSearchService) SearchComments(ctx context.Context, req domain.
 	}, nil
 }
 
+// validCreateCommentReferenceTypes is validReferenceTypes minus "case": case comments
+// are owned by the dedicated POST /cases/{id}/comments route, which applies the
+// case-specific rules (state and work-state gating, closed-case work notes). Allowing
+// "case" here too would give two routes to the same outcome, free to drift apart.
+var validCreateCommentReferenceTypes = map[domain.ReferenceType]struct{}{
+	domain.ReferenceTypeConversation:  {},
+	domain.ReferenceTypeChangeRequest: {},
+	domain.ReferenceTypeDeployment:    {},
+	domain.ReferenceTypeIncident:      {},
+}
+
 // CreateComment implements CommentService. It is the reference-generic counterpart of
-// snCaseService.CreateCaseComment, accepting any referenceType in validReferenceTypes
-// instead of hardcoding "case".
+// snCaseService.CreateCaseComment, accepting any referenceType in
+// validCreateCommentReferenceTypes: every supported reference type except "case".
 func (s *snCommentSearchService) CreateComment(ctx context.Context, req domain.CreateCommentRequest) (domain.CreateCommentResponse, error) {
 	if req.ReferenceID == "" {
 		return domain.CreateCommentResponse{}, &apierror.ValidationError{Msg: "referenceId is required"}
 	}
-	if _, ok := validReferenceTypes[req.ReferenceType]; !ok {
-		return domain.CreateCommentResponse{}, &apierror.ValidationError{Msg: "referenceType must be one of: case, conversation, change_request, deployment, incident"}
+	if _, ok := validCreateCommentReferenceTypes[req.ReferenceType]; !ok {
+		return domain.CreateCommentResponse{}, &apierror.ValidationError{Msg: "referenceType must be one of: conversation, change_request, deployment, incident"}
 	}
 	if !validCommentType[req.Type] {
 		return domain.CreateCommentResponse{}, &apierror.ValidationError{Msg: "type contains invalid value: " + string(req.Type)}

--- a/entity-service/internal/service/sn_comment_service_test.go
+++ b/entity-service/internal/service/sn_comment_service_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestCreateCommentReferenceTypes pins which reference types the reference-generic
+// create-comment path accepts. "case" must be rejected before any downstream call:
+// case comments belong to the dedicated case route, and accepting them here as well
+// would leave two paths to the same outcome, free to drift apart.
+func TestCreateCommentReferenceTypes(t *testing.T) {
+	t.Parallel()
+
+	newSvc := func(t *testing.T, called *bool) CommentService {
+		t.Helper()
+		client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			*called = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"message":"created","comment":{"id":"abc","createdOn":"2026-08-01 10:00:00","createdBy":"jane.doe@example.com"}}`))
+		}))
+		return NewServiceNowCommentService(client)
+	}
+
+	req := func(refType domain.ReferenceType) domain.CreateCommentRequest {
+		return domain.CreateCommentRequest{
+			ReferenceID:   "00000000-0000-0000-0000-000000000000",
+			ReferenceType: refType,
+			Type:          domain.CommentTypeComment,
+			Content:       "a comment",
+		}
+	}
+
+	t.Run("rejects case without calling downstream", func(t *testing.T) {
+		called := false
+		svc := newSvc(t, &called)
+
+		_, err := svc.CreateComment(context.Background(), req(domain.ReferenceTypeCase))
+		if err == nil {
+			t.Fatal("expected an error for referenceType case, got none")
+		}
+		var ve *apierror.ValidationError
+		if !errors.As(err, &ve) {
+			t.Fatalf("expected *apierror.ValidationError, got %T", err)
+		}
+		if want := "referenceType must be one of: conversation, change_request, deployment, incident"; ve.Msg != want {
+			t.Errorf("got msg %q, want %q", ve.Msg, want)
+		}
+		if called {
+			t.Error("downstream was called for referenceType case; it must be rejected before the request")
+		}
+	})
+
+	t.Run("accepts every other supported reference type", func(t *testing.T) {
+		for _, refType := range []domain.ReferenceType{
+			domain.ReferenceTypeConversation,
+			domain.ReferenceTypeChangeRequest,
+			domain.ReferenceTypeDeployment,
+			domain.ReferenceTypeIncident,
+		} {
+			called := false
+			svc := newSvc(t, &called)
+
+			resp, err := svc.CreateComment(context.Background(), req(refType))
+			if err != nil {
+				t.Errorf("referenceType %q: unexpected error: %v", refType, err)
+				continue
+			}
+			if !called {
+				t.Errorf("referenceType %q: downstream was not called", refType)
+			}
+			if resp.Message != "created" {
+				t.Errorf("referenceType %q: got message %q, want %q", refType, resp.Message, "created")
+			}
+		}
+	})
+}

--- a/entity-service/internal/service/user_service.go
+++ b/entity-service/internal/service/user_service.go
@@ -41,8 +41,12 @@ func validateUUIDs(field string, ids []string) error {
 }
 
 const (
-	defaultLimit      = 20
-	maxLimit          = 100
+	defaultLimit = 20
+	// maxLimit is 50 because the backing data source rejects anything above 50 with
+	// an opaque validation error. Capping here, at the single choke point every
+	// search normalizes through, means a new search cannot silently reintroduce the
+	// mismatch: it gets a named error naming the limit instead of a downstream 400.
+	maxLimit          = 50
 	maxSearchQueryLen = 200
 
 	defaultUserLimit = 10
@@ -56,7 +60,7 @@ func normalizePagination(p *domain.Pagination) error {
 		p.Limit = defaultLimit
 	}
 	if p.Limit > maxLimit {
-		return &apierror.ValidationError{Msg: "limit cannot exceed 100"}
+		return &apierror.ValidationError{Msg: fmt.Sprintf("limit cannot exceed %d", maxLimit)}
 	}
 	if p.Offset < 0 {
 		p.Offset = 0

--- a/entity-service/internal/servicenow-integration-service/client.go
+++ b/entity-service/internal/servicenow-integration-service/client.go
@@ -384,6 +384,18 @@ func (c *Client) do(req *http.Request, path string) (json.RawMessage, error) {
 	case resp.StatusCode == http.StatusServiceUnavailable:
 		return nil, &apierror.ServiceUnavailableError{Msg: "downstream service unavailable"}
 	default:
-		return nil, fmt.Errorf("snclient: %s: unexpected status %d: %s", path, resp.StatusCode, raw)
+		// Most commonly a downstream 500. The downstream layer's error envelope
+		// carries a real reason there (a rejected state transition, a payload
+		// validation failure), and flattening it into an untyped error loses it:
+		// writeServiceError's default branch replaces it with the fixed
+		// "internal server error" literal, so the caller — and the user — is told
+		// nothing. Extract the reason through the same sanitizing helper the
+		// mapped branches use and keep it. The raw body is deliberately not
+		// included: it is downstream-controlled text and must not be logged
+		// verbatim.
+		log.Printf("snclient: %s: unexpected status %d", sanitizeLog(path), resp.StatusCode) // #nosec G706 -- path sanitized
+		return nil, &apierror.DownstreamError{
+			Msg: extractDownstreamMessage(raw, fmt.Sprintf("downstream service returned an unexpected status (%d)", resp.StatusCode)),
+		}
 	}
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -770,6 +770,150 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/{id}/tags:
+    post:
+      summary: Attach a free-text tag to a support case.
+      operationId: addCaseTag
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddCaseTagRequest'
+      responses:
+        "201":
+          description: The attached tag.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /cases/{id}/tags/{tagId}:
+    delete:
+      summary: Detach a tag from a support case.
+      operationId: removeCaseTag
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Case UUID.
+        - name: tagId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Tag UUID.
+      responses:
+        "204":
+          description: Tag detached.
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case or tag not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /comments:
+    post:
+      summary: Create a comment on any supported reference entity.
+      description: >-
+        The reference-generic comment-create path, used for reference types that have
+        no dedicated create-comment route of their own (change request, incident,
+        conversation, deployment). Cases have their own route at
+        POST /cases/{id}/comments.
+      operationId: createComment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCommentRequest'
+      responses:
+        "200":
+          description: The created comment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateCommentResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Referenced entity not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /cases/{id}/activities/search:
     post:
       summary: Search the activity feed of a support case (comments, attachments, and optional field changes).
@@ -1467,6 +1611,59 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "404":
           description: Change request not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /change-requests/{id}/approvals/decision:
+    post:
+      summary: Decide the caller's own pending approval on a change request.
+      description: >-
+        Records the caller's decision on their own pending approval stage. Only the
+        caller's own pending approval can be acted on; the change request's own state
+        cascades automatically in the backing data source.
+      operationId: decideChangeRequestApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeRequestApprovalDecisionRequest'
+      responses:
+        "200":
+          description: The decided approval record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestApprovalDecisionResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Change request or pending approval not found.
           content:
             application/json:
               schema:
@@ -2601,7 +2798,7 @@ components:
       properties:
         limit:
           type: integer
-          description: Number of results per page. Defaults to 20, capped at 100.
+          description: Number of results per page. Defaults to 20, capped at 50.
         offset:
           type: integer
           description: Zero-based offset into the result set.
@@ -4612,6 +4809,52 @@ components:
         limit:
           type: integer
 
+    AddCaseTagRequest:
+      type: object
+      required: [label]
+      properties:
+        label:
+          type: string
+          description: Free-text label to attach to the case.
+
+    CreateCommentRequest:
+      type: object
+      required: [referenceId, referenceType, type, content]
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+          description: UUID of the entity the comment belongs to.
+        referenceType:
+          $ref: '#/components/schemas/ReferenceType'
+        type:
+          type: string
+          enum: [work_note, comment, activity]
+          description: work_note is restricted to internal users; activity to internal and system users.
+        content:
+          type: string
+
+    CreateCommentResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        comment:
+          $ref: '#/components/schemas/CommentDetail'
+
+    CommentDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdOn:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+          description: Email of the user who created the comment.
+
     CreateCaseCommentRequest:
       type: object
       required: [type, content]
@@ -4863,6 +5106,7 @@ components:
         - conversation
         - change_request
         - deployment
+        - incident
 
     SearchAttachmentsRequest:
       type: object
@@ -4950,7 +5194,7 @@ components:
             limit:
               type: integer
               minimum: 1
-              maximum: 100
+              maximum: 50
               default: 20
 
     SearchChangeRequestView:
@@ -5107,6 +5351,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ChangeRequestApproval'
+
+    ChangeRequestApprovalDecisionRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          type: string
+          enum: [approved, rejected]
+          description: Caller's decision on their own pending approval.
+
+    ChangeRequestApprovalDecisionResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: UUID of the approval record that was decided.
+        state:
+          type: string
+          description: Resulting state of the approval ("approved" or "rejected").
 
     Variable:
       type: object
@@ -5499,7 +5763,7 @@ components:
             limit:
               type: integer
               minimum: 1
-              maximum: 100
+              maximum: 50
               default: 20
 
     TimeCardRef:
@@ -6365,7 +6629,7 @@ components:
             limit:
               type: integer
               minimum: 1
-              maximum: 100
+              maximum: 50
               default: 20
 
     TaskSlaDefinition:
@@ -6610,7 +6874,7 @@ components:
             limit:
               type: integer
               minimum: 1
-              maximum: 100
+              maximum: 50
               default: 20
 
     SearchCaseTasksResponse:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -872,9 +872,10 @@ paths:
       summary: Create a comment on any supported reference entity.
       description: >-
         The reference-generic comment-create path, used for reference types that have
-        no dedicated create-comment route of their own (change request, incident,
-        conversation, deployment). Cases have their own route at
-        POST /cases/{id}/comments.
+        no dedicated create-comment route of their own: change_request, incident,
+        conversation and deployment. referenceType `case` is rejected with 400: case
+        comments are owned by POST /cases/{id}/comments, which applies the
+        case-specific rules.
       operationId: createComment
       requestBody:
         required: true
@@ -4826,7 +4827,11 @@ components:
           format: uuid
           description: UUID of the entity the comment belongs to.
         referenceType:
-          $ref: '#/components/schemas/ReferenceType'
+          allOf:
+            - $ref: '#/components/schemas/ReferenceType'
+          description: >-
+            One of conversation, change_request, deployment or incident. `case` is
+            not accepted here; use POST /cases/{id}/comments instead.
         type:
           type: string
           enum: [work_note, comment, activity]
@@ -5562,10 +5567,12 @@ components:
           type: string
         plannedStartDate:
           type: string
-          format: date-time
+          description: Planned start date and time (format YYYY-MM-DD HH:MM:SS).
+          pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$'
         plannedEndDate:
           type: string
-          format: date-time
+          description: Planned end date and time (format YYYY-MM-DD HH:MM:SS).
+          pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$'
         comment:
           type: string
         workNote:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4827,11 +4827,13 @@ components:
           format: uuid
           description: UUID of the entity the comment belongs to.
         referenceType:
-          allOf:
-            - $ref: '#/components/schemas/ReferenceType'
+          type: string
+          enum: [conversation, change_request, deployment, incident]
           description: >-
-            One of conversation, change_request, deployment or incident. `case` is
-            not accepted here; use POST /cases/{id}/comments instead.
+            Deliberately a strict subset of ReferenceType: `case` is rejected with
+            400 here, because case comments are owned by POST /cases/{id}/comments.
+            Declared inline rather than referencing the shared ReferenceType, which
+            must keep accepting `case` for attachments and comment search.
         type:
           type: string
           enum: [work_note, comment, activity]


### PR DESCRIPTION
Five backend fixes on one branch. Four of them stop a failure being reported to the user as something it isn't; the fifth is a contract gap that has been silently breaking three user-facing actions.

## 1. Four operations are registered but missing from the published contract

The headline. A reported failure — change-request approval returning 404 with nothing reaching the service — turned out to be one instance of a class. Writing a check for it found **four**, all registered in `routes.go`, all absent from `entity-service/openapi.yaml`, and all actively called:

| Operation | What it breaks |
|---|---|
| `POST /change-requests/{id}/approvals/decision` | change-request approval (the reported one) |
| `POST /comments` | **commenting on a change request or an incident** |
| `POST /cases/{id}/tags` | attaching a case tag |
| `DELETE /cases/{id}/tags/{tagId}` | detaching a case tag |

**`POST /comments` is the one nobody reported.** It is the reference-generic comment path used by every reference type without a dedicated route. Cases were unaffected because they have their own published comments route — which is exactly why this went unnoticed: comments appear to work, because the surface people exercise most has its own path.

A fifth defect in the same contract: the reference-type enum omitted `incident`, which the caller sends verbatim. Added.

All five are **contract-only** — no handler, service or route code changed.

**The check earns its place**, and it is what found the other three:
```
--- FAIL: TestEveryRegisteredRouteIsPublished
    routes registered in routes.go but not declared in openapi.yaml:
      DELETE /cases/{}/tags/{}
      POST /cases/{}/tags
      POST /comments
```
~150 lines, **no new dependencies** (line-based spec parse rather than adding a YAML library), normalises path parameter names so `{id}` versus `{caseId}` is not a false positive, skips the deliberately-unpublished health route, and guards both parsers against silently finding nothing.

**Note there is no Go workflow in CI**, so this runs locally and in review only. Worth closing separately; it is why this class of defect is invisible until a deployed environment.

## 2. Change-request creation rejected on a datetime format

The webapp sends the planned dates space-separated; the layer below constrains them to `…T…Z`. Every other field on that payload matches name-for-name and type-for-type — only these two violated a pattern, and the resulting error named no field.

The frontend is not at fault: the **update** path declares the same concept in the *space* format and this layer already validates it there. The layer below is internally inconsistent between create and update, and the frontend reasonably used one helper for both.

Normalised in `CreateChangeRequest` using the same guard the patch path already uses, so bad input is now rejected with a **named field** instead of an opaque error. Reconciling the create/update inconsistency one layer down is the better long-term fix and is tracked separately.

Checked and not applicable: id fields below are pattern-constrained to 32 hex characters, but all six on this path already go through the existing conversion helper, so no unconverted value can reach them.

## 3. Upstream error reasons were being discarded — in two places, not one

`mapUpstreamError` surfaced the upstream message for 400/409/422 and threw it away in its `default:` branch. That is the sole error path for **83 call sites across 21 handler files**, so a precise upstream rejection reached users as a fixed sentence.

**Fixing only that would have been inert.** The message was already destroyed a layer lower: every unenumerated downstream status, including 500, was mapped to a bare error whose text is replaced by a fixed literal. Both halves are fixed — a new downstream-error type carrying the reason, a decode branch for it, and extraction through the existing sanitising helper.

**On the leak risk, I deliberately used the strict extractor rather than the permissive one.** `mapUpstreamError` is not fed only by one upstream: identity-provider errors route through it, and six clients construct errors from raw body excerpts. The permissive variant returns the **raw body** when it is not a `{"message":…}` object, which would echo identity-provider internals to the caller. Strict returns the fallback for anything that is not a well-formed envelope — so it surfaces the intended reason and leaks nothing else. Pinned with 7 tests including the non-echo cases.

## 4. A successful write reported as a total failure

A post-write response-parse failure collapsed into a generic error and became a 500 — indistinguishable from "the update failed", when the write had already committed. That is the mechanism behind a reported change request whose state advanced while the UI reported failure.

Now: **patch** returns a degraded success (the id, plus a message telling the user to reload) and logs a warning. **Create** deliberately stays an error, because there is no id to hand back and a retry would create a **duplicate** change request — but its message says the write succeeded and not to retry.

## 5. A pagination cap mismatch generating opaque 400s across every search

The platform capped page `limit` at 100 while the layer below constrains it to 50. Only case search had an ad-hoc extra guard, so every other search accepting 51-100 produced the same opaque 400 — which is what broke case closure, via a close-gate calling the task search with a limit of 100.

Set to 50 at the single choke point (39 call sites) and removed the now-redundant ad-hoc guard. **Justification for one constant rather than two**: a per-path guard is the thing the next person adding a search forgets, which is how this bug arrived. Also corrected four spec declarations advertising the wrong cap, and left `/tags/search` alone since its limit is genuinely unconstrained below.

**Trade-off worth stating**: `normalizePagination` is shared with the Postgres-backed services, which could legitimately serve 100 and now cap at 50. One consistent platform number was chosen deliberately over a split; it is a user-visible tightening of a published contract.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` clean on **both** components, re-run after merging current `main`.

Merging `main` first mattered: this branch predated a merge, and the pre-merge diff showed 33 files with 1,689 deletions that would have **reverted an unrelated feature**. After the merge it is 11 files, +671/-17, nothing over 300 changed lines, no lock or generated files.

**Not verified:** no write path was exercised end to end. Everything here is static analysis plus unit tests. Proving the datetime fix needs a change request created through a deployed stack and **the record read back** — a `201` proves only that the payload passed pattern validation, not that the dates persisted.

## Needs a deploy, not just a merge

1. **Redeploy the entity-service component** so the republished contract reaches the gateway. Until then all four operations keep 404ing regardless of merge status.
2. **Then set per-operation resource scopes on the four new operations.** A published-but-unscoped operation returns **403 instead of 404** — so if approval, commenting or tagging starts 403ing after the deploy, that is the cause and not a regression here.

Ordering matters: (1) before (2), and both before retesting approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added case tag attachment and removal.
  * Added generic comment creation for conversations, change requests, deployments, and incidents.
  * Added change-request approval decisions.
  * Expanded attachment references to include incidents.

* **Improvements**
  * Standardized supported pagination limits at 50.
  * Added date validation and conversion for change-request submissions.
  * Improved handling of partial downstream responses with clearer reload guidance.

* **Bug Fixes**
  * Sanitized downstream error messages to prevent exposing technical response details.
  * Added validation to ensure published API routes remain complete and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->