### PR TITLE
[CSM Portal Microapp] Fix TopBar overlap and case/incident/change-request sort order in microapp

### DIFF
--- a/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
+++ b/apps/csm-portal/microapp/src/components/home/AssignedToMeSection.tsx
@@ -20,6 +20,7 @@ import { currentUser } from "@src/services/currentUser";
 import { dashboard } from "@src/services/dashboard";
 import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
 import { ErrorState } from "@components/support/ErrorState";
+import { compareByUpdatedOnDesc } from "@utils/dateTime";
 import { RefreshButton } from "./RefreshButton";
 
 // The signed-in user's own non-closed cases — mirrors the webapp's "Assigned to me" widget
@@ -32,7 +33,9 @@ export function AssignedToMeSection() {
     dashboard.assignedToMe(currentUserId ?? null),
   );
 
-  const items = data?.items ?? [];
+  // sortBy: updatedOn desc is sent on the request (see dashboard.ts) but isn't reliably honored
+  // upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = (data?.items ?? []).sort((a, b) => compareByUpdatedOnDesc(a.updatedOn, b.updatedOn));
 
   return (
     <Stack gap={1.5}>

--- a/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/TopBar.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Box, IconButton, Typography, pxToRem } from "@wso2/oxygen-ui";
+import { Box, IconButton, Typography, pxToRem, useTheme } from "@wso2/oxygen-ui";
 import { ArrowLeft, Grip } from "@wso2/oxygen-ui-icons-react";
 import { goToMyAppsScreen } from "@components/microapp-bridge";
 import { ConfirmDialog } from "@components/common/ConfirmDialog";
