### PR TITLE
[CSM Portal] stop re-fetching the cases list when /users/me resolves

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -25,6 +25,7 @@ import {
   mapCaseSearchViewToRow,
   resolveAssignedUserIds,
 } from "@features/csm-cases/utils/caseSearchPayload";
+import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import type { BeCaseSearchPayload, BeCaseSearchResponse } from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
@@ -71,12 +72,20 @@ export function useGetCsmCases(
   const logger = useLogger();
   const api = useBackendApi();
   // Signed-in email, to resolve `assigneeIsMe` per row against the assigned
-  // engineer's email. In the key so a late-arriving claim recomputes.
+  // engineer's email. In the key so a late-arriving claim recomputes — this
+  // applies to every row regardless of the assignee filter, so it stays
+  // unconditional.
   const currentUserEmail = useIdTokenClaims()?.email;
-  // The caller's platform UUID, fetched once app-wide (CurrentUserProvider) and
-  // used to resolve the `@me` assignee filter. In the key so a late-arriving id
-  // re-resolves an `@me` selection.
+  // The caller's platform UUID, fetched once app-wide (CurrentUserProvider)
+  // and used only to resolve an `@me` assignee filter (see
+  // `resolveAssignedUserIds`) — nothing else reads it. Only fold it into the
+  // key when `@me` is actually selected: `/users/me` is a real network call
+  // that resolves after the id starts as `undefined`, and keying on it
+  // unconditionally meant every page load re-fetched the exact same
+  // unfiltered search a second time the moment it arrived, for every user,
+  // regardless of whether any assignee filter was active at all.
   const currentUserId = useCurrentUser().user?.id;
+  const wantsMe = filters.assignees.includes(ASSIGNEE_ME_TOKEN);
 
   const offset = page * pageSize;
   const search = filters.search.trim();
@@ -99,7 +108,7 @@ export function useGetCsmCases(
       [...filters.engagementTypes].sort(),
       [...filters.productNames].sort(),
       currentUserEmail ?? "",
-      currentUserId ?? "",
+      wantsMe ? (currentUserId ?? "") : "",
       page,
       pageSize,
       sortOrder,


### PR DESCRIPTION
## Purpose
The Cases list fired an extra, wasted `POST /cases/search` on every page load — the exact same unfiltered search sent twice — the moment `GET /users/me` resolved, for every user, regardless of whether any assignee filter was active.

## Goals
- The Cases list only re-fetches when something that actually affects the search result changes.
- No change to correctness for the case that legitimately needs this: an `@me` assignee filter selected before `/users/me` has resolved.

## Approach
- `useGetCsmCases`'s React Query key unconditionally included the signed-in user's platform id (`currentUserId`), kept there so a late-arriving `@me` assignee selection re-resolves once `/users/me` responds.
- That id is only ever read for resolving an `@me` assignee filter (inside `resolveAssignedUserIds`) — nothing else in the hook uses it. With no assignee filter active, the id has zero effect on the outgoing request, but the key still changed from `""` to the real id once `/users/me` resolved, and React Query treated that as a new query.
- Fix: only fold `currentUserId` into the key when `filters.assignees.includes(ASSIGNEE_ME_TOKEN)`. Left `currentUserEmail` in the key unconditionally — it's used separately, for per-row `assigneeIsMe` marking regardless of any filter, and isn't part of this bug.
- Live-verified via a real network capture (JS stack trace on each `fetch` call) that the extra request's call site and timing lined up exactly with `/users/me`'s response, before changing anything.

## User stories
As any CSM Portal user, opening the Cases list doesn't trigger a redundant, duplicate search in the background.

## Release note
Fixed: the Cases list sent one extra, unnecessary search request on every page load.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: no existing test covers this hook's query-key construction directly. Full suite run locally: 551 passed, 9 pre-existing failures unrelated to this change (same set confirmed throughout other recent CSM Portal PRs — none touch this hook or the cases list).
- Verified against staging: live network capture before/after — 3 `/cases/search` calls on page load down to 2 (the remaining 2 are React StrictMode's dev-only double-invoke of the lazy-loaded route element, confirmed by temporarily disabling StrictMode and observing no change; not present in a production build).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint`, `pnpm run test`, `pnpm run build` all passing locally (via the `./node_modules/.bin/` workaround for the local `pnpm` CLI issue).