### PR TITLE
[CSM Portal Microapp] Add copy-to-clipboard button for case ID on the detail page (microapp)

### DIFF
--- a/apps/csm-portal/microapp/src/components/common/CopyIconButton.tsx
+++ b/apps/csm-portal/microapp/src/components/common/CopyIconButton.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { IconButton, Tooltip, pxToRem } from "@wso2/oxygen-ui";
+import { Check, Copy } from "@wso2/oxygen-ui-icons-react";
+
+// Mirrors the customer-portal microapp's OverlineSlot copy affordance
+// (components/features/detail/OverlineSlot.tsx): tap copies `value`, the icon swaps to a
+// checkmark and the tooltip reads "Copied!" for 2s, then reverts.
+export function CopyIconButton({ value, "aria-label": ariaLabel }: { value: string; "aria-label": string }) {
+  const [copied, setCopied] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard access denied or unavailable — nothing actionable to do here.
+    }
+  };
+
+  return (
+    <Tooltip
+      title={copied ? "Copied!" : "Copy"}
+      open={copied || hovered}
+      onOpen={() => setHovered(true)}
+      onClose={() => setHovered(false)}
+    >
+      <IconButton size="small" color={copied ? "success" : "default"} onClick={handleCopy} aria-label={ariaLabel}>
+        {copied ? <Check size={pxToRem(16)} /> : <Copy size={pxToRem(16)} />}
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -58,6 +58,7 @@ import type {
   Comment,
 } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { CopyIconButton } from "@components/common/CopyIconButton";
 import { SeverityChip, StatusChip } from "@components/support/Chips";
 import { ErrorState } from "@components/support/ErrorState";
 import { ALL_SEVERITIES, SEVERITY_LABELS, TYPE_CONFIG } from "@components/support/config";
@@ -477,12 +478,13 @@ function CaseSummarySection({
   return (
     <Stack gap={1.5}>
       <Stack gap={0.5}>
-        <Stack direction="row" alignItems="center" gap={1}>
+        <Stack direction="row" alignItems="center" gap={0.5}>
           <Icon size={pxToRem(18)} color={color} />
           <Typography variant="subtitle2" color="text.secondary">
             {caseDetail.number}
             {caseDetail.wso2Id ? ` · ${caseDetail.wso2Id}` : ""}
           </Typography>
+          <CopyIconButton value={caseDetail.wso2Id || caseDetail.number} aria-label="Copy case ID" />
         </Stack>
 
         <Typography variant="h6">{caseDetail.subject}</Typography>


### PR DESCRIPTION
## Summary
- Add a copy icon next to the case number/ID on the case detail page. Tapping it copies the ID, swaps the icon to a checkmark, and shows a "Copied!" tooltip for 2 seconds before reverting.
- Mirrors the customer-portal microapp's existing `OverlineSlot` copy affordance (same icons, same clipboard/timeout/tooltip logic), extracted into a standalone `CopyIconButton` since this app's `TopBar` has no title slot to host it in — it renders inline next to the case number instead.

## Test plan
- [x] Open a case's detail page, tap the copy icon next to the case number, and confirm the clipboard contains the case's `wso2Id`.
- [x] Confirm the icon swaps to a checkmark and the tooltip reads "Copied!" for ~2s, then reverts to the copy icon.