### PR TITLE
[CSM Portal] Show the Case column on My time sheets

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import TimeCardsTable from "@features/csm-timecards/components/TimeCardsTable";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+const CARD: CsmTimeCard = {
+  id: "tc-1",
+  caseId: "case-1",
+  caseNumber: "CS0352584",
+  projectId: "proj-1",
+  projectName: "Acme Project",
+  workDate: "2026-07-01",
+  userId: "user-1",
+  userName: "Jane Doe",
+  state: "submitted",
+  billable: true,
+  totalMinutes: 30,
+};
+
+const ROLE_CTX = { isOwner: false, isApprover: false, isAdmin: false };
+
+describe("TimeCardsTable column visibility", () => {
+  it("shows the Case column but not the Engineer column on the personal view (My time sheets)", () => {
+    render(
+      <TimeCardsTable
+        cards={[CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        roleFor={() => ROLE_CTX}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Case" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Engineer" }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByText("CS0352584")).toBeInTheDocument();
+    expect(screen.queryByText("Jane Doe")).not.toBeInTheDocument();
+  });
+
+  it("shows both the Case and Engineer columns when showEngineerColumn is set (All / Approvals)", () => {
+    render(
+      <TimeCardsTable
+        cards={[CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        showEngineerColumn
+        roleFor={() => ROLE_CTX}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Case" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Engineer" })).toBeInTheDocument();
+
+    expect(screen.getByText("CS0352584")).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
@@ -35,14 +35,19 @@ interface TimeCardsTableProps {
   skeletonCount?: number;
   emptyText: string;
   /** Which field rows are clustered by — cards for the same case (or the same
-   * engineer) sort adjacent to each other; both Case and Engineer stay
-   * visible as their own columns regardless (see `showCaseEngineerColumns`),
-   * this only controls ordering. */
+   * engineer) sort adjacent to each other; whether that grouping key has its
+   * own visible column is a separate decision (see `showCaseColumn` /
+   * `showEngineerColumn` below), this prop only controls ordering. */
   groupBy: TimeCardGroupBy;
-  /** Show the Case and Engineer columns. Off on "My time sheets", where every
-   * card already belongs to the signed-in user — an Engineer column would be
-   * redundant, and there's no cross-case grouping to distinguish either. */
-  showCaseEngineerColumns?: boolean;
+  /** Show the Case column. On for all three tabs, including "My time
+   * sheets" — a personal sheet still spans every case the engineer worked
+   * on, so the case number is the most useful column on the row, not the
+   * least. Defaults to on; only tests turn it off. */
+  showCaseColumn?: boolean;
+  /** Show the Engineer column. Off on "My time sheets", where every card
+   * already belongs to the signed-in user and an Engineer column would be
+   * redundant; on for "All" and "Approvals", which span multiple engineers. */
+  showEngineerColumn?: boolean;
   /** Show the Approve/Reject buttons alongside the view-details eye icon in
    * the Actions column. Off outside the Approvals tab, where `roleFor`
    * already makes `cardActions` return none per row anyway — this just
@@ -75,7 +80,8 @@ export default function TimeCardsTable({
   skeletonCount = 6,
   emptyText,
   groupBy,
-  showCaseEngineerColumns = false,
+  showCaseColumn = true,
+  showEngineerColumn = false,
   showActionsColumn = false,
   roleFor,
   onCardAction,
@@ -86,7 +92,8 @@ export default function TimeCardsTable({
   const [detailCard, setDetailCard] = useState<CsmTimeCard | null>(null);
 
   const headerCells = [
-    ...(showCaseEngineerColumns ? ["Case", "Engineer"] : []),
+    ...(showCaseColumn ? ["Case"] : []),
+    ...(showEngineerColumn ? ["Engineer"] : []),
     "Project",
     "Date",
     "Minutes",
@@ -94,7 +101,8 @@ export default function TimeCardsTable({
     "Actions",
   ];
   const grid = [
-    ...(showCaseEngineerColumns ? ["minmax(120px, 0.9fr)", "minmax(140px, 1fr)"] : []),
+    ...(showCaseColumn ? ["minmax(120px, 0.9fr)"] : []),
+    ...(showEngineerColumn ? ["minmax(140px, 1fr)"] : []),
     "minmax(160px, 1.4fr)",
     "minmax(90px, 0.6fr)",
     "minmax(90px, 0.6fr)",
@@ -201,15 +209,15 @@ export default function TimeCardsTable({
                   borderColor: "divider",
                 }}
               >
-                {showCaseEngineerColumns && (
-                  <>
-                    <Typography role="cell" variant="body2" noWrap title={c.caseNumber}>
-                      {c.caseNumber}
-                    </Typography>
-                    <Typography role="cell" variant="body2" noWrap title={c.userName}>
-                      {c.userName}
-                    </Typography>
-                  </>
+                {showCaseColumn && (
+                  <Typography role="cell" variant="body2" noWrap title={c.caseNumber}>
+                    {c.caseNumber}
+                  </Typography>
+                )}
+                {showEngineerColumn && (
+                  <Typography role="cell" variant="body2" noWrap title={c.userName}>
+                    {c.userName}
+                  </Typography>
                 )}
                 <Tooltip title={c.projectName}>
                   <Typography role="cell" variant="body2" noWrap>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -528,7 +528,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 cards={allFilteredCards}
                 isLoading={allCards.isLoading}
                 groupBy={groupBy}
-                showCaseEngineerColumns
+                showEngineerColumn
                 roleFor={allRoleFor}
                 onCardAction={handleCardAction}
                 emptyText={anyFilterActive ? "No time cards match the current filters." : "No time logged yet."}
@@ -597,7 +597,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
                 cards={approvalsFilteredCards}
                 isLoading={queue.isLoading}
                 groupBy={groupBy}
-                showCaseEngineerColumns
+                showEngineerColumn
                 showActionsColumn
                 roleFor={approvalsRole}
                 onCardAction={handleCardAction}


### PR DESCRIPTION
## What was wrong

On the **My time sheets** tab, no row identifies which case the time card belongs to. Cards are only distinguishable by date and hours, even though each card already carries a case reference (`caseId` / `caseNumber` on the row model).

## Why

`TimeCardsTable` gated the Case and Engineer columns behind a single `showCaseEngineerColumns` prop. The page passed it on **All** and **Approvals**, and omitted it on **My time sheets**. The component's own doc comment gave the reasoning:

> Show the Case and Engineer columns. Off on "My time sheets", where every card already belongs to the signed-in user — an Engineer column would be redundant, and there's no cross-case grouping to distinguish either.

The first half is right: on a personal view, an Engineer column is redundant since every card is the signed-in user's. The second half doesn't hold: a personal time sheet spans every case the engineer worked on, so the case number is exactly the column a personal view most needs, not the one it can drop. Bundling both columns behind one flag meant the correct call on Engineer silently took Case down with it.

## What changed

Split the single flag into two independent props on `TimeCardsTable`:

- `showCaseColumn` — defaults to `true`, so Case now renders on all three tabs, including My time sheets.
- `showEngineerColumn` — defaults to `false`; passed explicitly on the All and Approvals tabs, same as before.

Kept the header list, the row cells, and the `gridTemplateColumns` entries in step for each column independently (each one only contributes its own header/cell/width, no longer a single all-or-nothing pair). Reworded the stale doc comments on both props (and on `groupBy`, which referenced the old combined flag) so the reasoning behind each column's visibility is readable at the declaration and matches current behaviour.

The header alignment logic (`i === headerCells.length - 1 ? "end" : …`) reads the header list at render time, so it stays correct automatically as the visible-column set changes per tab — no index math needed updating.

### The two related checks from the report

- **Group-by-case on My time sheets**: that tab already hard-codes `groupBy="case"` (no visible toggle) with no code change needed — now that Case is a visible column, that fixed grouping reads sensibly instead of clustering against an invisible key.
- **CSV export**: `timeCardCsvExport.ts`'s `CSV_HEADER` already includes `"Case"` unconditionally, and the same export function/button is used by all three tabs, so the personal-view export already carried the case number. No change needed there.

## Verification

Worktree based on current `origin/main`. Real output:

```
$ npx tsc -b
(clean, no output)

$ npx eslint src/features/csm-timecards/components/TimeCardsTable.tsx \
    src/features/csm-timecards/components/TimeCardsTable.test.tsx \
    src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
(clean, no output)

$ npx vitest run
 Test Files  3 failed | 69 passed (72)
      Tests  9 failed | 571 passed (580)
```

The 9 failures are pre-existing and confined to `CaseActionBar.test.tsx`, `CaseActivitiesFeed.test.tsx`, and `CsmAnnouncementsPage.test.tsx` — unrelated to this change and unaffected by it. Added `TimeCardsTable.test.tsx`, asserting the Case column renders (with its value) and the Engineer column does not on the personal-view configuration, and that both render when `showEngineerColumn` is set — pinning the exact behaviour this PR fixes.

## Diff

3 files changed: `TimeCardsTable.tsx`, `CsmTimeCardsPage.tsx` (two one-line prop-name updates), and the new test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time-card tables now display Case and Engineer columns independently.
  * Case information is shown by default, while Engineer information can be enabled separately.
  * Updated All and Approvals views to use the new column visibility behavior.

* **Bug Fixes**
  * Improved table layouts and data visibility for personal and engineer-focused views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->