@@ -29,6 +29,7 @@ export function TopBar() {
   const navigate = useNavigate();
   const isRootPath = ROOT_PATHS.includes(location.pathname);
   const mode = useThemeMode();
+  const theme = useTheme();
 
   return (
     <Box
@@ -49,6 +50,7 @@ export function TopBar() {
         // this TopBar has no such content, so it needs the calc instead.
         pt: "calc(var(--safe-top, 44px) + 28px)",
         backgroundColor: `${mode === "light" ? "white" : "black"} !important`,
+        zIndex: theme.zIndex.appBar,
       }}
     >
       <Box sx={{ minWidth: 32 }}>

--- a/apps/csm-portal/microapp/src/components/operations/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ChangeRequestsTab.tsx
@@ -25,7 +25,7 @@ import { EmptyState } from "@components/support/EmptyState";
 import { ErrorState } from "@components/support/ErrorState";
 import { SearchBar } from "@components/support/SearchBar";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
-import { formatDate } from "@utils/dateTime";
+import { compareByUpdatedOnDesc, formatDate } from "@utils/dateTime";
 import { ChangeRequestCard, ChangeRequestCardSkeleton } from "./ChangeRequestCard";
 import { ChangeRequestsFiltersSheet } from "./ChangeRequestsFiltersSheet";
 import { CHANGE_REQUEST_IMPACT_LABELS, CHANGE_REQUEST_STATE_LABELS } from "./config";
@@ -154,7 +154,9 @@ function ChangeRequestListContent({ search, filters }: { search: string; filters
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const items = data.pages.flatMap((page) => page.items);
+  // sortBy: updatedOn desc is sent on every request (see changeRequests.ts) but isn't reliably
+  // honored upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = data.pages.flatMap((page) => page.items).sort((a, b) => compareByUpdatedOnDesc(a.updatedOn, b.updatedOn));
 
   if (items.length === 0) return <EmptyState message="No change requests found." />;
 

--- a/apps/csm-portal/microapp/src/components/operations/IncidentsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/IncidentsTab.tsx
@@ -25,6 +25,7 @@ import { EmptyState } from "@components/support/EmptyState";
 import { ErrorState } from "@components/support/ErrorState";
 import { SearchBar } from "@components/support/SearchBar";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { compareByUpdatedOnDesc } from "@utils/dateTime";
 import { IncidentCard, IncidentCardSkeleton } from "./IncidentCard";
 import { IncidentsFiltersSheet } from "./IncidentsFiltersSheet";
 import {
@@ -129,7 +130,9 @@ function IncidentListContent({ search, filters }: { search: string; filters: Inc
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const items = data.pages.flatMap((page) => page.items);
+  // sortBy: updatedOn desc is sent on every request (see incidents.ts) but isn't reliably
+  // honored upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = data.pages.flatMap((page) => page.items).sort((a, b) => compareByUpdatedOnDesc(a.updatedOn, b.updatedOn));
 
   if (items.length === 0) return <EmptyState message="No incidents found." />;
 

--- a/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/operations/ServiceRequestsTab.tsx
@@ -30,6 +30,7 @@ import { SearchBar } from "@components/support/SearchBar";
 import { FILTERABLE_STATES, STATE_LABELS, TAB_CONFIG, WORK_STATE_LABEL } from "@components/support/config";
 import { countActiveFilters, EMPTY_FILTERS, toCaseSearchFilters, type CaseFilters } from "@components/support/filters";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { compareByUpdatedOnDesc } from "@utils/dateTime";
 import { ServiceRequestsFiltersSheet } from "./ServiceRequestsFiltersSheet";
 
 const ALL_STATES_TAB = "all" as const;
@@ -156,7 +157,9 @@ function ServiceRequestListContent({
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const items = data.pages.flatMap((page) => page.items);
+  // sortBy: updatedOn desc is sent on every request (see cases.ts) but isn't reliably honored
+  // upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = data.pages.flatMap((page) => page.items).sort((a, b) => compareByUpdatedOnDesc(a.updatedOn, b.updatedOn));
 
   if (items.length === 0) return <EmptyState message={TAB_CONFIG.service_request.emptyMessage} />;
 

--- a/apps/csm-portal/microapp/src/components/security-center/SecurityReportsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/security-center/SecurityReportsTab.tsx
@@ -21,6 +21,7 @@ import { Plus, SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { securityReports } from "@src/services/securityReports";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { compareByUpdatedOnDesc } from "@utils/dateTime";
 import { useInfiniteScrollSentinel } from "@utils/useInfiniteScrollSentinel";
 import {
   countActiveSecurityReportFilters,
@@ -52,7 +53,11 @@ export function SecurityReportsTab() {
     securityReports.infinite({ ...filters, search: debouncedSearch }),
   );
 
-  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  // sortBy: updatedOn desc is sent on every request (see securityReports.ts) but isn't reliably
+  // honored upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = (data?.pages.flatMap((p) => p.items) ?? []).sort((a, b) =>
+    compareByUpdatedOnDesc(a.updatedOn, b.updatedOn),
+  );
   const total = data?.pages[0]?.total ?? items.length;
 
   const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });

--- a/apps/csm-portal/microapp/src/pages/AnnouncementsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/AnnouncementsPage.tsx
@@ -20,6 +20,7 @@ import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { announcements } from "@src/services/announcements";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { compareByUpdatedOnDesc } from "@utils/dateTime";
 import {
   countActiveAnnouncementFilters,
   EMPTY_ANNOUNCEMENT_FILTERS,
@@ -44,7 +45,11 @@ export default function AnnouncementsPage() {
     announcements.infinite({ ...filters, search: debouncedSearch }),
   );
 
-  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  // sortBy: updatedOn desc is sent on every request (see announcements.ts) but isn't reliably
+  // honored upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = (data?.pages.flatMap((p) => p.items) ?? []).sort((a, b) =>
+    compareByUpdatedOnDesc(a.updatedOn, b.updatedOn),
+  );
   const total = data?.pages[0]?.total ?? items.length;
 
   const sentinelRef = useRef<HTMLDivElement>(null);

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -364,6 +364,11 @@ function CaseDetailContent({ id }: { id: string }) {
           );
         }
         void queryClient.invalidateQueries({ queryKey: ["case", id, "comments"] });
+        // A comment (like a state transition, see invalidateCase above) bumps the case's own
+        // updatedOn server-side — without this, neither this page's own "Updated On" nor the
+        // cases list's sort order pick up the change until something else happens to invalidate
+        // them.
+        invalidateCase();
         // An attachment-only submission (no text) where every upload failed posted nothing at
         // all — resolve false so the composer keeps the picked files for retry instead of
         // clearing them after showing the error. A submission with text still succeeds here

--- a/apps/csm-portal/microapp/src/pages/EngagementsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/EngagementsPage.tsx
@@ -20,6 +20,7 @@ import { SlidersHorizontal } from "@wso2/oxygen-ui-icons-react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { engagements } from "@src/services/engagements";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { compareByUpdatedOnDesc } from "@utils/dateTime";
 import { countActiveEngagementFilters, EMPTY_ENGAGEMENT_FILTERS, type EngagementFilters } from "@utils/engagements";
 import { SearchBar } from "@components/support/SearchBar";
 import { EmptyState } from "@components/support/EmptyState";
@@ -44,7 +45,11 @@ export default function EngagementsPage() {
     engagements.infinite({ ...filters, search: debouncedSearch }),
   );
 
-  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  // sortBy: updatedOn desc is sent on every request (see engagements.ts) but isn't reliably
+  // honored upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = (data?.pages.flatMap((p) => p.items) ?? []).sort((a, b) =>
+    compareByUpdatedOnDesc(a.updatedOn, b.updatedOn),
+  );
   const total = data?.pages[0]?.total ?? items.length;
 
   const sentinelRef = useRef<HTMLDivElement>(null);

--- a/apps/csm-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SupportPage.tsx
@@ -42,6 +42,7 @@ import {
   WORK_STATE_LABEL,
 } from "@components/support/config";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
+import { compareByUpdatedOnDesc } from "@utils/dateTime";
 
 const ALL_STATES_TAB = "all" as const;
 type StateTabValue = CaseState | typeof ALL_STATES_TAB;
@@ -180,7 +181,9 @@ function CaseListContent({
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const items = data.pages.flatMap((page) => page.items);
+  // sortBy: updatedOn desc is sent on every request (see cases.ts) but isn't reliably honored
+  // upstream — re-sort client-side as a backstop. See compareByUpdatedOnDesc for why.
+  const items = data.pages.flatMap((page) => page.items).sort((a, b) => compareByUpdatedOnDesc(a.updatedOn, b.updatedOn));
   const total = data.pages[0]?.total ?? items.length;
 
   if (items.length === 0) return <EmptyState message={TAB_CONFIG.case.emptyMessage} />;

--- a/apps/csm-portal/microapp/src/services/changeRequests.ts
+++ b/apps/csm-portal/microapp/src/services/changeRequests.ts
@@ -72,11 +72,17 @@ const createChangeRequest = async (payload: ChangeRequestCreatePayloadDto): Prom
 const CHANGE_REQUEST_PAGE_LIMIT = 20;
 
 export const changeRequests = {
-  infinite: (payload: Omit<ChangeRequestSearchPayloadDto, "pagination"> = {}) =>
+  // Most-recently-updated first, mirroring cases.ts's infinite (updatedOn desc) — not left to the
+  // backend's default order.
+  infinite: (payload: Omit<ChangeRequestSearchPayloadDto, "pagination" | "sortBy"> = {}) =>
     infiniteQueryOptions({
       queryKey: ["change-requests", "infinite", payload],
       queryFn: ({ pageParam }) =>
-        searchChangeRequests({ ...payload, pagination: { offset: pageParam, limit: CHANGE_REQUEST_PAGE_LIMIT } }),
+        searchChangeRequests({
+          ...payload,
+          sortBy: { field: "updatedOn", order: "desc" },
+          pagination: { offset: pageParam, limit: CHANGE_REQUEST_PAGE_LIMIT },
+        }),
       initialPageParam: 0,
       getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
     }),

--- a/apps/csm-portal/microapp/src/services/incidents.ts
+++ b/apps/csm-portal/microapp/src/services/incidents.ts
@@ -80,11 +80,17 @@ const createIncident = async (payload: IncidentCreatePayloadDto): Promise<Incide
 const INCIDENT_PAGE_LIMIT = 20;
 
 export const incidents = {
-  infinite: (payload: Omit<IncidentSearchPayloadDto, "pagination"> = {}) =>
+  // Most-recently-updated first, mirroring cases.ts's infinite (updatedOn desc) — not left to the
+  // backend's default order.
+  infinite: (payload: Omit<IncidentSearchPayloadDto, "pagination" | "sortBy"> = {}) =>
     infiniteQueryOptions({
       queryKey: ["incidents", "infinite", payload],
       queryFn: ({ pageParam }) =>
-        searchIncidents({ ...payload, pagination: { offset: pageParam, limit: INCIDENT_PAGE_LIMIT } }),
+        searchIncidents({
+          ...payload,
+          sortBy: { field: "updatedOn", order: "desc" },
+          pagination: { offset: pageParam, limit: INCIDENT_PAGE_LIMIT },
+        }),
       initialPageParam: 0,
       getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
     }),

--- a/apps/csm-portal/microapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/microapp/src/utils/dateTime.ts
@@ -60,6 +60,18 @@ export const parseBackendTimestamp = (raw: string): Date => new Date(normalizeBa
 export const parseOptionalBackendTimestamp = (raw: string | null | undefined): Date | null =>
   raw ? parseBackendTimestamp(raw) : null;
 
+// The backend is asked to sort every list by updatedOn desc, but that request isn't reliably
+// honored upstream (confirmed live: cases with an older updatedOn have shown up ranked above
+// more recently updated ones despite the request carrying the correct sortBy). Re-sort
+// client-side as a defensive backstop so what's on screen is at least correctly ordered,
+// even though it can't fix the page-boundary itself if the backend's own pagination cursor
+// isn't following this order. Missing/invalid dates sort last rather than crashing the compare.
+export function compareByUpdatedOnDesc(a: Date | null, b: Date | null): number {
+  const aTime = a && !Number.isNaN(a.getTime()) ? a.getTime() : -Infinity;
+  const bTime = b && !Number.isNaN(b.getTime()) ? b.getTime() : -Infinity;
+  return bTime - aTime;
+}
+
 /**
  * Lists the IANA time zones the runtime supports, for the profile time-zone picker.
  * Uses `Intl.supportedValuesOf` where available; falls back to the browser's own zone


### PR DESCRIPTION
## Summary
- Fix the sticky TopBar getting visually covered by scrolling case cards (missing `z-index` — case cards use `backdrop-filter`, which creates a stacking context that won a DOM-order tiebreak against the topbar).
- Add the missing `sortBy: updatedOn desc` to Change Requests and Incidents search requests (Operations tab), matching every other list in the app.
- Fix `CaseDetailPage` not invalidating the case/list caches after posting a comment, so a comment-driven update wasn't reflected until something else triggered a refetch.
- Add a client-side sort backstop applied to every "newest-first" list (Support, Operations tabs, Announcements, Engagements, Security Reports, Home's "Assigned to me"), since live testing showed the upstream entity service doesn't reliably honor the requested sort even though the outgoing request is correct.

## Test plan
- [ ] Scroll the Support case list on a device/simulator and confirm the TopBar/"Go to Apps" pill stays fully covered by the sticky bar's background instead of cards showing through it.
- [ ] Confirm Support, Operations (Service Requests / Change Requests / Incidents), Announcements, Engagements, and Security Reports lists show newest-`updatedOn`-first.
- [ ] Post a comment on a case and confirm the case detail's "Updated On" and the Support list both refresh without a manual reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Lists for cases, incidents, change requests, service requests, security reports, announcements, and engagements now consistently show recently updated items first.
  - Items with missing or invalid update dates are placed at the end.
  - Case details and list views now refresh correctly after comments or attachments are submitted.
  - The top navigation bar maintains the correct layering above page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->